### PR TITLE
Fixed issues in SLN, FSPROJ and PROPS files

### DIFF
--- a/src/Dynamo.2012.sln
+++ b/src/Dynamo.2012.sln
@@ -113,8 +113,8 @@ Global
 		{0EFABBF0-2B81-4423-B8E2-6111FBE69B79}.Debug|x86.ActiveCfg = Debug|x86
 		{0EFABBF0-2B81-4423-B8E2-6111FBE69B79}.Debug|x86.Build.0 = Debug|x86
 		{0EFABBF0-2B81-4423-B8E2-6111FBE69B79}.Release|Any CPU.ActiveCfg = Release|x64
-		{0EFABBF0-2B81-4423-B8E2-6111FBE69B79}.Release|Mixed Platforms.ActiveCfg = Release|x64
-		{0EFABBF0-2B81-4423-B8E2-6111FBE69B79}.Release|Mixed Platforms.Build.0 = Release|x64
+		{0EFABBF0-2B81-4423-B8E2-6111FBE69B79}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{0EFABBF0-2B81-4423-B8E2-6111FBE69B79}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{0EFABBF0-2B81-4423-B8E2-6111FBE69B79}.Release|x86.ActiveCfg = Release|x86
 		{0EFABBF0-2B81-4423-B8E2-6111FBE69B79}.Release|x86.Build.0 = Release|x86
 		{2B0F2800-6F62-4869-9074-088C5F6DCCA2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -173,6 +173,7 @@ Global
 		{9ADADC68-36A3-4A21-9B54-298154A88720}.Release|x86.ActiveCfg = Release|Any CPU
 		{9ADADC68-36A3-4A21-9B54-298154A88720}.Release|x86.Build.0 = Release|Any CPU
 		{95192F1A-3265-4986-8D07-50F8FD4F2439}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95192F1A-3265-4986-8D07-50F8FD4F2439}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{95192F1A-3265-4986-8D07-50F8FD4F2439}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{95192F1A-3265-4986-8D07-50F8FD4F2439}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{95192F1A-3265-4986-8D07-50F8FD4F2439}.Debug|x86.ActiveCfg = Debug|Any CPU

--- a/src/Dynamo.CS.props
+++ b/src/Dynamo.CS.props
@@ -4,6 +4,7 @@
 	<OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\$(Platform)\$(Configuration)</OutputPath>
 	<NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\extern\NUnit</NunitPath>
 	<REVITAPI  Condition=" '$(REVITAPI)' == '' ">C:\Program Files\Autodesk\Revit Architecture 2014</REVITAPI>
+	<REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Vasari Beta 3</REVITAPI>
 	<BaseIntermediateOutputPath>$(OutputPath)\int\</BaseIntermediateOutputPath>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -16,6 +17,7 @@
   	<OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\$(Platform)\$(Configuration)</OutputPath>
 	<NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\extern\NUnit</NunitPath>
 	<REVITAPI  Condition=" '$(REVITAPI)' == '' ">C:\Program Files\Autodesk\Revit Architecture 2014</REVITAPI>
+	<REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Vasari Beta 3</REVITAPI>
 	<BaseIntermediateOutputPath>$(OutputPath)\int\</BaseIntermediateOutputPath>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>

--- a/src/FScheme/FScheme.2012.fsproj
+++ b/src/FScheme/FScheme.2012.fsproj
@@ -16,7 +16,7 @@
 -->
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets">
-  <Import Project="$(SolutionDir)..\Dynamo.CS.props" />
+    <Import Project="$(ProjectDir)..\Dynamo.CS.props" />
   </ImportGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
- Merge recent updates from "Dynamo.sln" into "Dynamo.2012.sln"
- Fixed "FScheme.2012.fsproj" to use the right environment variable "ProjectDir" instead of "SolutionDir"
- Made "Dynamo.CS.props" falls back on to Vasari path if Revit 2014 does not exist

NOTE: The change in PROPS file will not affect existing build set-ups
