### PR TITLE
Fix: MAGN-159 (nodes are not editable after undo/redo)

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -1590,6 +1590,13 @@ namespace Dynamo.Models
             helper.SetAttribute("isVisible", this.IsVisible);
             helper.SetAttribute("isUpstreamVisible", this.IsUpstreamVisible);
             helper.SetAttribute("lacing", this.ArgumentLacing.ToString());
+
+            if (context == SaveContext.Undo)
+            {
+                // Fix: MAGN-159 (nodes are not editable after undo/redo).
+                helper.SetAttribute("interactionEnabled", this.interactionEnabled);
+                helper.SetAttribute("nodeState", this.state.ToString());
+            }
         }
 
         protected override void DeserializeCore(XmlElement element, SaveContext context)
@@ -1616,12 +1623,23 @@ namespace Dynamo.Models
             this.isUpstreamVisible = helper.ReadBoolean("isUpstreamVisible", true);
             this.argumentLacing = helper.ReadEnum("lacing", LacingStrategy.Disabled);
 
-            // TODO(Ben): We need to raise property change events 
-            // here for those data members we directly changed.
-            RaisePropertyChanged("NickName");
-            RaisePropertyChanged("ArgumentLacing");
-            RaisePropertyChanged("IsVisible");
-            RaisePropertyChanged("IsUpstreamVisible");
+            if (context == SaveContext.Undo)
+            {
+                // Fix: MAGN-159 (nodes are not editable after undo/redo).
+                interactionEnabled = helper.ReadBoolean("interactionEnabled", true);
+                this.state = helper.ReadEnum("nodeState", ElementState.ACTIVE);
+
+                // We only notify property changes in an undo/redo operation. Normal
+                // operations like file loading or copy-paste have the models created
+                // in different ways and their views will always be up-to-date with 
+                // respect to their models.
+                RaisePropertyChanged("InteractionEnabled");
+                RaisePropertyChanged("State");
+                RaisePropertyChanged("NickName");
+                RaisePropertyChanged("ArgumentLacing");
+                RaisePropertyChanged("IsVisible");
+                RaisePropertyChanged("IsUpstreamVisible");
+            }
         }
 
         #endregion


### PR DESCRIPTION
**Problem**
"NodeModel.interactionEnabled" and "state" data members are not included when a NodeModel is serialized for undo. Therefore, during a redo-operation, these states are defaulted to "false" and "dead" respectively, causing a node view to be disabled.

**Solution**
Record both "interactionEnabled" and "state" data members of NodeModel in SerializationCore method when the SaveContext is set to "SaveContext.Undo".

**Unit Test**
Passes DynamoPythonTests, DynamoCoreTests, DynamoCoreUITests and DSCoreNodesTests

No meaningful unit test cases can be written for this as this is a pure visual thing. When the command framework is put in place, then the node states can be validated after undo/redo operations. For now that is not possible.
