### PR TITLE
Removed "Dictionary<string, object> data" in ModelEventArgs

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -19,6 +19,7 @@ using NUnit.Framework;
 using Enum = System.Enum;
 using String = System.String;
 using ProtoCore.DSASM;
+using Dynamo.ViewModels;
 
 namespace Dynamo.Models
 {
@@ -1377,7 +1378,25 @@ namespace Dynamo.Models
                 node.GUID = Guid.NewGuid();
             }
 
-            dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.OnRequestNodeCentered(this, new ModelEventArgs(node, data));
+            bool transCoords = false;
+            if (data.ContainsKey("transformFromOuterCanvasCoordinates"))
+                transCoords = true;
+
+            ModelEventArgs args = null;
+            if (data.ContainsKey("x") && data.ContainsKey("y"))
+            {
+                double x = ((double)data["x"]);
+                double y = ((double)data["y"]);
+                args = new ModelEventArgs(node, x, y, transCoords);
+            }
+            else
+            {
+                // The position of the new node has not been specified.
+                args = new ModelEventArgs(node, transCoords);
+            }
+
+            DynamoViewModel vm = dynSettings.Controller.DynamoViewModel;
+            vm.CurrentSpaceViewModel.OnRequestNodeCentered(this, args);
 
             node.EnableInteraction();
 
@@ -1754,8 +1773,9 @@ namespace Dynamo.Models
 
             if (parameters == null)
             {
-                inputs.Add("transformFromOuterCanvasCoordinates", true);
-                dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.OnRequestNodeCentered(this, new ModelEventArgs(n, inputs));
+                ModelEventArgs args = new ModelEventArgs(n, x, y, true);
+                DynamoViewModel vm = dynSettings.Controller.DynamoViewModel;
+                vm.CurrentSpaceViewModel.OnRequestNodeCentered(this, args);
             }
 
             object id;
@@ -1804,12 +1824,31 @@ namespace Dynamo.Models
 
     public class ModelEventArgs : EventArgs
     {
-        public ModelBase Model { get; set; }
-        public Dictionary<string, object> Data { get; set; }
-        public ModelEventArgs(ModelBase n, Dictionary<string, object> d)
+        public ModelBase Model { get; private set; }
+        public double X { get; private set; }
+        public double Y { get; private set; }
+        public bool PositionSpecified { get; private set; }
+        public bool TransformCoordinates { get; private set; }
+
+        public ModelEventArgs(ModelBase model)
+            : this(model, false)
         {
-            Model = n;
-            Data = d;
+        }
+
+        public ModelEventArgs(ModelBase model, bool transformCoordinates)
+        {
+            Model = model;
+            PositionSpecified = false;
+            TransformCoordinates = transformCoordinates;
+        }
+
+        public ModelEventArgs(ModelBase model, double x, double y, bool transformCoordinates)
+        {
+            Model = model;
+            X = x;
+            Y = y;
+            PositionSpecified = true;
+            TransformCoordinates = transformCoordinates;
         }
     }
 

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -211,7 +211,7 @@ namespace Dynamo.Search.SearchElements
             var placedNode = dynSettings.Controller.DynamoViewModel.Model.Nodes.Find((node) => node.GUID == guid);
             if (placedNode != null)
             {
-                dynSettings.Controller.OnRequestSelect(this, new ModelEventArgs(placedNode, null));
+                dynSettings.Controller.OnRequestSelect(this, new ModelEventArgs(placedNode));
             }
         }
 

--- a/src/DynamoCore/UI/Views/dynWorkspaceView.xaml.cs
+++ b/src/DynamoCore/UI/Views/dynWorkspaceView.xaml.cs
@@ -151,38 +151,32 @@ namespace Dynamo.Views
 
         void vm_RequestNodeCentered(object sender, EventArgs e)
         {
-            double x = 0;
-            double y = 0;
-            ModelBase node = (e as ModelEventArgs).Model;
-            Dictionary<string, object> data = (e as ModelEventArgs).Data;
+            ModelEventArgs args = e as ModelEventArgs;
+            ModelBase node = args.Model;
 
-            x = outerCanvas.ActualWidth / 2.0;
-            y = outerCanvas.ActualHeight / 2.0;
+            double x = outerCanvas.ActualWidth / 2.0;
+            double y = outerCanvas.ActualHeight / 2.0;
 
             // apply small perturbation
             // so node isn't right on top of last placed node
             if (currentNodeCascadeOffset > 96.0)
-            {
                 currentNodeCascadeOffset = 0.0;
-            }
 
             x += currentNodeCascadeOffset;
             y += currentNodeCascadeOffset;
 
             currentNodeCascadeOffset += 24.0;
-            
-            var transformFromOuterCanvas = data.ContainsKey("transformFromOuterCanvasCoordinates");
 
-            if (data.ContainsKey("x"))
-                x = (double)data["x"];
-
-            if (data.ContainsKey("y"))
-                y = (double)data["y"];
+            if (args.PositionSpecified)
+            {
+                x = args.X;
+                y = args.Y;
+            }
 
             Point dropPt = new Point(x, y);
 
             // Transform dropPt from outerCanvas space into zoomCanvas space
-            if (transformFromOuterCanvas)
+            if (args.TransformCoordinates)
             {
                 if (WorkBench != null)
                 {

--- a/src/DynamoCore/ViewModels/DynamoViewModel.cs
+++ b/src/DynamoCore/ViewModels/DynamoViewModel.cs
@@ -737,8 +737,8 @@ namespace Dynamo.ViewModels
                 }
             }
 
-            dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.OnRequestCenterViewOnElement(this, new ModelEventArgs(e,null));
-            
+            DynamoViewModel dvm = dynSettings.Controller.DynamoViewModel;
+            dvm.CurrentSpaceViewModel.OnRequestCenterViewOnElement(this, new ModelEventArgs(e));
         }
         
         public void ShowSaveDialogIfNeededAndSaveResult(object parameter)

--- a/src/DynamoElementsTests/CoreTests.cs
+++ b/src/DynamoElementsTests/CoreTests.cs
@@ -435,7 +435,7 @@ namespace Dynamo.Tests
             // select all of them one by one
             for (int i = 0; i < numNodes; i++)
             {
-                dynSettings.Controller.OnRequestSelect(this, new ModelEventArgs(null, null));
+                dynSettings.Controller.OnRequestSelect(this, new ModelEventArgs(null));
             }
         }
 

--- a/src/DynamoRevit/DynamoController_Revit.cs
+++ b/src/DynamoRevit/DynamoController_Revit.cs
@@ -102,8 +102,8 @@ namespace Dynamo
             if (foundNodes.Any())
             {
                 dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.OnRequestCenterViewOnElement(
-                    this, 
-                    new ModelEventArgs(foundNodes.First(), null));
+                    this, new ModelEventArgs(foundNodes.First()));
+
                 DynamoSelection.Instance.ClearSelection();
                 foundNodes.ForEach(DynamoSelection.Instance.Selection.Add);
             }


### PR DESCRIPTION
#### Background

This is mainly to resolve this task of mine (which is part of a bigger command framework task). For more technical details please refer to the following task:

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-198
#### Unit tests

No new code has been introduced, and test cases that are affected are still passing: DynamoCoreUITests, DynamoCoreTests, DynamoPythonTests and DSCoreNodesTests.
