### PR TITLE
Fix for showstopper defect MAGN-261

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -408,7 +408,7 @@ namespace Dynamo.Models
         {
             if (null == undoRecorder)
                 return;
-            if (null == models || (models.Count <= 0))
+            if (!ShouldProceedWithRecording(models))
                 return;
 
             undoRecorder.BeginActionGroup();
@@ -431,8 +431,8 @@ namespace Dynamo.Models
 
         internal void RecordCreatedModels(List<ModelBase> models)
         {
-            if (null == models || (models.Count <= 0))
-                return; // There's nothing for deletion.
+            if (!ShouldProceedWithRecording(models))
+                return; // There's nothing created.
 
             this.undoRecorder.BeginActionGroup();
             foreach (ModelBase model in models)
@@ -442,7 +442,7 @@ namespace Dynamo.Models
 
         internal void RecordAndDeleteModels(List<ModelBase> models)
         {
-            if (null == models || (models.Count <= 0))
+            if (!ShouldProceedWithRecording(models))
                 return; // There's nothing for deletion.
 
             // Gather a list of connectors first before the nodes they connect
@@ -493,6 +493,14 @@ namespace Dynamo.Models
             }
 
             this.undoRecorder.EndActionGroup(); // Conclude the deletion.
+        }
+
+        private static bool ShouldProceedWithRecording(List<ModelBase> models)
+        {
+            if (null != models)
+                models.RemoveAll((x) => (x == null));
+
+            return (null != models && (models.Count > 0));
         }
 
         #endregion

--- a/src/DynamoCore/Properties/AssemblyInfo.cs
+++ b/src/DynamoCore/Properties/AssemblyInfo.cs
@@ -51,3 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("0.7.0.*")]
+
+[assembly: InternalsVisibleTo("DynamoCoreTests")]

--- a/src/DynamoElementsTests/CoreTests.cs
+++ b/src/DynamoElementsTests/CoreTests.cs
@@ -479,6 +479,72 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void TestRecordModelsForModificationWithEmptyInput()
+        {
+            WorkspaceModel workspace = Controller.DynamoViewModel.CurrentSpace;
+            Assert.AreEqual(false, workspace.CanUndo);
+
+            // Calling the method with a null argument.
+            workspace.RecordModelsForModification(null);
+            Assert.AreEqual(false, workspace.CanUndo);
+
+            // Calling the method with an empty list.
+            List<ModelBase> models = new List<ModelBase>();
+            workspace.RecordModelsForModification(models);
+            Assert.AreEqual(false, workspace.CanUndo);
+
+            // Calling the method with a list full of null.
+            models.Add(null);
+            models.Add(null);
+            workspace.RecordModelsForModification(models);
+            Assert.AreEqual(false, workspace.CanUndo);
+        }
+
+        [Test]
+        public void TestRecordCreatedModelsWithEmptyInput()
+        {
+            WorkspaceModel workspace = Controller.DynamoViewModel.CurrentSpace;
+            Assert.AreEqual(false, workspace.CanUndo);
+
+            // Calling the method with a null argument.
+            workspace.RecordCreatedModels(null);
+            Assert.AreEqual(false, workspace.CanUndo);
+
+            // Calling the method with an empty list.
+            List<ModelBase> models = new List<ModelBase>();
+            workspace.RecordCreatedModels(models);
+            Assert.AreEqual(false, workspace.CanUndo);
+
+            // Calling the method with a list full of null.
+            models.Add(null);
+            models.Add(null);
+            workspace.RecordCreatedModels(models);
+            Assert.AreEqual(false, workspace.CanUndo);
+        }
+
+        [Test]
+        public void TestRecordAndDeleteModelsWithEmptyInput()
+        {
+            WorkspaceModel workspace = Controller.DynamoViewModel.CurrentSpace;
+            Assert.AreEqual(false, workspace.CanUndo);
+
+            // Calling the method with a null argument.
+            workspace.RecordAndDeleteModels(null);
+            Assert.AreEqual(false, workspace.CanUndo);
+
+            // Calling the method with an empty list.
+            List<ModelBase> models = new List<ModelBase>();
+            workspace.RecordAndDeleteModels(models);
+            Assert.AreEqual(false, workspace.CanUndo);
+
+            // Calling the method with a list full of null.
+            models.Add(null);
+            models.Add(null);
+            workspace.RecordAndDeleteModels(models);
+            Assert.AreEqual(false, workspace.CanUndo);
+        }
+
+        [Test]
         public void CanSumTwoNumbers()
         {
             var model = dynSettings.Controller.DynamoModel;


### PR DESCRIPTION
#### Background

This pull request is meant to resolve a crash in Dynamo:

MAGN-261 Paste input/output node is crashing Dynamo
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-261
1. Fix: MAGN-261 Paste input/output node is crashing Dynamo
2. Added three new test cases to verify the fix
3. Added "InternalsVisibleTo" attribute to "DynamoCore" so its internals are visible to "DynamoCoreTests.dll"
#### Unit Testing

These new test cases are added to verify the fix:
- TestRecordModelsForModificationWithEmptyInput
- TestRecordCreatedModelsWithEmptyInput
- TestRecordAndDeleteModelsWithEmptyInput
