### PR TITLE
Fix for "Align All" undo issue MAGN-275

### DIFF
--- a/src/DynamoCore/ViewModels/WorkspaceViewModel.cs
+++ b/src/DynamoCore/ViewModels/WorkspaceViewModel.cs
@@ -518,6 +518,13 @@ namespace Dynamo.ViewModels
 
             if (DynamoSelection.Instance.Selection.Count <= 1) return;
 
+            // All the models in the selection will be modified, 
+            // record their current states before anything gets changed.
+            IEnumerable<ModelBase> models = null;
+            SmartCollection<ISelectable> selection = DynamoSelection.Instance.Selection;
+            models = selection.Cast<ModelBase>().Where(x => x is ModelBase);
+            _model.RecordModelsForModification(models.ToList());
+
             if (alignType == "HorizontalCenter")  // make vertial line of elements
             {
                 var xAll = GetSelectionAverageX();


### PR DESCRIPTION
#### Background

This commit is to fix the following defect:

MAGN-275 Align All is not recorded for Undo
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-275

Note that "UpdateSelectionOffsets" method is also removed along with this fix. The method re-inserts the selected nodes into selection just to compute OffsetData for dragging (at a later time). This is no longer necessary as StateMachine replaced the need of OffsetData during dragging.
#### Unit Testing

Existing unit tests are passing: DynamoCoreUITests, DynamoCoreTests, DynamoMSOfficeTests, DynamoPythonTests, DSCoreNodesTests, DSCoreNodesTests.
