### PR TITLE
For for showstopper defect in copy-and-paste MAGN-299

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1048,7 +1048,7 @@ namespace Dynamo.Models
 
             //clear the selection so we can put the
             //paste contents in
-            DynamoSelection.Instance.Selection.Reset(new List<ISelectable>());
+            DynamoSelection.Instance.ClearSelection();
 
             var nodes = dynSettings.Controller.ClipBoard.OfType<NodeModel>();
 


### PR DESCRIPTION
#### Background

This pull request is meant to fix the following showstopper and normal defects:
[MAGN-299 Nodes cannot be selected after copy/paste](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-299)
[MAGN-221 After Copy-Paste parent node remains in selected state](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-221)

"DynamoSelection.Instance.Selection" is of type "SmartCollection" (an ObservableCollection). In the "Paste" command handler, its contents are cleared by a call to "Selection.Reset" and all the ISelectable in there were removed without first clearing their "selected" flag. This causes the node to appear selected but is no longer in the selection. It causes subsequent selection and deselection to fail since its state goes out-of-sync with the selection set.

The fix is to use "DynamoSelection.Instance.ClearSelection" instead of "Selection.Reset" because "ClearSelection" internally loops through all the selected nodes and clear their "selected" flags.
#### Unit testing

All NUnit test cases passed: DSCoreNodesTest, DynamoCoreUITests, DynamoMSOfficeTests, DynamoPythonTests and DynamoCoreTests.
