### PR TITLE
Fix for showstopper defect MAGN-280

### DIFF
--- a/src/DynamoCore/UI/Commands/WorkspaceCommands.cs
+++ b/src/DynamoCore/UI/Commands/WorkspaceCommands.cs
@@ -5,8 +5,6 @@ namespace Dynamo.ViewModels
     public partial class WorkspaceViewModel
     {
         private DelegateCommand _hideCommand;
-        private DelegateCommand _crossSelectCommand;
-        private DelegateCommand _containSelectCommand;
         private DelegateCommand _setCurrentOffsetCommand;
         private DelegateCommand _nodeFromSelectionCommand;
         private DelegateCommand _setZoomCommand;
@@ -36,28 +34,6 @@ namespace Dynamo.ViewModels
                     _hideCommand = new DelegateCommand(Hide, CanHide);
 
                 return _hideCommand;
-            }
-        }
-
-        public DelegateCommand CrossSelectCommand
-        {
-            get
-            {
-                if(_crossSelectCommand == null)
-                    _crossSelectCommand = new DelegateCommand(CrossingSelect, CanCrossSelect);
-
-                return _crossSelectCommand;
-            }
-        }
-
-        public DelegateCommand ContainSelectCommand
-        {
-            get
-            {
-                if(_containSelectCommand == null)
-                    _containSelectCommand = new DelegateCommand(ContainSelect, CanContainSelect);
-
-                return _containSelectCommand;
             }
         }
 

--- a/src/DynamoCore/UI/StateMachine.cs
+++ b/src/DynamoCore/UI/StateMachine.cs
@@ -228,14 +228,6 @@ namespace Dynamo.ViewModels
                 }
                 else if (this.currentState == State.WindowSelection)
                 {
-                    // TODO(Ben): Can we not only select those nodes that we 
-                    // have not previously selected? Of course that requires 
-                    // us to take deselection into consideration.
-                    // 
-                    // Clear the selected elements before reselecting 
-                    // all nodes that fall within the selection window.
-                    DynamoSelection.Instance.ClearSelection();
-
                     // When the mouse is held down, reposition the drag selection box.
                     double x = Math.Min(mouseDownPos.X, mouseCursor.X);
                     double y = Math.Min(mouseDownPos.Y, mouseCursor.Y);
@@ -257,11 +249,7 @@ namespace Dynamo.ViewModels
                     this.owningWorkspace.RequestSelectionBoxUpdate(this, args);
 
                     var rect = new Rect(x, y, width, height);
-
-                    if (isCrossSelection)
-                        owningWorkspace.CrossSelectCommand.Execute(rect);
-                    else
-                        owningWorkspace.ContainSelectCommand.Execute(rect);
+                    owningWorkspace.SelectInRegion(rect, isCrossSelection);
                 }
                 else if (this.currentState == State.DragSetup)
                 {

--- a/src/DynamoCore/ViewModels/WorkspaceViewModel.cs
+++ b/src/DynamoCore/ViewModels/WorkspaceViewModel.cs
@@ -448,6 +448,63 @@ namespace Dynamo.ViewModels
             return true;
         }
 
+        internal void SelectInRegion(Rect region, bool isCrossSelect)
+        {
+            bool fullyEnclosed = !isCrossSelect;
+
+            foreach (NodeModel n in Model.Nodes)
+            {
+                double x0 = n.X;
+                double y0 = n.Y;
+
+                if (IsInRegion(region, n, fullyEnclosed))
+                {
+                    if (!DynamoSelection.Instance.Selection.Contains(n))
+                        DynamoSelection.Instance.Selection.Add(n);
+                }
+                else
+                {
+                    if (n.IsSelected)
+                        DynamoSelection.Instance.Selection.Remove(n);
+                }
+            }
+
+            foreach (var n in Model.Notes)
+            {
+                double x0 = n.X;
+                double y0 = n.Y;
+
+                if (IsInRegion(region, n, fullyEnclosed))
+                {
+                    if (!DynamoSelection.Instance.Selection.Contains(n))
+                        DynamoSelection.Instance.Selection.Add(n);
+                }
+                else
+                {
+                    if (n.IsSelected)
+                        DynamoSelection.Instance.Selection.Remove(n);
+                }
+            }
+        }
+
+        private static bool IsInRegion(Rect region, ILocatable locatable, bool fullyEnclosed)
+        {
+            double x0 = locatable.X;
+            double y0 = locatable.Y;
+
+            if (false == fullyEnclosed) // Cross selection.
+            {
+                Rect test = new Rect(x0, y0, locatable.Width, locatable.Height);
+                return region.IntersectsWith(test);
+            }
+            else // Contain selection.
+            {
+                double x1 = x0 + locatable.Width;
+                double y1 = y0 + locatable.Height;
+                return (region.Contains(x0, y0) && region.Contains(x1, y1));
+            }
+        }
+
         public double GetSelectionAverageX()
         {
             return DynamoSelection.Instance.Selection.Where((x) => x is ILocatable)
@@ -622,111 +679,6 @@ namespace Dynamo.ViewModels
             // can hide anything but the home workspace
             return dynSettings.Controller.DynamoViewModel.Model.HomeSpace != this._model;
         }
-
-        private void ContainSelect(object parameters)
-        {
-            var rect = (Rect)parameters;
-
-            foreach (NodeModel n in Model.Nodes)
-            {
-                double x0 = n.X;
-                double y0 = n.Y;
-                double x1 = x0 + n.Width;
-                double y1 = y0 + n.Height;
-
-                bool contains = rect.Contains(x0, y0) && rect.Contains(x1, y1);
-                if (contains)
-                {
-                    if (!DynamoSelection.Instance.Selection.Contains(n))
-                        DynamoSelection.Instance.Selection.Add(n);
-                }
-                else
-                {
-                    //if the node is not contained but is selected, unselect it 
-                    if (n.IsSelected)
-                    {
-                        DynamoSelection.Instance.Selection.Remove(n);
-                    }   
-                }
-            }
-
-            foreach (var n in Model.Notes)
-            {
-                double x0 = n.X;
-                double y0 = n.Y;
-                double x1 = x0 + n.Width;
-                double y1 = y0 + n.Height;
-
-                bool contains = rect.Contains(x0, y0) && rect.Contains(x1, y1);
-                if (contains)
-                {
-                    if (!DynamoSelection.Instance.Selection.Contains(n))
-                        DynamoSelection.Instance.Selection.Add(n);
-                }
-                else
-                {
-                    if (n.IsSelected)
-                    {
-                        DynamoSelection.Instance.Selection.Remove(n);
-                    } 
-                }
-            }
-        }
-
-        private bool CanContainSelect(object parameters)
-        {
-            return true;
-        }
-
-        private void CrossingSelect(object parameters)
-        {
-            var rect = (Rect)parameters;
-
-            foreach (NodeModel n in Model.Nodes)
-            {
-                double x0 = n.X;
-                double y0 = n.Y;
-
-                bool intersects = rect.IntersectsWith(new Rect(x0, y0, n.Width, n.Height));
-                if (intersects)
-                {
-                    if (!DynamoSelection.Instance.Selection.Contains(n))
-                        DynamoSelection.Instance.Selection.Add(n);
-                }
-                else
-                {
-                    if (n.IsSelected)
-                    {
-                        DynamoSelection.Instance.Selection.Remove(n);
-                    }
-                }
-            }
-
-            foreach (var n in Model.Notes)
-            {
-                double x0 = n.X;
-                double y0 = n.Y;
-
-                bool intersects = rect.IntersectsWith(new Rect(x0, y0, n.Width, n.Height));
-                if (intersects)
-                {
-                    if (!DynamoSelection.Instance.Selection.Contains(n))
-                        DynamoSelection.Instance.Selection.Add(n);
-                }
-                else
-                {
-                    if (n.IsSelected)
-                    {
-                        DynamoSelection.Instance.Selection.Remove(n);
-                    }
-                }
-            }
-        }
-
-        private bool CanCrossSelect(object parameters)
-        {
-            return true;
-        } 
 
         private void SetCurrentOffset(object parameter)
         {


### PR DESCRIPTION
#### Background

This commit is meant to fix the following defect:

[MAGN-280 Dragging of selection area causes flickering of nodes](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-280)

From the way CrossSelectCommand, ContainSelectionCommand commands are implemented, there is no reason why selection needs to be cleared for each mouse-move. This is especially redundant since we are already clearing the selection at the beginning of window selection (during mouse-down).
#### Unit testing

All test cases passed: DynamoPythonTests, DynamoCoreUITests, DynamoCoreTests, DynamoMSOfficeTests and DSCoreNodesTests.
