### PR TITLE
Updated "ConnectorModel.Make" method to take "PortType" instead of "int"

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -780,7 +780,7 @@ namespace Dynamo.Utilities
                     var guidEnd = new Guid(guidEndAttrib.Value);
                     int startIndex = Convert.ToInt16(intStartAttrib.Value);
                     int endIndex = Convert.ToInt16(intEndAttrib.Value);
-                    int portType = Convert.ToInt16(portTypeAttrib.Value);
+                    PortType portType = ((PortType)Convert.ToInt16(portTypeAttrib.Value));
 
                     //find the elements to connect
                     NodeModel start = null;

--- a/src/DynamoCore/Core/NodeCollapser.cs
+++ b/src/DynamoCore/Core/NodeCollapser.cs
@@ -305,7 +305,7 @@ namespace Dynamo.Utilities
                                                   inputReceiverNode,
                                                   0,
                                                   inputReceiverData,
-                                                  0 );
+                                                  PortType.INPUT);
 
                     if (conn1 != null)
                         newNodeWorkspace.Connectors.Add(conn1);
@@ -317,7 +317,7 @@ namespace Dynamo.Utilities
                                                      curriedNode.InnerNode,
                                                      0,
                                                      0,
-                                                     0);
+                                                     PortType.INPUT);
                     if (conn != null)
                         newNodeWorkspace.Connectors.Add(conn);
 
@@ -327,7 +327,7 @@ namespace Dynamo.Utilities
                         inputReceiverNode,
                         0,
                         inputReceiverData,
-                        0);
+                        PortType.INPUT);
 
                     if (conn2 != null)
                         newNodeWorkspace.Connectors.Add(conn2);
@@ -397,7 +397,7 @@ namespace Dynamo.Utilities
                                 node,
                                 outputSenderData,
                                 0,
-                                0 );
+                                PortType.INPUT);
                     
                     if (conn != null)
                         newNodeWorkspace.Connectors.Add(conn);
@@ -448,7 +448,7 @@ namespace Dynamo.Utilities
                         curriedNode.InnerNode,
                         outputSenderData,
                         targetPortIndex + 1,
-                        0);
+                        PortType.INPUT);
 
                     if (conn != null)
                         newNodeWorkspace.Connectors.Add(conn);
@@ -481,7 +481,7 @@ namespace Dynamo.Utilities
                                     collapsedNode,
                                     nodeTuple.Item2,
                                     nodeTuple.Item3,
-                                    0 );
+                                    PortType.INPUT);
 
                 if (conn != null)
                     currentWorkspace.Connectors.Add(conn);
@@ -495,7 +495,7 @@ namespace Dynamo.Utilities
                                     nodeTuple.Item1,
                                     nodeTuple.Item2,
                                     nodeTuple.Item3,
-                                    0 );
+                                    PortType.INPUT);
 
                 if (conn != null)
                     currentWorkspace.Connectors.Add(conn);

--- a/src/DynamoCore/Models/ConnectorModel.cs
+++ b/src/DynamoCore/Models/ConnectorModel.cs
@@ -69,7 +69,7 @@ namespace Dynamo.Models
         /// <param name="endIndex"></param>
         /// <param name="portType"></param>
         /// <returns>The valid connector model or null if the connector is invalid</returns>
-        public static ConnectorModel Make(NodeModel start, NodeModel end, int startIndex, int endIndex, int portType)
+        public static ConnectorModel Make(NodeModel start, NodeModel end, int startIndex, int endIndex, PortType portType)
         {
             if (start != null && end != null && start != end && startIndex >= 0
                 && endIndex >= 0 && start.OutPorts.Count > startIndex && end.InPorts.Count > endIndex )
@@ -80,7 +80,7 @@ namespace Dynamo.Models
             return null;
         }
 
-        private ConnectorModel(NodeModel start, NodeModel end, int startIndex, int endIndex, int portType )
+        private ConnectorModel(NodeModel start, NodeModel end, int startIndex, int endIndex, PortType portType)
         {
             //Stopwatch sw = new Stopwatch();
             //sw.Start();
@@ -88,7 +88,7 @@ namespace Dynamo.Models
 
             PortModel endPort = null;
 
-            if (portType == 0)
+            if (portType == PortType.INPUT)
                 endPort = end.InPorts[endIndex];
 
             pStart.Connect(this);

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -788,7 +788,7 @@ namespace Dynamo.Models
                     var guidEnd = new Guid(guidEndAttrib.Value);
                     int startIndex = Convert.ToInt16(intStartAttrib.Value);
                     int endIndex = Convert.ToInt16(intEndAttrib.Value);
-                    int portType = Convert.ToInt16(portTypeAttrib.Value);
+                    PortType portType = ((PortType)Convert.ToInt16(portTypeAttrib.Value));
 
                     //find the elements to connect
                     NodeModel start = null;
@@ -814,7 +814,7 @@ namespace Dynamo.Models
                     }
 
                     var newConnector = ConnectorModel.Make(start, end,
-                                                        startIndex, endIndex, portType);
+                        startIndex, endIndex, portType);
 
                     //Stopwatch addTimer = new Stopwatch();
                     //addTimer.Start();
@@ -1577,7 +1577,7 @@ namespace Dynamo.Models
                 int startIndex = (int)connectionData["port_start"];
                 int endIndex = (int)connectionData["port_end"];
 
-                var c = ConnectorModel.Make(start, end, startIndex, endIndex, 0);
+                var c = ConnectorModel.Make(start, end, startIndex, endIndex, PortType.INPUT);
 
                 if (c != null)
                     CurrentWorkspace.Connectors.Add(c);

--- a/src/DynamoCore/UI/StateMachine.cs
+++ b/src/DynamoCore/UI/StateMachine.cs
@@ -372,8 +372,8 @@ namespace Dynamo.ViewModels
                         second = start;
                     }
 
-                    ConnectorModel newConnectorModel = ConnectorModel.Make(
-                        firstPort.Owner, second.Owner, firstPort.Index, second.Index, 0);
+                    ConnectorModel newConnectorModel = ConnectorModel.Make(firstPort.Owner,
+                        second.Owner, firstPort.Index, second.Index, PortType.INPUT);
 
                     if (newConnectorModel == null) // The connector is invalid
                         return false;


### PR DESCRIPTION
#### Background

Updated "ConnectorModel.Make" method to take "PortType" instead of "int". The reason for this is because it makes the method more self explanatory and caller must explicitly specify "PortType.Output" instead of "1", which is much less likely to get wrong.
#### Test scenarios

The following are a few scenarios for testing (I have tested most of them to ensure the code changes do not break anything that they affect).
1. Open custom node should retain the connectors
2. Open regular Dynamo file
3. Establish a new connector
4. Undo and redo connector's creation
5. Collapse a set of node in a given workspace
#### Unit testing

All existing NUnit test cases passed: DynamoPythonTests, DynamoCoreUITests, DynamoCoreTests, DynamoMSOfficeTests, DSCoreNodesTests.
