### PR TITLE
Added 6 new tests for Sample files.

### DIFF
--- a/src/DynamoRevitTests/SampleTests.cs
+++ b/src/DynamoRevitTests/SampleTests.cs
@@ -263,5 +263,168 @@ namespace Dynamo.Tests
         {
             Assert.Inconclusive();
         }
+
+        [Test]
+        public void Attractor_1()
+        {
+            var model = dynSettings.Controller.DynamoModel;
+
+            string samplePath = Path.Combine(_samplesPath, @".\10 Attractor\Attractor Logic_End.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            model.Open(testPath);
+
+            // check all the nodes and connectors are loaded
+            Assert.AreEqual(15, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(20, model.CurrentWorkspace.Connectors.Count);
+
+            dynSettings.Controller.RunExpression(true);
+        }
+
+        [Test]
+        public void Attractor_2()
+        {
+            var model = dynSettings.Controller.DynamoModel;
+
+            string samplePath = Path.Combine(_samplesPath, @".\10 Attractor\Attractor Logic_Start.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            model.Open(testPath);
+
+            // check all the nodes and connectors are loaded
+            Assert.AreEqual(17, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(17, model.CurrentWorkspace.Connectors.Count);
+
+            dynSettings.Controller.RunExpression(true);
+        }
+
+        [Test]
+        public void IndexedFamilyInstances()
+        {
+            var model = dynSettings.Controller.DynamoModel;
+
+            //string modelPath = Path.GetFullPath(Path.Combine(_samplesPath, @".\11 Indexed Family Instances\IndexedFamilyInstances.rfa"));
+            //SwapCurrentModel(modelPath);
+
+            string samplePath = Path.Combine(_samplesPath, @".\11 Indexed Family Instances\Indexed Family Instances.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            model.Open(testPath);
+
+            // check all the nodes and connectors are loaded
+            Assert.AreEqual(11, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(11, model.CurrentWorkspace.Connectors.Count);
+
+            dynSettings.Controller.RunExpression(true);
+        }
+
+        //[Test]
+        //public void AdaptiveComponentPlacement()
+        //{
+        //    var model = dynSettings.Controller.DynamoModel;
+
+        //    //string modelPath = Path.GetFullPath(Path.Combine(_samplesPath, @".\18 Adaptive Components\Adaptive Component Placement.rfa"));
+        //    //SwapCurrentModel(modelPath);
+
+        //    string samplePath = Path.Combine(_samplesPath, @".\18 Adaptive Components\Adaptive Component Placement.dyn");
+        //    string testPath = Path.GetFullPath(samplePath);
+
+        //    model.Open(testPath);
+
+        //    // check all the nodes and connectors are loaded
+        //    Assert.AreEqual(11, model.CurrentWorkspace.Nodes.Count);
+        //    Assert.AreEqual(10, model.CurrentWorkspace.Connectors.Count);
+
+        //    dynSettings.Controller.RunExpression(true);
+        //}
+
+        [Test]
+        public void Tesselation_1()
+        {
+            var model = dynSettings.Controller.DynamoModel;
+
+            string modelPath = Path.GetFullPath(Path.Combine(_samplesPath, @".\16 Tesselation\tesselation.rfa"));
+            SwapCurrentModel(modelPath);
+
+            string samplePath = Path.Combine(_samplesPath, @".\16 Tesselation\2dDomain.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            model.Open(testPath);
+
+            // check all the nodes and connectors are loaded
+            Assert.AreEqual(17, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(23, model.CurrentWorkspace.Connectors.Count);
+
+            dynSettings.Controller.RunExpression(true);
+
+            //var watch = model.CurrentWorkspace.NodeFromWorkspace<NewList>("789c1592-b64c-4a97-8f1a-8cef3d0cc2d0");
+            //FSharpList<FScheme.Value> actual = watch.GetValue(0).GetListFromFSchemeValue();
+            //Assert.AreEqual(0, actual.Length);
+
+        }
+
+        [Test]
+        public void Tesselation_2()
+        {
+            var model = dynSettings.Controller.DynamoModel;
+
+            string modelPath = Path.GetFullPath(Path.Combine(_samplesPath, @".\16 Tesselation\tesselation.rfa"));
+            SwapCurrentModel(modelPath);
+
+            string samplePath = Path.Combine(_samplesPath, @".\16 Tesselation\tesselation with coincident grids.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            model.Open(testPath);
+
+            // check all the nodes and connectors are loaded
+            Assert.AreEqual(12, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(16, model.CurrentWorkspace.Connectors.Count);
+
+            dynSettings.Controller.RunExpression(true);
+
+        }
+
+        [Test]
+        public void Tesselation_3()
+        {
+            var model = dynSettings.Controller.DynamoModel;
+
+            string modelPath = Path.GetFullPath(Path.Combine(_samplesPath, @".\16 Tesselation\tesselation.rfa"));
+            SwapCurrentModel(modelPath);
+
+            string samplePath = Path.Combine(_samplesPath, @".\16 Tesselation\tesselation.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            model.Open(testPath);
+
+            // check all the nodes and connectors are loaded
+            Assert.AreEqual(8, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(10, model.CurrentWorkspace.Connectors.Count);
+
+            dynSettings.Controller.RunExpression(true);
+
+        }
+
+        //[Test]
+        //public void Tesselation_4()
+        //{
+        //    var model = dynSettings.Controller.DynamoModel;
+
+        //    string modelPath = Path.GetFullPath(Path.Combine(_samplesPath, @".\16 Tesselation\tesselation.rfa"));
+        //    SwapCurrentModel(modelPath);
+
+        //    string samplePath = Path.Combine(_samplesPath, @".\16 Tesselation\tesselation_types.dyn");
+        //    string testPath = Path.GetFullPath(samplePath);
+
+        //    model.Open(testPath);
+
+        //    // check all the nodes and connectors are loaded
+        //    Assert.AreEqual(11, model.CurrentWorkspace.Nodes.Count);
+        //    Assert.AreEqual(12, model.CurrentWorkspace.Connectors.Count);
+
+        //    dynSettings.Controller.RunExpression(true);
+
+        //}
+
     }
 }

--- a/test/revit/DynamoRevitTests.xml
+++ b/test/revit/DynamoRevitTests.xml
@@ -81,7 +81,12 @@
 				<test name="InstParamSample" runDynamo="True" modelPath=".\empty.rfa"/>
 				<test name="InstParam2MassesSample" runDynamo="True" modelPath=".\empty.rfa"/>
 				<test name="InstParam2MassesDrivingEachOtherSample" runDynamo="True" modelPath=".\empty.rfa"/>
-				<test name="InstParam2MassesDrivingEachOtherSample" runDynamo="True" modelPath=".\empty.rfa"/>
+				<test name="Attractor_1" runDynamo="True" modelPath=".\empty.rfa"/>
+				<test name="Attractor_2" runDynamo="True" modelPath=".\empty.rfa"/>
+				<test name="IndexedFamilyInstances" runDynamo="True" modelPath="..\..\doc\distrib\Samples\11 Indexed Family Instances\IndexedFamilyInstances.rfa"/>
+				<test name="Tesselation_1" runDynamo="True" modelPath=".\empty.rfa"/>
+				<test name="Tesselation_2" runDynamo="True" modelPath=".\empty.rfa"/>
+				<test name="Tesselation_3" runDynamo="True" modelPath=".\empty.rfa"/>
 			</testFixture>
 			<testFixture name="SolidTests">
 				<test name="BlendSolid" runDynamo="True" modelPath=".\empty.rfa"/>


### PR DESCRIPTION
- 3 for Tessellation
- 2 for Attractor
- 1 for inst pram

Removed one duplicate sample test from DynamoRevitTests under SampleTests.cs "InstParam2MassesDrivingEachOtherSample"

Also commented out two newly added test cases because they are currently  failing. I will investigate on the failure and will turn them on in next submission. 
- AdaptiveComponentPlacement
- Tesselation_4
