### PR TITLE
Integration of Command Framework and NUnit Tests

### DIFF
--- a/src/DynamoCore/Core/DynamoController.cs
+++ b/src/DynamoCore/Core/DynamoController.cs
@@ -260,9 +260,6 @@ namespace Dynamo
             this.InfoBubbleViewModel = new InfoBubbleViewModel();
 
             AddPythonBindings();
-
-            // Kick start the automation run, if possible.
-            this.DynamoViewModel.BeginCommandPlayback();
         }
 
         #endregion

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -158,6 +158,7 @@ limitations under the License.
     <Compile Include="Nodes\Geometry.cs" />
     <Compile Include="PackageManager\PackageManagerClient.cs" />
     <Compile Include="Search\SearchElements\CustomNodeSearchElement.cs" />
+    <Compile Include="UI\Commands\AutomationSettings.cs" />
     <Compile Include="UI\Commands\BrowserItemCommands.cs" />
     <Compile Include="UI\Commands\Commands.cs" />
     <Compile Include="Core\DynamoLogger.cs" />

--- a/src/DynamoCore/UI/Commands/AutomationSettings.cs
+++ b/src/DynamoCore/UI/Commands/AutomationSettings.cs
@@ -1,0 +1,271 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Threading;
+using System.Xml;
+using Dynamo.Utilities;
+using DynCmd = Dynamo.ViewModels.DynamoViewModel;
+
+namespace Dynamo.ViewModels
+{
+    class AutomationSettings
+    {
+        #region Class Data Members
+
+        internal enum Mode { None, Playback, Recording }
+
+        /// <summary>
+        /// This attribute specifies if Dynamo main window should be 
+        /// closed after all the loaded commands have been played back. 
+        /// This is set to "true" by default for recorded command files.
+        /// </summary>
+        /// 
+        private const string ExitAttribName = "ExitAfterPlayback";
+
+        /// <summary>
+        /// This attribute specifies the amount of time in milliseconds that 
+        /// Dynamo window should pause before closing. This value is ignored 
+        /// if ExitAttribName is set to "false" (in which case Dynamo 
+        /// window will not be closed after playback is completed).
+        /// </summary>
+        /// 
+        private const string PauseAttribName = "PauseAfterPlaybackInMs";
+
+        private System.Windows.Window mainWindow = null;
+        private DynamoViewModel owningViewModel = null;
+        private DispatcherTimer playbackTimer = null;
+        private List<DynCmd.RecordableCommand> loadedCommands = null;
+        private List<DynCmd.RecordableCommand> recordedCommands = null;
+
+        #endregion
+
+        #region Class Properties
+
+        internal int PauseAfterPlayback { get; private set; }
+        internal bool ExitAfterPlayback { get; private set; }
+        internal Mode CurrentMode { get; private set; }
+
+        internal bool CanSaveRecordedCommands
+        {
+            get
+            {
+                if (null == recordedCommands)
+                    return false;
+
+                return (recordedCommands.Count > 0);
+            }
+        }
+
+        #endregion
+
+        #region Class Operational Methods
+
+        internal AutomationSettings(DynamoViewModel vm, string commandFilePath)
+        {
+            this.PauseAfterPlayback = 10; // 10ms after playback is done.
+            this.ExitAfterPlayback = true; // Exit Dynamo after playback.
+
+            this.CurrentMode = Mode.None;
+            if (LoadCommandFromFile(commandFilePath))
+                this.CurrentMode = Mode.Playback;
+            else
+            {
+                this.CurrentMode = Mode.Recording;
+                recordedCommands = new List<DynCmd.RecordableCommand>();
+            }
+
+            this.owningViewModel = vm;
+            if (null == this.owningViewModel)
+                throw new ArgumentNullException("vm");
+        }
+
+        internal void BeginCommandPlayback(System.Windows.Window mainWindow)
+        {
+            if (this.CurrentMode != Mode.Playback)
+                return; // Not currently in playback mode.
+
+            if (null != this.playbackTimer)
+            {
+                // Ensure that this method is not called more than once.
+                throw new InvalidOperationException(
+                    "Internal error: 'BeginCommandPlayback' called twice");
+            }
+
+            this.mainWindow = mainWindow;
+            System.Diagnostics.Debug.Assert(null == playbackTimer);
+            playbackTimer = new DispatcherTimer();
+
+            // Serialized commands for playback.
+            playbackTimer.Interval = TimeSpan.FromMilliseconds(20);
+            playbackTimer.Tick += OnPlaybackTimerTick;
+            playbackTimer.Start();
+        }
+
+        internal void RecordCommand(DynCmd.RecordableCommand command)
+        {
+            // In the playback mode 'this.recordedCommands' will be 
+            // 'null' so that the incoming command will not be recorded.
+            if (null != recordedCommands)
+            {
+                if (command.Redundant && (recordedCommands.Count > 0))
+                {
+                    // If a command is being marked "Redundant", then we will 
+                    // only be interested in the most recent one. If we already
+                    // have another instance recorded immediately prior to this,
+                    // then replace the old instance with the new (for details,
+                    // see "RecordableCommand.Redundant" property).
+                    // 
+                    var previousCommand = recordedCommands.Last();
+                    if (previousCommand.GetType() != command.GetType())
+                        recordedCommands.Add(command);
+                    else
+                    {
+                        // Replace the existing command instead of adding.
+                        recordedCommands[recordedCommands.Count - 1] = command;
+                    }
+                }
+                else
+                    recordedCommands.Add(command);
+            }
+        }
+
+        internal string SaveRecordedCommands()
+        {
+            XmlDocument document = new XmlDocument();
+            XmlElement commandRoot = document.CreateElement("Commands");
+            document.AppendChild(commandRoot);
+
+            // Create attributes that applied to the entire recording.
+            XmlElementHelper helper = new XmlElementHelper(commandRoot);
+            helper.SetAttribute(ExitAttribName, ExitAfterPlayback);
+            helper.SetAttribute(PauseAttribName, PauseAfterPlayback);
+
+            foreach (DynCmd.RecordableCommand command in recordedCommands)
+                commandRoot.AppendChild(command.Serialize(document));
+
+            string format = "Commands-{0:yyyyMMdd-hhmmss}.xml";
+            string xmlFileName = string.Format(format, DateTime.Now);
+            string xmlFilePath = Path.Combine(Path.GetTempPath(), xmlFileName);
+
+            // Save recorded commands into XML file and open it in viewer.
+            document.Save(xmlFilePath);
+            return xmlFilePath;
+        }
+
+        #endregion
+
+        #region Private Class Helper Methods
+
+        private bool LoadCommandFromFile(string commandFilePath)
+        {
+            if (string.IsNullOrEmpty(commandFilePath))
+                return false;
+            if (File.Exists(commandFilePath) == false)
+                return false;
+
+            if (null != loadedCommands)
+            {
+                throw new InvalidOperationException(
+                    "Internal error: 'LoadCommandFromFile' called twice");
+            }
+
+            try
+            {
+                // Attempt to load the XML from the specified path.
+                XmlDocument document = new XmlDocument();
+                document.Load(commandFilePath);
+
+                // Get to the root node of this Xml document.
+                XmlElement commandRoot = document.FirstChild as XmlElement;
+                if (null == commandRoot || (null == commandRoot.ChildNodes))
+                    return false;
+
+                // Read in optional attributes from the command root element.
+                XmlElementHelper helper = new XmlElementHelper(commandRoot);
+                this.ExitAfterPlayback = helper.ReadBoolean(ExitAttribName, true);
+                this.PauseAfterPlayback = helper.ReadInteger(PauseAttribName, 10);
+
+                loadedCommands = new List<DynCmd.RecordableCommand>();
+                foreach (XmlNode node in commandRoot.ChildNodes)
+                {
+                    DynCmd.RecordableCommand command = null;
+                    command = DynCmd.RecordableCommand.Deserialize(node as XmlElement);
+                    if (null != command)
+                        loadedCommands.Add(command);
+                }
+            }
+            catch (Exception)
+            {
+                // Something is wrong with the Xml file, invalidate the 
+                // data member that points to it, and return from here.
+                return false;
+            }
+
+            // Even though the Xml file can properly be loaded, it is still 
+            // possible that the loaded content did not result in any useful 
+            // commands. In this case simply return false, indicating failure.
+            // 
+            return (null != loadedCommands && (loadedCommands.Count > 0));
+        }
+
+        private void OnPlaybackTimerTick(object sender, EventArgs e)
+        {
+            DispatcherTimer timer = sender as DispatcherTimer;
+            timer.Stop(); // Stop the timer before command completes.
+
+            if (loadedCommands.Count <= 0) // There's nothing else for playback.
+            {
+                if (this.ExitAfterPlayback == false)
+                {
+                    // The playback is done, but the command file indicates that
+                    // Dynamo should not be shutdown after the playback, so here
+                    // we simply invalidate the timer.
+                    // 
+                    this.playbackTimer = null;
+                }
+                else
+                {
+                    // The command file requires Dynamo be shutdown after all 
+                    // commands has been played back. If that's the case, we'll
+                    // reconfigure the callback to a shutdown timer, and then 
+                    // change its interval to the duration specified earlier.
+                    // 
+                    this.playbackTimer.Tick -= OnPlaybackTimerTick;
+                    this.playbackTimer.Tick += OnShutdownTimerTick;
+
+                    var interval = TimeSpan.FromMilliseconds(PauseAfterPlayback);
+                    this.playbackTimer.Interval = interval;
+                    this.playbackTimer.Start(); // Start shutdown timer.
+                }
+
+                return;
+            }
+
+            // Remove the first command from the loaded commands.
+            DynCmd.RecordableCommand nextCommand = loadedCommands[0];
+            loadedCommands.RemoveAt(0);
+
+            // Execute the command, this may take a while longer than the timer
+            // inverval (usually very short), that's why the timer was stopped 
+            // before the command execution starts. After the command is done,
+            // the timer is then resumed for the next command in queue.
+            // 
+            nextCommand.Execute(this.owningViewModel);
+            timer.Start();
+        }
+
+        private void OnShutdownTimerTick(object sender, EventArgs e)
+        {
+            this.playbackTimer.Stop();
+            this.playbackTimer = null;
+
+            // This causes the main window to close (and exit application).
+            mainWindow.Close();
+        }
+
+        #endregion
+    }
+}

--- a/src/DynamoCore/UI/Commands/DynamoCommands.cs
+++ b/src/DynamoCore/UI/Commands/DynamoCommands.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Input;
-using System.Windows.Threading;
-using System.Xml;
 using Dynamo.Models;
 using Dynamo.Selection;
 using Dynamo.Utilities;
@@ -15,9 +12,7 @@ namespace Dynamo.ViewModels
     partial class DynamoViewModel
     {
         // Automation related data members.
-        private string commandFilePath = null;
-        private DispatcherTimer playbackTimer = null;
-        private List<RecordableCommand> recordedCommands = null;
+        private AutomationSettings automationSettings = null;
 
         #region Automation Related Methods
 
@@ -25,111 +20,31 @@ namespace Dynamo.ViewModels
         /// DynamoController calls this method at the end of its initialization
         /// sequence so that loaded commands, if any, begin to playback.
         /// </summary>
-        /// <returns>Returns true if the playback is successfully set up, or 
-        /// false otherwise.</returns>
-        internal bool BeginCommandPlayback()
+        internal void BeginCommandPlayback(System.Windows.Window mainWindow)
         {
-            if (string.IsNullOrEmpty(this.commandFilePath))
-                return false; // Dynamo is not created to playback commands.
-
-            List<RecordableCommand> loadedCommands = null;
-
-            try
-            {
-                // Attempt to load the XML from the specified path.
-                XmlDocument document = new XmlDocument();
-                document.Load(this.commandFilePath);
-
-                // Get to the root node of this Xml document.
-                XmlNode commandRoot = document.FirstChild;
-                if (null == commandRoot || (null == commandRoot.ChildNodes))
-                    return false;
-
-                loadedCommands = new List<RecordableCommand>();
-                foreach (XmlNode node in commandRoot.ChildNodes)
-                {
-                    RecordableCommand command = null;
-                    command = RecordableCommand.Deserialize(node as XmlElement);
-                    if (null != command)
-                        loadedCommands.Add(command);
-                }
-            }
-            catch (Exception)
-            {
-                // Something is wrong with the Xml file, invalidate the 
-                // data member that points to it, and return from here.
-                this.commandFilePath = null;
-                return false;
-            }
-
-            // Even though the Xml file can properly be loaded, it is still 
-            // possible that the loaded content did not result in any useful 
-            // commands. In this case simply return false, indicating failure.
-            // 
-            if (null == loadedCommands || (loadedCommands.Count <= 0))
-                return false;
-
-            // Ensure that this method is not called more than once.
-            System.Diagnostics.Debug.Assert(null == playbackTimer);
-            playbackTimer = new DispatcherTimer();
-
-            // Serialized commands for playback.
-            playbackTimer.Tag = loadedCommands;
-            playbackTimer.Interval = TimeSpan.FromMilliseconds(500);
-            playbackTimer.Tick += OnPlaybackTimerTick;
-            playbackTimer.Start();
-            return true;
-        }
-
-        private void OnPlaybackTimerTick(object sender, EventArgs e)
-        {
-            DispatcherTimer timer = sender as DispatcherTimer;
-            timer.Stop(); // Stop the timer before command completes.
-
-            List<RecordableCommand> loadedCommands = null;
-            loadedCommands = timer.Tag as List<RecordableCommand>;
-
-            if (loadedCommands.Count <= 0)
-            {
-                this.playbackTimer = null;
-                return;
-            }
-
-            // Remove the first command from the loaded commands.
-            RecordableCommand nextCommand = loadedCommands[0];
-            loadedCommands.RemoveAt(0);
-
-            // Execute the command, this may take a while longer than the timer
-            // inverval (usually very short), that's why the timer was stopped 
-            // before the command execution starts. After the command is done,
-            // the timer is then resumed for the next command in queue.
-            // 
-            nextCommand.Execute(this);
-            timer.Start();
+            if (null != automationSettings)
+                automationSettings.BeginCommandPlayback(mainWindow);
         }
 
         private void SaveRecordedCommands(object parameters)
         {
-            XmlDocument document = new XmlDocument();
-            XmlElement commandRoot = document.CreateElement("Commands");
-            document.AppendChild(commandRoot);
-
-            foreach (RecordableCommand command in recordedCommands)
-                commandRoot.AppendChild(command.Serialize(document));
-
-            string format = "Commands-{0:yyyyMMdd-hhmmss}.xml";
-            string xmlFileName = string.Format(format, DateTime.Now);
-            string xmlFilePath = Path.Combine(Path.GetTempPath(), xmlFileName);
-
-            // Save recorded commands into XML file and open it in viewer.
-            document.Save(xmlFilePath);
-            if (System.IO.File.Exists(xmlFilePath))
-                System.Diagnostics.Process.Start(xmlFilePath);
+            if (null != automationSettings)
+            {
+                string xmlFilePath = automationSettings.SaveRecordedCommands();
+                if (string.IsNullOrEmpty(xmlFilePath) == false)
+                {
+                    if (System.IO.File.Exists(xmlFilePath))
+                        System.Diagnostics.Process.Start(xmlFilePath);
+                }
+            }
         }
 
         private bool CanSaveRecordedCommands(object parameters)
         {
-            return (null != recordedCommands && (recordedCommands.Count > 0));
+            if (null == automationSettings)
+                return false;
+
+            return automationSettings.CanSaveRecordedCommands;
         }
 
         #endregion
@@ -138,30 +53,8 @@ namespace Dynamo.ViewModels
 
         internal void ExecuteCommand(RecordableCommand command)
         {
-            // In the playback mode 'this.recordedCommands' will be 
-            // 'null' so that the incoming command will not be recorded.
-            if (null != recordedCommands)
-            {
-                if (command.Redundant && (recordedCommands.Count > 0))
-                {
-                    // If a command is being marked "Redundant", then we will 
-                    // only be interested in the most recent one. If we already
-                    // have another instance recorded immediately prior to this,
-                    // then replace the old instance with the new (for details,
-                    // see "RecordableCommand.Redundant" property).
-                    // 
-                    var previousCommand = recordedCommands.Last();
-                    if (previousCommand.GetType() != command.GetType())
-                        recordedCommands.Add(command);
-                    else
-                    {
-                        // Replace the existing command instead of adding.
-                        recordedCommands[recordedCommands.Count - 1] = command;
-                    }
-                }
-                else
-                    recordedCommands.Add(command);
-            }
+            if (null != this.automationSettings)
+                this.automationSettings.RecordCommand(command);
 
             command.Execute(this);
         }
@@ -248,6 +141,37 @@ namespace Dynamo.ViewModels
                     CurrentSpaceViewModel.CancelConnection();
                     break;
             }
+        }
+
+        private void DeleteModelImpl(DeleteModelCommand command)
+        {
+            List<ModelBase> modelsToDelete = new List<ModelBase>();
+            if (command.ModelGuid != Guid.Empty)
+            {
+                modelsToDelete.Add(CurrentSpace.GetModelInternal(command.ModelGuid));
+            }
+            else
+            {
+                // When nothing is specified then it means all selected models.
+                foreach (ISelectable selectable in DynamoSelection.Instance.Selection)
+                {
+                    if (selectable is ModelBase)
+                        modelsToDelete.Add(selectable as ModelBase);
+                }
+            }
+
+            _model.DeleteModelInternal(modelsToDelete);
+        }
+
+        private void UndoRedoImpl(UndoRedoCommand command)
+        {
+            if (command.CmdOperation == UndoRedoCommand.Operation.Undo)
+                CurrentSpace.Undo();
+            else if (command.CmdOperation == UndoRedoCommand.Operation.Redo)
+                CurrentSpace.Redo();
+
+            UndoCommand.RaiseCanExecuteChanged();
+            RedoCommand.RaiseCanExecuteChanged();
         }
 
         #endregion

--- a/src/DynamoCore/UI/Commands/RecordableCommands.cs
+++ b/src/DynamoCore/UI/Commands/RecordableCommands.cs
@@ -94,6 +94,10 @@ namespace Dynamo.ViewModels
                         return DragSelectionCommand.DeserializeCore(element);
                     case "MakeConnectionCommand":
                         return MakeConnectionCommand.DeserializeCore(element);
+                    case "DeleteModelCommand":
+                        return DeleteModelCommand.DeserializeCore(element);
+                    case "UndoRedoCommand":
+                        return UndoRedoCommand.DeserializeCore(element);
                 }
 
                 string message = string.Format("Unknown command: {0}", element.Name);
@@ -467,6 +471,89 @@ namespace Dynamo.ViewModels
 
             #endregion
         }
+
+        internal class DeleteModelCommand : RecordableCommand
+        {
+            #region Public Class Methods
+
+            internal DeleteModelCommand(Guid modelGuid)
+            {
+                this.ModelGuid = modelGuid;
+            }
+
+            internal static DeleteModelCommand DeserializeCore(XmlElement element)
+            {
+                XmlElementHelper helper = new XmlElementHelper(element);
+                System.Guid modelGuid = helper.ReadGuid("ModelGuid");
+                return new DeleteModelCommand(modelGuid);
+            }
+
+            #endregion
+
+            #region Public Command Properties
+
+            internal Guid ModelGuid { get; private set; }
+
+            #endregion
+
+            #region Protected Overridable Methods
+
+            protected override void ExecuteCore(DynamoViewModel dynamoViewModel)
+            {
+                dynamoViewModel.DeleteModelImpl(this);
+            }
+
+            protected override void SerializeCore(XmlElement element)
+            {
+                XmlElementHelper helper = new XmlElementHelper(element);
+                helper.SetAttribute("ModelGuid", this.ModelGuid);
+            }
+
+            #endregion
+        }
+
+        internal class UndoRedoCommand : RecordableCommand
+        {
+            #region Public Class Methods
+
+            internal enum Operation { Undo, Redo }
+
+            internal UndoRedoCommand(Operation operation)
+            {
+                this.CmdOperation = operation;
+            }
+
+            internal static UndoRedoCommand DeserializeCore(XmlElement element)
+            {
+                XmlElementHelper helper = new XmlElementHelper(element);
+                int operation = helper.ReadInteger("CmdOperation");
+                return new UndoRedoCommand((Operation)operation);
+            }
+
+            #endregion
+
+            #region Public Command Properties
+
+            internal Operation CmdOperation { get; private set; }
+
+            #endregion
+
+            #region Protected Overridable Methods
+
+            protected override void ExecuteCore(DynamoViewModel dynamoViewModel)
+            {
+                dynamoViewModel.UndoRedoImpl(this);
+            }
+
+            protected override void SerializeCore(XmlElement element)
+            {
+                XmlElementHelper helper = new XmlElementHelper(element);
+                helper.SetAttribute("CmdOperation", ((int)this.CmdOperation));
+            }
+
+            #endregion
+        }
+
     }
 
     // internal class XxxYyyCommand : RecordableCommand

--- a/src/DynamoCore/UI/Views/DynamoView.xaml.cs
+++ b/src/DynamoCore/UI/Views/DynamoView.xaml.cs
@@ -195,7 +195,9 @@ namespace Dynamo.Controls
             _vm.RequestUserSaveWorkflow += new WorkspaceSaveEventHandler(_vm_RequestUserSaveWorkflow);
 
             dynSettings.Controller.ClipBoard.CollectionChanged += new System.Collections.Specialized.NotifyCollectionChangedEventHandler(ClipBoard_CollectionChanged);
-        
+
+            // Kick start the automation run, if possible.
+            _vm.BeginCommandPlayback(this);
         }
 
         private PackageManagerPublishView _pubPkgView;

--- a/src/DynamoCore/ViewModels/NodeViewModel.cs
+++ b/src/DynamoCore/ViewModels/NodeViewModel.cs
@@ -9,6 +9,7 @@ using Dynamo.Selection;
 using Dynamo.Utilities;
 using System.Windows;
 using Dynamo.Core;
+using DynCmd = Dynamo.ViewModels.DynamoViewModel;
 
 namespace Dynamo.ViewModels
 {
@@ -565,7 +566,8 @@ namespace Dynamo.ViewModels
 
         private void DeleteNodeAndItsConnectors(object parameter)
         {
-            dynSettings.Controller.DynamoModel.Delete(nodeLogic);
+            var command = new DynCmd.DeleteModelCommand(nodeLogic.GUID);
+            dynSettings.Controller.DynamoViewModel.ExecuteCommand(command);
         }
 
         void SetLacingType(object param)

--- a/src/DynamoCoreUITests/DynamoCoreUITests.csproj
+++ b/src/DynamoCoreUITests/DynamoCoreUITests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="DynamoTestUI.cs" />
     <Compile Include="PackageManagerUITests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RecordedTests.cs" />
     <Compile Include="VisualizationManagerUITests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DynamoCoreUITests/RecordedTests.cs
+++ b/src/DynamoCoreUITests/RecordedTests.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Windows;
+using Dynamo.Controls;
+using Dynamo.Models;
+using Dynamo.Utilities;
+using Dynamo.ViewModels;
+using NUnit.Framework;
+
+namespace Dynamo.Tests.UI
+{
+    [TestFixture]
+    public class RecordedTests
+    {
+        // For access within test cases.
+        private WorkspaceModel workspace = null;
+        private DynamoController controller = null;
+
+        [SetUp]
+        public void Start()
+        {
+        }
+
+        [TearDown]
+        public void Exit()
+        {
+            this.controller = null;
+        }
+
+        [Test, RequiresSTA]
+        public void TestCreateNodes()
+        {
+            RunCommandsFromFile("CreateNodesAndConnectors.xml");
+            Assert.AreEqual(5, workspace.Nodes.Count);
+        }
+
+        [Test, RequiresSTA]
+        public void TestCreateConnectors()
+        {
+            RunCommandsFromFile("CreateNodesAndConnectors.xml");
+            Assert.AreEqual(4, workspace.Connectors.Count);
+        }
+
+        [Test, RequiresSTA]
+        public void TestDeleteCommands()
+        {
+            RunCommandsFromFile("CreateAndDeleteNodes.xml");
+            Assert.AreEqual(4, workspace.Nodes.Count);
+            Assert.AreEqual(2, workspace.Connectors.Count);
+
+            // This dictionary maps each of the node GUIDs, to a Boolean 
+            // flag indicating that if the node exists or deleted.
+            Dictionary<string, bool> nodeExistenceMap = new Dictionary<string, bool>()
+            {
+                { "ba59fa31-919d-4e67-b7c6-b58589a7093f", true },
+                { "42058bba-c2fd-4e49-8d76-44c45d0dc597", false },
+                { "5c92e961-8095-49bb-828d-1f3c14f9a005", true },
+                { "d5ad0ff6-9314-4e22-947f-7ba967ad4758", false },
+                { "4d2b71b4-d2c1-4695-afcf-6f7ec05c71f5", true },
+                { "a71328b2-dee7-45d6-8070-44ecebc358d9", true },
+            };
+
+            VerifyModelExistence(nodeExistenceMap);
+        }
+
+        [Test, RequiresSTA]
+        public void TestUndoRedoNodesAndConnections()
+        {
+            RunCommandsFromFile("UndoRedoNodesAndConnections.xml");
+            Assert.AreEqual(2, workspace.Connectors.Count);
+
+            // This dictionary maps each of the node GUIDs, to a Boolean 
+            // flag indicating that if the node exists or deleted.
+            Dictionary<string, bool> nodeExistenceMap = new Dictionary<string, bool>()
+            {
+                { "fec0ae4f-f3b7-4b33-b728-c75e5415d73c", true },
+                { "168298c7-f003-48f8-a346-0061086f8e3a", true },
+                { "69ee3a47-0a9a-4746-ace3-6643d508f235", true },
+            };
+
+            VerifyModelExistence(nodeExistenceMap);
+        }
+
+        private void VerifyModelExistence(Dictionary<string, bool> modelExistenceMap)
+        {
+            var nodes = workspace.Nodes;
+            foreach (var pair in modelExistenceMap)
+            {
+                Guid guid = Guid.Parse(pair.Key);
+                var node = nodes.FirstOrDefault((x) => (x.GUID == guid));
+                bool nodeExists = (null != node);
+                Assert.AreEqual(nodeExists, pair.Value);
+            }
+        }
+
+        private void RunCommandsFromFile(string commandFileName)
+        {
+            string commandFilePath = DynamoTestUI.GetTestDirectory();
+            commandFilePath = Path.Combine(commandFilePath, @"core\recorded\");
+            commandFilePath = Path.Combine(commandFilePath, commandFileName);
+
+            // Create the controller to run alongside the view.
+            controller = DynamoController.MakeSandbox(commandFilePath);
+
+            // Create the view.
+            var dynamoView = new DynamoView();
+            dynamoView.DataContext = controller.DynamoViewModel;
+            controller.UIDispatcher = dynamoView.Dispatcher;
+            dynamoView.ShowDialog();
+
+            Assert.IsNotNull(controller);
+            Assert.IsNotNull(controller.DynamoModel);
+            Assert.IsNotNull(controller.DynamoModel.CurrentWorkspace);
+            workspace = controller.DynamoModel.CurrentWorkspace;
+        }
+    }
+}

--- a/src/DynamoElementsTests/CustomNodes.cs
+++ b/src/DynamoElementsTests/CustomNodes.cs
@@ -193,7 +193,9 @@ namespace Dynamo.Tests
 
             var numNodes = model.CurrentWorkspace.Nodes.Count;
 
-            model.Delete(model.CurrentWorkspace.FirstNodeFromWorkspace<Addition>());
+            List<ModelBase> modelsToDelete = new List<ModelBase>();
+            modelsToDelete.Add(model.CurrentWorkspace.FirstNodeFromWorkspace<Addition>());
+            model.DeleteModelInternal(modelsToDelete);
 
             Assert.AreEqual(numNodes - 1, model.CurrentWorkspace.Nodes.Count);
         }

--- a/src/DynamoElementsTests/VisualizationManagerTests.cs
+++ b/src/DynamoElementsTests/VisualizationManagerTests.cs
@@ -4,6 +4,7 @@ using Dynamo.Nodes;
 using Dynamo.Utilities;
 using NUnit.Framework;
 using System.Linq;
+using Dynamo.Models;
 
 namespace Dynamo.Tests
 {
@@ -317,7 +318,9 @@ namespace Dynamo.Tests
 
             //delete a node and ensure that the renderables are cleaned up
             var pointNode = model.Nodes.FirstOrDefault(x => x is Point3DNode);
-            model.Delete(pointNode);
+            List<ModelBase> modelsToDelete = new List<ModelBase>();
+            modelsToDelete.Add(pointNode);
+            model.DeleteModelInternal(modelsToDelete);
 
             viz.GetRenderableCounts(
                 out pointCount, out lineCount, out meshCount, out xCount, out yCount, out zCount);

--- a/test/core/recorded/CreateAndDeleteNodes.xml
+++ b/test/core/recorded/CreateAndDeleteNodes.xml
@@ -1,0 +1,40 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10">
+  <CreateNodeCommand NodeId="ba59fa31-919d-4e67-b7c6-b58589a7093f" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="42058bba-c2fd-4e49-8d76-44c45d0dc597" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="5c92e961-8095-49bb-828d-1f3c14f9a005" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="d5ad0ff6-9314-4e22-947f-7ba967ad4758" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="4d2b71b4-d2c1-4695-afcf-6f7ec05c71f5" NodeName="Add" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="a71328b2-dee7-45d6-8070-44ecebc358d9" NodeName="Multiply" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <SelectModelCommand ModelGuid="a71328b2-dee7-45d6-8070-44ecebc358d9" Modifiers="0" />
+  <DragSelectionCommand X="303" Y="209.6" DragOperation="0" />
+  <DragSelectionCommand X="553" Y="115.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="4d2b71b4-d2c1-4695-afcf-6f7ec05c71f5" Modifiers="0" />
+  <DragSelectionCommand X="406" Y="298.6" DragOperation="0" />
+  <DragSelectionCommand X="571" Y="334.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="ba59fa31-919d-4e67-b7c6-b58589a7093f" Modifiers="0" />
+  <DragSelectionCommand X="283" Y="200.6" DragOperation="0" />
+  <DragSelectionCommand X="77" Y="66.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="42058bba-c2fd-4e49-8d76-44c45d0dc597" Modifiers="0" />
+  <DragSelectionCommand X="309" Y="228.6" DragOperation="0" />
+  <DragSelectionCommand X="72" Y="174.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="5c92e961-8095-49bb-828d-1f3c14f9a005" Modifiers="0" />
+  <DragSelectionCommand X="330" Y="251.6" DragOperation="0" />
+  <DragSelectionCommand X="80" Y="292.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="d5ad0ff6-9314-4e22-947f-7ba967ad4758" Modifiers="0" />
+  <DragSelectionCommand X="370" Y="280.6" DragOperation="0" />
+  <DragSelectionCommand X="90" Y="413.6" DragOperation="1" />
+  <MakeConnectionCommand NodeId="ba59fa31-919d-4e67-b7c6-b58589a7093f" PortIndex="0" Type="1" ConnectionMode="0" />
+  <MakeConnectionCommand NodeId="a71328b2-dee7-45d6-8070-44ecebc358d9" PortIndex="1" Type="0" ConnectionMode="1" />
+  <MakeConnectionCommand NodeId="42058bba-c2fd-4e49-8d76-44c45d0dc597" PortIndex="0" Type="1" ConnectionMode="0" />
+  <MakeConnectionCommand NodeId="a71328b2-dee7-45d6-8070-44ecebc358d9" PortIndex="0" Type="0" ConnectionMode="1" />
+  <MakeConnectionCommand NodeId="5c92e961-8095-49bb-828d-1f3c14f9a005" PortIndex="0" Type="1" ConnectionMode="0" />
+  <MakeConnectionCommand NodeId="4d2b71b4-d2c1-4695-afcf-6f7ec05c71f5" PortIndex="1" Type="0" ConnectionMode="1" />
+  <MakeConnectionCommand NodeId="d5ad0ff6-9314-4e22-947f-7ba967ad4758" PortIndex="0" Type="1" ConnectionMode="0" />
+  <MakeConnectionCommand NodeId="4d2b71b4-d2c1-4695-afcf-6f7ec05c71f5" PortIndex="0" Type="0" ConnectionMode="1" />
+  <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
+  <SelectModelCommand ModelGuid="42058bba-c2fd-4e49-8d76-44c45d0dc597" Modifiers="0" />
+  <DeleteModelCommand ModelGuid="42058bba-c2fd-4e49-8d76-44c45d0dc597" />
+  <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
+  <SelectInRegionCommand X="18" Y="373.6" Width="161" Height="108" IsCrossSelection="false" />
+  <DeleteModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" />
+</Commands>

--- a/test/core/recorded/CreateNodesAndConnectors.xml
+++ b/test/core/recorded/CreateNodesAndConnectors.xml
@@ -1,0 +1,38 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10">
+  <CreateNodeCommand NodeId="40e6c06b-aea9-45dc-a1a4-a06cee83db23" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="f653dc4f-24ab-4c45-a6b0-1a71f04db588" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="f63decb5-84f1-45b1-8b41-bb4ceb0dca70" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="11b01141-6d4d-4a9f-a946-147ddc7c3d2c" NodeName="Add" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="27025873-2ec8-4db9-b501-ed54e529c92e" NodeName="Multiply" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <SelectModelCommand ModelGuid="40e6c06b-aea9-45dc-a1a4-a06cee83db23" Modifiers="0" />
+  <DragSelectionCommand X="345" Y="199.6" DragOperation="0" />
+  <DragSelectionCommand X="163" Y="88.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="f653dc4f-24ab-4c45-a6b0-1a71f04db588" Modifiers="0" />
+  <DragSelectionCommand X="373" Y="221.6" DragOperation="0" />
+  <DragSelectionCommand X="181" Y="246.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="f63decb5-84f1-45b1-8b41-bb4ceb0dca70" Modifiers="0" />
+  <DragSelectionCommand X="402" Y="249.6" DragOperation="0" />
+  <DragSelectionCommand X="297" Y="165.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="11b01141-6d4d-4a9f-a946-147ddc7c3d2c" Modifiers="0" />
+  <DragSelectionCommand X="441" Y="271.6" DragOperation="0" />
+  <DragSelectionCommand X="527" Y="142.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="27025873-2ec8-4db9-b501-ed54e529c92e" Modifiers="0" />
+  <DragSelectionCommand X="459" Y="301.6" DragOperation="0" />
+  <DragSelectionCommand X="349" Y="303.6" DragOperation="1" />
+  <MakeConnectionCommand NodeId="40e6c06b-aea9-45dc-a1a4-a06cee83db23" PortIndex="0" Type="1" ConnectionMode="0" />
+  <MakeConnectionCommand NodeId="11b01141-6d4d-4a9f-a946-147ddc7c3d2c" PortIndex="0" Type="0" ConnectionMode="1" />
+  <MakeConnectionCommand NodeId="f653dc4f-24ab-4c45-a6b0-1a71f04db588" PortIndex="0" Type="1" ConnectionMode="0" />
+  <MakeConnectionCommand NodeId="11b01141-6d4d-4a9f-a946-147ddc7c3d2c" PortIndex="1" Type="0" ConnectionMode="1" />
+  <MakeConnectionCommand NodeId="f63decb5-84f1-45b1-8b41-bb4ceb0dca70" PortIndex="0" Type="1" ConnectionMode="0" />
+  <MakeConnectionCommand NodeId="27025873-2ec8-4db9-b501-ed54e529c92e" PortIndex="0" Type="0" ConnectionMode="1" />
+  <SelectModelCommand ModelGuid="27025873-2ec8-4db9-b501-ed54e529c92e" Modifiers="0" />
+  <DragSelectionCommand X="350" Y="299.6" DragOperation="0" />
+  <DragSelectionCommand X="569" Y="329.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
+  <MakeConnectionCommand NodeId="11b01141-6d4d-4a9f-a946-147ddc7c3d2c" PortIndex="0" Type="1" ConnectionMode="0" />
+  <MakeConnectionCommand NodeId="27025873-2ec8-4db9-b501-ed54e529c92e" PortIndex="1" Type="0" ConnectionMode="1" />
+  <SelectModelCommand ModelGuid="11b01141-6d4d-4a9f-a946-147ddc7c3d2c" Modifiers="0" />
+  <DragSelectionCommand X="526" Y="147.6" DragOperation="0" />
+  <DragSelectionCommand X="438" Y="53.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
+</Commands>

--- a/test/core/recorded/UndoRedoNodesAndConnections.xml
+++ b/test/core/recorded/UndoRedoNodesAndConnections.xml
@@ -1,0 +1,34 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10">
+  <CreateNodeCommand NodeId="fec0ae4f-f3b7-4b33-b728-c75e5415d73c" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="168298c7-f003-48f8-a346-0061086f8e3a" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="69ee3a47-0a9a-4746-ace3-6643d508f235" NodeName="Add" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <SelectModelCommand ModelGuid="fec0ae4f-f3b7-4b33-b728-c75e5415d73c" Modifiers="0" />
+  <DragSelectionCommand X="284" Y="203.6" DragOperation="0" />
+  <DragSelectionCommand X="181" Y="126.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="168298c7-f003-48f8-a346-0061086f8e3a" Modifiers="0" />
+  <DragSelectionCommand X="303" Y="229.6" DragOperation="0" />
+  <DragSelectionCommand X="139" Y="300.6" DragOperation="1" />
+  <SelectModelCommand ModelGuid="69ee3a47-0a9a-4746-ace3-6643d508f235" Modifiers="0" />
+  <DragSelectionCommand X="348" Y="249.6" DragOperation="0" />
+  <DragSelectionCommand X="447" Y="184.6" DragOperation="1" />
+  <MakeConnectionCommand NodeId="168298c7-f003-48f8-a346-0061086f8e3a" PortIndex="0" Type="1" ConnectionMode="0" />
+  <MakeConnectionCommand NodeId="69ee3a47-0a9a-4746-ace3-6643d508f235" PortIndex="0" Type="0" ConnectionMode="1" />
+  <MakeConnectionCommand NodeId="69ee3a47-0a9a-4746-ace3-6643d508f235" PortIndex="1" Type="0" ConnectionMode="0" />
+  <MakeConnectionCommand NodeId="fec0ae4f-f3b7-4b33-b728-c75e5415d73c" PortIndex="0" Type="1" ConnectionMode="1" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+</Commands>


### PR DESCRIPTION
#### Background

This pull request represents the first integration of command framework into NUnit test cases. These recorded test cases replay commands as they were issued during a real user scenario.

In a regular UI NUnit test, even though the dispatcher is created as the result of having DynamoView, it does not get an opportunity to run (i.e. pump messages in its queue). The command playback takes a different approach, instead of creating a modeless DynamoView (DynamoView.Show), it creates a modal DynamoView (ShowDialog). This allows the DynamoView to show up and handle events for as long as the command playback is still running (the playback eventually closes DynamoView as soon as playback is done). After DynamoView returns from command playback, NUnit test cases then given a chance to run. Not only does this exercise View-Model and Model codes, it also tests corresponding View codes.
#### What are Ready (or Not)

As of this pull request, the following commands are folded to make use of the command framework:
- CreateNodeCommand
- CreateNoteCommand
- SelectInRegionCommand
- SelectModelCommand
- DeleteModelCommand
- DragSelectionCommand
- MakeConnectionCommand
- UndoRedoCommand

The following important functionalities are missing and will be implemented in subsequent submissions:
- The ability to modify node contents
- The ability to deal with +/- buttons on list nodes
- The ability to copy-and-paste

There are various other commands that will be folded into the command framework as soon as the need arises. For example, "Align All to Left" command is currently placed on the lowest priority and will only be made available as needed.
#### Recording and Playback
##### Support commands as listed above can be recorded with the following steps:
- Perform actions with DynamoSandbox.exe (e.g. create a node, and move it)
- Press CTRL+SHIFT+R to store the recorded commands into an XML
- The newly generated XML file will open up with the default viewer of XML file
##### To playback the command XML file:
- Launch DynamoSandbox with the following command line argument:
  - DynamoSandbox.exe /c "X:\file\path\command.xml"
- DynamoSandbox automatically shuts down after the command playback is done. To prevent that, open the XML file and change "ExitAfterPlayback" attribute to "false".
#### Testing

The following functionality of Dynamo are involved in the code changes in this pull request, and should be tested as a regular user:
- Undo-redo functionality
- Node deletion
#### Unit Testing

Introduced NUnit test cases in a new category "RecordedTests":
- TestCreateNodes
- TestCreateConnectors
- TestDeleteCommands
- TestUndoRedoNodesAndConnections.

Tests cases are passing:
- DynamoPythonTests
- DynamoCoreUITests
- DynamoMSOfficeTests
- DynamoCoreTests
- DSCoreNodesTests.

Revit related test cases are producing the same result as in the master branch (through RunRevitTests.py).
