### PR TITLE
Port reduction crash fix

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -1334,6 +1334,11 @@ namespace Dynamo.Models
             double verticalOffset = 2.9;
             PortType portType;
             int index = GetPortIndex(portModel, out portType);
+
+            //If the port was not found, then it should have just been deleted. Return from function
+            if (index == -1)
+                return verticalOffset;
+
             if (portType == PortType.INPUT)
             {
                 for (int i = 0; i < index; i++)


### PR DESCRIPTION
fix for issue :
When CBN code changes and cause less number of ports like in picture,
![cbnporterror](https://f.cloud.github.com/assets/5274938/1471055/e661f02e-45d2-11e3-9f90-a9aa491fca22.JPG)

Then any connector attached to the port being deleted will redraw itself, and will crash when it cannot find the port model. 

 Tried to simulate this in a test by opening a file and changing the code directly. Didnt work :| Not sure how to test this.
