### PR TITLE
Tab file name missing fix.

### DIFF
--- a/src/DynamoCore/UI/Converters.cs
+++ b/src/DynamoCore/UI/Converters.cs
@@ -258,6 +258,19 @@ namespace Dynamo.Controls
         }
     }
 
+    public class PathToSaveStateConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return (value is string && !string.IsNullOrEmpty(value as string)) ? "Saved" : "Unsaved";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+    }
+
     public class WorkspaceTypeConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter,

--- a/src/DynamoCore/UI/Themes/DynamoConverters.xaml
+++ b/src/DynamoCore/UI/Themes/DynamoConverters.xaml
@@ -37,6 +37,7 @@
     <controls:PortNameConverter x:Key="PortNameConverter"/>
     <controls:FilePathDisplayConverter x:Key="FilePathDisplayConverter"/>
     <controls:PathToFileNameConverter x:Key="PathToFileNameConverter"/>
+    <controls:PathToSaveStateConverter x:Key="PathToSaveStateConverter" />
     <controls:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
     <controls:ShowHideConsoleMenuItemConverter x:Key="ShowHideConsoleMenuConverter"/>
     <controls:ShowHideFullscreenWatchMenuItemConverter x:Key="ShowHideFullscreenWatchMenuConverter"/>

--- a/src/DynamoCore/UI/Views/DynamoView.xaml
+++ b/src/DynamoCore/UI/Views/DynamoView.xaml
@@ -805,17 +805,49 @@
                                                             Value="Normal" />
                                                 </DataTrigger>
 
-                                                <DataTrigger Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}"
-                                                             Value="{x:Type models:HomeWorkspaceModel}">
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}"
+                                                                   Value="{x:Type models:HomeWorkspaceModel}" />
+                                                        <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
+                                                                   Value="Unsaved" />
+                                                    </MultiDataTrigger.Conditions>
                                                     <Setter Property="Text"
                                                             Value="Home" />
-                                                </DataTrigger>
-
-                                                <DataTrigger Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}"
-                                                             Value="{x:Type models:CustomNodeWorkspaceModel}">
+                                                </MultiDataTrigger>
+                                                
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}"
+                                                                   Value="{x:Type models:HomeWorkspaceModel}" />
+                                                        <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
+                                                                   Value="Saved" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Text"
+                                                            Value="{Binding Path=FileName, Converter={StaticResource PathToFileNameConverter}}" />
+                                                </MultiDataTrigger>
+                                                
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}"
+                                                                   Value="{x:Type models:CustomNodeWorkspaceModel}" />
+                                                        <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
+                                                                   Value="Unsaved" />
+                                                    </MultiDataTrigger.Conditions>
                                                     <Setter Property="Text"
                                                             Value="{Binding Name}" />
-                                                </DataTrigger>
+                                                </MultiDataTrigger>
+                                                
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding Converter={StaticResource WorkspaceTypeConverter}}"
+                                                                   Value="{x:Type models:CustomNodeWorkspaceModel}" />
+                                                        <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
+                                                                   Value="Saved" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Text"
+                                                            Value="{Binding Path=FileName, Converter={StaticResource PathToFileNameConverter}}" />
+                                                </MultiDataTrigger>
 
                                             </Style.Triggers>
                                         </Style>


### PR DESCRIPTION
Tab will now reflect workspace file name + extension i.e. .dyn/.dyf after saving instead of just Home and CustomNodeName

Fix for MAGN-500
