### PR TITLE
Fixed Hotkey for controlling background preview.

### DIFF
--- a/src/DynamoCore/UI/Views/DynamoView.xaml
+++ b/src/DynamoCore/UI/Views/DynamoView.xaml
@@ -341,7 +341,7 @@
             </Canvas>
             <controls:Watch3DView Margin="0,20,0,0"
                                           Visibility="{Binding FullscreenWatchShowing, Mode=TwoWay, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                            IsHitTestVisible="{Binding CanNavigateBackground}">
+                                            IsHitTestVisible="{Binding WatchPreviewHitTest}">
 
             </controls:Watch3DView>
         </Grid>

--- a/src/DynamoCore/ViewModels/DynamoViewModel.cs
+++ b/src/DynamoCore/ViewModels/DynamoViewModel.cs
@@ -329,7 +329,13 @@ namespace Dynamo.ViewModels
                 _watchEscapeIsDown = value;
                 RaisePropertyChanged("WatchEscapeIsDown");
                 RaisePropertyChanged("ShouldBeHitTestVisible");
+                RaisePropertyChanged("WatchPreviewHitTest");
             }
+        }
+
+        public bool WatchPreviewHitTest
+        {
+            get { return ( WatchEscapeIsDown || CanNavigateBackground ); }
         }
 
         public bool IsHomeSpace
@@ -368,6 +374,7 @@ namespace Dynamo.ViewModels
             {
                 canNavigateBackground = value;
                 RaisePropertyChanged("CanNavigateBackground");
+                RaisePropertyChanged("WatchBackgroundHitTest");
 
                 int workspace_index = CurrentWorkspaceIndex;
 


### PR DESCRIPTION
Adding a new property that take note of both boolean WatchEscapeIsDown and CanNavigateBackground for the hit test of the "Watch3DView".
## For Testing:

1) Holding down Escape, temporary goes to navigate mode of the 3D background preview. (Middle mouse and right click)
2) Releasing will return to normal canvas control.
