### PR TITLE
UpdateValueCore method override for CodeBlockNodeModel

### DIFF
--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -195,6 +195,17 @@ namespace Dynamo.Nodes
             Code = helper.ReadString("CodeText");
             shouldFocus = helper.ReadBoolean("ShouldFocus");
         }
+
+        protected override bool UpdateValueCore(string name, string value)
+        {
+            if (name == "Code")
+            {
+                this.Code = value;
+                return true;
+            }
+            return base.UpdateValueCore(name, value);
+        }
+
         protected override void SerializeCore(XmlElement element, SaveContext context)
         {
             base.SerializeCore(element, context);


### PR DESCRIPTION
Introduced the implementation of the UpdateValueCore method so that the CodeBlockNode.
