### PR TITLE
Fix for MAGN-721 Geometry should not be selected while window selecting.

### DIFF
--- a/src/DynamoCore/UI/StateMachine.cs
+++ b/src/DynamoCore/UI/StateMachine.cs
@@ -68,8 +68,6 @@ namespace Dynamo.ViewModels
         internal void CancelActiveState()
         {
             stateMachine.CancelActiveState();
-
-            OnDragSelectionEnded(this, EventArgs.Empty);
         }
 
         internal void BeginDragSelection(Point mouseCursor)
@@ -387,14 +385,6 @@ namespace Dynamo.ViewModels
             /// </summary>
             internal void CancelActiveState()
             {
-                if (currentState == State.Connection)
-                {
-                    var command = new DynCmd.MakeConnectionCommand(Guid.Empty, -1,
-                        PortType.INPUT, DynCmd.MakeConnectionCommand.Mode.Cancel);
-
-                    var dynamoViewModel = dynSettings.Controller.DynamoViewModel;
-                    dynamoViewModel.ExecuteCommand(command);
-                }
                 SetCurrentState(State.None);
                 ignoreMouseClick = true;
             }
@@ -514,7 +504,6 @@ namespace Dynamo.ViewModels
 
                 if (this.currentState == State.WindowSelection)
                 {
-                    CancelWindowSelection();
                     SetCurrentState(State.None);
                     return true; // Mouse event handled.
                 }
@@ -673,6 +662,9 @@ namespace Dynamo.ViewModels
 
             private void CancelWindowSelection()
             {
+                // visualization unpause
+                owningWorkspace.OnDragSelectionEnded(this, EventArgs.Empty);
+
                 SelectionBoxUpdateArgs args = null;
                 args = new SelectionBoxUpdateArgs(Visibility.Collapsed);
                 this.owningWorkspace.RequestSelectionBoxUpdate(this, args);
@@ -724,6 +716,9 @@ namespace Dynamo.ViewModels
                 this.owningWorkspace.RequestSelectionBoxUpdate(this, args);
 
                 SetCurrentState(State.WindowSelection);
+
+                // visualization pause
+                owningWorkspace.OnDragSelectionStarted(this, EventArgs.Empty);
             }
 
             #endregion


### PR DESCRIPTION
Modified StateMachine to pause visualization manager during windowing selecting regarding to performance issues.

I had it checked with Ritesh and the previous behavior is back again.

During the testing, the following non-related bugs were discovered:
1. MAGN-728
2. MAGN-729
3. MAGN-730
