### PR TITLE
Code cleanup on ZoomTest and remove console output

### DIFF
--- a/src/DynamoCore/ViewModels/WorkspaceViewModel.cs
+++ b/src/DynamoCore/ViewModels/WorkspaceViewModel.cs
@@ -829,7 +829,11 @@ namespace Dynamo.ViewModels
 
         private bool CanSetZoom(object zoom)
         {
-            return true;
+            double setZoom = Convert.ToDouble(zoom);
+            if (setZoom >= WorkspaceModel.ZOOM_MINIMUM && setZoom <= WorkspaceModel.ZOOM_MAXIMUM)
+                return true;
+            else
+                return false;
         }
 
         private bool _fitViewActualZoomToggle = false;

--- a/src/DynamoCoreUITests/CoreUITests.cs
+++ b/src/DynamoCoreUITests/CoreUITests.cs
@@ -166,35 +166,26 @@ namespace Dynamo.Tests.UI
 
         [Test]
         [Category("DynamoUI")]
-        public void CanZoomIn()
+        public void CanZoom()
         {
             WorkspaceModel workspaceModel = Vm.CurrentSpaceViewModel._model;
-            double zoom = workspaceModel.Zoom;
-
-            Vm.ZoomInCommand.Execute(null);
-
+            WorkspaceViewModel workspaceVM = Vm.CurrentSpaceViewModel;
+            double zoom;
+            
+            // Test Zoom in
+            zoom = workspaceModel.Zoom;
+            if ( Vm.ZoomInCommand.CanExecute(null) )
+                Vm.ZoomInCommand.Execute(null);
             Assert.Greater(workspaceModel.Zoom, zoom);
-        }
 
-        [Test]
-        [Category("DynamoUI")]
-        public void CanZoomOut()
-        {
-            WorkspaceModel workspaceModel = Vm.CurrentSpaceViewModel._model;
-            double zoom = workspaceModel.Zoom;
-
-            Vm.ZoomOutCommand.Execute(null);
-
+            // Test Zoom out
+            zoom = workspaceModel.Zoom;
+            if (Vm.ZoomOutCommand.CanExecute(null))
+                Vm.ZoomOutCommand.Execute(null);
             Assert.Greater(zoom, workspaceModel.Zoom);
-        }
 
-        [Test]
-        [Category("DynamoUI")]
-        public void CanSetZoom()
-        {
-            WorkspaceModel workspaceModel = Vm.CurrentSpaceViewModel._model;
+            // Test can set zoom (at random zoom for 10 times)
             int testLoop = 10;
-
             for (int i = 0; i < testLoop; i++)
             {
                 // Get random number for the zoom
@@ -203,93 +194,61 @@ namespace Dynamo.Tests.UI
                 Random random = new Random();
                 double randomNumber = random.NextDouble() * (upperBound - lowerBound) + lowerBound;
 
-                Vm.CurrentSpaceViewModel.SetZoomCommand.Execute(randomNumber);
+                if (Vm.CurrentSpaceViewModel.SetZoomCommand.CanExecute(randomNumber))
+                    Vm.CurrentSpaceViewModel.SetZoomCommand.Execute(randomNumber);
 
                 // Check Zoom is correct
                 Assert.AreEqual(randomNumber, workspaceModel.Zoom);
             }
-        }
 
-        [Test]
-        [Category("DynamoUI")]
-        public void CanSetZoomBorderTest()
-        {
-            WorkspaceModel workspaceModel = Vm.CurrentSpaceViewModel._model;
-            WorkspaceViewModel workspaceVM = Vm.CurrentSpaceViewModel;
+            // Border Test for Set Zoom
+            // Min zoom
+            zoom = WorkspaceModel.ZOOM_MINIMUM;
+            if (workspaceVM.SetZoomCommand.CanExecute(zoom))
+                workspaceVM.SetZoomCommand.Execute(zoom);
+            Assert.AreEqual(zoom, workspaceModel.Zoom);
+            // Zoom out over limit (check that it does not zoom out)
+            if (Vm.ZoomOutCommand.CanExecute(null))
+                Vm.ZoomOutCommand.Execute(null);
+            Assert.AreEqual(zoom, workspaceModel.Zoom);
+            
+            // Max zoom
+            zoom = WorkspaceModel.ZOOM_MAXIMUM;
+            if (workspaceVM.SetZoomCommand.CanExecute(zoom))
+                workspaceVM.SetZoomCommand.Execute(zoom);
+            Assert.AreEqual(zoom, workspaceModel.Zoom);
+            // Zoom in over limit (check that it does not zoom in)
+            if (Vm.ZoomInCommand.CanExecute(null))
+                Vm.ZoomInCommand.Execute(null);
+            Assert.AreEqual(zoom, workspaceModel.Zoom);
 
-            workspaceVM.SetZoomCommand.Execute(WorkspaceModel.ZOOM_MINIMUM);
-            Assert.AreEqual(WorkspaceModel.ZOOM_MINIMUM, workspaceModel.Zoom);
+            // Above Max Limit Test
+            zoom = WorkspaceModel.ZOOM_MAXIMUM + 0.1;
+            if (workspaceVM.SetZoomCommand.CanExecute(zoom))
+                workspaceVM.SetZoomCommand.Execute(zoom);
+            Assert.AreNotEqual(zoom, workspaceModel.Zoom);
 
-            workspaceVM.SetZoomCommand.Execute(WorkspaceModel.ZOOM_MAXIMUM);
-            Assert.AreEqual(WorkspaceModel.ZOOM_MAXIMUM, workspaceModel.Zoom);
+            // Below Min Limit Test
+            zoom = WorkspaceModel.ZOOM_MINIMUM - 0.1;
+            if (workspaceVM.SetZoomCommand.CanExecute(zoom))
+                workspaceVM.SetZoomCommand.Execute(zoom);
+            Assert.AreNotEqual(zoom, workspaceModel.Zoom);
 
-            workspaceVM.SetZoomCommand.Execute(WorkspaceModel.ZOOM_MAXIMUM + 0.1);
-            Assert.AreNotEqual(WorkspaceModel.ZOOM_MAXIMUM, workspaceModel.Zoom);
-
-            workspaceVM.SetZoomCommand.Execute(WorkspaceModel.ZOOM_MINIMUM - 0.1);
-            Assert.AreNotEqual(WorkspaceModel.ZOOM_MINIMUM, workspaceModel.Zoom);
-        }
-
-        [Test]
-        [Category("DynamoUI")]
-        public void CanZoomInLimit()
-        {
-            WorkspaceModel workspaceModel = Vm.CurrentSpaceViewModel._model;
-            WorkspaceViewModel workspaceVM = Vm.CurrentSpaceViewModel;
-
-            // Zoom to max zoom value
-            workspaceVM.SetZoomCommand.Execute(WorkspaceModel.ZOOM_MAXIMUM);
-
-            Vm.ZoomInCommand.Execute(null);
-
-            // Check it does not zoom in anymore
-            Assert.AreEqual(WorkspaceModel.ZOOM_MAXIMUM, workspaceModel.Zoom);
-        }
-
-        [Test]
-        [Category("DynamoUI")]
-        public void CanZoomOutLimit()
-        {
-            WorkspaceModel workspaceModel = Vm.CurrentSpaceViewModel._model;
-            WorkspaceViewModel workspaceVM = Vm.CurrentSpaceViewModel;
-
-            // Zoom to max zoom value
-            workspaceVM.SetZoomCommand.Execute(WorkspaceModel.ZOOM_MINIMUM);
-
-            Vm.ZoomOutCommand.Execute(null);
-
-            // Check it does not zoom out anymore
-            Assert.AreEqual(WorkspaceModel.ZOOM_MINIMUM, workspaceModel.Zoom);
-        }
-
-        [Test, RequiresSTA]
-        [Category("DynamoUI")]
-        public void ZoomInOutStressTest()
-        {
-            WorkspaceModel workspaceModel = Vm.CurrentSpaceViewModel._model;
-            WorkspaceViewModel workspaceVM = Vm.CurrentSpaceViewModel;
-
+            // Stress Test
             // Zoom in and out repeatly
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 20; i++)
             {
-                for (int stepIn = 0; stepIn < 30; stepIn++)
+                for (int stepIn = 0; stepIn < 20; stepIn++)
                 {
                     if (Vm.ZoomInCommand.CanExecute(null))
-                    {
                         Vm.ZoomInCommand.Execute(null);
-                        Console.WriteLine("Zoom in " + stepIn);
-                    }
                 }
-                for (int stepOut = 0; stepOut < 30; stepOut++)
+                for (int stepOut = 0; stepOut < 20; stepOut++)
                 {
                     if (Vm.ZoomOutCommand.CanExecute(null))
-                    {
                         Vm.ZoomOutCommand.Execute(null);
-                        Console.WriteLine("Zoom out " + stepOut);
-                    }
                 }
             }
-
             // Doesn't crash the system
             Assert.True(true);
         }


### PR DESCRIPTION
Remove console output for zoom stress test that floods console with multiple lines, this may slow down the build.
