### PR TITLE
Fix for unable to commit changes after library collapse.

### DIFF
--- a/src/DynamoCore/UI/Views/SearchView.xaml.cs
+++ b/src/DynamoCore/UI/Views/SearchView.xaml.cs
@@ -142,7 +142,20 @@ namespace Dynamo.Search
 
         void SearchViewModel_RequestReturnFocusToSearch(object sender, EventArgs e)
         {
-            Keyboard.Focus(SearchTextBox);
+            if (this.Visibility != Visibility.Collapsed)
+                Keyboard.Focus(SearchTextBox);
+            else
+                MoveFocusToNextUIElement();
+        }
+
+        void MoveFocusToNextUIElement()
+        {
+            // Gets the element with keyboard focus.
+            UIElement elementWithFocus = Keyboard.FocusedElement as UIElement;
+
+            // Change keyboard focus.
+            if (elementWithFocus != null)
+                elementWithFocus.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
         }
 
         void SearchViewModel_RequestFocusSearch(object sender, EventArgs e)


### PR DESCRIPTION
Issue identified:
When library is collapsed, focus could not be return to the search textbox inside, which current code is performing, hence focus remains within the node causing commit to not happen.

Fix:
-Added codes to shift the focus out of current node when workspace area is clicked.

Fix for MAGN-588
