### PR TITLE
Not copy RevitAPIUI.dll to local

### DIFF
--- a/src/RevitServices/RevitServices.csproj
+++ b/src/RevitServices/RevitServices.csproj
@@ -56,6 +56,7 @@ limitations under the License.
     </Reference>
     <Reference Include="RevitAPIUI">
       <HintPath>$(REVITAPI)\RevitAPIUI.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
To fix MAGN-743. Otherwise all dependent assemblies will be copied to local folder and a same dll will be loaded twice from difference location. 
