### PR TITLE
Fix: MAGN-774 Crash after convert to custom node and undo

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -294,6 +294,19 @@ namespace Dynamo.Models
             }
         }
 
+        /// <summary>
+        /// Get the current UndoRedoRecorder that is associated with the current 
+        /// WorkspaceModel. Note that external parties should not have the needs 
+        /// to access the recorder directly, so this property is exposed just as 
+        /// a "temporary solution". Before using this property, consider using 
+        /// WorkspaceModel.RecordModelsForUndo method which allows for multiple 
+        /// modifications in a single action group.
+        /// </summary>
+        internal UndoRedoRecorder UndoRecorder
+        {
+            get { return undoRecorder; }
+        }
+
         #endregion
 
         protected WorkspaceModel(

--- a/src/DynamoElementsTests/DynamoUnitTest.cs
+++ b/src/DynamoElementsTests/DynamoUnitTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Dynamo.FSchemeInterop;
 using Dynamo.Utilities;
@@ -32,6 +34,18 @@ namespace Dynamo.Tests
             }
 
             base.Cleanup();
+        }
+
+        protected void VerifyModelExistence(Dictionary<string, bool> modelExistenceMap)
+        {
+            var nodes = Controller.DynamoModel.CurrentWorkspace.Nodes;
+            foreach (var pair in modelExistenceMap)
+            {
+                Guid guid = Guid.Parse(pair.Key);
+                var node = nodes.FirstOrDefault((x) => (x.GUID == guid));
+                bool nodeExists = (null != node);
+                Assert.AreEqual(nodeExists, pair.Value);
+            }
         }
 
         private void StartDynamo()

--- a/test/core/collapse/collapse-number-chain.dyn
+++ b/test/core/collapse/collapse-number-chain.dyn
@@ -1,0 +1,40 @@
+<Workspace Version="0.6.3.20352" X="116" Y="247" zoom="1" Description="" Category="" Name="Home">
+  <Elements>
+    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="5a503c02-13a7-4def-9fb6-52101117219e" nickname="Number" x="90" y="120" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="10" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="6e7bdd5a-6c3c-4588-bb7d-bb49c969812b" nickname="Number" x="90" y="360" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="20" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="da2cbc80-a278-4699-96fa-a22d7762a42d" nickname="Number" x="270" y="360" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="30" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="28cff154-ef78-43fa-bcc9-f86e00ce2ced" nickname="Number" x="450" y="360" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="40" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="7ad3d045-c620-4817-8723-afd3c266555b" nickname="Number" x="630" y="360" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="50" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="e8388f0d-2438-4b8b-87d1-f473c9e2c9a8" nickname="Number" x="810" y="360" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="60" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.Addition type="Dynamo.Nodes.Addition" guid="fed04d43-aad6-4782-a3c4-a86925e6b538" nickname="Add" x="270" y="120" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
+    <Dynamo.Nodes.Addition type="Dynamo.Nodes.Addition" guid="5e0d6637-5156-4b60-b49d-3c9aedd71884" nickname="Add" x="450" y="120" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
+    <Dynamo.Nodes.Addition type="Dynamo.Nodes.Addition" guid="98350887-4839-4ece-a4ad-37137cb11f52" nickname="Add" x="630" y="120" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
+    <Dynamo.Nodes.Addition type="Dynamo.Nodes.Addition" guid="8f4a460d-dada-4ecd-a0ca-9adb32d36f12" nickname="Add" x="810" y="120" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
+    <Dynamo.Nodes.Addition type="Dynamo.Nodes.Addition" guid="9cbbfa9c-fb5d-4a18-8d4b-5a02d842724e" nickname="Add" x="990" y="120" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="5a503c02-13a7-4def-9fb6-52101117219e" start_index="0" end="fed04d43-aad6-4782-a3c4-a86925e6b538" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="6e7bdd5a-6c3c-4588-bb7d-bb49c969812b" start_index="0" end="fed04d43-aad6-4782-a3c4-a86925e6b538" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="da2cbc80-a278-4699-96fa-a22d7762a42d" start_index="0" end="5e0d6637-5156-4b60-b49d-3c9aedd71884" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="28cff154-ef78-43fa-bcc9-f86e00ce2ced" start_index="0" end="98350887-4839-4ece-a4ad-37137cb11f52" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="7ad3d045-c620-4817-8723-afd3c266555b" start_index="0" end="8f4a460d-dada-4ecd-a0ca-9adb32d36f12" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="e8388f0d-2438-4b8b-87d1-f473c9e2c9a8" start_index="0" end="9cbbfa9c-fb5d-4a18-8d4b-5a02d842724e" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="fed04d43-aad6-4782-a3c4-a86925e6b538" start_index="0" end="5e0d6637-5156-4b60-b49d-3c9aedd71884" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="5e0d6637-5156-4b60-b49d-3c9aedd71884" start_index="0" end="98350887-4839-4ece-a4ad-37137cb11f52" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="98350887-4839-4ece-a4ad-37137cb11f52" start_index="0" end="8f4a460d-dada-4ecd-a0ca-9adb32d36f12" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="8f4a460d-dada-4ecd-a0ca-9adb32d36f12" start_index="0" end="9cbbfa9c-fb5d-4a18-8d4b-5a02d842724e" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
# Background

This pull request is meant to fix the following defect:

[MAGN-774 Crash after convert to custom node and undo](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-774)

Prior to this submission, **NodeCollapser.Collapse** has never been recorded for undo-redo. For this reason, the following operations would yield unexpected results (or even crash):
1. Perform some actions (e.g. create node, connections, etc)
2. Select few nodes and convert to custom node (CTRL+D)
3. Undo

The undo operation in Step 3 will result in actions of Step 1 to be undone (as if Step 2 never happened). This will result in crash if Step 2 requires anything from Step 1.
# Unit Testing
- All the existing test cases are passing with this fix
- I have added **CanCollapseAndUndoRedo** to completely test the fix
