### PR TITLE
Fixed http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-782

### DIFF
--- a/src/DynamoCore/VisualizationManager/VisualizationManager.cs
+++ b/src/DynamoCore/VisualizationManager/VisualizationManager.cs
@@ -468,8 +468,10 @@ namespace Dynamo
                     continue;
 
                 NodeModel node = pair.Value.Item2;
-
-                if(node.OldValue != null)
+                //We no longer depend on OldValue, as long as the given node has
+                //registered it's render description with Visualization manager
+                //we will be able to visualize the given node. -Sharad
+                if(node != null)
                     drawables.Add(node.GUID.ToString());
 
                 if (node.IsUpstreamVisible)
@@ -478,6 +480,38 @@ namespace Dynamo
             }
 
             return drawables;
+        }
+
+        /// <summary>
+        /// Gets list of drawable Ids as registered with visualization manager 
+        /// for all the output port of the given node.
+        /// </summary>
+        /// <param name="node">Node</param>
+        /// <returns>List of Drawable Ids</returns>
+        private static List<string> GetDrawableIds(NodeModel node)
+        {
+            List<string> drawables = new List<String>();
+            for (int i = 0; i < node.OutPortData.Count; ++i)
+            {
+                string identifier = GetDrawableId(node, i);
+                if (!string.IsNullOrEmpty(identifier))
+                    drawables.Add(identifier);
+            }
+
+            return drawables;
+        }
+
+        /// <summary>
+        /// Gets the drawable Id as registered with visualization manager for
+        /// the given output port on the given node.
+        /// </summary>
+        /// <param name="node">Node</param>
+        /// <param name="outPortIndex">Output port index</param>
+        /// <returns>Drawable Id</returns>
+        private static string GetDrawableId(NodeModel node, int outPortIndex)
+        {
+            var output = node.GetAstIdentifierForOutputIndex(outPortIndex);
+            return GraphToDSCompiler.GraphUtilities.ASTListToCode(new List<ProtoCore.AST.AssociativeAST.AssociativeNode> { output });
         }
 
         /// <summary>
@@ -727,17 +761,8 @@ namespace Dynamo
             var drawables = new Dictionary<NodeModel, Dictionary<string, object>>();
             foreach (var node in dynSettings.Controller.DynamoModel.Nodes)
             {
-                string varName = node.VariableToPreview;
-                var graphItems = dynSettings.Controller.EngineController.GetGraphicItems(varName);
-                if (graphItems != null)
-                {
-                    var drawableItems = new Dictionary<string, object>();
-                    for (int i = 0; i < graphItems.Count(); ++i)
-                    {
-                        drawableItems.Add(i.ToString(), graphItems[i]);
-                    }
-                    drawables.Add(node, drawableItems);
-                }
+                var drawableItems = GetDrawablesFromNode(node);
+                drawables.Add(node, drawableItems);
             }
             return drawables;
 #else
@@ -766,7 +791,24 @@ namespace Dynamo
         /// <returns></returns>
         public static Dictionary<string, object> GetDrawablesFromNode(NodeModel node)
         {
+#if USE_DSENGINE
+            var drawableItems = new Dictionary<string, object>();
+            List<string> drawableIds = GetDrawableIds(node);
+            foreach (var varName in drawableIds)
+            {
+                var graphItems = dynSettings.Controller.EngineController.GetGraphicItems(varName);
+                if (graphItems != null)
+                {
+                    for (int i = 0; i < graphItems.Count(); ++i)
+                    {
+                        drawableItems.Add(varName+i, graphItems[i]);
+                    }
+                }
+            }
+            return drawableItems;
+#else
             return GetDrawableFromValue(new List<int>(), node.OldValue);
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
This submission fixes the geometry display for all the statements in
CBN. It also allows geometry to be viewed in Watch3D node. At this
moment Watch3D node displays all the geometry created by the node, it
doesn't distinguish the geometry coming from specific output port.

GetAllDrawablesInModel() queries the variable name corresponding to each output port in the codeblock node and then for those variables it queries the graphic items and updates the render description with the visualization manager.
