### PR TITLE
Fix MAGN-851: Node to Code disabled in the UI

### DIFF
--- a/src/DynamoCore/UI/Views/dynWorkspaceView.xaml.cs
+++ b/src/DynamoCore/UI/Views/dynWorkspaceView.xaml.cs
@@ -164,6 +164,7 @@ namespace Dynamo.Views
         void Selection_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
             ViewModel.NodeFromSelectionCommand.RaiseCanExecuteChanged();
+            ViewModel.NodeToCodeCommand.RaiseCanExecuteChanged();
         }
 
         /// <summary>


### PR DESCRIPTION
That's because the menu item is enabled or not is controlled by DelegateCommand.CanExecute(). For N2C menu item, it is enabled or not depends on if the selection set is empty or not. But its status should be updated whenever the selection set is changed. 
