### PR TITLE
Quick fix for info bubble popping out in unwanted situation.

### DIFF
--- a/src/DynamoCore/UI/Views/dynNodeView.xaml.cs
+++ b/src/DynamoCore/UI/Views/dynNodeView.xaml.cs
@@ -15,6 +15,7 @@ using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using System.Windows.Media;
 using DynCmd = Dynamo.ViewModels.DynamoViewModel;
+using System.Windows.Threading;
 
 namespace Dynamo.Controls
 {
@@ -40,6 +41,8 @@ namespace Dynamo.Controls
             get { return viewModel; }
             private set { viewModel = value; }
         }
+
+        private DispatcherTimer twoSecondsWaitTimer;
 
         #region constructors
 
@@ -296,12 +299,27 @@ namespace Dynamo.Controls
             double actualWidth = textBlock.ActualWidth * dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.Zoom;
             double actualHeight = textBlock.ActualHeight * dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.Zoom;
             Point botRight = new Point(topLeft.X + actualWidth, topLeft.Y + actualHeight);
-            ViewModel.ShowTooltipCommand.Execute(new InfoBubbleDataPacket(InfoBubbleViewModel.Style.NodeTooltip, topLeft,
-                botRight, tooltipContent, InfoBubbleViewModel.Direction.Bottom));
+
+            twoSecondsWaitTimer = new DispatcherTimer();
+            twoSecondsWaitTimer.Interval = TimeSpan.FromSeconds(2); // two seconds wait
+
+            twoSecondsWaitTimer.Tick += delegate(object sender1, EventArgs e1)
+            {
+                dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.Dispatcher.BeginInvoke((new Action(() =>
+                {
+                    ViewModel.ShowTooltipCommand.Execute(new InfoBubbleDataPacket(InfoBubbleViewModel.Style.NodeTooltip, topLeft,
+                        botRight, tooltipContent, InfoBubbleViewModel.Direction.Bottom));
+                })));
+            };
+
+            twoSecondsWaitTimer.Start();
         }
 
         private void NickNameBlock_OnMouseLeave(object sender, MouseEventArgs e)
         {
+            if (twoSecondsWaitTimer.IsEnabled)
+                twoSecondsWaitTimer.Stop();
+
             if (ViewModel != null)
                 ViewModel.FadeOutTooltipCommand.Execute(null);
             else if (dynSettings.Controller != null)
@@ -320,12 +338,27 @@ namespace Dynamo.Controls
             double actualWidth = inputPort.ActualWidth * dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.Zoom;
             double actualHeight = inputPort.ActualHeight * dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.Zoom;
             Point botRight = new Point(topLeft.X + actualWidth, topLeft.Y + actualHeight);
-            ViewModel.ShowTooltipCommand.Execute(new InfoBubbleDataPacket(InfoBubbleViewModel.Style.NodeTooltip, topLeft,
-                botRight, content, InfoBubbleViewModel.Direction.Right));
+
+            twoSecondsWaitTimer = new DispatcherTimer();
+            twoSecondsWaitTimer.Interval = TimeSpan.FromSeconds(2); // two seconds wait
+
+            twoSecondsWaitTimer.Tick += delegate(object sender1, EventArgs e1)
+            {
+                dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.Dispatcher.BeginInvoke((new Action(() =>
+                {
+                    ViewModel.ShowTooltipCommand.Execute(new InfoBubbleDataPacket(InfoBubbleViewModel.Style.NodeTooltip, topLeft,
+                        botRight, content, InfoBubbleViewModel.Direction.Right));
+                })));
+            };
+
+            twoSecondsWaitTimer.Start();
         }
 
         private void InputPort_OnMouseLeave(object sender, MouseEventArgs e)
         {
+            if (twoSecondsWaitTimer.IsEnabled)
+                twoSecondsWaitTimer.Stop();
+
             if (ViewModel != null)
                 ViewModel.FadeOutTooltipCommand.Execute(null);
             else if (dynSettings.Controller != null)
@@ -349,12 +382,27 @@ namespace Dynamo.Controls
             double actualWidth = outputPort.ActualWidth * dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.Zoom;
             double actualHeight = outputPort.ActualHeight * dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.Zoom;
             Point botRight = new Point(topLeft.X + actualWidth, topLeft.Y + actualHeight);
-            ViewModel.ShowTooltipCommand.Execute(new InfoBubbleDataPacket(InfoBubbleViewModel.Style.NodeTooltip, topLeft,
-                botRight, content, InfoBubbleViewModel.Direction.Left));
+
+            twoSecondsWaitTimer = new DispatcherTimer();
+            twoSecondsWaitTimer.Interval = TimeSpan.FromSeconds(2); // two seconds wait
+
+            twoSecondsWaitTimer.Tick += delegate(object sender1, EventArgs e1)
+            {
+                dynSettings.Controller.DynamoViewModel.CurrentSpaceViewModel.Dispatcher.BeginInvoke((new Action(() =>
+                {
+                    ViewModel.ShowTooltipCommand.Execute(new InfoBubbleDataPacket(InfoBubbleViewModel.Style.NodeTooltip, topLeft,
+                        botRight, content, InfoBubbleViewModel.Direction.Left));
+                })));
+            };
+
+            twoSecondsWaitTimer.Start();
         }
 
         private void OutputPort_OnMouseLeave(object sender, MouseEventArgs e)
         {
+            if (twoSecondsWaitTimer.IsEnabled)
+                twoSecondsWaitTimer.Stop();
+
             if (ViewModel != null)
                 ViewModel.FadeOutTooltipCommand.Execute(null);
             else if (dynSettings.Controller != null)


### PR DESCRIPTION
## Improvement to node tooltip

Implemented a quick fix for to prevent tooltip popping up when user did not intend to do so.
2 seconds wait before showing node tooltip on:
- node name
- node input port(s)
- node output port(s)

MAGN-857
