### PR TITLE
MAGN-859 Fixing Caret and selection of text broken in all the dialog

### DIFF
--- a/src/DynamoCore/UI/Themes/DynamoModern.xaml
+++ b/src/DynamoCore/UI/Themes/DynamoModern.xaml
@@ -632,7 +632,7 @@
                                                     ContentTemplate="{TemplateBinding ContentTemplate}"
                                                     CanContentScroll="{TemplateBinding CanContentScroll}" />
                         </Grid>
-                        <Grid Background="Transparent">
+                        <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
.Causes: Scrollviewer's grid background is set to transparent covering it's content (TextBox)
