### PR TITLE
Node Model get node to code name

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -699,6 +699,18 @@ namespace Dynamo.Models
                                    GetAstIdentifierForOutputIndex(output.Index))));
         }
 
+        /// <summary>
+        /// Given a port model, It returns the name of the variable that will be 
+        /// created if this node was converted into a code block node using the 
+        /// Node To Code method
+        /// </summary>
+        /// <param name="portModel"></param>
+        /// <returns></returns>
+        internal virtual string GetNodeToCodeName(PortModel portModel)
+        {
+            return "var_" + this.GUID.ToString().Replace("-","");
+        }
+
         #endregion
 
         #region Input and Output Connections

--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -355,6 +355,16 @@ namespace Dynamo.Nodes
             return (codeStatements[statementIndex].AstNode as BinaryExpressionNode).LeftNode as IdentifierNode;
         }
 
+        internal override string GetNodeToCodeName(PortModel portModel)
+        {
+            if (portModel.ToolTipContent == "Statement Output")
+            {
+                int index = OutPorts.IndexOf(portModel);
+                return (GetAstIdentifierForOutputIndex(index) as IdentifierNode).Value;
+            }
+            return portModel.ToolTipContent;
+        }
+
         #endregion
 
         #region Private Methods


### PR DESCRIPTION
Part of Node To Code. A function to get the name of that variable in the new Code Block Node.
The port model is udes particular for the CodeBlockNodeModel override as it is like multiple nodes in one.
