### PR TITLE
Node Tooltip Delay Timer fix

### DIFF
--- a/src/DynamoCore/Core/Configurations.cs
+++ b/src/DynamoCore/Core/Configurations.cs
@@ -102,7 +102,7 @@ namespace Dynamo.Core
         #endregion
 
         #region Node Tooltip
-        public static int NodeToolTipFadeInDelayInSeconds = 2;
+        public static int ToolTipFadeInDelayInMS = 2000;
 
         public static SolidColorBrush NodeTooltipFrameFill = new SolidColorBrush(Color.FromRgb(255, 255, 255));
         public static double NodeTooltipFrameStrokeThickness = 1;

--- a/src/DynamoCore/ViewModels/InfoBubbleViewModel.cs
+++ b/src/DynamoCore/ViewModels/InfoBubbleViewModel.cs
@@ -36,13 +36,13 @@ namespace Dynamo.ViewModels
     {
         public enum Style
         {
+            None,
             LibraryItemPreview,
             NodeTooltip,
             Error,
             ErrorCondensed,
             Preview,
-            PreviewCondensed,
-            None
+            PreviewCondensed
         }
         public enum Direction
         {


### PR DESCRIPTION
## Important fix

This is fixing a crash upon null pointer exception (Added null checks to fix this)
## Changes
1. Renamed timer
2. Refactored delay duration into config file
3. Made timer stop after one tick (this was accidentally left out in previous pull)
