### PR TITLE
Separating out FScheme and DSEngine test cases to get the clear results

### DIFF
--- a/test/core/recorded/ShiftSelectAllNode.xml
+++ b/test/core/recorded/ShiftSelectAllNode.xml
@@ -1,4 +1,4 @@
-<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="150">
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
   <CreateNodeCommand NodeId="b12ce9c8-8c23-43c4-987d-759c6f623998" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
   <CreateNodeCommand NodeId="d75441ef-a710-4c79-8740-d110e3f69648" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
   <CreateNodeCommand NodeId="3cb07fa2-73ee-446a-9c87-0793f8353f5b" NodeName="Add" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />


### PR DESCRIPTION
This check-in about resolving false failure because of the execution engine

As we have removed all FScheme Nodes from CB, as a result of this there were so many test cases failure because those were using FScheme nodes. These test cases got included in CB branch as a result of merge from Master to CB.

So to handle this situation until we completely moved to DS Engine, we have to run these test cases in both Master as well as CB, to track the regression. 

I have created two extended classes from RecrdedTests and moved related test cases to those two classes. I have also created addition 12 new test cases in RecordedTestDSEngine to capture those scenarios using DS nodes.

Now in CB branch only DS engine related test will run so that we will get clean and correct results. 

Now onward testes cases added in Master will get added in RecordedTestsFScheme class and DS engine test cases will get added in RecordedTestsDSEngine (I will send another pull request from CB to have this class in RecordedTests.cs)

Summary:

In Master only Tests which are under RecordedTests class will get execute and all tests are passing on latest master.

In CB only Tests which are under RecordedTestsDSEngine class will get execute and all tests are passing on latest CB. (I will send another pull request from CB to have these changes in.)

By separating these two check-ins; it will help Ben to merge changes from Master to CB easily. 
