### PR TITLE
Fix: Double-clicking on Python node does not bring up editor

### DIFF
--- a/src/DynamoCore/UI/Views/dynNodeView.xaml.cs
+++ b/src/DynamoCore/UI/Views/dynNodeView.xaml.cs
@@ -265,9 +265,9 @@ namespace Dynamo.Controls
             {
                 if (ViewModel.GotoWorkspaceCommand.CanExecute(null))
                 {
+                    e.Handled = true;
                     ViewModel.GotoWorkspaceCommand.Execute(null);
                 }
-                e.Handled = true;
             }
         }
 

--- a/src/DynamoPython/dynPython.cs
+++ b/src/DynamoPython/dynPython.cs
@@ -370,8 +370,8 @@ namespace Dynamo.Nodes
             if (e.ClickCount >= 2)
             {
                 EditScriptContent();
-                e.Handled = true;
             }
+            e.Handled = true;
         }
 
         public override bool RequiresRecalc


### PR DESCRIPTION
This is meant to fix the following user reported issue:

[No more double-click to edit Python scripts?](https://github.com/ikeough/Dynamo/issues/677)

Internal defect: [MAGN-528 Double click on python nodes does not open for edit](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-528)

It appears the second click in a double-click event is eaten by **dynNodeView.topControl_MouseLeftButtonDown** method, but it does not actually do anything with it. Now we only set **e.Handled** to **true** if the method actually handles the click event. This way the second click has the chance of getting to **dynPython.nodeUI_MouseDown** method for processing (instead of eating it up).
