### PR TITLE
Copy asm libraries to bin/dll folder after build

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -666,7 +666,9 @@ limitations under the License.
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(SolutionDir)..\extern\DesignScript\*" "$(OutputPath)"</PostBuildEvent>
+    <PostBuildEvent>copy /Y "$(SolutionDir)..\extern\DesignScript\*" "$(OutputPath)"
+mkdir "$(OutputPath)\dll"
+copy /Y "$(SolutionDir)..\extern\DynamoAsm\*" "$(OutputPath)\dll"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Previously asm libraries would be copied to bin/dll folder by DynmaoAsm project in post build event. This project has been removed from solution. 

Not all libraries are needed, e.g., LigG. After Peter finish protogeometry work, we should do clean up. But now just copy asm libraries to that folder so that the installer could be created for ChocoButter branch and we can use protogeometry.
