### PR TITLE
Fix: MAGN-982 Dynamo crashing while switching workspace.

### DIFF
--- a/src/DynamoCore/ViewModels/NodeViewModel.cs
+++ b/src/DynamoCore/ViewModels/NodeViewModel.cs
@@ -465,14 +465,16 @@ namespace Dynamo.ViewModels
             if (this.PreviewBubble == null)
                 return;
 
-            UpdatePreviewBubbleContent();
-            if (dynSettings.Controller.IsShowPreviewByDefault)
+            var vm = dynSettings.Controller.DynamoViewModel;
+            if (vm.CurrentSpaceViewModel.Nodes.Contains(this))
             {
-                this.PreviewBubble.ChangeInfoBubbleStateCommand.Execute(InfoBubbleViewModel.State.Pinned);
-            }
-            else
-            {
-                this.PreviewBubble.ChangeInfoBubbleStateCommand.Execute(InfoBubbleViewModel.State.Minimized);
+                UpdatePreviewBubbleContent();
+
+                var command = this.PreviewBubble.ChangeInfoBubbleStateCommand;
+                if (dynSettings.Controller.IsShowPreviewByDefault)
+                    command.Execute(InfoBubbleViewModel.State.Pinned);
+                else
+                    command.Execute(InfoBubbleViewModel.State.Minimized);
             }
         }
 
@@ -540,6 +542,10 @@ namespace Dynamo.ViewModels
             if (this.PreviewBubble == null || this.NodeModel is Watch || dynSettings.Controller == null)
                 return;
 
+            var vm = dynSettings.Controller.DynamoViewModel;
+            if (!vm.CurrentSpaceViewModel.Previews.Contains(this.PreviewBubble))
+                return;
+
             //create data packet to send to preview bubble
             InfoBubbleViewModel.Style style = InfoBubbleViewModel.Style.PreviewCondensed;
             Point topLeft = new Point(NodeModel.X, NodeModel.Y);
@@ -547,10 +553,7 @@ namespace Dynamo.ViewModels
             string content = this.OldValue;
             InfoBubbleViewModel.Direction connectingDirection = InfoBubbleViewModel.Direction.Top;
             InfoBubbleDataPacket data = new InfoBubbleDataPacket(style, topLeft, botRight, content, connectingDirection);
-
-            var vm = dynSettings.Controller.DynamoViewModel;
-            if (vm.CurrentSpaceViewModel.Previews.Contains(this.PreviewBubble))
-                this.PreviewBubble.UpdateContentCommand.Execute(data);
+            this.PreviewBubble.UpdateContentCommand.Execute(data);
         }
 
         private void UpdatePreviewBubblePosition()


### PR DESCRIPTION
# Background

This is meant to fix the defect: [MAGN-982 Dynamo crashing while switching workspace](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-982)
# The problem

The two data members of **InfoBubbleState** and **InfoBubbleStyle** have gone-out of-sync in the scenario outlined in the defect. When user toggles the **Show All Preview** from **View** menu, only **InfoBubbleState** is set and not **InfoBubbleStyle**. The difference is method that sets the **InfoBubbleStyle**  (**UpdatePreviewBubbleContent**) has a condition to exclude nodes that are not in the current workspace, but **InfoBubbleState** is being set regardless of whether the node is in current workspace. That difference causes these two data member to go out-of-sync.
# The solution

The fix of course is to make them consistent. When **Show All Preview** is set, only nodes that belong to the current workspace are getting their **InfoBubbleState** and **InfoBubbleStyle** data members set (through commands).
