### PR TITLE
Fixed Python with Variable Inputs not moving when dragged.

### DIFF
--- a/src/DynamoPython/dynPython.cs
+++ b/src/DynamoPython/dynPython.cs
@@ -370,8 +370,9 @@ namespace Dynamo.Nodes
             if (e.ClickCount >= 2)
             {
                 EditScriptContent();
+                e.Handled = true;
             }
-            e.Handled = true;
+            
         }
 
         public override bool RequiresRecalc


### PR DESCRIPTION
moved e.handled = true into if statement so node could be moved correctly

I think this was missed when changes were made to this file in another branch, this now matches the other python node above.
