### PR TITLE
Fix a showstopper where menu item is not clickable

### DIFF
--- a/src/DynamoCore/UI/Themes/MenuStyleDictionary.xaml
+++ b/src/DynamoCore/UI/Themes/MenuStyleDictionary.xaml
@@ -155,6 +155,11 @@
                             <ColumnDefinition Width="10" />
                             <ColumnDefinition Width="10" />
                         </Grid.ColumnDefinitions>
+                        <Border Name="CheckMarkBackground"
+                                Grid.Column="0"
+                                Background="Transparent"
+                                HorizontalAlignment="Stretch"
+                                Visibility="Visible" />
                         <ContentPresenter Name="Icon"
                                           Grid.Column="0"
                                           Margin="6,0,6,0"
@@ -256,12 +261,11 @@
                                           Margin="6,0,6,0"
                                           VerticalAlignment="Center"
                                           ContentSource="Icon" />
-                        <Border Name="Check"
+                        <Border Name="CheckMarkBackground"
                                 Grid.Column="0"
-                                Width="13"
-                                Height="13"
-                                HorizontalAlignment="Center"
-                                Visibility="Collapsed">
+                                Background="Transparent"
+                                HorizontalAlignment="Stretch"
+                                Visibility="Visible">
                             <Image Name="CheckMark"
                                    Width="8"
                                    Height="8"
@@ -293,18 +297,12 @@
                     </Trigger>
                     <Trigger Property="IsChecked"
                              Value="true">
-                        <Setter TargetName="Check"
-                                Property="Visibility"
-                                Value="Visible" />
                         <Setter TargetName="CheckMark"
                                 Property="Visibility"
                                 Value="Visible" />
                     </Trigger>
                     <Trigger Property="IsChecked"
                              Value="false">
-                        <Setter TargetName="Check"
-                                Property="Visibility"
-                                Value="Collapsed" />
                         <Setter TargetName="CheckMark"
                                 Property="Visibility"
                                 Value="Hidden" />


### PR DESCRIPTION
This pull request fixes the [showstopper issue MAGN-733](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-733) where menu item is not clickable. The problem was that the `Border` XAML element was too narrow, and hidden when the menu item is unchecked. The fix is: instead of hiding the `Border` element, make it always visible and make its `Background` attribute to be `Transparent`. What this essentially mean to WPF is that the visual element is hit-testable, thereby achieving what we wanted for our menu item.
