### PR TITLE
Fixed a crash in Double Slider when its min/max values are updated

### DIFF
--- a/src/Libraries/CoreNodesUI/Input/Sliders.cs
+++ b/src/Libraries/CoreNodesUI/Input/Sliders.cs
@@ -235,6 +235,25 @@ namespace Dynamo.Nodes
         }
 
         #endregion
+
+        protected override bool UpdateValueCore(string name, string value)
+        {
+            var converter = new DoubleDisplay();
+            switch (name)
+            {
+                case "Min":
+                    Min = ((double)converter.ConvertBack(value, typeof(double), null, null));
+                    return true; // UpdateValueCore handled.
+                case "Max":
+                    Max = ((double)converter.ConvertBack(value, typeof(double), null, null));
+                    return true; // UpdateValueCore handled.
+                case "Value":
+                    Value = ((double)converter.ConvertBack(value, typeof(double), null, null));
+                    return true; // UpdateValueCore handled.
+            }
+
+            return base.UpdateValueCore(name, value);
+        }
     }
 
 


### PR DESCRIPTION
This is meant to fix the crash in DoubleSlider [reported internally](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1313).

`DoubleSlider.UpdateValueCore` method was not implemented and the call fall-through to the base class `ModelBase` which throws an exception to highlight the problem.
