### PR TITLE
DynamoController.Testing property is made static

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -862,7 +862,7 @@ namespace Dynamo.Utilities
                 dynSettings.Controller.DynamoModel.WriteToLog("There was an error opening the workbench.");
                 dynSettings.Controller.DynamoModel.WriteToLog(ex);
 
-                if (controller.Testing)
+                if (DynamoController.IsTestMode)
                     Assert.Fail(ex.Message);
 
                 def = null;

--- a/src/DynamoCore/Core/DynamoController.cs
+++ b/src/DynamoCore/Core/DynamoController.cs
@@ -67,7 +67,7 @@ namespace Dynamo
 
         private readonly Dictionary<string, object> builtInFunctions = new Dictionary<String, object>();
 
-        private bool testing = false;
+        private static bool testing = false;
 
         protected VisualizationManager visualizationManager;
 
@@ -92,10 +92,10 @@ namespace Dynamo
         /// with the assumption that the entire test will be wrapped in an
         /// idle thread call.
         /// </summary>
-        public bool Testing 
+        public static bool IsTestMode 
         {
-            get { return testing; }
-            set { testing = value; }
+            get { return DynamoController.testing; }
+            set { DynamoController.testing = value; }
         }
 
         ObservableCollection<ModelBase> clipBoard = new ObservableCollection<ModelBase>();
@@ -475,7 +475,7 @@ namespace Dynamo
 
                 OnRunCompleted(this, false);
 
-                if (Testing)
+                if (IsTestMode)
                     Assert.Fail(ex.Message + ":" + ex.StackTrace);
             }
             finally
@@ -558,7 +558,7 @@ namespace Dynamo
                 //If we are testing, we need to throw an exception here
                 //which will, in turn, throw an Assert.Fail in the 
                 //Evaluation thread.
-                if (Testing)
+                if (IsTestMode)
                     throw new Exception(ex.Message);
             }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -98,7 +98,7 @@ namespace Dynamo.Models
                 DynamoLogger.Instance.Log(ex);
                 Debug.WriteLine(ex.Message + ":" + ex.StackTrace);
 
-                if (dynSettings.Controller.Testing)
+                if (DynamoController.IsTestMode)
                     Assert.Fail(ex.Message);
 
                 return null;

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -992,7 +992,7 @@ namespace Dynamo.Models
 
                     Error(ex.Message);
 
-                    if (dynSettings.Controller.Testing)
+                    if (DynamoController.IsTestMode)
                         throw new Exception(ex.Message);
 
                     _errorCount++;

--- a/src/DynamoCore/VisualizationManager/VisualizationManager.cs
+++ b/src/DynamoCore/VisualizationManager/VisualizationManager.cs
@@ -376,7 +376,7 @@ namespace Dynamo
             var worker = new BackgroundWorker();
             worker.DoWork += VisualizationUpdateThread;
 
-            if(dynSettings.Controller.Testing)
+            if (DynamoController.IsTestMode)
                 VisualizationUpdateThread(null,null);
             else
                 worker.RunWorkerAsync();

--- a/src/DynamoCoreUITests/UpdateManagerUITests.cs
+++ b/src/DynamoCoreUITests/UpdateManagerUITests.cs
@@ -27,10 +27,8 @@ namespace DynamoCoreUITests
             AppDomain.CurrentDomain.AssemblyResolve += AssemblyHelper.CurrentDomain_AssemblyResolve;
 
             var env = new ExecutionEnvironment();
-            Controller = new DynamoController(env, typeof(DynamoViewModel), "None", null, updateManager, new UnitsManager(), new DefaultWatchHandler(), new PreferenceSettings())
-            {
-                Testing = true
-            };
+            Controller = new DynamoController(env, typeof(DynamoViewModel), "None", null, updateManager, new UnitsManager(), new DefaultWatchHandler(), new PreferenceSettings());
+            DynamoController.IsTestMode = true;
 
             //create the view
             Ui = new DynamoView { DataContext = Controller.DynamoViewModel };

--- a/src/DynamoElementsTests/DynamoUnitTest.cs
+++ b/src/DynamoElementsTests/DynamoUnitTest.cs
@@ -54,10 +54,8 @@ namespace Dynamo.Tests
         protected void StartDynamo()
         {
             //create a new instance of the ViewModel
-            Controller = new DynamoController(new ExecutionEnvironment(), typeof (DynamoViewModel), Context.NONE, new UpdateManager.UpdateManager(), new UnitsManager(), new DefaultWatchHandler(), new PreferenceSettings())
-            {
-                Testing = true
-            };
+            Controller = new DynamoController(new ExecutionEnvironment(), typeof (DynamoViewModel), Context.NONE, new UpdateManager.UpdateManager(), new UnitsManager(), new DefaultWatchHandler(), new PreferenceSettings());
+            DynamoController.IsTestMode = true;
         }
 
         /// <summary>
@@ -67,10 +65,8 @@ namespace Dynamo.Tests
         protected void StartDynamo(IUpdateManager updateManager, IUnitsManager unitsManager, IWatchHandler watchHandler, IPreferences preferences)
         {
             //create a new instance of the ViewModel
-            Controller = new DynamoController(new ExecutionEnvironment(), typeof(DynamoViewModel), Context.NONE, updateManager, unitsManager, watchHandler, preferences)
-            {
-                Testing = true
-            };
+            Controller = new DynamoController(new ExecutionEnvironment(), typeof(DynamoViewModel), Context.NONE, updateManager, unitsManager, watchHandler, preferences);
+            DynamoController.IsTestMode = true;
         }
 
         /// <summary>

--- a/src/DynamoRevit/DynamoController_Revit.cs
+++ b/src/DynamoRevit/DynamoController_Revit.cs
@@ -744,7 +744,7 @@ namespace Dynamo
 
             //If we're in a debug run or not already in the idle thread, then run the Cleanup Delegate
             //from the idle thread. Otherwise, just run it in this thread.
-            if (dynSettings.Controller.DynamoViewModel.RunInDebug || !InIdleThread && !Testing)
+            if (dynSettings.Controller.DynamoViewModel.RunInDebug || !InIdleThread && !IsTestMode)
             {
                 IdlePromise.ExecuteOnIdle(cleanup, false);
                 IdlePromise.ExecuteOnIdle(rename, false);
@@ -811,12 +811,12 @@ namespace Dynamo
                     !topElements.Any(CheckRequiresTransaction.TraverseUntilAny);
 
                 //If we don't need to be in the idle thread...
-                if (noIdleThread || Testing)
+                if (noIdleThread || IsTestMode)
                 {
                     //DynamoLogger.Instance.Log("Running expression in evaluation thread...");
                     TransMode = TransactionMode.Manual; //Manual transaction control
 
-                    if (Testing)
+                    if (IsTestMode)
                         TransMode = TransactionMode.Automatic;
 
                     InIdleThread = false; //Not in idle thread at the moment

--- a/src/DynamoRevitTests/DynamoRevitTests.cs
+++ b/src/DynamoRevitTests/DynamoRevitTests.cs
@@ -88,10 +88,8 @@ namespace Dynamo.Tests
                 };
 
                 //create a new instance of the ViewModel
-                Controller = new DynamoController(new ExecutionEnvironment(), typeof (DynamoViewModel), Context.NONE, new UpdateManager.UpdateManager(), units, new DefaultWatchHandler(), new PreferenceSettings())
-                    {
-                        Testing = true
-                    };
+                Controller = new DynamoController(new ExecutionEnvironment(), typeof (DynamoViewModel), Context.NONE, new UpdateManager.UpdateManager(), units, new DefaultWatchHandler(), new PreferenceSettings());
+                DynamoController.IsTestMode = true;
             }
             catch (Exception ex)
             {

--- a/src/DynamoTestFramework/DynamoTestFramework.cs
+++ b/src/DynamoTestFramework/DynamoTestFramework.cs
@@ -242,10 +242,8 @@ namespace Dynamo.Tests
             var r = new Regex(@"\b(Autodesk |Structure |MEP |Architecture )\b");
             string context = r.Replace(RevitData.Application.Application.VersionName, "");
 
-            var dynamoController = new DynamoController_Revit(DynamoRevitApp.env, DynamoRevitApp.Updater, typeof(DynamoRevitViewModel), context, units)
-                {
-                    Testing = true
-                };
+            var dynamoController = new DynamoController_Revit(DynamoRevitApp.env, DynamoRevitApp.Updater, typeof(DynamoRevitViewModel), context, units);
+            DynamoController.IsTestMode = true;
         }
 
         private void CalculateTotalsOnResultsRoot(resultType result)


### PR DESCRIPTION
We needed `DynamoLogger` to not log information during test, and some test cases do not even have `dynSettings.Controller` instantiated. So in order for `DynamoLogger` to know if it is running under test, we need to make `DynamoController.IsTestMode` (formerly `DynamoController.Testing`) property static.
