### PR TITLE
Fixed recorded command files that caused a test case to hang

### DIFF
--- a/test/core/recorded/Function_redef04.xml
+++ b/test/core/recorded/Function_redef04.xml
@@ -1,4 +1,4 @@
-<Commands ExitAfterPlayback="false" PauseAfterPlaybackInMs="10" CommandIntervalInMs="250">
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
   <CreateNodeCommand NodeId="48af4731-99bb-42c7-848b-a6b812206ffb" NodeName="Code Block" X="257" Y="240" DefaultPosition="false" TransformCoordinates="true" />
   <UpdateModelValueCommand ModelGuid="48af4731-99bb-42c7-848b-a6b812206ffb" Name="Code" Value="def test(i:int) &#xA;{&#xA;a=a+1;&#xA;return = i;&#xA;};" />
   <CreateNodeCommand NodeId="0953f2fd-9f50-42f5-9de4-80d4dd93e866" NodeName="Code Block" X="424" Y="254" DefaultPosition="false" TransformCoordinates="true" />

--- a/test/core/recorded/Function_redef04a.xml
+++ b/test/core/recorded/Function_redef04a.xml
@@ -1,4 +1,4 @@
-<Commands ExitAfterPlayback="false" PauseAfterPlaybackInMs="10" CommandIntervalInMs="250">
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
   <CreateNodeCommand NodeId="48af4731-99bb-42c7-848b-a6b812206ffb" NodeName="Code Block" X="257" Y="240" DefaultPosition="false" TransformCoordinates="true" />
   <UpdateModelValueCommand ModelGuid="48af4731-99bb-42c7-848b-a6b812206ffb" Name="Code" Value="def test(i:int) &#xA;{&#xA;a=a+1;&#xA;return = i;&#xA;};" />
   <CreateNodeCommand NodeId="0953f2fd-9f50-42f5-9de4-80d4dd93e866" NodeName="Code Block" X="424" Y="254" DefaultPosition="false" TransformCoordinates="true" />


### PR DESCRIPTION
`ExitAfterPlayback` was set to `false` during local debugging, and subsequently submitted by mistake. This causes CI system to hang, making it `true` so that the test can proceed.
