### PR TITLE
Recorded UI test failure fixes (20 test cases)

### DIFF
--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -47,11 +47,13 @@ namespace Dynamo.Tests.UI
             SetupDirectories();
         }
 
-        [TearDown]
-        public void Exit()
+        protected void Exit()
         {
-            this.Controller.ShutDown(true);
-            this.Controller = null;
+            if (this.Controller != null)
+            {
+                this.Controller.ShutDown(true);
+                this.Controller = null;
+            }
         }
 
         #endregion


### PR DESCRIPTION
Additional `TearDown` in `RecordedTests` class performs redundant clean-up of `Controller` which was already destroyed in the base class `DynamoUnitTest`. This causes `NullReferenceException` when `Controller.ShutDown` is invoked. This commit removes that and fixes the following test failures:

```
Dynamo.Tests.UI.RecordedTests.TestCreateNodeCommand
Dynamo.Tests.UI.RecordedTests.TestCreateNoteCommand
Dynamo.Tests.UI.RecordedTests.TestDeleteModelCommand
Dynamo.Tests.UI.RecordedTests.TestDragSelectionCommand
Dynamo.Tests.UI.RecordedTests.TestMakeConnectionCommand
Dynamo.Tests.UI.RecordedTests.TestRunCancelCommand
Dynamo.Tests.UI.RecordedTests.TestSelectInRegionCommand
Dynamo.Tests.UI.RecordedTests.TestSelectModelCommand
Dynamo.Tests.UI.RecordedTests.TestUndoRedoCommand
Dynamo.Tests.UI.RecordedTests.TestUpdateModelValueCommand
Dynamo.Tests.UI.RecordedTestsDSEngine.RecordedTests.TestCreateNodeCommand
Dynamo.Tests.UI.RecordedTestsDSEngine.RecordedTests.TestCreateNoteCommand
Dynamo.Tests.UI.RecordedTestsDSEngine.RecordedTests.TestDeleteModelCommand
Dynamo.Tests.UI.RecordedTestsDSEngine.RecordedTests.TestDragSelectionCommand
Dynamo.Tests.UI.RecordedTestsDSEngine.RecordedTests.TestMakeConnectionCommand
Dynamo.Tests.UI.RecordedTestsDSEngine.RecordedTests.TestRunCancelCommand
Dynamo.Tests.UI.RecordedTestsDSEngine.RecordedTests.TestSelectInRegionCommand
Dynamo.Tests.UI.RecordedTestsDSEngine.RecordedTests.TestSelectModelCommand
Dynamo.Tests.UI.RecordedTestsDSEngine.RecordedTests.TestUndoRedoCommand
Dynamo.Tests.UI.RecordedTestsDSEngine.RecordedTests.TestUpdateModelValueCommand
```
