### PR TITLE
Fixed migration methods for "StringFilename" and "StringDirectory" nodes

### DIFF
--- a/src/DynamoCore/Nodes/dynBaseTypes.cs
+++ b/src/DynamoCore/Nodes/dynBaseTypes.cs
@@ -5961,11 +5961,22 @@ namespace Dynamo.Nodes
         public static NodeMigrationData Migrate_0630_to_0700(NodeMigrationData data)
         {
             NodeMigrationData migrationData = new NodeMigrationData(data.Document);
-            migrationData.AppendNode(MigrationManager.CloneAndChangeType(
-                data.MigratedNodes.ElementAt(0), "DSCore.File.Directory"));
+            XmlElement original = data.MigratedNodes.ElementAt(0);
+            var cloned = MigrationManager.CloneAndChangeType(original, "DSCore.File.Directory");
 
+            var document = original.OwnerDocument;
+            foreach (XmlNode childNode in original.ChildNodes)
+            {
+                if (childNode.Name.Equals(typeof(string).FullName))
+                {
+                    var childElement = document.CreateElement(typeof(string).FullName);
+                    childElement.InnerText = childNode.Attributes[0].Value;
+                    cloned.AppendChild(childElement);
+                }
+            }
+
+            migrationData.AppendNode(cloned);
             return migrationData;            
-
         }
     }
 
@@ -6010,9 +6021,21 @@ namespace Dynamo.Nodes
         public static NodeMigrationData Migrate_0630_to_0700(NodeMigrationData data)
         {
             NodeMigrationData migrationData = new NodeMigrationData(data.Document);
-            migrationData.AppendNode(MigrationManager.CloneAndChangeType(
-                data.MigratedNodes.ElementAt(0), "DSCore.File.Filename"));
+            XmlElement original = data.MigratedNodes.ElementAt(0);
+            var cloned = MigrationManager.CloneAndChangeType(original, "DSCore.File.Filename");
 
+            var document = original.OwnerDocument;
+            foreach (XmlNode childNode in original.ChildNodes)
+            {
+                if (childNode.Name.Equals(typeof(string).FullName))
+                {
+                    var childElement = document.CreateElement(typeof(string).FullName);
+                    childElement.InnerText = childNode.Attributes[0].Value;
+                    cloned.AppendChild(childElement);
+                }
+            }
+
+            migrationData.AppendNode(cloned);
             return migrationData;            
         }
     }


### PR DESCRIPTION
Previously as `Dynamo.Nodes.StringFilename` and `StringDirectory` nodes were migrated, their child element `System.String` is dropped. This commit fixes the problem where this string value gets migrated over to the newly cloned node, updating its `InnerText` property (the new node does not make use of attribute).
