### PR TITLE
Temp fix: mark node as dirty when its connections are updated

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -734,7 +734,6 @@ namespace Dynamo.Models
             if (!Outputs.ContainsKey(portData))
                 Outputs[portData] = new HashSet<Tuple<int, NodeModel>>();
             Outputs[portData].Add(Tuple.Create(inputData, nodeLogic));
-            RequiresRecalc = true;
         }
 
         internal void DisconnectInput(int data)


### PR DESCRIPTION
Otherwise AST node won't be generated for the graph node that changes connection from one input node to the other input node . 
