### PR TITLE
Fix "Defect-MAGN-590.xml" that was mistakenly slowed down

### DIFF
--- a/test/core/recorded/Defect-MAGN-590.xml
+++ b/test/core/recorded/Defect-MAGN-590.xml
@@ -1,4 +1,4 @@
-<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="500">
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="750" CommandIntervalInMs="20">
   <CreateNodeCommand NodeId="8630afc1-3d59-4e76-9fca-faa12e6973ea" NodeName="Code Block" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
   <UpdateModelValueCommand ModelGuid="8630afc1-3d59-4e76-9fca-faa12e6973ea" Name="Code" Value="a=1;&#xD;&#xA;b=2;&#xD;&#xA;c=3;" />
   <CreateNodeCommand NodeId="90841beb-9dbe-4a75-9d26-19bd9bea8906" NodeName="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />


### PR DESCRIPTION
The slight pause should have been introduced after all the commands are done playing back (i.e. `PauseAfterPlaybackInMs`), not in between two commands (i.e. `CommandIntervalInMs`). That `500ms` slowdown accumulates to slow down the whole test. We need a pause after the final update so that background worker has a chance to finish the evaluation.
