### PR TITLE
Temporary disabled "UpdateRenderPackage" if it's called in unit test

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -2009,7 +2009,7 @@ namespace Dynamo.Models
         {
             //Avoid attempting an update after the controller 
             //has shut down.
-            if (dynSettings.Controller == null)
+            if (dynSettings.Controller == null || (DynamoController.IsTestMode))
                 return;
 
             //dispose of the current render package


### PR DESCRIPTION
Hi Ian, this is for you to look at. Not optimal for sure, but it gets the test cases `DynamoCoreUITests` going. I'm sure you'll be able to get to the bottom of this real soon when you wake up. This slowdown starts showing up with this commit, which led to me disabling this method call:

[Label map working for data collection AND IEnumerables](https://github.com/DynamoDS/Dynamo/commit/3cc5861882fba10d744dd2db027ca5cc23ceb790)

Thanks again, man.
