### PR TITLE
Add async dispatch to WebClient request

### DIFF
--- a/src/DynamoCore/UpdateManager/UpdateManager.cs
+++ b/src/DynamoCore/UpdateManager/UpdateManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.ComponentModel;
+using System.Threading;
 using System.Windows;
 using Dynamo.Interfaces;
 using Dynamo.UI;
@@ -118,9 +119,14 @@ namespace Dynamo.UpdateManager
             Data = string.Empty;
             Path = path;
 
-            var client = new WebClient();
-            client.OpenReadAsync(path);
-            client.OpenReadCompleted += ReadResult;
+            new Thread(() =>
+                {
+                    var client = new WebClient();
+
+                    client.OpenReadCompleted += ReadResult;
+                    client.OpenReadAsync(path);
+                }).Start();
+
         }
 
         /// <summary>


### PR DESCRIPTION
@ikeough Please review.

System.Net.WebClient appears to be rather buggy.

The OpenAsyncRead blocks the thread for around 12s if there is no network connection. Consequently it needs wrapping in another thread dispatch otherwise this becomes pure startup delay when, say, on an aircraft. This is contrary to what to what the documentation about WebClient says, where it explicitly claims this call doesn't block. http://msdn.microsoft.com/en-us/library/system.net.webclient.openreadasync(v=vs.110).aspx

I have written a series of simple reproduction cases to narrow the time sink down to precisely this call. Let me know if you need the demo code to reproduce on your end. The conditions I'm seeing it in are in a Parrallels Vm, anytime the Mac has its network card switched off.

Also, the callback handler (client.OpenReadCompleted += ReadResult;) should be registered before the call is dispatched, otherwise there is a race condition.

I'm not entirely sure if there are threading requirements on this that stop it being safe to run from an arbitrary thread, if there are, please don't accept this pull request, and let me know what thread marshalling you need and I'll add it in.

In general, we should not be doing expensive operations like opening a web client from a ctor. We can fix that with the update overhaul after 0.7.0.

Let me know what you think
