### PR TITLE
Not automatically update the graph if custom node is updated

### DIFF
--- a/src/DynamoCore/Core/CustomNodeDefinition.cs
+++ b/src/DynamoCore/Core/CustomNodeDefinition.cs
@@ -354,8 +354,9 @@ namespace Dynamo
                 topMost.Select(x => x.Item2.GetAstIdentifierForOutputIndex(x.Item1) as AssociativeNode).ToList(),
                 parameters);
 
-            if (success)
-                controller.UpdateGraph();
+            // Not update graph until Run 
+            // if (success)
+            //    controller.UpdateGraph();
         }
 
         #endregion

--- a/src/DynamoCore/Core/DynamoController.cs
+++ b/src/DynamoCore/Core/DynamoController.cs
@@ -384,7 +384,8 @@ namespace Dynamo
 
 
 #if USE_DSENGINE
-            if (!EngineController.GenerateGraphSyncData(DynamoViewModel.Model.HomeSpace.Nodes))
+            EngineController.GenerateGraphSyncData(DynamoViewModel.Model.HomeSpace.Nodes);
+            if (!EngineController.HasPendingGraphSyncData())
             {
                 return;
             }

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -2033,9 +2033,13 @@ namespace Dynamo.Models
             //{
                 foreach (var varName in drawableIds)
                 {
-                    var mirrorData = dynSettings.Controller.EngineController.GetMirror(varName).GetData();
-                    AddToLabelMap(mirrorData, labelMap, ident);
-                    count++;
+                    var mirror = dynSettings.Controller.EngineController.GetMirror(varName);
+                    if (mirror != null)
+                    {
+                        var mirrorData = mirror.GetData();
+                        AddToLabelMap(mirrorData, labelMap, ident);
+                        count++;
+                    }
                 } 
             //}
 

--- a/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
+++ b/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
@@ -11,6 +11,16 @@ using ProtoCore.Runtime;
 
 namespace ProtoCore.DSASM.Mirror
 {
+    public class SymbolNotFoundException: Exception
+    {
+        public SymbolNotFoundException(string symbolName)
+            : base("Cannot find symbol: " + symbolName)
+        {
+            this.SymbolName = symbolName;
+        }
+
+        public string SymbolName { get; private set; } 
+    }
 
     //Status: Draft, experiment
     
@@ -771,7 +781,11 @@ namespace ProtoCore.DSASM.Mirror
                 index = exe.runtimeSymbols[block].IndexOf(name, classcope, Constants.kInvalidIndex);
             }
 
-            if (index != Constants.kInvalidIndex)
+            if (Constants.kInvalidIndex == index)
+            {
+                throw new SymbolNotFoundException(name);
+            }
+            else
             {
                 if (exe.runtimeSymbols[block].symbolList[index].arraySizeList != null)
                 {
@@ -784,8 +798,6 @@ namespace ProtoCore.DSASM.Mirror
                 return retVal;
 
             }
-            throw new NotImplementedException("{F5ACC95F-AEC9-486D-BC82-FF2CB26E7E6A}"); //@TODO(Luke): Replace this with a symbol lookup exception
-
         }
 
         public void UpdateValue(int line, int index, int value)


### PR DESCRIPTION
This submission is to fix MAGN-1426 [Design] Should Updating the custom node definition propagate the update of already placed custom node without Pressing Run.

The fix is, if a custom node is modified, the graph won't be updated immediately (so function definition won't be injected into the VM and the update won't be triggered). Instead, the graph sync data will be queued until user clicks "Run" button. 
