### PR TITLE
Defined variables in CBN should include unbound variable that has input

### DIFF
--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -110,8 +110,24 @@ namespace Dynamo.Nodes
         public List<string> GetDefinedVariableNames()
         {
             var defVarNames = new List<string>();
+            
+            // For unbound identifier, if there is an input connect to it,
+            // it is defined variable. 
+            for (int i = 0; i < inputIdentifiers.Count; i++)
+            {
+                var unboundIdentifier = inputIdentifiers[i];
+                if (this.Inputs.ContainsKey(i))
+                {
+                    defVarNames.Add(unboundIdentifier);
+                }
+            }
+
+            // Then get all variabled on the LHS of the statements
             foreach (Statement stmnt in codeStatements)
+            {
                 defVarNames.AddRange(Statement.GetDefinedVariableNames(stmnt, true));
+            }
+
             return defVarNames;
         }
 


### PR DESCRIPTION
This submission is to fix MAGN-2169 Adding imperative code block node in Dynamo breaks VM. 

To find out whether a variable has been defined or not in other CBN, we should include those unbound variables but have inputs, these unbound variables should be treated as defined variables as well.
