### PR TITLE
Use "AreEqual" instead of "IsTrue" to display specific double value

### DIFF
--- a/test/DynamoCoreTests/DSEvaluationTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationTest.cs
@@ -129,7 +129,7 @@ namespace Dynamo.Tests
             else if (value is int)
                 Assert.AreEqual((int)value, Convert.ToInt32(data.Data));
             else if (value is double)
-                Assert.IsTrue(Math.Abs((double)value - Convert.ToDouble(data.Data)) < 0.00001);
+                Assert.AreEqual((double)value, Convert.ToDouble(data.Data), 0.00001);
             else
                 Assert.AreEqual(value, data.Data);
         }


### PR DESCRIPTION
Currently the following test cases fail with one error message: `Expected: True`. That doesn't quite tell what is the resulting value, only `True` or `False`. This request fixes that by using `Assert.AreEqual` (instead of the current `Assert.IsTrue`) method.

```
Dynamo.Tests.CoreDynTests.AddSubtractMapReduceFilterBasic
Dynamo.Tests.CoreDynTests.Cosine
Dynamo.Tests.CoreDynTests.OrNode
Dynamo.Tests.CoreDynTests.Repeat
Dynamo.Tests.CoreDynTests.Sine
Dynamo.Tests.CoreDynTests.Tangent
Dynamo.Tests.CustomNodes.FilterWithCustomNode
Dynamo.Tests.CustomNodes.MultipleOutputs
Dynamo.Tests.CustomNodes.PartialApplicationWithMultipleOutputs
Dynamo.Tests.DSLibraryTest.TestLibraryAcrossSessions
Dynamo.Tests.ListTests.Combine_ComplexTest
Dynamo.Tests.ListTests.Smooth_InputListNode
Dynamo.Tests.ListTests.Smooth_SimpleTest
Dynamo.Tests.ListTests.Sort_NumbersfFromDiffInput
Dynamo.Tests.ListTests.SortBy_SimpleTest
Dynamo.Tests.UI.CoreUserInterfaceTests.PreferenceSetting
```
