### PR TITLE
Submitting for build failure

### DIFF
--- a/src/Libraries/DynamoWatch3D/Watch3D.csproj
+++ b/src/Libraries/DynamoWatch3D/Watch3D.csproj
@@ -34,10 +34,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FScheme">
-      <HintPath>..\..\..\bin\AnyCPU\Debug\FScheme.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="FSharp.Core" />
     <Reference Include="HelixToolkit.Wpf">
       <HintPath>..\..\..\extern\Helix3D\NET40\HelixToolkit.Wpf.dll</HintPath>
@@ -64,6 +60,10 @@
       <Project>{7858FA8C-475F-4B8E-B468-1F8200778CF8}</Project>
       <Name>DynamoCore</Name>
       <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Legacy\FScheme\FScheme.2012.fsproj"> 
+      <Project>{f0e5a3e5-bdd0-41ae-848e-ded9efc5fa7f}</Project>
+      <Name>FScheme.2012</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
The value of FScheme.dll is hardcoded to point to debug folder. This causes failure during compilation- So change reference path to point to the FSchem.2012 project which will be picked up at Compile time based on configuration

Submitting on behalf of Monika
