### PR TITLE
Fix MAGN2228, avoid the flood of symbol redefinition warnings in CBN

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -719,7 +719,7 @@ namespace ProtoAssociative
             //AppendInstruction(instr, line, col);
             updatePcDictionary(line, col);
         }
-		
+        
         protected override void EmitRetb( int line = ProtoCore.DSASM.Constants.kInvalidIndex, int col = ProtoCore.DSASM.Constants.kInvalidIndex,
             int endline = ProtoCore.DSASM.Constants.kInvalidIndex, int endcol = ProtoCore.DSASM.Constants.kInvalidIndex)
         {
@@ -738,7 +738,7 @@ namespace ProtoAssociative
             updatePcDictionary(line, col);
         }
 
-		protected override void EmitRetcn(int blockId = Constants.kInvalidIndex, int line = ProtoCore.DSASM.Constants.kInvalidIndex, int col = ProtoCore.DSASM.Constants.kInvalidIndex,
+        protected override void EmitRetcn(int blockId = Constants.kInvalidIndex, int line = ProtoCore.DSASM.Constants.kInvalidIndex, int col = ProtoCore.DSASM.Constants.kInvalidIndex,
             int endline = ProtoCore.DSASM.Constants.kInvalidIndex, int endcol = ProtoCore.DSASM.Constants.kInvalidIndex)
         {
             Instruction instr = new Instruction();
@@ -756,7 +756,7 @@ namespace ProtoAssociative
             //AppendInstruction(instr, line, col);
             updatePcDictionary(line, col);
         }
-		
+        
         protected override void EmitReturn(int line = ProtoCore.DSASM.Constants.kInvalidIndex, int col = ProtoCore.DSASM.Constants.kInvalidIndex,
             int endline = ProtoCore.DSASM.Constants.kInvalidIndex, int endcol = ProtoCore.DSASM.Constants.kInvalidIndex)
         {
@@ -2203,8 +2203,8 @@ namespace ProtoAssociative
             end
             if node is functioncall
                 foreach arg in functioncallArgs
-	                def ssastack[]
-	                def astlist[]
+                    def ssastack[]
+                    def astlist[]
                     DFSEmit_SSA_AST(ref arg, ssastack, astlist)
                 end
             end
@@ -3371,7 +3371,7 @@ namespace ProtoAssociative
             else
                 // Update the existing entry
                 exprIdFlagList[exprUID] = kvp.value
- 	        end
+            end
         end
 
         */
@@ -3931,8 +3931,11 @@ namespace ProtoAssociative
                 {
                     if (compilePass > AssociativeCompilePass.kClassName && !ssaTransformed)
                     {
-                        //Audit class table for multiple symbol definition and emit warning.
-                        this.core.ClassTable.AuditMultipleDefinition(this.core.BuildStatus);
+                        if (!core.IsParsingCodeBlockNode && !core.Options.IsDeltaExecution)
+                        {
+                            //Audit class table for multiple symbol definition and emit warning.
+                            this.core.ClassTable.AuditMultipleDefinition(this.core.BuildStatus);
+                        }
                         codeblock.Body = BuildSSA(codeblock.Body, context);
                         ssaTransformed = true;
                         if (core.Options.DumpIL)
@@ -4203,17 +4206,17 @@ namespace ProtoAssociative
 
         /*
          proc EmitIdentNode(identnode, graphnode)
-	        if ssa
-		        // Check an if this identifier is array indexed
-		        // The array index is a secondary property and is not the original array property of the AST. this is required because this array index is meant only to resolve graphnode dependency with arrays
-		        if node.arrayindex.secondary is valid
-			        dimension = traverse(node.arrayindex.secondary)
+            if ssa
+                // Check an if this identifier is array indexed
+                // The array index is a secondary property and is not the original array property of the AST. this is required because this array index is meant only to resolve graphnode dependency with arrays
+                if node.arrayindex.secondary is valid
+                    dimension = traverse(node.arrayindex.secondary)
 
-			        // Create a new dependent with the array indexing
-			        dependent = new GraphNode(identnode.name, dimension)
-			        graphnode.pushdependent(dependent)
-		        end
-	        end
+                    // Create a new dependent with the array indexing
+                    dependent = new GraphNode(identnode.name, dimension)
+                    graphnode.pushdependent(dependent)
+                end
+            end
         end
 
          */
@@ -7401,9 +7404,9 @@ namespace ProtoAssociative
         //          // list stored in the first procedure found in the assignment expression
         //          foreach noderef in firstProc.updatedProperties	
         //              def n = graphnode.firstProcRefIndex
-	    //              def autogenRef = updateNodeRef[n]
+        //              def autogenRef = updateNodeRef[n]
         //              autogenRef.append(noderef)
-	    //              graphnode.pushUpdateRef(autogenRef)
+        //              graphnode.pushUpdateRef(autogenRef)
         //          end
         //      end
         //  end
@@ -7960,7 +7963,7 @@ namespace ProtoAssociative
                     def lefttype = invalid
                     def updateNodeRef = null 
                     dfsgetsymbollist(node.left, lefttype, updateNodeRef)
-	
+    
                     // Get the first procedure call in the rhs
                     // This stack is populated on traversing the entire RHS
                     def firstProc = functionCallStack.first()
@@ -7994,29 +7997,29 @@ namespace ProtoAssociative
                 ssaPtrList = new List
 
                 proc EmitBinaryExpression(bnode, graphnode)
-	                if bnode is assignment
+                    if bnode is assignment
                         graphnode = new graphnode
 
                         if bnode is an SSA pointer expression
-	                        if bnode.rhs is an identifier
-		                        // Push the start pointer
-		                        ssaPtrList.push(node.rhs)
-	                        else if bnode.rhs is an identifierlist
-		                        // Push the rhs of the dot operator
-		                        ssaPtrList.push(node.rhs.rhs)
-	                        else
-		                        Assert unhandled
-	                        end
+                            if bnode.rhs is an identifier
+                                // Push the start pointer
+                                ssaPtrList.push(node.rhs)
+                            else if bnode.rhs is an identifierlist
+                                // Push the rhs of the dot operator
+                                ssaPtrList.push(node.rhs.rhs)
+                            else
+                                Assert unhandled
+                            end
                         end
 
-		                emit(bnode.rhs)
+                        emit(bnode.rhs)
                         emit(bnode.lhs)
 
                         if (bnode is an SSA pointer expression 
                             and bnode is the last expression in the SSA factor/term
-	                        ssaPtrList.Clear()
+                            ssaPtrList.Clear()
                         end
-	                end
+                    end
                 end
 
             */
@@ -8913,12 +8916,12 @@ namespace ProtoAssociative
             TryBlockNode tryNode = exceptionNode.tryBlock;
             Validity.Assert(tryNode != null);
             foreach (var subnode in tryNode.body)
-	        {
-		        ProtoCore.Type inferedType = new ProtoCore.Type();
+            {
+                ProtoCore.Type inferedType = new ProtoCore.Type();
                 inferedType.UID = (int) ProtoCore.PrimitiveType.kTypeVar;
                 inferedType.IsIndexable = false;
                 DfsTraverse(subnode, ref inferedType, false, graphNode, subPass);
-	        }
+            }
             exceptionHandler.EndPc = pc;
 
             // Jmp to code after catch block


### PR DESCRIPTION
Fix show-stopper defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2228#: CBN not usable if Dynamo running on top of Revit.
