### PR TITLE
Fix regressed test case CoreDynTests.MultipleOutputs

### DIFF
--- a/test/DynamoCoreTests/CoreDynTests.cs
+++ b/test/DynamoCoreTests/CoreDynTests.cs
@@ -72,7 +72,7 @@ namespace Dynamo.Tests
             Dictionary<int, object> validationData = new Dictionary<int,object>()
             {
 
-                {1,0},
+                {0,0},
             };
 
             SelectivelyAssertPreviewValues("a4d6ecce-0fe7-483d-a4f2-cd8cddefa25c", validationData);


### PR DESCRIPTION
List.RestOfItems returns multiple values in a dictionary. Irony this test case passed because it didn't return value properly (not returning a dictionary). Fix the validation of value. Test framework also needs enhancement to handle the validation of dictionary.  
