### PR TITLE
Fixes Null marshaling in collection and List tests

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
@@ -63,6 +63,9 @@ namespace ProtoFFI
                 case ProtoCore.PrimitiveType.kTypeVoid:
                     protoType.Name = ProtoCore.DSDefinitions.Keyword.Void;
                     break;
+                case ProtoCore.PrimitiveType.kTypeNull:
+                    protoType.Name = ProtoCore.DSDefinitions.Keyword.Null;
+                    break;
                 default:
                     throw new NotSupportedException(string.Format("Primitive type {0} is not supported for marshaling.", type));
             }
@@ -288,8 +291,12 @@ namespace ProtoFFI
 
         #region CS_ARRAY_TO_DS_ARRAY
 
-        private ProtoCore.Type GetApproxDSType(System.Type type)
+        private ProtoCore.Type GetApproxDSType(object obj)
         {
+            if (null == obj)
+                return CreateType(ProtoCore.PrimitiveType.kTypeNull);
+
+            Type type = obj.GetType();
             if(type == typeof(string))
                 return StringMarshaler.kType;
             ProtoCore.Type dsType;
@@ -321,7 +328,7 @@ namespace ProtoFFI
 
             foreach (var item in collection)
             {
-                ProtoCore.Type dsType = GetApproxDSType(item.GetType());
+                ProtoCore.Type dsType = GetApproxDSType(item);
                 StackValue value = primitiveMarshaler.Marshal(item, context, dsi, dsType);
                 sv[index] = value;
                 ++index;
@@ -337,7 +344,7 @@ namespace ProtoFFI
 
             foreach (var item in enumerable)
             {
-                ProtoCore.Type dsType = GetApproxDSType(item.GetType());
+                ProtoCore.Type dsType = GetApproxDSType(item);
                 StackValue value = primitiveMarshaler.Marshal(item, context, dsi, dsType);
                 svs.Add(value);
             }
@@ -358,11 +365,11 @@ namespace ProtoFFI
             {
                 var value = dictionary[key];
 
-                ProtoCore.Type keyType = GetApproxDSType(key.GetType());
+                ProtoCore.Type keyType = GetApproxDSType(key);
                 StackValue dsKey = primitiveMarshaler.Marshal(key, context, dsi, keyType);
                 GCUtils.GCRetain(dsKey, core);
 
-                ProtoCore.Type valueType = GetApproxDSType(value.GetType());
+                ProtoCore.Type valueType = GetApproxDSType(value);
                 StackValue dsValue = primitiveMarshaler.Marshal(value, context, dsi, valueType);
                 GCUtils.GCRetain(dsValue, core);
 

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -19,7 +19,7 @@ namespace DSCore
         /// <returns name="list">Filtered list.</returns>
         /// <search>unique, remove, duplicates</search>
         public static IList UniqueItems(
-            [ArbitraryDimensionArrayImport] IList list)
+            IList list)
         {
             return list.Cast<object>().Distinct().ToList();
         }
@@ -32,7 +32,7 @@ namespace DSCore
         /// <returns name="bool">Whether list contains the given item.</returns>
         /// <search>contains,item,search</search>
         public static bool ContainsItem(
-            [ArbitraryDimensionArrayImport] IList list, 
+            IList list, 
             object item)
         {
             return list.Contains(item);
@@ -45,7 +45,7 @@ namespace DSCore
         /// <returns name="list">New list.</returns>
         /// <search>reverse,flip</search>
         public static IList Reverse(
-            [ArbitraryDimensionArrayImport] IList list)
+            IList list)
         {
             return list.Cast<object>().Reverse().ToList();
         }
@@ -74,8 +74,8 @@ namespace DSCore
         /// <returns name="lists">Sublists of the given list.</returns>
         /// <search>sub,sublist,build</search>
         public static IList Sublists(
-            [ArbitraryDimensionArrayImport] IList list,
-            [ArbitraryDimensionArrayImport] IList ranges,
+            IList list,
+            IList ranges,
             int offset)
         {
             var result = new List<object>();
@@ -114,8 +114,7 @@ namespace DSCore
         /// <param name="list">List to be sorted.</param>
         /// <returns name="list">Sorted list.</returns>
         /// <search>sort,order</search>
-        public static IList Sort(
-            [ArbitraryDimensionArrayImport] IList list)
+        public static IList Sort(IList list)
         {
             return list.Cast<object>().OrderBy(x => x).ToList();
         }
@@ -126,8 +125,7 @@ namespace DSCore
         /// <param name="list">List to take the minimum value from.</param>
         /// <returns name="min">Minimum value from the list.</returns>
         /// <search>min,minimum,least,smallest</search>
-        public static object MinimumItem(
-            [ArbitraryDimensionArrayImport] IList list)
+        public static object MinimumItem(IList list)
         {
             return list.Cast<object>().Min();
         }
@@ -138,8 +136,7 @@ namespace DSCore
         /// <param name="list">List to take the maximum value from.</param>
         /// <returns name="max">Maximum value from the list.</returns>
         /// <search>max,maximum,greatest,largest,biggest</search>
-        public static object MaximumItem(
-            [ArbitraryDimensionArrayImport] IList list)
+        public static object MaximumItem(IList list)
         {
             return list.Cast<object>().Max();
         }
@@ -156,8 +153,8 @@ namespace DSCore
         [MultiReturn("in", "var[]..[]")]
         [MultiReturn("out", "var[]..[]")]
         public static Dictionary<string, object> FilterByBoolMask(
-            [ArbitraryDimensionArrayImport] IList list,
-            [ArbitraryDimensionArrayImport] IList mask)
+            IList list,
+            IList mask)
         {
             var result = FilterByMaskHelper(list.Cast<object>(), mask.Cast<object>());
 
@@ -206,7 +203,7 @@ namespace DSCore
         [MultiReturn("first", "var[]..[]")]
         [MultiReturn("rest", "var[]..[]")]
         public static IDictionary Deconstruct(
-            [ArbitraryDimensionArrayImport] IList list)
+            IList list)
         {
             return new Dictionary<string, object>
             {
@@ -223,8 +220,8 @@ namespace DSCore
         /// <returns name="list">New list.</returns>
         /// <search>insert,add,item,front</search>
         public static IList AddItemToFront(
-            object item,
-            [ArbitraryDimensionArrayImport] IList list)
+            [ArbitraryDimensionArrayImport] object item,
+            IList list)
         {
             var newList = new ArrayList { item };
             newList.AddRange(list);
@@ -241,7 +238,7 @@ namespace DSCore
         /// <returns name="list">List of extracted items.</returns>
         /// <search>take,get,sub,sublist</search>
         public static IList TakeItems(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int amount)
         {
             var genList = list.Cast<object>();
@@ -258,7 +255,7 @@ namespace DSCore
         /// <returns name="list">List of remaining items.</returns>
         /// <search>drop,remove</search>
         public static IList DropItems(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int amount)
         {
             var genList = list.Cast<object>();
@@ -275,7 +272,7 @@ namespace DSCore
         /// <returns name="list">Shifted list.</returns>
         /// <search>shift</search>
         public static IList ShiftIndices(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int amount)
         {
             if (amount == 0)
@@ -296,7 +293,7 @@ namespace DSCore
         /// <returns name="item">Item in the list at the given index.</returns>
         /// <search>get,item,index,fetch</search>
         public static object GetItemAtIndex(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int index)
         {
             return list[index];
@@ -315,7 +312,7 @@ namespace DSCore
         /// <returns name="items">Items in the slice of the given list.</returns>
         /// <search>list,sub,sublist,slice</search>
         public static IList Slice(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int? start = null,
             int? count = null,
             int step = 1)
@@ -382,12 +379,10 @@ namespace DSCore
         /// <returns name="list">List with items removed.</returns>
         /// <search>remove,index,indices,cull</search>
         public static IList RemoveItemAtIndex(
-            [ArbitraryDimensionArrayImport] IList list,
-            [ArbitraryDimensionArrayImport] object indices)
+            IList list,
+            int[] indices)
         {
-            return indices is ICollection
-                ? list.Cast<object>().Where((_, i) => !((IList)indices).Contains(i)).ToList()
-                : list.Cast<object>().Where((_, i) => i != (int)indices).ToList();
+            return list.Cast<object>().Where((_, i) => !indices.Contains(i)).ToList();
         }
 
         /// <summary>
@@ -402,7 +397,7 @@ namespace DSCore
         /// <returns name="list">List with items removed.</returns>
         /// <search>drop,nth,remove,cull,every</search>
         public static IList DropEveryNthItem(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int n,
             int offset = 0)
         {
@@ -424,7 +419,7 @@ namespace DSCore
         /// <returns name="items">Items from the list.</returns>
         /// <search>fetch,take,every,nth</search>
         public static IList TakeEveryNthItem(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int n,
             int offset = 0)
         {
@@ -448,7 +443,7 @@ namespace DSCore
         /// <returns name="bool">Whether the list is empty.</returns>
         /// <search>test,is,empty</search>
         public static bool IsEmpty(
-            [ArbitraryDimensionArrayImport] IList list)
+            IList list)
         {
             return list.Count == 0;
         }
@@ -460,7 +455,7 @@ namespace DSCore
         /// <returns name="count">List length.</returns>
         /// <search>list,length,count</search>
         public static int Count(
-            [ArbitraryDimensionArrayImport] IList list)
+            IList list)
         {
             return list.Count;
         }
@@ -487,7 +482,7 @@ namespace DSCore
         /// <returns name="item">First item in the list.</returns>
         /// <search>get,fetch,first,item</search>
         public static object FirstItem(
-            [ArbitraryDimensionArrayImport] IList list)
+            IList list)
         {
             return list[0];
         }
@@ -499,7 +494,7 @@ namespace DSCore
         /// <returns name="rest">Rest of the list.</returns>
         /// <search>get,fetch,rest</search>
         public static IList RestOfItems(
-            [ArbitraryDimensionArrayImport] IList list)
+            IList list)
         {
             return list.Cast<object>().Skip(1).ToList();
         }
@@ -512,7 +507,7 @@ namespace DSCore
         /// <returns name="lists">List of lists.</returns>
         /// <search>chop</search>
         public static IList Chop(
-            [ArbitraryDimensionArrayImport] IList list, 
+            IList list, 
             int subLength)
         {
             if (list.Count < subLength)
@@ -549,7 +544,7 @@ namespace DSCore
         /// <returns name="diagonals">Lists of elements along matrix diagonals.</returns>
         /// <search>diagonal,right,matrix</search>
         public static IList DiagonalRight(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int subLength)
         {
             object[] flatList = null;
@@ -614,7 +609,7 @@ namespace DSCore
         /// <returns name="diagonals">Lists of elements along matrix diagonals.</returns>
         /// <search>diagonal,left,matrix</search>
         public static IList DiagonalLeft(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int rowLength)
         {
             object[] flatList = null;
@@ -724,7 +719,7 @@ namespace DSCore
         /// <returns name="list">List of repeated lists.</returns>
         /// <search>repeat,repeated,duplicate</search>
         public static IList Repeat(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int amount)
         {
             var result = new ArrayList();
@@ -743,7 +738,7 @@ namespace DSCore
         /// <returns name="last">Last item in the list.</returns>
         /// <search>get,fetch,last,item</search>
         public static object LastItem(
-            [ArbitraryDimensionArrayImport] IList list)
+            IList list)
         {
             if (list.Count == 0)
                 throw new ArgumentException("Cannot get the last item in an empty list.", "list");
@@ -758,7 +753,7 @@ namespace DSCore
         /// <returns name="list">Randomized list.</returns>
         /// <search>random,randomize,shuffle,jitter</search>
         public static IList Shuffle(
-            [ArbitraryDimensionArrayImport] IList list)
+            IList list)
         {
             var rng = new Random();
             return list.Cast<object>().OrderBy(_ => rng.Next()).ToList();
@@ -772,7 +767,7 @@ namespace DSCore
         /// <returns name="perm">Permutations of the list of the given length.</returns>
         /// <search>permutation,permutations</search>
         public static IList Permutations(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int? length = null)
         {
             return
@@ -793,7 +788,7 @@ namespace DSCore
         /// <returns name="comb">Combinations of the list of the given length.</returns>
         /// <search>combination,combinations</search>
         public static IList Combinations(
-            [ArbitraryDimensionArrayImport] IList list,
+            IList list,
             int length,
             bool replace = false)
         {

--- a/src/Migrations/CoreNodes/dynBaseTypes.cs
+++ b/src/Migrations/CoreNodes/dynBaseTypes.cs
@@ -830,7 +830,7 @@ namespace Dynamo.Nodes
             //create the node itself
             XmlElement dsCoreNode = MigrationManager.CreateFunctionNodeFrom(oldNode);
             MigrationManager.SetFunctionSignature(dsCoreNode, "DSCoreNodes.dll",
-                "List.RemoveItemsAtIndices", "List.RemoveItemsAtIndices@var[]..[],var[]");
+                "List.RemoveItemAtIndex", "List.RemoveItemAtIndex@var[]..[],int[]");
 
             migratedData.AppendNode(dsCoreNode);
             string dsCoreNodeId = MigrationManager.GetGuidFromXmlElement(dsCoreNode);

--- a/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
@@ -467,5 +467,23 @@ d2 = TestData.SumList({1, 2, {3, 4}, {5, {6, {7}}}});
             code = string.Format("import(\"{0}\");\r\n{1}", dummy.AssemblyQualifiedName, code);
             ExecuteAndVerify(code, data);
         }
+
+        [Test]
+        public void Test_MarshalingNullInCollection()
+        {
+            string code = @"
+                     list = {1, null, ""test"", true, 3.5};
+                     l1 = TestData.AddItemToFront(null, list);
+                     l2 = TestData.AddItemToFront(list, list);";
+            ValidationData[] data = 
+            { 
+                new ValidationData { ValueName = "l1", ExpectedValue = new object[] {null, 1, null, "test", true, 3.5}} ,
+                new ValidationData { ValueName = "l2", ExpectedValue = new object[] {new object[]{1, null, "test", true, 3.5}, 1, null, "test", true, 3.5}} , 
+            };
+
+            Type dummy = typeof(FFITarget.TestData);
+            code = string.Format("import(\"{0}\");\r\n{1}", dummy.AssemblyQualifiedName, code);
+            ExecuteAndVerify(code, data);
+        }
     }
 }


### PR DESCRIPTION
- CollectionMarshaler was throwing exception when any item was null
  while getting the approx DS type of the items in the collection. Fixed
  this by proper null check.
- Removed ArbitraryDimensionArrayImport from IList parameters as by
  default IList will be marshaled as arbitrary dimension array.
- ArbitraryDimensionArrayImport attribute is applied to item parameter
  of AddItemToFront method, so that a collection can be added to the front
  of the list.
- indices parameter of method List.RemoveItemAtIndex is changed to int[]
  from object so that only integers are passed. VM will automatically
  promote single object to a collection while calling this method.
