### PR TITLE
Marshaling of generic IEnumerable

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
@@ -256,8 +256,12 @@ namespace ProtoFFI
         public override object UnMarshal(StackValue dsObject, ProtoCore.Runtime.Context context, Interpreter dsi, Type expectedCLRType)
         {
             Type arrayType = expectedCLRType;
-            if(expectedCLRType.IsGenericType)
-                arrayType = expectedCLRType.GetGenericArguments()[0].MakeArrayType();
+            Type elementType = GetElementType(expectedCLRType);
+            if (expectedCLRType.IsGenericType)
+            {
+                elementType = expectedCLRType.GetGenericArguments()[0];
+                arrayType = elementType.MakeArrayType();
+            }
 
             ICollection collection = null;
             //If dsObject is non array pointer but the expectedCLRType is IEnumerable, promote the dsObject to a collection.
@@ -270,23 +274,22 @@ namespace ProtoFFI
             else //Convert DS Array to CS Collection
                 collection = ToICollection(dsObject, context, dsi, arrayType);
 
-            if (typeof(ICollection).IsAssignableFrom(expectedCLRType) && expectedCLRType.IsGenericType)
-                return Activator.CreateInstance(expectedCLRType, new[] { collection });
-
-            if (expectedCLRType.IsArray)
+            if (expectedCLRType.IsArray || expectedCLRType.IsGenericType)
             {
                 ArrayList list = collection as ArrayList;
                 if (null != list)
-                {
-                    var elementType = expectedCLRType.GetElementType();
-                    if (elementType == null)
-                        elementType = typeof(object);
-
                     return list.ToArray(elementType);
-                }
             }
 
             return collection;
+        }
+
+        private static Type GetElementType(Type expectedCLRType)
+        {
+            var elementType = expectedCLRType.GetElementType();
+            if (elementType == null)
+                elementType = typeof(object);
+            return elementType;
         }
 
         #region CS_ARRAY_TO_DS_ARRAY

--- a/test/Engine/FFITarget/DummyGeometry.cs
+++ b/test/Engine/FFITarget/DummyGeometry.cs
@@ -33,6 +33,11 @@ namespace FFITarget
         {
             return DummyPoint.ByCoordinates(X + direction.X, Y + direction.Y, Z + direction.Z);
         }
+
+        public static DummyPoint Centroid(IList<DummyPoint> points)
+        {
+            return ByCoordinates(points.Average(p => p.X), points.Average(p => p.Y), points.Average(p => p.Z));
+        }
     }
 
     public class DummyVector

--- a/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
@@ -261,6 +261,22 @@ namespace ProtoFFITests
         }
 
         [Test]
+        public void TestMarshalingIEnumerableOfDummyPoint()
+        {
+            String code =
+            @"
+               points = DummyPoint.ByCoordinates(1..5, 0, 0);
+               centroid = DummyPoint.Centroid(points);
+               x = centroid.X;
+            ";
+            Type t = typeof(FFITarget.DummyPoint);
+            code = string.Format("import(\"{0}\");\r\n{1}", t.AssemblyQualifiedName, code);
+            ValidationData[] data = { new ValidationData { ValueName = "x", ExpectedValue = 3.0, BlockIndex = 0 },
+                                    };
+            ExecuteAndVerify(code, data);
+        }
+
+        [Test]
         public void TestArrayPromotion()
         {
             String code =


### PR DESCRIPTION
Fixing defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2292

Extracted element type from generic type and used that to construct
array, so that the typed array can be converted to IEnumerable<T>
