### PR TITLE
Generate the final ssa binary assignment node after the rhs is transformed

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -2804,27 +2804,28 @@ namespace ProtoAssociative
             if (node is BinaryExpressionNode)
             {
                 BinaryExpressionNode astBNode = node as BinaryExpressionNode;
-                BinaryExpressionNode bnode = new BinaryExpressionNode();
+                AssociativeNode leftNode = null;
+                AssociativeNode rightNode = null;
+                bool isSSAAssignment = false;
                 if (ProtoCore.DSASM.Operator.assign == astBNode.Optr)
                 {
-                    bnode.Optr = ProtoCore.DSASM.Operator.assign;
-                    bnode.LeftNode = astBNode.LeftNode;
+                    leftNode = astBNode.LeftNode;
                     DFSEmitSSA_AST(astBNode.RightNode, ssaStack, ref astlist);
                     AssociativeNode assocNode = ssaStack.Pop();
 
                     if (assocNode is BinaryExpressionNode)
                     {
-                        bnode.RightNode = (assocNode as BinaryExpressionNode).LeftNode;
+                        rightNode = (assocNode as BinaryExpressionNode).LeftNode;
                     }
                     else
                     {
-                        bnode.RightNode = assocNode;
+                        rightNode = assocNode;
                     }
 
-                    bnode.isSSAAssignment = false;
+                    isSSAAssignment = false;
                 }
                 else
-                { 
+                {
                     BinaryExpressionNode tnode = new BinaryExpressionNode();
                     tnode.Optr = astBNode.Optr;
 
@@ -2836,17 +2837,20 @@ namespace ProtoAssociative
                     tnode.LeftNode = prevnode is BinaryExpressionNode ? (prevnode as BinaryExpressionNode).LeftNode : prevnode;
                     tnode.RightNode = lastnode is BinaryExpressionNode ? (lastnode as BinaryExpressionNode).LeftNode : lastnode;
 
-                    bnode.Optr = ProtoCore.DSASM.Operator.assign; 
 
                     // Left node
                     var identNode = nodeBuilder.BuildIdentfier(ProtoCore.Utils.CoreUtils.BuildSSATemp(core));
-                    bnode.LeftNode = identNode;
+                    leftNode = identNode;
 
                     // Right node
-                    bnode.RightNode = tnode;
+                    rightNode = tnode;
 
-                    bnode.isSSAAssignment = true;
+                    isSSAAssignment = true;
                 }
+
+                BinaryExpressionNode bnode = new BinaryExpressionNode(leftNode, rightNode, ProtoCore.DSASM.Operator.assign);
+                bnode.isSSAAssignment = isSSAAssignment;
+
                 astlist.Add(bnode);
                 ssaStack.Push(bnode);
             }

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -2063,16 +2063,10 @@ namespace ProtoCore.DSASM
                     bool allowSSADownstream = false;
                     if (core.Options.ExecuteSSA)
                     {
-                        //allowSSADownstream = graphNode.UID > executingGraphNode.UID;
-
-                        // Is within the same ssa range
+                        // Check if we allow downstream update
                         if (exprUID == graphNode.exprUID)
                         {
-                            // Make sure these are valid subscripts - Assert perhaps?
-                            if (graphNode.SSASubscript != ProtoCore.DSASM.Constants.kInvalidIndex && executingGraphNode.SSASubscript != ProtoCore.DSASM.Constants.kInvalidIndex)
-                            {
-                                allowSSADownstream = graphNode.SSASubscript > executingGraphNode.SSASubscript;
-                            }
+                            allowSSADownstream = graphNode.AstID > executingGraphNode.AstID;
                         }
                     }
 

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -2931,6 +2931,34 @@ z=Point.ByCoordinates(y,a,a);
 
         }
 
+        [Test]
+        public void TestCodeblockModification08()
+        {
+            List<string> codes = new List<string>() 
+            {
+                "a = 1;",
+                "x = a; x = x + 1;",
+                "a = 2;"
+            };
+
+            Guid guid1 = System.Guid.NewGuid();
+            Guid guid2 = System.Guid.NewGuid();
+
+            List<Subtree> added = new List<Subtree>();
+            added.Add(CreateSubTreeFromCode(guid1, codes[0]));
+            added.Add(CreateSubTreeFromCode(guid2, codes[1]));
+            var syncData = new GraphSyncData(null, added, null);
+            astLiveRunner.UpdateGraph(syncData);
+            AssertValue("x", 2);
+
+
+            // Modify the CBN
+            List<Subtree> modified = new List<Subtree>();
+            modified.Add(CreateSubTreeFromCode(guid1, codes[2]));
+            syncData = new GraphSyncData(null, null, modified);
+            astLiveRunner.UpdateGraph(syncData);
+            AssertValue("x", 3);
+        }
 
         [Test]
         public void TestEmptyCodeblock01()


### PR DESCRIPTION
1. Delay generation of final ssa after the rhs is transformed
2. Downstream update only requires checking the graph ast ID
3. Testcase for modifying the operand of an increment operation
