### PR TITLE
Remove object class related methods while importing.

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -372,7 +372,7 @@ namespace ProtoFFI
                     continue;
 
                 //Don't include overriden methods or generic methods
-                if (m.IsPublic && !m.IsGenericMethod && (m == m.GetBaseDefinition() || (m.GetBaseDefinition().DeclaringType == baseType && baseType == typeof(Object))))
+                if (m.IsPublic && !m.IsGenericMethod && m == m.GetBaseDefinition())
                 {
                     AssociativeNode node = ParseAndRegisterFunctionPointer(isDisposable, ref hasDisposeMethod, m);
                     classnode.funclist.Add(node);


### PR DESCRIPTION
- Fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2112
- methods ToString(), GetHashCode(), Equals(), GetType() are removed from import.
