### PR TITLE
Hide functions whose names start with double underscores

### DIFF
--- a/src/DynamoCore/Library/Library.cs
+++ b/src/DynamoCore/Library/Library.cs
@@ -903,6 +903,8 @@ namespace Dynamo.DSEngine
             foreach (var function in functions)
             {
                 string qualifiedName = function.QualifiedName;
+                if (CoreUtils.StartsWithDoubleUnderscores(qualifiedName))
+                    continue;
                 FunctionGroup functionGroup;
                 if (!_builtinFunctionGroups.TryGetValue(qualifiedName, out functionGroup))
                 {
@@ -1001,7 +1003,8 @@ namespace Dynamo.DSEngine
             }
 
             string procName = proc.name;
-            if (CoreUtils.IsSetter(procName) || CoreUtils.IsDisposeMethod(procName))
+            if (CoreUtils.IsSetter(procName) || CoreUtils.IsDisposeMethod(procName) ||
+                CoreUtils.StartsWithDoubleUnderscores(procName))
             { 
                 return;
             }

--- a/src/Engine/ProtoCore/DSASM/DSasmDefs.cs
+++ b/src/Engine/ProtoCore/DSASM/DSasmDefs.cs
@@ -522,6 +522,7 @@ namespace ProtoCore.DSASM
         public const string kTempProcLeftVar = "%temp_proc_var_";
         public const string kImportData = "ImportData";
         public const char kLongestPostfix = 'L';
+        public const string kDoubleUnderscores = "__";
     }
 
     public enum MemoryRegion

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -466,6 +466,12 @@ namespace ProtoCore.Utils
             return propertyName.StartsWith(ProtoCore.DSASM.Constants.kSetterPrefix);
         }
 
+        public static bool StartsWithDoubleUnderscores(string name)
+        {
+            Validity.Assert(null != name);
+            return name.StartsWith(ProtoCore.DSASM.Constants.kDoubleUnderscores);
+        }
+
         public static bool TryGetOperator(string methodName, out Operator op)
         {
             Validity.Assert(null != methodName);


### PR DESCRIPTION
This submission hide functions from the library view if their names start with double underscores.
