### PR TITLE
Clear error/warning of CBN after undo

### DIFF
--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -408,6 +408,7 @@ namespace Dynamo.Nodes
                 WorkSpace.Modified();
             }
 
+            ClearError();
             if (!string.IsNullOrEmpty(errorMessage))
             {
                 Error(errorMessage);


### PR DESCRIPTION
This submission is to fix MAGN-2378: Warning don't get cleared after resolving code error.
