### PR TITLE
Avoid throwing exceptions when a parameter is optional

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
+++ b/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
@@ -295,13 +295,20 @@ namespace ProtoFFI
                         param = Type.Missing;
                     else 
                         param = marshaller.UnMarshal(opArg, c, dsi, paramType);
-
+ 
                     //null is passed for a value type, so we must return null 
-                    //rather than interpreting any value from null. fix defect 1462014 
+                    //rather than interpreting any value from null. fix defect 1462014
                     if (!paramType.IsGenericType && paramType.IsValueType && param == null)
-                        throw new System.InvalidCastException(string.Format("Null value cannot be cast to {0}", paraminfos[i].ParameterType.Name));
-
-                    parameters.Add(param);
+                    {
+                        if (!paraminfos[i].IsOptional)
+                            throw new System.InvalidCastException(string.Format("Null value cannot be cast to {0}", paraminfos[i].ParameterType.Name));
+                        else
+                            parameters.Add(Type.Missing);
+                    }
+                    else
+                    {
+                        parameters.Add(param);
+                    }
                 }
                 catch (System.InvalidCastException ex)
                 {


### PR DESCRIPTION
When a parameter has a default value, we add Type.Missing as the value of the parameter instead of throwing exceptions which will simply not call the C# function at all.

It is verified to work with calling a FFI function (C#) with parameters which have default values. 
It is verified in both cases:
1). It is working correctly when given different input values for the parameters with default values;
2). It is working correctly when not given input values for the parameters with default values.
