### PR TITLE
Add a flag to force to execute all ast nodes

### DIFF
--- a/src/DynamoCore/DSEngine/EngineController.cs
+++ b/src/DynamoCore/DSEngine/EngineController.cs
@@ -260,6 +260,23 @@ namespace Dynamo.DSEngine
             GraphSyncData data = syncDataManager.GetSyncData();
             syncDataManager.ResetStates();
 
+            var reExecuteNodesIds = controller.DynamoViewModel.Model.HomeSpace.Nodes
+                                                                    .Where(n => n.RequiresReExecute)
+                                                                    .Select(n => n.GUID);
+            if (reExecuteNodesIds.Any() && data.ModifiedSubtrees != null)
+            {
+                for (int i = 0; i < data.ModifiedSubtrees.Count; ++i)
+                {
+                    var st = data.ModifiedSubtrees[i];
+                    if (reExecuteNodesIds.Contains(st.GUID))
+                    {
+                        Subtree newSt = new Subtree(st.AstNodes, st.GUID);
+                        newSt.ForceExecution = true;
+                        data.ModifiedSubtrees[i] = newSt;
+                    }
+                }
+            }
+
             if ((data.AddedSubtrees != null && data.AddedSubtrees.Count > 0) ||
                 (data.ModifiedSubtrees != null && data.ModifiedSubtrees.Count > 0) ||
                 (data.DeletedSubtrees != null && data.DeletedSubtrees.Count > 0))

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -2010,6 +2010,17 @@ namespace Dynamo.Models
             } 
         }
 
+        /// <summary>
+        ///     This property forces all AST nodes that generated from this node
+        ///     to be executed, even there is no change in AST nodes.
+        /// </summary>
+        public virtual bool RequiresReExecute
+        {
+            get
+            {
+                return false;
+            }
+        }
         #endregion
 
         /// <summary>

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -31,11 +31,13 @@ namespace ProtoScript.Runners
     {
         public Guid GUID;
         public List<AssociativeNode> AstNodes;
+        public bool ForceExecution;
 
         public Subtree(List<AssociativeNode> astNodes, System.Guid guid)
         {
             GUID = guid;
             AstNodes = astNodes;
+            ForceExecution = false;
         }
     }
 
@@ -957,12 +959,15 @@ namespace ProtoScript.Runners
             {
                 // Check if node exists in the prev AST list
                 bool nodeFound = false;
-                foreach (AssociativeNode prevNode in st.AstNodes)
+                if (!subtree.ForceExecution)
                 {
-                    if (prevNode.Equals(node))
+                    foreach (AssociativeNode prevNode in st.AstNodes)
                     {
-                        nodeFound = true;
-                        break;
+                        if (prevNode.Equals(node))
+                        {
+                            nodeFound = true;
+                            break;
+                        }
                     }
                 }
 
@@ -1448,7 +1453,15 @@ namespace ProtoScript.Runners
                         {
                             if (null != oldSubTree.AstNodes)
                             {
-                                var removedNodes = GetInactiveASTList(oldSubTree.AstNodes, st.AstNodes);
+                                List<AssociativeNode> removedNodes = null;
+                                if (st.ForceExecution)
+                                {
+                                    removedNodes = oldSubTree.AstNodes;
+                                }
+                                else
+                                {
+                                    removedNodes = GetInactiveASTList(oldSubTree.AstNodes, st.AstNodes);
+                                }
                                 DeactivateGraphnodes(removedNodes);
 
                                 foreach (var node in removedNodes)

--- a/src/Libraries/Revit/RevitNodesUI/Selection.cs
+++ b/src/Libraries/Revit/RevitNodesUI/Selection.cs
@@ -153,6 +153,13 @@ namespace Dynamo.Nodes
             }
         }
 
+        public override bool RequiresReExecute
+        {
+            get
+            {
+                return true;
+            }
+        }
         #region protected constructors
 
         protected DSElementSelection(Func<string, Element> action, string message)


### PR DESCRIPTION
This change only affects the delta computation. 

I only handled selection node here, we probably need a general way to extend to other kinds of Revit nodes. 
