### PR TITLE
Remove bitwise operators and assignment operator

### DIFF
--- a/src/DynamoCore/Library/Library.cs
+++ b/src/DynamoCore/Library/Library.cs
@@ -1003,10 +1003,12 @@ namespace Dynamo.DSEngine
                 new FunctionDescriptor(null, null, Op.GetOpFunction(Operator.or), GetBinaryFuncArgs(), null, FunctionType.GenericFunction),
                
                 new FunctionDescriptor(null, null, Op.GetOpFunction(Operator.nq), GetBinaryFuncArgs(), null, FunctionType.GenericFunction),
+                /*
                 new FunctionDescriptor(null, null, Op.GetOpFunction(Operator.assign), GetBinaryFuncArgs(), null, FunctionType.GenericFunction),
                 new FunctionDescriptor(null, null, Op.GetOpFunction(Operator.bitwiseand), GetBinaryFuncArgs(), null, FunctionType.GenericFunction),
                 new FunctionDescriptor(null, null, Op.GetOpFunction(Operator.bitwiseor), GetBinaryFuncArgs(), null, FunctionType.GenericFunction),
                 new FunctionDescriptor(null, null, Op.GetOpFunction(Operator.bitwisexor), GetBinaryFuncArgs(), null, FunctionType.GenericFunction),
+                */
 
                 new FunctionDescriptor(null, null, Op.GetUnaryOpFunction(UnaryOperator.Not), GetUnaryFuncArgs(), null, FunctionType.GenericFunction),
             };


### PR DESCRIPTION
This submission is to fix 070 alpha defect: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2485

DS has removed the support for bitwise operators. It doesn't make sense to include '=' in library. 
