### PR TITLE
Fix GC issue in switch lacing strategy

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1638,7 +1638,7 @@ namespace ProtoCore
                         , null, core);
 
                     GCUtils.GCRetain(newSV, core);
-                    GCUtils.GCRelease(oldSv, core);
+                    // GCUtils.GCRelease(oldSv, core);
 
                     oldSv = newSV;
                 }

--- a/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
+++ b/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
@@ -149,9 +149,10 @@ namespace ProtoCore.Mirror
 
             try
             {
+                ProtoCore.DSASM.Interpreter interpreter = new ProtoCore.DSASM.Interpreter(core, false);
                 var helper = ProtoFFI.DLLFFIHandler.GetModuleHelper(ProtoFFI.FFILanguage.CSharp);
                 var marshaler = helper.GetMarshaller(core);
-                return marshaler.UnMarshal(svData, null, null, typeof(object));
+                return marshaler.UnMarshal(svData, null, interpreter, typeof(object));
             }
             catch (System.Exception)
             {


### PR DESCRIPTION
This submission fixes defects
- MAGN-2319 With Run automatically ON Lacing - Cross Product does not take effect.
- MAGN2504: Warning for Dispose on changing lacing options.

These defects are because of two issues:
- GC, the input parameter is GCed when it is promoted to an array. 
- Replication guide is assigned to ssa variable, which causes incorrect delta computation.
