### PR TITLE
Fix MAGN-2528 Warning disappear after clicking on node and then on canvas.

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -920,13 +920,20 @@ namespace Dynamo.Models
                     // if there are inputs without connections
                     // mark as dead; otherwise, if the original state is dead,
                     // update it as active.
-                    if (State == ElementState.Active)
+                    if (inPorts.Any(x => !x.Connectors.Any() && !(x.UsingDefaultValue && x.DefaultValueEnabled)))
                     {
-                        if (inPorts.Any(x => !x.Connectors.Any() && !(x.UsingDefaultValue && x.DefaultValueEnabled)))
+                        if (State == ElementState.Active)
+                        {
                             State = ElementState.Dead;
+                        }
                     }
-                    else if (State == ElementState.Dead)
-                        State = ElementState.Active;
+                    else
+                    {
+                        if (State == ElementState.Dead)
+                        {
+                            State = ElementState.Active;
+                        }
+                    }
                 });
 
             if (dynSettings.Controller != null &&


### PR DESCRIPTION
That is because deselection of a node will validate all its connections and set its state accordingly. If a node's state is warning or error, it shouldn't be set to dead or active. 
