### PR TITLE
Fix crash for watch of partial function on Revit

### DIFF
--- a/src/DynamoRevit/RevitWatchHandler.cs
+++ b/src/DynamoRevit/RevitWatchHandler.cs
@@ -56,7 +56,7 @@ namespace Dynamo.Applications
 
         internal WatchViewModel ProcessThing(object value, string tag, bool showRawData = true)
         {
-            var node = new WatchViewModel(value.ToString(), tag);
+            var node = new WatchViewModel(ToString(value), tag);
             return node;
         }
 
@@ -85,12 +85,19 @@ namespace Dynamo.Applications
             var classMirror = data.Class;
             if (null != classMirror)
             {
+                if (data.Data == null && !data.IsNull) //Must be a DS Class instance.
+                    return ProcessThing(classMirror.ClassName, tag); //just show the class name.
                 return ProcessThing(data.Data, tag);
             }
 
             //Finally for all else get the string representation of data as watch content.
-            string previewData = data.Data.ToString();
+            string previewData = ToString(data.Data);
             return new WatchViewModel(previewData, tag);
+        }
+
+        private string ToString(object obj)
+        {
+            return obj != null ? obj.ToString() : "null";
         }
 
         public WatchViewModel Process(dynamic value, string tag, bool showRawData = true)


### PR DESCRIPTION
- Fixed null pointer exception for watch in RevitWatchHandler
- For partial function, it now shows _SingleFunctionObject
- Fixed
  http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2522
  http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2495
  http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2264
