### PR TITLE
Fixed "Apply Function" node having a different input port when loaded

### DIFF
--- a/src/Libraries/CoreNodesUI/HigherOrder/Apply.cs
+++ b/src/Libraries/CoreNodesUI/HigherOrder/Apply.cs
@@ -23,11 +23,17 @@ namespace DSCoreNodesUI.HigherOrder
 
         protected override string GetInputName(int index)
         {
+            if (index == 0)
+                return "func";
+
             return "arg" + index;
         }
 
         protected override string GetInputTooltip(int index)
         {
+            if (index == 0)
+                return "Function to apply.";
+
             return "Argument #" + index;
         }
 


### PR DESCRIPTION
This pull request fixes the following defect:

[MAGN-2540 Apply function , when reload the .dyn file the parameter name changes to arg from func](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2540)

This only affects the first argument, and the effect does not go beyond being cosmetic.
