### PR TITLE
Partial Defect Fix: MAGN-2502 - Removed call to AuditCodeLocation from RuntimeStatus

### DIFF
--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -145,12 +145,12 @@ namespace ProtoCore
         {
             filename = filename ?? string.Empty;
 
-            if (string.IsNullOrEmpty(filename) || 
-                line == Constants.kInvalidIndex || 
-                col == Constants.kInvalidIndex)
-            {
-                CodeGen.AuditCodeLocation(core, ref filename, ref line, ref col);
-            }
+            //if (string.IsNullOrEmpty(filename) || 
+            //    line == Constants.kInvalidIndex || 
+            //    col == Constants.kInvalidIndex)
+            //{
+            //    CodeGen.AuditCodeLocation(core, ref filename, ref line, ref col);
+            //}
 
             var warningMsg = string.Format(WarningMessage.kConsoleWarningMessage, 
                                            message, filename, line, col);


### PR DESCRIPTION
AuditCodeLocation() is no longer used for error reporting as new error reporting is based on expression id's and not line and column nos. This function was throwing irrelevant exceptions. However new error reporting also has limitations with imperative code.
