### PR TITLE
String Node implementation

### DIFF
--- a/src/DynamoCore/UI/UIPartials.cs
+++ b/src/DynamoCore/UI/UIPartials.cs
@@ -629,7 +629,7 @@ namespace Dynamo.Nodes
         }
     }
 
-    public abstract partial class String
+    public abstract partial class AbstractString
     {
         public override void editWindowItem_Click(object sender, RoutedEventArgs e)
         {
@@ -657,6 +657,55 @@ namespace Dynamo.Nodes
                 return true;
             }
 
+            return base.UpdateValueCore(name, value);
+        }
+    }
+
+    public partial class StringInput : AbstractString
+    {
+        public override void SetupCustomUIElements(dynNodeView ui)
+        {
+            var nodeUI = ui as dynNodeView;
+
+            base.SetupCustomUIElements(nodeUI);
+
+            //add a text box to the input grid of the control
+            var tb = new StringTextBox
+            {
+                AcceptsReturn = true,
+                AcceptsTab = true,
+                TextWrapping = TextWrapping.Wrap,
+                MaxWidth = 200,
+                VerticalAlignment = VerticalAlignment.Top
+            };
+
+            nodeUI.inputGrid.Children.Add(tb);
+            System.Windows.Controls.Grid.SetColumn(tb, 0);
+            System.Windows.Controls.Grid.SetRow(tb, 0);
+
+            tb.DataContext = this;
+            tb.BindToProperty(new System.Windows.Data.Binding("Value")
+            {
+                Mode = BindingMode.TwoWay,
+                Converter = new StringDisplay(),
+                Source = this,
+                UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+            });
+        }
+
+        protected override bool UpdateValueCore(string name, string value)
+        {
+            if (name == "Value")
+            {
+                var converter = new StringDisplay();
+                this.Value = ((string)converter.ConvertBack(value, typeof(string), null, null));
+                return true; // UpdateValueCore handled.
+            }
+
+            // There's another 'UpdateValueCore' method in 'String' base class,
+            // since they are both bound to the same property, 'StringInput' 
+            // should be given a chance to handle the property value change first
+            // before the base class 'String'.
             return base.UpdateValueCore(name, value);
         }
     }

--- a/src/Migrations/CoreNodes/dynBaseTypes.cs
+++ b/src/Migrations/CoreNodes/dynBaseTypes.cs
@@ -2245,50 +2245,6 @@ namespace Dynamo.Nodes
         }
     }
 
-    public partial class StringInput : MigrationNode
-    {
-        [NodeMigration(from: "0.5.3.0", to: "0.6.3.0")]
-        public static NodeMigrationData Migrate_0530_to_0600(NodeMigrationData data)
-        {
-            NodeMigrationData migrationData = new NodeMigrationData(data.Document);
-
-            XmlNode nodeElement = data.MigratedNodes.ElementAt(0);
-            XmlNode newNode = nodeElement.CloneNode(true);
-
-            var query = from XmlNode subNode in newNode.ChildNodes
-                        where subNode.Name.Equals(typeof(string).FullName)
-                        from XmlAttribute attr in subNode.Attributes
-                        where attr.Name.Equals("value")
-                        select attr;
-
-            foreach (XmlAttribute attr in query)
-                attr.Value = HttpUtility.UrlDecode(attr.Value);
-
-            migrationData.AppendNode(newNode as XmlElement);
-            return migrationData;
-        }
-
-        [NodeMigration(from: "0.6.3.0", to: "0.7.0.0")]
-        public static NodeMigrationData Migrate_0630_to_0700(NodeMigrationData data)
-        {
-            NodeMigrationData migrationData = new NodeMigrationData(data.Document);
-            XmlElement original = data.MigratedNodes.ElementAt(0);
-
-            // Escape special characters for display in code block node.
-            string content = ExtensionMethods.GetChildNodeStringValue(original);
-            content = content.Replace("\r\n", "\\n");
-            content = content.Replace("\t", "\\t");
-            content = content.Replace("\"", "\\\"");
-            content = string.Format("\"{0}\";", content);
-
-            XmlElement newNode = MigrationManager.CreateCodeBlockNodeFrom(original);
-            newNode.SetAttribute("CodeText", content);
-            migrationData.AppendNode(newNode);
-            return migrationData;
-        }
-
-    }
-
     public partial class StringDirectory : StringFilename
     {
         [NodeMigration(from: "0.6.3.0", to: "0.7.0.0")]


### PR DESCRIPTION
- StringInput class is implemented for String node
- The base class String is renamed with AbstractString, because it
  creates problem in node instantiation. String class gets registered as
  String node, instead of StringInput class because of it's name.
- Implemented buildAST method to compile to correct expression for
  string.
- For now migration method is still available on this node, so it will
  still be migrated to CBN. Tracked with
  http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2376
