### PR TITLE
Graphnodes with functioncalls should only be memoized at the global scope

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -6317,8 +6317,9 @@ namespace ProtoAssociative
                     graphNode.firstProc = procNode;
                     graphNode.firstProcRefIndex = graphNode.dependentList.Count - 1;
 
-                    // Memoize the graphnode that contains a user-defined function call
-                    if (!procNode.isExternal)
+                    // Memoize the graphnode that contains a user-defined function call in the global scope
+                    bool inGlobalScope = ProtoCore.DSASM.Constants.kGlobalScope == globalProcIndex && ProtoCore.DSASM.Constants.kInvalidIndex == globalClassIndex;
+                    if (!procNode.isExternal && inGlobalScope)
                     {
                         core.GraphNodeCallList.Add(graphNode);
                     }

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -2184,6 +2184,48 @@ z=Point.ByCoordinates(y,a,a);
         }
 
         [Test]
+        public void TestSimpleFunctionRedefinition02()
+        {
+            List<string> codes = new List<string>() 
+            {
+                "def f() { return = null;}",
+                "def f() { return = 10; }",
+                "x = f();"
+            };
+
+            Guid guid1 = System.Guid.NewGuid();
+            Guid guid2 = System.Guid.NewGuid();
+
+            {
+                List<Subtree> added = new List<Subtree>();
+                added.Add(CreateSubTreeFromCode(guid1, codes[0]));
+
+                var syncData = new GraphSyncData(null, added, null);
+                astLiveRunner.UpdateGraph(syncData);
+            }
+
+            {
+                // Modify the function 
+                List<Subtree> modified = new List<Subtree>();
+                modified.Add(CreateSubTreeFromCode(guid1, codes[1]));
+
+                var syncData = new GraphSyncData(null, null, modified);
+                astLiveRunner.UpdateGraph(syncData);
+            }
+
+
+            {
+                // Call the function
+                List<Subtree> added = new List<Subtree>();
+                added.Add(CreateSubTreeFromCode(guid2, codes[2]));
+
+                var syncData = new GraphSyncData(null, added, null);
+                astLiveRunner.UpdateGraph(syncData);
+                AssertValue("x", 10);
+            }
+        }
+
+        [Test]
         public void TestFunctionRedefinitionOnNewNode01()
         {
             List<string> codes = new List<string>() 


### PR DESCRIPTION
These graphnodes are referred to when determining what graphnodes to
execute if a function definition was modified
