### PR TITLE
Fix default value issue

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -768,17 +768,17 @@ namespace ProtoFFI
                     paramNode.ArgumentType = argType;
                 }
 
-                //if (parameter.IsOptional)
-                //{
-                //    var lhs = paramNode.NameNode;
+                if (parameter.IsOptional)
+                {
+                    var lhs = paramNode.NameNode;
 
-                //    var defaultValue = parameter.DefaultValue;
-                //    if (defaultValue != null)
-                //    {
-                //        var rhs = AstFactory.BuildPrimitiveNodeFromObject(defaultValue);
-                //        paramNode.NameNode = AstFactory.BuildBinaryExpression(lhs, rhs, ProtoCore.DSASM.Operator.assign);
-                //    }
-                //}
+                    var defaultValue = parameter.DefaultValue;
+                    if (defaultValue != null)
+                    {
+                        var rhs = AstFactory.BuildPrimitiveNodeFromObject(defaultValue);
+                        paramNode.NameNode = AstFactory.BuildBinaryExpression(lhs, rhs, ProtoCore.DSASM.Operator.assign);
+                    }
+                }
                 argumentSignature.AddArgument(paramNode);
             }
 

--- a/src/Engine/ProtoCore/ProcedureTable.cs
+++ b/src/Engine/ProtoCore/ProcedureTable.cs
@@ -330,13 +330,17 @@ namespace ProtoCore.DSASM
                 return currentProcedure;
             }
 
-            // For every procedure in this table
+            // how many default parameters are used
+            int defaultParamNum = Int32.MaxValue;
+
             for (int n = 0; n < procList.Count; ++n)
             {
-                int defaultArgNum = procList[n].argInfoList.Count(X => X.isDefault);
-                if (name == procList[n].name
-                    && procList[n].argTypeList.Count >= argTypeList.Count
-                    && (procList[n].argTypeList.Count - argTypeList.Count <= defaultArgNum))
+                var proc = procList[n];
+                var argNum = proc.argTypeList.Count;
+                var paramNum = argTypeList.Count;
+                int defaultArgNum = proc.argInfoList.Count(X => X.isDefault);
+
+                if (name.Equals(proc.name) && (argNum >= paramNum) && (argNum - paramNum <= defaultArgNum))
                 {
 #if STATIC_TYPE_CHECKING
                     int currentDist = procList[n].GetDistance(name, argTypeList, classtable);
@@ -356,10 +360,19 @@ namespace ProtoCore.DSASM
                     }
 #else
                     if (!isStaticOrConstructor ||
-                        (isStaticOrConstructor && (procList[n].isStatic || procList[n].isConstructor)))
+                        (isStaticOrConstructor && (proc.isStatic || proc.isConstructor)))
                     {
-                        currentProcedure = n;
-                        break;
+                        var num = argNum - paramNum;
+                        if (num < defaultParamNum)
+                        {
+                            defaultParamNum = num;
+                            currentProcedure = n;
+                        }
+
+                        if (defaultParamNum == 0)
+                        {
+                            break;
+                        }
                     }
 #endif
                 }

--- a/test/DynamoCoreTests/DSEvaluationTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationTest.cs
@@ -645,7 +645,16 @@ namespace Dynamo.Tests
             RunModel(@"core\dsevaluation\Apply.dyn");
             AssertPreviewValue("11b2c7b2-2854-4e46-a8fa-4d1d52ebf4b7", 20);
         }
+
+
+        [Test]
+        public void DefaultValueTest()
+        {
+            RunModel(@"core\dsevaluation\DefaultValue.dyn");
+            AssertPreviewValue("be9d1181-a83e-4f25-887f-6197aa8d581e", 5.0);
+        }
     }
+
     [Category("DSCustomNode")]
     class CustomNodeEvaluation : DSEvaluationUnitTest
     {

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
@@ -8696,5 +8696,33 @@ p = foo(x);
             thisTest.VerifyBuildWarningCount(0);
         }
 
+        [Test]
+        public void TestMultiOverLoadWithDefaultArg()
+        {
+            string code = @"
+class Bar
+{
+}
+
+class Foo
+{
+    def foo(x = 0, y = 0, z = 0)
+    {
+        return = 41;
+    }
+    
+    def foo(x : Bar)
+    {
+        return = 42;
+    }
+}
+
+b = Bar();
+f = Foo();
+r = f.foo(b); // shoudn't be resolved to foo(x = 0, y = 0, z = 0)
+";
+            ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, "");
+            thisTest.Verify("r", 42);
+        }
     }
 }

--- a/test/core/dsevaluation/DefaultValue.dyn
+++ b/test/core/dsevaluation/DefaultValue.dyn
@@ -1,0 +1,27 @@
+<Workspace Version="0.7.0.32927" X="168.470238061079" Y="288.751747704804" zoom="0.852765925581498" Description="" Category="" Name="Home">
+  <Elements>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="2a7d2808-e7dc-4468-858a-fda52220b38a" nickname="CoordinateSystem.Identity" x="170.602295912551" y="332.636739970304" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.CoordinateSystem.Identity" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="26eccc87-e198-4e09-a4e2-cc63b2e948a5" nickname="CoordinateSystem.Translate" x="573.426148212396" y="175.320816358789" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.CoordinateSystem.Translate@Autodesk.DesignScript.Geometry.Vector" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="39df78d4-ae2a-4119-a5f4-ded715e4558c" nickname="Vector.ByCoordinates" x="458.130968885105" y="454.897863734274" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DoubleSlider type="Dynamo.Nodes.DoubleSlider" guid="38729614-2510-47d1-99f0-4edf2ac58b9d" nickname="Double Slider" x="26.8379594262751" y="514.49248185038" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double>5</System.Double>
+      <Range min="0" max="100" />
+    </Dynamo.Nodes.DoubleSlider>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="be7623a2-ba93-4be9-8052-5d64b0bf8fde" nickname="CoordinateSystem.Origin" x="882.593915966086" y="95.1582828835255" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.CoordinateSystem.Origin" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="be9d1181-a83e-4f25-887f-6197aa8d581e" nickname="Point.X" x="1177.04805754426" y="123.813216124355" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.X" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="2a7d2808-e7dc-4468-858a-fda52220b38a" start_index="0" end="26eccc87-e198-4e09-a4e2-cc63b2e948a5" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="26eccc87-e198-4e09-a4e2-cc63b2e948a5" start_index="0" end="be7623a2-ba93-4be9-8052-5d64b0bf8fde" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="39df78d4-ae2a-4119-a5f4-ded715e4558c" start_index="0" end="26eccc87-e198-4e09-a4e2-cc63b2e948a5" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="38729614-2510-47d1-99f0-4edf2ac58b9d" start_index="0" end="39df78d4-ae2a-4119-a5f4-ded715e4558c" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="38729614-2510-47d1-99f0-4edf2ac58b9d" start_index="0" end="39df78d4-ae2a-4119-a5f4-ded715e4558c" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="38729614-2510-47d1-99f0-4edf2ac58b9d" start_index="0" end="39df78d4-ae2a-4119-a5f4-ded715e4558c" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="be7623a2-ba93-4be9-8052-5d64b0bf8fde" start_index="0" end="be9d1181-a83e-4f25-887f-6197aa8d581e" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
Enable default value for FFI. 

Fix method resolution issue at code gen.  Previously the code gen just simply returns the first function whose arguments' number is larger than the number of input parameters (so that default arguments will be used) without considering other functions which have better match. 

Test cases in language and in Dynamo are added. 
