### PR TITLE
Support range expression x..#y..z

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -4545,6 +4545,7 @@ namespace ProtoAssociative
             var toNode = range.ToNode;
             var stepNode = range.StepNode;
             var stepOp = range.stepoperator;
+            var hasAmountOperator = range.HasRangeAmountOperator;
 
             bool isStepValid = true;
             string warningMsg = string.Empty;
@@ -4569,50 +4570,65 @@ namespace ProtoAssociative
                 {
                     case ProtoCore.DSASM.RangeStepOperator.stepsize:
 
-                        if (stepNode == null && end < current)
+                        if (!hasAmountOperator)
                         {
-                            step = -1;
-                        }
+                            if (stepNode == null && end < current)
+                            {
+                                step = -1;
+                            }
 
-                        if (step == 0)
-                        {
-                            isStepValid = false;
-                            warningMsg = WarningMessage.kRangeExpressionWithStepSizeZero;
+                            if (step == 0)
+                            {
+                                isStepValid = false;
+                                warningMsg = WarningMessage.kRangeExpressionWithStepSizeZero;
+                            }
+                            else if ((end > current && step < 0) || (end < current && step > 0))
+                            {
+                                isStepValid = false;
+                                warningMsg = WarningMessage.kRangeExpressionWithInvalidStepSize;
+                            }
                         }
-                        else if ((end > current && step < 0) || (end < current && step > 0))
-                        {
-                            isStepValid = false;
-                            warningMsg = WarningMessage.kRangeExpressionWithInvalidStepSize;
-                       }
 
                        break;
 
                     case ProtoCore.DSASM.RangeStepOperator.num:
 
-                        if (stepNode != null && stepNode is DoubleNode &&
-                            subPass == AssociativeSubCompilePass.kNone)
-                        {
-                            buildStatus.LogWarning(WarningID.kInvalidRangeExpression,
-                                                   WarningMessage.kRangeExpressionWithNonIntegerStepNumber,
-                                                   core.CurrentDSFileName,
-                                                   stepNode.line,
-                                                   stepNode.col);
-                        }
-                        else if (step <= 0)
-                        {
-                            isStepValid = false;
-                            warningMsg = WarningMessage.kRangeExpressionWithNegativeStepNumber;
-                        }
+                       if (hasAmountOperator)
+                       {
+                           isStepValid = false;
+                           warningMsg = WarningMessage.kRangeExpressionWithStepSizeZero;
+                       }
+                       else
+                       {
+                           if (stepNode != null && stepNode is DoubleNode &&
+                               subPass == AssociativeSubCompilePass.kNone)
+                           {
+                               buildStatus.LogWarning(WarningID.kInvalidRangeExpression,
+                                                      WarningMessage.kRangeExpressionWithNonIntegerStepNumber,
+                                                      core.CurrentDSFileName,
+                                                      stepNode.line,
+                                                      stepNode.col);
+                           }
+                           else if (step <= 0)
+                           {
+                               isStepValid = false;
+                               warningMsg = WarningMessage.kRangeExpressionWithNegativeStepNumber;
+                           }
+                       }
 
-                        break;
+                       break;
 
                     case ProtoCore.DSASM.RangeStepOperator.approxsize:
-                        if (step == 0)
+                        if (hasAmountOperator)
+                        {
+                            isStepValid = false;
+                            warningMsg = WarningMessage.kRangeExpressionConflictOperator;
+                        }
+                        else if (step == 0)
                         {
                             isStepValid = false;
                             warningMsg = WarningMessage.kRangeExpressionWithStepSizeZero;
                         }
-
                         break;
 
                     default:
@@ -4658,7 +4674,8 @@ namespace ProtoAssociative
                 toNode, 
                 stepNode ?? new NullNode(), 
                 op, 
-                AstFactory.BuildBooleanNode(stepNode != null)
+                AstFactory.BuildBooleanNode(stepNode != null),
+                AstFactory.BuildBooleanNode(hasAmountOperator),
             };
             var rangeExprFunc = AstFactory.BuildFunctionCall(Constants.kFunctionRangeExpression, 
                                                              arguments);

--- a/src/Engine/ProtoCore/BuildStatus.cs
+++ b/src/Engine/ProtoCore/BuildStatus.cs
@@ -69,6 +69,8 @@ namespace ProtoCore
             public const string kRangeExpressionWithInvalidStepSize = "The step size of range expression is invalid.";
             public const string kRangeExpressionWithNonIntegerStepNumber = "The step number of range expression should be integer.";
             public const string kRangeExpressionWithNegativeStepNumber = "The step number of range expression should be greater than 0.";
+            public const string kRangeExpressionWithInvalidAmount = "The amount of step is invalid.";
+            public const string kRangeExpressionConflictOperator = "The amount operator cannot be used together with step operator.";
             public const string kTypeUndefined = "Type '{0}' is not defined.";
             public const string kMethodAlreadyDefined = "Method '{0}()' is already defined.";
             public const string kReturnTypeUndefined = "Return type '{0}' of method '{1}()' is not defined.";

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -700,7 +700,8 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, ProtoCore.Type>("end", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, 0)),
                         new KeyValuePair<string, ProtoCore.Type>("step", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, 0)),
                         new KeyValuePair<string, ProtoCore.Type>("op", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeInt, 0)),
-                        new KeyValuePair<string, ProtoCore.Type>("nostep", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeBool, 0))
+                        new KeyValuePair<string, ProtoCore.Type>("nostep", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeBool, 0)),
+                        new KeyValuePair<string, ProtoCore.Type>("hasAmountOp", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeBool, 0))
                     },
                     ID = BuiltInMethods.MethodID.kRangeExpression
                 },

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -1514,6 +1514,7 @@ namespace ProtoCore.AST.AssociativeAST
         public AssociativeNode ToNode { get; set; }
         public AssociativeNode StepNode { get; set; }
         public RangeStepOperator stepoperator { get; set; }
+        public bool HasRangeAmountOperator { get; set; }
 
         public RangeExprNode()
         {
@@ -1530,6 +1531,7 @@ namespace ProtoCore.AST.AssociativeAST
                 StepNode = NodeUtils.Clone(rhs.StepNode);
             }
             stepoperator = rhs.stepoperator;
+            HasRangeAmountOperator = rhs.HasRangeAmountOperator;
         }
 
         public override bool Equals(object other)
@@ -1541,7 +1543,8 @@ namespace ProtoCore.AST.AssociativeAST
             return FromNode.Equals(otherNode.FromNode) &&
                    ToNode.Equals(otherNode.ToNode) &&
                    stepoperator.Equals(otherNode.stepoperator) &&
-                   ((StepNode == otherNode.StepNode) || (StepNode != null && StepNode.Equals(otherNode.StepNode)));
+                   ((StepNode == otherNode.StepNode) || (StepNode != null && StepNode.Equals(otherNode.StepNode))) &&
+                   HasRangeAmountOperator == otherNode.HasRangeAmountOperator;
         }
 
         public override string ToString()
@@ -1554,6 +1557,8 @@ namespace ProtoCore.AST.AssociativeAST
 
             buf.Append(FromNode);
             buf.Append("..");
+            if (HasRangeAmountOperator)
+                buf.Append("#");
             buf.Append(ToNode);
 
             if (StepNode != null)

--- a/src/Engine/ProtoCore/Parser/ImperativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/ImperativeAST.cs
@@ -857,6 +857,7 @@ namespace ProtoCore.AST.ImperativeAST
         public ImperativeNode ToNode { get; set; }
         public ImperativeNode StepNode { get; set; }
         public ProtoCore.DSASM.RangeStepOperator stepoperator { get; set; }
+        public bool HasRangeAmountOperator { get; set; }
 
         public RangeExprNode()
         {
@@ -871,6 +872,7 @@ namespace ProtoCore.AST.ImperativeAST
                 StepNode = ProtoCore.Utils.NodeUtils.Clone(rhs.StepNode);
             }
             stepoperator = rhs.stepoperator;
+            HasRangeAmountOperator = rhs.HasRangeAmountOperator;
         }
 
         // Check if this can be unified associative range expr 
@@ -884,6 +886,8 @@ namespace ProtoCore.AST.ImperativeAST
 
             buf.Append(FromNode.ToString());
             buf.Append("..");
+            if (HasRangeAmountOperator)
+                buf.Append("#");
             buf.Append(ToNode.ToString());
 
             if (StepNode != null)

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -2312,8 +2312,13 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		if (la.kind == 22) {
 			ProtoCore.AST.AssociativeAST.RangeExprNode rnode = new ProtoCore.AST.AssociativeAST.RangeExprNode(); 
 			rnode.FromNode = node; NodeUtils.CopyNodeLocation(rnode, node);
+			bool hasRangeAmountOperator = false;
 			
 			Get();
+			if (la.kind == 69) {
+				Associative_rangeAmountOperator(out hasRangeAmountOperator);
+			}
+			rnode.HasRangeAmountOperator = hasRangeAmountOperator; 
 			Associative_ArithmeticExpression(out node);
 			rnode.ToNode = node; 
 			if (la.kind == 22) {
@@ -2351,6 +2356,12 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			}
 			
 		}
+	}
+
+	void Associative_rangeAmountOperator(out bool hasRangeAmountOperator) {
+		hasRangeAmountOperator = false; 
+		Expect(69);
+		hasRangeAmountOperator = true; 
 	}
 
 	void Associative_rangeStepOperator(out RangeStepOperator op) {
@@ -3663,8 +3674,13 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			ProtoCore.AST.ImperativeAST.RangeExprNode rnode = new ProtoCore.AST.ImperativeAST.RangeExprNode(); 
 			rnode.FromNode = node;
 			NodeUtils.SetNodeStartLocation(rnode, rnode.FromNode);
+			bool hasAmountOperator = false;
 			
 			Get();
+			if (la.kind == 69) {
+				Imperative_rangeAmountOperator(out hasAmountOperator);
+			}
+			rnode.HasRangeAmountOperator = hasAmountOperator; 
 			Imperative_rel(out node);
 			rnode.ToNode = node;
 			NodeUtils.SetNodeEndLocation(rnode, rnode.ToNode);
@@ -3736,6 +3752,12 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			node = bNode;
 			
 		}
+	}
+
+	void Imperative_rangeAmountOperator(out bool hasAmountOperator) {
+		hasAmountOperator = false; 
+		Expect(69);
+		hasAmountOperator = true; 
 	}
 
 	void Imperative_rangeStepOperator(out RangeStepOperator op) {

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1410,13 +1410,19 @@ Associative_RangeExpr<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
     [
                                         (.  ProtoCore.AST.AssociativeAST.RangeExprNode rnode = new ProtoCore.AST.AssociativeAST.RangeExprNode(); 
                                             rnode.FromNode = node; NodeUtils.CopyNodeLocation(rnode, node);
+                                            bool hasRangeAmountOperator = false;
                                         .)
         rangeop
-        Associative_ArithmeticExpression<out node>  (. rnode.ToNode = node; .)
+        [Associative_rangeAmountOperator<out hasRangeAmountOperator>]
+                                        (. rnode.HasRangeAmountOperator = hasRangeAmountOperator; .)
+        Associative_ArithmeticExpression<out node>  
+                                        (. rnode.ToNode = node; .)
         [                               (. RangeStepOperator op; .)
             rangeop
-            Associative_rangeStepOperator<out op>   (. rnode.stepoperator = op; .)
-            Associative_ArithmeticExpression<out node> (. rnode.StepNode = node; .)
+            Associative_rangeStepOperator<out op>   
+                                        (. rnode.stepoperator = op; .)
+            Associative_ArithmeticExpression<out node> 
+                                        (. rnode.StepNode = node; .)
         ]
 
                                         (. node = rnode; .)
@@ -1585,6 +1591,15 @@ Associative_PostFixOp<out UnaryOperator op>
     |
     "--"    
         (. op = UnaryOperator.Decrement; .)
+)
+.
+
+Associative_rangeAmountOperator<out bool hasRangeAmountOperator>
+= 
+    (. hasRangeAmountOperator = false; .)
+(
+    '#' 
+    (. hasRangeAmountOperator = true; .)
 )
 .
 

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -608,8 +608,11 @@ Imperative_rel<out node>
                                     (.  ProtoCore.AST.ImperativeAST.RangeExprNode rnode = new ProtoCore.AST.ImperativeAST.RangeExprNode(); 
                                         rnode.FromNode = node;
                                         NodeUtils.SetNodeStartLocation(rnode, rnode.FromNode);
+                                        bool hasAmountOperator = false;
                                     .)
     rangeop
+    [Imperative_rangeAmountOperator<out hasAmountOperator>]
+                                    (. rnode.HasRangeAmountOperator = hasAmountOperator; .)
     Imperative_rel<out node>                    (.
                                                     rnode.ToNode = node;
                                                     NodeUtils.SetNodeEndLocation(rnode, rnode.ToNode);
@@ -1400,6 +1403,15 @@ Imperative_PostFixOp<out UnaryOperator op>
         |
         "--"    (. op = UnaryOperator.Decrement; .)
     )
+.
+
+Imperative_rangeAmountOperator<out bool hasAmountOperator>
+=
+    (. hasAmountOperator = false; .)
+(
+    '#'
+    (. hasAmountOperator = true; .)
+)
 .
 
 Imperative_rangeStepOperator<out RangeStepOperator op>

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -58,6 +58,8 @@ namespace ProtoCore
             public const string kAmbigousMethodDispatch = "Candidate function could not be located on final replicated dispatch GUARD {FDD1F347-A9A6-43FB-A08E-A5E793EC3920}.";
             public const string kInvalidArguments = "Argument is invalid.";
             public const string kInvalidArgumentsInRangeExpression = "The value that used in range expression should be either interger or double.";
+            public const string kInvalidAmountInRangeExpression = "The amount in range expression should be an positive integer.";
+            public const string kNoStepSizeInAmountRangeExpression = "No step size is specified in amount range expression.";
             public const string kFileNotFound = "'{0}' doesn't exist.";
             public const string kPropertyNotFound = "Object does not have a property '{0}'.";
             public const string kPropertyOfClassNotFound = "Class '{0}' does not have a property '{1}'.";

--- a/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
@@ -1561,6 +1561,22 @@ c = f(a<1L>,b<2>);";
         }
 
         [Test]
+        public void RangeExpr06()
+        {
+            string code = @"
+x1 = 0..#(-1)..5;
+x2 = 0..#0..5;
+x3 = 0..#1..10;
+x4 = 0..#5..10;
+";
+            ExecutionMirror mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("x1", null);
+            thisTest.Verify("x2", new object[] { });
+            thisTest.Verify("x3", new object[] { 0 });
+            thisTest.Verify("x4", new object[] { 0, 10, 20, 30, 40 });
+        }
+
+        [Test]
         public void FunctionWithinConstr001()
         {
             String code =

--- a/test/Engine/ProtoTest/Imperative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Imperative/MicroFeatureTests.cs
@@ -429,6 +429,25 @@ namespace ProtoTest.Imperative
             Assert.IsTrue((Double)mirror.GetValue("f").Payload == 15);
         }
 
+        [Test]
+        public void RangeExpr06()
+        {
+            string code = @"
+x1; x2; x3; x4;
+[Imperative]
+{
+    x1 = 0..#(-1)..5;
+    x2 = 0..#0..5;
+    x3 = 0..#1..10;
+    x4 = 0..#5..10;
+}
+";
+            ExecutionMirror mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("x1", null);
+            thisTest.Verify("x2", new object[] {});
+            thisTest.Verify("x3", new object[] {0});
+            thisTest.Verify("x4", new object[] {0, 10, 20, 30, 40});
+        }
 
         [Test]
         public void WhileStatement01()


### PR DESCRIPTION
This submission is to support range expression syntax `x..#y..z` where `x` is the start value, `y` is the amount of elements in the result list, `z` is the step size. So the result list is `{x, x + z, x + 2*z, ...}` which has "y" elements. 
