### PR TITLE
Determine array dimensionality based on Generics in FFI

### DIFF
--- a/test/Engine/FFITarget/DummyCollection.cs
+++ b/test/Engine/FFITarget/DummyCollection.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FFITarget
+{
+    public class DummyCollection
+    {
+        public static IList ReturnIList(IEnumerable<int> data)
+        {
+            return data.ToList();
+        }
+
+        public static IList AcceptIEnumerablOfIList(IEnumerable<IList> data)
+        {
+            return data.ToList();
+        }
+
+        public static IList AcceptIEnumerablOfIListInt(IEnumerable<IList<int>> data)
+        {
+            return data.ToList();
+        }
+
+        public static IList AcceptListOfList(List<List<int>> data)
+        {
+            return data;
+        }
+
+        public static IList Accept3DList(List<List<List<int>>> data)
+        {
+            return data;
+        }
+
+        public static IList<DummyPoint> ReturnListOf5Points()
+        {
+            return new List<DummyPoint> { new DummyPoint(){ X = 1, Y = 2, Z = 3}, 
+                new DummyPoint(){ X = 2, Y = 2, Z = 3}, new DummyPoint(){ X = 3, Y = 2, Z = 3}, 
+                new DummyPoint(){ X = 4, Y = 2, Z = 3}, new DummyPoint(){ X = 5, Y = 2, Z = 3}};
+        }
+
+        public static object AcceptListOf5PointsReturnAsObject(IEnumerable<DummyPoint> points)
+        {
+            return points;
+        }
+
+        public static IDictionary ReturnIDictionary()
+        {
+            IDictionary dictionary = new Dictionary<string, int>();
+            dictionary.Add("A", 1);
+            dictionary.Add("B", 2);
+            dictionary.Add("C", 3);
+            dictionary.Add("D", 4);
+            return dictionary;
+        }
+
+        public static IDictionary AcceptDictionary(Dictionary<string, int> dictionary)
+        {
+            return dictionary;
+        }
+    }
+}

--- a/test/Engine/FFITarget/FFITarget.csproj
+++ b/test/Engine/FFITarget/FFITarget.csproj
@@ -48,6 +48,7 @@
     <Compile Include="AbstractDisposeTracert.cs" />
     <Compile Include="ClassFunctionality.cs" />
     <Compile Include="DisposeTracer.cs" />
+    <Compile Include="DummyCollection.cs" />
     <Compile Include="DummyGeometry.cs" />
     <Compile Include="InheritenceTests.cs" />
     <Compile Include="ManagedElementExample.cs" />

--- a/test/Engine/ProtoTest/FFITests/ArgumentMarshalingTests.cs
+++ b/test/Engine/ProtoTest/FFITests/ArgumentMarshalingTests.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using ProtoCore.DSASM;
+using ProtoTestFx.TD;
+
+namespace ProtoFFITests
+{
+    [TestFixture]
+    class ArgumentMarshalingTests 
+    {
+        TestFrameWork theTest = null;
+        [SetUp]
+        public void Setup()
+        {
+            theTest = new TestFrameWork();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            theTest.CleanUp();
+        }
+
+        [Test]
+        public void TestReturnIList()
+        {
+            string code = @"                import(DummyCollection from ""FFITarget.dll"");                a = 1..5;                b = DummyCollection.ReturnIList(a);                ";
+            
+            theTest.RunScriptSource(code);
+            var methods = theTest.GetMethods("DummyCollection", "ReturnIList");
+            //IList is marshaled as arbitrary rank var array
+            Assert.AreEqual((int)ProtoCore.PrimitiveType.kTypeVar, methods[0].ReturnType.Value.UID);
+            Assert.AreEqual(Constants.kArbitraryRank, methods[0].ReturnType.Value.rank);
+            var args = methods[0].GetArgumentTypes();
+            Assert.AreEqual((int)ProtoCore.PrimitiveType.kTypeInt, args[0].UID);
+            Assert.AreEqual(1, args[0].rank); //Expecting it tobe marshaled as 1D array
+
+            theTest.Verify("b", new int[] { 1, 2, 3, 4, 5 });
+        }
+
+        [Test]
+        public void TestAcceptIEnumerablOfIList()
+        {
+            string code = @"                import(DummyCollection from ""FFITarget.dll"");                a = {1..5, 6..10};                b = DummyCollection.AcceptIEnumerablOfIList(a);                ";
+
+            theTest.RunScriptSource(code);
+            var methods = theTest.GetMethods("DummyCollection", "AcceptIEnumerablOfIList");
+            //IEnumerable<IList> ==> var[]..[]
+            var args = methods[0].GetArgumentTypes();
+            Assert.AreEqual((int)ProtoCore.PrimitiveType.kTypeVar, args[0].UID);
+            Assert.AreEqual(Constants.kArbitraryRank, args[0].rank); //Expecting it tobe marshaled as arbitrary dimension array
+
+            theTest.Verify("b", new List<object> { new int[] { 1, 2, 3, 4, 5 }, new int[] { 6, 7, 8, 9, 10 } });
+        }
+
+        [Test]
+        public void TestAcceptIEnumerablOfIListInt()
+        {
+            string code = @"                import(DummyCollection from ""FFITarget.dll"");                a = {1..5, 6..10};                b = DummyCollection.AcceptIEnumerablOfIListInt(a);                ";
+
+            theTest.RunScriptSource(code);
+            var methods = theTest.GetMethods("DummyCollection", "AcceptIEnumerablOfIListInt");
+            //IEnumerable<IList<int>> ==> int[][]
+            var args = methods[0].GetArgumentTypes();
+            Assert.AreEqual((int)ProtoCore.PrimitiveType.kTypeInt, args[0].UID);
+            Assert.AreEqual(2, args[0].rank); //Expecting it tobe marshaled as 2D array
+
+            theTest.Verify("b", new List<object> { new int[] { 1, 2, 3, 4, 5 }, new int[] { 6, 7, 8, 9, 10 } });
+        }
+
+        [Test]
+        public void TestAcceptListOfList()
+        {
+            string code = @"                import(DummyCollection from ""FFITarget.dll"");                a = {1..5, 6..10};                b = DummyCollection.AcceptListOfList(a);                ";
+
+            theTest.RunScriptSource(code);
+            var methods = theTest.GetMethods("DummyCollection", "AcceptListOfList");
+            //List<List<int>> ==> int[][]
+            var args = methods[0].GetArgumentTypes();
+            Assert.AreEqual((int)ProtoCore.PrimitiveType.kTypeInt, args[0].UID);
+            Assert.AreEqual(2, args[0].rank); //Expecting it tobe marshaled as 2D array
+
+            theTest.Verify("b", new List<object> { new int[] { 1, 2, 3, 4, 5 }, new int[] { 6, 7, 8, 9, 10 } });
+        }
+
+        [Test]
+        public void TestAccept3DList()
+        {
+            string code = @"                import(DummyCollection from ""FFITarget.dll"");                a = {{1..5}};                b = DummyCollection.Accept3DList(a);                ";
+
+            theTest.RunScriptSource(code);
+            var methods = theTest.GetMethods("DummyCollection", "Accept3DList");
+            //List<List<List<int>>> ==> int[][][]
+            var args = methods[0].GetArgumentTypes();
+            Assert.AreEqual((int)ProtoCore.PrimitiveType.kTypeInt, args[0].UID);
+            Assert.AreEqual(3, args[0].rank); //Expecting it tobe marshaled as 3D array
+
+            theTest.Verify("b", new List<object> { new List<object> { new int[] { 1, 2, 3, 4, 5 } } });
+        }
+
+        [Test]
+        public void TestReturnListOf5Points()
+        {
+            string code = @"                import(DummyCollection from ""FFITarget.dll"");                b = DummyCollection.ReturnListOf5Points();                c = Count(b);                ";
+
+            theTest.RunScriptSource(code);
+            var methods = theTest.GetMethods("DummyCollection", "ReturnListOf5Points");
+            //Verify DummyPoint class is marshaled
+            Assert.IsTrue(ProtoCore.DSASM.Constants.kInvalidIndex != theTest.GetClassIndex("DummyPoint"));
+
+            //IList<DummyPoint> ==> DummyPoint[]
+            Assert.AreEqual("FFITarget.DummyPoint", methods[0].ReturnType.Value.Name);
+            Assert.AreEqual(1, methods[0].ReturnType.Value.rank);
+
+            var args = methods[0].GetArgumentTypes();
+            Assert.IsTrue(args == null || args.Count == 0);
+            
+            theTest.Verify("c", 5);
+        }
+
+        [Test]
+        public void TestAcceptListOf5PointsReturnAsObject()
+        {
+            string code = @"                import(DummyCollection from ""FFITarget.dll"");                a = DummyCollection.ReturnListOf5Points();                b = DummyCollection.AcceptListOf5PointsReturnAsObject(a);                c = Count(b);                ";
+
+            theTest.RunScriptSource(code);
+            var methods = theTest.GetMethods("DummyCollection", "AcceptListOf5PointsReturnAsObject");
+            //Verify DummyPoint class is marshaled
+            Assert.IsTrue(ProtoCore.DSASM.Constants.kInvalidIndex != theTest.GetClassIndex("DummyPoint"));
+
+            //object is marshaled as arbitrary rank var array
+            Assert.AreEqual((int)ProtoCore.PrimitiveType.kTypeVar, methods[0].ReturnType.Value.UID);
+            Assert.AreEqual(Constants.kArbitraryRank, methods[0].ReturnType.Value.rank);
+
+            //IEnumerable<DummyPoint> ==> DummyPoint[]
+            var args = methods[0].GetArgumentTypes();
+            Assert.AreEqual("FFITarget.DummyPoint", args[0].Name);
+            Assert.AreEqual(1, args[0].rank); //Expecting it tobe marshaled as 3D array
+
+            theTest.Verify("c", 5);
+        }
+    }
+}

--- a/test/Engine/ProtoTest/ProtoTest.csproj
+++ b/test/Engine/ProtoTest/ProtoTest.csproj
@@ -120,6 +120,7 @@
     <Compile Include="DSASM\ExecutionMirrorTests.cs" />
     <Compile Include="DSASM\StackOverflowTests.cs" />
     <Compile Include="EventTests\EventTest.cs" />
+    <Compile Include="FFITests\ArgumentMarshalingTests.cs" />
     <Compile Include="FFITests\ContextInjectionTests.cs" />
     <Compile Include="FFITests\CSFFIDataMarshalingTest.cs" />
     <Compile Include="FFITests\CSFFIDispose.cs" />

--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -539,7 +539,9 @@ namespace ProtoTestFx.TD
 
         public void Verify(string dsVariable, object expectedValue, int startBlock = 0)
         {
-            Verify(testMirror, dsVariable, expectedValue, startBlock);
+            RuntimeMirror mirror = new RuntimeMirror(dsVariable, startBlock, testCore);
+            AssertValue(mirror.GetData(), expectedValue);
+            //Verify(testMirror, dsVariable, expectedValue, startBlock);
         }
 
         public static void VerifyBuildWarning(ProtoCore.BuildData.WarningID id)
@@ -643,6 +645,12 @@ namespace ProtoTestFx.TD
                 Assert.AreEqual(value, data.Data);
         }
 
+        public IList<MethodMirror> GetMethods(string className, string methodName)
+        {
+            ClassMirror classMirror = new ClassMirror(className, testCore);
+            return classMirror.GetOverloads(methodName);
+        }
+
         private static void AssertCollection(MirrorData data, IEnumerable collection)
         {
             Assert.IsTrue(data.IsCollection);
@@ -652,6 +660,11 @@ namespace ProtoTestFx.TD
             {
                 AssertValue(elements[i++], item);
             }
-        }    
+        }
+
+        public void CleanUp()
+        {
+            testCore.Cleanup();
+        }
     }
 }


### PR DESCRIPTION
- FFI inspects the Generic arguments to determine the array
  dimensionality.
- Added test cases, 1 test is failing due to other issue.
- Fixed http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2419
- Fixed http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2529
