### PR TITLE
Remove Revit test from configuration

### DIFF
--- a/src/Config.xml
+++ b/src/Config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AnalyseParams>
 	<Executable><!-- Required.   -->C:\Program Files (x86)\NUnit 2.6.2\bin\nunit-console.exe</Executable>
-	<Arguments>DynamoCoreUITests.dll DynamoPythonTests.dll DynamoMSOfficeTests.dll DynamoCoreTests.dll DSRevitNodesTests.dll DSCoreNodesTests.dll /noshadow /xml=nunit-result.xml</Arguments>
+	<Arguments>DynamoCoreUITests.dll DynamoPythonTests.dll DynamoMSOfficeTests.dll DynamoCoreTests.dll  DSCoreNodesTests.dll /noshadow /xml=nunit-result.xml</Arguments>
 	<WorkingDir>..\bin\AnyCPU\Release\</WorkingDir>
 	<Output>Coverage.xml</Output> <!-- Change the value to html-->
 	<ReportType>xml</ReportType><!-- Change the value to html -->


### PR DESCRIPTION
There is separate test suite for Dynamo with Revit.
So removing it from coverage settings
