### PR TITLE
Migration with default values

### DIFF
--- a/src/DynamoCore/Models/Migration.cs
+++ b/src/DynamoCore/Models/Migration.cs
@@ -885,6 +885,19 @@ namespace Dynamo.Models
         {
             return element.Attributes["guid"].Value;
         }
+
+        public static void AddDefaultValues(XmlElement element, int portCount)
+        {
+            XmlDocument document = element.OwnerDocument;
+
+            for (int i = 0; i < portCount; i++)
+            {
+                XmlElement newChild = document.CreateElement("PortInfo");
+                newChild.SetAttribute("index", i.ToString());
+                newChild.SetAttribute("default", "True");
+                element.AppendChild(newChild);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Migrations/RevitNodes/XYZ.cs
+++ b/src/Migrations/RevitNodes/XYZ.cs
@@ -10,8 +10,17 @@ namespace Dynamo.Nodes
         [NodeMigration(from: "0.6.3.0", to: "0.7.0.0")]
         public static NodeMigrationData Migrate_0630_to_0700(NodeMigrationData data)
         {
-            return MigrateToDsFunction(data, "ProtoGeometry.dll", "Point.ByCoordinates",
-                "Point.ByCoordinates@double,double,double");
+            NodeMigrationData migrationData = new NodeMigrationData(data.Document);
+
+            XmlElement oldNode = data.MigratedNodes.ElementAt(0);
+            var newNode = MigrationManager.CreateFunctionNodeFrom(oldNode);
+            MigrationManager.SetFunctionSignature(newNode, "ProtoGeometry.dll",
+                "Point.ByCoordinates", "Point.ByCoordinates@double,double,double");
+            migrationData.AppendNode(newNode);
+
+            MigrationManager.AddDefaultValues(newNode, 3);
+
+            return migrationData;
         }
     }
 


### PR DESCRIPTION
The new method will add child elements into the migrated node based on the input port count, such as:

```
<Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" ... >
  <PortInfo index="0" default="True" />
  <PortInfo index="1" default="True" />
  <PortInfo index="2" default="True" />
</Dynamo.Nodes.DSFunction>
```
