### PR TITLE
Defect fix - MAGN-2600 Excel used in graph not closing completely

### DIFF
--- a/src/DynamoCore/Core/DynamoController.cs
+++ b/src/DynamoCore/Core/DynamoController.cs
@@ -357,7 +357,7 @@ namespace Dynamo
 
             PreferenceSettings.Save();
 
-            //dynSettings.Controller.DynamoModel.OnCleanup(null);
+            dynSettings.Controller.DynamoModel.OnCleanup(null);
             dynSettings.Controller = null;
             
             DynamoSelection.Instance.ClearSelection();


### PR DESCRIPTION
This call is necessary to shutdown Excel on Dynamo cleanup. Checked with Ian that it's safe to turn back on.
