### PR TITLE
Added check for Dummy nodes available in Sample file.

### DIFF
--- a/doc/distrib/Samples/22 Color/OverrideGraphicsInView_Families.dyn
+++ b/doc/distrib/Samples/22 Color/OverrideGraphicsInView_Families.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="0.7.0.29305" X="-638.183909741053" Y="22.842159586446" zoom="1.1" Description="" Category="" Name="Home">
+<Workspace Version="0.6.0.29305" X="-638.183909741053" Y="22.842159586446" zoom="1.1" Description="" Category="" Name="Home">
   <Elements>
     <Dynamo.Nodes.OverrideColorInView type="Dynamo.Nodes.OverrideColorInView" guid="ecb2936d-6ee9-4b99-9ab1-24269ffedfc5" nickname="Override Element Color in View" x="1623.66666666666" y="354.647222222223" isVisible="true" isUpstreamVisible="true" lacing="Longest">
       <Run />

--- a/doc/distrib/Samples/22 Color/OverrideGraphicsInView_Walls.dyn
+++ b/doc/distrib/Samples/22 Color/OverrideGraphicsInView_Walls.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="0.7.0.29305" X="-205.926265866442" Y="16.728016900406" zoom="0.8" Description="" Category="" Name="Home">
+<Workspace Version="0.6.0.29305" X="-205.926265866442" Y="16.728016900406" zoom="0.8" Description="" Category="" Name="Home">
   <Elements>
     <Dynamo.Nodes.OverrideColorInView type="Dynamo.Nodes.OverrideColorInView" guid="ecb2936d-6ee9-4b99-9ab1-24269ffedfc5" nickname="Override Element Color in View" x="1623.66666666666" y="354.647222222223" isVisible="true" isUpstreamVisible="true" lacing="Longest">
       <Run />

--- a/doc/distrib/Samples/23 Data Import and Export/ExcelDataExport.dyn
+++ b/doc/distrib/Samples/23 Data Import and Export/ExcelDataExport.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="0.7.0.26602" X="-3382.82723374721" Y="-188.134871658737" zoom="1.2" Description="" Category="" Name="Home">
+<Workspace Version="0.6.0.26602" X="-3382.82723374721" Y="-188.134871658737" zoom="1.2" Description="" Category="" Name="Home">
   <Elements>
     <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="19e102a5-6746-435b-a222-fb461a015b9e" nickname="Number" x="32.7692307692308" y="164.401514470599" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
       <System.Double value="1..60..#20" />

--- a/doc/distrib/Samples/23 Data Import and Export/ExcelDataExtract.dyn
+++ b/doc/distrib/Samples/23 Data Import and Export/ExcelDataExtract.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="0.7.0.26602" X="-1878.12584430905" Y="-244.960556332599" zoom="0.8" Description="" Category="" Name="Home">
+<Workspace Version="0.6.0.26602" X="-1878.12584430905" Y="-244.960556332599" zoom="0.8" Description="" Category="" Name="Home">
   <Elements>
     <Dynamo.Nodes.CurvesThroughPoints type="Dynamo.Nodes.CurvesThroughPoints" guid="e2add186-f38a-4adb-b568-77af767c7979" nickname="Lines Through XYZ" x="1247.03465555651" y="1030.8637650683" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
     <Dynamo.Nodes.WriteDataToExcelWorksheet type="Dynamo.Nodes.WriteDataToExcelWorksheet" guid="1524812c-e27c-4536-aaac-cb9d06e5632c" nickname="Write Data To Excel Worksheet" x="3648.06607830772" y="698.226312897007" isVisible="true" isUpstreamVisible="true" lacing="Disabled">

--- a/doc/distrib/Samples/23 Data Import and Export/ExcelDataImport.dyn
+++ b/doc/distrib/Samples/23 Data Import and Export/ExcelDataImport.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="0.7.0.4515" X="228.963793709828" Y="-464.397798142829" zoom="1" Description="" Category="" Name="Home">
+<Workspace Version="0.6.0.4515" X="228.963793709828" Y="-464.397798142829" zoom="1" Description="" Category="" Name="Home">
   <Elements>
     <Dynamo.Nodes.StringFilename type="Dynamo.Nodes.StringFilename" guid="f02a4d31-8830-4399-ad98-bba06139e07c" nickname="File Path" x="15.7951855881458" y="687.555698425671" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
       <System.String value="C:\Autodesk\Dynamo\Core\samples\23 Data Import and Export\DataImport.xlsx" />

--- a/doc/distrib/Samples/23 Data Import and Export/WebRequest.dyn
+++ b/doc/distrib/Samples/23 Data Import and Export/WebRequest.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="0.7.0.21202" X="171.906043124212" Y="-8.18686522165177" zoom="0.7" Description="" Category="" Name="Home">
+<Workspace Version="0.6.0.21202" X="171.906043124212" Y="-8.18686522165177" zoom="0.7" Description="" Category="" Name="Home">
   <Elements>
     <Dynamo.Nodes.WebRequest type="Dynamo.Nodes.WebRequest" guid="c80485ff-659d-4822-a53b-29a59269a2bd" nickname="Web Request" x="188.425205099508" y="590.24194315114" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
     <Dynamo.Nodes.StringInput type="Dynamo.Nodes.StringInput" guid="1fa5ca80-6bdd-4190-b9fe-48877ca3cb05" nickname="String" x="-79.5747949004921" y="590.24194315114" isVisible="true" isUpstreamVisible="true" lacing="Disabled">

--- a/doc/distrib/Samples/24 Lists/PassingFunctions.dyn
+++ b/doc/distrib/Samples/24 Lists/PassingFunctions.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="0.7.0.14830" X="260.363892192467" Y="-856.571691271689" zoom="1" Description="" Category="" Name="Home">
+<Workspace Version="0.6.0.14830" X="260.363892192467" Y="-856.571691271689" zoom="1" Description="" Category="" Name="Home">
   <Elements>
     <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="3599a2da-c801-4c51-8036-09ca0cd24d9a" nickname="Number" x="154.556966490296" y="1063.86728395062" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
       <System.Double value="0..2" />

--- a/test/Libraries/Revit/DynamoRevitTests/DynamoRevitTests.csproj
+++ b/test/Libraries/Revit/DynamoRevitTests/DynamoRevitTests.csproj
@@ -101,9 +101,17 @@
     <Compile Include="ViewTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\DynamoUtilities\DynamoUtilities.csproj">
+      <Project>{b5f435cb-0d8a-40b1-a4f7-5ecb3ce792a9}</Project>
+      <Name>DynamoUtilities</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\src\Engine\ProtoCore\ProtoCore.csproj">
       <Project>{7A9E0314-966F-4584-BAA3-7339CBB849D1}</Project>
       <Name>ProtoCore</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\src\Libraries\CoreNodesUI\CoreNodesUI.csproj">
+      <Project>{d8262d40-4880-41e4-91e4-af8f480c8637}</Project>
+      <Name>CoreNodesUI</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\..\src\Libraries\DynamoUnits\Units.csproj">
       <Project>{6e0a079e-85f1-45a1-ad5b-9855e4344809}</Project>

--- a/test/Libraries/Revit/DynamoRevitTests/SampleTests.cs
+++ b/test/Libraries/Revit/DynamoRevitTests/SampleTests.cs
@@ -1,12 +1,21 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using Dynamo.Nodes;
 using Dynamo.Selection;
+using System.Linq;
 using Dynamo.Utilities;
 using NUnit.Framework;
-
+using System.Collections.Generic;
+using Dynamo.DSEngine;
+using ProtoCore.Mirror;
+using System.Collections;
+using Dynamo.Models;
+using DSCoreNodesUI;
+using DSCore.File;
 namespace Dynamo.Tests
 {
     [TestFixture]
-    class SampleTests:DynamoRevitUnitTestBase
+    class SampleTests : DynamoRevitUnitTestBase
     {
         [Test]
         [TestModel(@".\empty.rfa")]
@@ -18,7 +27,23 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+
+            // check all the nodes and connectors are loaded
+            Assert.AreEqual(8, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(8, model.CurrentWorkspace.Connectors.Count);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             dynSettings.Controller.RunExpression(true);
+
+
         }
 
         [Test]
@@ -32,6 +57,16 @@ namespace Dynamo.Tests
 
             //test running the expression
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             dynSettings.Controller.RunExpression(true);
 
             //test copying and pasting the workflow
@@ -51,6 +86,15 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
         }
 
@@ -64,6 +108,15 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
         }
 
@@ -77,6 +130,15 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
         }
 
@@ -196,7 +258,18 @@ namespace Dynamo.Tests
             Assert.IsTrue(dynSettings.Controller.CustomNodeManager.AddFileToPath(customDefPath2) != null);
 
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
+
         }
 
         [Test]
@@ -209,6 +282,16 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
 
         }
@@ -227,11 +310,20 @@ namespace Dynamo.Tests
             Assert.IsTrue(dynSettings.Controller.CustomNodeManager.AddFileToPath(customDefPath) != null);
 
             model.Open(testPath);
-            Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
+            dynSettings.Controller.RunExpression(true);
         }
 
         [Test]
-        [TestModel(@"..\..\doc\distrib\Samples\08 Get Set Family Params\inst param.rvt")]
+        [TestModel(@"..\..\..\doc\distrib\Samples\08 Get Set Family Params\inst param.rvt")]
         public void InstParamSample()
         {
             var model = dynSettings.Controller.DynamoModel;
@@ -240,11 +332,20 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
-            Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
+            dynSettings.Controller.RunExpression(true);
         }
 
         [Test]
-        [TestModel(@"..\..\doc\distrib\Samples\08 Get Set Family Params\inst param mass families.rvt")]
+        [TestModel(@"..\..\..\doc\distrib\Samples\08 Get Set Family Params\inst param mass families.rvt")]
         public void InstParam2MassesSample()
         {
             var model = dynSettings.Controller.DynamoModel;
@@ -253,11 +354,21 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
-            Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
+            dynSettings.Controller.RunExpression(true);
         }
 
         [Test]
-        [TestModel(@"..\..\doc\distrib\Samples\08 Get Set Family Params\inst param mass families.rvt")]
+        [TestModel(@"..\..\..\doc\distrib\Samples\08 Get Set Family Params\inst param mass families.rvt")]
         public void InstParam2MassesDrivingEachOtherSample()
         {
             var model = dynSettings.Controller.DynamoModel;
@@ -266,6 +377,16 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
         }
 
@@ -286,6 +407,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(15, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(20, model.CurrentWorkspace.Connectors.Count);
@@ -304,6 +434,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(17, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(17, model.CurrentWorkspace.Connectors.Count);
@@ -312,7 +451,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [TestModel(@"..\..\doc\distrib\Samples\11 Indexed Family Instances\IndexedFamilyInstances.rfa")]
+        [TestModel(@"..\..\..\doc\distrib\Samples\11 Indexed Family Instances\IndexedFamilyInstances.rfa")]
         public void IndexedFamilyInstances()
         {
             var model = dynSettings.Controller.DynamoModel;
@@ -322,6 +461,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(12, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(13, model.CurrentWorkspace.Connectors.Count);
@@ -329,7 +477,7 @@ namespace Dynamo.Tests
             Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
         }
 
-        [Ignore]
+        [Test]
         [TestModel(@".\empty.rfa")]
         public void AdaptiveComponentPlacement()
         {
@@ -340,6 +488,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(11, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(10, model.CurrentWorkspace.Connectors.Count);
@@ -348,7 +505,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [TestModel(@"..\..\doc\distrib\Samples\16 Tesselation\tesselation.rfa")]
+        [TestModel(@"..\..\..\doc\distrib\Samples\16 Tesselation\tesselation.rfa")]
         public void Tesselation_1()
         {
             var model = dynSettings.Controller.DynamoModel;
@@ -357,6 +514,15 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
 
             // check all the nodes and connectors are loaded
             Assert.AreEqual(17, model.CurrentWorkspace.Nodes.Count);
@@ -371,7 +537,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [TestModel(@"..\..\doc\distrib\Samples\16 Tesselation\tesselation.rfa")]
+        [TestModel(@"..\..\..\doc\distrib\Samples\16 Tesselation\tesselation.rfa")]
         public void Tesselation_2()
         {
             var model = dynSettings.Controller.DynamoModel;
@@ -380,6 +546,15 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
 
             // check all the nodes and connectors are loaded
             Assert.AreEqual(12, model.CurrentWorkspace.Nodes.Count);
@@ -390,7 +565,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [TestModel(@"..\..\doc\distrib\Samples\16 Tesselation\tesselation.rfa")]
+        [TestModel(@"..\..\..\doc\distrib\Samples\16 Tesselation\tesselation.rfa")]
         public void Tesselation_3()
         {
             var model = dynSettings.Controller.DynamoModel;
@@ -400,6 +575,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(8, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(10, model.CurrentWorkspace.Connectors.Count);
@@ -408,8 +592,8 @@ namespace Dynamo.Tests
 
         }
 
-        [Ignore]
-        [TestModel(@"..\..\doc\distrib\Samples\16 Tesselation\tesselation.rfa")]
+        [Test]
+        [TestModel(@"..\..\..\doc\distrib\Samples\16 Tesselation\tesselation.rfa")]
         public void Tesselation_4()
         {
             var model = dynSettings.Controller.DynamoModel;
@@ -418,6 +602,15 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
 
             // check all the nodes and connectors are loaded
             Assert.AreEqual(11, model.CurrentWorkspace.Nodes.Count);
@@ -438,9 +631,18 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
-            Assert.AreEqual(13, model.CurrentWorkspace.Nodes.Count);
-            Assert.AreEqual(14, model.CurrentWorkspace.Connectors.Count);
+            Assert.AreEqual(17, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(18, model.CurrentWorkspace.Connectors.Count);
 
             Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
 
@@ -457,9 +659,18 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
-            Assert.AreEqual(10, model.CurrentWorkspace.Nodes.Count);
-            Assert.AreEqual(10, model.CurrentWorkspace.Connectors.Count);
+            Assert.AreEqual(14, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(14, model.CurrentWorkspace.Connectors.Count);
 
             Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
 
@@ -476,6 +687,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(15, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(17, model.CurrentWorkspace.Connectors.Count);
@@ -484,7 +704,8 @@ namespace Dynamo.Tests
 
         }
 
-        [Ignore]
+        [Test]
+        [TestModel(@".\empty.rfa")]
         public void Formulas_ScalableCircle()
         {
             var model = dynSettings.Controller.DynamoModel;
@@ -494,6 +715,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(11, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(11, model.CurrentWorkspace.Connectors.Count);
@@ -502,66 +732,85 @@ namespace Dynamo.Tests
 
         }
 
-        [Ignore]
+        [Test]
+        [TestModel(@".\empty.rfa")]
         public void Spreadsheets_ExcelToStuff()
         {
-            //var model = dynSettings.Controller.DynamoModel;
+            var model = dynSettings.Controller.DynamoModel;
 
-            //string samplePath = Path.Combine(_samplesPath, @".\15 Spreadsheets\Excel to Stuff.dyn");
-            //string testPath = Path.GetFullPath(samplePath);
-            //model.Open(testPath);
+            string samplePath = Path.Combine(_samplesPath, @".\15 Spreadsheets\Excel to Stuff.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+            model.Open(testPath);
 
-            //// check all the nodes and connectors are loaded
-            //Assert.AreEqual(22, model.CurrentWorkspace.Nodes.Count);
-            //Assert.AreEqual(18, model.CurrentWorkspace.Connectors.Count);
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
 
-            //var workspace = model.CurrentWorkspace;
-            //var filePickerNode = workspace.FirstNodeFromWorkspace<StringFilename>();
+            double noOfNdoes = nodes.Count();
 
-            //// remap the file name as Excel requires an absolute path
-            //var excelFilePath = Path.Combine(_samplesPath, @".\15 Spreadsheets\");
-            ////excelFilePath = Path.Combine(excelFilePath, excelFileName);
-            //excelFilePath = Path.Combine(excelFilePath, "helix.xlsx");
-            //filePickerNode.Value = excelFilePath;
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
 
-            //Assert.IsFalse(string.IsNullOrEmpty(excelFilePath));
-            //Assert.IsTrue(File.Exists(excelFilePath));
+            // check all the nodes and connectors are loaded
+            Assert.AreEqual(22, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(18, model.CurrentWorkspace.Connectors.Count);
 
-            //Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
+            var workspace = model.CurrentWorkspace;
+            var filePickerNode = workspace.FirstNodeFromWorkspace<Filename>();
 
-            Assert.Inconclusive("Porting : StringFileName");
+            // remap the file name as Excel requires an absolute path
+            var excelFilePath = Path.Combine(_samplesPath, @".\15 Spreadsheets\");
+            //excelFilePath = Path.Combine(excelFilePath, excelFileName);
+            excelFilePath = Path.Combine(excelFilePath, "helix.xlsx");
+            filePickerNode.Value = excelFilePath;
+
+            Assert.IsFalse(string.IsNullOrEmpty(excelFilePath));
+            Assert.IsTrue(File.Exists(excelFilePath));
+
+            Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
+
+            //Assert.Inconclusive("Porting : StringFileName");
         }
 
         [Test]
         [TestModel(@".\empty.rfa")]
         public void Spreadsheets_CSVToStuff()
         {
-            //var model = dynSettings.Controller.DynamoModel;
+            var model = dynSettings.Controller.DynamoModel;
 
-            //string samplePath = Path.Combine(_samplesPath, @".\15 Spreadsheets\CSV to Stuff.dyn");
-            //string testPath = Path.GetFullPath(samplePath);
-            //model.Open(testPath);
+            string samplePath = Path.Combine(_samplesPath, @".\15 Spreadsheets\CSV to Stuff.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+            model.Open(testPath);
 
-            //// check all the nodes and connectors are loaded
-            //Assert.AreEqual(11, model.CurrentWorkspace.Nodes.Count);
-            //Assert.AreEqual(8, model.CurrentWorkspace.Connectors.Count);
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
 
-            //var workspace = model.CurrentWorkspace;
-            //var filePickerNode = workspace.FirstNodeFromWorkspace<StringFilename>();
+            double noOfNdoes = nodes.Count();
 
-            //// remap the file name as CSV requires an absolute path
-            //var excelFilePath = Path.Combine(_samplesPath, @".\15 Spreadsheets\");
-            //excelFilePath = Path.Combine(excelFilePath, "helix_smaller.csv");
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
 
-            //filePickerNode.Value = excelFilePath;
+            // check all the nodes and connectors are loaded
+            Assert.AreEqual(11, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(7, model.CurrentWorkspace.Connectors.Count);
 
-            //Assert.IsFalse(string.IsNullOrEmpty(excelFilePath));
-            //Assert.IsTrue(File.Exists(excelFilePath));
+            var workspace = model.CurrentWorkspace;
+            var filePickerNode = workspace.FirstNodeFromWorkspace<Filename>();
 
-            ////dynSettings.Controller.RunExpression(true);
-            Assert.Inconclusive("Porting : StringFileName");
+            // remap the file name as CSV requires an absolute path
+            var excelFilePath = Path.Combine(_samplesPath, @".\15 Spreadsheets\");
+            excelFilePath = Path.Combine(excelFilePath, "helix_smaller.csv");
+
+            filePickerNode.Value = excelFilePath;
+
+            Assert.IsFalse(string.IsNullOrEmpty(excelFilePath));
+            Assert.IsTrue(File.Exists(excelFilePath));
+
+            //dynSettings.Controller.RunExpression(true);
+            //Assert.Inconclusive("Porting : StringFileName");
         }
-        
+
         [Test]
         [TestModel(@".\empty.rfa")]
         public void Rendering_hill_climbing_simple()
@@ -571,36 +820,46 @@ namespace Dynamo.Tests
 
             var model = dynSettings.Controller.DynamoModel;
             // look at the sample folder and one directory up to get the distrib folder and combine with defs folder
-            string customNodePath = Path.Combine(Path.Combine(_samplesPath,@"..\\"), @".\dynamo_packages\Dynamo Sample Custom Nodes\dyf\");
+            string customNodePath = Path.Combine(Path.Combine(_samplesPath, @"..\\"), @".\dynamo_packages\Dynamo Sample Custom Nodes\dyf\");
             // get the full path to the distrib folder and def folder
             string fullCustomNodePath = Path.GetFullPath(customNodePath);
 
             string samplePath = Path.Combine(_samplesPath, @".\25 Rendering\hill_climbing_simple.dyn");
             string testPath = Path.GetFullPath(samplePath);
-           
+
             // make sure that the two custom nodes we need exist
             string customDefPath1 = Path.Combine(fullCustomNodePath, "ProduceChild.dyf");
             string customDefPath2 = Path.Combine(fullCustomNodePath, "DecideNewParent.dyf");
 
             Assert.IsTrue(File.Exists(customDefPath1), "Cannot find specified custom definition to load for testing at." + customDefPath1);
-            Assert.IsTrue(File.Exists(customDefPath2), "Cannot find specified custom definition to load for testing."+ customDefPath2);
-            
- Assert.DoesNotThrow(() =>
-              dynSettings.Controller.CustomNodeManager.AddFileToPath(customDefPath2));
- Assert.DoesNotThrow(() =>
-               dynSettings.Controller.CustomNodeManager.AddFileToPath(customDefPath1));
+            Assert.IsTrue(File.Exists(customDefPath2), "Cannot find specified custom definition to load for testing." + customDefPath2);
+
+            Assert.DoesNotThrow(() =>
+                         dynSettings.Controller.CustomNodeManager.AddFileToPath(customDefPath2));
+            Assert.DoesNotThrow(() =>
+                          dynSettings.Controller.CustomNodeManager.AddFileToPath(customDefPath1));
 
 
 
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             Assert.AreEqual(2, dynSettings.Controller.CustomNodeManager.LoadedCustomNodes.Count);
             // check all the nodes and connectors are loaded
             Assert.AreEqual(7, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(12, model.CurrentWorkspace.Connectors.Count);
-           
-             Assert.DoesNotThrow(() =>dynSettings.Controller.RunExpression(true));
 
-           
+            Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
+
+
             var workspace = model.CurrentWorkspace;
 
             Assert.Fail("Mike to update for CB2B1");
@@ -624,7 +883,7 @@ namespace Dynamo.Tests
 
 
         }
-        
+
         #region 14 Curves
 
         [Test]
@@ -637,6 +896,15 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
 
             // check all the nodes and connectors are loaded
             Assert.AreEqual(47, model.CurrentWorkspace.Nodes.Count);
@@ -657,6 +925,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(33, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(33, model.CurrentWorkspace.Connectors.Count);
@@ -675,6 +952,15 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
 
             // check all the nodes and connectors are loaded
             Assert.AreEqual(15, model.CurrentWorkspace.Nodes.Count);
@@ -695,6 +981,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(17, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(16, model.CurrentWorkspace.Connectors.Count);
@@ -713,6 +1008,15 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
 
             // check all the nodes and connectors are loaded
             Assert.AreEqual(13, model.CurrentWorkspace.Nodes.Count);
@@ -733,6 +1037,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(15, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(13, model.CurrentWorkspace.Connectors.Count);
@@ -752,6 +1065,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(13, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(13, model.CurrentWorkspace.Connectors.Count);
@@ -770,6 +1092,15 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
+
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
 
             // check all the nodes and connectors are loaded
             Assert.AreEqual(14, model.CurrentWorkspace.Nodes.Count);
@@ -794,6 +1125,15 @@ namespace Dynamo.Tests
 
             model.Open(testPath);
 
+            var nodes = Controller.DynamoModel.Nodes.OfType<DummyNode>();
+
+            double noOfNdoes = nodes.Count();
+
+            if (noOfNdoes >= 1)
+            {
+                Assert.Fail("Number of Dummy Node found in Sample: " + noOfNdoes);
+            }
+
             // check all the nodes and connectors are loaded
             Assert.AreEqual(12, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(12, model.CurrentWorkspace.Connectors.Count);
@@ -811,7 +1151,6 @@ namespace Dynamo.Tests
             string testPath = Path.GetFullPath(samplePath);
 
             model.Open(testPath);
-
             // check all the nodes and connectors are loaded
             Assert.AreEqual(10, model.CurrentWorkspace.Nodes.Count);
             Assert.AreEqual(11, model.CurrentWorkspace.Connectors.Count);


### PR DESCRIPTION
- Test cases for Samples were not having any kind of verification other than Number of Nodes and Connectors.  So the first thing I did, I have added check for Dummy nodes in Sample. After this change there are few Samples which are failing now.
- Updated Revit file path for few samples which was using specific Revit file.
- There are few dyn files which was having Version 0.7 and because of that those were not migrating correctly, so I have changed that version to 0.6 and now those are getting migrated correctly.

In next check in I will add more verification for the Samples which are passing now.
