### PR TITLE
Hide "Use Default Value" menu from output port

### DIFF
--- a/src/DynamoCore/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCore/UI/Themes/Modern/Ports.xaml
@@ -44,7 +44,7 @@
             </interactivity:Interaction.Triggers>
 
             <Grid.ContextMenu>
-                <ContextMenu>
+                <ContextMenu Visibility="{Binding Path=DefaultValueEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <MenuItem Header="Use Default Value"
                               IsCheckable="True"
                               IsEnabled="{Binding Path=DefaultValueEnabled, Mode=TwoWay}"


### PR DESCRIPTION
This pull request hides `Use Default Value` contextual menu from both input and output ports that do not have default value (i.e. with `PortModel.DefaultValueEnabled` set to `false`).

It is to fix the following defect that is tracked internally:
- [MAGN-643 Use default value should not be available on output port of any node](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-643)
