### PR TITLE
Proposed change to complete failed promises

### DIFF
--- a/src/Libraries/Revit/RevitServices/Threading/IdlePromise.cs
+++ b/src/Libraries/Revit/RevitServices/Threading/IdlePromise.cs
@@ -121,12 +121,6 @@ namespace RevitServices.Threading
                     try
                     {
                         p();
-
-                    }
-                    catch (Exception)
-                    {
-
-                        throw;
                     }
                     finally
                     {


### PR DESCRIPTION
Right now, the protection loop doesn't mark the promises as redeemed if they fail.

This means that it can get into an infinite loop which can cause a contention fight with the viz manager, if anything within the promise takes the viz lock.

This would cause it to stop trying to re-execute failed transactions. What do you think Stephen? Is this right, do we want to put in the protection somewhere else?
