### PR TITLE
Fix for DynamoRevitUnitTestBase

### DIFF
--- a/test/Libraries/Revit/DynamoRevitTests/DynamoRevitTests.cs
+++ b/test/Libraries/Revit/DynamoRevitTests/DynamoRevitTests.cs
@@ -65,12 +65,6 @@ namespace Dynamo.Tests
                 _emptyModelPath = Path.Combine(_testPath, "empty.rfa");
                 _emptyModelPath1 = Path.Combine(_testPath, "empty1.rfa");
             }
-
-            //create the transaction manager object
-            TransactionManager.SetupManager(new AutomaticTransactionStrategy());
-
-            //tests do not run from idle thread
-            TransactionManager.Instance.DoAssertInIdleThread = false;
         }
 
         private void StartDynamo()
@@ -89,6 +83,12 @@ namespace Dynamo.Tests
             {
                 Console.WriteLine(ex.StackTrace);
             }
+
+            //create the transaction manager object
+            TransactionManager.SetupManager(new AutomaticTransactionStrategy());
+
+            //tests do not run from idle thread
+            TransactionManager.Instance.DoAssertInIdleThread = false;
         }
 
         /// <summary>


### PR DESCRIPTION
To switch off the idle thread checking when running tests under DynamoRevitUnitTestBase.

Previously, test cases such as "DynamoRevitTester.ReferencePointTests.ReferencePoint" were passing while silently throwing an exception "Cannot start a transaction outside of the Revit idle thread".  In these cases, the Revit nodes were loaded properly (not converted to dummy nodes) but they would return null values.

This change is based on the Setup method of [RevitNodeTestBase](https://github.com/DynamoDS/Dynamo/blob/master/test/Libraries/Revit/RevitNodesTests/RevitNodeTestBase.cs).
