### PR TITLE
Migration for LoftForm

### DIFF
--- a/src/Migrations/RevitNodes/Solid.cs
+++ b/src/Migrations/RevitNodes/Solid.cs
@@ -16,9 +16,9 @@ namespace Dynamo.Nodes
 
             //create the node itself
             XmlElement dsRevitNode = MigrationManager.CreateFunctionNodeFrom(oldNode);
-            MigrationManager.SetFunctionSignature(dsRevitNode, "RevitNodes.dll", 
-                "Form.ByLoftingCurveReferences", 
-                "Form.ByLoftingCurveReferences@CurveReference[],bool");
+            MigrationManager.SetFunctionSignature(dsRevitNode, "RevitNodes.dll",
+                "Form.ByLoftingCurveElements",
+                "Form.ByLoftingCurveElements@CurveElement[],bool");
 
             migratedData.AppendNode(dsRevitNode);
             string dsRevitNodeId = MigrationManager.GetGuidFromXmlElement(dsRevitNode);


### PR DESCRIPTION
- Migrate LoftForm to Form.ByLoftingCurveElements instead of
  Form.ByLoftingCurveReferences
- We don't have nodes that return CurveReference, so we don't need
  Form.ByLoftingCurveReferences.
