### PR TITLE
Added CBN utility function for use in code to node implementation

### DIFF
--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -144,6 +144,27 @@ namespace Dynamo.Nodes
             return cbn.inputIdentifiers.IndexOf(variableName);
         }
 
+        /// <summary>
+        ///  Returns the corresponding output port index for a given defined variable 
+        /// </summary>
+        /// <param name="variableName"></param>
+        /// <returns></returns>
+        public int GetOutportIndex(string variableName)
+        {
+            var svs = CodeBlockUtils.GetStatementVariables(codeStatements, true);
+            for (int i = 0; i < codeStatements.Count; i++)
+            {
+                Statement s = codeStatements[i];
+                if (CodeBlockUtils.DoesStatementRequireOutputPort(svs, i))
+                {
+                    List<string> varNames = Statement.GetDefinedVariableNames(s, true);
+                    if (varNames.Contains(variableName))
+                        return i;
+                }
+            }
+            return -1;
+        }
+
         #endregion
 
         #region Properties


### PR DESCRIPTION
This is not used in Dynamo currently but is used by external host for code to node functionality. Adding code 2 node functionality in bits (from local branch) and not all at once so as to make sure it does not break existing stuff and at the same time does not rot as Dynamo source is updated every day. I need to slowly start checking stuff in as my code easily gets out of date really fast given the pace of development in Dynamo. 
