### PR TITLE
Removed class RecordedTestFSceme from RecordedTests.cs

### DIFF
--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -646,328 +646,7 @@ namespace DynamoCoreUITests
         #endregion
     }
 
-#if !USE_DSENGINE
-
-    class RecordedTestsFScheme : RecordedTests
-    {
-        [Test, RequiresSTA]
-        public void Defect_MAGN_159()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-159
-
-            RunCommandsFromFile("Defect_MAGN_159.xml", true);
-
-            Assert.AreEqual(1, workspace.Nodes.Count);
-            Assert.AreEqual(0, workspace.Connectors.Count);
-
-            var number1 = GetNode("045decd1-7454-4b85-b92e-d59d35f31ab2") as DoubleInput;
-            Assert.AreEqual(8, (number1.OldValue as FScheme.Value.Number).Item);
-        }
-
-        [Ignore, RequiresSTA]
-        public void Defect_MAGN_160()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-160
-
-            // List node cannot be created  ( current limitation for button click)
-            RunCommandsFromFile("Defect_MAGN_160.xml");
-
-            //Assert.AreEqual(1, workspace.Nodes.Count);
-            //Assert.AreEqual(0, workspace.Connectors.Count);
-
-            //var number1 = GetNode("045decd1-7454-4b85-b92e-d59d35f31ab2") as DoubleInput;
-            //Assert.AreEqual(8, (number1.OldValue as FScheme.Value.Number).Item);
-        }
-
-        [Test, RequiresSTA, Category("Failing")]
-        public void Defect_MAGN_164()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-164
-
-            RunCommandsFromFile("Defect_MAGN_164.xml", true);
-
-            Assert.AreEqual(2, workspace.Nodes.Count);
-            Assert.AreEqual(0, workspace.Connectors.Count);
-
-            var number1 = GetNode("2e1e5f33-52fc-4cc9-9d4a-33e46ec64a53") as DoubleInput;
-            Assert.AreEqual(30, (number1.OldValue as FScheme.Value.Number).Item);
-
-            var string1 = GetNode("a4ba7320-3cb8-4524-bc8c-8688d7abc599") as StringInput;
-            Assert.AreEqual("Dynamo", (string1.OldValue as FScheme.Value.String).Item);
-        }
-
-        [Test, RequiresSTA]
-        public void Defect_MAGN_190()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-190
-            RunCommandsFromFile("Defect_MAGN_190.xml");
-
-            Assert.AreEqual(2, workspace.Nodes.Count);
-            Assert.AreEqual(1, workspace.Connectors.Count);
-
-        }
-
-        [Test, RequiresSTA]
-        public void Defect_MAGN_225()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-225
-
-            // TODO: Rename this XML to match the test case name.
-            RunCommandsFromFile("TestConnectionReplacementUndo.xml");
-            var nodes = workspaceViewModel.Nodes;
-
-            Assert.NotNull(nodes);
-            Assert.AreEqual(3, nodes.Count);
-        }
-
-        [Test, RequiresSTA]
-        public void Defect_MAGN_397()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-397
-            RunCommandsFromFile("Defect_MAGN_397.xml");
-
-            Assert.AreEqual(2, workspace.Nodes.Count);
-            Assert.AreEqual(1, workspace.Connectors.Count);
-        }
-
-        [Test, RequiresSTA]
-        public void Defect_MAGN_429()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-429
-            RunCommandsFromFile("Defect_MAGN_429.xml");
-
-            Assert.AreEqual(0, workspace.Nodes.Count);
-            Assert.AreEqual(0, workspace.Connectors.Count);
-
-        }
-
-        [Test, RequiresSTA]
-        public void Defect_MAGN_478()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-478
-            RunCommandsFromFile("Defect_MAGN_478.xml");
-
-            Assert.AreEqual(1, workspace.Notes.Count);
-        }
-
-        [Test, RequiresSTA]
-        public void Defect_MAGN_491()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-491
-
-            // TODO: Rename this XML to match the test case name.
-            RunCommandsFromFile("Defect-MAGN-491.xml");
-            var connectors = workspaceViewModel.Connectors;
-            Assert.NotNull(connectors);
-            Assert.AreEqual(2, connectors.Count);
-
-            // Get to the only two connectors in the session.
-            ConnectorViewModel firstConnector = connectors[0];
-            ConnectorViewModel secondConnector = connectors[1];
-
-            // Find out the corresponding ports they connect to.
-            Point firstPoint = firstConnector.ConnectorModel.End.Center;
-            Point secondPoint = secondConnector.ConnectorModel.End.Center;
-
-            Assert.AreEqual(firstPoint.X, firstConnector.CurvePoint3.X);
-            Assert.AreEqual(firstPoint.Y, firstConnector.CurvePoint3.Y);
-            Assert.AreEqual(secondPoint.X, secondConnector.CurvePoint3.X);
-            Assert.AreEqual(secondPoint.Y, secondConnector.CurvePoint3.Y);
-        }
-
-        [Test, RequiresSTA]
-        public void Defect_MAGN_520()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-520
-            RunCommandsFromFile("Defect_MAGN_520.xml");
-
-            Assert.AreEqual(2, workspace.Nodes.Count);
-            Assert.AreEqual(0, workspace.Connectors.Count);
-        }
-
-        [Test, RequiresSTA]
-        public void Defect_MAGN_520_WithCrossSelection()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-520
-            RunCommandsFromFile("Defect_MAGN_520_WithCrossSelection.xml");
-
-            Assert.AreEqual(3, workspace.Nodes.Count);
-            Assert.AreEqual(0, workspace.Connectors.Count);
-        }
-
-        [Test, RequiresSTA]
-        public void Defect_MAGN_57()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-57
-            RunCommandsFromFile("Defect_MAGN_57.xml");
-
-            Assert.AreEqual(7, workspace.Nodes.Count);
-            Assert.AreEqual(5, workspace.Connectors.Count);
-
-        }
-
-        [Test, RequiresSTA]
-        public void Defect_MAGN_581()
-        {
-            // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-581
-            RunCommandsFromFile("Defect_MAGN_581.xml");
-
-            Assert.AreEqual(2, workspace.Nodes.Count);
-            Assert.AreEqual(1, workspace.Connectors.Count);
-        }
-
-        [Test, RequiresSTA]
-        public void ShiftSelectAllNode()
-        {
-            RunCommandsFromFile("ShiftSelectAllNode.xml");
-
-            Assert.AreEqual(4, workspace.Nodes.Count);
-            Assert.AreEqual(4, workspace.Connectors.Count);
-        }
-
-        [Test, RequiresSTA]
-        public void TestCreateConnectors()
-        {
-            RunCommandsFromFile("CreateNodesAndConnectors.xml");
-            Assert.AreEqual(4, workspace.Connectors.Count);
-        }
-
-        [Test, RequiresSTA]
-        public void TestCreateNodesAndRunExpression()
-        {
-            RunCommandsFromFile("CreateNodesAndRunExpression.xml");
-            var number1 = GetNode("e37873fb-ef3f-4864-b7e5-9417e0ad014c") as DoubleInput;
-            var number2 = GetNode("977ce97c-22f5-4155-ae22-d0c3a6f82f19") as DoubleInput;
-            var addition = GetNode("cf8c52b1-fbee-4674-ba73-6ee0d09463f2") as Addition;
-
-            Assert.IsNotNull(number1);
-            Assert.IsNotNull(number2);
-            Assert.IsNotNull(addition);
-
-            Assert.AreEqual(4, ((number1.OldValue as FScheme.Value.Number).Item), 0.000001);
-            Assert.AreEqual(2, ((number2.OldValue as FScheme.Value.Number).Item), 0.000001);
-            Assert.AreEqual(6, ((addition.OldValue as FScheme.Value.Number).Item), 0.000001);
-        }
-
-        [Test, RequiresSTA]
-        public void TestCreateNodes()
-        {
-            RunCommandsFromFile("CreateNodesAndConnectors.xml");
-            Assert.AreEqual(5, workspace.Nodes.Count);
-        }
-
-        [Test, RequiresSTA]
-        public void TestDeleteCommands()
-        {
-            RunCommandsFromFile("CreateAndDeleteNodes.xml");
-            Assert.AreEqual(4, workspace.Nodes.Count);
-            Assert.AreEqual(2, workspace.Connectors.Count);
-
-            // This dictionary maps each of the node GUIDs, to a Boolean 
-            // flag indicating that if the node exists or deleted.
-            Dictionary<string, bool> nodeExistenceMap = new Dictionary<string, bool>()
-            {
-                { "ba59fa31-919d-4e67-b7c6-b58589a7093f", true },
-                { "42058bba-c2fd-4e49-8d76-44c45d0dc597", false },
-                { "5c92e961-8095-49bb-828d-1f3c14f9a005", true },
-                { "d5ad0ff6-9314-4e22-947f-7ba967ad4758", false },
-                { "4d2b71b4-d2c1-4695-afcf-6f7ec05c71f5", true },
-                { "a71328b2-dee7-45d6-8070-44ecebc358d9", true },
-            };
-
-            VerifyModelExistence(nodeExistenceMap);
-        }
-
-        [Test, RequiresSTA]
-        public void TestUndoRedoNodesAndConnections()
-        {
-            RunCommandsFromFile("UndoRedoNodesAndConnections.xml");
-            Assert.AreEqual(2, workspace.Connectors.Count);
-
-            // This dictionary maps each of the node GUIDs, to a Boolean 
-            // flag indicating that if the node exists or deleted.
-            Dictionary<string, bool> nodeExistenceMap = new Dictionary<string, bool>()
-            {
-                { "fec0ae4f-f3b7-4b33-b728-c75e5415d73c", true },
-                { "168298c7-f003-48f8-a346-0061086f8e3a", true },
-                { "69ee3a47-0a9a-4746-ace3-6643d508f235", true },
-            };
-
-            VerifyModelExistence(nodeExistenceMap);
-        }
-
-        [Test, RequiresSTA]
-        public void TestUpdateNodeCaptions()
-        {
-            RunCommandsFromFile("UpdateNodeCaptions.xml");
-            Assert.AreEqual(0, workspace.Connectors.Count);
-            Assert.AreEqual(1, workspace.Notes.Count);
-            Assert.AreEqual(2, workspace.Nodes.Count);
-
-            var number = GetNode("0b171995-528b-480a-b203-9cee49fcec9d") as DoubleInput;
-            var strIn = GetNode("d17de86f-0665-4e22-abd4-d16360ee17d7") as StringInput;
-            var note = GetNode("6aed237b-beb6-4a24-8774-9b7e29615be1") as NoteModel;
-
-            Assert.IsNotNull(number);
-            Assert.IsNotNull(strIn);
-            Assert.IsNotNull(note);
-
-            Assert.AreEqual("Caption 1", number.NickName);
-            Assert.AreEqual("Caption 2", strIn.NickName);
-            Assert.AreEqual("Caption 3", note.Text);
-        }
-
-        [Test, RequiresSTA]
-        public void TestUpdateNodeContents()
-        {
-            RunCommandsFromFile("UpdateNodeContents.xml");
-            Assert.AreEqual(0, workspace.Connectors.Count);
-            Assert.AreEqual(5, workspace.Nodes.Count);
-
-            var number = GetNode("2ba65a2e-c3dd-4d27-9d18-9bf123835fb8") as DoubleInput;
-            var slider = GetNode("2279f845-4ba9-4300-a6c3-a566cd8b4a32") as DoubleSliderInput;
-            var strIn = GetNode("d33abcb6-50fd-4d18-ac89-87adb2d28053") as StringInput;
-            var formula = GetNode("540fffbb-4f5b-4496-9231-eba5b04e388c") as Formula;
-            var sublist = GetNode("0a60f132-25a0-4b7c-85f2-3c31f39ef9da") as Sublists;
-
-            Assert.IsNotNull(number);
-            Assert.IsNotNull(slider);
-            Assert.IsNotNull(strIn);
-            Assert.IsNotNull(formula);
-            Assert.IsNotNull(sublist);
-
-            Assert.AreEqual("12.34", number.Value);
-            Assert.AreEqual(23.45, slider.Min, 0.000001);
-            Assert.AreEqual(34.56, slider.Value, 0.000001);
-            Assert.AreEqual(45.67, slider.Max, 0.000001);
-            Assert.AreEqual("Test String Input", strIn.Value);
-            Assert.AreEqual("d", sublist.Value);
-
-            Assert.AreEqual("a+b+c", formula.FormulaString);
-            Assert.AreEqual(3, formula.InPorts.Count);
-            Assert.AreEqual(1, formula.OutPorts.Count);
-        }
-
-        [Test, RequiresSTA]
-        public void TestVerifyRuntimeValues()
-        {
-            RunCommandsFromFile("VerifyRuntimeValues.xml", true);
-            Assert.AreEqual(2, workspace.Connectors.Count);
-            Assert.AreEqual(3, workspace.Nodes.Count);
-
-            var number1 = GetNode("76b951e9-a815-4fb9-bec1-fbd1178fa113") as DoubleInput;
-            var number2 = GetNode("1a3efb71-52df-46e8-95ab-a130e9a885ce") as DoubleInput;
-            var addition = GetNode("9182323d-a4fd-40eb-905b-8ec415d17926") as Addition;
-
-            Assert.AreEqual(12.34, (number1.OldValue as FScheme.Value.Number).Item);
-            Assert.AreEqual(56.78, (number2.OldValue as FScheme.Value.Number).Item);
-            Assert.AreEqual(69.12, (addition.OldValue as FScheme.Value.Number).Item);
-        }
-
-    }
-
-#else
-
+    
     class RecordedTestsDSEngine : RecordedTests
     {
         #region Basic CodeBlockNode Test Cases
@@ -1896,13 +1575,13 @@ namespace DynamoCoreUITests
             Assert.AreEqual(3, workspace.Nodes.Count);
             Assert.AreEqual(1, workspace.Connectors.Count);
 
-            
+
             var cbn = GetNode("babc4816-96e6-495c-8489-7a650d1bfb25") as CodeBlockNodeModel;
             Assert.AreNotEqual(ElementState.Error, cbn.State);
-            
-            AssertValue("e", 1); 
+
+            AssertValue("e", 1);
             cbn = GetNode("d4d53e20-1514-4349-83e1-7cb5c533a3e0") as CodeBlockNodeModel;
-            AssertValue("p", 1); 
+            AssertValue("p", 1);
             Exit();
             Start();
             // redefine function - test if the CBN reexecuted
@@ -2000,12 +1679,12 @@ namespace DynamoCoreUITests
                 if (commandTag == "Tag-204ca7e6")
                 {
                     AssertPreviewValue("53cd0201-273c-43f4-8815-8531db75d68c", null);
-                    
+
                 }
                 else if (commandTag == "Tag-2f9b6919")
                 {
                     AssertPreviewValue("53cd0201-273c-43f4-8815-8531db75d68c", true);
-                    
+
                 }
             });
         }
@@ -2060,45 +1739,45 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-         public void Deffect_1412CreateList()
-         {
-             // This is a UI test to test for interaction crashes the application
- 
-             RunCommandsFromFile("Deffect_1412CreateList.xml");
-             Assert.AreEqual(4, workspace.Nodes.Count);
-             Assert.AreEqual(2, workspace.Connectors.Count);
-         }
-         [Test, RequiresSTA]
-         public void Deffect_1344PythonEditor()
-         {
-             // This is a UI test to test for interaction crashes the application
- 
-             RunCommandsFromFile("Deffect_1344PythonEditor.xml");
-             Assert.AreEqual(3, workspace.Nodes.Count);
-             Assert.AreEqual(2, workspace.Connectors.Count);
-         }
-         [Test, RequiresSTA]
-         public void Deffect_2208Delete_CBN()
-         {
-             // This is a UI test to test for interaction crashes the application
- 
-             RunCommandsFromFile("Defect_MAGN_2208.xml");
-             Assert.AreEqual(0, workspace.Nodes.Count);
-         }
-         [Test, RequiresSTA]
-         public void Deffect_2201Watch_CBN()
-         {
-             RunCommandsFromFile("Defect_MAGN_2201.xml");
-             Assert.AreEqual(3, workspace.Nodes.Count);
-         }
-         [Test, RequiresSTA]
-         public void Deffect_747MultiReference()
-         {
-             RunCommandsFromFile("defect_MAGN_747.xml", true);
-             Assert.AreEqual(1, workspace.Nodes.Count);
-             AssertPreviewValue("a76409a1-1280-428c-9cf7-16580c48ff96",1);
-             
-         }
+        public void Deffect_1412CreateList()
+        {
+            // This is a UI test to test for interaction crashes the application
+
+            RunCommandsFromFile("Deffect_1412CreateList.xml");
+            Assert.AreEqual(4, workspace.Nodes.Count);
+            Assert.AreEqual(2, workspace.Connectors.Count);
+        }
+        [Test, RequiresSTA]
+        public void Deffect_1344PythonEditor()
+        {
+            // This is a UI test to test for interaction crashes the application
+
+            RunCommandsFromFile("Deffect_1344PythonEditor.xml");
+            Assert.AreEqual(3, workspace.Nodes.Count);
+            Assert.AreEqual(2, workspace.Connectors.Count);
+        }
+        [Test, RequiresSTA]
+        public void Deffect_2208Delete_CBN()
+        {
+            // This is a UI test to test for interaction crashes the application
+
+            RunCommandsFromFile("Defect_MAGN_2208.xml");
+            Assert.AreEqual(0, workspace.Nodes.Count);
+        }
+        [Test, RequiresSTA]
+        public void Deffect_2201Watch_CBN()
+        {
+            RunCommandsFromFile("Defect_MAGN_2201.xml");
+            Assert.AreEqual(3, workspace.Nodes.Count);
+        }
+        [Test, RequiresSTA]
+        public void Deffect_747MultiReference()
+        {
+            RunCommandsFromFile("defect_MAGN_747.xml", true);
+            Assert.AreEqual(1, workspace.Nodes.Count);
+            AssertPreviewValue("a76409a1-1280-428c-9cf7-16580c48ff96", 1);
+
+        }
 
 
         [Test, RequiresSTA]
@@ -2263,7 +1942,7 @@ namespace DynamoCoreUITests
                     AssertPreviewValue("3f309016-7b00-4487-9b68-f0640e892d39", 10);
 
                 }
-                
+
             });
 
             NodeModel nodeModel = Controller.DynamoModel.CurrentWorkspace.NodeFromWorkspace(
@@ -2281,7 +1960,7 @@ namespace DynamoCoreUITests
         public void Defect_MAGN_2102()
         {
             // more details available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2102
-            
+
             RunCommandsFromFile("Defect_MAGN_2102.xml", false, (commandTag) =>
             {
                 var workspace = Controller.DynamoModel.CurrentWorkspace;
@@ -2431,7 +2110,7 @@ namespace DynamoCoreUITests
                     Assert.AreEqual(2, workspace.Nodes.Count);
                     Assert.AreEqual(3, workspace.Connectors.Count);
 
-                    AssertPreviewValue("2be171fb-2f81-4244-88ec-a8827a77e150", 
+                    AssertPreviewValue("2be171fb-2f81-4244-88ec-a8827a77e150",
                         new int[] { 5, 5, 5 });
                 }
                 else if (commandTag == "ThirdRun")
@@ -2440,7 +2119,7 @@ namespace DynamoCoreUITests
                     Assert.AreEqual(4, workspace.Nodes.Count);
                     Assert.AreEqual(5, workspace.Connectors.Count);
 
-                    AssertPreviewValue("2be171fb-2f81-4244-88ec-a8827a77e150", 
+                    AssertPreviewValue("2be171fb-2f81-4244-88ec-a8827a77e150",
                         new int[] { 5, 5, 5, 6, 7 });
                 }
                 else if (commandTag == "FourthRun")
@@ -2449,7 +2128,7 @@ namespace DynamoCoreUITests
                     Assert.AreEqual(4, workspace.Nodes.Count);
                     Assert.AreEqual(4, workspace.Connectors.Count);
 
-                    AssertPreviewValue("2be171fb-2f81-4244-88ec-a8827a77e150", 
+                    AssertPreviewValue("2be171fb-2f81-4244-88ec-a8827a77e150",
                         new int[] { 5, 5, 5, 6 });
                 }
 
@@ -2459,7 +2138,7 @@ namespace DynamoCoreUITests
                     Assert.AreEqual(4, workspace.Nodes.Count);
                     Assert.AreEqual(3, workspace.Connectors.Count);
 
-                    AssertPreviewValue("2be171fb-2f81-4244-88ec-a8827a77e150", 
+                    AssertPreviewValue("2be171fb-2f81-4244-88ec-a8827a77e150",
                         new int[] { 5, 5, 5 });
                 }
 
@@ -2503,7 +2182,7 @@ namespace DynamoCoreUITests
                     Assert.AreEqual(13, workspace.Connectors.Count);
 
                     AssertPreviewValue("6e2b9ef1-7749-40ec-9319-b43832c1891f",
-                        new int[][] {new int[] { 2, 8, 9, 3 } });
+                        new int[][] { new int[] { 2, 8, 9, 3 } });
                 }
                 else if (commandTag == "SecondRun")
                 {
@@ -2626,7 +2305,7 @@ namespace DynamoCoreUITests
                     Assert.AreEqual(2, workspace.Nodes.Count);
                     Assert.AreEqual(1, workspace.Connectors.Count);
 
-                    AssertPreviewValue("55b87e32-7279-49bf-982c-91d06b349439", 
+                    AssertPreviewValue("55b87e32-7279-49bf-982c-91d06b349439",
                         new int[] { 0, 1, 2, 3 });
                 }
                 else if (commandTag == "SecondRun")
@@ -2639,7 +2318,7 @@ namespace DynamoCoreUITests
                         ("bc2c4de8-43a1-4b36-b0d6-309423664089");
 
                     Assert.AreNotEqual(ElementState.Warning, node.State);
-                    AssertPreviewValue("bc2c4de8-43a1-4b36-b0d6-309423664089", 
+                    AssertPreviewValue("bc2c4de8-43a1-4b36-b0d6-309423664089",
                         new int[] { 0, 1, 2, 3 });
                 }
                 else if (commandTag == "LastRun")
@@ -2708,7 +2387,7 @@ namespace DynamoCoreUITests
                     Assert.AreEqual(3, workspace.Nodes.Count);
                     Assert.AreEqual(2, workspace.Connectors.Count);
 
-                    AssertPreviewValue("826ba392-b385-4960-89cc-c076c3abffb0", 
+                    AssertPreviewValue("826ba392-b385-4960-89cc-c076c3abffb0",
                         new int[] { 0, 1, 2, 3 });
 
                     AssertPreviewValue("8765fc5f-4edd-482c-8541-9acb6e39352c",
@@ -3041,5 +2720,4 @@ namespace DynamoCoreUITests
         #endregion
     }
 
-#endif
 }


### PR DESCRIPTION
Until now we kept both classes because FScheme based tests were running on Master (0.6.3) but now that it is not required

I have already moved all tests from RecordedTestFSceme class to RecordedTestsDSEngine class (by creating region "Test Moved from FScheme") and changed their evaluation to DSEngine.
