### PR TITLE
Limmit the maximum size of a regular Watch node

### DIFF
--- a/src/DynamoCore/UI/Configurations.cs
+++ b/src/DynamoCore/UI/Configurations.cs
@@ -6,12 +6,16 @@ namespace Dynamo.UI
     public class Configurations
     {
         #region Dynamo Universal Constants
+
         // Add 0.5 to place the point in the middle of a pixel to sharpen it
         public static readonly double PixelSharpeningConstant = 0.5;
         public static readonly string BackupFolderName = "backup";
         public static readonly string FilePathAttribName = "TargetXmlFilePath";
         public static readonly double DoubleSliderTextBoxWidth = 55.0;
         public static readonly double IntegerSliderTextBoxWidth = 30.0;
+        public static readonly double MaxWatchNodeWidth = 280.0;
+        public static readonly double MaxWatchNodeHeight = 310.0;
+
         #endregion
 
         #region Usage Reporting Error Message

--- a/src/DynamoCore/UI/UIPartials.cs
+++ b/src/DynamoCore/UI/UIPartials.cs
@@ -554,6 +554,13 @@ namespace Dynamo.Nodes
         public void SetupCustomUIElements(dynNodeView nodeUI)
         {
             _watchTree = new WatchTree();
+
+            // MAGN-2446: Fixes the maximum width/height of watch node so it won't 
+            // go too crazy on us. Note that this is only applied to regular watch 
+            // node so it won't be limiting the size of image/3D watch nodes.
+            // 
+            nodeUI.PresentationGrid.MaxWidth = Configurations.MaxWatchNodeWidth;
+            nodeUI.PresentationGrid.MaxHeight = Configurations.MaxWatchNodeHeight;
             nodeUI.PresentationGrid.Children.Add(_watchTree);
 
             if (Root == null)


### PR DESCRIPTION
##### Background

This pull request places limitation on Watch node's width and height (to design specified values of `280px` and `310px` respectively). The fix is meant for the following defect:

[MAGN-2446 Watch node gets unusably long](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2446)

**Note**: This pull request doesn't completely solve everything described in the proposed design, but it makes the Watch node usable again by not allowing it to go crazily long. I will be requesting to lower the priority of this defect and defer it to a later time to address the rest of enhancement works (e.g. display more details of the watched content).

![maximum-watch-node-fix](https://cloud.githubusercontent.com/assets/5086849/2825275/c78283c2-cf47-11e3-9fb5-080a99937725.png)
##### Unit Tests

This is a UI-only change we can't quite make a test case for.
