### PR TITLE
Fix List.Transpose()

### DIFF
--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -655,15 +655,21 @@ namespace DSCore
             if (lists.Count == 0 || !lists.Cast<object>().Any(x => x is IList))
                 return lists;
 
-            var genList = lists.Cast<IList>();
-            var maxLength = genList.Max(subList => subList.Count); 
-            var emptyList = Enumerable.Range(0, maxLength).Select(i => new ArrayList());
+            var ilists = lists.Cast<IList>();
+            var maxLength = ilists.Max(subList => subList.Count); 
+            List<ArrayList> transposedList = Enumerable.Range(0, maxLength)
+                                                       .Select(i => new ArrayList())
+                                                       .ToList();
 
-            var ret = genList.Aggregate(emptyList, 
-                                       (accList, list) => accList.Zip(list.Cast<object>(), (os, o) => { os.Add(o); return os; })
-                                                                 .Concat(accList.Skip(list.Count)));
+            foreach (var sublist in ilists)
+            {
+                for (int i = 0; i < sublist.Count; i++)
+                {
+                    transposedList[i].Add(sublist[i]);                
+                }
+            }
 
-            return ret.ToList();
+            return transposedList;
         }
 
         

--- a/test/DynamoCoreTests/Nodes/ListTests.cs
+++ b/test/DynamoCoreTests/Nodes/ListTests.cs
@@ -511,7 +511,6 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [Category("Failing")]
         public void TestTransposeNormalInput()
         {
             // Input array                  Expected output array


### PR DESCRIPTION
Fix MAGN-3173 List.Transpose runs infinitely in this case(http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3173)
Lazy evaluation in Linq expression causes huge memory consumption which halts Dynamo. Change to imperative implementation. 
