### PR TITLE
Avoid mirror data query if info bubble is hidden

### DIFF
--- a/src/DynamoCore/ViewModels/NodeViewModel.cs
+++ b/src/DynamoCore/ViewModels/NodeViewModel.cs
@@ -393,11 +393,11 @@ namespace Dynamo.ViewModels
                     break;
                 case "OldValue":
                     RaisePropertyChanged("OldValue");
-                    UpdatePreviewBubbleContent();
+                    UpdatePreviewBubbleContent(false);
                     RaisePropertyChanged("CanDisplayLabels");
                     break;
                 case "IsUpdated":
-                    UpdatePreviewBubbleContent();
+                    UpdatePreviewBubbleContent(false);
                     break;
                 case "X":
                     RaisePropertyChanged("Left");
@@ -492,7 +492,7 @@ namespace Dynamo.ViewModels
             var vm = dynSettings.Controller.DynamoViewModel;
             if (vm.CurrentSpaceViewModel.Nodes.Contains(this))
             {
-                UpdatePreviewBubbleContent();
+                UpdatePreviewBubbleContent(true);
 
                 var command = PreviewBubble.ChangeInfoBubbleStateCommand;
                 command.Execute(
@@ -563,7 +563,7 @@ namespace Dynamo.ViewModels
             ErrorBubble.UpdatePositionCommand.Execute(data);
         }
 
-        private void UpdatePreviewBubbleContent()
+        private void UpdatePreviewBubbleContent(bool forceDataQuery)
         {
             if (PreviewBubble == null || NodeModel is Watch || dynSettings.Controller == null)
                 return;
@@ -571,6 +571,12 @@ namespace Dynamo.ViewModels
             var vm = dynSettings.Controller.DynamoViewModel;
             if (!vm.CurrentSpaceViewModel.Previews.Contains(PreviewBubble))
                 return;
+
+            if (PreviewBubble.InfoBubbleState == InfoBubbleViewModel.State.Minimized)
+            {
+                if (forceDataQuery == false)
+                    return;
+            }
 
             //create data packet to send to preview bubble
             const InfoBubbleViewModel.Style style = InfoBubbleViewModel.Style.PreviewCondensed;
@@ -831,7 +837,7 @@ namespace Dynamo.ViewModels
             if (PreviewBubble == null)
                 return;
 
-            UpdatePreviewBubbleContent();
+            UpdatePreviewBubbleContent(true);
             PreviewBubble.ZIndex = 5;
             PreviewBubble.OnRequestAction(
                 new InfoBubbleEventArgs(InfoBubbleEventArgs.Request.Show));


### PR DESCRIPTION
Hi Luke/Ian,

This pull request is a temporary measure to ease the `SymbolNotFoundException` pain, especially in the cases where a value query is not even desirable (i.e. when info bubble is in a hidden state). Ultimately the following still need to happen to completely improve the situation:
- Info bubble should be completely reworked to show more meaningful information (work-in-progress)
- `VisualizationManager` needs to avoid querying the variable's `MirrorData` if it is not necessary.
#### Important:

After this tweak, the following call-stack is still seen with each selection change (regardless of the number of nodes in selection). Each of the selection operation results in 6 queries to get the `MirrorData`, that might not be necessary (can we cache the `MirrorData` on the `NodeModel` instead? But of course that presents a serious problem to thread safety when `LiveRunner` tries to modify the same `MirrorData` on a separate thread. I was under the impression that a `MirrorData` is made for each query, so there _might not_ be any thread safety issue after all. Something to consider.)

```
ProtoCore.dll!ProtoCore.DSASM.Mirror.ExecutionMirror.GetValue(string name, int b...
ProtoCore.dll!ProtoCore.Mirror.RuntimeMirror.RuntimeMirror(string varname, int b...
ProtoCore.dll!ProtoCore.Mirror.Reflection.Reflect(string varname, int blockDecl,...
ProtoScript.dll!ProtoScript.Runners.LiveRunner.InspectNodeValue(string nodeName)...
DynamoCore.dll!Dynamo.DSEngine.LiveRunnerServices.GetMirror(string var) Line 52 ...
DynamoCore.dll!Dynamo.DSEngine.EngineController.GetMirror(string variableName) L...
DynamoCore.dll!Dynamo.DSEngine.EngineController.GetGraphicItems(string variableN...
DynamoCore.dll!Dynamo.Models.NodeModel.UpdateRenderPackage() Line 1463 + 0x46 by...
DynamoCore.dll!Dynamo.VisualizationManager.UpdateRenderPackagesThread.AnonymousM...
[External Code]
DynamoCore.dll!Dynamo.VisualizationManager.UpdateRenderPackagesThread(object sen...
[External Code]
```
