### PR TITLE
Fixed two test cases and turned them on by removing Assert for inconclusive.

### DIFF
--- a/test/Libraries/Revit/DynamoRevitTests/SelectionTests.cs
+++ b/test/Libraries/Revit/DynamoRevitTests/SelectionTests.cs
@@ -24,6 +24,8 @@ namespace Dynamo.Tests
             //open the test file
             model.Open(testPath);
 
+            AssertNoDummyNodes();
+
             //first assert that we have only one node
             var nodeCount = dynSettings.Controller.DynamoModel.Nodes.Count;
             Assert.AreEqual(1, nodeCount);
@@ -66,6 +68,8 @@ namespace Dynamo.Tests
 
             //open the test file
             model.Open(testPath);
+
+            AssertNoDummyNodes();
 
             Assert.DoesNotThrow(() => dynSettings.Controller.RunExpression(true));
 


### PR DESCRIPTION
These two test cases were marked as Assert.Inconclusive because there were some deprecated nodes, now all nodes are getting migrated correctly so by changing node type I make them worked. These tests are now passing.
