### PR TITLE
Zero touch import cleanup for RevitNodes library

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/CurveElement.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/CurveElement.cs
@@ -8,7 +8,7 @@ using RevitServices.Persistence;
 
 namespace Revit.Elements
 {
-    public abstract class CurveElement : Element, IGraphicItem
+    public abstract class CurveElement : Element
     {
         public override Autodesk.Revit.DB.Element InternalElement
         {
@@ -115,7 +115,7 @@ namespace Revit.Elements
 
         #endregion
 
-        public void Tessellate(IRenderPackage package, double tol, int gridLines)
+        public override void Tessellate(IRenderPackage package, double tol, int gridLines)
         {
             //Ensure that the object is still alive
             if (!IsAlive) return;

--- a/src/Libraries/Revit/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Element.cs
@@ -27,7 +27,7 @@ namespace Revit.Elements
         /// <summary>
         /// A reference to the current Document.
         /// </summary>
-        [IsVisibleInDynamoLibrary(false)]
+        [SupressImportIntoVM]
         public static Document Document
         {
             get { return DocumentManager.Instance.CurrentDBDocument; }
@@ -54,7 +54,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get the Name of the Element
         /// </summary>
-        [IsVisibleInDynamoLibrary(false)]
+        [SupressImportIntoVM]
         public string Name
         {
             get
@@ -92,7 +92,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get the Element Unique Id for this element
         /// </summary>
-        [IsVisibleInDynamoLibrary(false)]
+        [SupressImportIntoVM]
         public string UniqueId
         {
             get
@@ -104,8 +104,7 @@ namespace Revit.Elements
         /// <summary>
         /// A reference to the element
         /// </summary>
-        //[SupressImportIntoVM]
-        [IsVisibleInDynamoLibrary(false)]
+        [SupressImportIntoVM]
         public abstract Autodesk.Revit.DB.Element InternalElement
         {
             get;
@@ -137,7 +136,6 @@ namespace Revit.Elements
         /// Default implementation of dispose that removes the element from the
         /// document
         /// </summary>
-        [IsVisibleInDynamoLibrary(false)]
         public virtual void Dispose()
         {
 
@@ -171,12 +169,13 @@ namespace Revit.Elements
         /// A basic implementation of ToString for Elements
         /// </summary>
         /// <returns></returns>
-        [IsVisibleInDynamoLibrary(false)]
+        [SupressImportIntoVM]
         public override string ToString()
         {
             return this.GetType().Name;
         }
 
+        [SupressImportIntoVM]
         public virtual string ToString(string format, IFormatProvider formatProvider)
         {
             // As a default, return the standard string representation.
@@ -184,8 +183,8 @@ namespace Revit.Elements
             return ToString();
         }
 
-        [IsVisibleInDynamoLibrary(false)]
-        public void Tessellate(IRenderPackage package, double tol, int gridLines)
+        [SupressImportIntoVM]
+        public virtual void Tessellate(IRenderPackage package, double tol, int gridLines)
         {
             // Do nothing. We implement this method only to prevent the GraphicDataProvider from
             // attempting to interrogate the public properties, some of which may require regeneration

--- a/src/Libraries/Revit/RevitNodes/Elements/InternalUtilities/ElementQueries.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/InternalUtilities/ElementQueries.cs
@@ -7,7 +7,7 @@ using RevitServices.Persistence;
 
 namespace Revit.Elements.InternalUtilities
 {
-    [IsVisibleInDynamoLibrary(false)]
+    [SupressImportIntoVM]
     public static class ElementQueries
     {
         public static IList<Element> OfFamilyType(FamilySymbol familyType)

--- a/src/Libraries/Revit/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -15,7 +15,7 @@ namespace Revit.Elements
     /// Element wrapper supplies tools for wrapping Autodesk.Revit.DB.Element types
     /// in their associated Revit.Elements.Element wrapper
     /// </summary>
-    [IsVisibleInDynamoLibrary(false)]
+    [SupressImportIntoVM]
     public static class ElementWrapper
     {
         /// <summary>

--- a/src/Libraries/Revit/RevitNodes/Elements/ModelText.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/ModelText.cs
@@ -234,11 +234,11 @@ namespace Revit.Elements
         /// <summary>
         /// The Position of the ModelText Element
         /// </summary>
-        public XYZ Position
+        public Point Position
         {
             get
             {
-                return ((LocationPoint) InternalElement.Location).Point;
+                return ((LocationPoint) InternalElement.Location).Point.ToPoint();
             }
         }
 

--- a/src/Libraries/Revit/RevitNodes/Elements/UnknownElement.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/UnknownElement.cs
@@ -6,7 +6,7 @@ namespace Revit.Elements
     /// A Revit Element of an unknown type.  This allows an arbitrary element
     /// to be passed around in the graph.
     /// </summary>
-    [IsVisibleInDynamoLibrary(false)]
+    [SupressImportIntoVM]
     public class UnknownElement : Element
     {
         /// <summary>

--- a/src/Libraries/Revit/RevitNodes/Elements/Views/Sheet.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Views/Sheet.cs
@@ -93,7 +93,7 @@ namespace Revit.Elements.Views
         /// <param name="sheetNumber"></param>
         /// <param name="titleBlockFamilySymbol"></param>
         /// <param name="views"></param>
-        public Sheet(string sheetName, string sheetNumber, Autodesk.Revit.DB.FamilySymbol titleBlockFamilySymbol, IEnumerable<Autodesk.Revit.DB.View> views)
+        private Sheet(string sheetName, string sheetNumber, Autodesk.Revit.DB.FamilySymbol titleBlockFamilySymbol, IEnumerable<Autodesk.Revit.DB.View> views)
         {
 
             //Phase 1 - Check to see if the object exists

--- a/src/Libraries/Revit/RevitNodes/GeometryConversion/GeometryObjectConverter.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryConversion/GeometryObjectConverter.cs
@@ -11,7 +11,7 @@ using Point = Autodesk.DesignScript.Geometry.Point;
 
 namespace Revit.GeometryConversion
 {
-    [IsVisibleInDynamoLibrary(false)]
+    [SupressImportIntoVM]
     public static class GeometryObjectConverter
     {
         /// <summary>

--- a/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoFace.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoFace.cs
@@ -22,7 +22,7 @@ namespace Revit.GeometryConversion
             return revitFace.InternalFace.ToSurface();
         }
 
-        public static Surface ToSurface(this Autodesk.Revit.DB.Face face)
+        internal static Surface ToSurface(this Autodesk.Revit.DB.Face face)
         {
             if (face == null) return null;
 
@@ -39,7 +39,7 @@ namespace Revit.GeometryConversion
             return revitFace.InternalFace.ToUntrimmedSurface();
         }
 
-        public static Surface ToUntrimmedSurface(this Autodesk.Revit.DB.Face face)
+        internal static Surface ToUntrimmedSurface(this Autodesk.Revit.DB.Face face)
         {
             if (face == null) return null;
 
@@ -60,7 +60,7 @@ namespace Revit.GeometryConversion
             return revitFace.InternalFace.EdgeLoops();
         }
 
-        public static PolyCurve[] EdgeLoops(this Autodesk.Revit.DB.Face face)
+        internal static PolyCurve[] EdgeLoops(this Autodesk.Revit.DB.Face face)
         {
             if (face == null) return null;
 

--- a/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoMesh.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoMesh.cs
@@ -7,7 +7,7 @@ using Autodesk.DesignScript.Runtime;
 
 namespace Revit.GeometryConversion
 {
-    [IsVisibleInDynamoLibrary(false)]
+    [SupressImportIntoVM]
     public static class RevitToProtoMesh
     {
         public static Autodesk.DesignScript.Geometry.Mesh ToProtoType(this Autodesk.Revit.DB.Mesh mesh)

--- a/src/Libraries/Revit/RevitNodes/GeometryObjects/GeometryObject.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryObjects/GeometryObject.cs
@@ -9,7 +9,6 @@ using Autodesk.Revit.DB;
 
 namespace Revit.GeometryObjects
 {
-    //[SupressImportIntoVM]
     public abstract class GeometryObject : IGraphicItem
     {
         /// <summary>
@@ -24,13 +23,13 @@ namespace Revit.GeometryObjects
         /// Simple implementation of ToString - override for customized behavior
         /// </summary>
         /// <returns></returns>
-        [IsVisibleInDynamoLibrary(false)]
+        [SupressImportIntoVM]
         public override string ToString()
         {
             return GetType().FullName;
         }
 
-        [IsVisibleInDynamoLibrary(false)]
+        [SupressImportIntoVM]
         public abstract void Tessellate(IRenderPackage package, double tol, int gridLines);
 
         /// <summary>

--- a/src/Libraries/Revit/RevitNodes/GeometryObjects/InternalUtilities/GeometryObjectWrapper.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryObjects/InternalUtilities/GeometryObjectWrapper.cs
@@ -7,7 +7,7 @@ using Microsoft.CSharp.RuntimeBinder;
 
 namespace Revit.GeometryObjects
 {
-    [IsVisibleInDynamoLibrary(false)]
+    [SupressImportIntoVM]
     public static class GeometryObjectWrapper
     {
         /// <summary>

--- a/src/Libraries/Revit/RevitNodes/References/Reference.cs
+++ b/src/Libraries/Revit/RevitNodes/References/Reference.cs
@@ -16,6 +16,7 @@ namespace Revit.References
     [IsVisibleInDynamoLibrary(false)]
     public abstract class Reference
     {
+        [SupressImportIntoVM]
         public static Document Document
         {
             get { return DocumentManager.Instance.CurrentDBDocument; }


### PR DESCRIPTION
- Ensured proper usage of [SupressImportIntoVM] vs.
  [IsVisibleInDynamoLibrary(false)]
- ElementQueries, ElementWrapper as well as conversion utility classes
  are suppressed from import to VM.
- Ensured that none of the methods based on Revit DB API classes are
  exposed to VM.
