### PR TITLE
Avoided redundant EngineController creation

### DIFF
--- a/src/DynamoCore/Core/DynamoController.cs
+++ b/src/DynamoCore/Core/DynamoController.cs
@@ -268,7 +268,7 @@ namespace Dynamo
             dynSettings.PackageLoader.LoadPackages();
 
             DisposeLogic.IsShuttingDown = false;
-            EngineController = new EngineController(this, false);
+
             //This is necessary to avoid a race condition by causing a thread join
             //inside the vm exec
             //TODO(Luke): Push this into a resync call with the engine controller
@@ -674,9 +674,12 @@ namespace Dynamo
         public virtual void ResetEngine()
         {
             if (EngineController != null)
+            {
                 EngineController.Dispose();
+                EngineController = null;
+            }
 
-            EngineController = new EngineController(this, true);
+            EngineController = new EngineController(this);
         }
 
         public void RequestRedraw()

--- a/src/DynamoCore/DSEngine/EngineController.cs
+++ b/src/DynamoCore/DSEngine/EngineController.cs
@@ -28,7 +28,7 @@ namespace Dynamo.DSEngine
         private int shortVarCounter = 0;
         private DynamoController controller;
 
-        public EngineController(DynamoController controller, bool isReset)
+        public EngineController(DynamoController controller)
         {
             libraryServices = LibraryServices.GetInstance();
             libraryServices.LibraryLoading += this.LibraryLoading;

--- a/src/DynamoRevit/DynamoController_Revit.cs
+++ b/src/DynamoRevit/DynamoController_Revit.cs
@@ -393,9 +393,12 @@ namespace Dynamo
                 () =>
                 {
                     if (EngineController != null)
+                    {
                         EngineController.Dispose();
+                        EngineController = null;
+                    }
 
-                    EngineController = new EngineController(this, true);
+                    EngineController = new EngineController(this);
                 });
         }
 


### PR DESCRIPTION
Found this while investigating memory leaks through CLR Profiler. We are unnecessarily creating `EngineController` in the constructor of `DynamoController`. Remove this line makes the following difference as indicated by CLR Profiler (both these numbers are obtained by just launching Dynamo and closing it down).
##### Before removal

```
Allocated bytes:                162,528,272
Relocated bytes:                 76,849,582
Final Heap bytes:                25,543,222
Objects finalized:                    1,321
Critical objects finalized:           1,172
Gen 0 collections:                       24
Gen 1 collections:                        8
Gen 2 collections:                        3
Induced collections:                      1
Gen 0 Heap bytes:                 6,803,236
Gen 1 Heap bytes:                 7,462,987
Gen 2 Heap bytes:                17,543,690
Large Object Heap bytes:            377,480
Handles created:                     17,174
Handles destroyed:                   14,123
Handles surviving:                    3,051
Heap Dumps:                               0
Comments:                                 0
```
##### After removal

```
Allocated bytes:                140,123,591
Relocated bytes:                 76,864,879
Final Heap bytes:                25,517,276
Objects finalized:                    1,546
Critical objects finalized:           1,367
Gen 0 collections:                       23
Gen 1 collections:                        7
Gen 2 collections:                        3
Induced collections:                      1
Gen 0 Heap bytes:                 6,115,452
Gen 1 Heap bytes:                 5,307,437
Gen 2 Heap bytes:                14,197,600
Large Object Heap bytes:            636,968
Handles created:                     17,148
Handles destroyed:                   14,097
Handles surviving:                    3,051
Heap Dumps:                               0
Comments:                                 0
```
