### PR TITLE
Fixed auto-merge issue

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -309,8 +309,6 @@ namespace Dynamo.Models
         {
             get
             {
-                var mirrorData = dynSettings.Controller.EngineController.GetMirror(AstIdentifierForPreview.Value);
-                return mirrorData == null ? null : mirrorData.GetData();
                 if (cachedMirrorData != null)
                     return cachedMirrorData;
 


### PR DESCRIPTION
The original code just didn't make sense (it always return before the rest of the codes). That's because `OldValue` got mistakenly merged into `CachedValue`, which was right below it.
