### PR TITLE
Fix a showstopper as CBN fails to show previews and geometries

### DIFF
--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -156,6 +156,11 @@ namespace Dynamo.Nodes
             }
         }
 
+        public override string AstIdentifierBase
+        {
+            get { return (State == ElementState.Error) ? null : previewVariable; }
+        }
+
         public string Code
         {
             get { return code; }
@@ -230,11 +235,6 @@ namespace Dynamo.Nodes
         #endregion
 
         #region Protected Methods
-
-        public override string VariableToPreview
-        {
-            get { return (State == ElementState.Error) ? null : previewVariable; }
-        }
 
         protected override void SaveNode(XmlDocument xmlDoc, XmlElement nodeElement, SaveContext context)
         {
@@ -527,6 +527,7 @@ namespace Dynamo.Nodes
             // instead of the full expression with array indexers.
             // 
             previewVariable = duplicatedNode.Value;
+            this.identifier = null; // Reset preview identifier for regeneration.
         }
 
         /// <summary>
@@ -816,7 +817,7 @@ namespace Dynamo.Nodes
                 var ident = identNode.Value;
                 if ((inputIdentifiers.Contains(ident) || definedVars.Contains(ident)) 
                     && !tempVariables.Contains(ident)
-                    && !identNode.Equals(AstIdentifierForPreview))
+                    && !identNode.Equals(this.identifier))
                 {
                     identNode.Name = identNode.Value = LocalizeIdentifier(ident);
                 }

--- a/test/DynamoCoreTests/DSEvaluationTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationTest.cs
@@ -98,7 +98,7 @@ namespace Dynamo.Tests
             var model = Controller.DynamoModel;
             var node = model.CurrentWorkspace.NodeFromWorkspace(guid);
             Assert.IsNotNull(node);
-            return  node.VariableToPreview;
+            return node.AstIdentifierBase;
         }
 
         private RuntimeMirror GetRuntimeMirror(string varName)

--- a/test/Libraries/Revit/DynamoRevitTests/DynamoRevitTests.cs
+++ b/test/Libraries/Revit/DynamoRevitTests/DynamoRevitTests.cs
@@ -243,7 +243,7 @@ namespace Dynamo.Tests
             var model = Controller.DynamoModel;
             var node = model.CurrentWorkspace.NodeFromWorkspace(guid);
             Assert.IsNotNull(node);
-            return node.VariableToPreview;
+            return node.AstIdentifierBase;
         }
 
         private RuntimeMirror GetRuntimeMirror(string varName)

--- a/test/Libraries/Revit/DynamoRevitTests/TransformTest.cs
+++ b/test/Libraries/Revit/DynamoRevitTests/TransformTest.cs
@@ -48,7 +48,7 @@ namespace Dynamo.Tests
 
             // Check node output
             NodeModel node = model.CurrentWorkspace.NodeFromWorkspace("58d488dd-b668-467f-b3ac-d46b5a97fabe");
-            RuntimeMirror mirror = Controller.EngineController.GetMirror(node.VariableToPreview);
+            RuntimeMirror mirror = Controller.EngineController.GetMirror(node.AstIdentifierBase);
             Assert.IsNotNull(mirror);
 
             var point = mirror.GetData().Data as Point;
@@ -88,7 +88,7 @@ namespace Dynamo.Tests
 
             // Check node output
             NodeModel node = model.CurrentWorkspace.NodeFromWorkspace("7fdb538d-22a3-412c-b646-d0fb23ca2dc6");
-            RuntimeMirror mirror = Controller.EngineController.GetMirror(node.VariableToPreview);
+            RuntimeMirror mirror = Controller.EngineController.GetMirror(node.AstIdentifierBase);
             Assert.IsNotNull(mirror);
 
             var point = mirror.GetData().Data as Point;
@@ -128,7 +128,7 @@ namespace Dynamo.Tests
 
             // Check node output
             NodeModel node = model.CurrentWorkspace.NodeFromWorkspace("783ce70c-789d-4c2a-ad40-c16d6d933fd4");
-            RuntimeMirror mirror = Controller.EngineController.GetMirror(node.VariableToPreview);
+            RuntimeMirror mirror = Controller.EngineController.GetMirror(node.AstIdentifierBase);
             Assert.IsNotNull(mirror);
 
             var point = mirror.GetData().Data as Point;


### PR DESCRIPTION
##### Background

This submission fixes the following show-stopper defect (tracked internally):
- [MAGN-3236 Geometry doesn't appear from CBN](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3236)

The following changes were made for this fix:
- `NodeModel.AstIdentifierBase` is now made `public` and `virtual` (for CBN)
- Identical property `NodeModel.VariableToPreview` is replaced by `AstIdentifierBase`
- Fixed an incorrect condition in `NodeModel.PrintValue` (for info bubble display)
- Test cases are updated to refer to `AstIdentifierBase` instead of `VariableToPreview`
##### Preview

This is how the fix worked on my machine:
![preview-geometry-issues-with-cbn](https://cloud.githubusercontent.com/assets/5086849/2860810/e4a1d5e6-d1d3-11e3-97d4-d4f8a06ae61b.png)
##### Testing Scenarios

I have tested with the following cases and it appears to be working fine:
- Multiple lines with simple data types in CBN
- Multiple lines with geometries in CBN
- Modified CBN contents by renaming variables
- Modified CBN contents by changing literal values
- Modified CBN contents by changing orders of lines
- Undo and redo above modifications
