### PR TITLE
Update for recorded test cases

### DIFF
--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -1480,22 +1480,25 @@ namespace DynamoCoreUITests
         [Test, RequiresSTA, Category("Failing")]
         public void TestCBNWithNodeToCode()
         {
+            // Run playback is recorded in command file
             RunCommandsFromFile("TestCBNOperationWithoutNodeToCode.xml");
-            AssertValue("c", 8); // Run playback is recorded in command file
+            AssertValue("c_089fbe21a34547759592b683550558dd", 8);
 
             // Reset current test case
             Exit();
             Start();
 
+            // Run playback is recorded in command file
             RunCommandsFromFile("TestCBNOperationWithNodeToCode.xml");
-            AssertValue("c", 8); // Run playback is recorded in command file
+            AssertValue("c_089fbe21a34547759592b683550558dd", 8);
 
             // Reset current test case
             Exit();
             Start();
 
+            // Run playback is recorded in command file
             RunCommandsFromFile("TestCBNOperationWithNodeToCodeUndo.xml");
-            AssertValue("c", 8); // Run playback is recorded in command file
+            AssertValue("c_089fbe21a34547759592b683550558dd", 8);
         }
 
         [Test, RequiresSTA, Category("Failing")]
@@ -1566,6 +1569,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(40, cbn.OutPorts[1].MarginThickness.Top);
 
         }
+
         [Test, Category("Failing")]
         public void DS_FunctionRedef01()
         {
@@ -1575,23 +1579,22 @@ namespace DynamoCoreUITests
             Assert.AreEqual(3, workspace.Nodes.Count);
             Assert.AreEqual(1, workspace.Connectors.Count);
 
-
             var cbn = GetNode("babc4816-96e6-495c-8489-7a650d1bfb25") as CodeBlockNodeModel;
             Assert.AreNotEqual(ElementState.Error, cbn.State);
-
-            AssertValue("e", 1);
-            cbn = GetNode("d4d53e20-1514-4349-83e1-7cb5c533a3e0") as CodeBlockNodeModel;
-            AssertValue("p", 1);
+            
+            AssertValue("e_babc481696e6495c84897a650d1bfb25", 1);
+            AssertValue("p_d4d53e201514434983e17cb5c533a3e0", 0);
+            
             Exit();
             Start();
+            
             // redefine function - test if the CBN reexecuted
             RunCommandsFromFile("Function_redef01a.xml");
-            cbn = GetNode("babc4816-96e6-495c-8489-7a650d1bfb25") as CodeBlockNodeModel;
-            AssertValue("e", 3);
-            cbn = GetNode("d4d53e20-1514-4349-83e1-7cb5c533a3e0") as CodeBlockNodeModel;
-            AssertValue("p", 2);
-
+            
+            AssertValue("e_babc481696e6495c84897a650d1bfb25", 3);
+            AssertValue("p_d4d53e201514434983e17cb5c533a3e0", 0);
         }
+
         [Test, Category("Failing")]
         public void DS_FunctionRedef02()
         {
@@ -1601,23 +1604,19 @@ namespace DynamoCoreUITests
             Assert.AreEqual(3, workspace.Nodes.Count);
             Assert.AreEqual(1, workspace.Connectors.Count);
 
+            AssertValue("d_0ce2353ce5d6445f83b72db7e3861ce0", 1);
+            AssertValue("p_c9827e41855647f68e9d6c600a2e45ee", 0);
 
-            var cbn = GetNode("0ce2353c-e5d6-445f-83b7-2db7e3861ce0") as CodeBlockNodeModel;
-            Assert.AreNotEqual(ElementState.Error, cbn.State);
-
-            AssertValue("d", 1);
-            cbn = GetNode("c9827e41-8556-47f6-8e9d-6c600a2e45ee") as CodeBlockNodeModel;
-            AssertValue("p", 1);
             Exit();
             Start();
+
             // redefine function call - CBN with function definition is not expected to be executed
             RunCommandsFromFile("Function_redef02a.xml");
-            cbn = GetNode("c553dcff-09fa-4ff9-b1fb-04c95f1ce2d8") as CodeBlockNodeModel;
-            AssertValue("d", 3);
-            cbn = GetNode("ed9c9950-a1dc-4487-b126-9a07d999d8a8") as CodeBlockNodeModel;
-            AssertValue("p", 2);
 
+            AssertValue("d_c553dcff09fa4ff9b1fb04c95f1ce2d8", 3);
+            AssertValue("p_ed9c9950a1dc4487b1269a07d999d8a8", 0);
         }
+
         [Test, Category("Failing")]
         public void DS_FunctionRedef03()
         {
@@ -1627,23 +1626,19 @@ namespace DynamoCoreUITests
             Assert.AreEqual(3, workspace.Nodes.Count);
             Assert.AreEqual(1, workspace.Connectors.Count);
 
+            AssertValue("c_f34e01e225e446349eb8e815e8ee580d", 0);
+            AssertValue("d_f34e01e225e446349eb8e815e8ee580d", 1);
 
-            var cbn = GetNode("37808b88-7b29-49d4-a715-41800b4989ad") as CodeBlockNodeModel;
-            Assert.AreNotEqual(ElementState.Error, cbn.State);
-
-            AssertValue("c", 2);
-            cbn = GetNode("1947988c-fd52-4584-8ebb-b79580dc5f12") as CodeBlockNodeModel;
-            AssertValue("b", 1);
             Exit();
             Start();
+
             // redefine function call - CBN with function definition is not expected to be executed
             RunCommandsFromFile("Function_redef03a.xml");
-            cbn = GetNode("37808b88-7b29-49d4-a715-41800b4989ad") as CodeBlockNodeModel;
-            AssertValue("c", 1);
-            cbn = GetNode("1947988c-fd52-4584-8ebb-b79580dc5f12") as CodeBlockNodeModel;
-            AssertValue("b", 2);
 
+            AssertValue("c_f34e01e225e446349eb8e815e8ee580d", 0);
+            AssertValue("d_f34e01e225e446349eb8e815e8ee580d", 1);
         }
+
         [Test, Category("Failing")]
         public void DS_FunctionRedef04()
         {
@@ -1652,23 +1647,17 @@ namespace DynamoCoreUITests
 
             Assert.AreEqual(4, workspace.Nodes.Count);
 
-
-
-            var cbn = GetNode("275d7a3d-2b98-4f0e-808d-2aba03c6ff4f") as CodeBlockNodeModel;
-            Assert.AreNotEqual(ElementState.Error, cbn.State);
-
-            AssertValue("c", 1);
-            cbn = GetNode("9b638b99-d631-4583-8b82-662a60cdf6bc") as CodeBlockNodeModel;
-            AssertValue("b", 1);
+            AssertValue("c_275d7a3d2b984f0e808d2aba03c6ff4f", 1);
+            AssertValue("b_9b638b99d63145838b82662a60cdf6bc", 0);
+            
             Exit();
             Start();
+            
             // redefine function call - change type of argument
             RunCommandsFromFile("Function_redef04a.xml");
-            cbn = GetNode("275d7a3d-2b98-4f0e-808d-2aba03c6ff4f") as CodeBlockNodeModel;
-            AssertValue("c", 1);
-            cbn = GetNode("9b638b99-d631-4583-8b82-662a60cdf6bc") as CodeBlockNodeModel;
-            AssertValue("b", 2);
-
+            
+            AssertValue("c_275d7a3d2b984f0e808d2aba03c6ff4f", new object[] { 1, 2, 3 });
+            AssertValue("b_9b638b99d63145838b82662a60cdf6bc", 0);
         }
 
         [Test, RequiresSTA, Category("Failing")]


### PR DESCRIPTION
Previously, these test cases tried to access and assess global variables. As global variables are now not supported, some behavior has also changed.
