### PR TITLE
Fix changeSetApplier on handling VM graphnodes

### DIFF
--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -176,7 +176,7 @@ namespace ProtoScript.Runners
                 {
                     foreach (var gnode in core.DSExecutable.instrStreamList[0].dependencyGraph.GraphList)
                     {
-                        if (gnode.AstID == bNode.ID)
+                        if (gnode.OriginalAstID == bNode.OriginalAstID)
                         {
                             gnode.isActive = false;
                         }
@@ -347,7 +347,9 @@ namespace ProtoScript.Runners
                     if (!st.ForceExecution)
                     {
                         removedNodes = GetInactiveASTList(oldSubTree.AstNodes, st.AstNodes);
-                        csData.RemovedBinaryNodesFromModification.AddRange(removedNodes);
+                        // We only need the removed binary ASTs
+                        // Function definitions are handled in ChangeSetData.RemovedFunctionDefNodesFromModification
+                        csData.RemovedBinaryNodesFromModification.AddRange(removedNodes.Where(n => n is BinaryExpressionNode));
                     }
 
                     // There is a bug in DeactivateGraphNodes(), otherwise we


### PR DESCRIPTION
1. Use the OriginalAST property to check for redefined statements .
   AstID is only used within the core VM execution
2. Fix old testcases with invalid results
3. Add testcase simulating  modification of connections to a CBN
