### PR TITLE
Fix MAGN-3264: longest lacing does not work for default argument

### DIFF
--- a/src/DynamoCore/Nodes/DSFunction.cs
+++ b/src/DynamoCore/Nodes/DSFunction.cs
@@ -248,20 +248,30 @@ namespace Dynamo.Nodes
 
                     for (int i = 0; i < inputs.Count(); ++i)
                     {
+                        ArrayNameNode astNode = null;
+
                         if (inputs[i] is ArrayNameNode)
                         {
-                            var astNode = NodeUtils.Clone(inputs[i]) as ArrayNameNode;
-                            astNode.ReplicationGuides = new List<AssociativeNode>();
+                            astNode = NodeUtils.Clone(inputs[i]) as ArrayNameNode;
+                            
+                        }
+                        else
+                        {
+                            var exprListNode  = new ExprListNode();
+                            exprListNode.list.Add(NodeUtils.Clone(inputs[i]));
+                            astNode = exprListNode;
+                        }
 
-                            var guideNode = new ReplicationGuideNode
+                        astNode.ReplicationGuides = new List<AssociativeNode>()
+                        {
+                            new ReplicationGuideNode
                             {
                                 RepGuide = AstFactory.BuildIdentifier("1"),
                                 IsLongest = true
-                            };
+                            }
+                        };
 
-                            astNode.ReplicationGuides.Add(guideNode);
-                            inputs[i] = astNode;
-                        }
+                        inputs[i] = astNode;
                     }
                     break;
 
@@ -270,20 +280,29 @@ namespace Dynamo.Nodes
                     int guide = 1;
                     for (int i = 0; i < inputs.Count(); ++i)
                     {
+                        ArrayNameNode astNode = null;
+
                         if (inputs[i] is ArrayNameNode)
                         {
-                            var astNode = NodeUtils.Clone(inputs[i]) as ArrayNameNode;
-                            astNode.ReplicationGuides = new List<AssociativeNode>();
+                            astNode = NodeUtils.Clone(inputs[i]) as ArrayNameNode;
+                        }
+                        else
+                        {
+                            var exprListNode  = new ExprListNode();
+                            exprListNode.list.Add(NodeUtils.Clone(inputs[i]));
+                            astNode = exprListNode;
+                        }
 
-                            var guideNode = new ReplicationGuideNode
+                        astNode.ReplicationGuides = new List<AssociativeNode>()
+                        {
+                            new ReplicationGuideNode
                             {
                                 RepGuide = AstFactory.BuildIdentifier(guide.ToString())
-                            };
+                            }
+                        };
 
-                            astNode.ReplicationGuides.Add(guideNode);
-                            inputs[i] = astNode;
-                            guide++;
-                        }
+                        inputs[i] = astNode;
+                        guide++;
                     }
                     break;
             }

--- a/test/DynamoCoreTests/DSEvaluationTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationTest.cs
@@ -768,6 +768,14 @@ namespace Dynamo.Tests
             RunModel(@"core\dsevaluation\apply_property.dyn");
             AssertPreviewValue("2cbadbce-ee25-4f90-8309-3b81bf4fdfd9", 42.0);
         }
+
+        [Test]
+        public void Defect_MAGN_3264()
+        {
+            // Function object to property method and used in apply 
+            RunModel(@"core\dsevaluation\Defect_MAGN_3264.dyn");
+            AssertPreviewValue("eaa2b29f-b5f4-4017-a143-3fb2d4af349c", new double[] {0, 1, 2, 3, 4});
+        }
     }
 
     [Category("DSCustomNode")]

--- a/test/core/dsevaluation/Defect_MAGN_3264.dyn
+++ b/test/core/dsevaluation/Defect_MAGN_3264.dyn
@@ -1,0 +1,21 @@
+<Workspace Version="0.7.0.19565" X="0" Y="0" zoom="1" Description="" Category="" Name="Home">
+  <Elements>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="74b1dd64-491c-42e0-b8a6-62ceebfe00fe" nickname="Point.ByCoordinates" x="396" y="219.5" isVisible="true" isUpstreamVisible="true" lacing="Longest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="f7d7dc66-21df-4608-9a36-c6e774a7acda" nickname="Code Block" x="118" y="182" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="zs = {0, 1, 2, 3, 4};" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="eaa2b29f-b5f4-4017-a143-3fb2d4af349c" nickname="Point.Z" x="637" y="212.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Z" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="74b1dd64-491c-42e0-b8a6-62ceebfe00fe" start_index="0" end="eaa2b29f-b5f4-4017-a143-3fb2d4af349c" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="f7d7dc66-21df-4608-9a36-c6e774a7acda" start_index="0" end="74b1dd64-491c-42e0-b8a6-62ceebfe00fe" end_index="2" portType="0" />
+  </Connectors>
+  <Notes />
+  <SessionTraceData>
+    <NodeTraceData NodeId="74b1dd64-491c-42e0-b8a6-62ceebfe00fe">
+      <CallsiteTraceData>PFNPQVAtRU5WOkVudmVsb3BlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zOnhzZD0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiIHhtbG5zOlNPQVAtRU5DPSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VuY29kaW5nLyIgeG1sbnM6U09BUC1FTlY9Imh0dHA6Ly9zY2hlbWFzLnhtbHNvYXAub3JnL3NvYXAvZW52ZWxvcGUvIiB4bWxuczpjbHI9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vc29hcC9lbmNvZGluZy9jbHIvMS4wIiBTT0FQLUVOVjplbmNvZGluZ1N0eWxlPSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VuY29kaW5nLyI+DQo8U09BUC1FTlY6Qm9keT4NCjxhMTpDYWxsU2l0ZV94MDAyQl9UcmFjZVNlcmlhbGlzZXJIZWxwZXIgaWQ9InJlZi0xIiB4bWxuczphMT0iaHR0cDovL3NjaGVtYXMubWljcm9zb2Z0LmNvbS9jbHIvbnNhc3NlbS9Qcm90b0NvcmUvUHJvdG9Db3JlJTJDJTIwVmVyc2lvbiUzRDAuMC4wLjAlMkMlMjBDdWx0dXJlJTNEbmV1dHJhbCUyQyUyMFB1YmxpY0tleVRva2VuJTNEbnVsbCI+DQo8TnVtYmVyT2ZFbGVtZW50cz4xPC9OdW1iZXJPZkVsZW1lbnRzPg0KPEJhc2UtMF9IYXNEYXRhPmZhbHNlPC9CYXNlLTBfSGFzRGF0YT4NCjxCYXNlLTBfSGFzTmVzdGVkRGF0YT50cnVlPC9CYXNlLTBfSGFzTmVzdGVkRGF0YT4NCjxCYXNlLTBfTmVzdGVkRGF0YUNvdW50PjU8L0Jhc2UtMF9OZXN0ZWREYXRhQ291bnQ+DQo8QmFzZS0wLTBfSGFzRGF0YT5mYWxzZTwvQmFzZS0wLTBfSGFzRGF0YT4NCjxCYXNlLTAtMF9IYXNOZXN0ZWREYXRhPmZhbHNlPC9CYXNlLTAtMF9IYXNOZXN0ZWREYXRhPg0KPEJhc2UtMC0xX0hhc0RhdGE+ZmFsc2U8L0Jhc2UtMC0xX0hhc0RhdGE+DQo8QmFzZS0wLTFfSGFzTmVzdGVkRGF0YT5mYWxzZTwvQmFzZS0wLTFfSGFzTmVzdGVkRGF0YT4NCjxCYXNlLTAtMl9IYXNEYXRhPmZhbHNlPC9CYXNlLTAtMl9IYXNEYXRhPg0KPEJhc2UtMC0yX0hhc05lc3RlZERhdGE+ZmFsc2U8L0Jhc2UtMC0yX0hhc05lc3RlZERhdGE+DQo8QmFzZS0wLTNfSGFzRGF0YT5mYWxzZTwvQmFzZS0wLTNfSGFzRGF0YT4NCjxCYXNlLTAtM19IYXNOZXN0ZWREYXRhPmZhbHNlPC9CYXNlLTAtM19IYXNOZXN0ZWREYXRhPg0KPEJhc2UtMC00X0hhc0RhdGE+ZmFsc2U8L0Jhc2UtMC00X0hhc0RhdGE+DQo8QmFzZS0wLTRfSGFzTmVzdGVkRGF0YT5mYWxzZTwvQmFzZS0wLTRfSGFzTmVzdGVkRGF0YT4NCjwvYTE6Q2FsbFNpdGVfeDAwMkJfVHJhY2VTZXJpYWxpc2VySGVscGVyPg0KPC9TT0FQLUVOVjpCb2R5Pg0KPC9TT0FQLUVOVjpFbnZlbG9wZT4NCg==</CallsiteTraceData>
+    </NodeTraceData>
+  </SessionTraceData>
+</Workspace>


### PR DESCRIPTION
This submission is to fix defect MAGN-3264 Longest lacing does not work, for nodes with default value if one of the arguments is an array. 

That's because when a function node compiled to AST node, its default values are compiled to literal AST node like int node or double node which doesn't contain replication guide. The fix is to put them in expression list so that we could append replication guide to them.

Test case DSEvaluationTest.Defect_MAGN_3264 added. 
