### PR TITLE
Fix magn-1525: wrong error msg when a non existent constructor is being called

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -1307,11 +1307,11 @@ namespace ProtoAssociative
                         {
                             if (subPass == AssociativeSubCompilePass.kNone)
                             {
-                                string message = String.Format(WarningMessage.kCallingNonStaticMethod,
+                                string message = String.Format(WarningMessage.kStaticMethodNotFound,
                                                                className,
                                                                procName);
 
-                                buildStatus.LogWarning(WarningID.kCallingNonStaticMethodOnClass,
+                                buildStatus.LogWarning(WarningID.kFunctionNotFound,
                                                        message,
                                                        core.CurrentDSFileName,
                                                        dotCall.line,

--- a/src/Engine/ProtoCore/BuildStatus.cs
+++ b/src/Engine/ProtoCore/BuildStatus.cs
@@ -61,8 +61,9 @@ namespace ProtoCore
             public const string kPropertyIsInaccessible = "Property '{0}' is inaccessible.";
             public const string kMethodIsInaccessible = "Method '{0}()' is inaccessible.";
             public const string kCallingConstructorInConstructor = "Cannot call constructor '{0}()' in itself.";
-            public const string kPropertyNotFound = "Property '{0}' not found";
-            public const string kMethodNotFound = "Method '{0}()' not found";
+            public const string kPropertyNotFound = "Property '{0}' not found.";
+            public const string kMethodNotFound = "Method '{0}()' not found.";
+            public const string kStaticMethodNotFound = "Cannot find static method or constructor {0}.{1}().";
             public const string kUnboundIdentifierMsg = "Variable '{0}' hasn't been defined yet.";
             public const string kFunctionNotReturnAtAllCodePaths = "Method '{0}()' doesn't return at all code paths.";
             public const string kRangeExpressionWithStepSizeZero = "The step size of range expression should not be 0.";


### PR DESCRIPTION
Give a more friendly error message for calling a non-exist method on class; fix test case T111_Class_Constructor_Negative_1467598.
