### PR TITLE
Fix magn1571: indexing into string does not work properly

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -4194,6 +4194,13 @@ namespace ProtoCore.DSASM
             try
             {
                 result = GetIndexedArray(thisArray, dims);
+
+                // If the source object is a string and the result is an array
+                // of character, wrap it into a string. 
+                if (result.IsArray() && thisArray.IsString())
+                {
+                    result = StackValue.BuildString(result.opdata);
+                }
             }
             catch (ArgumentOutOfRangeException)
             {

--- a/test/Engine/ProtoTest/TD/MultiLangTests/StringTest.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/StringTest.cs
@@ -649,12 +649,49 @@ r = a;
 
 
         [Test]
-        public void TestStringIndexing()
+        public void TestStringIndexing01()
         {
             String code =
                 @"                s = ""abc"";                r = s[0];                ";
             thisTest.RunScriptSource(code);
             thisTest.Verify("r", 'a');
+        }
+
+        [Test]
+        public void TestStringIndexing02()
+        {
+            String code =
+                @"                s = ""abcdef"";                r = s[1..3];                ";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("r", "bcd");
+        }
+
+        [Test]
+        public void TestStringIndexing03()
+        {
+            String code =
+                @"                s = ""abcdef"";                r = s[-1];                ";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("r", 'f');
+        }
+
+        [Test]
+        public void TestStringIndexing04()
+        {
+            String code =
+                @"                s = ""abcdef"";                r = s[(-1)..(-3)];                ";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("r", "fed");
+        }
+
+        [Test]
+        public void TestStringIndexing05()
+        {
+            String code =
+                @"                s = """";                r = s[0];                ";
+            thisTest.RunScriptSource(code);
+            // Will get an index out of range runtime warning
+            TestFrameWork.VerifyRuntimeWarning(ProtoCore.RuntimeData.WarningID.kOverIndexing);
         }
     }
 }


### PR DESCRIPTION
Fix issue that it is able to index into string and change its value but not able to return indexed string value. That because at runtime we only check the object is array or not. Should add checking for string as well.

Related test case added. 
