### PR TITLE
Removed NUnit dependency from DynamoCore

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -8,7 +8,6 @@ using Dynamo.Models;
 using Dynamo.Nodes;
 using System.IO;
 using Dynamo.ViewModels;
-using NUnit.Framework;
 using Enum = System.Enum;
 using Utils = Dynamo.Nodes.Utilities;
 using DynCmd = Dynamo.ViewModels.DynamoViewModel;
@@ -976,7 +975,7 @@ namespace Dynamo.Utilities
                 dynSettings.Controller.DynamoModel.WriteToLog(ex);
 
                 if (DynamoController.IsTestMode)
-                    Assert.Fail(ex.Message);
+                    throw ex; // Rethrow for NUnit.
 
                 def = null;
                 return false;

--- a/src/DynamoCore/Core/DynamoController.cs
+++ b/src/DynamoCore/Core/DynamoController.cs
@@ -20,7 +20,6 @@ using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using DynamoUnits;
 using Microsoft.Practices.Prism.ViewModel;
-using NUnit.Framework;
 using String = System.String;
 using DynCmd = Dynamo.ViewModels.DynamoViewModel;
 using Dynamo.UI.Prompts;
@@ -449,8 +448,8 @@ namespace Dynamo
 
                 OnRunCancelled(true);
 
-                if (IsTestMode)
-                    Assert.Fail(ex.Message + ":" + ex.StackTrace);
+                if (IsTestMode) // Throw exception for NUnit.
+                    throw new Exception(ex.Message + ":" + ex.StackTrace);
             }
             finally
             {

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -85,10 +85,6 @@ limitations under the License.
       <HintPath>..\..\extern\Newtonsoft.json\Newtonsoft.Json.dll</HintPath>
       <HintPath>..\..\extern\Newtonsoft.JsonBin\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(NunitPath)\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="ProtoGeometry, Version=0.1.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\extern\ProtoGeometry\ProtoGeometry.dll</HintPath>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -15,7 +15,6 @@ using Dynamo.Nodes;
 using Dynamo.Utilities;
 using Dynamo.Selection;
 using Microsoft.Practices.Prism;
-using NUnit.Framework;
 using Enum = System.Enum;
 using String = System.String;
 using DynCmd = Dynamo.ViewModels.DynamoViewModel;
@@ -100,7 +99,7 @@ namespace Dynamo.Models
                 Debug.WriteLine(ex.Message + ":" + ex.StackTrace);
 
                 if (DynamoController.IsTestMode)
-                    Assert.Fail(ex.Message);
+                    throw ex; // Rethrow for NUnit.
 
                 return null;
             }

--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -14,7 +14,6 @@ using ProtoCore.BuildData;
 using ArrayNode = ProtoCore.AST.AssociativeAST.ArrayNode;
 using Node = ProtoCore.AST.Node;
 using Operator = ProtoCore.DSASM.Operator;
-using NUnit.Framework;
 using System.Windows.Media;
 using System.Windows;
 using Dynamo.UI;

--- a/src/DynamoCore/Nodes/Function.cs
+++ b/src/DynamoCore/Nodes/Function.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Xml;
 using Dynamo.Models;
 using Dynamo.Utilities;
-using NUnit.Framework;
 using ProtoCore.AST.AssociativeAST;
 
 #endregion


### PR DESCRIPTION
This is to fix an internally tracked defect:
- [MAGN-1177 DynamoCore should not reference NUnit](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1177)
