### PR TITLE
Add a broken test case for live runner

### DIFF
--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -4080,20 +4080,6 @@ OUT = 100"", {""IN""}, {{}}); x = x;"
         [Test]
         public void TestNestedLanguageBlockExecution()
         {
-            /*
-               r = [Imperative]
-               {
-                   if (true)
-                   {
-                       return = [Associative] { return = 42; }
-                   }
-                   else
-                   {
-                       return = [Associative] { return = 43; }
-                   }
-               }
-             */
-
             List<string> codes = new List<string>() 
             {
                @"r = [Imperative]


### PR DESCRIPTION
LiveRunner doesn't work for nested language block. Add a test case for it, some nodes (e.g., IF node) are blocked because of this defect. 
