### PR TITLE
Not to put literal value in expression list for replication guide

### DIFF
--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -2761,9 +2761,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
             else
             {
-                var exprListNode = new ExprListNode();
-                exprListNode.list.Add(NodeUtils.Clone(node));
-                repNode = exprListNode;
+                return node;
             }
 
             repNode.ReplicationGuides = guides.Select(g => new ReplicationGuideNode


### PR DESCRIPTION
In my pull request https://github.com/DynamoDS/Dynamo/pull/1615 I put a literal value in an expression list so that replication guide could be appended. But this fix is wrong. As the value is promoted to an array, it cause the return value from function which uses longest lacing strategy _and_ uses default value becomes an array. 

So in this pull request that logic is removed. It fixes issue MAGN-3408 Null outputs from Raybounce node. 

At the same time, I reopen defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3264.
