### PR TITLE
Select Divided Surface Families (MAGN-3338)

### DIFF
--- a/src/Migrations/RevitNodes/Selection.cs
+++ b/src/Migrations/RevitNodes/Selection.cs
@@ -36,11 +36,8 @@ namespace Dynamo.Nodes
                 oldNode, "Dynamo.Nodes.DSDividedSurfaceFamiliesSelection", "Select Divided Surface Families");
             migrationData.AppendNode(newNode);
 
-            // DO NOT clone the sub nodes. The behavior of this node changed from 0.6.3 to 0.7.0
-            // and we want to ensure that the user will need to reselect.
-
-            //foreach (XmlElement subNode in oldNode.ChildNodes)
-            //    newNode.AppendChild(subNode.Clone());
+            foreach (XmlElement subNode in oldNode.ChildNodes)
+                newNode.AppendChild(subNode.Clone());
 
             return migrationData;
         }


### PR DESCRIPTION
- Fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3338
- For compatibility with 0.6.3, we need to extract the Divided Surface
  Families from Forms as well.
- Implemented ElementSelector.DividedSurfaceFamiliesByUniqueId and
  ensured the selection node calls this method.

/// <summary>


/// Gets list of DividedSurface families from the given uniqueId. If given
/// uniqueId does not refer to Autodesk.Revit.DB.FamilyInstance, then it
/// gets the list of families using DividedSurfaceData.
/// </summary>


