### PR TITLE
Changed SoapFormatter to BinaryFormatter.

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Soap;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using ProtoCore.BuildData;
 using ProtoCore.DSASM;
@@ -82,7 +82,7 @@ namespace ProtoCore
                     Byte[] data = Convert.FromBase64String(info.GetString(marker + objectID + "_Data"));
 
 
-                    IFormatter formatter = new SoapFormatter();
+                    IFormatter formatter = new BinaryFormatter();
                     MemoryStream s = new MemoryStream(data);
 
                     srtd.Data = (ISerializable) formatter.Deserialize(s);
@@ -119,7 +119,7 @@ namespace ProtoCore
                     //Serialise the object
                     using (MemoryStream s = new MemoryStream())
                     {
-                        IFormatter formatter = new SoapFormatter();
+                        IFormatter formatter = new BinaryFormatter();
                         formatter.Serialize(s, Data);
                         info.AddValue(marker + objectID + "_Data", Convert.ToBase64String(s.ToArray()));
                     }
@@ -300,7 +300,7 @@ namespace ProtoCore
 
             Byte[] data = Convert.FromBase64String(serializedTraceData);
 
-            IFormatter formatter = new SoapFormatter();
+            IFormatter formatter = new BinaryFormatter();
             MemoryStream s = new MemoryStream(data);
 
             TraceSerialiserHelper helper = (TraceSerialiserHelper)formatter.Deserialize(s);
@@ -413,7 +413,7 @@ namespace ProtoCore
             using (MemoryStream memoryStream = new MemoryStream())
             {
 
-                IFormatter formatter = new SoapFormatter();
+                IFormatter formatter = new BinaryFormatter();
                 formatter.Serialize(memoryStream, helper);
 
                 return Convert.ToBase64String(memoryStream.ToArray());


### PR DESCRIPTION
Persistence between Dynamo sessions is not working for me for implementations of ISerializable that have an Id type that uses generics. For example, in your class MultipleSerializableId, you are storing List<string> and List<int> in your named data slot.  This works for binding in-session.  I could be wrong because I have not tested this with Revit, but I don't believe any method that sets trace data with SetElementsForTrace will be able to save trace data to the .dyn file as you currently have it because SoapFormatter doesn't support doing that.  Have you tested between-session rebinding with Revit for MultipleSerializableId?  I will be really confused if you have and it works.  I have tested this change in Inventor and it works.

If there is a reason that it has to be SoapFormatter, can we talk about a way to switch between the two? Or SoapFormatter be tried first, then BinaryFormatter if that fails?  For trace data that has to store lots of disparate data, having to resort to replacing something like List'<Tuple<string, int , int, byte[]>> to a series of arrays, zipping them back together, etc doesn't seem good.  
