### PR TITLE
Associate SSA graphnodes to their final assignment graphnode at codegen

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -3982,6 +3982,7 @@ namespace ProtoAssociative
             }
 
             ResolveFinalNodeRefs();
+            ResolveSSADependencies();
 
             if (codeBlock.parent == null)  // top-most langauge block
             {
@@ -7378,8 +7379,41 @@ namespace ProtoAssociative
 
             ProtoCore.Type type = new ProtoCore.Type();
         }
-
         
+        /// <summary>
+        /// Associate the SSA'd graphnodes to the final assignment graphnode
+        /// 
+        /// Given:
+        ///     a = b + c   ->  t0 = a
+        ///                     t1 = b
+        ///                     t2 = t0 + t1
+        ///                     a = t2
+        ///                     
+        /// Store the SSA graphnodes:
+        ///     t0, t1, t2
+        ///     
+        /// in the final graphnode 
+        ///     a = t2;
+        ///     
+        /// </summary>
+        private void ResolveSSADependencies()
+        {
+            foreach (ProtoCore.AssociativeGraph.GraphNode graphNode in codeBlock.instrStream.dependencyGraph.GraphList)
+            {
+                if (graphNode != null && graphNode.IsSSANode())
+                {
+                    if (graphNode.lastGraphNode != null)
+                    {
+                        SymbolNode dependentSymbol = graphNode.updateNodeRefList[0].nodeList[0].symbol;
+                        if (!graphNode.lastGraphNode.symbolListWithinExpression.Contains(dependentSymbol))
+                        {
+                            graphNode.lastGraphNode.symbolListWithinExpression.Add(dependentSymbol);
+                        }
+                    }
+                }
+            }
+        }
+
         //
         //  proc ResolveFinalNodeRefs()
         //      foreach graphnode in graphnodeList

--- a/src/Engine/ProtoCore/AssociativeGraph.cs
+++ b/src/Engine/ProtoCore/AssociativeGraph.cs
@@ -16,21 +16,6 @@ namespace ProtoCore.AssociativeEngine
     public class Utils
     {
         /// <summary>
-        /// This function sets the modified temp graphnodes to the last graphnode in a statement
-        /// </summary>
-        /// <param name="graphnode"></param>
-        public static void SetFinalGraphNodeRuntimeDependents(AssociativeGraph.GraphNode graphnode)
-        {
-            if (null != graphnode && graphnode.IsSSANode())
-            {
-                if (null != graphnode.lastGraphNode)
-                {
-                    graphnode.lastGraphNode.symbolListWithinExpression.Add(graphnode.updateNodeRefList[0].nodeList[0].symbol);
-                }
-            }
-        }
-
-        /// <summary>
         /// Finds all graphnodes associated with each AST and marks them dirty
         /// </summary>
         /// <param name="nodeList"></param>

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -375,11 +375,6 @@ namespace ProtoCore.DSASM
                         {
                             SetupGraphEntryPoint(pc);
                         }
-
-                        if (core.Options.ExecuteSSA)
-                        {
-                            ProtoCore.AssociativeEngine.Utils.SetFinalGraphNodeRuntimeDependents(Properties.executingGraphNode);
-                        }
                     }
                 }
             }
@@ -1447,10 +1442,6 @@ namespace ProtoCore.DSASM
                     if (graphNode.isReturn || graphNode.updateNodeRefList[0].nodeList.Count > 0)
                     {
                         graphNode.isDirty = false;
-                        if (core.Options.ExecuteSSA)
-                        {
-                            ProtoCore.AssociativeEngine.Utils.SetFinalGraphNodeRuntimeDependents(graphNode);
-                        }
 
                         // In function calls, the first graphnode in the function is executed first and was not marked 
                         // If this is the case, just move on to the next graphnode
@@ -2336,12 +2327,6 @@ namespace ProtoCore.DSASM
                     entryNode = graphNode;
                 }
             }
-
-            if (core.Options.ExecuteSSA)
-            {
-                ProtoCore.AssociativeEngine.Utils.SetFinalGraphNodeRuntimeDependents(entryNode);
-            }
-
             pc = setentry;
         }
 
@@ -2377,10 +2362,6 @@ namespace ProtoCore.DSASM
 
             Properties.executingGraphNode = entryNode;
 
-            if (core.Options.ExecuteSSA)
-            {
-                ProtoCore.AssociativeEngine.Utils.SetFinalGraphNodeRuntimeDependents(entryNode);
-            }
             pc = setentry;
         }
 


### PR DESCRIPTION
1. Move SSA graphnode association at codegen
2. Remove this functionality from the runtime
