### PR TITLE
fix defect MAGN-217: Delete key is not working for deleting text from search field.

### DIFF
--- a/src/DynamoCore/UI/Views/SearchView.xaml.cs
+++ b/src/DynamoCore/UI/Views/SearchView.xaml.cs
@@ -142,6 +142,49 @@ namespace Dynamo.Search
                         e.Handled = true;
                         dynSettings.Controller.DynamoViewModel.DeleteCommand.Execute(null);
                     }
+
+                    //if there are no nodes being selected, the delete key should 
+                    //delete the text in the search box of library preview
+                    else {
+
+                        //if there is no text, then jump out of the switch
+                        if (String.IsNullOrEmpty(SearchTextBox.Text))
+                        {
+                            break;
+                        }
+                        else 
+                        {
+                            int cursorPosition = SearchTextBox.SelectionStart;
+                            string searchBoxText = SearchTextBox.Text;
+
+                            //if some piece of text is seleceted by users.
+                            //delete this piece of text
+                            if (SearchTextBox.SelectedText != "")
+                            {
+                                searchBoxText = searchBoxText.Remove(cursorPosition, 
+                                    SearchTextBox.SelectionLength);
+                            }
+
+                            //if there is no text selected, delete the character after the cursor
+                            else 
+                            {
+                                
+                                //the cursor is at the end of this text string
+                                if (cursorPosition == searchBoxText.Length)
+                                {
+                                    break;
+                                }
+                                else 
+                                {
+                                    searchBoxText = searchBoxText.Remove(cursorPosition, 1);
+                                }
+                            }
+
+                            //update the SearchTextBox's text and the cursor position
+                            SearchTextBox.Text = searchBoxText;
+                            SearchTextBox.SelectionStart = cursorPosition;
+                        }
+                    }
                     break;
 
                 case Key.Tab:


### PR DESCRIPTION
Add the event handler to handle the delete key event. If there is node selecting, the delete key will delete the node. If not, the delete key will delete the text from the search field.
[MAGN-217](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-217)
