### PR TITLE
Fix MAGN-3451 Name of the node displayed does not match after migration 

### DIFF
--- a/src/Migrations/RevitNodes/UV.cs
+++ b/src/Migrations/RevitNodes/UV.cs
@@ -122,6 +122,7 @@ namespace Dynamo.Nodes
                 "dom[0][1]+Math.RandomList\n" +
                 "(ucount*vcount)\n" +
                 "*(dom[1][1]-dom[0][1]);");
+            codeBlockNode.SetAttribute("nickname", "Random UV");
             migrationData.AppendNode(codeBlockNode);
             string codeBlockNodeId = MigrationManager.GetGuidFromXmlElement(codeBlockNode);
 


### PR DESCRIPTION
 Assign a name, "Random UV", for the CBN to improve the readability,
[MAGN-3451](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3451)
