### PR TITLE
Remove deleted nodes from node state table in sync data manager

### DIFF
--- a/src/DynamoCore/DSEngine/SyncDataManager.cs
+++ b/src/DynamoCore/DSEngine/SyncDataManager.cs
@@ -44,7 +44,7 @@ namespace Dynamo.DSEngine
                 states.Remove(key);
             }
      
-            states.Keys.ToList().ForEach(key => states[key] = State.NoChange);
+            states.Keys.ToList().ForEach(key => states[key] = State.Clean);
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Dynamo.DSEngine
 
         internal enum State
         {
-            NoChange,
+            Clean,
             Added,
             Modified,
             Deleted


### PR DESCRIPTION
This pull request is to fix defect [MAGN-3552: Undoing a delete operation sends a AST-modified event not an AST-created event](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3552).

SyncDataManager internally keeps a node's GUID -> node's state map. Previously after the graph is evaluated (Run button is clicked), all nodes' states are changed to State.Clean, including those deleted nodes. Therefore if the delete operation is undone, that node is marked as modified.

The change is to remove all deleted in the state map instead of changing their states to State.Clean. 

Did some manual test and run DynamoCoreTest, looks it is fine. 
