### PR TITLE
DynamoPaths

### DIFF
--- a/src/DynamoCore/Core/DynamoController.cs
+++ b/src/DynamoCore/Core/DynamoController.cs
@@ -263,7 +263,7 @@ namespace Dynamo
         public DynamoController(string context, IUpdateManager updateManager,
             IWatchHandler watchHandler, IPreferences preferences, string corePath)
         {
-            DynamoPaths.SetupDynamoPaths(corePath);
+            DynamoPaths.SetupDynamoPathsCore(corePath);
 
             DebugSettings = new DebugSettings();
 

--- a/src/DynamoCore/Library/Library.cs
+++ b/src/DynamoCore/Library/Library.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+
+using DynamoUtilities;
+
 using GraphToDSCompiler;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.BuildData;
@@ -484,18 +487,6 @@ namespace Dynamo.DSEngine
         private readonly Dictionary<string, Dictionary<string, FunctionGroup>> importedFunctionGroups =
             new Dictionary<string, Dictionary<string, FunctionGroup>>(new LibraryPathComparer());
 
-        private readonly List<string> preloadLibraries = new List<string>
-        {
-            "ProtoGeometry.dll",
-            "DSCoreNodes.dll",
-            "DSOffice.dll",
-            "DSIronPython.dll",
-            "FunctionObject.ds",
-            "Optimize.ds",
-            "DynamoUnits.dll",
-            "Tessellation.dll"
-        };
-
         private List<string> libraries;
 
         private LibraryServices()
@@ -571,7 +562,7 @@ namespace Dynamo.DSEngine
         private void PreloadLibraries()
         {
             GraphUtilities.Reset();
-            libraries = preloadLibraries.ToList();
+            libraries = DynamoPaths.PreloadLibraries;
             GraphUtilities.PreloadAssembly(libraries);
         }
 

--- a/src/DynamoRevit/DynamoController_Revit.cs
+++ b/src/DynamoRevit/DynamoController_Revit.cs
@@ -75,11 +75,6 @@ namespace Dynamo
             MigrationManager.Instance.MigrationTargets.Add(typeof(WorkspaceMigrationsRevit));
             ElementNameStore = new Dictionary<ElementId, string>();
 
-            var revitPath = Path.Combine(DynamoPaths.MainExecPath, @"Revit_2014\RevitNodes.dll");
-            var raasPath = Path.Combine(DynamoPaths.MainExecPath, @"Revit_2014\SimpleRaaS.dll");
-            EngineController.ImportLibrary(revitPath);
-            EngineController.ImportLibrary(raasPath);
-            
             //IronPythonEvaluator.InputMarshaler.RegisterMarshaler((WrappedElement element) => element.InternalElement);
             IronPythonEvaluator.OutputMarshaler.RegisterMarshaler((Element element) => element.ToDSType(true));
             //IronPythonEvaluator.OutputMarshaler.RegisterMarshaler((IList<Element> elements) => elements.Select(e=>e.ToDSType(true)));

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -50,15 +50,7 @@ namespace Dynamo.Applications
         {
             try
             {
-                // The executing assembly will be in Revit_20xx, so 
-                // we have to walk up one level. Unfortunately, we
-                // can't use DynamoPaths here because those are not
-                // initialized until the controller is constructed.
-                var assDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                DynamoPaths.SetupDynamoPaths(Path.GetFullPath(assDir + @"\.."));
-                
-                //add an additional node processing folder
-                DynamoPaths.Nodes.Add(Path.Combine(assDir, "nodes"));
+                SetupDynamoPaths();
 
                 AppDomain.CurrentDomain.AssemblyResolve += AssemblyHelper.ResolveAssembly;
 
@@ -102,6 +94,28 @@ namespace Dynamo.Applications
                 MessageBox.Show(ex.ToString());
                 return Result.Failed;
             }
+        }
+
+        private static void SetupDynamoPaths()
+        {
+            // The executing assembly will be in Revit_20xx, so 
+            // we have to walk up one level. Unfortunately, we
+            // can't use DynamoPaths here because those are not
+            // initialized until the controller is constructed.
+            var assDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+            // Add the Revit_20xx folder for assembly resolution
+            DynamoPaths.AddResolutionPath(assDir);
+            
+            // Setup the core paths
+            DynamoPaths.SetupDynamoPathsCore(Path.GetFullPath(assDir + @"\.."));
+
+            // Add Revit-specific paths for loading.
+            DynamoPaths.AddPreloadLibrary(Path.Combine(assDir, "RevitNodes.dll"));
+            DynamoPaths.AddPreloadLibrary(Path.Combine(assDir, "SimpleRaaS.dll"));
+
+            //add an additional node processing folder
+            DynamoPaths.Nodes.Add(Path.Combine(assDir, "nodes"));
         }
 
         /// <summary>

--- a/src/DynamoUtilities/AssemblyHelper.cs
+++ b/src/DynamoUtilities/AssemblyHelper.cs
@@ -28,18 +28,21 @@ namespace Dynamo.Utilities
                     return Assembly.LoadFrom(assemblyPath);
                 }
 
-                // Then check the dynamo revit path
-                assemblyPath = Path.Combine(DynamoPaths.DynamoRevit, new AssemblyName(args.Name).Name + ".dll");
-                if (File.Exists(assemblyPath))
-                {
-                    return Assembly.LoadFrom(assemblyPath);
-                }
-
                 // Then check the dll path
                 assemblyPath = Path.Combine(DynamoPaths.Asm, new AssemblyName(args.Name).Name + ".dll");
                 if (File.Exists(assemblyPath))
                 {
                     return Assembly.LoadFrom(assemblyPath);
+                }
+
+                // Then check all additional resolution paths
+                foreach (var addPath in DynamoPaths.AdditionalResolutionPaths)
+                {
+                    assemblyPath = Path.Combine(addPath, new AssemblyName(args.Name).Name + ".dll");
+                    if (File.Exists(assemblyPath))
+                    {
+                        return Assembly.LoadFrom(assemblyPath);
+                    }
                 }
 
                 return null;

--- a/src/DynamoUtilities/DynamoPaths.cs
+++ b/src/DynamoUtilities/DynamoPaths.cs
@@ -12,6 +12,9 @@ namespace DynamoUtilities
     /// </summary>
     public static class DynamoPaths
     {
+        private static List<string> preloadLibaries = new List<string>();
+        private static List<string> addResolvePaths = new List<string>();
+
         /// <summary>
         /// The main execution path of Dynamo. This is the directory
         /// which contains DynamoCore.dll
@@ -42,9 +45,26 @@ namespace DynamoUtilities
         public static string Asm { get; set; }
 
         // All 'nodes' folders.
-        public static HashSet<string> Nodes { get; set; } 
+        public static HashSet<string> Nodes { get; set; }
 
-        public static string DynamoRevit { get; set; }
+        /// <summary>
+        /// Libraries to be preloaded by library services.
+        /// </summary>
+        public static List<string> PreloadLibraries
+        {
+            get { return preloadLibaries; }
+            set { preloadLibaries = value; }
+        }
+
+        /// <summary>
+        /// Additional paths that should be searched during
+        /// assembly resolution
+        /// </summary>
+        public static List<string> AdditionalResolutionPaths
+        {
+            get { return addResolvePaths; }
+            set { addResolvePaths = value; }
+        }
 
         /// <summary>
         /// Provided a main execution path, find other Dynamo paths
@@ -52,7 +72,8 @@ namespace DynamoUtilities
         /// the beginning of a Dynamo session.
         /// </summary>
         /// <param name="mainExecPath">The main execution directory of Dynamo.</param>
-        public static void SetupDynamoPaths(string mainExecPath)
+        /// <param name="preloadLibraries">A list of libraries to preload.</param>
+        public static void SetupDynamoPathsCore(string mainExecPath)
         {
             if (Directory.Exists(mainExecPath))
             {
@@ -67,7 +88,6 @@ namespace DynamoUtilities
             Packages = Path.Combine(MainExecPath , "dynamo_packages");
             Asm = Path.Combine(MainExecPath, "dll");
             Ui = Path.Combine(MainExecPath , "UI");
-            DynamoRevit = Path.Combine(MainExecPath, "Revit_2015");
 
             if (Nodes == null)
             {
@@ -89,6 +109,49 @@ namespace DynamoUtilities
             Debug.WriteLine(sb);
 #endif
 
+            PreloadLibraries = new List<string>();
+            AdditionalResolutionPaths = new List<string>();
+
+            var preloadLibraries = new List<string>
+            {
+                "ProtoGeometry.dll",
+                "DSCoreNodes.dll",
+                "DSOffice.dll",
+                "DSIronPython.dll",
+                "FunctionObject.ds",
+                "Optimize.ds",
+                "DynamoUnits.dll",
+                "Tessellation.dll"
+            };
+
+            foreach (var lib in preloadLibraries)
+            {
+                AddPreloadLibrary(lib);
+            }
+        }
+
+        /// <summary>
+        /// Add a library for preloading with a check.
+        /// </summary>
+        /// <param name="path"></param>
+        public static void AddPreloadLibrary(string path)
+        {
+            if (!PreloadLibraries.Contains(path))
+            {
+                PreloadLibraries.Add(path);
+            }
+        }
+
+        /// <summary>
+        /// Adds a library for resolution with a check.
+        /// </summary>
+        /// <param name="path"></param>
+        public static void AddResolutionPath(string path)
+        {
+            if (!AdditionalResolutionPaths.Contains(path))
+            {
+                AdditionalResolutionPaths.Add(path);
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request moves the list of paths for preloading into DynamoPaths and adds a collection of additional assembly resolution paths which are iterated over during assembly resolutions. It corrects a previous addition of a DynamoRevit property which made DynamoPaths too Revit specific. It adds two methods to DynamoPaths for adding preload paths and additional assembly resolution paths with checks.

It also removes two library load calls from the Revit controller's construction. Those paths are now added in OnStartup to the preload libraries collection. This solves an issue with Dynamo on Revit_2015 looking for files in the Revit_2014 folder.
