### PR TITLE
Defect Fix: MAGN-3373 Passing xlsx file to Import.csv crashes Dynamo

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -837,7 +837,8 @@ namespace ProtoCore.Lang
             List<String> rowsCollection = new List<String>();
             List<Object[]> CSVdatalist = new List<Object[]>();
             int colNum = 0;
-            using (StreamReader sr = File.OpenText(path))
+            var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using (var sr = new StreamReader(fileStream))
             {
 
                 while (!sr.EndOfStream)


### PR DESCRIPTION
Crash happened because the same file that was opened in Excel was being read from, using File.OpenText.  You can't use File.OpenText for this, OpenText tries to open the file in "shared read" mode which fails if another application/thread has the file open for writing. We have to use the FileStream class and open the file for reading with sharing mode set to ReadWrite. 
