### PR TITLE
Fix for LibraryCustomization xml files missing due to Dynamo path change...

### DIFF
--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 
+using DynamoUtilities;
+
 namespace Dynamo.DSEngine
 {
     public static class DocumentationServices
@@ -47,7 +49,7 @@ namespace Dynamo.DSEngine
 
         public static bool ResolveForAssembly(string assemblyLocation, ref string documentationPath)
         {
-            Dynamo.Nodes.Utilities.ResolveLibraryPath(ref assemblyLocation);
+            DynamoPathManager.Instance.ResolveLibraryPath(ref assemblyLocation);
 
             if (!File.Exists(assemblyLocation))
             {

--- a/src/DynamoCore/Library/Library.cs
+++ b/src/DynamoCore/Library/Library.cs
@@ -681,7 +681,7 @@ namespace Dynamo.DSEngine
                 return;
             }
 
-            if (!Nodes.Utilities.ResolveLibraryPath(ref library))
+            if (!DynamoPathManager.Instance.ResolveLibraryPath(ref library))
             {
                 string errorMessage = string.Format("Cannot find library path: {0}.", library);
                 OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(library, errorMessage));

--- a/src/DynamoCore/Library/LibraryCustomization.cs
+++ b/src/DynamoCore/Library/LibraryCustomization.cs
@@ -4,41 +4,39 @@ using System.IO;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
+using DynamoUtilities;
+
 namespace Dynamo.DSEngine
 {
     public class LibraryCustomizationServices
     {
-        private static Dictionary<string, bool> _triedPaths = new Dictionary<string, bool>();
-        private static Dictionary<string, LibraryCustomization> _cache = new Dictionary<string, LibraryCustomization>();
+        private static Dictionary<string, bool> triedPaths = new Dictionary<string, bool>();
+        private static Dictionary<string, LibraryCustomization> cache = new Dictionary<string, LibraryCustomization>();
 
         public static LibraryCustomization GetForAssembly(string assemblyPath)
         {
-            if (_triedPaths.ContainsKey(assemblyPath))
+            if (triedPaths.ContainsKey(assemblyPath))
             {
-                return _triedPaths[assemblyPath] ? _cache[assemblyPath] : null;
+                return triedPaths[assemblyPath] ? cache[assemblyPath] : null;
             }
 
             var customizationPath = "";
             if (ResolveForAssembly(assemblyPath, ref customizationPath))
             {
                 var c = new LibraryCustomization(XDocument.Load(customizationPath));
-                _triedPaths.Add(assemblyPath, true);
-                _cache.Add(assemblyPath, c);
+                triedPaths.Add(assemblyPath, true);
+                cache.Add(assemblyPath, c);
                 return c;
             }
-            else
-            {
-                _triedPaths.Add(assemblyPath, false);
-                return null;
-            }
+
+            triedPaths.Add(assemblyPath, false);
+            return null;
             
         }
 
         public static bool ResolveForAssembly(string assemblyLocation, ref string customizationPath)
         {
-            Dynamo.Nodes.Utilities.ResolveLibraryPath(ref assemblyLocation);
-
-            if (!File.Exists(assemblyLocation))
+            if (!DynamoPathManager.Instance.ResolveLibraryPath(ref assemblyLocation))
             {
                 return false;
             }

--- a/src/DynamoCore/Nodes/BaseTypes.cs
+++ b/src/DynamoCore/Nodes/BaseTypes.cs
@@ -8,6 +8,9 @@ using Dynamo.Models;
 using Dynamo.Services;
 using Dynamo.Utilities;
 using System.Globalization;
+
+using DynamoUtilities;
+
 using ProtoCore.AST.AssociativeAST;
 using System.IO;
 using Dynamo.UI;
@@ -232,37 +235,6 @@ namespace Dynamo.Nodes
                 "might be missing from your workflow.");
 
             return null;
-        }
-
-        /// <summary>
-        /// Given an initial file path with the file name, resolve the full path
-        /// to the target file. The search happens in the following order:
-        /// 
-        /// 1. Alongside DynamoCore.dll folder (i.e. the "Add-in" folder).
-        /// 2. System path resolution.
-        /// 
-        /// </summary>
-        /// <param name="library">The initial library file path.</param>
-        /// <returns>Returns true if the requested file can be located, or false
-        /// otherwise.</returns>
-        public static bool ResolveLibraryPath(ref string library)
-        {
-            if (File.Exists(library)) // Absolute path, we're done here.
-                return true;
-
-            // Give add-in folder a higher priority and look alongside "DynamoCore.dll".
-            string assemblyName = Path.GetFileName(library); // Strip out possible directory.
-            string currAsmLocation = System.Reflection.Assembly.GetCallingAssembly().Location;
-            var asmPath = Path.Combine(Path.GetDirectoryName(currAsmLocation), assemblyName);
-
-            if (File.Exists(asmPath)) // Found under add-in folder...
-            {
-                library = asmPath;
-                return true;
-            }
-
-            library = Path.GetFullPath(library); // Fallback on system search.
-            return File.Exists(library);
         }
 
         /// <summary>


### PR DESCRIPTION
...s, move ResolveLibraryPath method from Dynamo.Nodes.Utilities to DynamoPathManager. Fixes MAGN-3812. 

@ikeough
