### PR TITLE
Fix the regression for the preview function

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -1452,6 +1452,7 @@ namespace Dynamo.Models
                 return;
             }
 
+            ClearRenderPackages();
             if (State == ElementState.Error ||
                 !IsVisible ||
                 CachedValue == null)


### PR DESCRIPTION
@lukechurch 

When we update the render packages, we need to clear the old render packages so that if the node is invisible, there is no content in the render packages.
