### PR TITLE
Correctly convert units of PolyCurve when creating Revit Floor, improve ...

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/Floor.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Floor.cs
@@ -95,7 +95,7 @@ namespace Revit.Elements
                 throw new ArgumentNullException("outlineCurves");
             }
 
-            return ByOutlineTypeAndLevel(PolyCurve.ByJoinedCurves(outlineCurves).InHostUnits(), floorType, level);
+            return ByOutlineTypeAndLevel(PolyCurve.ByJoinedCurves(outlineCurves), floorType, level);
         }
 
         /// <summary>

--- a/test/Libraries/Revit/RevitNodesTests/Elements/FloorTests.cs
+++ b/test/Libraries/Revit/RevitNodesTests/Elements/FloorTests.cs
@@ -10,9 +10,16 @@ namespace DSRevitNodesTests.Elements
     [TestFixture]
     public class FloorTests : GeometricRevitNodeTest
     {
+
+        private double BoundingBoxVolume(BoundingBox bb)
+        {
+            var val = bb.MaxPoint.Subtract(bb.MinPoint.AsVector());
+            return Math.Abs( val.X * val.Y * val.Z );
+        }
+
         [Test]
         [TestModel(@".\Empty.rvt")]
-        public void ByOutlineTypeAndLevel_ValidArgs()
+        public void ByOutlineTypeAndLevel_CurveArrayFloorTypeLevel_ProducesFloorWithCorrectArea()
         {
             var elevation = 100;
             var level = Level.ByElevation(elevation);
@@ -28,12 +35,37 @@ namespace DSRevitNodesTests.Elements
             var floorType = FloorType.ByName("Generic - 12\"");
 
             var floor = Floor.ByOutlineTypeAndLevel(outline, floorType, level);
-            Assert.NotNull(floor);
+
+            BoundingBoxVolume(floor.BoundingBox).ShouldBeApproximately(100 * 100 * 0.3048, 1e-3);
         }
 
         [Test]
         [TestModel(@".\Empty.rvt")]
-        public void ByOutlineTypeAndLevel_NullArgument()
+        public void ByOutlineTypeAndLevel_PolyCurveFloorTypeLevel_ProducesFloorWithCorrectArea()
+        {
+            var elevation = 100;
+            var level = Level.ByElevation(elevation);
+
+            var outline = new[]
+            {
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, 0, 0), Point.ByCoordinates(100, 0, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(100, 0, 0), Point.ByCoordinates(100, 100, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(100, 100, 0), Point.ByCoordinates(0, 100, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, 100, 0), Point.ByCoordinates(0, 0, 0))
+            };
+
+            var polyCurveOutline = PolyCurve.ByJoinedCurves(outline);
+
+            var floorType = FloorType.ByName("Generic - 12\"");
+
+            var floor = Floor.ByOutlineTypeAndLevel(polyCurveOutline, floorType, level);
+
+            BoundingBoxVolume(floor.BoundingBox).ShouldBeApproximately(100*100*0.3048, 1e-3);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ByOutlineTypeAndLevel_CurveArrayFloorTypeLevel_ThrowsExceptionWithNullArgument()
         {
             var elevation = 100;
             var level = Level.ByElevation(elevation);


### PR DESCRIPTION
...unit tests to check floor area is correct for both static constructors

This fixes MAGN-3821.

@ikeough 
