### PR TITLE
Fix the remaining issues for MAGN-3785

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Element.cs
@@ -486,6 +486,11 @@ namespace Revit.Elements
             get
             {
                 //Ensure that the object is still alive
+                
+                //Check whether the internal element Id is null
+                if (null == InternalElementId)
+                    return false;
+
                 return !ElementIDLifecycleManager<int>.GetInstance().IsRevitDeleted(this.InternalElementId.IntegerValue);
             }
         }

--- a/src/Libraries/Revit/RevitServices/Persistence/DocumentManager.cs
+++ b/src/Libraries/Revit/RevitServices/Persistence/DocumentManager.cs
@@ -160,6 +160,9 @@ namespace RevitServices.Persistence
                      TransactionManager.Instance.EnsureInTransaction(
                                   DocumentManager.Instance.CurrentDBDocument);
                      Instance.CurrentDBDocument.Regenerate();
+                     //To ensure the transaction is closed in the idle process
+                     //so that the element is updated after this.
+                     TransactionManager.Instance.ForceCloseTransaction();
                  }
                  );
             }

--- a/src/Libraries/Revit/RevitServices/Transactions/TransactionManager.cs
+++ b/src/Libraries/Revit/RevitServices/Transactions/TransactionManager.cs
@@ -308,6 +308,11 @@ namespace RevitServices.Transactions
             if (Transaction == null || Transaction.GetStatus() != TransactionStatus.Started)
             {
                 TransactionManager.Log("Starting Transaction.");
+                
+                // Dispose the old transaction so that it won't impact the new transaction
+                if (null != Transaction)
+                    Transaction.Dispose();
+
                 Transaction = new Transaction(document, "Dynamo Script");
                 Transaction.Start();
 


### PR DESCRIPTION
@lukechurch

This submission fixes some remaining issues with the case in MAGN-3785:
1). Concurrency issues: sometimes multiple threads are accessing the same queue: Promises in IdlePromise,  with one thread to enqueue and another thread to dequeue. This submission adds a lock to prevent write access to the same data.

2). Transaction issues:
     2.1). The old transaction is not disposed before a new transaction of the same name is created. This submission disposes the old transaction immediately before the new transaction is created.
     2.2). In the idle task, the transaction is not committed after the task is done. This causes the transaction's status to be RolledBack later. This submission commits the transaction in the idle task when the document is regenerated.
