### PR TITLE
fixed crash when clicking invalid watch element: MAGN-3708

### DIFF
--- a/src/DynamoRevit/RevitWatchHandler.cs
+++ b/src/DynamoRevit/RevitWatchHandler.cs
@@ -30,7 +30,11 @@ namespace Dynamo.Applications
             var id = element.Id;
 
             var node = new WatchViewModel(element.ToString(dynSettings.Controller.PreferenceSettings.NumberFormat, CultureInfo.InvariantCulture), tag);
-            node.Clicked += () => DocumentManager.Instance.CurrentUIDocument.ShowElements(element.InternalElement);
+            node.Clicked += () =>
+            {
+                if (element.InternalElement.IsValidObject)
+                    DocumentManager.Instance.CurrentUIDocument.ShowElements(element.InternalElement);
+            };
             node.Link = id.ToString(CultureInfo.InvariantCulture);
 
             return node;


### PR DESCRIPTION
Had to add a check to make sure the element was still valid before trying to have Revit show it in the view.

@ikeough @pboyer
