### PR TITLE
Fix MAGN-3218 Walls created on first run are not cleaned up

### DIFF
--- a/src/Libraries/Revit/RevitServices/Persistence/DocumentManager.cs
+++ b/src/Libraries/Revit/RevitServices/Persistence/DocumentManager.cs
@@ -99,11 +99,16 @@ namespace RevitServices.Persistence
         /// <param name="element">The UUID of the element to delete</param>
         public void DeleteElement(ElementUUID element)
         {
-            TransactionManager.Instance.EnsureInTransaction(CurrentDBDocument);
+            ElementId id = ElementBinder.GetIdForUUID(CurrentDBDocument, element);
 
-            CurrentDBDocument.Delete(ElementBinder.GetIdForUUID(CurrentDBDocument, element));
+            if (null != id)
+            {
+                TransactionManager.Instance.EnsureInTransaction(CurrentDBDocument);
 
-            TransactionManager.Instance.TransactionTaskDone();
+                CurrentDBDocument.Delete(id);
+
+                TransactionManager.Instance.TransactionTaskDone();
+            }
         }
 
 

--- a/src/Libraries/Revit/RevitServices/Persistence/ElementBinder.cs
+++ b/src/Libraries/Revit/RevitServices/Persistence/ElementBinder.cs
@@ -220,7 +220,10 @@ namespace RevitServices.Persistence
         /// <returns></returns>
         public static ElementId GetIdForUUID(Document document, ElementUUID uuid)
         {
-            return document.GetElement(uuid.UUID).Id;
+            Element e = document.GetElement(uuid.UUID);
+            if (e != null)
+                return e.Id;
+            return null;
         }
 
 


### PR DESCRIPTION
@lukechurch

The .dyn file contains trace data which is meaningful only for a specific Revit file.

When we are trying to run the graph for a new Revit file and trying to delete the old elements, we can not find them by using the UUIDs because the new Revit file does not contain those elements. In this case, we can just do nothing in the delete operation.
