### PR TITLE
Fix for #1871, Refactor get_EndParameter -> GetEndParameter

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/ReferencePoint.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/ReferencePoint.cs
@@ -122,7 +122,7 @@ namespace Revit.Elements
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="z"></param>
-        private ReferencePoint(double x, double y, double z)
+        private ReferencePoint(XYZ xyz)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldRefPt =
@@ -132,14 +132,14 @@ namespace Revit.Elements
             if (oldRefPt != null)
             {
                 InternalSetReferencePoint(oldRefPt);
-                InternalSetPosition(new XYZ(x, y, z));
+                InternalSetPosition(xyz);
                 return;
             }
 
             //Phase 2- There was no existing point, create one
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            InternalSetReferencePoint(Document.FamilyCreate.NewReferencePoint(new XYZ(x, y, z)));
+            InternalSetReferencePoint(Document.FamilyCreate.NewReferencePoint(xyz));
 
             TransactionManager.Instance.TransactionTaskDone();
 
@@ -196,8 +196,7 @@ namespace Revit.Elements
         {
             get
             {
-                DocumentManager.Regenerate();
-                return InternalReferencePoint.Position.X;
+                return Point.X;
             }
             set { InternalSetPosition(new XYZ(value, Y, Z)); }
         }
@@ -207,8 +206,7 @@ namespace Revit.Elements
         {
             get
             {
-                DocumentManager.Regenerate();
-                return InternalReferencePoint.Position.Y;
+                return Point.Y;
             }
             set { InternalSetPosition(new XYZ(X, value, Z)); }
         }
@@ -218,8 +216,7 @@ namespace Revit.Elements
         {
             get
             {
-                DocumentManager.Regenerate();
-                return InternalReferencePoint.Position.Z;
+                return Point.Z;
             }
             set { InternalSetPosition(new XYZ(X, Y, value)); }
         }
@@ -228,6 +225,7 @@ namespace Revit.Elements
         {
             get
             {
+                DocumentManager.Regenerate();
                 return InternalReferencePoint.Position.ToPoint();
             }
         }
@@ -285,7 +283,7 @@ namespace Revit.Elements
             {
                 throw new Exception("ReferencePoint Elements can only be created in a Family Document");
             }
-            return new ReferencePoint(x, y, z);
+            return ByPoint(Point.ByCoordinates(x, y, z));
         }
 
         /// <summary>
@@ -305,7 +303,7 @@ namespace Revit.Elements
                 throw new Exception("ReferencePoint Elements can only be created in a Family Document");
             }
 
-            return new ReferencePoint(pt.X, pt.Y, pt.Z);
+            return new ReferencePoint(pt.ToXyz());
         }
 
         /// <summary>
@@ -332,9 +330,9 @@ namespace Revit.Elements
                 throw new ArgumentNullException("direction");
             }
 
-            var pt = basePoint.ToXyz() + direction.ToXyz() * distance;
+            var pt = (Point) basePoint.Translate(direction.Scale(distance));
 
-            return new ReferencePoint(pt.X, pt.Y, pt.Z);
+            return new ReferencePoint(pt.ToXyz());
 
         }
 
@@ -342,7 +340,7 @@ namespace Revit.Elements
         /// Create a Reference Point at a particular length along a curve
         /// </summary>
         /// <param name="elementCurveReference"></param>
-        /// <param name="length"></param>
+        /// <param name="length">Distance in meters along the curve</param>
         /// <returns></returns>
         public static ReferencePoint ByLengthOnCurveReference(object elementCurveReference, double length)
         {
@@ -357,7 +355,7 @@ namespace Revit.Elements
             }
 
             return new ReferencePoint(ElementCurveReference.TryGetCurveReference(elementCurveReference).InternalReference, 
-                length, PointOnCurveMeasurementType.SegmentLength, PointOnCurveMeasureFrom.Beginning);
+                UnitConverter.DynamoToHostFactor * length, PointOnCurveMeasurementType.SegmentLength, PointOnCurveMeasureFrom.Beginning);
         }
 
         /// <summary>
@@ -429,8 +427,7 @@ namespace Revit.Elements
         {
             try
             {
-                return string.Format("Reference Point: Location=(X={0}, Y={1}, Z={2})", InternalReferencePoint.Position.X,
-                                    InternalReferencePoint.Position.Y, InternalReferencePoint.Position.Z);
+                return string.Format("Reference Point: Location=(X={0}, Y={1}, Z={2})", X, Y, Z);
             }
             catch (Exception e)
             {
@@ -442,8 +439,8 @@ namespace Revit.Elements
         {
             try
             {
-                return string.Format("Reference Point: Location=(X={0}, Y={1}, Z={2})", InternalReferencePoint.Position.X.ToString(format),
-                                    InternalReferencePoint.Position.Y.ToString(format), InternalReferencePoint.Position.Z.ToString(format));
+                return string.Format("Reference Point: Location=(X={0}, Y={1}, Z={2})", X.ToString(format),
+                                    Y.ToString(format), Z.ToString(format));
             }
             catch (Exception e)
             {

--- a/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoCurve.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoCurve.cs
@@ -93,8 +93,8 @@ namespace Revit.GeometryConversion
             var fd = Math.Abs(fsp - fep);
 
             // these are the start and end parameters of the bound curve
-            var sp = crv.get_EndParameter(0);
-            var ep = crv.get_EndParameter(1);
+            var sp = crv.GetEndParameter(0);
+            var ep = crv.GetEndParameter(1);
 
             // get the normalized parameters for trim
             var nsp = Math.Abs(fsp - sp) / fd;
@@ -125,8 +125,8 @@ namespace Revit.GeometryConversion
             var fd = Math.Abs(fsp - fep);
 
             // these are the start and end parameters of the bound curve
-            var sp = crv.get_EndParameter(0);
-            var ep = crv.get_EndParameter(1);
+            var sp = crv.GetEndParameter(0);
+            var ep = crv.GetEndParameter(1);
 
             // get the normalized parameters for trim
             var nsp = Math.Abs(fsp - sp)/fd;


### PR DESCRIPTION
This pull request fixes an issue where geometry conversion was not not done properly in the constructor or geometry extraction methods in ReferencePoint.  

ReferencePoint is unique in RevitNodes in that you can directly supply numeric values for the placement of the Point.  This pull request insures that all of these values are correctly converted on ReferencePoint creation, and correctly converted back from the internal representation in feet when previewed in Dynamo (to meters).

This pull request also replaces all usages of get_EndParameter in RevitNodes with the 2014 version - GetEndParameter.  get_EndParameter does not exist in Revit2015, so many of these conversions were failing.

@ikeough

![curveconversion](https://cloud.githubusercontent.com/assets/916345/3472725/3590ce18-02cf-11e4-8068-58191d7d9b4e.PNG)
