### PR TITLE
Exposed new properties from RenderPackage

### DIFF
--- a/src/DynamoCore/DSEngine/RenderPackage.cs
+++ b/src/DynamoCore/DSEngine/RenderPackage.cs
@@ -60,6 +60,18 @@ namespace Dynamo.DSEngine
             set { lineStripVertexCounts = value; }
         }
 
+        public List<byte> PointVertexColors
+        {
+            get { return pointVertexColors; }
+            set { pointVertexColors = value; }
+        }
+
+        public List<byte> TriangleVertexColors
+        {
+            get { return triangleVertexColor; }
+            set { triangleVertexColor = value; }
+        }
+
         /// <summary>
         /// Store the number of items stored in the RenderPackage
         /// </summary>


### PR DESCRIPTION
This pull request exposes two new properties on `RenderPackage` class:

``` cs
PointVertexColors
TriangleVertexColors
```

These are not currently used anywhere (they simply return the internal data members just like all other properties before them), but as soon as the interface `IRenderPackage` has them, it will be extremely helpful. More on that next time.

Hi @pboyer, could you help me to take a quick look at these? Thanks a ton!
