### PR TITLE
Fix the issue that the application hangs when the preview button is clic...

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -92,6 +92,8 @@ namespace Dynamo.Applications
 
                 RegisterAdditionalUpdaters(application);
 
+                RevThread.IdlePromise.MainThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+
                 return Result.Succeeded;
             }
             catch (Exception ex)

--- a/src/Libraries/Revit/RevitServices/Persistence/DocumentManager.cs
+++ b/src/Libraries/Revit/RevitServices/Persistence/DocumentManager.cs
@@ -158,22 +158,25 @@ namespace RevitServices.Persistence
         /// </summary>
         public static void Regenerate()
         {
-            if (TransactionManager.Instance.DoAssertInIdleThread)
+            if (!IdlePromise.IsInMainThread)
             {
-                IdlePromise.ExecuteOnIdleSync(() =>
-                 {
-                     TransactionManager.Instance.EnsureInTransaction(
-                                  DocumentManager.Instance.CurrentDBDocument);
-                     Instance.CurrentDBDocument.Regenerate();
-                     //To ensure the transaction is closed in the idle process
-                     //so that the element is updated after this.
-                     TransactionManager.Instance.ForceCloseTransaction();
-                 }
-                 );
-            }
-            else
-            {
-                Instance.CurrentDBDocument.Regenerate();
+                if (TransactionManager.Instance.DoAssertInIdleThread)
+                {
+                    IdlePromise.ExecuteOnIdleSync(() =>
+                     {
+                         TransactionManager.Instance.EnsureInTransaction(
+                                      DocumentManager.Instance.CurrentDBDocument);
+                         Instance.CurrentDBDocument.Regenerate();
+                         //To ensure the transaction is closed in the idle process
+                         //so that the element is updated after this.
+                         TransactionManager.Instance.ForceCloseTransaction();
+                     }
+                     );
+                }
+                else
+                {
+                    Instance.CurrentDBDocument.Regenerate();
+                }
             }
         }
     }

--- a/src/Libraries/Revit/RevitServices/Threading/IdlePromise.cs
+++ b/src/Libraries/Revit/RevitServices/Threading/IdlePromise.cs
@@ -28,6 +28,31 @@ namespace RevitServices.Threading
     /// </summary>
     public static class IdlePromise
     {
+        static int mainThreadId = -1;
+        //This function is used for accessing the main thread Id.
+        //It must be set correctly before used.
+        public static int MainThreadId
+        {
+            get
+            {
+                return mainThreadId;
+            }
+            set
+            {
+                mainThreadId = value;
+            }
+        }
+
+        //This function is used to check whether the current thread is the main thread.
+        //It must be used after MainThreadId is set properly.
+        public static bool IsInMainThread
+        {
+            get
+            {
+                return System.Threading.Thread.CurrentThread.ManagedThreadId == mainThreadId;
+            }
+        }
+
         //The lock will be used to prevent write access to Promises by multiple threads
         //at the same time. For example, one thread might be calling the Enqueue method
         //while another thread is calling the Dequeue method.


### PR DESCRIPTION
@lukechurch

It is found that the application hangs when the preview button is clicked for some Revit nodes. The reason is that a main thread is waiting for a thread to complete which in turn is waiting for the main thread.

This submission checks whether the current thread is the main thread before it may cause the deadlock.
