### PR TITLE
Change nickname of categories node.

### DIFF
--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -16,6 +16,8 @@ namespace Dynamo.Search.SearchElements
     /// A search element representing a local node </summary>
     public partial class NodeSearchElement : SearchElementBase, IEquatable<NodeSearchElement>
     {
+        private string _fullName ;
+
         #region Properties
 
         /// <summary>
@@ -46,7 +48,6 @@ namespace Dynamo.Search.SearchElements
         public override string Description { get { return _description; } }
 
         private bool _searchable = true;
-
         public override bool Searchable { get { return _searchable; } }
 
         public void SetSearchable(bool s)
@@ -89,7 +90,8 @@ namespace Dynamo.Search.SearchElements
         /// <param name="name"></param>
         /// <param name="description"></param>
         /// <param name="tags"></param>
-        public NodeSearchElement(string name, string description, IEnumerable<string> tags)
+        /// <param name="fullName"></param>
+        public NodeSearchElement(string name, string description, IEnumerable<string> tags, string fullName = "")
         {
             this.Node = null;
             this._name = name;
@@ -97,11 +99,12 @@ namespace Dynamo.Search.SearchElements
             this.Keywords = String.Join(" ", tags);
             this._type = "Node";
             this._description = description;
+            this._fullName = fullName;
         }
 
         public virtual NodeSearchElement Copy()
         {
-            var f = new NodeSearchElement(this.Name, this.Description, new List<string>());
+            var f = new NodeSearchElement(this.Name, this.Description, new List<string>(), this._fullName);
             f.FullCategoryName = this.FullCategoryName;
             return f;
         }
@@ -126,7 +129,7 @@ namespace Dynamo.Search.SearchElements
             // create node
             var guid = Guid.NewGuid();
             dynSettings.Controller.DynamoViewModel.ExecuteCommand(
-                new DynCmd.CreateNodeCommand(guid, this.Name, 0, 0, true, true));
+                new DynCmd.CreateNodeCommand(guid, this._fullName, 0, 0, true, true));
 
             // select node
             var placedNode = dynSettings.Controller.DynamoViewModel.Model.Nodes.Find((node) => node.GUID == guid);

--- a/src/DynamoCore/ViewModels/SearchViewModel.cs
+++ b/src/DynamoCore/ViewModels/SearchViewModel.cs
@@ -935,7 +935,7 @@ namespace Dynamo.ViewModels
                 description = (attribs[0] as NodeDescriptionAttribute).ElementDescription;
             }
 
-            var searchEle = new NodeSearchElement(name, description, tags);
+            var searchEle = new NodeSearchElement(name, description, tags, t.FullName);
 
             attribs = t.GetCustomAttributes(typeof(NodeSearchableAttribute), false);
             bool searchable = true;


### PR DESCRIPTION
This fixes a name collision caused by the old node, and the new node
having exactly the same name.

For @kronz to review.
