### PR TITLE
Fix method resolution error in FaceAnalysisDisplay node

### DIFF
--- a/src/Libraries/Revit/RevitNodes/AnalysisDisplay/FaceAnalysisDisplay.cs
+++ b/src/Libraries/Revit/RevitNodes/AnalysisDisplay/FaceAnalysisDisplay.cs
@@ -115,7 +115,7 @@ namespace Revit.AnalysisDisplay
         /// <param name="sampleUvPoints"></param>
         /// <param name="samples"></param>
         /// <returns></returns>
-        public static FaceAnalysisDisplay ByViewFacePointsAndValues(View view, ElementFaceReference elementFaceReference,
+        public static FaceAnalysisDisplay ByViewFacePointsAndValues(View view, object elementFaceReference,
                         double[][] sampleUvPoints, double[] samples)
         {
 
@@ -144,7 +144,7 @@ namespace Revit.AnalysisDisplay
                 throw new Exception("The number of sample points and number of samples must be the same");
             }
 
-            return new FaceAnalysisDisplay(view.InternalView, elementFaceReference.InternalReference, sampleUvPoints.ToUvs(), samples);
+            return new FaceAnalysisDisplay(view.InternalView, ElementFaceReference.TryGetFaceReference(elementFaceReference).InternalReference, sampleUvPoints.ToUvs(), samples);
         }
 
         #endregion


### PR DESCRIPTION
`Select Face` node returns a `ProtoGeometry.Surface` which can't be converted to `ElementFaceReference` directly, so changing the type of parameter to `object` and then call `ElementFaceReference.TryGetFaceReference()` to do the conversion from ProtoGeometry to Revit element.

This fixes defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3895

@ikeough , please help to review it. 
