### PR TITLE
Fix for Node Preview size

### DIFF
--- a/src/DynamoCore/UI/Views/PreviewControl.xaml.cs
+++ b/src/DynamoCore/UI/Views/PreviewControl.xaml.cs
@@ -299,14 +299,29 @@ namespace Dynamo.UI.Controls
 
         private Size ComputeSmallContentSize()
         {
-            this.smallContentGrid.Measure(new Size()
-            {
+            Size maxSize = new Size(){
                 Width = Configurations.MaxCondensedPreviewWidth,
                 Height = Configurations.MaxCondensedPreviewHeight
-            });
+            };
+
+            this.smallContentGrid.Measure(maxSize);
+            Size smallContentGridSize = this.smallContentGrid.DesiredSize;
+
+            foreach (UIElement child in smallContentGrid.Children)
+            {
+                child.Measure(maxSize);
+                if (child.DesiredSize.Width > smallContentGridSize.Width)
+                {
+                    smallContentGridSize.Width = child.DesiredSize.Width + 10;
+                }
+                if (child.DesiredSize.Height > smallContentGridSize.Height)
+                {
+                    smallContentGridSize.Height = child.DesiredSize.Height + 10;
+                }
+            }
 
             // Add padding since we are sizing the centralizedGrid.
-            return ContentToControlSize(this.smallContentGrid.DesiredSize);
+            return ContentToControlSize(smallContentGridSize);
         }
 
         private Size ComputeLargeContentSize()


### PR DESCRIPTION
Fixes an issue with the Node Preview, where the first time the preview is generated, it's a small default size instead of the size it should be.  This is evident on long preview boxes the first time you hover over them.

You actually want to Measure the TextBox, a child of smallContentGrid, to get it's size and make the preview that size instead.  Add a 10 units for a margin.  I'm looping through all children, but that might not be necessary.

Related to Issue 1930, but I can't see how to link the issue with the pull request.  #gitnoob
https://github.com/DynamoDS/Dynamo/issues/1930
