### PR TITLE
Proxy conversion methods for converting a Point or Vector to XYZ

### DIFF
--- a/src/Libraries/Revit/RevitNodes/GeometryConversion/GeometryPrimitiveConverter.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryConversion/GeometryPrimitiveConverter.cs
@@ -29,6 +29,16 @@ namespace Revit.GeometryConversion
             return rbb;
         }
 
+        public static Autodesk.Revit.DB.XYZ ToRevitType(this Autodesk.DesignScript.Geometry.Point pt, bool convertUnits = true)
+        {
+            return pt.ToXyz(convertUnits);
+        }
+
+        public static Autodesk.Revit.DB.XYZ ToRevitType(this Vector vec, bool convertUnits = false)
+        {
+            return vec.ToXyz(convertUnits);
+        }
+
         public static Autodesk.Revit.DB.XYZ ToXyz(this Autodesk.DesignScript.Geometry.Point pt, bool convertUnits = true)
         {
             if (convertUnits) pt = pt.InHostUnits();


### PR DESCRIPTION
This better aligns with the rest of the GeometryObject conversion methods, which use "ToProtoType()"

@ikeough 
