### PR TITLE
Remove regen call from ReferencePoint.Point

### DIFF
--- a/test/Libraries/Revit/RevitNodesTests/Elements/ReferencePointTests.cs
+++ b/test/Libraries/Revit/RevitNodesTests/Elements/ReferencePointTests.cs
@@ -7,9 +7,6 @@ using NUnit.Framework;
 
 using Revit.GeometryConversion;
 
-using RevitServices.Persistence;
-using RevitServices.Transactions;
-
 using RTF.Framework;
 
 using Form = Revit.Elements.Form;


### PR DESCRIPTION
This is a simple and obvious fix - properties should not have a regen side effect.  

Further, the original regen call was introduced only for the case where a ReferencePoint is constructed on a Face Reference.  I've moved the only regen call to the constructor where such a ReferencePoint is created, so it is invoked only once.  Incidentally, this also removes an undiscovered crash where the regen call was invoked from an InfoBubble.  

@lukechurch, @ikeough
