### PR TITLE
Crash Fix for Graph cleanup MAGN-3977

### DIFF
--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -100,7 +100,7 @@ namespace GraphLayout
                         if (conn[xi, zi] == 0)
                             conn[xi, zi] = e != null ? 1 : -1;
 
-                        if (conn[xi, yi] + conn[yi, zi] + conn[xi, zi] == 3)
+                        if (e != null && conn[xi, yi] + conn[yi, zi] + conn[xi, zi] == 3)
                             e.Active = false;
 
                     }


### PR DESCRIPTION
RemoveTransitiveEdges() crashes while de-activating a null edge in
certain scenarios. Put a null check to avoid the crash.

Fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3977
