### PR TITLE
Fix or MAGN-4059 with hardening for release builds and a data request trap for debug

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -154,6 +154,16 @@ namespace ProtoCore
                         return null;
                     else
                     {
+#if DEBUG
+
+                        Validity.Assert(NestedData != null, "Nested data has changed null status since last check, suspected race");
+                        Validity.Assert(NestedData.Count > 0, "Empty subnested array, please file repo data with @lukechurch, relates to MAGN-4059");
+#endif
+
+                        //Safety trap to protect against an empty array, need repro test to figure out why this is getting set with empty arrays
+                        if (NestedData.Count == 0)
+                            return null;
+
                         SingleRunTraceData nestedTraceData = NestedData[0];
                         return nestedTraceData.GetLeftMostData();
                     }


### PR DESCRIPTION
I can't repro the case that is causing this nested data to be empty, so I've added a trap that detects it and requests more data on debug builds, and on release builds hardens the behaviour
