### PR TITLE
Pass LiveRunner configration across session

### DIFF
--- a/src/DynamoCore/DSEngine/LiveRunnerServices.cs
+++ b/src/DynamoCore/DSEngine/LiveRunnerServices.cs
@@ -14,8 +14,8 @@ namespace Dynamo.DSEngine
     {
         internal static ILiveRunner CreateLiveRunner(EngineController controller)
         {
-            LiveRunner.Options option = new LiveRunner.Options();
-            return new LiveRunner(option);
+            LiveRunner.Configuration configuration = new LiveRunner.Configuration();
+            return new LiveRunner(configuration);
         }
     }
 
@@ -28,15 +28,10 @@ namespace Dynamo.DSEngine
         {
             this.controller = controller;
             liveRunner = LiveRunnerFactory.CreateLiveRunner(controller);
-
-            liveRunner.GraphUpdateReady += GraphUpdateReady;
-            liveRunner.NodeValueReady += NodeValueReady;
         }
       
         public void Dispose()
         {
-            liveRunner.GraphUpdateReady -= GraphUpdateReady;
-            liveRunner.NodeValueReady -= NodeValueReady;
             if (liveRunner is IDisposable)
                 (liveRunner as IDisposable).Dispose();
         }


### PR DESCRIPTION
This pull request fixes issue that live runner doesn't pass its configuration to the core when it is re-initialized (Live runner is re-initialized for each session or loading a library).

Some refactoring:
- Rename LiveRunner.Option to LiveRunner.Configuration. It is pretty confusing between executionOption (which is the configuration that needs to be passed to the core's option for each session) and coreOption (which is the option that needs to be passed to the core)
- Initialize LiveRunner.Configuration's properties 
- Delete some dead code and some cleanup. 
