### PR TITLE
Parser fix to Associative Range expression node - MAGN-3873 range expres...

### DIFF
--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -2446,7 +2446,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		Associative_ArithmeticExpression(out node);
 		if (la.kind == 22) {
 			ProtoCore.AST.AssociativeAST.RangeExprNode rnode = new ProtoCore.AST.AssociativeAST.RangeExprNode(); 
-			rnode.FromNode = node; NodeUtils.CopyNodeLocation(rnode, node);
+			rnode.FromNode = node; NodeUtils.SetNodeStartLocation(rnode, node);
 			bool hasRangeAmountOperator = false;
 			
 			Get();
@@ -2456,13 +2456,17 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			rnode.HasRangeAmountOperator = hasRangeAmountOperator; 
 			Associative_ArithmeticExpression(out node);
 			rnode.ToNode = node; 
+			NodeUtils.SetNodeEndLocation(rnode, node);
+			
 			if (la.kind == 22) {
 				RangeStepOperator op; 
 				Get();
 				Associative_rangeStepOperator(out op);
 				rnode.stepoperator = op; 
 				Associative_ArithmeticExpression(out node);
-				rnode.StepNode = node; 
+				rnode.StepNode = node;
+				NodeUtils.SetNodeEndLocation(rnode, node);
+				
 			}
 			node = rnode; 
 		}

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1563,20 +1563,24 @@ Associative_RangeExpr<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
     Associative_ArithmeticExpression<out node>
     [
                                         (.  ProtoCore.AST.AssociativeAST.RangeExprNode rnode = new ProtoCore.AST.AssociativeAST.RangeExprNode(); 
-                                            rnode.FromNode = node; NodeUtils.CopyNodeLocation(rnode, node);
+                                            rnode.FromNode = node; NodeUtils.SetNodeStartLocation(rnode, node);
                                             bool hasRangeAmountOperator = false;
                                         .)
         rangeop
         [Associative_rangeAmountOperator<out hasRangeAmountOperator>]
                                         (. rnode.HasRangeAmountOperator = hasRangeAmountOperator; .)
         Associative_ArithmeticExpression<out node>  
-                                        (. rnode.ToNode = node; .)
+                                        (. rnode.ToNode = node; 
+                                            NodeUtils.SetNodeEndLocation(rnode, node);
+                                        .)
         [                               (. RangeStepOperator op; .)
             rangeop
             Associative_rangeStepOperator<out op>   
                                         (. rnode.stepoperator = op; .)
             Associative_ArithmeticExpression<out node> 
-                                        (. rnode.StepNode = node; .)
+                                        (. rnode.StepNode = node;
+                                           NodeUtils.SetNodeEndLocation(rnode, node);
+                                        .)
         ]
 
                                         (. node = rnode; .)


### PR DESCRIPTION
...sion start with negative value fails to create input port

The analysis of this defect revealed that the end line and end column properties of the range expression node were not set for a non-assignment statement. This PR fixes this issue.
