### PR TITLE
Fix MAGN-2578 After deleting Point from Revit, Select Model Element still display it reference no

### DIFF
--- a/src/Libraries/Revit/RevitNodesUI/Selection.cs
+++ b/src/Libraries/Revit/RevitNodesUI/Selection.cs
@@ -263,9 +263,13 @@ namespace Dynamo.Nodes
 
         void Updater_ElementsDeleted(Document document, IEnumerable<ElementId> deleted)
         {
-            if (SelectedElement != null && document == selectionOwner && deleted.Contains(SelectedElement))
+            if (SelectedElement != null && document.Equals(selectionOwner) && deleted.Contains(SelectedElement))
             {
                 SelectedElement = null;
+
+                RaisePropertyChanged("SelectedElement");
+                RaisePropertyChanged("SelectionText");
+                RequiresRecalc = true;
             }
         }
 
@@ -681,9 +685,13 @@ namespace Dynamo.Nodes
 
         void Updater_ElementsDeleted(Document document, IEnumerable<ElementId> deleted)
         {
-            if (SelectedElement != null && document == selectionOwner)
+            if (SelectedElement != null && document.Equals(selectionOwner))
             {
                 SelectedElement = SelectedElement.Where(x => !deleted.Contains(x)).ToList();
+
+                RaisePropertyChanged("SelectedElement");
+                RaisePropertyChanged("SelectionText");
+                RequiresRecalc = true;
             }
         }
 


### PR DESCRIPTION
@lukechurch 

After deleting the elements, in the event handler, besides updating the selected element property, we also need to raise event to update the UI properly. This submission also fixes an issue that the documents are compared by comparing the variable directly.
