### PR TITLE
Fix MAGN-2575 [CRASH] when there are some nodes which are referencing geometries from Revit.

### DIFF
--- a/src/DynamoRevit/DynamoController_Revit.cs
+++ b/src/DynamoRevit/DynamoController_Revit.cs
@@ -316,6 +316,10 @@ namespace Dynamo
                 DocumentManager.Instance.CurrentUIApplication.ActiveUIDocument;
 
                 DynamoViewModel.RunEnabled = true;
+
+                //In the case that the current document is null, we also need to do
+                //a reset for the current document.
+                ResetForNewDocument();
             }
         }
 


### PR DESCRIPTION
@lukechurch

In this case, a Revit document is opened, closed. Then when it is re-opened, we need to reset the data for the new document. Otherwise for the selection node, the elements there will still come from the old documents which will cause exceptions/crash later. This submission exactly fixes this problem.
