### PR TITLE
Fix MAGN-4095 Getting crash while running Document after closing and reopening again.

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -354,7 +354,6 @@ namespace Dynamo.Applications
             DocumentManager.Instance.CurrentUIApplication.ViewActivating -=
                 Application_ViewActivating;
 
-            AppDomain.CurrentDomain.AssemblyResolve -= AssemblyHelper.ResolveAssembly;
             AppDomain.CurrentDomain.AssemblyResolve -=
                 Analyze.Render.AssemblyHelper.ResolveAssemblies;
 

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -45,7 +45,7 @@ namespace Dynamo.Applications
             {
                 SetupDynamoPaths(application);
 
-                AppDomain.CurrentDomain.AssemblyResolve += AssemblyHelper.ResolveAssembly;
+                SubscribeAssemblyResolvingEvent();
 
                 ControlledApplication = application.ControlledApplication;
 
@@ -94,6 +94,8 @@ namespace Dynamo.Applications
 
         public Result OnShutdown(UIControlledApplication application)
         {
+            UnsubscribeAssemblyResolvingEvent();
+
             return Result.Succeeded;
         }
 
@@ -150,6 +152,16 @@ namespace Dynamo.Applications
                 DynamoPathManager.Instance.ASMVersion = DynamoPathManager.Asm.Version220;
                 DynamoPathManager.Instance.SetLibGPath(Path.Combine(DynamoPathManager.Instance.MainExecPath, "libg_220"));
             }
+        }
+
+        private void SubscribeAssemblyResolvingEvent()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += AssemblyHelper.ResolveAssembly;
+        }
+
+        private void UnsubscribeAssemblyResolvingEvent()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve -= AssemblyHelper.ResolveAssembly;
         }
     }
 }


### PR DESCRIPTION
@lukechurch

This submission fixes the crash when Dynamo tries to read trace data using SoapFormatter. The formatter will require the type information related to the object to be desialized and it will try to load the assembly. But unfortunately if we close the plugin, the resolver is removed. As a result, the assembly will not be found and the formatter will throw an exception. Ideally the resolver should be removed when the plugin is shutdown. This submission makes the fix the remove the resolver at the right time.
