### PR TITLE
Fix to var declaration node ToString method

### DIFF
--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -991,7 +991,7 @@ namespace ProtoCore.AST.AssociativeAST
             {
                 buf.Append(NameNode);
                 string argType = ArgumentType.ToString();
-                if (!string.IsNullOrEmpty(argType))
+                if (!string.IsNullOrEmpty(argType) && !argType.Equals("null"))
                     buf.Append(" : " + argType);
             }
             else


### PR DESCRIPTION
The Problem:
class Foo
{
a;
}

is converted in the ToString method to:
class Foo
{
a : null;
}

This is now fixed.
