### PR TITLE
Remove DisableInteraction() call in NodeFactory

### DIFF
--- a/src/DynamoCore/Models/NodeFactory.cs
+++ b/src/DynamoCore/Models/NodeFactory.cs
@@ -133,9 +133,7 @@ namespace Dynamo.Models
         {
             try
             {
-                var newEl = (NodeModel)Activator.CreateInstance(type, this.workspaceModel);
-                newEl.DisableInteraction();
-                return newEl;
+                return (NodeModel)Activator.CreateInstance(type, this.workspaceModel);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
DisableInteraction is an outdated method call from when Dynamo had drag & drop.  This erroneous call was causing code block nodes to be deactivated on workspace open.
