### PR TITLE
Fix null reference in EditWindow - just use Owner

### DIFF
--- a/src/DynamoCore/UI/Prompts/EditWindow.xaml.cs
+++ b/src/DynamoCore/UI/Prompts/EditWindow.xaml.cs
@@ -51,9 +51,10 @@ namespace Dynamo.UI.Prompts
             {
                 ModelBase model = GetBoundModel(expr.DataItem);
 
+                var ele = this.Owner as DynamoView;
+
                 string propName = expr.ParentBinding.Path.Path;
 
-                var ele = WPF.FindUpVisualTree<DynamoView>(this);
                 ele.dynamoViewModel.ExecuteCommand(
                     new DynCmd.UpdateModelValueCommand(
                         model.GUID, propName, editText.Text));


### PR DESCRIPTION
This fixes #2131.  The issue where was to simply use the cached version of DynamoView, which is assigned in the constructor, instead of looking it up again.
