### PR TITLE
Remove asynchronous search in Dynamo

### DIFF
--- a/src/DynamoCore/UI/Commands/SearchCommands.cs
+++ b/src/DynamoCore/UI/Commands/SearchCommands.cs
@@ -49,5 +49,6 @@ namespace Dynamo.ViewModels
                 return hideSearch;
             }
         }
+
     }
 }

--- a/src/DynamoCore/UI/Views/SearchView.xaml.cs
+++ b/src/DynamoCore/UI/Views/SearchView.xaml.cs
@@ -26,8 +26,6 @@ namespace Dynamo.Search
         private readonly SearchViewModel viewModel;
         private readonly DynamoViewModel dynamoViewModel;
 
-        readonly DispatcherTimer searchTimer = new DispatcherTimer { Interval = new TimeSpan(0, 0, 0, 0, 100), IsEnabled = false };
-
         public SearchView(SearchViewModel searchViewModel, DynamoViewModel dynamoViewModel)
         {
             this.viewModel = searchViewModel;
@@ -47,8 +45,6 @@ namespace Dynamo.Search
                     SearchTextBox.InputBindings.AddRange(view.InputBindings);
                 }
             };
-
-            searchTimer.Tick += SearchTimerTick;
         }
 
         void Dispatcher_ShutdownStarted(object sender, EventArgs e)
@@ -228,18 +224,6 @@ namespace Dynamo.Search
             if (binding != null)
                 binding.UpdateSource();
 
-            searchTimer.IsEnabled = true;
-            searchTimer.Stop();
-            searchTimer.Start();
-        }
-
-        void SearchTimerTick(object sender, EventArgs e)
-        {
-            searchTimer.IsEnabled = false;
-
-            Debug.WriteLine("Updating search results...");
-            // end of timer processing
-            // Execute command to pop search stack
             this.viewModel.SearchCommand.Execute(null);
         }
 

--- a/src/DynamoCore/ViewModels/SearchViewModel.cs
+++ b/src/DynamoCore/ViewModels/SearchViewModel.cs
@@ -4,6 +4,8 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Windows.Threading;
+
 using Dynamo.Models;
 using Dynamo.Nodes;
 using Dynamo.Nodes.Search;
@@ -188,7 +190,7 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        ///     Asynchronously performs a search and updates the observable SearchResults property.
+        ///     Performs a search and updates the observable SearchResults property.
         /// </summary>
         /// <param name="query"> The search query </param>
         public void SearchAndUpdateResults(string query)
@@ -196,74 +198,104 @@ namespace Dynamo.ViewModels
             if (Visible != true)
                 return;
 
-            Task<IEnumerable<SearchElementBase>>.Factory.StartNew(() =>
+            var result = this.Model.Search(query);
+
+            // Remove old execute handler from old top result
+            if (topResult.Items.Any() && topResult.Items.First() is NodeSearchElement)
             {
-                lock (Model.SearchDictionary)
+                var oldTopResult = topResult.Items.First() as NodeSearchElement;
+                oldTopResult.Executed -= this.ExecuteElement;
+            }
+
+            // deselect the last selected item
+            if (visibleSearchResults.Count > SelectedIndex)
+            {
+                visibleSearchResults[SelectedIndex].IsSelected = false;
+            }
+
+            // clear visible results list
+            visibleSearchResults.Clear();
+
+            // if the search query is empty, go back to the default treeview
+            if (string.IsNullOrEmpty(query))
+            {
+                foreach (var ele in this.Model.BrowserRootCategories)
                 {
-                    return Model.Search(query);
+                    ele.CollapseToLeaves();
+                    ele.SetVisibilityToLeaves(true);
                 }
-            }).ContinueWith((t) =>
+
+                // hide the top result
+                topResult.Visibility = false;
+                return;
+            }
+
+            // otherwise, first collapse all
+            foreach (var root in this.Model.BrowserRootCategories)
             {
-                lock (visibleSearchResults)
+                root.CollapseToLeaves();
+                root.SetVisibilityToLeaves(false);
+            }
+
+            // if there are any results, add the top result 
+            if (result.Any() && result.ElementAt(0) is NodeSearchElement)
+            {
+                topResult.Items.Clear();
+
+                var firstRes = (result.ElementAt(0) as NodeSearchElement);
+
+                var copy = firstRes.Copy();
+                copy.Executed += this.ExecuteElement;
+
+                var catName = MakeShortCategoryString(firstRes.FullCategoryName);
+
+                var breadCrumb = new BrowserInternalElement(catName, topResult);
+                breadCrumb.AddChild(copy);
+                topResult.AddChild(breadCrumb);
+
+                topResult.SetVisibilityToLeaves(true);
+                copy.ExpandToRoot();
+
+            }
+
+            // for all of the other results, show them in their category
+            foreach (var ele in result)
+            {
+                ele.Visibility = true;
+                ele.ExpandToRoot();
+            }
+
+            // create an ordered list of visible search results
+            var baseBrowserItem = new BrowserRootElement("root");
+            foreach (var root in Model.BrowserRootCategories)
+            {
+                baseBrowserItem.Items.Add(root);
+            }
+
+            baseBrowserItem.GetVisibleLeaves(ref visibleSearchResults);
+
+            if (visibleSearchResults.Any())
+            {
+                this.SelectedIndex = 0;
+                visibleSearchResults[0].IsSelected = true;
+            }
+
+            SearchResults.Clear();
+            visibleSearchResults.ToList()
+                .ForEach(x => SearchResults.Add((NodeSearchElement)x));
+        }
+
+        private static string MakeShortCategoryString(string fullCategoryName)
+        {
+            var catName = fullCategoryName.Replace(".", " > ");
+
+            // if the category name is too long, we strip off the interior categories
+            if (catName.Length > 50)
+            {
+                var s = catName.Split('>').Select(x => x.Trim()).ToList();
+                if (s.Count() > 4)
                 {
-                    // Remove old execute handler from old top result
-                    if (topResult.Items.Any() && topResult.Items.First() is NodeSearchElement)
-                    {
-                        var oldTopResult = topResult.Items.First() as NodeSearchElement;
-                        oldTopResult.Executed -= this.ExecuteElement;
-                    }
-
-                    // deselect the last selected item
-                    if (visibleSearchResults.Count > SelectedIndex)
-                    {
-                        visibleSearchResults[SelectedIndex].IsSelected = false;
-                    }
-
-                    // clear visible results list
-                    visibleSearchResults.Clear();
-
-                    // if the search query is empty, go back to the default treeview
-                    if (string.IsNullOrEmpty(query))
-                    {
-
-                        foreach (var ele in this.Model.BrowserRootCategories)
-                        {
-                            ele.CollapseToLeaves();
-                            ele.SetVisibilityToLeaves(true);
-                        }
-
-                        // hide the top result
-                        topResult.Visibility = false;
-
-                        return;
-                    }
-
-                    // otherwise, first collapse all
-                    foreach (var root in this.Model.BrowserRootCategories)
-                    {
-                        root.CollapseToLeaves();
-                        root.SetVisibilityToLeaves(false);
-                    }
-
-                    // if there are any results, add the top result 
-                    if (t.Result.Any() && t.Result.ElementAt(0) is NodeSearchElement)
-                    {
-                        topResult.Items.Clear();
-
-                        var firstRes = (t.Result.ElementAt(0) as NodeSearchElement);
-
-                        var copy = firstRes.Copy();
-                        copy.Executed += this.ExecuteElement;
-
-                        var catName = firstRes.FullCategoryName.Replace(".", " > ");
-
-                        // if the category name is too long, we strip off the interior categories
-                        if (catName.Length > 50)
-                        {
-                            var s = catName.Split('>').Select(x => x.Trim()).ToList();
-                            if (s.Count() > 4)
-                            {
-                                s = new List<string>()
+                    s = new List<string>()
                                         {
                                             s[0],
                                             "...",
@@ -271,76 +303,11 @@ namespace Dynamo.ViewModels
                                             s[s.Count - 2],
                                             s[s.Count - 1]
                                         };
-                                catName = String.Join(" > ", s);
-                            }
-                        }
-
-                        var breadCrumb = new BrowserInternalElement(catName, topResult);
-                        breadCrumb.AddChild(copy);
-                        topResult.AddChild(breadCrumb);
-
-                        topResult.SetVisibilityToLeaves(true);
-                        copy.ExpandToRoot();
-
-                    }
-
-                    // for all of the other results, show them in their category
-                    foreach (var ele in this.Model.SearchElements)
-                    {
-                        if (t.Result.Contains(ele))
-                        {
-                            ele.Visibility = true;
-                            ele.ExpandToRoot();
-                        }
-                    }
-
-                    // create an ordered list of visible search results
-                    var baseBrowserItem = new BrowserRootElement("root");
-                    foreach (var root in Model.BrowserRootCategories)
-                    {
-                        baseBrowserItem.Items.Add(root);
-                    }
-
-                    baseBrowserItem.GetVisibleLeaves(ref visibleSearchResults);
-
-                    if (visibleSearchResults.Any())
-                    {
-                        this.SelectedIndex = 0;
-                        visibleSearchResults[0].IsSelected = true;
-                    }
-
-                    SearchResults.Clear();
-                    visibleSearchResults.ToList().ForEach(x => SearchResults.Add((NodeSearchElement)x));
+                    catName = String.Join(" > ", s);
                 }
-
             }
-            , TaskScheduler.FromCurrentSynchronizationContext()); // run continuation in ui thread
-        }
 
-        /// <summary>
-        ///     Synchronously performs a search using the current SearchText
-        /// </summary>
-        /// <param name="query"> The search query </param>
-        public void SearchAndUpdateResultsSync()
-        {
-            SearchAndUpdateResultsSync(SearchText);
-        }
-
-        /// <summary>
-        ///     Synchronously Performs a search and updates the observable SearchResults property
-        ///     on the current thread.
-        /// </summary>
-        /// <param name="query"> The search query </param>
-        public void SearchAndUpdateResultsSync(string query)
-        {
-            var result = Model.Search(query);
-
-            SearchResults.Clear();
-            foreach (var node in result)
-            {
-                SearchResults.Add(node);
-            }
-            SelectedIndex = 0;
+            return catName;
         }
 
         #endregion

--- a/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
+++ b/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
@@ -29,7 +29,7 @@ namespace Dynamo.Tests
             var examplePath = Path.Combine(GetTestDirectory(), @"core\combine", "Sequence2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
             
-            ViewModel.SearchViewModel.SearchAndUpdateResultsSync("Sequence2");
+            ViewModel.SearchViewModel.SearchAndUpdateResults("Sequence2");
             Assert.AreEqual(1, ViewModel.SearchViewModel.SearchResults.Count);
             Assert.AreEqual("Sequence2", ViewModel.SearchViewModel.SearchResults[0].Name);
         }

--- a/test/DynamoCoreTests/SearchSideEffects.cs
+++ b/test/DynamoCoreTests/SearchSideEffects.cs
@@ -40,10 +40,10 @@ namespace Dynamo.Tests
             Assert.AreEqual(model.CurrentWorkspace.Name, "Home");
 
             // search and results are correct
-            ViewModel.SearchViewModel.SearchAndUpdateResultsSync("Input");
+            ViewModel.SearchViewModel.SearchAndUpdateResults("Input");
             Assert.AreEqual(0, ViewModel.SearchViewModel.SearchResults.Count(x => x.Name == "Input"));
 
-            ViewModel.SearchViewModel.SearchAndUpdateResultsSync("Output");
+            ViewModel.SearchViewModel.SearchAndUpdateResults("Output");
             Assert.AreEqual(0, ViewModel.SearchViewModel.SearchResults.Count(x => x.Name == "Output"));
         }
 
@@ -58,11 +58,11 @@ namespace Dynamo.Tests
             Assert.AreEqual(model.CurrentWorkspace.Name, "Sequence2");
 
             // search and results are correct
-            ViewModel.SearchViewModel.SearchAndUpdateResultsSync("Input");
+            ViewModel.SearchViewModel.SearchAndUpdateResults("Input");
             Assert.AreEqual(1, ViewModel.SearchViewModel.SearchResults.Count(x => x.Name == "Input"));
             Assert.AreEqual("Input", ViewModel.SearchViewModel.SearchResults[0].Name);
 
-            ViewModel.SearchViewModel.SearchAndUpdateResultsSync("Output");
+            ViewModel.SearchViewModel.SearchAndUpdateResults("Output");
             Assert.AreEqual(1, ViewModel.SearchViewModel.SearchResults.Count(x => x.Name == "Output"));
             Assert.AreEqual("Output", ViewModel.SearchViewModel.SearchResults[0].Name);
 

--- a/test/DynamoCoreTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreTests/WorkspaceSaving.cs
@@ -653,7 +653,7 @@ namespace Dynamo.Tests
 
             var newId = nodeWorkspace.CustomNodeDefinition.FunctionId;
 
-            ViewModel.SearchViewModel.SearchAndUpdateResultsSync("Constant2");
+            ViewModel.SearchViewModel.SearchAndUpdateResults("Constant2");
             Assert.AreEqual(originalNumElements + 1, ViewModel.Model.SearchModel.SearchDictionary.NumElements);
 
             Assert.AreEqual(2, ViewModel.SearchViewModel.SearchResults.Count);
@@ -751,7 +751,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(originalNumElements + 1, ViewModel.Model.SearchModel.SearchDictionary.NumElements);
 
             // search for refactored node
-            ViewModel.SearchViewModel.SearchAndUpdateResultsSync("TheNoodle");
+            ViewModel.SearchViewModel.SearchAndUpdateResults("TheNoodle");
 
             // results are correct
             Assert.AreEqual(1, ViewModel.SearchViewModel.SearchResults.Count);
@@ -759,7 +759,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(newId, node3.Guid);
 
             // search for un-refactored node
-            ViewModel.SearchViewModel.SearchAndUpdateResultsSync("Constant2");
+            ViewModel.SearchViewModel.SearchAndUpdateResults("Constant2");
 
             // results are correct
             Assert.AreEqual(1, ViewModel.SearchViewModel.SearchResults.Count);
@@ -805,7 +805,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(originalNumElements + 1, ViewModel.Model.SearchModel.SearchDictionary.NumElements);
 
             // search common base name
-            ViewModel.SearchViewModel.SearchAndUpdateResultsSync("Constant2");
+            ViewModel.SearchViewModel.SearchAndUpdateResults("Constant2");
 
             // results are correct
             Assert.AreEqual(2, ViewModel.SearchViewModel.SearchResults.Count);


### PR DESCRIPTION
### Changes

This pull request removes the `DispatcherTimer` in `SearchView` and the asynchronous `SearchAndUpdateResults` method in `SearchViewModel`.   Instead, all search is done synchronously.
### Results

I found search to be feel far more responsive, while also fixing issue #1908.  Notably, this removes any need to create a search Task or lock any data structures in the SearchViewModel class.  

However, it's possible we could run into performance issues on slower machines.  Is there a way to test this?  

@Benglin @ikeough
