### PR TITLE
Fix MAGN-3140

### DIFF
--- a/src/Libraries/Revit/RevitServices/Persistence/ElementBinder.cs
+++ b/src/Libraries/Revit/RevitServices/Persistence/ElementBinder.cs
@@ -37,7 +37,6 @@ namespace RevitServices.Persistence
         {
             StringID = (string) info.GetValue("stringID", typeof (string));
             IntID = (int)info.GetValue("intID", typeof(int));
-
         }
     }
 
@@ -46,14 +45,12 @@ namespace RevitServices.Persistence
     [Serializable]
     public class MultipleSerializableId : ISerializable
     {
-
-
         public List<String> StringIDs { get; set; }
-        public List<int> IDs { get; set; }
+        public List<int> IntIDs { get; set; }
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            Validity.Assert(StringIDs.Count == IDs.Count);
+            Validity.Assert(StringIDs.Count == IntIDs.Count);
 
             int numberOfElements = StringIDs.Count;
 
@@ -62,28 +59,25 @@ namespace RevitServices.Persistence
             for (int i = 0; i < numberOfElements; i++)
             {
                 info.AddValue("stringID-" + i, StringIDs[i], typeof(string));
-                info.AddValue("intID-" + i, IDs[i], typeof(int));
+                info.AddValue("intID-" + i, IntIDs[i], typeof(int));
             }
-
         }
 
         public MultipleSerializableId()
         {
-            StringIDs = new List<string>();
-            IDs = new List<int>();
-
+            InitializeDataMembers();
         }
 
         public MultipleSerializableId(IEnumerable<Element> elements)
         {
+            InitializeDataMembers();
+
             foreach (Element element in elements)
             {
                 StringIDs.Add(element.UniqueId);
-                IDs.Add(element.Id.IntegerValue);
-            }
-            
+                IntIDs.Add(element.Id.IntegerValue);
+            }            
         }
-
 
         /// <summary>
         /// Ctor used by the serialisation engine
@@ -92,6 +86,8 @@ namespace RevitServices.Persistence
         /// <param name="context"></param>
         public MultipleSerializableId(SerializationInfo info, StreamingContext context)
         {
+            InitializeDataMembers();
+
             int numberOfElements = info.GetInt32("numberOfElements");
 
             for (int i = 0; i < numberOfElements; i++)
@@ -100,11 +96,16 @@ namespace RevitServices.Persistence
                 int intID = (int) info.GetValue("intID-" + i, typeof (int));
 
                 StringIDs.Add(stringID);
-                IDs.Add(intID);
+                IntIDs.Add(intID);
             }
 
         }
         
+        private void InitializeDataMembers()
+        {
+            StringIDs = new List<String>();
+            IntIDs = new List<int>();
+        }
     }
 
 

--- a/test/Libraries/Revit/RevitServicesTests/RevitServicesTests.cs
+++ b/test/Libraries/Revit/RevitServicesTests/RevitServicesTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Runtime.Serialization.Formatters.Soap;
 using Autodesk.Revit.DB;
 using NUnit.Framework;
 using System;
@@ -152,11 +152,7 @@ namespace RevitServicesTests
         [Test]
         public void TestRoundTripElementSerialisation()
         {
-
-            // Use a BinaryFormatter or SoapFormatter.
-            IFormatter formatter = new BinaryFormatter();
-            //IFormatter formatter = new SoapFormatter();
-
+            IFormatter formatter = new SoapFormatter();
 
             // Create an instance of the type and serialize it.
             var elementId = new SerializableId
@@ -165,22 +161,19 @@ namespace RevitServicesTests
                 StringID = "{BE507CAC-7F23-43D6-A2B4-13F6AF09046F}"
             };
 
-
             //Serialise to a test memory stream
             var m = new MemoryStream();
             formatter.Serialize(m, elementId);
             m.Flush();
-
 
             //Reset the stream
             m.Seek(0, SeekOrigin.Begin);
 
             //Readback
             var readback = (SerializableId)formatter.Deserialize(m);
-            
+
             Assert.IsTrue(readback.IntID == 42);
             Assert.IsTrue(readback.StringID.Equals("{BE507CAC-7F23-43D6-A2B4-13F6AF09046F}"));
-
         }
 
         [Test]
@@ -200,13 +193,65 @@ namespace RevitServicesTests
             elementId = (SerializableId)ElementBinder.GetRawDataFromTrace();
             Assert.IsTrue(elementId.IntID == 42);
             Assert.IsTrue(elementId.StringID == "{BE507CAC-7F23-43D6-A2B4-13F6AF09046F}");
-
-
-
-
-
         }
 
+
+        [Test]
+        public void TestRoundTripElementSerialisationForMultipleIDs()
+        {
+            IFormatter formatter = new SoapFormatter();
+
+            // Create an instance of the type and serialize it.
+            var elementIDs = new MultipleSerializableId
+            {
+                IntIDs = { 42, 20 },
+                StringIDs = { "{BE507CAC-7F23-43D6-A2B4-13F6AF09046F}", "{A79294BF-6D27-4B86-BEE9-D6921C11D495}" }
+            };
+
+            //Serialise to a test memory stream
+            var m = new MemoryStream();
+            formatter.Serialize(m, elementIDs);
+            m.Flush();
+
+            //Reset the stream
+            m.Seek(0, SeekOrigin.Begin);
+
+            //Readback
+            var readback = (MultipleSerializableId)formatter.Deserialize(m);
+
+            //Verify that the data is correct
+            Assert.IsTrue(readback.IntIDs.Count == 2);
+            Assert.IsTrue(readback.IntIDs[0] == 42);
+            Assert.IsTrue(readback.IntIDs[1] == 20);
+            Assert.IsTrue(readback.StringIDs.Count == 2);
+            Assert.IsTrue(readback.StringIDs[0].Equals("{BE507CAC-7F23-43D6-A2B4-13F6AF09046F}"));
+            Assert.IsTrue(readback.StringIDs[1].Equals("{A79294BF-6D27-4B86-BEE9-D6921C11D495}"));
+        }
+
+        [Test]
+        public void RawTraceInteractionTestWithMultipleIDs()
+        {
+            var elementIDs = new MultipleSerializableId
+            {
+                IntIDs = { 42, 20 },
+                StringIDs = { "{BE507CAC-7F23-43D6-A2B4-13F6AF09046F}", "{A79294BF-6D27-4B86-BEE9-D6921C11D495}" }
+            };
+
+            //Raw write
+            ElementBinder.SetRawDataForTrace(elementIDs);
+            elementIDs = null;
+
+            //Readback
+            var readback = (MultipleSerializableId)ElementBinder.GetRawDataFromTrace();
+
+            //Verify that the data is correct
+            Assert.IsTrue(readback.IntIDs.Count == 2);
+            Assert.IsTrue(readback.IntIDs[0] == 42);
+            Assert.IsTrue(readback.IntIDs[1] == 20);
+            Assert.IsTrue(readback.StringIDs.Count == 2);
+            Assert.IsTrue(readback.StringIDs[0].Equals("{BE507CAC-7F23-43D6-A2B4-13F6AF09046F}"));
+            Assert.IsTrue(readback.StringIDs[1].Equals("{A79294BF-6D27-4B86-BEE9-D6921C11D495}"));
+        }
 
 
     }

--- a/test/Libraries/Revit/RevitServicesTests/RevitServicesTests.csproj
+++ b/test/Libraries/Revit/RevitServicesTests/RevitServicesTests.csproj
@@ -65,6 +65,7 @@ limitations under the License.
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization.Formatters.Soap" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="RevitServicesTests.cs" />


### PR DESCRIPTION
@lukechurch

In the case there are multiple elements which require to be bound to a function call, a class with several IDs need to be supported. This submission makes MultipleSerializableId work for this purpose.

This submission also implemented two test cases to test the serialization/deserialization with SoapFormatter and also set/read the trace data for the new class.
