### PR TITLE
Fix for crash caused by invalid element in watch node: MAGN-3708

### DIFF
--- a/src/DynamoRevit/ViewModel/RevitWatchHandler.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatchHandler.cs
@@ -41,7 +41,11 @@ namespace Dynamo.Applications
             var node = new WatchViewModel(visualizationManager, 
                 element.ToString(preferences.NumberFormat, CultureInfo.InvariantCulture), tag);
 
-            node.Clicked += () => DocumentManager.Instance.CurrentUIDocument.ShowElements(element.InternalElement);
+            node.Clicked += () =>
+            {
+                if (element.InternalElement.IsValidObject)
+                    DocumentManager.Instance.CurrentUIDocument.ShowElements(element.InternalElement);
+            };
             node.Link = id.ToString(CultureInfo.InvariantCulture);
 
             return node;


### PR DESCRIPTION
@riteshchandawar @ikeough
This is the same fix that went in for Revit2015.
