### PR TITLE
Remove redundant ast assignment

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -711,14 +711,16 @@ namespace Dynamo.Models
 
             if (OutPortData.Count == 1)
             {
-                return
-                    result.Concat(
-                        new[]
-                        {
-                            AstFactory.BuildAssignment(
-                                AstIdentifierForPreview,
-                                GetAstIdentifierForOutputIndex(0))
-                        });
+                var firstOuputIdent = GetAstIdentifierForOutputIndex(0);
+                if (!AstIdentifierForPreview.Equals(firstOuputIdent))
+                {
+                    result = result.Concat(
+                    new[]
+                    {
+                        AstFactory.BuildAssignment(AstIdentifierForPreview, firstOuputIdent)
+                    });
+                }
+                return result;
             }
 
             var emptyList = AstFactory.BuildExprList(new List<AssociativeNode>());

--- a/src/DynamoCore/Nodes/Watch.cs
+++ b/src/DynamoCore/Nodes/Watch.cs
@@ -168,7 +168,7 @@ namespace Dynamo.Nodes
             var resultAst = new[]
             {
                 AstFactory.BuildAssignment(
-                    GetAstIdentifierForOutputIndex(0),
+                    AstFactory.BuildIdentifier(AstIdentifierBase + "_dummy"),
                     DataBridge.GenerateBridgeDataAst(GUID.ToString(), inputAstNodes[0])),
                 AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), inputAstNodes[0])
             };


### PR DESCRIPTION
This pull request is part of the fix for  [MAGN-4100](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4100#):
- A self assignment (e.g., `var_1 = var_1;` is generated in AST compilation. This kind of assignment which remove all dependencies on variable so that update stops working. Although essentially it is a language issue, rightnow the workaround is to remove this kind of assignment from AST nodes.
- For Watch node, in AST compilation there are two assignments are created. One is calling `VMDataBridge.DataBridge()` to register a callback in the VM, and assigning the return value to this variable. The other statement assigns input variable to this variable. The latter one removes previous dependency. So the fix is to assign `VMDataBridge.DataBridge()` to a dummy variable. 
