### PR TITLE
Update test case TS093_Param_notypedefined_indexing_Userdefined

### DIFF
--- a/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests.cs
@@ -2202,9 +2202,9 @@ namespace ProtoTest.TD.MultiLangTests
         public void TS093_Param_notypedefined_indexing_Userdefined()
         {
             string code =
-                    @"                    class A{ a = 0;}                    class B{                        b : A;                        constructor B(x : A, y : A)                        {                            b = x;                        }                    }                    points = { A.A(), A.A() };                    def CreateLine(points: var[] )                    {                        return = B.B(points[0], points[1]);                    }                    test = CreateLine(points);                    z=test.b.a;                    ";
+                    @"                    class A{ a = 1234;}                    class B{                        b : A;                        constructor B(x : A, y : A)                        {                            b = x;                        }                    }                    points = { A.A(), A.A() };                    def CreateLine(points: var[] )                    {                        return = B.B(points[0], points[1]);                    }                    test = CreateLine(points);                    z=test.b.a;                    ";
             thisTest.RunScriptSource(code);
-            thisTest.Verify("z", 0);
+            thisTest.Verify("z", 1234);
         }
 
         [Test]


### PR DESCRIPTION
This test case is invalid. Update it. 
