### PR TITLE
Update AssertValue() implementation

### DIFF
--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -713,9 +713,13 @@ namespace ProtoTestFx.TD
                 var values = value as IEnumerable;
                 if (object.ReferenceEquals(values, null))
                 {
-                    throw new AssertionException("The value is :" + data.Data.ToString() + "; but the expected value is " + value.ToString());
+                    string errorMessage = string.Format(
+                        "The value is {1}, but the expected value is {2}.",
+                        data.Data ?? "null",
+                        value);
+                    throw new AssertionException(errorMessage);
                 }
-                AssertCollection(data, value as IEnumerable);
+                AssertCollection(data, values);
             }
             else
             {


### PR DESCRIPTION
Previously when the data is a collection the test framework will try to cast the expected value to a collection and iterate values in it. But if the expected value is not a collection, an exception will be thrown out. This pull request fixes this issue.

Now there are 35 test cases previous had errors now just fail. 
