### PR TITLE
Specify the location of one reference project

### DIFF
--- a/src/Libraries/Tesellation/Tessellation.csproj
+++ b/src/Libraries/Tesellation/Tessellation.csproj
@@ -41,6 +41,7 @@
     </Reference>
     <Reference Include="ProtoInterface, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\extern\ProtoGeometry\ProtoInterface.dll</HintPath>
     </Reference>
     <Reference Include="RevitAPI">
       <HintPath>$(REVITAPI)\RevitAPI.dll</HintPath>


### PR DESCRIPTION
@ikeough

The reason that sometimes we need to build the solution twice is found. The first time we built the Tessellation project, because the ProtoInterface module has not been copied to the output folder, it will fail to find it so there will be errors. But the second time we build it, as the ProtoInterface module has been copied, there will be no errors. This submission fixes the issue by clearly specify the location of the reference project.
