### PR TITLE
Fix the issue that the run button can not be disabled

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -69,6 +69,7 @@ namespace Dynamo.Models
 
         private ObservableCollection<WorkspaceModel> workspaces = new ObservableCollection<WorkspaceModel>();
         private Dictionary<Guid, NodeModel> nodeMap = new Dictionary<Guid, NodeModel>();
+        private bool runEnabled = true;
 
         #endregion
 
@@ -193,7 +194,15 @@ namespace Dynamo.Models
             get { return CurrentWorkspace.Nodes.ToList(); }
         }
 
-        public bool RunEnabled { get; set; }
+        public bool RunEnabled
+        {
+            get { return runEnabled; }
+            set
+            {
+                runEnabled = value;
+                RaisePropertyChanged("RunEnabled");
+            }
+        }
         public bool RunInDebug { get; set; }
 
         /// <summary>

--- a/src/DynamoCore/ViewModels/DynamoViewModel.cs
+++ b/src/DynamoCore/ViewModels/DynamoViewModel.cs
@@ -76,11 +76,10 @@ namespace Dynamo.ViewModels
 
         public bool RunEnabled
         {
-            get { return runEnabled; }
+            get { return model.RunEnabled; }
             set
             {
-                runEnabled = value;
-                RaisePropertyChanged("RunEnabled");
+                model.RunEnabled = value;
             }
         }
 
@@ -747,6 +746,8 @@ namespace Dynamo.ViewModels
                 RaisePropertyChanged("IsPanning");
                 RaisePropertyChanged("IsOrbiting");
             }
+            else if (e.PropertyName == "RunEnabled")
+                RaisePropertyChanged("RunEnabled");
         }
 
         internal bool CanWriteToLog(object parameters)

--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -27,6 +27,7 @@ namespace DynamoCoreUITests
         private CommandCallback commandCallback = null;
 
         // For access within test cases.
+        protected DynamoView dynamoView = null;
         protected WorkspaceModel workspace = null;
         protected WorkspaceViewModel workspaceViewModel = null;
 
@@ -364,6 +365,25 @@ namespace DynamoCoreUITests
 
             });
         }
+        [Test, RequiresSTA]
+        public void TestRunEnabledButtonCanBeDisabled()
+        {
+            RunCommandsFromFile("TestRunEnabledButtonCanBeDisabled.xml", false, (commandTag) =>
+            {
+                //This test case is to verify that when RunEnabled is changed to false from the model, 
+                //the Run button is disabled. The strategy here is to directly modify the RunEnabled value
+                //in the model. But at that time, the view has not yet had a chance to refresh its button.
+                //So the process is separated into two steps. At the second step. the button status is checked.
+                if (commandTag == "OpenFile")
+                {
+                    ViewModel.Model.RunEnabled = false;
+                }
+                else if (commandTag == "CheckButtonIsDisabled")
+                {
+                    Assert.IsFalse(dynamoView.RunButton.IsEnabled);
+                }
+            });
+        }
         [Test]
         public void Deffect_CN_1143()
         {
@@ -659,7 +679,7 @@ namespace DynamoCoreUITests
             RegisterCommandCallback(commandCallback);
 
             // Create the view.
-            var dynamoView = new DynamoView(this.ViewModel);
+            dynamoView = new DynamoView(this.ViewModel);
             dynamoView.ShowDialog();
 
             Assert.IsNotNull(this.ViewModel);

--- a/test/core/recorded/TestRunEnabledButtonCanBeDisabled.xml
+++ b/test/core/recorded/TestRunEnabledButtonCanBeDisabled.xml
@@ -1,0 +1,4 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <PausePlaybackCommand Tag="OpenFile" PauseDurationInMs="20" />
+  <PausePlaybackCommand Tag="CheckButtonIsDisabled" PauseDurationInMs="20" />
+</Commands>


### PR DESCRIPTION
@benglin, @ikeough

This submission fixes the issue that the run button is not disabled when RunEnabled is set to false from the model. A test case is also added to check this.
