### PR TITLE
Merged "StartConfiguration" changes from "master" branch

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -72,7 +72,7 @@ namespace Dynamo.Applications.Models
         {
             // where necessary, assign defaults
             if (string.IsNullOrEmpty(configuration.Context))
-                configuration.Context = Core.Context.REVIT_2014;
+                configuration.Context = Core.Context.REVIT_2015;
             if (string.IsNullOrEmpty(configuration.DynamoCorePath))
             {
                 var asmLocation = Assembly.GetExecutingAssembly().Location;


### PR DESCRIPTION
This pull request intents to merge `StartConfiguration` changes from [another pull request](https://github.com/DynamoDS/Dynamo/pull/2180) into `Revit 2015` branch.
## Notes to Reviewers

Hi @ikeough, @pboyer, please take a look. Thanks!

**IMPORANT**: Note that the static method `RevitDynamoModel.Start` defaults `StartConfiguration.Context` to `Core.Context.REVIT_2014`, the same as existing code that is already on `Revit 2015` branch. Is that intentional or it should be updated to `Core.Context.REVIT_2015`?
