### PR TITLE
Showing tooltip with new library view design

### DIFF
--- a/src/DynamoCore/UI/Controls/StandardPanel.xaml
+++ b/src/DynamoCore/UI/Controls/StandardPanel.xaml
@@ -16,8 +16,6 @@
                TargetType="{x:Type ListBoxItem}">
             <EventSetter Event="MouseEnter"
                          Handler="OnListBoxItemMouseEnter" />
-            <EventSetter Event="MouseMove"
-                         Handler="OnListBoxItemMouseMove" />
         </Style>
     </UserControl.Resources>
     <Grid Visibility="{Binding Path=ClassDetailsVisibility,Converter={StaticResource BoolToVisibilityConverter}}">

--- a/src/DynamoCore/UI/Controls/StandardPanel.xaml.cs
+++ b/src/DynamoCore/UI/Controls/StandardPanel.xaml.cs
@@ -38,30 +38,11 @@ namespace Dynamo.UI.Controls
             ListBoxItem fromSender = sender as ListBoxItem;
             libraryToolTipPopup.PlacementTarget = fromSender;
             libraryToolTipPopup.SetDataContext(fromSender.DataContext);
-            //libraryToolTipPopup.DataContext = fromSender.DataContext;
         }
 
         private void OnPopupMouseLeave(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            if (!libraryToolTipPopup.isMouseOver)
             libraryToolTipPopup.SetDataContext(null);
-        }
-
-        private void OnListBoxItemMouseMove(object sender, System.Windows.Input.MouseEventArgs e)
-        {
-            Point point = Mouse.GetPosition(sender as IInputElement);
-            FrameworkElement nodeSearchButton = sender as FrameworkElement;
-            // We need to know whether mouse is inside tooltip.
-            // But we need to know it before mouse will leave nodeSearchButton, that's why
-            // we check where mouse pointer  is.
-            if (point.X >= (nodeSearchButton.ActualWidth - 50)) // 50 is transparent width of tooltip at the left side.
-            {
-                // Leave 3 pixels for case, when user move mouse to the bottom, not to the right.
-                if (point.Y <= (nodeSearchButton.ActualHeight - 3))
-                {
-                    libraryToolTipPopup.isMouseOver = true;
-                }
-            }
         }
 
     }

--- a/src/DynamoCore/UI/Views/TooltipWindow.xaml
+++ b/src/DynamoCore/UI/Views/TooltipWindow.xaml
@@ -9,7 +9,7 @@
              d:DesignHeight="300"
              d:DesignWidth="450"
              Background="#01000000"
-             MaxWidth="370">
+             MaxWidth="320">
     <UserControl.Resources>
         <ResourceDictionary>
             <controls:FullyQualifiedNameToDisplayConverter x:Key="FullyQualifiedNameToDisplayConverter" />
@@ -17,14 +17,9 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="50"></ColumnDefinition>
-            <ColumnDefinition Width="*"></ColumnDefinition>
-        </Grid.ColumnDefinitions>
         <Border CornerRadius="5"
                 Opacity=".95"
                 Background="#333333"
-                Grid.Column="1"
                 Padding="10">
             <Grid>
                 <Grid.RowDefinitions>


### PR DESCRIPTION
@Benglin , ok, I'll try... First, you need to understand how it worked before. 
# Before

We had treeview, where every element had the same rang. When user moved mouse thought elements, they gave their DataContext automatically to the tooltip, and tooltips' visibility was bound to its' DataContext. 
Example:
![image](https://cloud.githubusercontent.com/assets/8158404/4008535/9828508e-29d8-11e4-8596-bc7bdf2b198f.png)

Our mouse is on “Saturation”. Node button “Saturation” give its' DataContext to tooltip. Tooltip sees that DataContext is SearchNode and stays open. Then we move mouse next to “Evaluate”, which is ClassNode. “Evaluate” gives its' DataContext to tooltip, and tooltip sees that its' DataContext now is not SearchNode, so it should be invisible.
But now we have another story.
# Now

Example:

![image](https://cloud.githubusercontent.com/assets/8158404/4008540/a6afab20-29d8-11e4-9bae-edeec4ac44bc.png)

Our Mouse is on Method Button “ByARGB” and this button gives its' DataContext to tooltip, tooltip checks its' DataContext and sees that it is SearchNode and stays open. Well, it's as usually. But situation changes when we move mouse to the Class Button, e.g. to “Color”. “Color” won't give it's DataContext  to tooltip, “Color” even doesn't know that tooltip exists, because tooltip was created in Standard Panel.
# Solution to the problem

 That's why we need another logic, when mouse go away from Standard Panel. I have created value `isMouseOver`. When mouse came on Method Button, it gives its' DataContext to tooltip. But when mouse near right side of Method Button `isMouseOver` becomes `true`. And when mouse leave  Method Button DataContext of tooltip becomes null, but first Method Button checks whether `isMouseOver == false`.
You may ask why I didn't give `isMouseOver` true, when mouse enters border of tooltip. Well, first I have done like that, but... Look how it worked:
1) We move mouse out Method Button.
2) Method button gives null to tooltip's DataContext.
3) Mouse enter to tooltip, `isMouseOver` becomes true
4) tooltip loads cachedDataContext

But between 2) and 3) occurs blink of tooltip, just for a second it becomes invisible(because DataContext just for a moment becomes null).

Conclusion
Just repeat how it works now:
1) Move mouse on Method Button.
2) Method button gives DataContext to tooltip.
3) Tooltip becomes visible.

Here is 2 options:
- user move mouse to the tooltip
  4) Move mouse at the right side of MethodButton, `isMouseOver` becomes true.
  5) Mouse leave Method button, it checks whether `isMouseOver` true or false. It's true, nothing happens.
  6) Mouse come in tooltip.
  7) Mouse leave tooltip, `isMouseOver` becomes false, DataContext of tooltip becomes null.
  8) Tooltip closes.
- user move mouse down to the next class buttons
  4) User move mouse out of Method button.
  5) Method button check `isMouseOver`. `IsMouseOver` is false, then Method button gives null dataContext to tolltip.
  6) Tooltip closes.
