### PR TITLE
Fixes crash while copy paste of custom node.

### DIFF
--- a/src/DynamoCore/Nodes/Custom Nodes/CustomNodeController.cs
+++ b/src/DynamoCore/Nodes/Custom Nodes/CustomNodeController.cs
@@ -119,6 +119,7 @@ namespace Dynamo.Nodes
 
             outEl.SetAttribute("value", Definition.FunctionId.ToString());
             nodeElement.AppendChild(outEl);
+            nodeElement.SetAttribute("nickname", NickName);
         }
 
         public override void LoadNode(XmlNode nodeElement)


### PR DESCRIPTION
- Nickname is not serialized while copying custom node and while pasting
  it was trying to get it and hence crashed.
- Fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4235
