### PR TITLE
Fix crash when clicking on package manager website button

### DIFF
--- a/src/DynamoCore/UI/Views/InstalledPackagesView.xaml.cs
+++ b/src/DynamoCore/UI/Views/InstalledPackagesView.xaml.cs
@@ -27,6 +27,7 @@ namespace Dynamo.PackageManager.UI
 
         public InstalledPackagesView(InstalledPackagesViewModel viewModel)
         {
+            this.viewModel = viewModel;
             this.DataContext = viewModel;
             InitializeComponent();
         }


### PR DESCRIPTION
This is a relatively tiny fix.  The `viewModel` field was not assigned in the constructor - so clicking this button crashed Dynamo with a `NullReferenceException`.

@ikeough
