### PR TITLE
Fix nunit tests caused by null session

### DIFF
--- a/test/Libraries/Revit/RevitNodesTests/AssemblyResolver.cs
+++ b/test/Libraries/Revit/RevitNodesTests/AssemblyResolver.cs
@@ -25,7 +25,7 @@ namespace DSRevitNodesTests
             resolverSetup = true;
         }
 
-        private static string GetDynamoRootDirectory()
+        internal static string GetDynamoRootDirectory()
         {
             var assemPath = Assembly.GetExecutingAssembly().Location;
             var assemDir = new DirectoryInfo(Path.GetDirectoryName(assemPath));

--- a/test/Libraries/Revit/RevitNodesTests/GeometricRevitNodeTest.cs
+++ b/test/Libraries/Revit/RevitNodesTests/GeometricRevitNodeTest.cs
@@ -1,19 +1,92 @@
-﻿using Autodesk.DesignScript.Geometry;
+﻿using System;
+using System.IO;
+using System.Collections;
+using System.Collections.Generic;
+using Autodesk.DesignScript.Geometry;
+using Autodesk.DesignScript.Interfaces;
 
 using DynamoUnits;
+using DynamoUtilities;
 
 using NUnit.Framework;
 
 namespace DSRevitNodesTests
 {
+    /// <summary>
+    /// This is a temporary session class which is only used for nodes that are using Geometries.
+    /// When ProtoGeometry is loaded, the static instance GeometryFactory will be constructed which
+    /// requires a session to be present.
+    /// </summary>
+    class TestExecutionSession : IExecutionSession, IConfiguration, IDisposable
+    {
+        private Dictionary<string, object> configValues;
+        public TestExecutionSession()
+        {
+            configValues = new Dictionary<string, object>();
+        }
+
+        public IConfiguration Configuration
+        {
+            get { return this; }
+        }
+
+        public string SearchFile(string fileName)
+        {
+            var path = Path.Combine(RootModulePath, fileName);
+            if (File.Exists(path))
+                return path;
+            return fileName;
+        }
+
+        public string RootModulePath
+        {
+            get { return AssemblyResolver.GetDynamoRootDirectory(); }
+        }
+
+        public string[] IncludeDirectories
+        {
+            get { return new string[] { RootModulePath }; }
+        }
+
+        public bool IsDebugMode
+        {
+            get { return false; }
+        }
+
+        public object GetConfigValue(string config)
+        {
+            if (string.Compare(Autodesk.DesignScript.Interfaces.ConfigurationKeys.GeometryFactory, config) == 0)
+                return Path.Combine(DynamoPathManager.Instance.LibG, "LibG.ProtoInterface.dll");
+
+            if (configValues.ContainsKey(config))
+                return configValues[config];
+
+            return null;
+        }
+
+        public void SetConfigValue(string config, object value)
+        {
+            configValues[config] = value;
+        }
+
+        public void Dispose()
+        {
+            configValues.Clear();
+        }
+    }
+
     [TestFixture]
     public class GeometricRevitNodeTest : RevitNodeTestBase
     {
+        IExtensionApplication application = Application.Instance as IExtensionApplication;
+        TestExecutionSession session = new TestExecutionSession();
+
         [SetUp]
         public void SetUp()
         {
             AssemblyResolver.Setup();
 
+            application.OnBeginExecution(session);
             HostFactory.Instance.StartUp();
             SetUpHostUnits();
         }
@@ -28,6 +101,7 @@ namespace DSRevitNodesTests
         [TearDown]
         public void ShutDownHostFactory()
         {
+            application.OnEndExecution(session);
             HostFactory.Instance.ShutDown();
         }
 


### PR DESCRIPTION
@ke-yu 

What HostFactory.Instance.SetUp() is called, it requires a session to be present in the Application.Instance object. But unfortunately, it is reset to null after preload is completed. This will cause the geometry factory file path set incorrectly and result in a lot of failed test cases in RevitNodesTest.

This submission creates a temporary session class. In the SetUp method, we create a temporary session object and call OnBeginExecution to pass the session object to the application. In the TearDown method, we call OnEndExecution to reset the session object.
