### PR TITLE
Removing Category Failure for the tests which are now passing from Core UI Tests project.

### DIFF
--- a/test/DynamoCoreUITests/CoreUITests.cs
+++ b/test/DynamoCoreUITests/CoreUITests.cs
@@ -20,7 +20,7 @@ namespace DynamoCoreUITests
         #region SaveImageCommand
 
         [Test]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CanSaveImage()
         {
             string path = Path.Combine(TempFolder, "output.png");
@@ -33,7 +33,7 @@ namespace DynamoCoreUITests
         }
 
         [Test]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CannotSaveImageWithBadPath()
         {
             string path = "W;\aelout put.png";
@@ -78,7 +78,7 @@ namespace DynamoCoreUITests
         #region Zoom In and Out canvas
 
         [Test]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CanZoom()
         {
             WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
@@ -171,7 +171,7 @@ namespace DynamoCoreUITests
         #region Pan Left, Right, Top, Down Canvas
 
         [Test, RequiresSTA]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CanPanLeft()
         {
             WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
@@ -193,7 +193,7 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CanPanRight()
         {
             WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
@@ -215,7 +215,7 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CanPanUp()
         {
             WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
@@ -237,7 +237,7 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CanPanDown()
         {
             WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
@@ -263,7 +263,7 @@ namespace DynamoCoreUITests
         #region Fit to View
 
         [Test, RequiresSTA]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void FitViewWithNoNodes()
         {
             WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
@@ -283,7 +283,7 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CanFitView()
         {
             WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
@@ -307,7 +307,7 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CanFitViewTwiceForActualZoom()
         {
             WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
@@ -331,7 +331,7 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void FitViewStressTest()
         {
             WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
@@ -356,7 +356,7 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CanFitViewResetByZoom()
         {
             WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
@@ -384,7 +384,7 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CanFitViewResetByPan()
         {
             WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
@@ -558,7 +558,7 @@ namespace DynamoCoreUITests
         #region InfoBubble
 
         [Test]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void UpdateInfoBubble_ErrorBubble()
         {
             InfoBubbleViewModel infoBubble = new InfoBubbleViewModel(this.ViewModel);
@@ -605,7 +605,7 @@ namespace DynamoCoreUITests
         }
 
         [Test]
-        [Category("DynamoUI"), Category("Failing")]
+        [Category("DynamoUI")]
         public void CanDeleteANote()
         {
             ViewModel.AddNoteCommand.Execute(null);

--- a/test/DynamoCoreUITests/PackageManagerUITests.cs
+++ b/test/DynamoCoreUITests/PackageManagerUITests.cs
@@ -50,7 +50,7 @@ namespace DynamoCoreUITests
 
         #region PackageManagerPublishView
 
-        [Test, Category("Failing")]
+        [Test]
         public void CanOpenPackagePublishDialogAndWindowIsOwned()
         {
             var l = new PublishPackageViewModel(ViewModel);
@@ -71,7 +71,7 @@ namespace DynamoCoreUITests
             AssertWindowOwnedByDynamoView<PackageManagerPublishView>();
         }
 
-        [Test, Category("Failing")]
+        [Test]
         public void PackagePublishWindowClosesWithDynamo()
         {
             var l = new PublishPackageViewModel(ViewModel);
@@ -86,7 +86,7 @@ namespace DynamoCoreUITests
 
         #region InstalledPackagesView
 
-        [Test, Category("Failing")]
+        [Test]
         public void CanOpenManagePackagesDialogAndWindowIsOwned()
         {
             ViewModel.OnRequestManagePackagesDialog(null, null);
@@ -105,7 +105,7 @@ namespace DynamoCoreUITests
         //    AssertWindowOwnedByDynamoView<InstalledPackagesView>();
         //}
 
-        [Test, Category("Failing")]
+        [Test]
         public void ManagePackagesDialogClosesWithDynamo()
         {
             ViewModel.OnRequestManagePackagesDialog(null, null);
@@ -119,7 +119,7 @@ namespace DynamoCoreUITests
 
         #region PackageManagerSearchView
 
-        [Test, Category("Failing")]
+        [Test]
         public void CanOpenPackageSearchDialogAndWindowIsOwned()
         {
             ViewModel.OnRequestPackageManagerSearchDialog(null, null);
@@ -128,7 +128,7 @@ namespace DynamoCoreUITests
             AssertWindowOwnedByDynamoView<PackageManagerSearchView>();
         }
 
-        [Test, Category("Failing")]
+        [Test]
         public void CannotCreateDuplicatePackageSearchDialogs()
         {
             for (var i = 0; i < 10; i++)
@@ -139,7 +139,7 @@ namespace DynamoCoreUITests
             AssertWindowOwnedByDynamoView<PackageManagerSearchView>();
         }
 
-        [Test, Category("Failing")]
+        [Test]
         public void PackageSearchDialogClosesWithDynamo()
         {
             ViewModel.OnRequestPackageManagerSearchDialog(null, null);

--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -1205,7 +1205,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(2, connector.End.Index);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA]
         public void Defect_MAGN_775()
         {
             // The third undo operation should not crash.
@@ -2892,7 +2892,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(1, workspace.Notes.Count);
         }
 
-        [Test, Category("Failing")]
+        [Test]
         public void Defect_MAGN_491()
         {
             // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-491

--- a/test/DynamoCoreUITests/UpdateManagerUITests.cs
+++ b/test/DynamoCoreUITests/UpdateManagerUITests.cs
@@ -72,7 +72,6 @@ namespace DynamoCoreUITests
         }
 
         [Test]
-        [Category("Failing")]
         public void UpdateButtonNotCollapsedIfNotUpToDate()
         {
             var um_mock = new Mock<IUpdateManager>();
@@ -88,7 +87,6 @@ namespace DynamoCoreUITests
         }
 
         [Test]
-        [Category("Failing")]
         public void UpdateButtonCollapsedIfUpToDate()
         {
             var um_mock = new Mock<IUpdateManager>();
@@ -104,7 +102,6 @@ namespace DynamoCoreUITests
         }
 
         [Test]
-        [Category("Failing")]
         public void UpdateButtonCollapsedIfNotConnected()
         {
             var um_mock = new Mock<IUpdateManager>();


### PR DESCRIPTION
- As a part of defect MAGN-4178, Sharad asked me to turn on UI tests which are marked as Failure, if they are passing on current build.

So turning them ON by removing their category "Failure"

<h4>Reviewer</h4>

@Benglin @ikeough @lukechurch 

![image](https://cloud.githubusercontent.com/assets/5109531/4041392/35a9ba04-2cf5-11e4-9f7b-59af1e5201c5.png)
