### PR TITLE
Fix MAGN-3799 Revit 2015 crash switching documents.

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -30,6 +30,12 @@ namespace Dynamo.Applications.Models
 {
     public class RevitDynamoModel : DynamoModel
     {
+        /// <summary>
+        ///     Flag for syncing up document switches between Application.DocumentClosing and
+        ///     Application.DocumentClosed events.
+        /// </summary>
+        private bool updateCurrentUIDoc;
+
         #region Events
 
         public event EventHandler RevitDocumentChanged;
@@ -169,6 +175,8 @@ namespace Dynamo.Applications.Models
 
         private void SubscribeDocumentManagerEvents()
         {
+            DocumentManager.Instance.CurrentUIApplication.Application.DocumentClosing +=
+                Application_DocumentClosing;
             DocumentManager.Instance.CurrentUIApplication.Application.DocumentClosed +=
                 Application_DocumentClosed;
             DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened +=
@@ -180,6 +188,8 @@ namespace Dynamo.Applications.Models
 
         private void UnsubscribeDocumentManagerEvents()
         {
+            DocumentManager.Instance.CurrentUIApplication.Application.DocumentClosing -=
+                Application_DocumentClosing;
             DocumentManager.Instance.CurrentUIApplication.Application.DocumentClosed -=
                 Application_DocumentClosed;
             DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened -=
@@ -298,6 +308,21 @@ namespace Dynamo.Applications.Models
         }
 
         /// <summary>
+        /// Handler for Revit's DocumentClosing event.
+        /// This handler is called when a document is closing.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void Application_DocumentClosing(object sender, DocumentClosingEventArgs e)
+        {
+            // ReSharper disable once PossibleUnintendedReferenceComparison
+            if (DocumentManager.Instance.CurrentDBDocument.Equals(e.Document))
+            {
+                updateCurrentUIDoc = true;
+            }
+        }
+
+        /// <summary>
         /// Handler for Revit's DocumentClosed event.
         /// This handler is called when a document is closed.
         /// </summary>
@@ -320,8 +345,9 @@ namespace Dynamo.Applications.Models
             {
                 // If Dynamo's active UI document's document is the one that was just closed
                 // then set Dynamo's active UI document to whatever revit says is active.
-                if (DocumentManager.Instance.CurrentUIDocument.Document == null)
+                if (updateCurrentUIDoc)
                 {
+                    updateCurrentUIDoc = false;
                     DocumentManager.Instance.CurrentUIDocument =
                         DocumentManager.Instance.CurrentUIApplication.ActiveUIDocument;
                 }


### PR DESCRIPTION
@pboyer 

When a document is closed, the reference hold by us to the UI document is invalid in Revit 2015. An attempt to get its document will cause a crash. I have checked the code history and found that originally we are using a document closing event to check the document because at that time the UI document is still valid.

This submission recovers some of the code that has been deleted. The document comparison is done inside the document closing handler and when the document is closed, the UI document hold by us will be reset.

This problem does not occur in Revit 2014. It is found at the time the document is closed, we can still get the document of the UI document that is closed.
