### PR TITLE
DUI: Bug Tool-tip remains visible(switch to another program)

### DIFF
--- a/src/DynamoCore/UI/DynamoTextBox.cs
+++ b/src/DynamoCore/UI/DynamoTextBox.cs
@@ -500,13 +500,9 @@ namespace Dynamo.UI.Controls
         {
             var mainDynamoWindow = WPF.FindUpVisualTree<DynamoView>(this);
 
-            /*If window is no longer on top, then we can hide tooltip.
-             It's used, when we switch to another program.
-             We can not use CloseLibraryToolTipPopup, 
-             because it waits for 1 sec to close itself,
-             and we need to close tooltip immediately, 
-             at the same moment when we switch to another program.*/
-
+            // When Dynamo window goes behind another app, the tool-tip should be hidden right 
+            // away. We cannot use CloseLibraryToolTipPopup because it only hides the tool-tip 
+            // window after a pause.
             mainDynamoWindow.Deactivated += (Sender, args) =>
             {
                 this.DataContext = null;


### PR DESCRIPTION
# Summary

It's small PR.
Bug was fixed and I have added comments, so that it's clear what I have done. So, I will just copy these comments here.

When we create LibraryToolTipPopup, we also add `Deactivated` event to the main window.

``` c#
// If window is no longer on top, then we can hide tooltip.
// It's used, when we switch to another program.
 Application.Current.MainWindow.Deactivated += CloseLibraryToolTipPopupImmediately;
```

I used another method, that I called `CloseLibraryToolTipPopupImmediately`.

``` c#
// We can not use CloseLibraryToolTipPopup, 
// because it waits for 1 sec to close itself,
// and we need to close tooltip immediately, 
// at the same moment when we switch to another program. 
private void CloseLibraryToolTipPopupImmediately(object sender, EventArgs e)
{
      this.DataContext = null;
}
```
# Reviewers

@Benglin, please take a look.
