### PR TITLE
Fix Unit Tests that rely on Watch node

### DIFF
--- a/src/DynamoCore/Nodes/Watch.cs
+++ b/src/DynamoCore/Nodes/Watch.cs
@@ -86,6 +86,24 @@ namespace Dynamo.Nodes
             }
         }
 
+        private void EvaluationCompleted(object o)
+        {
+            CachedValue = o;
+            DispatchOnUIThread(
+                delegate
+                {
+                    //unhook the binding
+                    OnRequestBindingUnhook(EventArgs.Empty);
+
+                    Root.Children.Clear();
+                    Root.Children.Add(GetWatchNode());
+
+                    //rehook the binding
+                    OnRequestBindingRehook(EventArgs.Empty);
+                }
+            );
+        }
+
         public override void Destroy()
         {
             base.Destroy();
@@ -121,6 +139,12 @@ namespace Dynamo.Nodes
             return outputIndex == 0
                 ? AstIdentifierForPreview
                 : base.GetAstIdentifierForOutputIndex(outputIndex);
+        }
+
+        protected override void OnBuilt()
+        {
+            base.OnBuilt();
+            DataBridge.Instance.RegisterCallback(GUID.ToString(), EvaluationCompleted);
         }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(

--- a/src/DynamoCore/UI/UIPartials.cs
+++ b/src/DynamoCore/UI/UIPartials.cs
@@ -605,26 +605,6 @@ namespace Dynamo.Nodes
             ((PreferenceSettings)this.Workspace.DynamoModel.PreferenceSettings).PropertyChanged += PreferenceSettings_PropertyChanged;
 
             Root.PropertyChanged += Root_PropertyChanged;
-
-            DataBridge.Instance.RegisterCallback(GUID.ToString(), EvaluationCompleted);
-        }
-
-        private void EvaluationCompleted(object o)
-        {
-            CachedValue = o;
-            DispatchOnUIThread(
-                delegate
-                {
-                    //unhook the binding
-                    OnRequestBindingUnhook(EventArgs.Empty);
-
-                    Root.Children.Clear();
-                    Root.Children.Add(GetWatchNode());
-
-                    //rehook the binding
-                    OnRequestBindingRehook(EventArgs.Empty);
-                }
-            );
         }
 
         void Root_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -379,21 +379,15 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(examplePath, "filter-example.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
-            // check all the nodes and connectors are loaded
-            Assert.AreEqual(6, model.CurrentWorkspace.Connectors.Count);
-            Assert.AreEqual(6, model.CurrentWorkspace.Nodes.Count);
-
             // run the expression
             ViewModel.Model.RunExpression();
-
-            // wait for the expression to complete
-            Thread.Sleep(500);
 
             // check the output values are correctly computed
             var watchNode = model.CurrentWorkspace.FirstNodeFromWorkspace<Watch>();
             Assert.IsNotNull(watchNode);
 
             // odd numbers between 0 and 5
+            Assert.IsNotNull(watchNode.CachedValue);
             Assert.IsTrue(watchNode.CachedValue is ICollection);
             var list = (watchNode.CachedValue as ICollection).Cast<object>();
 


### PR DESCRIPTION
@riteshchandawar @aparajit-pratap 

VMDataBridge initialization was being done on the UI layer, which was causing the `CachedValue` property to never be set during execution.

Reviewers: feel free to merge after confirming that this fix corrects the failing tests
