### PR TITLE
Fix GroupByKey not working when KeySelector returns floats: MAGN-4348

### DIFF
--- a/src/Engine/ProtoCore/ExtendedLibraries/FunctionObject.ds
+++ b/src/Engine/ProtoCore/ExtendedLibraries/FunctionObject.ds
@@ -489,45 +489,22 @@ def GroupByKey(list : var[]..[], keyProjector: _FunctionObject)
     {
         if (list == null)
         {
-            return= null;
+            return = null;
         }
 
         _count = Count(list);
+        _keys = { };
+
         if (_count == 0)
         {
-            return = {};
+            return = _keys;
         }
-        
-        _groupedList = { };
-        for (_index in 0..(Count(list) - 1))
+
+        for (_index in 0..(_count - 1))
         {
-            _key = Apply(keyProjector, list[_index]);
-            if (!ContainsKey(_groupedList, _key))
-            {
-                _groupedList[_key] = { };
-            }
-            
-            _subList = _groupedList[_key];
-            _groupedList[_key] = Concat(_subList, { list[_index] });
+            _keys[_index] = Apply(keyProjector, list[_index]);
         }
-        
-        _finalGroupedList = { };
-        _current = 0;
-        _keys = GetKeys(_groupedList);
-        
-        for (_index in 0..(Count(_keys) - 1))
-        {
-            _key = _keys[_index];
-            _subList = _groupedList[_keys[_index]];
-            
-            if (_subList!= null)
-            {
-                _finalGroupedList[_current] = _subList;
-                _current = _current + 1;
-            }
-        }
-        
-        return = _finalGroupedList;
+        return = Sorting.groupByKey(list, _keys);
     };
 }
 

--- a/src/Libraries/CoreNodes/Sorting.cs
+++ b/src/Libraries/CoreNodes/Sorting.cs
@@ -5,6 +5,7 @@ using Autodesk.DesignScript.Runtime;
 
 namespace DSCore
 {
+    // ReSharper disable InconsistentNaming
     /// <summary>
     /// Utility methods for sorting by keys. These should be suppressed from becoming nodes, instead
     /// they will be wrapped by DS implementations that accept a key mapping function.
@@ -64,13 +65,15 @@ namespace DSCore
                     .ToList();
         }
 
-        //public static IList groupByKey(IList list, IList keys)
-        //{
-        //    return
-        //        list.Cast<object>().Zip(keys.Cast<object>(), (item, key) => new { item, key })
-        //            .GroupBy(x => x.key)
-        //            .Select(x => x.Select(y => y.item).ToList())
-        //            .ToList();
-        //}
+        [IsVisibleInDynamoLibrary(false)]
+        public static IList groupByKey(IList list, IList keys)
+        {
+            return
+                list.Cast<object>().Zip(keys.Cast<object>(), (item, key) => new { item, key })
+                    .GroupBy(x => x.key)
+                    .Select(x => x.Select(y => y.item).ToList())
+                    .ToList();
+        }
     }
+    // ReSharper restore InconsistentNaming
 }


### PR DESCRIPTION
@aparajit-pratap
@ke-yu (wrote the original implementation)

The problem with the original implementation is that the key->value mapping were stored in a DS Dictionary. When the keys were floating points numbers, the mapping would get confused and drop data. I have re-implemented `GroupByKey` to dispatch to a C# helper function, similar to how our sorting functions are implemented.
