### PR TITLE
Harden Selection Nodes

### DIFF
--- a/src/Libraries/Revit/RevitNodesUI/Selection.cs
+++ b/src/Libraries/Revit/RevitNodesUI/Selection.cs
@@ -21,8 +21,6 @@ using Dynamo.Models;
 using Dynamo.UI;
 using ProtoCore.AST.AssociativeAST;
 using Revit.Interactivity;
-
-using RevitServices.Elements;
 using RevitServices.Persistence;
 using Element = Revit.Elements.Element;
 
@@ -626,11 +624,8 @@ namespace Dynamo.Nodes
                 if (selectedElements != null)
                 {
                     selectionOwner = DocumentManager.Instance.CurrentDBDocument;
-                    
-                    selectedUniqueIds.Clear();
-                    foreach (var el in selectedElements.Select(id => selectionOwner.GetElement(id)).Where(el => el != null)) {
-                        selectedUniqueIds.Add(el.UniqueId);
-                    }
+                    selectedUniqueIds =
+                        selectedElements.Select(x => selectionOwner.GetElement(x).UniqueId).ToList();
                 }
 
                 if (dirty)


### PR DESCRIPTION
@ke-yu @junmendoza PTAL I thought you guys might like to see this because it's one of the stability issues that we've been talking about and it touches the story of working back and forth between Dynamo and a host application and keeping your AST in sync with operations in the host application. For a little background, the Selection nodes are the nodes in Dynamo for Revit which allow the user to select one or multiple elements from the Revit model. This could include faces of solids, or Revit elements. These nodes also have to update when the user deletes an element from Revit manually.

This PR adds some hardening to selection nodes on Revit. Please see the inline notes for more information.

@lukechurch I don't think it's the force reexecute on these that is being weird. I think it's more about null propagation and exception handling.
