### PR TITLE
Selection node hardening

### DIFF
--- a/src/Libraries/Revit/RevitNodesUI/Selection.cs
+++ b/src/Libraries/Revit/RevitNodesUI/Selection.cs
@@ -647,9 +647,9 @@ namespace Dynamo.Nodes
                     selectionOwner = DocumentManager.Instance.CurrentDBDocument;
                     
                     selectedUniqueIds.Clear();
-                    foreach (var el in selectedElements.Select(id => selectionOwner.GetElement(id)).Where(el => el != null)) {
-                        selectedUniqueIds.Add(el.UniqueId);
-                    }
+                    var elements = selectedElements.Select(id => selectionOwner.GetElement(id))
+                        .Where(el => el != null).Select(el=>el.UniqueId);
+                    selectedUniqueIds.AddRange(elements);
                 }
 
                 if (dirty)


### PR DESCRIPTION
@ke-yu @junmendoza PTAL I thought you guys might like to see this because it's one of the stability issues that we've been talking about and it touches the story of working back and forth between Dynamo and a host application and keeping your AST in sync with operations in the host application. For a little background, the Selection nodes are the nodes in Dynamo for Revit which allow the user to select one or multiple elements from the Revit model. This could include faces of solids, or Revit elements. These nodes also have to update when the user deletes an element from Revit manually.

This PR adds some hardening to selection nodes on Revit. Please see the inline notes for more information.

There is still some instability when you delete elements in the document and these methods are re-triggered, but I can't pin it down. It happens in CreateCLRObject(...):if play with these nodes for a while, selecting multiple elements and deleting those elements in the doc (all with Run Auto on) then  eventually you'll get InvalidOperationException("Unable to locate managed object for given dsObject.");

@lukechurch I don't think it's the force reexecute on these that is being weird. I think it's more about null propagation and exception handling.
