### PR TITLE
Fix null reference crash in preview window

### DIFF
--- a/src/DynamoCore/UI/Views/PreviewControl.xaml.cs
+++ b/src/DynamoCore/UI/Views/PreviewControl.xaml.cs
@@ -253,16 +253,9 @@ namespace Dynamo.UI.Controls
                     // when it is multi-dimensional array)?
                     cachedSmallContent = "Array";
                 }
-                else if (mirrorData.IsNull)
+                else 
                 {
-                    cachedSmallContent = "null";
-                }
-                else
-                {
-                    var stringData = mirrorData.Data.ToString();
-                    if (mirrorData.Data is bool)
-                        stringData = stringData.ToLower();
-                    cachedSmallContent = stringData;
+                    cachedSmallContent = mirrorData.StringData;
                 }
             }
 

--- a/src/Engine/ProtoCore/Reflection/MirrorData.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorData.cs
@@ -191,6 +191,35 @@ namespace ProtoCore
             }
 
             /// <summary>
+            /// Return string representation of data
+            /// </summary>
+            public string StringData
+            {
+                get
+                {
+                    if (object.ReferenceEquals(Data, null))
+                    {
+                        return "null";
+                    }
+                    else
+                    {
+                        if (this.IsNull)
+                        {
+                            return "null";
+                        }
+                        else if (Data is bool)
+                        {
+                            return Data.ToString().ToLower();
+                        }
+                        else
+                        {
+                            return Data.ToString();
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
             /// Gets the CLR object for all the value type or FFI objects, else null
             /// </summary>
             public object Data


### PR DESCRIPTION
That's because MirrorData.Data could be null.

A property `MirrorData.StringData` is added to handle the string representation logic. 
