### PR TITLE
Add tools/CBNLanguageComparisonTests/GenerateTests.cs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ Dynamo.sln.DotSettings
 extern/DynamoAsm/
 extern/ASM/
 
+tools/CBNLanguageComparisonTests/GenerateTests.cs


### PR DESCRIPTION
This file is generated every time CBNLanguageComparisonTests.sln is built - so not required to be submitted
