### PR TITLE
MAGN-4378: Only 1 library category is open at a given time

### DIFF
--- a/src/DynamoCore/UI/Views/LibraryView.xaml
+++ b/src/DynamoCore/UI/Views/LibraryView.xaml
@@ -192,17 +192,11 @@
                                   Template="{StaticResource CategoryExpanderTemplate}"
                                   Foreground="#DDD"
                                   FontSize="13">
-                            <Expander.Style>
-                                <!--Select not more than one category-->
-                                <Style TargetType="{x:Type Expander}">
-                                    <Setter Property="IsExpanded">
-                                        <Setter.Value>
-                                            <Binding Path="IsSelected"
-                                                     RelativeSource="{RelativeSource AncestorType={x:Type ListViewItem}}" />
-                                        </Setter.Value>
-                                    </Setter>
-                                </Style>
-                            </Expander.Style>
+                            <!--Select not more than one category-->
+                            <Expander.IsExpanded>
+                                <Binding Path="IsSelected"
+                                         RelativeSource="{RelativeSource AncestorType={x:Type ListViewItem}}" />
+                            </Expander.IsExpanded>
                             <!-- This is inner list (showing subcategories) -->
                             <ListView Name="SubCategoryListView"
                                       ItemTemplateSelector="{StaticResource ClassObjectTemplateSelector}"


### PR DESCRIPTION
# Description:

e.g. opening geometry collapses core
# Solution:

New Style for Expander.
# Reviewers

@Benglin, please take a look.

Link to YouTrack:
[MAGN-4378 Only 1 library category is open at a given time](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4378)
