### PR TITLE
Clearing the workspace

### DIFF
--- a/src/DynamoCore/Utilities/Extensions.cs
+++ b/src/DynamoCore/Utilities/Extensions.cs
@@ -32,7 +32,7 @@ namespace Dynamo.Utilities
             this ObservableCollection<T> coll, Predicate<T> predicate )
         {
 
-            for (int i = coll.Count; i == 0; i-- )
+            for (int i = coll.Count - 1; i >= 0; i-- )
             {
                 if ( predicate.Invoke( coll[i] ) )
                 {

--- a/src/DynamoWebServer/WebServer.cs
+++ b/src/DynamoWebServer/WebServer.cs
@@ -3,7 +3,6 @@ using System.Configuration;
 using System.Net;
 using System.Windows;
 using System.Windows.Threading;
-using System.Linq;
 
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
@@ -19,6 +18,7 @@ using SuperSocket.SocketBase.Config;
 
 using SuperWebSocket;
 using System.Threading;
+using Dynamo.Models;
 
 namespace DynamoWebServer
 {
@@ -145,19 +145,12 @@ namespace DynamoWebServer
                         
                         foreach (var guid in nodeInfos.Keys)
                         {
-
                             searchModel.RemoveNodeAndEmptyParentCategory(guid);
-
-                            var name = nodeInfos[guid].Name;
-                            dynamoModel.Workspaces.RemoveAll(elem => 
-                                {
-                                    // To avoid deleting home workspace 
-                                    // because of coincidence in the names
-                                    return elem != dynamoModel.HomeSpace && elem.Name == name;
-                                });
-
                             customNodeManager.LoadedCustomNodes.Remove(guid);
                         }
+
+                        // remove custom node definitions
+                        dynamoModel.Workspaces.RemoveAll(elem => elem is CustomNodeWorkspaceModel);
 
                         nodeInfos.Clear();
                         dynamoModel.Clear(null);


### PR DESCRIPTION
When a new session is connected there should be empty home workspace and no loaded custom nodes;
It's important the clearing is finished before processing RecordableCommands. So there was added synchronization mechanism - executing commands wait for finishing of clearing
