### PR TITLE
Eliminated code copying between DefaultWatchHandler and RevitWatchHandler

### DIFF
--- a/src/DynamoCore/Interfaces/IWatchHandler.cs
+++ b/src/DynamoCore/Interfaces/IWatchHandler.cs
@@ -22,22 +22,22 @@ namespace Dynamo.Interfaces
     }
 
     /// <summary>
-    /// The default watch handler.
+    ///     The default watch handler.
     /// </summary>
     public class DefaultWatchHandler : IWatchHandler
     {
-        private const string NULL_STRING = "null";
+        public const string NULL_STRING = "null";
 
         private readonly IPreferences preferences;
         private readonly IVisualizationManager visualizationManager;
 
-        public DefaultWatchHandler(IVisualizationManager manager, PreferenceSettings preferences)
+        public DefaultWatchHandler(IVisualizationManager manager, IPreferences preferences)
         {
             visualizationManager = manager;
             this.preferences = preferences;
         }
 
-        internal WatchViewModel ProcessThing(object value, string tag, bool showRawData = true)
+        internal WatchViewModel ProcessThing(object value, string tag, bool showRawData)
         {
             WatchViewModel node;
 
@@ -59,7 +59,7 @@ namespace Dynamo.Interfaces
             return node;
         }
 
-        internal WatchViewModel ProcessThing(SIUnit unit, string tag, bool showRawData = true)
+        internal WatchViewModel ProcessThing(SIUnit unit, string tag, bool showRawData)
         {
             return showRawData
                 ? new WatchViewModel(
@@ -69,17 +69,17 @@ namespace Dynamo.Interfaces
                 : new WatchViewModel(visualizationManager, unit.ToString(), tag);
         }
 
-        internal WatchViewModel ProcessThing(double value, string tag, bool showRawData = true)
+        internal WatchViewModel ProcessThing(double value, string tag, bool showRawData)
         {
             return new WatchViewModel(visualizationManager, value.ToString(preferences.NumberFormat, CultureInfo.InvariantCulture), tag);
         }
 
-        internal WatchViewModel ProcessThing(string value, string tag, bool showRawData = true)
+        internal WatchViewModel ProcessThing(string value, string tag, bool showRawData)
         {
             return new WatchViewModel(visualizationManager, value, tag);
         }
 
-        internal WatchViewModel ProcessThing(MirrorData data, string tag, bool showRawData = true)
+        internal WatchViewModel ProcessThing(MirrorData data, string tag, bool showRawData)
         {
             if (data.IsCollection)
             {
@@ -106,7 +106,7 @@ namespace Dynamo.Interfaces
             if (null != classMirror)
             {
                 if (data.Data == null && !data.IsNull) //Must be a DS Class instance.
-                    return ProcessThing(classMirror.ClassName, tag); //just show the class name.
+                    return ProcessThing(classMirror.ClassName, tag, showRawData); //just show the class name.
                 return Process(data.Data, tag, showRawData);
             }
 
@@ -117,14 +117,14 @@ namespace Dynamo.Interfaces
         private static string ToString(object obj)
         {
             return ReferenceEquals(obj, null)
-                ? "null"
+                ? NULL_STRING
                 : (obj is bool ? obj.ToString().ToLower() : obj.ToString());
         }
 
         public WatchViewModel Process(dynamic value, string tag, bool showRawData = true)
         {
             return Object.ReferenceEquals(value, null)
-                ? new WatchViewModel(visualizationManager, "null", tag)
+                ? new WatchViewModel(visualizationManager, NULL_STRING, tag)
                 : ProcessThing(value, tag, showRawData);
         }
     }

--- a/src/DynamoRevit/ViewModel/RevitWatchHandler.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatchHandler.cs
@@ -13,32 +13,26 @@ using Element = Revit.Elements.Element;
 namespace Dynamo.Applications
 {
     /// <summary>
-    /// An Revit-specific implementation of IWatchHandler that is set on the DynamoViewModel at startup.
-    /// The main Process method dynamically dispatches to the appropriate
-    /// internal method based on the type. For every time for which you would like
-    /// to have a custom representation in the watch, you will need an additional
-    /// method on this handler
-    /// 
-    /// NOTE:
-    /// Many of these methods duplicate those found in the DefaultWatchHandler.
-    /// As such, this class should extend DefaultWatchHandler. However, because the processsing
-    /// methods are dynamically dispatched, it doesn't play nicely with inheritance and these
-    /// methods have to be duplicated here.
+    ///     An Revit-specific implementation of IWatchHandler that is set on the DynamoViewModel at startup.
+    ///     The main Process method dynamically dispatches to the appropriate
+    ///     internal method based on the type. For every time for which you would like
+    ///     to have a custom representation in the watch, you will need an additional
+    ///     method on this handler
     /// </summary>
     public class RevitWatchHandler : IWatchHandler
     {
-        private const string NULL_STRING = "null";
-
+        private readonly IWatchHandler baseHandler;
         private readonly IVisualizationManager visualizationManager;
         private readonly IPreferences preferences;
 
         public RevitWatchHandler(IVisualizationManager vizManager, IPreferences prefs)
         {
+            baseHandler = new DefaultWatchHandler(vizManager, prefs);
             preferences = prefs;
             visualizationManager = vizManager;
         }
 
-        internal WatchViewModel ProcessThing(Element element, string tag, bool showRawData = true)
+        internal WatchViewModel ProcessThing(Element element, string tag, bool showRawData)
         {
             var id = element.Id;
 
@@ -55,94 +49,22 @@ namespace Dynamo.Applications
             return node;
         }
 
-        internal WatchViewModel ProcessThing(object value, string tag, bool showRawData = true)
+        //If no dispatch target is found, then invoke base watch handler.
+        internal WatchViewModel ProcessThing(object obj, string tag, bool showRawData)
         {
-            WatchViewModel node;
-
-            if (value is IEnumerable)
-            {
-                var list = (value as IEnumerable).Cast<dynamic>().ToList();
-
-                node = new WatchViewModel(visualizationManager, list.Count == 0 ? "Empty List" : "List", tag, true);
-                foreach (var e in list.Select((element, idx) => new { element, idx }))
-                {
-                    node.Children.Add(Process(e.element, tag + ":" + e.idx, showRawData));
-                }
-            }
-            else
-            {
-                node = new WatchViewModel(visualizationManager, ToString(value), tag);
-            }
-
-            return node;
+            return baseHandler.Process(obj, tag, showRawData);
         }
 
-        internal WatchViewModel ProcessThing(SIUnit unit, string tag, bool showRawData = true)
-        {
-            if (showRawData)
-                return new WatchViewModel(visualizationManager, 
-                    unit.Value.ToString(preferences.NumberFormat, CultureInfo.InvariantCulture), 
-                    tag);
-
-            return new WatchViewModel(visualizationManager, unit.ToString(), tag);
-        }
-
-        internal WatchViewModel ProcessThing(double value, string tag, bool showRawData = true)
-        {
-            return new WatchViewModel(visualizationManager, value.ToString(preferences.NumberFormat, CultureInfo.InvariantCulture), tag);
-        }
-
-        internal WatchViewModel ProcessThing(string value, string tag, bool showRawData = true)
-        {
-            return new WatchViewModel(visualizationManager, value, tag);
-        }
-
-        internal WatchViewModel ProcessThing(MirrorData data, string tag, bool showRawData = true)
+        internal WatchViewModel ProcessThing(MirrorData data, string tag, bool showRawData)
         {
             try
             {
-                if (data.IsCollection)
-                {
-                    var list = data.GetElements();
-
-                    var node = new WatchViewModel(visualizationManager, list.Count == 0 ? "Empty List" : "List", tag, true);
-                    foreach (var e in list.Select((element, idx) => new { element, idx }))
-                    {
-                        node.Children.Add(ProcessThing(e.element, tag + ":" + e.idx, showRawData));
-                    }
-
-                    return node;
-                }
-
-                // MAGN-3494: If "data.Data" is null, then return a "null" string 
-                // representation instead of casting it as dynamic (that leads to 
-                // a crash).
-                if (data.IsNull || data.Data == null)
-                    return new WatchViewModel(visualizationManager, NULL_STRING, tag);
-
-                //If the input data is an instance of a class, create a watch node
-                //with the class name and let WatchHandler process the underlying CLR data
-                var classMirror = data.Class;
-                if (null != classMirror)
-                {
-                    if (data.Data == null && !data.IsNull) //Must be a DS Class instance.
-                        return ProcessThing(classMirror.ClassName, tag); //just show the class name.
-                    return Process(data.Data, tag, showRawData);
-                }
-
-                //Finally for all else get the string representation of data as watch content.
-                return Process(data.Data, tag, showRawData);
+                return baseHandler.Process(data, tag, showRawData);
             }
             catch (Exception)
             {
-                return ProcessThing(data.Data, tag, showRawData);
+                return Process(data.Data, tag, showRawData);
             }
-            
-        }
-
-        private static string ToString(object obj)
-        {
-            return obj != null ? obj.ToString() : "null";
         }
 
         public WatchViewModel Process(dynamic value, string tag, bool showRawData = true)


### PR DESCRIPTION
@ikeough 

`RevitWatchHandler` now contains an instance of `DefaultWatchHandler`. If there doesn't exist a dynamic dispatch target for the object being handled by the `RevitWatchHandler`, then the `DefaultWatchHandler` is invoked.

This could be abstracted further to generically support composition of `IWatchHandlers`, but that can be implemented at a later time if necessary.
