### PR TITLE
For consistency changing category from Failing to Failure

### DIFF
--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -497,7 +497,7 @@ namespace DynamoCoreUITests
 
         #region General Node Operations Test Cases
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         public void MultiPassValidationSample()
         {
             RunCommandsFromFile("MultiPassValidationSample.xml", false, (commandTag) =>
@@ -517,7 +517,7 @@ namespace DynamoCoreUITests
             });
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         public void TestModifyPythonNodes()
         {
             RunCommandsFromFile("ModifyPythonNodes.xml");
@@ -531,7 +531,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual("# Modification 4", pvarin.Script);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         public void TestModifyPythonNodesUndo()
         {
             RunCommandsFromFile("ModifyPythonNodesUndo.xml");
@@ -545,7 +545,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual("# Modification 2", pvarin.Script);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         public void TestModifyPythonNodesUndoRedo()
         {
             RunCommandsFromFile("ModifyPythonNodesUndoRedo.xml");
@@ -559,7 +559,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual("# Modification 4", pvarin.Script);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         public void CreateAndUseCustomNode()
         {
             RunCommandsFromFile("CreateAndUseCustomNode.xml");
@@ -744,7 +744,7 @@ namespace DynamoCoreUITests
     {
         #region Basic CodeBlockNode Test Cases
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         public void TestBasicCodeBlockNodePortCreation()
         {
             RunCommandsFromFile("TestBasicPortCreation.xml");
@@ -790,7 +790,7 @@ namespace DynamoCoreUITests
         /// Creates a Code Block Node with a single line comment and multi line comment 
         /// checks if the ports are created properly and at the correct height
         /// </summary>
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         public void TestCommentsInCodeBlockNode()
         {
             RunCommandsFromFile("TestCommentsInCodeBlockNode.xml");
@@ -813,7 +813,7 @@ namespace DynamoCoreUITests
         /// Create a code block node with some ports connected and others unconnected. Change all variable names
         /// and ensure that connectors remain to the port index.
         /// </summary>
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         public void TestCodeBlockNodeConnectionOnCodeChange()
         {
             RunCommandsFromFile("TestCodeBlockNodeConnectionSwitching.xml");
@@ -842,7 +842,7 @@ namespace DynamoCoreUITests
         /// Creates 3 number nodes and an add (+) nodes. Connects 2 of the number
         /// nodes to the + node. Then converts all the nodes to Code.
         /// </summary>
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         public void TestConvertAllNodesToCode()
         {
             RunCommandsFromFile("TestConvertAllNodesToCode.xml");
@@ -902,7 +902,7 @@ namespace DynamoCoreUITests
         /// Ensures that redo works for NodeToCode by converting a set of nodes to
         /// code and then undoing and redoing it again.
         /// </summary>
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         public void TestConvertAllNodesToCodeUndoRedo()
         {
             RunCommandsFromFile("TestConvertAllNodesToCodeUndoRedo.xml");
@@ -948,7 +948,7 @@ namespace DynamoCoreUITests
             VerifyModelExistence(nodeExistenceMap);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         public void TestUndoRedoNodesAndConnections_DS()
         {
             RunCommandsFromFile("TestUndoRedoNodesAndConnection_DS.xml");
@@ -966,7 +966,7 @@ namespace DynamoCoreUITests
             VerifyModelExistence(nodeExistenceMap);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         public void TestUpdateNodeCaptions_DS()
         {
             RunCommandsFromFile("TestUpdateNodeCaptions_DS.xml");
@@ -1029,7 +1029,7 @@ namespace DynamoCoreUITests
             //Assert.Inconclusive("Porting : DoubleInput");
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_164_DS()
         {
@@ -1051,7 +1051,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_190_DS()
         {
@@ -1073,7 +1073,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_225_DS()
         {
@@ -1086,7 +1086,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_397_DS()
         {
@@ -1097,7 +1097,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(0, workspace.Connectors.Count);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_411()
         {
@@ -1114,7 +1114,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual("b", cbn.InPortData[1].ToolTipString);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_429_DS()
         {
@@ -1126,7 +1126,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_478_DS()
         {
@@ -1138,7 +1138,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(1, workspace.Notes.Count);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_491_DS()
         {
@@ -1165,7 +1165,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(secondPoint.Y, secondConnector.CurvePoint3.Y);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_520_DS()
         {
@@ -1176,7 +1176,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(0, workspace.Connectors.Count);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_520_WithCrossSelection_DS()
         {
@@ -1189,7 +1189,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(0, workspace.Connectors.Count);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_581_DS()
         {
@@ -1200,7 +1200,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(1, workspace.Connectors.Count);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_590()
         {
@@ -1227,7 +1227,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(0, workspace.Connectors.Count);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_585()
         {
@@ -1249,7 +1249,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(1, cbn.InPorts.Count);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_605()
         {
@@ -1282,7 +1282,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_624()
         {
@@ -1309,7 +1309,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_624_1()
         {
@@ -1343,7 +1343,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_590_1()
         {
@@ -1376,7 +1376,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_589_1()
         {
@@ -1409,7 +1409,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_589_2()
         {
@@ -1439,7 +1439,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_589_3()
         {
@@ -1478,7 +1478,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_828()
         {
@@ -1504,7 +1504,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(4, cbn.OutPorts[0].MarginThickness.Top);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_613()
         {
@@ -1526,7 +1526,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_904()
         {
@@ -1551,7 +1551,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_830()
         {
@@ -1576,7 +1576,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_803()
         {
@@ -1604,7 +1604,7 @@ namespace DynamoCoreUITests
         /// Eventually the evaluation will be done at record playback side thus remove the need
         /// of having multiple files.
         /// </summary>
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void TestCBNWithNodeToCode()
         {
@@ -1629,7 +1629,7 @@ namespace DynamoCoreUITests
             AssertValue("c_089fbe21a34547759592b683550558dd", 8);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_902()
         {
@@ -1651,7 +1651,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_422()
         {
@@ -1676,7 +1676,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_422_1()
         {
@@ -1795,7 +1795,7 @@ namespace DynamoCoreUITests
             AssertValue("b_9b638b99d63145838b82662a60cdf6bc", 0);
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void MethodResolutionFailRedef_MAGN_2262()
         {
@@ -2858,7 +2858,7 @@ namespace DynamoCoreUITests
 
         #region Tests moved from FScheme
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_159_AnotherScenario()
         {
@@ -2887,7 +2887,7 @@ namespace DynamoCoreUITests
             //Assert.AreEqual(8, (number1.OldValue as FScheme.Value.Number).Item);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_164()
         {
@@ -2903,7 +2903,7 @@ namespace DynamoCoreUITests
             AssertPreviewValue("635bd033-03f6-4b98-b03d-a5c3c2969607", 10);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_190()
         {
@@ -2915,7 +2915,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_225()
         {
@@ -2929,7 +2929,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(3, nodes.Count);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_397()
         {
@@ -2940,7 +2940,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(1, workspace.Connectors.Count);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_429()
         {
@@ -2952,7 +2952,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_478()
         {
@@ -2988,7 +2988,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(secondPoint.Y, secondConnector.CurvePoint3.Y);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_520()
         {
@@ -2999,7 +2999,7 @@ namespace DynamoCoreUITests
             AssertPreviewValue("41f52d8e-1a88-4f09-a2f1-f14e61d81f2c", 4);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_520_WithCrossSelection()
         {
@@ -3024,7 +3024,7 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, RequiresSTA, Category("Failing")]
+        [Test, RequiresSTA, Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_581()
         {
@@ -3035,7 +3035,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(1, workspace.Connectors.Count);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         public void ShiftSelectAllNode()
         {
             RunCommandsFromFile("ShiftSelectAllNode.xml");
@@ -3044,14 +3044,14 @@ namespace DynamoCoreUITests
             Assert.AreEqual(4, workspace.Connectors.Count);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         public void TestCreateConnectors()
         {
             RunCommandsFromFile("CreateNodesAndConnectors.xml");
             Assert.AreEqual(4, workspace.Connectors.Count);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         public void TestCreateNodesAndRunExpression()
         {
             RunCommandsFromFile("CreateNodesAndRunExpression.xml");
@@ -3059,14 +3059,14 @@ namespace DynamoCoreUITests
 
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         public void TestCreateNodes()
         {
             RunCommandsFromFile("CreateNodesAndConnectors.xml");
             Assert.AreEqual(5, workspace.Nodes.Count);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         public void TestDeleteCommands()
         {
             RunCommandsFromFile("CreateAndDeleteNodes.xml");
@@ -3088,7 +3088,7 @@ namespace DynamoCoreUITests
             VerifyModelExistence(nodeExistenceMap);
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         public void TestUndoRedoNodesAndConnections()
         {
             RunCommandsFromFile("UndoRedoNodesAndConnections.xml");
@@ -3155,7 +3155,7 @@ namespace DynamoCoreUITests
             //Assert.Inconclusive("Porting : DoubleInput");
         }
 
-        [Test, Category("Failing")]
+        [Test, Category("Failure")]
         public void TestVerifyRuntimeValues()
         {
             RunCommandsFromFile("VerifyRuntimeValues.xml", true);


### PR DESCRIPTION
As everywhere we have marked failed Test Cases as Failure, so changing the same for this project to maintain consistency.

<h4>Reviewer</h4>

@junmendoza 
