### PR TITLE
Migrate lacing in MigrateToDSFunction methods.

### DIFF
--- a/src/Migrations/MigrationHelpers.cs
+++ b/src/Migrations/MigrationHelpers.cs
@@ -20,6 +20,7 @@ namespace Migrations
             element.SetAttribute("assembly", assembly);
             element.SetAttribute("nickname", nickname);
             element.SetAttribute("function", funcName);
+            element.SetAttribute("lacing", xmlNode.Attributes["lacing"].Value);
 
             NodeMigrationData migrationData = new NodeMigrationData(data.Document);
             migrationData.AppendNode(element);
@@ -34,6 +35,7 @@ namespace Migrations
             element.SetAttribute("assembly", assembly);
             element.SetAttribute("nickname", nickname);
             element.SetAttribute("function", funcName);
+            element.SetAttribute("lacing", xmlNode.Attributes["lacing"].Value);
 
             NodeMigrationData migrationData = new NodeMigrationData(data.Document);
             migrationData.AppendNode(element);


### PR DESCRIPTION
This pull requests adds lacing migration as noted in #1887. The MigrateToDSFunction method, which is responsible for migrating "old" xml elements representing nodes did not set the attribute for lacing on the new node.

@lukechurch PTAL.
