### PR TITLE
MAGN-4157

### DIFF
--- a/src/DynamoCore/UI/Converters.cs
+++ b/src/DynamoCore/UI/Converters.cs
@@ -1547,10 +1547,9 @@ namespace Dynamo.Controls
         {
             if ((bool) value != true) return "(Up-to-date)";
 
-            if (!(parameter is DynamoViewModel)) return "Could not get version";
-
             var latest = UpdateManager.UpdateManager.Instance.AvailableVersion;
-            return latest;
+
+            return latest != null? latest.ToString() : "Could not get version.";
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
Problem:
The about box's version number text block was showing "Could not get version."

Solution:
This error was introduced during the Dynamo Core refactoring. Logic was added to the converter to check whether the DynamoViewModel being passed as a parameter was null. The DynamoViewModel was NEVER being passed as a parameter and the object received was actually just text saying "DataContext", so the condition would never evaluate to true and the text returned from the converter would always be "Could not get version." We only need to check whether the AvailableVersion property on the UpdateManager instance is null to return the error string, or we return its value.

@lukechurch PTAL.
