### PR TITLE
Fix MAGN-4522 When building Dynamo using visual studio, DynamoSandbox does not open, if there is no folder Autodesk in programfiles

### DIFF
--- a/src/DynamoUtilities/DynamoPathManager.cs
+++ b/src/DynamoUtilities/DynamoPathManager.cs
@@ -349,9 +349,7 @@ namespace DynamoUtilities
             {
                 subDirs = root.GetDirectories();
             }
-            // This is thrown if even one of the files requires permissions greater 
-            // than the application provides. 
-            catch (UnauthorizedAccessException e)
+            catch (Exception e)
             {
                 // TODO: figure out how to print to the console that Sandbox needs higher permissions
                 return false;


### PR DESCRIPTION
@Benglin 

The reason is that if the directory does not exist, it will throw an exception other than UnauthorizedAccessException which is not caught. As a result, the application crashes.
