### PR TITLE
Fix MAGN-4451 strange behavior with Run Automatic and Revit Document close/reopen.

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -136,16 +136,19 @@ namespace Dynamo.Applications
                 IdlePromise.ExecuteOnShutdown(
                     delegate
                     {
-                        TransactionManager.Instance.EnsureInTransaction(DocumentManager.Instance.CurrentDBDocument);
-
-                        var keeperId = vizManager.KeeperId;
-
-                        if (keeperId != ElementId.InvalidElementId)
+                        if (null != DocumentManager.Instance.CurrentDBDocument)
                         {
-                            DocumentManager.Instance.CurrentUIDocument.Document.Delete(keeperId);
-                        }
+                            TransactionManager.Instance.EnsureInTransaction(DocumentManager.Instance.CurrentDBDocument);
 
-                        TransactionManager.Instance.ForceCloseTransaction();
+                            var keeperId = vizManager.KeeperId;
+
+                            if (keeperId != ElementId.InvalidElementId)
+                            {
+                                DocumentManager.Instance.CurrentUIDocument.Document.Delete(keeperId);
+                            }
+
+                            TransactionManager.Instance.ForceCloseTransaction();
+                        }
                     });
 
             return viewModel;

--- a/src/Libraries/Revit/RevitServices/Transactions/TransactionManager.cs
+++ b/src/Libraries/Revit/RevitServices/Transactions/TransactionManager.cs
@@ -302,7 +302,7 @@ namespace RevitServices.Transactions
         /// <summary>
         ///     Starts a RevitAPI Transaction that will be managed by this TransactionManager instance.
         /// </summary>
-        /// <param name="document">Document (DB) to start a Transaction for.</param>
+        /// <param name="document">Document (DB) to start a Transaction for. The parameter can not be null.</param>
         public TransactionHandle StartTransaction(Document document)
         {
             if (Transaction == null || Transaction.GetStatus() != TransactionStatus.Started)
@@ -310,7 +310,7 @@ namespace RevitServices.Transactions
                 TransactionManager.Log("Starting Transaction.");
                 
                 // Dispose the old transaction so that it won't impact the new transaction
-                if (null != Transaction)
+                if (null != Transaction && Transaction.IsValidObject)
                     Transaction.Dispose();
 
                 Transaction = new Transaction(document, "Dynamo Script");
@@ -332,7 +332,7 @@ namespace RevitServices.Transactions
         {
             get
             {
-                return Transaction != null 
+                return Transaction != null && Transaction.IsValidObject
                     && Transaction.GetStatus() == TransactionStatus.Started;
             }
         }


### PR DESCRIPTION
@pboyer 

If all the documents have been closed and when we shut down Dynamo, there will be no valid documents for a transaction. An attempt to create a transaction will fail and an exception will be thrown. Also as the old transaction object has been disposed, it means the transaction object hold in the wrapper is invalid. This submission prevents the case by checking the document pointer when Dynamo is shutdown.
