### PR TITLE
Merge small changes from a much larger pull request

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -470,7 +470,7 @@ namespace Dynamo.Models
             // Runtime warnings take precedence over build warnings.
             foreach (var warning in updateTask.RuntimeWarnings)
             {
-                var message = string.Join("\n", warning.Value);
+                var message = string.Join("\n", warning.Value.Select(w => w.Message));
                 messages.Add(warning.Key, message);
             }
 
@@ -481,7 +481,7 @@ namespace Dynamo.Models
                 if (messages.ContainsKey(warning.Key))
                     continue;
 
-                var message = string.Join("\n", warning.Value);
+                var message = string.Join("\n", warning.Value.Select(w => w.Message));
                 messages.Add(warning.Key, message);
             }
 

--- a/src/DynamoCore/Properties/AssemblyInfo.cs
+++ b/src/DynamoCore/Properties/AssemblyInfo.cs
@@ -54,3 +54,4 @@ using System.Windows.Resources;
 
 [assembly: InternalsVisibleTo("DynamoCoreTests")]
 [assembly: InternalsVisibleTo("DynamoCoreUITests")]
+[assembly: InternalsVisibleTo("DynamoRevitDS")]


### PR DESCRIPTION
This pull request fixes the way build-time/runtime warnings are displayed on the nodes. Prior to this fix only `RuntimeWarnings` and `BuildWarnings` are displayed on the bubble, instead I should be showing their `Message` content.

Hi @junmendoza, please help reviewing this, thanks!
