### PR TITLE
Fix to test fx APIs to retrieve correct var names from preview nodes

### DIFF
--- a/test/DynamoCoreTests/DynamoViewModelUnitTest.cs
+++ b/test/DynamoCoreTests/DynamoViewModelUnitTest.cs
@@ -152,8 +152,11 @@ namespace Dynamo.Tests
             var model = ViewModel.Model;
             var node = model.CurrentWorkspace.NodeFromWorkspace(guid);
             Assert.IsNotNull(node);
-            
-            if(node.OutPorts.Count > 1) 
+
+            int outportCount = node.OutPorts.Count;
+            Assert.IsTrue(outportCount > 0);
+
+            if(outportCount > 1) 
                 return node.AstIdentifierBase; 
             else 
                 return node.GetAstIdentifierForOutputIndex(0).Value;
@@ -165,8 +168,11 @@ namespace Dynamo.Tests
             var model = ViewModel.Model;
             var node = model.CurrentWorkspace.NodeFromWorkspace(guid);
             Assert.IsNotNull(node);
-            
-            if(node.OutPorts.Count > 1) 
+
+            int outportCount = node.OutPorts.Count;
+            Assert.IsTrue(outportCount > 0);
+
+            if (outportCount > 1) 
                 return node.AstIdentifierBase; 
             else 
                 return node.GetAstIdentifierForOutputIndex(0).Value;


### PR DESCRIPTION
Preview values for constant nodes such as number nodes and string nodes are returned as 'null' as the preview variable names they were queried with did not match their symbol names. As a result of which there was a `SymbolNotFoundException`. This is not an issue in normal execution as these nodes need not be previewed however this poses a problem in test frameworks, where they are previewed in tests. This is leading to a number of tests falsely failing.

This fix addresses this issue in the test framework locally.

@Benglin PTAL
