### PR TITLE
Fixed UI bugs in new code block editor

### DIFF
--- a/src/DynamoCore/UI/Controls/CodeBlockEditor.xaml
+++ b/src/DynamoCore/UI/Controls/CodeBlockEditor.xaml
@@ -9,24 +9,26 @@
              d:DesignHeight="300"
              d:DesignWidth="300">
     <UserControl.Resources>
-        <FontFamily x:Key="OpenSansRegular">../../Fonts/#Open Sans</FontFamily>
+        
     </UserControl.Resources>
     <Grid>
         <Border BorderBrush="#aaa"
-                BorderThickness="1,0,1,0">
+                BorderThickness="1,0,1,0"
+                VerticalAlignment="Top">
             <avalonedit:TextEditor x:Name="InnerTextEditor"
                                    FontSize="15px"
-                                   FontFamily="{StaticResource OpenSansRegular}"
+                                   FontFamily="Consolas"
                                    WordWrap="True"
                                    Foreground="#444"
                                    Padding="3 0 3 0"
                                    Background="#88FFFFFF"
-                                   MaxWidth="500"/>
+                                   MaxWidth="500"
+                                   ScrollViewer.VerticalScrollBarVisibility="Disabled"/>
         </Border>
         <TextBlock x:Name="WatermarkLabel"
                    Text="Your code goes here"
                    Foreground="#777777"
-                   FontFamily="{StaticResource OpenSansRegular}"
+                   FontFamily="Consolas"
                    FontSize="14.67px"
                    Padding="3 0 3 0"
                    Margin="3 0 3 0"

--- a/src/DynamoCore/UI/Controls/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCore/UI/Controls/CodeBlockEditor.xaml.cs
@@ -100,6 +100,8 @@ namespace Dynamo.UI.Controls
         /// <param name="e"></param>
         void TextArea_LostFocus(object sender, RoutedEventArgs e)
         {
+            this.InnerTextEditor.TextArea.ClearSelection();
+
             this.nodeViewModel.DynamoViewModel.ExecuteCommand(
                 new DynCmd.UpdateModelValueCommand(
                     this.nodeViewModel.NodeModel.GUID, "Code", this.InnerTextEditor.Text));


### PR DESCRIPTION
This submission fixes the following issues in the new code block editor:
1. Changed editor font to 'Consolas' - This fixed the issue with the quirky selection highlight below:
![image](https://cloud.githubusercontent.com/assets/5710686/4247513/d3c77cf4-3a5a-11e4-8c5e-ba292433b766.png)
2. Select the text in code block, click outside to commit, blue selection stays.
3. Clicking on the area shown doesn’t make the code block into editing mode - This was because this area was occupied by the vertical scrollbar, which has been disabled
 ![image](https://cloud.githubusercontent.com/assets/5710686/4247534/1fdef55e-3a5b-11e4-9d70-dfc2f0b98904.png)

and ofcourse we now have fixed width point as mentioned in point (1) :)

@Benglin PTAL
