### PR TITLE
Null check before getting lacing attribute from xml node

### DIFF
--- a/src/Migrations/MigrationHelpers.cs
+++ b/src/Migrations/MigrationHelpers.cs
@@ -20,7 +20,12 @@ namespace Migrations
             element.SetAttribute("assembly", assembly);
             element.SetAttribute("nickname", nickname);
             element.SetAttribute("function", funcName);
-            element.SetAttribute("lacing", xmlNode.Attributes["lacing"].Value);
+
+            var lacingAttribute = xmlNode.Attributes["lacing"];
+            if (lacingAttribute != null)
+            {
+                element.SetAttribute("lacing", lacingAttribute.Value);
+            }
 
             NodeMigrationData migrationData = new NodeMigrationData(data.Document);
             migrationData.AppendNode(element);


### PR DESCRIPTION
This pull request is to fix defect [MAGN-4614  Fail to migrate and open attached file. Dynamo.Tests.CoreTests.CanOpenGoodFile is failing](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4614).

Function element in this dyn file doesn't have `lacing` attribute, so getting value from `lacing` attribute will throw a `NullReference` exception. Add null checking before getting this attribute.  

@ikeough , for you.
