### PR TITLE
Fix DefaultWatchHandler not accessing RevitWatchHandler when traversing collections: MAGN-4347

### DIFF
--- a/src/DynamoCore/Nodes/Watch.cs
+++ b/src/DynamoCore/Nodes/Watch.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 
 using Dynamo.Controls;
+using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.ViewModels;
 
@@ -210,8 +211,8 @@ namespace Dynamo.Nodes
                 : InPorts[0].Connectors[0].Start.Owner.AstIdentifierForPreview.Name;
             
             return Root != null
-                ? dynamoViewModel.WatchHandler.Process(CachedValue, inputVar, Root.ShowRawData)
-                : dynamoViewModel.WatchHandler.Process(CachedValue, inputVar);
+                ? dynamoViewModel.WatchHandler.GenerateWatchViewModelForData(CachedValue, inputVar, Root.ShowRawData)
+                : dynamoViewModel.WatchHandler.GenerateWatchViewModelForData(CachedValue, inputVar);
         }
 
         public override void UpdateRenderPackage(int maxTessDivs)

--- a/src/DynamoCore/UI/Views/PreviewControl.xaml.cs
+++ b/src/DynamoCore/UI/Views/PreviewControl.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Dynamo.Controls;
+using Dynamo.Interfaces;
 using Dynamo.ViewModels;
 using ProtoCore.Mirror;
 using System;
@@ -280,7 +281,7 @@ namespace Dynamo.UI.Controls
             var rootDataContext = watchTree.DataContext as WatchViewModel;
 
             // Associate the data context to the view before binding.
-            cachedLargeContent = nodeViewModel.DynamoViewModel.WatchHandler.Process(
+            cachedLargeContent = nodeViewModel.DynamoViewModel.WatchHandler.GenerateWatchViewModelForData(
                 mirrorData, string.Empty, false);
 
             rootDataContext.Children.Add(cachedLargeContent);

--- a/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
+++ b/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
@@ -12,7 +12,6 @@ using Dynamo.Models;
 using ProtoCore.Mirror;
 using Revit.GeometryConversion;
 
-using RevitServices.Elements;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
 

--- a/src/DynamoRevit/ViewModel/RevitWatchHandler.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatchHandler.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections;
 using System.Globalization;
-using System.Linq;
 
 using Dynamo.Interfaces;
 using Dynamo.ViewModels;
-using DynamoUnits;
+
 using ProtoCore.Mirror;
 using RevitServices.Persistence;
 using Element = Revit.Elements.Element;
@@ -14,7 +12,7 @@ namespace Dynamo.Applications
 {
     /// <summary>
     ///     An Revit-specific implementation of IWatchHandler that is set on the DynamoViewModel at startup.
-    ///     The main Process method dynamically dispatches to the appropriate
+    ///     The main GenerateWatchViewModelForData method dynamically dispatches to the appropriate
     ///     internal method based on the type. For every time for which you would like
     ///     to have a custom representation in the watch, you will need an additional
     ///     method on this handler
@@ -32,7 +30,7 @@ namespace Dynamo.Applications
             visualizationManager = vizManager;
         }
 
-        internal WatchViewModel ProcessThing(Element element, string tag, bool showRawData)
+        private WatchViewModel ProcessThing(Element element, string tag, bool showRawData, WatchHandlerCallback callback)
         {
             var id = element.Id;
 
@@ -51,28 +49,28 @@ namespace Dynamo.Applications
         }
 
         //If no dispatch target is found, then invoke base watch handler.
-        internal WatchViewModel ProcessThing(object obj, string tag, bool showRawData)
+        private WatchViewModel ProcessThing(object obj, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return baseHandler.Process(obj, tag, showRawData);
+            return baseHandler.Process(obj, tag, showRawData, callback);
         }
 
-        internal WatchViewModel ProcessThing(MirrorData data, string tag, bool showRawData)
+        private WatchViewModel ProcessThing(MirrorData data, string tag, bool showRawData, WatchHandlerCallback callback)
         {
             try
             {
-                return baseHandler.Process(data, tag, showRawData);
+                return baseHandler.Process(data, tag, showRawData, callback);
             }
             catch (Exception)
             {
-                return Process(data.Data, tag, showRawData);
+                return callback(data.Data, tag, showRawData);
             }
         }
 
-        public WatchViewModel Process(dynamic value, string tag, bool showRawData = true)
+        public WatchViewModel Process(dynamic value, string tag, bool showRawData, WatchHandlerCallback callback)
         {
             return Object.ReferenceEquals(value, null)
                 ? new WatchViewModel(visualizationManager, "null", tag)
-                : ProcessThing(value, tag, showRawData);
+                : ProcessThing(value, tag, showRawData, callback);
         }
     }
 }

--- a/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
+++ b/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
@@ -606,9 +606,9 @@ namespace Dynamo.Tests
         /// <summary>
         /// TODO: This is to verify the fix for the following user report issue.
         /// Note that however this test case does not completely simulate the 
-        /// user scenario -- the "Watch.Process" does not even get called for 
+        /// user scenario -- the "Watch.GenerateWatchViewModelForData" does not even get called for 
         /// some reason. This test case passes now, but should be revisit later
-        /// for an enhancement which allows "Watch.Process" to be called (and 
+        /// for an enhancement which allows "Watch.GenerateWatchViewModelForData" to be called (and 
         /// crash without the fix).
         /// </summary>
         [Test]


### PR DESCRIPTION
@ikeough 

Due to the recent `IWatchHandler` refactor, when the `DefaultWatchHandler` is invoked from the `RevitWatchHandler`, any dynamic dispatch being done inside the `DefaultWatchHandler` does not invoke methods declared in the `RevitWatchHandler`. This is because all methods that perform dynamic dispatch in the `DefaultWatchHandler` invoke the dynamic `Process` method implemented on the `DefaultWatchHandler`.

The symptom of this was that when traversing collections (handled in the `DefaultWatchHandler`) of Revit `Element` instances, those instances were not being handled in the `RevitWatchHandler`, and thus the buttons wouldn't appear in the Watch node.

To fix this, I've added a callback argument that passes the appropriate `Process` method to all the dynamic dispatch targets. Whenever a `ProcessThing` method needs to perform a dynamic dispatch, it calls the function passed in via the `callback` argument, as opposed to directly calling the dynamic `Process` method. The callback is initially provided by the `GenerateWatchViewModelForData` method, which passes the original dynamic `Process` method as the callback.
