### PR TITLE
Change GCRetain() and GCRelease() order in BuildInFunctionEndPoint

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -500,6 +500,8 @@ namespace ProtoCore.Lang
                     throw new ProtoCore.Exceptions.CompilerInternalException("Unknown built-in method. {AAFAE85A-2AEB-4E8C-90D1-BCC83F27C852}");
             }
 
+            GCUtils.GCRetain(ret, core);
+
             // Dot operator is a special case and its arguments are not meant to be gc'd
             // The debugger will always get to here as it applies for only those built-ins that are also external
             // and therefore that the debugger does not break out of - pratapa
@@ -511,7 +513,6 @@ namespace ProtoCore.Lang
                 }
             }
 
-            GCUtils.GCRetain(ret, core);
             return ret;
 
         }


### PR DESCRIPTION
This pull request is to fix defect [MAGN-4605  Multi-output custom nodes do not always accurately output contents](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4605#).

When the VM returns from a builtin function, it will decrease the reference count for input parameters and then increase the reference count for return value. But, if the memory that the return value points to is part of the memory that the input parameter points to, this piece of memory may be garbage collected before it is returned.

An example is the input parameter is a dictionary. Because of array copy semantics, a temporary dictionary will be created and get garbage collected when the function is returned, and if return value is some value in the dictionary, garbage information will be returned as the whole dictionary is disposed. 

A quick fix is to change the order of increase/decrease reference count.

I'm thinking about introducing memory verification logic for some operations to catch this kind of memory corruption at the early stage. Will do that in the other pull request. 

@junmendoza , @lukechurch, @sharadkjaiswal   please take a look.
