### PR TITLE
Do not use CurveLoop in RevitGeometryFromMirrorData method

### DIFF
--- a/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
+++ b/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
@@ -90,7 +90,10 @@ namespace Dynamo
                 .Select(x => x.CachedValue);
 
             var geoms = new List<GeometryObject>();
-            values.ToList().ForEach(md=>RevitGeometryFromMirrorData(md, ref geoms));
+            foreach (var value in values)
+            {
+                RevitGeometryFromMirrorData(value, ref geoms);
+            }
 
             Draw(geoms);
         }
@@ -166,7 +169,14 @@ namespace Dynamo
                     var geom = data.Data as PolyCurve;
                     if (geom != null)
                     {
-                        geoms.AddRange(geom.ToRevitType());
+                        // We extract the curves explicitly rather than using PolyCurve's ToRevitType
+                        // extension method.  There is a potential issue with CurveLoop which causes
+                        // this method to introduce corrupt GNodes.  
+                        foreach (var c in geom.Curves())
+                        {
+                            geoms.Add(c.ToRevitType());
+                        }
+                        
                         return;
                     }
 


### PR DESCRIPTION
### Issue

Geometry display in the Revit viewport, the so called "GeomKeeper" API, was crashing repeatedly in a handful of workflows.  These workflows had the following in common:

1)  Usage of `PolyCurve`
2)  Usage of `Solid`

Alley discovered that the issue was likely having to do with memory corruption of Revit `Curve` objects passed to the GeomKeeper Element.  This is surprising, given that we were already using the standard Revit `Curve` creation APIs quite extensively without issue.
### Bug Origin

You can consider this a stop-gap fix.  We're still not totally sure what the underlying issue is, but it likely has to do with `CurveLoop`.  

In `RevitGeometryFromMirrorData`, `PolyCurve`'s are converted into `CurveLoop`'s by first the `ToRevitType` extension method.  Beyond the fact that there is no reason to create a `CurveLoop` here (which guarantees the collection of `Curve`'s is closed, not guaranteed by `PolyCurve`), we have reason to believe that enumerating the `Curve`'s in the `CurveLoop` (`CurveLoop` implements `IEnumerable<Curve>`) transfers ownership of the underlying native `Curve` incorrectly.  In short, the managed GC cleans up the `Curve`, corrupting the native `Curve`.  This is just a hunch, though.
### Fix

By removing the usage of `CurveLoop`, the crash is now unreproducible.
### Reviewers

@ikeough
