### PR TITLE
Fix to handle longest lacing on empty arrays

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1387,6 +1387,8 @@ namespace ProtoCore
                         throw new ReplicationCaseNotCurrentlySupported("Selected algorithm not supported");
                 }
 
+
+                bool hasEmptyArg = false;
                 foreach (int repIndex in repIndecies)
                 {
 
@@ -1401,6 +1403,9 @@ namespace ProtoCore
                     }
                     parameters.Add(subParameters);
 
+                    if (subParameters.Length == 0)
+                        hasEmptyArg = true;
+
                     switch (algorithm)
                     {
                         case ZipAlgorithm.Shortest:
@@ -1412,6 +1417,12 @@ namespace ProtoCore
                     }
 
                 }
+
+                // If we're being asked to replicate across an empty list
+                // then it's always going to be zero, as there will never be any
+                // data to pass to that parameter.
+                if (hasEmptyArg)
+                    retSize = 0;
 
                 StackValue[] retSVs = new StackValue[retSize];
                 SingleRunTraceData retTrace = newTraceData;

--- a/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
@@ -3000,6 +3000,28 @@ c = [Associative]
         }
 
         [Test]
+        public void TestLongestLacingWithEmptyList()
+        {
+            string code =
+@"
+        def foo(a : int, b : int)
+{
+    return = a + b;
+}
+
+x = {};
+x1 = {1};
+y = {1};
+
+o2 = foo(x<1L>, y<1L>);
+
+";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("o2", 0);
+        }
+
+
+        [Test]
         [Category("Failure")]
         public void TestComplexAssociativeUpdate()
         {


### PR DESCRIPTION
It used to crash, it now doesn't execute the function

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4566
