### PR TITLE
Disabled "heartbeatThread.Join" statement to avoid deadlock

### DIFF
--- a/src/DynamoCore/Services/Heartbeat.cs
+++ b/src/DynamoCore/Services/Heartbeat.cs
@@ -47,7 +47,17 @@ namespace Dynamo.Services
             System.Diagnostics.Debug.WriteLine("Heartbeat Destory Internal called");
 
             shutdownEvent.Set(); // Signal the shutdown event... 
-            heartbeatThread.Join(); // ... wait for thread to end.
+
+            // TODO: Temporary comment out this Join statement. It currently 
+            // causes Dynamo to go into a deadlock when it is shutdown for the 
+            // second time on Revit (that's when the HeartbeatThread is trying 
+            // to call 'GetStringRepOfWorkspaceSync' below (the method has no 
+            // chance of executing, and therefore, will never return due to the
+            // main thread being held up here waiting for the heartbeat thread 
+            // to end).
+            // 
+            // heartbeatThread.Join(); // ... wait for thread to end.
+
             heartbeatThread = null;
         }
 


### PR DESCRIPTION
## Background

This pull request fixes a deadlock that takes place while closing Dynamo in Revit. Here are the steps to reproduce the deadlock:
1. Start Revit, start Dynamo
2. Close Dynamo window
3. Start Dynamo
4. Close Dynamo window (deadlock)
## Testing

With the fix, I could repeat the above `Step 3` and `Step 4` for over 10 times without any issue.

I have also verified that the call to `GetStringRepOfWorkspaceSync` actually completes with the data in `outData`, and properly returns to the caller on a separate (heartbeat) thread. This means the following statement gets what it is supposed to get for logging purposes:

``` cs
private void ExecThread()
{
    while (true)
    {
        string workspace =
            dynamoModel.CurrentWorkspace
                       .GetStringRepOfWorkspaceSync();

        // We do get meaningful 'workspace' data here...
        InstrumentationLogger.LogPiiInfo("Workspace", workspace);
    }
}
```

Hi @lukechurch, please have a look, I'll merge this in to all other branches once this gets in.
