### PR TITLE
Disabled "heartbeatThread.Join" statement to avoid deadlock

### DIFF
--- a/src/DynamoCore/Services/Heartbeat.cs
+++ b/src/DynamoCore/Services/Heartbeat.cs
@@ -52,7 +52,17 @@ namespace Dynamo.Services
             System.Diagnostics.Debug.WriteLine("Heartbeat Destory Internal called");
 
             shutdownEvent.Set(); // Signal the shutdown event... 
-            heartbeatThread.Join(); // ... wait for thread to end.
+
+            // TODO: Temporary comment out this Join statement. It currently 
+            // causes Dynamo to go into a deadlock when it is shutdown for the 
+            // second time on Revit (that's when the HeartbeatThread is trying 
+            // to call 'GetStringRepOfWorkspaceSync' below (the method has no 
+            // chance of executing, and therefore, will never return due to the
+            // main thread being held up here waiting for the heartbeat thread 
+            // to end).
+            // 
+            // heartbeatThread.Join(); // ... wait for thread to end.
+
             heartbeatThread = null;
         }
 


### PR DESCRIPTION
See [original pull request](https://github.com/DynamoDS/Dynamo/pull/2465) for details of the fix and test scenarios.
