### PR TITLE
Tesselate NurbsCurve's with ASM before injection to Revit 2015

### DIFF
--- a/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
+++ b/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
@@ -4,9 +4,11 @@ using System.Linq;
 using System.Reflection;
 
 using Autodesk.DesignScript.Geometry;
+using Autodesk.DesignScript.Interfaces;
 using Autodesk.Revit.DB;
 
 using Dynamo.Core;
+using Dynamo.DSEngine;
 using Dynamo.Models;
 
 using ProtoCore.Mirror;
@@ -174,7 +176,10 @@ namespace Dynamo
                         // this method to introduce corrupt GNodes.  
                         foreach (var c in geom.Curves())
                         {
-                            geoms.Add(c.ToRevitType());
+                            // Tesselate the curve.  This greatly improves performance when
+                            // we're dealing with NurbsCurve's with high knot count, commonly
+                            // results of surf-surf intersections.
+                            Tesselate(c, ref geoms);
                         }
                         
                         return;
@@ -190,7 +195,10 @@ namespace Dynamo
                     var curve = data.Data as Curve;
                     if (curve != null)
                     {
-                        geoms.Add(curve.ToRevitType());
+                        // Tesselate the curve.  This greatly improves performance when
+                        // we're dealing with NurbsCurve's with high knot count, commonly
+                        // results of surf-surf intersections.
+                        Tesselate(curve, ref geoms);
                         return;
                     }
 
@@ -215,5 +223,29 @@ namespace Dynamo
                 }
             }
         }
+
+        private void Tesselate(Autodesk.DesignScript.Geometry.Curve curve, ref List<GeometryObject> geoms)
+        {
+            // use the ASM tesselation of the curve
+            var pkg = new RenderPackage();
+            curve.Tessellate(pkg, 0.1);
+
+            // get necessary info to enumerate and convert the lines
+            var lineCount = pkg.LineStripVertices.Count - 3;
+            var verts = pkg.LineStripVertices;
+
+            // we scale the tesselation rather than the curve
+            var conv = UnitConverter.DynamoToHostFactor;
+
+            // add the revit Lines to geometry collection
+            for (var i = 0; i < lineCount; i += 3)
+            {
+                var xyz0 = new XYZ(verts[i] * conv, verts[i + 1] * conv, verts[i + 2] * conv);
+                var xyz1 = new XYZ(verts[i + 3] * conv, verts[i + 4] * conv, verts[i + 5] * conv);
+
+                geoms.Add(Autodesk.Revit.DB.Line.CreateBound(xyz0, xyz1));
+            }
+        }
+
     }
 }


### PR DESCRIPTION
### Issue

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4680#

Zach was seeing enormous slowdowns when attempting to visualize `NurbsCurve`'s that were the result of `Surface`-`Surface` intersections.  ASM results in `NurbsCurve`'s with 500 control points for even simple plane-ellipsoid intersections.  Revit is very slow to tessellate these curves.  The core issue is that intersections should not result in such a large number of control points.  However, this is a very common workflow and it's not entirely straightforward to ask ASM to "just return less control points", so we need an immediate fix for this.  
### Fix

The simplest fix is provided here.  Instead of handing Revit Curve types, we pre-tessellate them with ASM.  Then we just hand GeomKeeper a bag of lines.  For `NurbsCurve`'s with a high number of control points, this vastly speeds up GeomKeeper.  For this workflow, we went from several minutes to tesselate (basically unusable), to a few seconds:

![tess](https://cloud.githubusercontent.com/assets/916345/4326257/661be8b2-3f6d-11e4-9655-ebb65f7874bb.PNG)

I know what you're thinking - "WOW!"  

I've also created a task for refining `Surface`-`Surface` intersection results:

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4690
### Reviewer

@ikeough 
