### PR TITLE
Harden TestLoadNoNamespaceClass

### DIFF
--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -28,8 +28,14 @@ namespace Dynamo.Tests
             libraryServices.LibraryLoadFailed += (sender, e) => Assert.Fail("Failed to load library: " + e.LibraryPath);
 
             string libraryPath = "FFITarget.dll";
-            libraryServices.ImportLibrary(libraryPath, ViewModel.Model.Logger);
-            Assert.IsTrue(libraryLoaded);
+
+            // All we need to do here is to ensure that the target has been loaded
+            // at some point, so if it's already thre, don't try and reload it
+            if (!libraryServices.Libraries.Any(x => x.EndsWith(libraryPath)))
+            {
+                libraryServices.ImportLibrary(libraryPath, ViewModel.Model.Logger);
+                Assert.IsTrue(libraryLoaded);
+            }
 
             // Get function groups for global classes with no namespace
             var functions = libraryServices.GetFunctionGroups(libraryPath)


### PR DESCRIPTION
TestLoadNoNamespaceClass was also testing the ability to load the FFITarget. This isn't ideal for a system test.

This PR hardens the test so that if the library is already loaded it doesn't attempt to reload it.

It should be followed up by a cleanup PR to:
- Add a support method to libraryServices: IsLibraryLoaded
- Fix the libraryServices.Reset support method

@aparajit-pratap PTAL
