### PR TITLE
MAGN-4737 Watch node crashes when attempting to process a Revit.Elements.ReferencePlane object.

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/ReferencePlane.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/ReferencePlane.cs
@@ -50,7 +50,7 @@ namespace Revit.Elements
         /// <param name="referencePlane"></param>
         private ReferencePlane( Autodesk.Revit.DB.ReferencePlane referencePlane)
         {
-            this.InternalReferencePlane = referencePlane;
+            InternalSetReferencePlane(referencePlane);
         }
 
         /// <summary>


### PR DESCRIPTION
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4737

Require merge into:
- [x] Revit2015
