### PR TITLE
Crash application if memory is corrupted

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -446,6 +446,11 @@ namespace ProtoCore.DSASM
 #endif
                 }
                 
+                // The reference count could be 0 if this heap object
+                // is a temporary heap object that hasn't been assigned
+                // to any variable yet, for example, Type.Coerce() may 
+                // allocate a new array and when this one is type converted
+                // again, it will be released. 
                 if (hs.Refcount > 0)
                 {
                     hs.Refcount--;


### PR DESCRIPTION
This pull request throws exception when we detect the memory is potentially corrupted. The verification is enabled through compiler flag HEAP_VERIFICATION.

Running ProtoTest gets a bunch of memory exceptions. So of them probably is false positive, need to investigate them. 

@lukechurch, @junmendoza please review the change. 
