### PR TITLE
Build Fix: Added missing namespaces

### DIFF
--- a/src/DynamoCore/Core/Threading/CompileCustomNodeAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/CompileCustomNodeAsyncTask.cs
@@ -1,7 +1,17 @@
-﻿namespace Dynamo.Core.Threading
-{
-#if ENABLE_DYNAMO_SCHEDULER
+﻿#if ENABLE_DYNAMO_SCHEDULER
 
+using System;
+using System.Collections.Generic;
+
+using Dynamo.DSEngine;
+using Dynamo.Models;
+
+using ProtoCore.AST.AssociativeAST;
+
+using ProtoScript.Runners;
+
+namespace Dynamo.Core.Threading
+{
     class CompileCustomNodeParams
     {
         internal EngineController EngineController { get; set; }
@@ -70,6 +80,6 @@
 
         #endregion
     }
+}
 
 #endif
-}

--- a/src/DynamoCore/Core/Threading/SetTraceDataAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/SetTraceDataAsyncTask.cs
@@ -1,7 +1,14 @@
-﻿namespace Dynamo.Core.Threading
-{
-#if ENABLE_DYNAMO_SCHEDULER
+﻿#if ENABLE_DYNAMO_SCHEDULER
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Dynamo.DSEngine;
+using Dynamo.Models;
+
+namespace Dynamo.Core.Threading
+{
     class SetTraceDataAsyncTask : AsyncTask
     {
         private EngineController engineController;
@@ -57,6 +64,6 @@
 
         #endregion
     }
+}
 
 #endif
-}

--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -1,10 +1,18 @@
-﻿using BuildWarning = ProtoCore.BuildData.WarningEntry;
+﻿#if ENABLE_DYNAMO_SCHEDULER
+
+using System;
+using System.Collections.Generic;
+
+using Dynamo.DSEngine;
+using Dynamo.Models;
+
+using ProtoScript.Runners;
+
+using BuildWarning = ProtoCore.BuildData.WarningEntry;
 using RuntimeWarning = ProtoCore.RuntimeData.WarningEntry;
 
 namespace Dynamo.Core.Threading
 {
-#if ENABLE_DYNAMO_SCHEDULER
-
     class UpdateGraphAsyncTask : AsyncTask
     {
         private GraphSyncData graphSyncData;
@@ -92,6 +100,6 @@ namespace Dynamo.Core.Threading
 
         #endregion
     }
+}
 
 #endif
-}

--- a/src/DynamoCore/DSEngine/EngineController.cs
+++ b/src/DynamoCore/DSEngine/EngineController.cs
@@ -1,5 +1,6 @@
 ﻿using Autodesk.DesignScript.Interfaces;
 
+using Dynamo.Core.Threading;
 using Dynamo.Models;
 using Dynamo.Nodes;
 using ProtoCore.AST.AssociativeAST;


### PR DESCRIPTION
Some namespaces were removed on the main branch because `ENABLE_DYNAMO_SCHEDULER` preprocessor is not defined in various `CSPROJ` files (because they are deemed to be not used). When the preprocessor is defined, the build fails because the namespaces are required by the newly enabled codes. This pull request fixes that by moving `ENABLE_DYNAMO_SCHEDULER` to encompass the namespaces so that they won't show up as `ReSharper` warnings when the preprocessor is not defined. This will not affect any existing build on any existing branch.

Hi @ke-yu, please have a look. Thanks!
