### PR TITLE
Fixed a crash defect in ColorRange

### DIFF
--- a/src/Libraries/CoreNodesUI/ColorRange.cs
+++ b/src/Libraries/CoreNodesUI/ColorRange.cs
@@ -94,22 +94,38 @@ namespace DSCoreNodesUI
                     object start = null;
                     object end = null;
 
-                    if (startMirror.GetData().IsCollection)
+                    if (startMirror == null)
                     {
-                        start = startMirror.GetData().GetElements().Select(x => x.Data).FirstOrDefault();
+                        start = Color.ByARGB(255, 192, 192, 192);
                     }
                     else
                     {
-                        start = startMirror.GetData().Data;
+                        if (startMirror.GetData().IsCollection)
+                        {
+                            start = startMirror.GetData().GetElements().
+                                Select(x => x.Data).FirstOrDefault();
+                        }
+                        else
+                        {
+                            start = startMirror.GetData().Data;
+                        }
                     }
 
-                    if (endMirror.GetData().IsCollection)
+                    if (endMirror == null)
                     {
-                        end = endMirror.GetData().GetElements().Select(x => x.Data).FirstOrDefault();
+                        end = Color.ByARGB(255, 64, 64, 64);
                     }
                     else
                     {
-                        end = endMirror.GetData().Data;
+                        if (endMirror.GetData().IsCollection)
+                        {
+                            end = endMirror.GetData().GetElements().
+                                Select(x => x.Data).FirstOrDefault();
+                        }
+                        else
+                        {
+                            end = endMirror.GetData().Data;
+                        }
                     }
 
                     Color startColor = start as Color;


### PR DESCRIPTION
This pull request fixes a crash issue in `Color Range` node that takes down Dynamo UI. The crashing issue is discovered during the development of `Dynamo Scheduler`, which happens to cause some inputs to `Color Range` to be `null`. The original source which resulted in `Color Range` crash has now been fixed in the scheduler, so it is no longer possible to reproduce this crash, however, failure to get an input `RuntimeMirror` should never crash Dynamo. Which is what this pull request fixes.

Hi @aparajit-pratap, if you could spare an eyeball for this, that'll be nice.
