### PR TITLE
Fix one failed test case: AddToList_EmptyList

### DIFF
--- a/test/DynamoCoreTests/Nodes/ListTests.cs
+++ b/test/DynamoCoreTests/Nodes/ListTests.cs
@@ -1456,7 +1456,7 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(GetTestDirectory(), @"core\list\AddToList_EmptyList.dyn");
             RunModel(openPath);
 
-            AssertPreviewValue("1976caa7-d45e-4a44-9faf-345d98337bbb", new[] { new[] { 0 } });
+            AssertPreviewValue("1976caa7-d45e-4a44-9faf-345d98337bbb", new[] { new object[] { string.Empty, 0 } });
         }
 
         [Test]


### PR DESCRIPTION
@aparajit-pratap @Steell 

The test case fails because the test case is not written correctly. If we create a list containing an empty string and 0, and later insert this list to an empty list. The list should look like {{'', 0}}. This submission fixes the failed test case by fixing the comparing value.
