### PR TITLE
Fixing two failing test cases

### DIFF
--- a/test/Libraries/Revit/DynamoRevitTests/ElementBindingTests.cs
+++ b/test/Libraries/Revit/DynamoRevitTests/ElementBindingTests.cs
@@ -289,12 +289,14 @@ namespace Dynamo.Tests
             var model = ViewModel.Model;
             var selNodes = model.AllNodes.Where(x => x is ElementSelection<Autodesk.Revit.DB.Element>);
             var selNode = selNodes.First() as ElementSelection<Autodesk.Revit.DB.Element>;
-            selNode.UpdateSelection(selNode.Selection.Concat(new[] { rp1 }));
+            IEnumerable<Element> selection1 = new[] { rp1 };
+            selNode.UpdateSelection(selection1);
             Assert.DoesNotThrow(() =>ViewModel.Model.RunExpression());
             var id1 = selNode.SelectionResults.First();
 
             //Select the second reference point in Dynamo
-            selNode.UpdateSelection(selNode.Selection.Concat(new[] { rp2 }));
+            IEnumerable<Element> selection2 = new[] { rp2 };
+            selNode.UpdateSelection(selection2);
             Assert.DoesNotThrow(() =>ViewModel.Model.RunExpression());
             var id2 = selNode.SelectionResults.First();
 

--- a/test/System/revit/Family/AC_locationInDividedSurface.dyn
+++ b/test/System/revit/Family/AC_locationInDividedSurface.dyn
@@ -1,31 +1,7 @@
-<Workspace Version="0.7.1.28556" X="-111.293740573152" Y="-63.9431803490627" zoom="1.1" Description="" Category="" Name="Home">
+<Workspace Version="0.7.2.26100" X="-152.919181977421" Y="57.6326769697795" zoom="0.744379385168428" Description="" Category="" Name="Home">
   <Elements>
     <Dynamo.Nodes.DSDividedSurfaceFamiliesSelection type="Dynamo.Nodes.DSDividedSurfaceFamiliesSelection" guid="6b95bab4-a1eb-4577-870a-5ff0f4f7dcaf" nickname="Select Divided Surface Families" x="244" y="212" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9cf" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9db" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9e7" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9f3" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9ff" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9d0" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9dc" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9e8" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9f4" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000ba00" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9d1" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9dd" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9e9" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9f5" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000ba01" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9d2" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9de" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9ea" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9f6" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000ba02" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9d3" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9df" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9eb" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9f7" />
-      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000ba03" />
+      <instance id="a46b884a-c5bd-429c-902f-0fae7e569e76-0000b9ae" />
     </Dynamo.Nodes.DSDividedSurfaceFamiliesSelection>
     <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="76076507-d16e-4480-802c-14ba87d88f81" nickname="FamilyInstance.Location" x="575.614973262032" y="249.470588235294" isVisible="true" isUpstreamVisible="true" lacing="Longest" assembly="RevitNodes.dll" function="Revit.Elements.FamilyInstance.Location" />
     <Dynamo.Nodes.Watch type="Dynamo.Nodes.Watch" guid="26ade69b-3f75-4e72-b831-7e6c34f1022d" nickname="Watch" x="820.053475935829" y="133.106951871658" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />


### PR DESCRIPTION
@ikeough @sharadkjaiswal 

This pull request fixes two failing test cases:
1). CanLocateAdaptiveComponentInSurface: In the serialized node, now the ID of the divided surface is stored other than all the divided surface family instances. This makes the old dyn file not usable. According to the node description: "select a divided surface and get its family instances". The current behavior should be correct. So I am modifying the dyn file to reflect this change.

2). CreateInRevitSelectInDynamoSelectDifferentElement: When updating the selection, ideally we do not need to operate on the node's Selection property. We can just create a new IEnumerable<Element> object which will contain the new selected elements. This will make the test case not depend on whether the node's Selection is cleared or not.

Required Merges:
- [x] Revit2015
