### PR TITLE
Fixed failing Tests due to missing Custom Node.

### DIFF
--- a/test/Libraries/Revit/DynamoRevitTests/MigrationTest.cs
+++ b/test/Libraries/Revit/DynamoRevitTests/MigrationTest.cs
@@ -83,13 +83,6 @@ namespace Dynamo.Tests
             TestMigration(@".\Migration\TestMigration_Geometry_Curve.dyn");
         }
 
-        [Test, Category("Failure")]
-        [TestModel(@".\empty.rfa")]
-        public void TestMigration_Geometry_Experimental()
-        {
-            TestMigration(@".\Migration\TestMigration_Geometry_Experimental.dyn");
-        }
-
         [Test]
         [TestModel(@".\empty.rfa")]
         public void TestMigration_Geometry_Intersect()

--- a/test/System/revit/Migration/BoundingBoxXYZ.dyf
+++ b/test/System/revit/Migration/BoundingBoxXYZ.dyf
@@ -1,0 +1,34 @@
+<Workspace Version="0.7.0.22524" X="80.4199818532848" Y="156.75505302711" zoom="0.658674852158217" Description="This node represents an upgrade of the &lt;0.6.3 BoundingBoxXYZ node to." Category="Migration" Name="BoundingBoxXYZ" ID="1e10c22b-18f6-452c-8220-4b1407c80b7b">
+  <Elements>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="d5777a55-1ff8-4f14-acf3-e2b60ade8123" nickname="Geometry.BoundingBox" x="436.559858207784" y="7.50528165203735" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.BoundingBox" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="2b8ce889-3b7f-46ce-84ee-75e2ae00a428" nickname="Cuboid.ByLengths" x="250" y="0" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Cuboid.ByLengths@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double">
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+      <PortInfo index="3" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="83bbdda5-a2a7-4b8a-8759-79291cac35f1" nickname="Input" x="0" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="coordinate system" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Output type="Dynamo.Nodes.Output" guid="547de5d3-3690-4ef5-8cb5-9346ddc382be" nickname="Output" x="671.559858207784" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="bounding box" />
+    </Dynamo.Nodes.Output>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="91b9fb0c-7df6-426c-8ebd-55ec7227160a" nickname="Input" x="1.436784615889" y="82.0818811981219" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="width" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="43e7d543-cd6d-468a-ba0c-b0b5b10262d4" nickname="Input" x="2.81587917022921" y="152.685179191323" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="length" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="6fcde3e0-9d8f-4269-a585-2a849b622217" nickname="Input" x="6.00531469875409" y="222.383306697432" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="height" />
+    </Dynamo.Nodes.Symbol>
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="d5777a55-1ff8-4f14-acf3-e2b60ade8123" start_index="0" end="547de5d3-3690-4ef5-8cb5-9346ddc382be" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="2b8ce889-3b7f-46ce-84ee-75e2ae00a428" start_index="0" end="d5777a55-1ff8-4f14-acf3-e2b60ade8123" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="83bbdda5-a2a7-4b8a-8759-79291cac35f1" start_index="0" end="2b8ce889-3b7f-46ce-84ee-75e2ae00a428" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="91b9fb0c-7df6-426c-8ebd-55ec7227160a" start_index="0" end="2b8ce889-3b7f-46ce-84ee-75e2ae00a428" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="43e7d543-cd6d-468a-ba0c-b0b5b10262d4" start_index="0" end="2b8ce889-3b7f-46ce-84ee-75e2ae00a428" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="6fcde3e0-9d8f-4269-a585-2a849b622217" start_index="0" end="2b8ce889-3b7f-46ce-84ee-75e2ae00a428" end_index="3" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>

--- a/test/System/revit/Migration/XyzGrid.dyf
+++ b/test/System/revit/Migration/XyzGrid.dyf
@@ -1,0 +1,56 @@
+<Workspace Version="0.7.0.27348" X="0" Y="0" zoom="1" Description="This node represents an upgrade of the 0.6.3 XyzGrid node to 0.7.x" Category="Migration" Name="XyzGrid" ID="9215492a-4cb9-4ec1-a111-c18d7f6fd5b3">
+  <Elements>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="5970a802-e70f-4173-a391-ac517cd0359a" nickname="Input" x="100" y="40" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="x-count" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="cf3ef487-c66e-44c2-bd4f-485e6ce8385d" nickname="Input" x="100" y="120" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="y-count" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="e926d930-0b86-48bd-b03e-47a1123ad2c7" nickname="Input" x="100" y="200" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="z-count" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="fd9ca17f-597e-46d8-9988-a0d8609ec22d" nickname="Input" x="100" y="320" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="x0" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="dcaed6a6-242f-446b-aa18-f90a2cd3a60e" nickname="Input" x="100" y="400" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="y0" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="635f299c-85d1-41dc-ae84-5caa407d09e5" nickname="Input" x="100" y="480" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="z0" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="198451f8-4b3b-454c-83f3-a2ee2089bc4f" nickname="Input" x="100" y="600" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="x-space" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="f5314681-0630-41f8-9bb9-af45bb84aa6c" nickname="Input" x="100" y="680" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="y-space" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="83d1dfb0-b8d8-4846-a1c6-7e0fca0c71a8" nickname="Input" x="100" y="760" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="z-space" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="b4a312b7-4361-42c8-8df4-298678ee0981" nickname="Code Block" x="400" y="180" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="xOrigin..#xCount..xSpacing;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="d2cfe6d7-5294-4518-8bb3-9141f3610a27" nickname="Code Block" x="400" y="360" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="yOrigin..#yCount..ySpacing;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="d910566e-5df3-47f3-bf6c-de86c8c2ba3a" nickname="Code Block" x="400" y="540" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="zOrigin..#zCount..zSpacing;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="0f70103d-ac32-45d4-b095-477484806d27" nickname="Code Block" x="775" y="360" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="Point.ByCoordinates(x&lt;3&gt;,y&lt;2&gt;,z&lt;1&gt;);" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="9eadfb4c-0db7-40d7-9772-e432d942bdb8" nickname="Flatten" x="1150" y="360" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="Flatten@var[]..[]" />
+    <Dynamo.Nodes.Output type="Dynamo.Nodes.Output" guid="5005cbe8-5825-4484-ab87-337f3537dbe5" nickname="Output" x="1325" y="361" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="Point[]" />
+    </Dynamo.Nodes.Output>
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="5970a802-e70f-4173-a391-ac517cd0359a" start_index="0" end="b4a312b7-4361-42c8-8df4-298678ee0981" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="cf3ef487-c66e-44c2-bd4f-485e6ce8385d" start_index="0" end="d2cfe6d7-5294-4518-8bb3-9141f3610a27" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="e926d930-0b86-48bd-b03e-47a1123ad2c7" start_index="0" end="d910566e-5df3-47f3-bf6c-de86c8c2ba3a" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="fd9ca17f-597e-46d8-9988-a0d8609ec22d" start_index="0" end="b4a312b7-4361-42c8-8df4-298678ee0981" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="dcaed6a6-242f-446b-aa18-f90a2cd3a60e" start_index="0" end="d2cfe6d7-5294-4518-8bb3-9141f3610a27" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="635f299c-85d1-41dc-ae84-5caa407d09e5" start_index="0" end="d910566e-5df3-47f3-bf6c-de86c8c2ba3a" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="198451f8-4b3b-454c-83f3-a2ee2089bc4f" start_index="0" end="b4a312b7-4361-42c8-8df4-298678ee0981" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="f5314681-0630-41f8-9bb9-af45bb84aa6c" start_index="0" end="d2cfe6d7-5294-4518-8bb3-9141f3610a27" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="83d1dfb0-b8d8-4846-a1c6-7e0fca0c71a8" start_index="0" end="d910566e-5df3-47f3-bf6c-de86c8c2ba3a" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="b4a312b7-4361-42c8-8df4-298678ee0981" start_index="0" end="0f70103d-ac32-45d4-b095-477484806d27" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d2cfe6d7-5294-4518-8bb3-9141f3610a27" start_index="0" end="0f70103d-ac32-45d4-b095-477484806d27" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d910566e-5df3-47f3-bf6c-de86c8c2ba3a" start_index="0" end="0f70103d-ac32-45d4-b095-477484806d27" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="9eadfb4c-0db7-40d7-9772-e432d942bdb8" start_index="0" end="5005cbe8-5825-4484-ab87-337f3537dbe5" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="0f70103d-ac32-45d4-b095-477484806d27" start_index="0" end="9eadfb4c-0db7-40d7-9772-e432d942bdb8" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>

--- a/test/System/revit/Samples/XyzGrid.dyf
+++ b/test/System/revit/Samples/XyzGrid.dyf
@@ -1,0 +1,56 @@
+<Workspace Version="0.7.0.27348" X="0" Y="0" zoom="1" Description="This node represents an upgrade of the 0.6.3 XyzGrid node to 0.7.x" Category="Migration" Name="XyzGrid" ID="9215492a-4cb9-4ec1-a111-c18d7f6fd5b3">
+  <Elements>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="5970a802-e70f-4173-a391-ac517cd0359a" nickname="Input" x="100" y="40" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="x-count" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="cf3ef487-c66e-44c2-bd4f-485e6ce8385d" nickname="Input" x="100" y="120" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="y-count" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="e926d930-0b86-48bd-b03e-47a1123ad2c7" nickname="Input" x="100" y="200" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="z-count" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="fd9ca17f-597e-46d8-9988-a0d8609ec22d" nickname="Input" x="100" y="320" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="x0" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="dcaed6a6-242f-446b-aa18-f90a2cd3a60e" nickname="Input" x="100" y="400" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="y0" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="635f299c-85d1-41dc-ae84-5caa407d09e5" nickname="Input" x="100" y="480" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="z0" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="198451f8-4b3b-454c-83f3-a2ee2089bc4f" nickname="Input" x="100" y="600" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="x-space" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="f5314681-0630-41f8-9bb9-af45bb84aa6c" nickname="Input" x="100" y="680" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="y-space" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="83d1dfb0-b8d8-4846-a1c6-7e0fca0c71a8" nickname="Input" x="100" y="760" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="z-space" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="b4a312b7-4361-42c8-8df4-298678ee0981" nickname="Code Block" x="400" y="180" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="xOrigin..#xCount..xSpacing;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="d2cfe6d7-5294-4518-8bb3-9141f3610a27" nickname="Code Block" x="400" y="360" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="yOrigin..#yCount..ySpacing;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="d910566e-5df3-47f3-bf6c-de86c8c2ba3a" nickname="Code Block" x="400" y="540" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="zOrigin..#zCount..zSpacing;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="0f70103d-ac32-45d4-b095-477484806d27" nickname="Code Block" x="775" y="360" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="Point.ByCoordinates(x&lt;3&gt;,y&lt;2&gt;,z&lt;1&gt;);" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="9eadfb4c-0db7-40d7-9772-e432d942bdb8" nickname="Flatten" x="1150" y="360" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="Flatten@var[]..[]" />
+    <Dynamo.Nodes.Output type="Dynamo.Nodes.Output" guid="5005cbe8-5825-4484-ab87-337f3537dbe5" nickname="Output" x="1325" y="361" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="Point[]" />
+    </Dynamo.Nodes.Output>
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="5970a802-e70f-4173-a391-ac517cd0359a" start_index="0" end="b4a312b7-4361-42c8-8df4-298678ee0981" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="cf3ef487-c66e-44c2-bd4f-485e6ce8385d" start_index="0" end="d2cfe6d7-5294-4518-8bb3-9141f3610a27" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="e926d930-0b86-48bd-b03e-47a1123ad2c7" start_index="0" end="d910566e-5df3-47f3-bf6c-de86c8c2ba3a" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="fd9ca17f-597e-46d8-9988-a0d8609ec22d" start_index="0" end="b4a312b7-4361-42c8-8df4-298678ee0981" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="dcaed6a6-242f-446b-aa18-f90a2cd3a60e" start_index="0" end="d2cfe6d7-5294-4518-8bb3-9141f3610a27" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="635f299c-85d1-41dc-ae84-5caa407d09e5" start_index="0" end="d910566e-5df3-47f3-bf6c-de86c8c2ba3a" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="198451f8-4b3b-454c-83f3-a2ee2089bc4f" start_index="0" end="b4a312b7-4361-42c8-8df4-298678ee0981" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="f5314681-0630-41f8-9bb9-af45bb84aa6c" start_index="0" end="d2cfe6d7-5294-4518-8bb3-9141f3610a27" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="83d1dfb0-b8d8-4846-a1c6-7e0fca0c71a8" start_index="0" end="d910566e-5df3-47f3-bf6c-de86c8c2ba3a" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="b4a312b7-4361-42c8-8df4-298678ee0981" start_index="0" end="0f70103d-ac32-45d4-b095-477484806d27" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d2cfe6d7-5294-4518-8bb3-9141f3610a27" start_index="0" end="0f70103d-ac32-45d4-b095-477484806d27" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d910566e-5df3-47f3-bf6c-de86c8c2ba3a" start_index="0" end="0f70103d-ac32-45d4-b095-477484806d27" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="9eadfb4c-0db7-40d7-9772-e432d942bdb8" start_index="0" end="5005cbe8-5825-4484-ab87-337f3537dbe5" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="0f70103d-ac32-45d4-b095-477484806d27" start_index="0" end="9eadfb4c-0db7-40d7-9772-e432d942bdb8" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
<h4>Summary</h4>

Below tests were failing due to missing custom node and Why those were missing custom node, is because we don't have installed version of Dynamo on EC and that is the reason it will not able to find Custom node in the following path .C:\ProgramData\Dynamo\0.7\definitions and it fails.

<h4>Solution</h4>

I have copied their required .dyf files to their test directory, so now when dyn file loads it is finding custom node correctly. Now below tests are started passing
- Attractor_1
- RefGridSlidersSample
- TestMigration_Analyze_Measure

Below test need more investigation as it is throwing exception while running expression.
- TestMIgration_Geometry_Point

Below test deleted because it was testing migration of Nodes form Experimental Geometry which we do not support.
-  TestMigration_Geometry_Experimental

<h4>Reviewer</h4>
- [x] @ikeough 
- [ ] @Randy-Ma 

<h4>Need Cherry Pick</h4>
- [ ] Master
