### PR TITLE
Fix test cases in ReferencePointTests

### DIFF
--- a/test/Libraries/Revit/RevitNodesTests/Elements/ReferencePointTests.cs
+++ b/test/Libraries/Revit/RevitNodesTests/Elements/ReferencePointTests.cs
@@ -18,7 +18,7 @@ using ReferencePoint = Revit.Elements.ReferencePoint;
 namespace RevitTestServices
 {
     [TestFixture]
-    internal class ReferencePointTests : RevitNodeTestBase
+    internal class ReferencePointTests : GeometricRevitNodeTest
     {
 
         internal XYZ InternalPosition(Revit.Elements.ReferencePoint point)


### PR DESCRIPTION
The test cases in ReferencePointTests are causing errors because LibG.ProtoInterface.dll can not be found. This submission fixes these test cases by inherit the test class from GeometricRevitNodeTest which will initialize the geometry test cases correctly.

@aparajit-pratap 
