### PR TITLE
Disabled "InstrumentationLogger" during test

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -385,7 +385,8 @@ namespace Dynamo.Models
 
         private void InitializeInstrumentationLogger()
         {
-            InstrumentationLogger.Start(this);
+            if (DynamoModel.IsTestMode == false)
+                InstrumentationLogger.Start(this);
         }
 
         private void InitializeCurrentWorkspace()


### PR DESCRIPTION
Hi @lukechurch, I'm disabling instrumentation during test. I was experimenting parallel test runner process and found the `CSharpAnalytics.AutoMeasurement.Start` throws an exception which says `CSharpAnalytics` data file is `being opened by another process`. The following minor tweak fixes the problem. Please have a look, thanks!
