### PR TITLE
Fix various failures in recorded test cases

### DIFF
--- a/src/DynamoCore/UI/Views/DynamoView.xaml.cs
+++ b/src/DynamoCore/UI/Views/DynamoView.xaml.cs
@@ -598,6 +598,14 @@ namespace Dynamo.Controls
 
         private void WindowClosing(object sender, CancelEventArgs e)
         {
+            // Test cases that make use of views (e.g. recorded tests) have 
+            // their own tear down logic as part of the test set-up (mainly 
+            // because DynamoModel should stay long enough for verification
+            // code to verify data much later than the window closing).
+            // 
+            if (DynamoModel.IsTestMode)
+                return;
+
             var sp = new DynamoViewModel.ShutdownParams(
                 shutdownHost: false,
                 allowCancellation: true,


### PR DESCRIPTION
This pull request reintroduces the check for `DynamoModel.IsTestMode` that exists in [the previous version](https://github.com/Benglin/Dynamo/blob/fbbdfc21dec3f98fc082c2417d32069ef138499f/src/DynamoCore/UI/Views/DynamoView.xaml.cs#L614) of `DynamoView.xaml.cs` before the shutdown sequence code went in. The check was accidentally removed by the shutdown sequencing work.

Hi @lukechurch, please have a look and I'll cross-merge it into `Revit 2015` branch once that's done. It should stabilize the test results.
