### PR TITLE
Fix to MAGN-4827 CBN holding the focus when it comes back with Redo operation

### DIFF
--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -29,6 +29,7 @@ namespace Dynamo.Nodes
         private List<string> tempVariables = new List<string>();
         private string previewVariable = null;
         private bool shouldFocus = true;
+        public bool ShouldFocus { get { return shouldFocus; } }
         private readonly DynamoLogger logger;
 
         private struct Formatting

--- a/src/DynamoCore/UI/Controls/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCore/UI/Controls/CodeBlockEditor.xaml.cs
@@ -31,7 +31,8 @@ namespace Dynamo.UI.Controls
     {
         private NodeViewModel nodeViewModel;
         private DynamoViewModel dynamoViewModel;
-
+        private CodeBlockNodeModel nodeModel = null;
+        
         public CodeBlockEditor()
         {
             InitializeComponent();
@@ -44,11 +45,17 @@ namespace Dynamo.UI.Controls
             this.nodeViewModel = nodeViewModel;
             this.dynamoViewModel = nodeViewModel.DynamoViewModel;
             this.DataContext = nodeViewModel.NodeModel;
+            this.nodeModel = nodeViewModel.NodeModel as CodeBlockNodeModel;
 
             // Register text editing events
             this.InnerTextEditor.TextChanged += InnerTextEditor_TextChanged;
             this.InnerTextEditor.TextArea.LostFocus += TextArea_LostFocus;
-            this.Loaded += (obj, args) => this.InnerTextEditor.TextArea.Focus();
+
+            // the code block should not be in focus upon undo/redo actions on node
+            if (this.nodeModel.ShouldFocus)
+            {
+                this.Loaded += (obj, args) => this.InnerTextEditor.TextArea.Focus();
+            }
 
             InitializeSyntaxHighlighter();
         }
@@ -89,6 +96,7 @@ namespace Dynamo.UI.Controls
             })
         );
         #endregion
+
 
         #region Generic Event Handlers
         /// <summary>
@@ -169,5 +177,5 @@ namespace Dynamo.UI.Controls
         #endregion
     }
 
-    
+
 }

--- a/src/Libraries/IronPython/IronPythonUI.csproj
+++ b/src/Libraries/IronPython/IronPythonUI.csproj
@@ -99,7 +99,9 @@
     <EmbeddedResource Include="Resources\field.png" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\ICSharpCode.PythonBinding.Resources.Python.xshd" />
+    <EmbeddedResource Include="Resources\ICSharpCode.PythonBinding.Resources.Python.xshd">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\method.png" />


### PR DESCRIPTION
The issue is that when a codeblock node is added and the action undone and redone OR if the codeblock is deleted and the action undone, the focus remains inside the code block and does not shift to the search window. This results in some weird behaviour such as the redo stack not being preserved in the first case. This is more apparent when there are more than one operations (Refer defect). This PR fixes the issue by preventing adding focus to the code block node when it is re-created in undo/redo situations. In these situations, the `ShouldFocus` property of the `CodeBlockNodeModel` is `false`.

Note: This fix should render few code block tests that test undo/redo scenarios (that have currently regressed) to pass

@Benglin PTAL
