### PR TITLE
Fixed migration for Project Point On Curve, which was broken because of name change in GetClosestPoint

### DIFF
--- a/src/Migrations/RevitNodes/Project.cs
+++ b/src/Migrations/RevitNodes/Project.cs
@@ -17,7 +17,7 @@ namespace Dynamo.Nodes
             XmlElement oldNode = data.MigratedNodes.ElementAt(0);
             var newNode = MigrationManager.CreateFunctionNodeFrom(oldNode);
             MigrationManager.SetFunctionSignature(newNode, "ProtoGeometry.dll",
-                "Geometry.GetClosestPoint", "Geometry.GetClosestPoint@Geometry");
+                "Geometry.ClosestPointTo", "Geometry.ClosestPointTo@Geometry");
             migrationData.AppendNode(newNode);
             string newNodeId = MigrationManager.GetGuidFromXmlElement(newNode);
 


### PR DESCRIPTION
<h4>Summary</h4>

Fixed migration for Project Point On Curve, which was broken because of name change in GetClosestPoint.

There were some changes made by Patrick for GetClosestPoint method. New new for this method is ClosestPointTo and as our migration for "Project Point on Curve" was referencing to GetClosestPoint, it was failing.

<h4>Solution</h4>

Updated migration to take ClosestPointTo and now it is migrating correctly. See below attached image.

<h4>Reviewer</h4>
- [x] @ikeough 
- [x] @aparajit-pratap 

<h4>Need Merge in</h4>
- [ ] Revit2015

![image](https://cloud.githubusercontent.com/assets/5109531/4470827/549fc8d6-492e-11e4-98a5-07eadd195b64.png)
