### PR TITLE
Don't return Exception.ToString() value in ToString method in ReferencePoint.ToString()

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/ReferencePoint.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/ReferencePoint.cs
@@ -423,9 +423,9 @@ namespace Revit.Elements
             {
                 return string.Format("Reference Point: Location=(X={0}, Y={1}, Z={2})", X, Y, Z);
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                return e.ToString();
+                return "Could not obtain ReferencePoint for preview!";
             }
         }
 
@@ -436,9 +436,9 @@ namespace Revit.Elements
                 return string.Format("Reference Point: Location=(X={0}, Y={1}, Z={2})", X.ToString(format),
                                     Y.ToString(format), Z.ToString(format));
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                return e.ToString();
+                return "Could not obtain ReferencePoint for preview!";
             }
         }
 


### PR DESCRIPTION
This Exception string is confusing for users.  Return something a bit more user friendly - let me know if you want something different.

@ikeough
