### PR TITLE
Element.Geometry returns object - one element or an IEnumerable

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/DividedPath.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/DividedPath.cs
@@ -5,10 +5,14 @@ using Autodesk.DesignScript.Geometry;
 using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
 
+using DSCore;
+
 using Revit.GeometryConversion;
 using Revit.GeometryReferences;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
+
+using String = System.String;
 
 namespace Revit.Elements
 {   
@@ -56,7 +60,7 @@ namespace Revit.Elements
             get
             {
                 DocumentManager.Regenerate();
-                return Geometry().Cast<Autodesk.DesignScript.Geometry.Point>();
+                return InternalGeometry().Cast<Autodesk.DesignScript.Geometry.Point>();
             }
         }
 

--- a/src/Libraries/Revit/RevitNodes/Elements/Topography.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Topography.cs
@@ -52,7 +52,7 @@ namespace Revit.Elements
         /// </summary>
         public Autodesk.DesignScript.Geometry.Mesh Mesh
         {
-            get { return Geometry().OfType<Autodesk.DesignScript.Geometry.Mesh>().First(); }
+            get { return InternalGeometry().OfType<Autodesk.DesignScript.Geometry.Mesh>().First(); }
         }
 
         #endregion

--- a/src/Libraries/Revit/RevitNodes/GeometryConversion/GeometryDebugging.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryConversion/GeometryDebugging.cs
@@ -17,7 +17,7 @@ namespace Revit.GeometryConversion
     {
         public static IEnumerable<Autodesk.Revit.DB.Solid> GetRevitSolids(Element ele)
         {
-            return ele.InternalGeometry().OfType<Autodesk.Revit.DB.Solid>().ToArray();
+            return ele.InternalRevitGeometry().OfType<Autodesk.Revit.DB.Solid>().ToArray();
         }
 
         public static IEnumerable<Surface> GetTrimmedSurfacesFromSolid(Autodesk.Revit.DB.Solid geom)

--- a/src/Libraries/Revit/RevitNodes/GeometryReferences/ElementCurveReference.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryReferences/ElementCurveReference.cs
@@ -86,7 +86,7 @@ namespace Revit.GeometryReferences
 
         private static ElementCurveReference TryGetCurveReference(Revit.Elements.Element curveObject, string nodeTypeString = "This node")
         {
-            var cs = curveObject.InternalGeometry().OfType<Autodesk.Revit.DB.Curve>();
+            var cs = curveObject.InternalRevitGeometry().OfType<Autodesk.Revit.DB.Curve>();
             if (cs.Any()) return new ElementCurveReference(cs.First());
 
             throw new ArgumentException(nodeTypeString + " requires a ElementCurveReference extracted from a Revit Element! " +

--- a/src/Libraries/Revit/RevitNodes/GeometryReferences/ElementFaceReference.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryReferences/ElementFaceReference.cs
@@ -68,10 +68,10 @@ namespace Revit.GeometryReferences
 
         private static ElementFaceReference TryGetFaceReference(Revit.Elements.Element curveObject, string nodeTypeString = "This node")
         {
-            var cs = curveObject.InternalGeometry().OfType<Autodesk.Revit.DB.Face>();
+            var cs = curveObject.InternalRevitGeometry().OfType<Autodesk.Revit.DB.Face>();
             if (cs.Any()) return new ElementFaceReference(cs.First());
 
-            var ss = curveObject.InternalGeometry().OfType<Autodesk.Revit.DB.Solid>();
+            var ss = curveObject.InternalRevitGeometry().OfType<Autodesk.Revit.DB.Solid>();
             if (ss.Any()) return new ElementFaceReference(ss.First().Faces.Cast<Autodesk.Revit.DB.Face>().First());
 
             throw new ArgumentException(nodeTypeString + " requires a ElementFaceReference extracted from a Revit Element! " +

--- a/test/Libraries/Revit/RevitNodesTests/Elements/ImportInstanceTests.cs
+++ b/test/Libraries/Revit/RevitNodesTests/Elements/ImportInstanceTests.cs
@@ -30,7 +30,7 @@ namespace RevitTestServices.Elements
             var import = Revit.Elements.ImportInstance.ByGeometry(cuboid);
 
             // extract geometry
-            var importGeometry = import.Geometry().First();
+            var importGeometry = import.InternalGeometry().First();
 
             Assert.IsAssignableFrom(typeof(Autodesk.DesignScript.Geometry.Solid), importGeometry);
 

--- a/test/Libraries/Revit/RevitNodesTests/GeometryConversion/RevitToProtoFaceTests.cs
+++ b/test/Libraries/Revit/RevitNodesTests/GeometryConversion/RevitToProtoFaceTests.cs
@@ -17,7 +17,7 @@ namespace RevitTestServices.GeometryConversion
             // extract revolved solid from doc
             var revolvedEllipse = ElementSelector.ByType<Autodesk.Revit.DB.Form>(true)
                 .Cast<Revit.Elements.Form>()
-                .SelectMany(x => x.InternalGeometry())
+                .SelectMany(x => x.InternalRevitGeometry())
                 .OfType<Autodesk.Revit.DB.Solid>()
                 .First();
 

--- a/test/Libraries/Revit/RevitNodesTests/GeometryConversion/RevitToProtoMeshTests.cs
+++ b/test/Libraries/Revit/RevitNodesTests/GeometryConversion/RevitToProtoMeshTests.cs
@@ -26,7 +26,7 @@ namespace RevitTestServices.GeometryConversion
             var allMeshesInDoc =
                 ElementSelector.ByType<Autodesk.Revit.DB.Architecture.TopographySurface>(true)
                     .Cast<Revit.Elements.Topography>()
-                    .SelectMany(x => x.InternalGeometry())
+                    .SelectMany(x => x.InternalRevitGeometry())
                     .OfType<Autodesk.Revit.DB.Mesh>()
                     .ToList();
 

--- a/test/Libraries/Revit/RevitNodesTests/GeometryConversion/RevitToProtoSolidTests.cs
+++ b/test/Libraries/Revit/RevitNodesTests/GeometryConversion/RevitToProtoSolidTests.cs
@@ -43,7 +43,7 @@ namespace RevitTestServices.GeometryConversion
         {
             var formSolids = ElementSelector.ByType<Autodesk.Revit.DB.Form>(true)
                 .Cast<Revit.Elements.Form>()
-                .SelectMany(x => x.InternalGeometry())
+                .SelectMany(x => x.InternalRevitGeometry())
                 .OfType<Autodesk.Revit.DB.Solid>();
 
             AssertAllSolidsAreConvertedProperly(formSolids);
@@ -55,7 +55,7 @@ namespace RevitTestServices.GeometryConversion
         {
             var formSolids = ElementSelector.ByType<Autodesk.Revit.DB.Form>(true)
                 .Cast<Revit.Elements.Form>()
-                .SelectMany(x => x.InternalGeometry())
+                .SelectMany(x => x.InternalRevitGeometry())
                 .OfType<Autodesk.Revit.DB.Solid>();
 
             AssertAllSolidsAreConvertedProperly(formSolids);
@@ -67,7 +67,7 @@ namespace RevitTestServices.GeometryConversion
         {
             var allSolidsInDoc = ElementSelector.ByType<Autodesk.Revit.DB.Wall>(true)
                 .Cast<Revit.Elements.Wall>()
-                .SelectMany(x => x.InternalGeometry())
+                .SelectMany(x => x.InternalRevitGeometry())
                 .OfType<Autodesk.Revit.DB.Solid>()
                 .ToList();
 


### PR DESCRIPTION
### Issue

The Element.Geometry previously always returned an array.  Certain Elements return more than one piece of geometry, so this was required.

However, this meant users would have to extract the first item when the Element returns a list.  This is considered confusing, so this fix changed `Element.Geometry` to return a single Geometry when the list is length 1.  

Here's an example: 

![selectmodelelement](https://cloud.githubusercontent.com/assets/916345/4481421/a1124d30-499f-11e4-9c32-3dc0070e1146.PNG)
### Caveats

This means that all old workflows which extracted the first item will fail.  This also means that workflows won't be able to predict the type of output.  This also might be confusing.  

I should say that I'm not totally comfortable with this change, but here it is for your consideration.
### Reviewers

@lukechurch @ikeough 
