### PR TITLE
MAGN-4845 Cannot reopen dyn with Family Types node saved with daily build

### DIFF
--- a/src/Libraries/CoreNodesUI/DropDown.cs
+++ b/src/Libraries/CoreNodesUI/DropDown.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net;
@@ -58,8 +59,7 @@ namespace DSCoreNodesUI
 
         protected override void SaveNode(XmlDocument xmlDoc, XmlElement nodeElement, SaveContext context)
         {
-            var item = Items[SelectedIndex];
-            nodeElement.SetAttribute("index", string.Format("{0}:{1}", SelectedIndex, XmlEscape(item.Name)));
+            nodeElement.SetAttribute("index", SaveSelectedIndex(SelectedIndex, Items));            
         }
 
         protected override void LoadNode(XmlNode nodeElement)
@@ -74,20 +74,48 @@ namespace DSCoreNodesUI
             if (attrib == null)
                 return;
 
-            var index = attrib.Value;
+            SelectedIndex = ParseSelectedIndex(attrib.Value, Items);
+        }
+
+        public static int ParseSelectedIndex(string index, IList<DynamoDropDownItem> items)
+        {
+            int selectedIndex = -1;
+
             var splits = index.Split(':');
             if (splits.Count() > 1)
             {
                 var name = XmlUnescape(index.Substring(index.IndexOf(':') + 1));
-                var item = Items.FirstOrDefault(i => i.Name == name);
-                SelectedIndex = item != null ? 
-                    Items.IndexOf(item) : 
-                    Convert.ToInt32(nodeElement.Attributes["index"].Value);
+                var item = items.FirstOrDefault(i => i.Name == name);
+                selectedIndex = item != null ?
+                    items.IndexOf(item) :
+                    -1;
             }
             else
             {
-                SelectedIndex = Convert.ToInt32(nodeElement.Attributes["index"].Value);  
+                var tempIndex = Convert.ToInt32(index);
+                selectedIndex = tempIndex > (items.Count - 1)? 
+                    -1:
+                    tempIndex ;
             }
+
+            return selectedIndex;
+        }
+
+        public static string SaveSelectedIndex(int index, IList<DynamoDropDownItem> items )
+        {
+            var result = "-1";
+
+            if (index == -1)
+            {
+                result = index.ToString();
+            }
+            else
+            {
+                var item = items[index];
+                result = string.Format("{0}:{1}", index, XmlEscape(item.Name));
+            }
+
+            return result;
         }
 
         private static string XmlEscape(string unescaped)

--- a/src/Libraries/CoreNodesUI/Enum.cs
+++ b/src/Libraries/CoreNodesUI/Enum.cs
@@ -141,27 +141,4 @@ namespace DSCoreNodesUI
             Items = Items.OrderBy(x => x.Name).ToObservableCollection();
         }
     }
-
-    public abstract class DropDownFromDictionary : DSDropDownBase
-    {
-        private Dictionary<string, object> dictionary;
-
-        protected DropDownFromDictionary(WorkspaceModel workspaceModel, string outputName, Dictionary<string,object> dictionary)
-            : base(workspaceModel, outputName)
-        {
-            this.dictionary = dictionary;
-        }
-
-        protected override void PopulateItems()
-        {
-            Items.Clear();
-
-            foreach (var kvp in dictionary)
-            {
-                Items.Add(new DynamoDropDownItem(kvp.Key, kvp.Value));
-            }
-
-            Items = Items.OrderBy(x => x.Name).ToObservableCollection();
-        }
-    }
 }

--- a/test/DynamoCoreUITests/DropDownTests.cs
+++ b/test/DynamoCoreUITests/DropDownTests.cs
@@ -1,14 +1,8 @@
 ﻿using System.Collections.Generic;
-using System.Xml;
 
 using DSCoreNodesUI;
-using Dynamo.Models;
+
 using Dynamo.Nodes;
-
-using DynamoCoreUITests;
-
-using Microsoft.Practices.Prism;
-
 using NUnit.Framework;
 
 namespace DynamoCoreUITests
@@ -17,45 +11,63 @@ namespace DynamoCoreUITests
     public class DropDownTests : DynamoTestUIBase
     {
         [Test]
+        public void Save_NothingSelected()
+        {
+            Assert.AreEqual(
+                "-1",
+                DSDropDownBase.SaveSelectedIndex(-1, TestList()));
+        }
+
+        [Test]
         public void Save_SelectedIndex()
         {
-            //var node = new TestDropDown(ViewModel.CurrentSpace, "test");
-
-            //node.SelectedIndex = 2;
-
-            //var xmlDoc = new XmlDocument();
-            //var dynEl = xmlDoc.CreateElement(node.GetType().ToString());
-            //xmlDoc.AppendChild(dynEl);
-            //node.Save(xmlDoc, dynEl, SaveContext.File);
-
+            Assert.AreEqual(
+                "2:banana:blueberry",
+                DSDropDownBase.SaveSelectedIndex(2, TestList()));
         }
 
         [Test]
-        public void Save_SelectedIndexAndName()
+        public void Load_NothingSelected()
         {
-            //var node = new TestDropDown(ViewModel.CurrentSpace, "test");
-
-            //node.SelectedIndex = 2;
-
-            //var xmlDoc = new XmlDocument();
-            //var dynEl = xmlDoc.CreateElement(node.GetType().ToString());
-            //        xmlDoc.AppendChild(dynEl);
-            //        node.Save(xmlDoc, dynEl, SaveContext.File);
-
+            Assert.AreEqual(-1, DSDropDownBase.ParseSelectedIndex("-1", TestList()));
         }
 
         [Test]
-        public void Load_SemiColons()
+        public void Load_Selection()
         {
-            
+            Assert.AreEqual(2, DSDropDownBase.ParseSelectedIndex("2:banana:blueberry", TestList()));
         }
 
         [Test]
-        public void Load_SpecialCharacters()
+        public void Load_SelectionIndexOnly()
         {
-            
+            Assert.AreEqual(2, DSDropDownBase.ParseSelectedIndex("2", TestList()));
         }
 
+        [Test]
+        public void Load_SelectionIndexOutOfRange()
+        {
+            Assert.AreEqual(-1, DSDropDownBase.ParseSelectedIndex("12", TestList()));
+        }
+
+        [Test]
+        public void Load_SelectionIndexNoNameMatch()
+        {
+            Assert.AreEqual(-1, DSDropDownBase.ParseSelectedIndex("2:foo", TestList()));
+        }
+
+        private static List<DynamoDropDownItem> TestList()
+        {
+            var items = new List<DynamoDropDownItem>
+            {
+                new DynamoDropDownItem("cat", "cat"),
+                new DynamoDropDownItem("dog", "dog"),
+                new DynamoDropDownItem("banana:blueberry", "stuff"),
+                new DynamoDropDownItem("!@#$%%%^&*()", "craziness")
+            };
+
+            return items;
+        }
 
     }
 }


### PR DESCRIPTION
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3832

Requires cherry-pick into:
- [x] Master

For Review:
- [x] @Steell 

This is in response to #2595. The change introduced yesterday to add name indexing to drop-down properties was not properly hardened. Specifically, for the Family Types node, where we list the items as foo:bar, the strategy of parsing using the : delimiter fell apart as the index would be saved as 1:foo:bar and when parsing we would just get back 1:foo. The new method uses substring to return everything after the first :. 

In addition, I've added tests to make sure that this doesn't break again. EVER. Edge cases are selection index of -1, out of bounds selection index, and missing name during lookup.
