### PR TITLE
Fixed issue MAGN3166 (List.Join Crashes)

### DIFF
--- a/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
@@ -42,6 +42,12 @@ namespace Dynamo.Nodes
             VarInputController.LoadNode(nodeElement);
         }
 
+        protected override void SerializeCore(XmlElement element, SaveContext context)
+        {
+            base.SerializeCore(element, context);
+            VarInputController.SerializeCore(element, context);
+        }
+
         protected override void DeserializeCore(XmlElement element, SaveContext context)
         {
             base.DeserializeCore(element, context);


### PR DESCRIPTION
Issue: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3166.
Dynamo will crash when we do:  Create a list.create node. Create List.Join node. Add in port for List.Join and connect to list.create outport. After that delete List.Join and Undo. Dynamo Crashes because there is no SerializeCore function in DsVarArgFunction.cs
@Benglin Please review it. Thanks
