### PR TITLE
Update messaging around error messaging as per EB's suggestion on previous PR

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -367,11 +367,25 @@ namespace ProtoCore
 
         #region Support Methods
 
+
+        /// <summary>
+        /// Report that whole function group couldn't be found
+        /// </summary>
+        /// <param name="core"></param>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        private StackValue ReportFunctionGroupNotFound(Core core)
+        {
+            core.RuntimeStatus.LogFunctionGroupNotFoundWarning(methodName);
+            return StackValue.Null;
+        }
+
+
         /// <summary>
         /// Internal support method for reporting a method that can't be located
         /// </summary>
         /// <returns></returns>
-        private StackValue ReportMethodNotFound(Core core, List<StackValue> arguments)
+        private StackValue ReportMethodNotFoundForArguments(Core core, List<StackValue> arguments)
         {
             core.RuntimeStatus.LogMethodResolutionWarning(methodName, classScope, arguments);
             return StackValue.Null;
@@ -1161,7 +1175,7 @@ namespace ProtoCore
                 if (core.Options.DumpFunctionResolverLogic)
                     core.DSExecutable.EventSink.PrintMessage(log.ToString());
 
-                return ReportMethodNotFound(core, arguments);
+                return ReportFunctionGroupNotFound(core);
             }
 
 
@@ -1217,7 +1231,7 @@ namespace ProtoCore
                 if (core.Options.DumpFunctionResolverLogic)
                     core.DSExecutable.EventSink.PrintMessage(log.ToString());
 
-                return ReportMethodNotFound(core, arguments);
+                return ReportMethodNotFoundForArguments(core, arguments);
             }
 
             StackValue ret = Execute(resolvesFeps, context, arguments, replicationInstructions, stackFrame, core, funcGroup);

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -67,9 +67,13 @@ namespace ProtoCore
             public const string kPropertyOfClassNotFound = "Class '{0}' does not have a property '{1}'.";
             public const string kPropertyInaccessible = "Property '{0}' is inaccessible.";
             public const string kMethodResolutionFailure = "Method resolution failure on: {0}() - 0CD069F4-6C8A-42B6-86B1-B5C17072751B.";
-            public const string kMethodResolutionFailureWithTypes = "Couldn't find a version of {0} that takes arguments of type {1}";
+            public const string kMethodResolutionFailureWithTypes = "One or more of the input types are not matching, please check that the right variable types are being passed to the inputs. Couldn't find a version of {0} that takes arguments of type {1}.";
             public const string kMethodResolutionFailureForOperator = "Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'.";
             public const string kConsoleWarningMessage = "> Runtime warning: {0}\n - \"{1}\" <line: {2}, col: {3}>";
+
+            public const string FUNCTION_GROUP_RESOLUTION_FAILURE =
+                "No function called {0} could be found. Please check the name of the function.";
+
         }
 
         public struct WarningEntry
@@ -205,6 +209,18 @@ namespace ProtoCore
         {
             LogWarning(ID, message, string.Empty, Constants.kInvalidIndex, Constants.kInvalidIndex);
         }
+
+        /// <summary>
+        /// Report that a function group couldn't be found
+        /// </summary>
+        /// <param name="methodName">The method that can't be found</param>
+        public void LogFunctionGroupNotFoundWarning(
+            string methodName)
+        {
+            String message = string.Format(WarningMessage.FUNCTION_GROUP_RESOLUTION_FAILURE, methodName);
+            LogWarning(WarningID.kMethodResolutionFailure, message);
+        }
+
 
         public void LogMethodResolutionWarning(string methodName,
                                                int classScope = Constants.kGlobalScope, 


### PR DESCRIPTION
And split the message caused by not being able to find any error function of the right name from where the arguments don't match
