### PR TITLE
Implemented two new async task classes

### DIFF
--- a/src/DynamoCore/Core/Threading/AggregateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/AggregateRenderPackageAsyncTask.cs
@@ -1,0 +1,142 @@
+﻿#if ENABLE_DYNAMO_SCHEDULER
+
+using Autodesk.DesignScript.Interfaces;
+
+using Dynamo.DSEngine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Dynamo.Models;
+
+namespace Dynamo.Core.Threading
+{
+    /// <summary>
+    /// This task is scheduled after one or more UpdateRenderPackageAsyncTask 
+    /// objects are scheduled for execution. During execution this task gathers 
+    /// render packages for a predefined set of NodeModel objects. This 
+    /// predefined set of NodeModel objects includes all the NodeModel in the 
+    /// given WorkspaceModel, if no specific NodeModel is specified during the 
+    /// creation of this task; otherwise, the set only includes all upstream 
+    /// NodeModel objects of the specified NodeModel.
+    /// </summary>
+    /// 
+    class AggregateRenderPackageAsyncTask : AsyncTask
+    {
+        #region Class Data Members and Properties
+
+        private readonly List<IRenderPackage> normalRenderPackages;
+        private readonly List<IRenderPackage> selectedRenderPackages;
+        private IEnumerable<NodeModel> duplicatedNodeReferences;
+
+        internal IEnumerable<IRenderPackage> NormalRenderPackages
+        {
+            get { return normalRenderPackages; }
+        }
+
+        internal IEnumerable<IRenderPackage> SelectedRenderPackages
+        {
+            get { return selectedRenderPackages; }
+        }
+
+        #endregion
+
+        #region Public Class Operational Methods
+
+        internal AggregateRenderPackageAsyncTask(DynamoScheduler scheduler)
+            : base(scheduler)
+        {
+            normalRenderPackages = new List<IRenderPackage>();
+            selectedRenderPackages = new List<IRenderPackage>();
+        }
+
+        /// <summary>
+        /// Call this method to determine if the task should be scheduled for 
+        /// execution.
+        /// </summary>
+        /// <param name="workspaceModel">Render packages for all the nodes in 
+        /// this workspaceModel will be extracted, if 'nodeModel' parameter is 
+        /// null.</param>
+        /// <param name="nodeModel">An optional NodeModel from which all upstream 
+        /// nodes are to be examined for render packages. If this parameter is 
+        /// null, render packages are extracted from all nodes in workspaceModel.
+        /// </param>
+        /// <returns>Returns true if the task should be scheduled for execution,
+        /// or false otherwise.</returns>
+        /// 
+        internal bool Initialize(WorkspaceModel workspaceModel, NodeModel nodeModel)
+        {
+            if (workspaceModel == null)
+                throw new ArgumentNullException("workspaceModel");
+
+            if (nodeModel == null) // No node is specified, gather all nodes.
+            {
+                // Duplicate a list of all nodes for consumption later.
+                duplicatedNodeReferences = workspaceModel.Nodes.ToList();
+            }
+            else
+            {
+                // Recursively gather all upstream nodes.
+                var gathered = new List<NodeModel>();
+                GatherAllUpstreamNodes(nodeModel, gathered);
+                duplicatedNodeReferences = gathered;
+            }
+
+            return duplicatedNodeReferences.Any();
+        }
+
+        #endregion
+
+        #region Protected Overridable Methods
+
+        protected override void ExecuteCore()
+        {
+            if (duplicatedNodeReferences == null)
+            {
+                const string message = "Initialize method was not called";
+                throw new InvalidOperationException(message);
+            }
+
+            foreach (var duplicatedNodeReference in duplicatedNodeReferences)
+            {
+                var rps = duplicatedNodeReference.RenderPackages;
+                foreach (var renderPackage in rps.OfType<RenderPackage>())
+                {
+                    if (!renderPackage.IsNotEmpty())
+                        continue;
+
+                    if (renderPackage.Selected)
+                        selectedRenderPackages.Add(renderPackage);
+                    else
+                        normalRenderPackages.Add(renderPackage);
+                }
+            }
+        }
+
+        protected override void HandleTaskCompletionCore()
+        {
+        }
+
+        #endregion
+
+        #region Private Class Helper Methods
+
+        private static void GatherAllUpstreamNodes(NodeModel nodeModel, List<NodeModel> gathered)
+        {
+            if ((nodeModel == null) || gathered.Contains(nodeModel))
+                return; // Look no further, node is already in the list.
+
+            gathered.Add(nodeModel); // Add to list first, avoiding re-entrant.
+
+            foreach (var upstreamNode in nodeModel.Inputs)
+            {
+                // Add all the upstream nodes found into the list.
+                GatherAllUpstreamNodes(upstreamNode.Value.Item2, gathered);
+            }
+        }
+
+        #endregion
+    }
+}
+
+#endif

--- a/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
@@ -1,0 +1,194 @@
+﻿#if ENABLE_DYNAMO_SCHEDULER
+
+using System;
+using System.Collections;
+using System.Linq;
+
+using GraphLayout;
+
+using ProtoCore.Mirror;
+using System.Collections.Generic;
+
+using Dynamo.DSEngine;
+using Dynamo.Models;
+using Autodesk.DesignScript.Interfaces;
+
+namespace Dynamo.Core.Threading
+{
+    class UpdateRenderPackageParams
+    {
+        internal int MaxTesselationDivisions { get; set; }
+        internal string PreviewIdentifierName { get; set; }
+        internal NodeModel Node { get; set; }
+        internal EngineController EngineController { get; set; }
+        internal IEnumerable<string> DrawableIds { get; set; }
+    }
+
+    /// <summary>
+    /// An asynchronous task to regenerate render packages for a given node. 
+    /// During execution the task retrieves the corresponding IGraphicItem from 
+    /// EngineController through a set of drawable identifiers supplied by the 
+    /// node. These IGraphicItem objects then fill the IRenderPackage objects 
+    /// with tessellated geometric data. Each of the resulting IRenderPackage 
+    /// objects is then tagged with a label.
+    /// </summary>
+    /// 
+    class UpdateRenderPackageAsyncTask : AsyncTask
+    {
+        #region Class Data Members and Properties
+
+        private int maxTesselationDivisions;
+        private bool displayLabels;
+        private bool isNodeSelected;
+        private string previewIdentifierName;
+        private EngineController engineController;
+        private IEnumerable<string> drawableIds;
+        private readonly List<IRenderPackage> renderPackages;
+
+        internal IEnumerable<IRenderPackage> RenderPackages
+        {
+            get { return renderPackages; }
+        }
+
+        #endregion
+
+        #region Public Class Operational Methods
+
+        internal UpdateRenderPackageAsyncTask(DynamoScheduler scheduler)
+            : base(scheduler)
+        {
+            renderPackages = new List<IRenderPackage>();
+        }
+
+        internal bool Initialize(UpdateRenderPackageParams initParams)
+        {
+            if (initParams == null)
+                throw new ArgumentNullException("initParams");
+            if (initParams.Node == null)
+                throw new ArgumentNullException("initParams.Node");
+            if (initParams.EngineController == null)
+                throw new ArgumentNullException("initParams.EngineController");
+            if (initParams.DrawableIds == null)
+                throw new ArgumentNullException("initParams.DrawableIds");
+
+            var nodeModel = initParams.Node;
+            if (!nodeModel.IsUpdated && (!nodeModel.RequiresRecalc))
+                return false; // Not has not been updated at all.
+
+            drawableIds = initParams.DrawableIds;
+            if (!drawableIds.Any())
+                return false; // Nothing to be drawn.
+
+            displayLabels = nodeModel.DisplayLabels;
+            isNodeSelected = nodeModel.IsSelected;
+            maxTesselationDivisions = initParams.MaxTesselationDivisions;
+            engineController = initParams.EngineController;
+            previewIdentifierName = initParams.PreviewIdentifierName;
+            return true;
+        }
+
+        #endregion
+
+        #region Protected Overridable Methods
+
+        protected override void ExecuteCore()
+        {
+            var data = from varName in drawableIds
+                       select engineController.GetMirror(varName)
+                       into mirror
+                       where mirror != null
+                       select mirror.GetData();
+
+            var labelMap = new List<string>();
+            foreach (var mirrorData in data)
+            {
+                AddToLabelMap(mirrorData, labelMap, previewIdentifierName);
+            }
+
+            int count = 0;
+            foreach (var drawableId in drawableIds)
+            {
+                var graphItems = engineController.GetGraphicItems(drawableId);
+                if (graphItems == null)
+                    continue;
+
+                foreach (var graphicItem in graphItems)
+                {
+                    var package = new RenderPackage(isNodeSelected, displayLabels)
+                    {
+                        Tag = labelMap.Count > count ? labelMap[count] : "?",
+                    };
+
+                    try
+                    {
+                        graphicItem.Tessellate(package, tol: -1.0,
+                            maxGridLines: maxTesselationDivisions);
+                    }
+                    catch (Exception e)
+                    {
+                        System.Diagnostics.Debug.WriteLine(
+                            "PushGraphicItemIntoPackage: " + e);
+                    }
+
+                    package.ItemsCount++;
+                    renderPackages.Add(package);
+                    count++;
+                }
+            }
+        }
+
+        protected override void HandleTaskCompletionCore()
+        {
+        }
+
+        #endregion
+
+        #region Private Class Helper Methods
+
+        // Add labels for each of a mirror data object's inner data object to a label map.
+        private static void AddToLabelMap(MirrorData data, List<string> map, string tag)
+        {
+            if (data.IsCollection)
+            {
+                var index = 0;
+                var elements = data.GetElements();
+                foreach (var element in elements)
+                {
+                    var newTag = string.Format("{0}:{1}", tag, index++);
+                    AddToLabelMap(element, map, newTag);
+                }
+            }
+            else if (data.Data is IEnumerable)
+            {
+                AddToLabelMap(data.Data as IEnumerable, map, tag);
+            }
+            else
+            {
+                map.Add(tag);
+            }
+        }
+
+        // Add labels for each object in an enumerable to a label map
+        private static void AddToLabelMap(IEnumerable list, List<string> map, string tag)
+        {
+            int count = 0;
+            foreach (var obj in list)
+            {
+                var newTag = string.Format("{0}:{1}", tag, count++);
+
+                if (obj is IEnumerable)
+                {
+                    AddToLabelMap(obj as IEnumerable, map, newTag);
+                }
+                else
+                {
+                    map.Add(newTag);
+                }
+            }
+        }
+
+        #endregion
+    }
+}
+
+#endif

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -139,6 +139,8 @@ limitations under the License.
     <Compile Include="Core\DebugSettings.cs" />
     <Compile Include="Core\DynamoRunner.cs" />
     <Compile Include="Core\Context.cs" />
+    <Compile Include="Core\Threading\AggregateRenderPackageAsyncTask.cs" />
+    <Compile Include="Core\Threading\UpdateRenderPackageAsyncTask.cs" />
     <Compile Include="Models\DynamoModelCommands.cs" />
     <Compile Include="Core\Threading\AsyncTask.cs" />
     <Compile Include="Core\Threading\CompileCustomNodeAsyncTask.cs" />


### PR DESCRIPTION
## Background

This pull request isolates the two new `AsyncTask` derived classes (conditionally disabled by compilation flag `ENABLE_DYNAMO_SCHEDULER`) for earlier review (overall code that consumes these new tasks can be found on [a separate branch](https://github.com/Benglin/Dynamo/compare/Vizcheduler)):
- `UpdateRenderPackageAsyncTask`
- `AggregateRenderPackageAsyncTask`

In the existing visualization process, there are two phases:
1. Render package creation phase
2. Visual update phase

The first of these two phases is done by `RenderManager.RenderExec` with support from `NodeModel` (i.e. `UpdateRenderPackage` method). The second phase was mostly done in `AggregateUpstreamRenderPackages` method or `VisualizationManager`.

While these worked for most of the time, they had several issues:
1. `RenderManager.RenderExec` runs on a background thread that is not synchronized with the thread that interacts with the virtual machine. The thread safety is not guaranteed between these threads, especially when it comes to `MirrorData` and `IGraphicItem` access.
2. `RenderManager.RenderExec` method accesses `WorkspaceModel.Nodes` collection directly from the background thread, causing rare but possible sharing violation when the `Nodes` collection can be freely updated by the UI thread.
3. `AggregateUpstreamRenderPackages` method (or any method that deals with gathering `IRenderPackage` objects from `NodeModel` objects) always run on the UI thread, unnecessarily blocking the UI for the duration of gathering the `IRenderPackage` objects.
## Solution

The two phases of visualization process are now performed in the following `AsyncTask` derived classes:
1. `UpdateRenderPackageAsyncTask` which generates `IRenderPackage` objects for a given `NodeModel` in the context of `ISchedulerThread`. The scheduler ensures this task is executed while the virtual machine is not accessing the same underlying data.
2. `AggregateRenderPackageAsyncTask` which gathers `IRenderPackage` objects in the context of `ISchedulerThread`, which is independent of UI thread.

Hi @ikeough, you are most familiar with the original visualization code, please have a look. Thanks!
