### PR TITLE
Fix MAGN-3093 select node (Select Model Element) to show in "error state" when nothing is selected

### DIFF
--- a/src/DynamoCore/DSEngine/EngineController.cs
+++ b/src/DynamoCore/DSEngine/EngineController.cs
@@ -393,7 +393,7 @@ namespace Dynamo.DSEngine
 
             foreach (var node in warningNodes)
             {
-                node.ClearError();
+                node.ClearRuntimeError();
             }
         }
 

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -934,7 +934,10 @@ namespace Dynamo.Models
             ToolTipText = "";
         }
 
-        public void ClearError()
+        /// <summary>
+        /// Clears the errors/warnings that are generated when running the graph
+        /// </summary>
+        public virtual void ClearRuntimeError()
         {
             State = ElementState.Dead;
             ClearTooltipText();

--- a/src/DynamoCore/Nodes/BaseTypes.cs
+++ b/src/DynamoCore/Nodes/BaseTypes.cs
@@ -949,7 +949,7 @@ namespace Dynamo.Nodes
                 }
 
                 RegisterInputPorts();
-                ClearError();
+                ClearRuntimeError();
             }
             catch (Exception e)
             {
@@ -1577,7 +1577,7 @@ namespace Dynamo.Nodes
                     }
 
                     RegisterInputPorts();
-                    ClearError();
+                    ClearRuntimeError();
 
                     ArgumentLacing = InPortData.Any() ? LacingStrategy.Longest : LacingStrategy.Disabled;
                 }

--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -193,7 +193,7 @@ namespace Dynamo.Nodes
 
                         EnableReporting();
 
-                        ClearError();
+                        ClearRuntimeError();
                         if (!string.IsNullOrEmpty(errorMessage))
                         {
                             Error(errorMessage);
@@ -388,7 +388,7 @@ namespace Dynamo.Nodes
                 Workspace.Modified();
             }
 
-            ClearError();
+            ClearRuntimeError();
             if (!string.IsNullOrEmpty(errorMessage))
             {
                 Error(errorMessage);

--- a/src/Libraries/CoreNodesUI/Formula.cs
+++ b/src/Libraries/CoreNodesUI/Formula.cs
@@ -224,7 +224,7 @@ namespace DSCoreNodesUI
             }
 
             RegisterInputPorts();
-            ClearError();
+            ClearRuntimeError();
         }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)

--- a/src/Libraries/CoreNodesUI/Selection.cs
+++ b/src/Libraries/CoreNodesUI/Selection.cs
@@ -58,6 +58,8 @@ namespace Dynamo.Nodes
                 else
                     selectionResults = null;
 
+                SetSelectionNodeState();
+
                 RaisePropertyChanged("SelectionResults");
                 RaisePropertyChanged("Text");
             }
@@ -118,6 +120,8 @@ namespace Dynamo.Nodes
 
             SelectCommand = new DelegateCommand(Select, CanBeginSelect);
             Prefix = prefix;
+
+            State = ElementState.Warning;
         }
 
         #endregion
@@ -142,9 +146,23 @@ namespace Dynamo.Nodes
             SelectionResults = new List<TResult>();
         }
 
+        public override void ClearRuntimeError()
+        {
+            //do nothing as the errors for the selection nodes
+            //are not created when running the graph
+        }
+
         #endregion
 
         #region private methods
+
+        private void SetSelectionNodeState()
+        {
+            if (null == selectionResults || selectionResults.Count == 0)
+                State = ElementState.Warning;
+            else if (State == ElementState.Warning)
+                State = ElementState.Active;
+        }
 
         protected bool CanBeginSelect(object parameter)
         {

--- a/test/Libraries/Revit/DynamoRevitTests/SelectionTests.cs
+++ b/test/Libraries/Revit/DynamoRevitTests/SelectionTests.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 
 using RevitServices.Persistence;
 using RTF.Framework;
+using Dynamo.Models;
 
 using Family = Autodesk.Revit.DB.Family;
 using FamilySymbol = Autodesk.Revit.DB.FamilySymbol;
@@ -318,10 +319,12 @@ namespace Dynamo.Tests
         {
             var element = GetPreviewValue(selectNode.GUID.ToString());
             Assert.NotNull(element);
+            Assert.IsTrue(selectNode.State != ElementState.Warning);
             selectNode.ClearSelections();
             RunCurrentModel();
             element = GetPreviewValue(selectNode.GUID.ToString());
             Assert.Null(element);
+            Assert.IsTrue(selectNode.State == ElementState.Warning);
         }
 
         /// <summary>
@@ -335,11 +338,13 @@ namespace Dynamo.Tests
         {
             var elements = GetPreviewCollection(selectNode.GUID.ToString());
             Assert.NotNull(elements);
+            Assert.IsTrue(selectNode.State != ElementState.Warning);
             Assert.Greater(elements.Count(), 0);
             selectNode.ClearSelections();
             RunCurrentModel();
             elements = GetPreviewCollection(selectNode.GUID.ToString());
             Assert.Null(elements);
+            Assert.IsTrue(selectNode.State == ElementState.Warning);
         }
 
         private void OpenAndAssertNoDummyNodes(string samplePath)


### PR DESCRIPTION
<h6>Reviewers</h6>
- [x] @ikeough 
- [x] @Steell 
- [x] @elayabharath 

<h6>Merge to</h6>
- [ ] Revit2015

<h6>Summary</h6>

This submission will make the select nodes in the warning mode when nothing is selected. This is achieved by setting the state of the nodes to Warning. When setting the selection results, we will check the present results, if there are no elements, the state will be set to Warning.

But every time when the graph is evaluated, all the errors/warnings in the related nodes will be cleared. The errors that ClearError() means to clear are those errors that are created when running the graph. The errors for the selection nodes when nothing is selected is more like a static or interactive error that are not generated when running the graph. As such, ClearError is renamed to ClearRuntimeError. It is overridden in the selection node class so that nothing is done to prevent the errors be cleared when the graph is run.

Some original test cases are modified so that the new behavior can be tested.

Here is the result:

<ul><li>Nothing is selected</li></ul>

![image](https://cloud.githubusercontent.com/assets/5584246/4557347/990a75b2-4ed2-11e4-829a-ca7a7c42edde.png)

<ul><li>Some elements are selected</li></ul>

![image](https://cloud.githubusercontent.com/assets/5584246/4557539/b988f7da-4ed4-11e4-9251-ac681a4cab5d.png)
