### PR TITLE
Fix magn-4837: nested custom node return nulls or crash on load/run of file IN revit any version 

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Globalization;
 using System.Linq;
 using System.Xml;
@@ -57,7 +58,7 @@ namespace Dynamo.Utilities
         /// </summary>
         public event DefinitionLoadHandler DefinitionLoaded;
 
-        public Dictionary<Guid, CustomNodeDefinition> LoadedCustomNodes = new Dictionary<Guid, CustomNodeDefinition>();
+        public OrderedDictionary LoadedCustomNodes = new OrderedDictionary();
 
         /// <summary>
         /// NodeNames </summary>
@@ -106,7 +107,7 @@ namespace Dynamo.Utilities
         /// <returns>A list of the current loaded custom node defs</returns>
         public IEnumerable<CustomNodeDefinition> GetLoadedDefinitions()
         {
-            return LoadedCustomNodes.Values;
+            return LoadedCustomNodes.Values.Cast<CustomNodeDefinition>();
         }
 
         /// <summary>
@@ -115,7 +116,17 @@ namespace Dynamo.Utilities
         /// <returns>False if SearchPath is not a valid directory, otherwise true</returns>
         public void AddFunctionDefinition(Guid id, CustomNodeDefinition def)
         {
-            LoadedCustomNodes[id] = def;
+            if (def.IsBeingLoaded)
+                return;
+
+            if (LoadedCustomNodes.Contains(id))
+            {
+                LoadedCustomNodes[id] = def;
+            }
+            else
+            {
+                LoadedCustomNodes.Add(id, def);
+            }
         }
 
         /// <summary>
@@ -177,7 +188,7 @@ namespace Dynamo.Utilities
         {
             var nodeInfo = GetNodeInfo(guid);
 
-            if (LoadedCustomNodes.ContainsKey(guid))
+            if (LoadedCustomNodes.Contains(guid))
                 LoadedCustomNodes.Remove(guid);
 
             if (NodeInfos.ContainsKey(guid))
@@ -238,7 +249,7 @@ namespace Dynamo.Utilities
         /// <param name="def">The definition for the function</param>
         public void SetFunctionDefinition(Guid guid, CustomNodeDefinition def)
         {
-            if (LoadedCustomNodes.ContainsKey(guid))
+            if (LoadedCustomNodes.Contains(guid))
             {
                 LoadedCustomNodes.Remove(guid);
             }
@@ -310,7 +321,7 @@ namespace Dynamo.Utilities
 
             if (IsInitialized(id))
             {
-                return LoadedCustomNodes[id];
+                return LoadedCustomNodes[id] as CustomNodeDefinition;
             }
             else
             {
@@ -375,12 +386,17 @@ namespace Dynamo.Utilities
         {
             var compiledNodes = new HashSet<Guid>();
 
-            foreach (
-                var idDefPair in
-                    LoadedCustomNodes.Where(idDefPair => !compiledNodes.Contains(idDefPair.Key)))
+            var enumerator =  LoadedCustomNodes.GetEnumerator();
+            while (enumerator.MoveNext())
             {
-                idDefPair.Value.Compile(this.dynamoModel, engine);
-                compiledNodes.Add(idDefPair.Key);
+                var guid = (Guid)enumerator.Key;
+                var def = enumerator.Value as CustomNodeDefinition;
+
+                if (!compiledNodes.Contains(guid))
+                {
+                    def.Compile(this.dynamoModel, engine);
+                    compiledNodes.Add(guid);
+                }
             }
         }
 
@@ -410,7 +426,7 @@ namespace Dynamo.Utilities
         /// <param name="guid">Whether the definition is stored with the manager.</param>
         public bool IsInitialized(Guid guid)
         {
-            return LoadedCustomNodes.ContainsKey(guid);
+            return LoadedCustomNodes.Contains(guid);
         }
 
         /// <summary>
@@ -465,7 +481,7 @@ namespace Dynamo.Utilities
             }
             else
             {
-                result = LoadedCustomNodes[guid];
+                result = LoadedCustomNodes[guid] as CustomNodeDefinition;
             }
 
             return true;
@@ -580,7 +596,7 @@ namespace Dynamo.Utilities
         /// <returns>A valid function definition if the CustomNodeDefinition is already loaded, otherwise null. </returns>
         public CustomNodeDefinition GetDefinitionFromWorkspace(WorkspaceModel workspace)
         {
-            return LoadedCustomNodes.Values.FirstOrDefault((def) => def.WorkspaceModel == workspace);
+            return LoadedCustomNodes.Values.Cast<CustomNodeDefinition>().FirstOrDefault((def) => def.WorkspaceModel == workspace);
         }
 
         /// <summary>
@@ -710,9 +726,7 @@ namespace Dynamo.Utilities
                     IsBeingLoaded = true
                 };
 
-                // set the node as loaded
                 LoadedCustomNodes.Remove(def.FunctionId);
-                LoadedCustomNodes.Add(def.FunctionId, def);
 
                 XmlNodeList elNodes = xmlDoc.GetElementsByTagName("Elements");
                 XmlNodeList cNodes = xmlDoc.GetElementsByTagName("Connectors");
@@ -922,6 +936,8 @@ namespace Dynamo.Utilities
                 def.IsBeingLoaded = false;
 
                 def.Compile(this.dynamoModel, this.dynamoModel.EngineController);
+
+                LoadedCustomNodes.Add(def.FunctionId, def);
 
                 ws.WatchChanges = true;
 


### PR DESCRIPTION
This pull request tries to fix defect [MAGN-4837: nested custom node return nulls or crash on load/run of file IN revit any version](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4837)

For the nested custom node that attached in this defect, the VM will execute following code snippets one by one: 
- Outer custom node

```
def func_2b59b1a2bb5440c583fd528ec9abc36b: var[]..[](points4 : var[]..[])
{
var_5ccd62b860a44ea899bfdce64a4f0d7f = _SingleFunctionObject(func_a7c1ac96e3594097a9a162e56a4c7336, 1, {}, {null}, true);
...
}
```
- Inner custom node

```
def func_a7c1ac96e3594097a9a162e56a4c7336: var[]..[](x : var[]..[])
{
    ...
}
```
- Global nodes

```
temp_0_26078a96_2730_44d9_8f1e_8d54cc30b060_26078a96273044d98f1e8d54cc30b060 = (1..10);
...
```

When opening a .dyn or .dyf file, nested custom node will always be compiled _before_ custom node in the outer scope. For this case, when compiling function `func_2b59b1a2bb5440c583fd528ec9abc36b()` the VM knows that `func_a7c1ac96e3594097a9a162e56a4c7336` is a function as it has been compiled, so a function pointer will be created.

But on Revit, `DynamoModel.ResetEngine()` is called at some point which consequently re-compiles all loaded custom nodes, so `func_2b59b1a2bb5440c583fd528ec9abc36b()` may be compiled _before_  `func_a7c1ac96e3594097a9a162e56a4c7336()`, therefore a null value is emitted.

It is not trivial to fundamentally fix the problem because essentially it is related to module management. Ideally the VM should maintain a dependency graph of modules and also needs to take module version and other information into account. 

A workaround is to change the data structure that contains loaded custom node so that their loading order will be kept. Here, `CustomManager.LoadedCustomNodes` is changed to `OrderedDictionary`. The other change is a custom node won't be added to `CustomManager.LoadedCustomNodes` until it is compiled. 

To TD --

Please test the following cases:
1. Load nested custom nodes, run.
2. Debug -> Force re-execute. Like I said, this option will force re-compilation for all custom nodes and this defect is caused by compilation consequence. 
3. Open nested custom node, modify and Run or Force re-execute.
4. Open outer scope custom node, modify and Run or Force re-execute.
5. Test on Revit and on Standalone. 

@Steell, please review the change. 
