### PR TITLE
Make face selection tests more stringent.

### DIFF
--- a/test/Libraries/Revit/DynamoRevitTests/SelectionTests.cs
+++ b/test/Libraries/Revit/DynamoRevitTests/SelectionTests.cs
@@ -151,7 +151,8 @@ namespace Dynamo.Tests
 
             // The select faces node returns a list of lists
             var list = GetFlattenedPreviewValues(selectNode.GUID.ToString());
-            Assert.AreEqual(1, list.Count);
+            Assert.AreEqual(1, list.Count());
+            Assert.IsInstanceOf<Surface>(list[0]);
 
             // Clear the selection
             selectNode.ClearSelections();
@@ -268,6 +269,7 @@ namespace Dynamo.Tests
             // The select faces node returns a list of lists
             var list = GetFlattenedPreviewValues(selectNode.GUID.ToString());
             Assert.AreEqual(3, list.Count);
+            Assert.IsInstanceOf<Surface>(list[0]);
 
             // Clear the selection
             selectNode.ClearSelections();


### PR DESCRIPTION
Face selection tests were verifying that the returned selection lists were the right size, but NOT that they had the right kind of thing in them.

Requires merge:
- [x] Revit2015

PTAL:
@Steell 
