### PR TITLE
Fixed failures in DynamoCoreUITests

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -800,6 +800,7 @@ namespace Dynamo.Models
             CurrentWorkspace.Notes.Clear();
 
             CurrentWorkspace.ClearUndoRecorder();
+            currentWorkspace.ResetWorkspace();
 
             this.ResetEngine();
             CurrentWorkspace.PreloadedTraceData = null;

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Windows.Documents;
 using System.Windows.Threading;
 
 namespace Dynamo.Models
@@ -59,6 +60,28 @@ namespace Dynamo.Models
                 runExpressionTimer.Start(); // reset timer
 
             }
+        }
+
+        protected override void ResetWorkspaceCore()
+        {
+            // It is possible for a timer to be started (due to the workspace 
+            // being modified) immediately before the DynamoModel gets destroyed.
+            // This is especially true for cases where multiple DynamoModel are
+            // re-created in a single app domain (e.g. across unit test cases, 
+            // or hosted scenario). Here OnRunExpression is unregistered from the
+            // DispatcherTimer so that it will never be called anymore after the 
+            // owning WorkspaceModel is destroyed.
+            // 
+            if (runExpressionTimer != null)
+            {
+                if (runExpressionTimer.IsEnabled)
+                    runExpressionTimer.Stop();
+
+                runExpressionTimer.Tick -= OnRunExpression;
+                runExpressionTimer = null;
+            }
+
+            base.ResetWorkspaceCore();
         }
     }
 }

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -601,6 +601,20 @@ namespace Dynamo.Models
             return SaveAs(FileName);
         }
 
+        internal void ResetWorkspace()
+        {
+            ResetWorkspaceCore();
+        }
+
+        /// <summary>
+        /// Derived workspace classes can choose to override 
+        /// this method to perform clean-up specific to them.
+        /// </summary>
+        /// 
+        protected virtual void ResetWorkspaceCore()
+        {
+        }
+
         //TODO: Replace all RequestSync calls with RaisePropertyChanged-style system, that way observable collections can catch any changes
         public void DisableReporting()
         {


### PR DESCRIPTION
## Background

A recent change causes unit test `RecordedTestsDSEngine.Defect_MAGN_520_DS` to throw an exception, which naturally fails the test case. What happened immediately after that was, most other tests that followed failed due to leftover components from the test preceding them.

For example, the following took place NUnit moves from `Defect_MAGN_520` to `Defect_MAGN_520_DS`:
1. Recorded command in `Defect_MAGN_520` performs an action that marks workspace as modified.
2. Setting `WorkspaceModel.Modified = true` causing `runExpressionTimer` to start ticking.
3. `Defect_MAGN_520` test case ended, destroying its `DynamoModel` before timer ticks.
4. `Defect_MAGN_520_DS` starts, creating its new instance of `DynamoModel`.
5. `Defect_MAGN_520_DS` starts its first recordable command, which gives a chance to the previous `runExpressionTimer` to tick (main UI dispatcher has a chance to pump since the playback starts).
6. The leftover `runExpressionTimer` ticks causing its `WorkspaceModel.OnRunExpression` to be called.
7. The `runExpressionTimer` holds on to the old `WorkspaceModel`, which calls the old `DynamoModel.RunExpression`.
8. Since the old `DynamoModel` has been shut down, its `DynamoScheduler` became `null`, causing `ArgumentNullException` in `AsyncTask` constructor.
## Note to reviewers

Hi @lukechurch @ikeough since this fixes the build I'm going to merge it in right away. Please have a look at a later time. Thanks!
