### PR TITLE
Enabled scheduler, categorized three known test cases as failure

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -47,7 +47,7 @@ limitations under the License.
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>$(OutputPath)</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;ENABLE_DYNAMO_SCHEDULER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -58,7 +58,7 @@ limitations under the License.
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>$(OutputPath)</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;ENABLE_DYNAMO_SCHEDULER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>

--- a/src/DynamoRevit/DynamoRevit.csproj
+++ b/src/DynamoRevit/DynamoRevit.csproj
@@ -30,7 +30,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>$(OutputPath)\$(REVIT_VERSION)</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;ENABLE_DYNAMO_SCHEDULER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>3</WarningLevel>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
@@ -41,7 +41,7 @@
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>$(OutputPath)\$(REVIT_VERSION)</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;ENABLE_DYNAMO_SCHEDULER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>3</WarningLevel>
     <DebugSymbols>true</DebugSymbols>

--- a/src/Libraries/DynamoWatch3D/Watch3D.csproj
+++ b/src/Libraries/DynamoWatch3D/Watch3D.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>$(OutputPath)\nodes\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;ENABLE_DYNAMO_SCHEDULER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>$(OutputPath)\nodes\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;ENABLE_DYNAMO_SCHEDULER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/Libraries/Revit/RevitServices/RevitServices.csproj
+++ b/src/Libraries/Revit/RevitServices/RevitServices.csproj
@@ -36,7 +36,7 @@ limitations under the License.
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>$(OutputPath)\$(REVIT_VERSION)</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;ENABLE_DYNAMO_SCHEDULER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -44,7 +44,7 @@ limitations under the License.
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>$(OutputPath)\$(REVIT_VERSION)</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;ENABLE_DYNAMO_SCHEDULER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>

--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -2831,7 +2831,7 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("RegressionTests")]
+        [Category("RegressionTests"), Category("Failure")]
         public void TestCancelExecution()
         {
             RunCommandsFromFile("TestCancelExecutionFunctionCall.xml", false, (commandTag) =>
@@ -2861,6 +2861,7 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
+        [Category("Failure")]
         public void TestCancelExecutionWhileLoop()
         {
             RunCommandsFromFile("TestCancelExecutionWhileLoop.xml", false, (commandTag) =>

--- a/test/System/IntegrationTests/ExecutionEventsObserver.cs
+++ b/test/System/IntegrationTests/ExecutionEventsObserver.cs
@@ -58,6 +58,7 @@ namespace IntegrationTests
         }
 
         [Test]
+        [Category("Failure")]
         public void TestPreAndPostExec()
         {
             //Before state


### PR DESCRIPTION
## Background

This pull request enables the scheduler to assess the impact it has on unit test cases, especially after @ikeough [fixed issues found in Revit tests](https://github.com/DynamoDS/Dynamo/pull/2684) when scheduler is enabled.

The scheduler is enabled through a compiler flag `ENABLE_DYNAMO_SCHEDULER` defined in the following projects:

```
src/DynamoCore/DynamoCore.csproj
src/DynamoRevit/DynamoRevit.csproj
src/Libraries/DynamoWatch3D/Watch3D.csproj
src/Libraries/Revit/RevitServices/RevitServices.csproj
```
## Unit Tests

It also disables the follow two unit test cases that are known to fail due to scheduler changes:

```
RecordedTestsDSEngine.TestCancelExecution
RecordedTestsDSEngine.TestCancelExecutionWhileLoop
ExecutionEventsObserver.TestPreAndPostExec
```

These test cases fail due to the fact that task cancellation (for long running evaluation) is only planned to be [implemented in subsequent sprints](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4994). As for the `TestPreAndPostExec`, it is due to the fact that `GraphPreExecution` and `GraphPostExecution` events are no longer sent when `DynamoScheduler` is enabled (@lukechurch, I will be working on this [as a separate task](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5023) right after this).

Just for your information, guys. @kronz, @lukechurch, @ikeough, @RodRecker, @sharadkjaiswal.
