### PR TITLE
Disable 'Run' button and re-enable it when graph update is done

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -524,6 +524,7 @@ namespace Dynamo.Models
             if (task.Initialize(EngineController, HomeSpace))
             {
                 task.Completed += OnUpdateGraphCompleted;
+                RunEnabled = false; // Disable 'Run' button.
                 scheduler.ScheduleForExecution(task);
             }
         }
@@ -581,6 +582,7 @@ namespace Dynamo.Models
             }
 
             // Notify listeners (optional) of completion.
+            RunEnabled = true; // Re-enable 'Run' button.
             OnEvaluationCompleted(this, EventArgs.Empty);
         }
 


### PR DESCRIPTION
Hi @ke-yu, this pull request restores the previous behaviour (that was missed in the new scheduler work): when `Run` is clicked, it is then disabled. When the task gets over, it becomes enabled again. Please have a look. Thanks!
