### PR TITLE
Fix regressions in test cases

### DIFF
--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -83,6 +83,12 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>ProtoCore.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;GC_REFERENCE_COUNTING</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <DefineConstants>TRACE;GC_REFERENCE_COUNTING</DefineConstants>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Compile Include="AssociativeGraph.cs" />


### PR DESCRIPTION
@ke-yu 

Some conditional definitions are not there in the Reivt2015 branch. This makes the compiler bypass some functions and as such some regression happens. I am adding the definitions to make the fix.
