### PR TITLE
Fix Applyupdate dirty node accumulation

### DIFF
--- a/src/Engine/ProtoCore/AssociativeGraph.cs
+++ b/src/Engine/ProtoCore/AssociativeGraph.cs
@@ -16,6 +16,27 @@ namespace ProtoCore.AssociativeEngine
     public class Utils
     {
         /// <summary>
+        /// Gets the number of dirty VM graphnodes at the global scope
+        /// </summary>
+        /// <param name="exe"></param>
+        /// <returns></returns>
+        public static int GetDirtyNodeCountAtGlobalScope(Executable exe)
+        {
+            Validity.Assert(exe != null);
+            int dirtyNodes = 0;
+            var graph = exe.instrStreamList[0].dependencyGraph;
+            var graphNodes = graph.GetGraphNodesAtScope(Constants.kInvalidIndex, Constants.kGlobalScope);
+            foreach (AssociativeGraph.GraphNode graphNode in graphNodes)
+            {
+                if (graphNode.isDirty)
+                {
+                    ++dirtyNodes;
+                }
+            }
+            return dirtyNodes;
+        }
+
+        /// <summary>
         /// Find and return all graphnodes that can be reached by executingGraphNode
         /// </summary>
         /// <param name="executingGraphNode"></param>
@@ -464,17 +485,19 @@ namespace ProtoCore.AssociativeEngine
         }
 
         /// <summary>
-        /// Finds all graphnodes associated with each AST and marks them dirty
+        ///  Finds all graphnodes associated with each AST and marks them dirty. Returns the first dirty node
         /// </summary>
+        /// <param name="core"></param>
         /// <param name="nodeList"></param>
-        /// <summary>
         /// <returns></returns>
-        public static void MarkGraphNodesDirty(Core core, IEnumerable<AST.AssociativeAST.AssociativeNode> nodeList)
+        public static AssociativeGraph.GraphNode MarkGraphNodesDirty(Core core, IEnumerable<AST.AssociativeAST.AssociativeNode> nodeList)
         {
             if (nodeList == null)
-                return;
+            {
+                return null;
+            }
 
-            bool setEntryPoint = false;
+            AssociativeGraph.GraphNode firstDirtyNode = null;
             foreach (var node in nodeList)
             {
                 var bNode = node as AST.AssociativeAST.BinaryExpressionNode;
@@ -487,16 +510,16 @@ namespace ProtoCore.AssociativeEngine
                 {
                     if (gnode.isActive && gnode.OriginalAstID == bNode.OriginalAstID)
                     {
-                        if (!setEntryPoint)
+                        if (firstDirtyNode == null)
                         {
-                            setEntryPoint = true;
-                            core.SetNewEntryPoint(gnode.updateBlock.startpc);
+                            firstDirtyNode = gnode;
                         }
                         gnode.isDirty = true;
                         gnode.isActive = true;
                     }
                 }
             }
+            return firstDirtyNode;
         }
 
         public static void MarkGraphNodesDirtyFromFunctionRedef(Core core, List<AST.AssociativeAST.AssociativeNode> fnodeList)

--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -1123,8 +1123,6 @@ namespace ProtoCore
 
         public int newEntryPoint { get; private set; }
 
-        public int DeferredUpdates { get; set; }
-
         public void SetNewEntryPoint(int pc)
         {
             newEntryPoint = pc;
@@ -1282,7 +1280,6 @@ namespace ProtoCore
         public void ResetForDeltaExecution()
         {
             Options.ApplyUpdate = false;
-            DeferredUpdates = 0; 
 
             ExecMode = InterpreterMode.kNormal;
             ExecutionState = (int)ExecutionStateEventArgs.State.kInvalid;

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -7092,7 +7092,6 @@ namespace ProtoCore.DSASM
                     Properties.executingGraphNode.isDirty = false;
                     pc = Properties.executingGraphNode.updateBlock.startpc;
                 }
-                core.DeferredUpdates += reachableNodes;
             }
             GC();
             return;

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -108,6 +108,7 @@ namespace ProtoScript.Runners
     public class ChangeSetData
     {
         public ChangeSetData() { }
+        public bool ContainsDeltaAST = false;
         public List<AssociativeNode> DeletedBinaryExprASTNodes;
         public List<AssociativeNode> DeletedFunctionDefASTNodes;
         public List<AssociativeNode> RemovedBinaryNodesFromModification;
@@ -150,8 +151,20 @@ namespace ProtoScript.Runners
 
         private void ApplyChangeSetForceExecute(ChangeSetData changeSet)
         {
-            // Mark all graphnodes dirty which are associated with the force exec ASTs
-            ProtoCore.AssociativeEngine.Utils.MarkGraphNodesDirty(core, changeSet.ForceExecuteASTList);
+            // Check if there are nodes to force execute
+            if (changeSet.ForceExecuteASTList.Count > 0)
+            {
+                // Mark all graphnodes dirty which are associated with the force exec ASTs
+                ProtoCore.AssociativeGraph.GraphNode firstDirtyNode = ProtoCore.AssociativeEngine.Utils.MarkGraphNodesDirty(core, changeSet.ForceExecuteASTList);
+                Validity.Assert(firstDirtyNode != null);
+
+                // If the only ASTs to execute are force exec, then set the entrypoint here.
+                // Otherwise the entrypoint is set by the code generator when the new ASTs are compiled
+                if (!changeSet.ContainsDeltaAST)
+                {
+                    core.SetNewEntryPoint(firstDirtyNode.updateBlock.startpc);
+                }
+            }
         }
 
 
@@ -512,7 +525,7 @@ namespace ProtoScript.Runners
             finalDeltaAstList.AddRange(GetDeltaAstListDeleted(syncData.DeletedSubtrees));
             finalDeltaAstList.AddRange(GetDeltaAstListAdded(syncData.AddedSubtrees));
             finalDeltaAstList.AddRange(GetDeltaAstListModified(syncData.ModifiedSubtrees));
-
+            csData.ContainsDeltaAST = finalDeltaAstList.Count > 0;
             return finalDeltaAstList;
         }
 
@@ -1535,7 +1548,7 @@ namespace ProtoScript.Runners
 
         private void ApplyUpdate()
         {
-            if (runnerCore.DeferredUpdates > 0)
+            if (ProtoCore.AssociativeEngine.Utils.GetDirtyNodeCountAtGlobalScope(runnerCore.DSExecutable) > 0)
             {
                 ResetForDeltaExecution();
                 runnerCore.Options.ApplyUpdate = true;

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -5175,6 +5175,56 @@ a = p.UpdateCount;
             astLiveRunner.UpdateGraph(syncData);
             AssertValue("a", 2);
         }
+
+        [Test]
+        public void TestTransactionUpdate04()
+        {
+            List<string> codes = new List<string>() 
+            {
+                @"import(""FFITarget.dll""); TestUpdateCount.Reset();", 
+                "x = 1;",
+                "p = TestUpdateCount.Ctor(x,0);",
+                "a = p.UpdateCount;",
+                "x = 10;",
+            };
+
+            List<Subtree> added = new List<Subtree>();
+
+            // Create CBN1 for import
+            Guid guid1 = System.Guid.NewGuid();
+            Guid guid2 = System.Guid.NewGuid();
+            Guid guid3 = System.Guid.NewGuid();
+            Guid guid4 = System.Guid.NewGuid();
+
+            // Create CBN1 for import
+            added.Add(CreateSubTreeFromCode(guid1, codes[0]));
+            // Create CBN2 for x and y
+            added.Add(CreateSubTreeFromCode(guid2, codes[1]));
+            // Create CBN3 for TestCount constructor
+            added.Add(CreateSubTreeFromCode(guid3, codes[2]));
+            // Create CBN4 for UpdateCount
+            added.Add(CreateSubTreeFromCode(guid4, codes[3]));
+
+            // Verify that UpateCount is only called once
+            var syncData = new GraphSyncData(null, added, null);
+            astLiveRunner.UpdateGraph(syncData);
+            AssertValue("a", 1);
+
+
+            // Modify CBN2 
+            Subtree subtree = CreateSubTreeFromCode(guid2, codes[4]);
+            List<Subtree> modified = new List<Subtree>();
+            modified.Add(subtree);
+
+            // Modify CBN3 with same contents with ForceExecution flag set
+            subtree = CreateSubTreeFromCode(guid3, codes[2]);
+            subtree.ForceExecution = true;
+            modified.Add(subtree);
+
+            syncData = new GraphSyncData(null, null, modified);
+            astLiveRunner.UpdateGraph(syncData);
+            AssertValue("a", 2);
+        }
     }
 
 }


### PR DESCRIPTION
1. By default, set the entrypoint of an execution session in the
   codegen. If there are force exec ASTs and no deltas, set entrypoint to be the first forceexec AST
2. Code cleanup
3. Add testcase

This fixes forceexec working in tandem with applyupdate:
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3891

@lukechurch @ikeough 
