### PR TITLE
Check for null before building string node.

### DIFF
--- a/src/Libraries/Revit/RevitNodesUI/Selection.cs
+++ b/src/Libraries/Revit/RevitNodesUI/Selection.cs
@@ -284,9 +284,20 @@ namespace Dynamo.Nodes
             {
                 var stableRef = GetIdentifierFromModelObject(results.First());
 
-                node = AstFactory.BuildFunctionCall(
+                // There are cases where Revit will fail to return a stable 
+                // identifier for a reference. Ex. the selection is a face on
+                // an Analysis Visualization. In this case, we want to return
+                // null instead of trying to pass that null into the BuildStringNode
+                if (stableRef == null)
+                {
+                    node = AstFactory.BuildNullNode();
+                }
+                else
+                {
+                    node = AstFactory.BuildFunctionCall(
                     func,
                     new List<AssociativeNode> { AstFactory.BuildStringNode(stableRef), });
+                }
             }
             else
             {


### PR DESCRIPTION
This pull request adds a null check in the ReferenceSelection AST building, which passes out a null node if the an id cannot be acquired from revit for a given reference.

A larger task has been opened to harden all ASTFactory methods:
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5096

Requires merge:
- [ ] Revit2015

PTAL:
@Steell 