### PR TITLE
Fix regression: Load geometry library for RecordedTests

### DIFF
--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -13,6 +13,8 @@ using Dynamo.Tests;
 using Dynamo.ViewModels;
 using NUnit.Framework;
 using Dynamo.UI;
+using DynamoUtilities;
+using System.Reflection;
 
 namespace DynamoCoreUITests
 {
@@ -38,6 +40,10 @@ namespace DynamoCoreUITests
         {
             // We do not call "base.Init()" here because we want to be able 
             // to create our own copy of Controller here with command file path.
+            DynamoPathManager.Instance.InitializeCore(
+              Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+
+            DynamoPathManager.PreloadAsmLibraries(DynamoPathManager.Instance);
         }
 
         [SetUp]


### PR DESCRIPTION
RecordedTest.Init() doesn't call `base.init()` to load geometry library.
