### PR TITLE
Fixing UpdateManagerUITests failures

### DIFF
--- a/src/DynamoCore/UpdateManager/UpdateManager.cs
+++ b/src/DynamoCore/UpdateManager/UpdateManager.cs
@@ -52,8 +52,32 @@ namespace Dynamo.UpdateManager
         bool CheckNewerDailyBuilds { get; set; }
         bool ForceUpdate { get; set; }
         string UpdateFileLocation { get; }
+        IUpdateManagerConfiguration Configuration { get; }
         event LogEventHandler Log;
         void OnLog(LogEventArgs args);
+    }
+
+    public interface IUpdateManagerConfiguration
+    {
+        /// <summary>
+        /// Defines download location for new installer
+        /// </summary>
+        string DownloadSourcePath { get; set; }
+
+        /// <summary>
+        /// Defines location for signature file to validate the new installer.
+        /// </summary>
+        string SignatureSourcePath { get; set; }
+
+        /// <summary>
+        /// Defines whether to consider daily builds for update, default is false.
+        /// </summary>
+        bool CheckNewerDailyBuild { get; set; }
+
+        /// <summary>
+        /// Defines whether to force update, default vlaue is false.
+        /// </summary>
+        bool ForceUpdate { get; set; }
     }
 
     /// <summary>
@@ -177,7 +201,7 @@ namespace Dynamo.UpdateManager
     /// <summary>
     /// Defines Update Manager Configuration settings.
     /// </summary>
-    public class UpdateManagerConfiguration
+    public class UpdateManagerConfiguration : IUpdateManagerConfiguration
     {
         private const string PRODUCTION_SOURCE_PATH_S = "http://dyn-builds-data.s3.amazonaws.com/";
         private const string PRODUCTION_SIG_SOURCE_PATH_S = "http://dyn-builds-data-sig.s3.amazonaws.com/";
@@ -463,7 +487,7 @@ namespace Dynamo.UpdateManager
         /// <summary>
         /// Returns the configuration settings.
         /// </summary>
-        public UpdateManagerConfiguration Configuration
+        public IUpdateManagerConfiguration Configuration
         {
             get 
             {
@@ -975,9 +999,8 @@ namespace Dynamo.UpdateManager
         /// </summary>
         internal static void CheckForProductUpdate()
         {
-            var self = Instance as UpdateManager;
-            var downloadUri = new Uri(self.Configuration.DownloadSourcePath);
-            self.CheckForProductUpdate(new UpdateRequest(downloadUri, self));
+            var downloadUri = new Uri(Instance.Configuration.DownloadSourcePath);
+            Instance.CheckForProductUpdate(new UpdateRequest(downloadUri, Instance));
         }
     }
 }

--- a/test/DynamoCoreUITests/UpdateManagerUITests.cs
+++ b/test/DynamoCoreUITests/UpdateManagerUITests.cs
@@ -22,6 +22,28 @@ namespace DynamoCoreUITests
     [TestFixture]
     public class UpdateManagerUITests : DynamoTestUIBase
     {
+        private const string DOWNLOAD_SOURCE_PATH_S = "http://downloadsourcepath/";
+        private const string SIGNATURE_SOURCE_PATH_S = "http://SignatureSourcePath/";
+
+        private static Mock<IUpdateManager> MockUpdateManager(string availableVersion, string productVersion)
+        {
+            var um_mock = new Mock<IUpdateManager>();
+            um_mock.Setup(um => um.AvailableVersion).Returns(BinaryVersion.FromString(availableVersion));
+            um_mock.Setup(um => um.ProductVersion).Returns(BinaryVersion.FromString(productVersion));
+
+            var config = new UpdateManagerConfiguration()
+            {
+                DownloadSourcePath = DOWNLOAD_SOURCE_PATH_S,
+                SignatureSourcePath = SIGNATURE_SOURCE_PATH_S
+            };
+            um_mock.Setup(um => um.Configuration).Returns(config);
+
+            var fieldInfo = typeof(UpdateManager).GetField("instance", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(fieldInfo);
+            fieldInfo.SetValue(UpdateManager.Instance, um_mock.Object);
+            return um_mock;
+        }
+
         private void Init()
         {
             AppDomain.CurrentDomain.AssemblyResolve += AssemblyHelper.ResolveAssembly;
@@ -60,12 +82,10 @@ namespace DynamoCoreUITests
         [Category("UnitTests")]
         public void UpdateButtonNotCollapsedIfNotUpToDate()
         {
-            var um_mock = new Mock<IUpdateManager>();
-            um_mock.Setup(um => um.AvailableVersion).Returns(BinaryVersion.FromString("9.9.9.9"));
-            um_mock.Setup(um => um.ProductVersion).Returns(BinaryVersion.FromString("1.1.1.1"));
-            var fieldInfo = typeof(UpdateManager).GetField("instance", BindingFlags.Static | BindingFlags.NonPublic);
-            fieldInfo.SetValue(UpdateManager.Instance, um_mock.Object);
-
+            const string availableVersion = "9.9.9.9";
+            const string productVersion = "1.1.1.1";
+            MockUpdateManager(availableVersion, productVersion);
+            
             Init();
 
             var stb = (ShortcutToolbar)View.shortcutBarGrid.Children[0];
@@ -78,11 +98,9 @@ namespace DynamoCoreUITests
         [Category("UnitTests")]
         public void UpdateButtonCollapsedIfUpToDate()
         {
-            var um_mock = new Mock<IUpdateManager>();
-            um_mock.Setup(um => um.AvailableVersion).Returns(BinaryVersion.FromString("1.1.1.1"));
-            um_mock.Setup(um => um.ProductVersion).Returns(BinaryVersion.FromString("9.9.9.9"));
-            var fieldInfo = typeof(UpdateManager).GetField("instance", BindingFlags.Static | BindingFlags.NonPublic);
-            fieldInfo.SetValue(UpdateManager.Instance, um_mock.Object);
+            const string availableVersion = "1.1.1.1";
+            const string productVersion = "9.9.9.9";
+            MockUpdateManager(availableVersion, productVersion);
 
             Init();
 
@@ -96,12 +114,10 @@ namespace DynamoCoreUITests
         [Category("UnitTests")]
         public void UpdateButtonCollapsedIfNotConnected()
         {
-            var um_mock = new Mock<IUpdateManager>();
-            um_mock.Setup(um => um.AvailableVersion).Returns(BinaryVersion.FromString(""));
-            um_mock.Setup(um => um.ProductVersion).Returns(BinaryVersion.FromString("9.9.9.9"));
-            var fieldInfo = typeof(UpdateManager).GetField("instance", BindingFlags.Static | BindingFlags.NonPublic);
-            fieldInfo.SetValue(UpdateManager.Instance, um_mock.Object);
-            
+            const string availableVersion = "";
+            const string productVersion = "9.9.9.9";
+            MockUpdateManager(availableVersion, productVersion);
+
             Init();
 
             var stb = (ShortcutToolbar)View.shortcutBarGrid.Children[0];


### PR DESCRIPTION
CheckForProductUpdate() assumed that UpdateManager.Instance will always
be of type UpdateManager, but the UpdateManagerUITests mock
IUpdateManager and set the instance for testing.
So this method failed in casting.

Exposed Configuration property to return IUpdateManagerConfiguration
from IUpdateManager interface so that this method doesn't assume
anything.

Updated testcases to mock the IUpdateManager with configuration
settings.
