### PR TITLE
Correct package loading, uninstallation order

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -355,8 +355,8 @@ namespace Dynamo.Models
             this.CustomNodeManager = new CustomNodeManager(this, DynamoPathManager.Instance.UserDefinitions);
             this.Loader = new DynamoLoader(this);
 
-            this.Loader.PackageLoader.DoCachedPackageUninstalls( preferences );
-            this.Loader.PackageLoader.LoadPackagesIntoDynamo( preferences );
+            // do package uninstalls first
+            this.Loader.PackageLoader.DoCachedPackageUninstalls(preferences);
 
             DisposeLogic.IsShuttingDown = false;
 
@@ -375,12 +375,16 @@ namespace Dynamo.Models
                 "Dynamo -- Build {0}",
                 Assembly.GetExecutingAssembly().GetName().Version));
 
-            this.Loader.ClearCachedAssemblies();
-            this.Loader.LoadNodeModels();
-
             MigrationManager.Instance.MigrationTargets.Add(typeof(WorkspaceMigrations));
 
             PackageManagerClient = new PackageManagerClient(this);
+
+            this.Loader.ClearCachedAssemblies();
+            this.Loader.LoadNodeModels();
+       
+            // load packages last
+            this.Loader.PackageLoader.LoadPackagesIntoDynamo(preferences);
+
         }
 
         private void InitializeInstrumentationLogger()


### PR DESCRIPTION
### Fix

This slightly modifies the order of loading/uninstalling packages in DynamoModel.  It is similar to the fix in the Solar Radiation Analysis PR, but it also insures that uninstall is done correctly.  

In short, this solution insures that package uninstalls are done immediately (i.e. before any other dll's are dynamically loaded) and does package loading last (insuring all requisite Dynamo core libraries are loaded last).  
### Reviewers

@ikeough  
