### PR TITLE
Fix the indeterminism in task ordering

### DIFF
--- a/src/DynamoCore/Core/Threading/DynamoSchedulerInternals.cs
+++ b/src/DynamoCore/Core/Threading/DynamoSchedulerInternals.cs
@@ -76,7 +76,14 @@ namespace Dynamo.Core.Threading
             if (taskQueue.Count < 2) // Nothing to reprioritize here.
                 return;
 
-            taskQueue.Sort(new AsyncTaskComparer());
+            // "List.Sort" method performs an unstable sort, which means if two 
+            // entries have the same key value, the resulting order may not be 
+            // the same order they originally appear on the list. Use "OrderBy" 
+            // method here to perform stable sort.
+            // 
+            var temp = taskQueue.ToList(); // Duplicate the source list.
+            taskQueue.Clear(); // Then it's safe to clear the source list.
+            taskQueue.AddRange(temp.OrderBy(t => t, new AsyncTaskComparer()));
         }
 
         private static void ProcessTaskInternal(AsyncTask asyncTask)

--- a/test/DynamoCoreTests/SchedulerTests.cs
+++ b/test/DynamoCoreTests/SchedulerTests.cs
@@ -133,6 +133,16 @@ namespace Dynamo
 
             return TaskMergeInstruction.KeepOther;
         }
+
+        protected override int CompareCore(AsyncTask otherTask)
+        {
+            // PrioritizedAsyncTask always come before InconsequentialAsyncTask.
+            if (otherTask is PrioritizedAsyncTask)
+                return 1;
+
+            // InconsequentialAsyncTask are always treated equal.
+            return base.CompareCore(otherTask);
+        }
     }
 
     class TimeStampGrabber


### PR DESCRIPTION
## Background

As of the existing implementation, `UpdateRenderPackageAsyncTask` task is considered of equal _weightage_ as compared to `AggregateRenderPackageAsyncTask`, so the order in which they are scheduled will be the order they are executed. The problem is, `DynamoScheduler.ReprioritizeTasksInQueue` makes use of `List.Sort` method for task ordering, and it is an unstable sort (i.e. the ultimate order of two equivalent tasks are not guaranteed to be the same as the order they originally appeared on the list).
## Changes

This pull request fixes such indeterminism in task ordering by replacing `List.Sort` with `Enumerable.OrderBy`, which results in the exact same order if two tasks are considered the same.
## Notes to reviewer

Hi @ikeough, please have a go with this one, it retains the behavior as `List.Sort`, as tested by all unit test cases around `DynamoScheduler`. Thanks for catching this!
