### PR TITLE
Changed URL for "Report A Bug" so that it can directly take user to reporting page.

### DIFF
--- a/src/DynamoCore/UI/Configurations.cs
+++ b/src/DynamoCore/UI/Configurations.cs
@@ -28,7 +28,7 @@ namespace Dynamo.UI
         public static string DynamoMoreSamples = "http://dynamobim.org/learn/#159";
         public static string DynamoDownloadLink = "http://dynamobim.org/download/";
         public static string GitHubDynamoLink = "https://github.com/DynamoDS/Dynamo";
-        public static string GitHubBugReportingLink = "https://github.com/DynamoDS/Dynamo/issues";
+        public static string GitHubBugReportingLink = "https://github.com/DynamoDS/Dynamo/issues/new";
 
         public static string UsageReportingErrorMessage = "Uh oh...\n\rWe're sorry - we tried to save your decisions, but something went wrong. The decision probably hasn't been saved. This really shouldn't have happened. Please get in touch via GitHub and send us this information.\n\rYou can also try deleting [FILEPATH] and trying again.\n\rDepending on your previous choice, instrumentation may still be running, if you're worried about this, please consider not using Dynamo until we've got back to you to solve the problem.\n\rSorry about that.";
         #endregion


### PR DESCRIPTION
Fix for MAGN-5130 (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5130)

Earlier URL for "Report A Bug" or "Send Issue" on start page was taking user to list of issues page rather than opening a new issue page on git hub.

_Note:_ If user is not signed in to Github then this new URL will take him to Sign In Page, if he has already signed in then it will open New Issue page.

<h4>Reviewer</h4>
- [ ] @sharadkjaiswal 

<h4>Need Merge to Revit 2015</h4>
- [ ] Merge to Revit2015

![image](https://cloud.githubusercontent.com/assets/5109531/4713694/ac31bb88-58e5-11e4-8808-ed881e0f5ad6.png)
