### PR TITLE
Prefixed double underscore to internal custom node names

### DIFF
--- a/src/DynamoCore/DSEngine/AstBuilder.cs
+++ b/src/DynamoCore/DSEngine/AstBuilder.cs
@@ -361,7 +361,7 @@ namespace Dynamo.DSEngine
         internal class StringConstants
         {
             public const string ParamPrefix = @"p_";
-            public const string FunctionPrefix = @"func_";
+            public const string FunctionPrefix = @"__func_";
             public const string VarPrefix = @"var_";
             public const string ShortVarPrefix = @"t_";
             public const string CustomNodeReturnVariable = @"%arr";


### PR DESCRIPTION
This is so that we can filter out these internal functions from CBN auto-complete. Custom node unit tests pass.

@ke-yu please review.
