### PR TITLE
Added semicolons for AssemblyGenerator to build when path to sources contain spaces

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblyInfoGenerator.csproj
+++ b/src/AssemblySharedInfoGenerator/AssemblyInfoGenerator.csproj
@@ -63,7 +63,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>$(SolutionDir)transform_all.bat $(ProjectDir)</PreBuildEvent>
+    <PreBuildEvent>"$(SolutionDir)transform_all.bat" "$(ProjectDir)"</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/transform_all.bat
+++ b/src/transform_all.bat
@@ -18,7 +18,7 @@ type t4list.txt
 
 :: transform all the templates
 for /f %%d in (t4list.txt) do (
-set file_name=%%d
+set file_name="%%d"
 set file_name=!file_name:~0,-3!.%extension%
 echo:  \--^> !file_name!    
 "%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\11.0\TextTransform.exe" -out !file_name! %%d


### PR DESCRIPTION
#### Purpose

Project `AssemblyInfoGenerator` fails during building.
![bat error](https://cloud.githubusercontent.com/assets/8158551/4714773/db426894-58f6-11e4-9335-55306bca2013.png)

The reason in that my path to cloned repository contains of spaces: `D:\Projects\Dynamo Library UI\git_orig`.

After changes solution is built successfully.
![bat success](https://cloud.githubusercontent.com/assets/8158551/4714870/dd04c23e-58f7-11e4-98c2-41d5e365c63b.PNG)
#### Modifications

Added semicolons to correct places.
#### Additional references

[MAGN-5135](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5135).
#### References

As I understand by closed PR @theanh0512 made tasks connected with AssemblyInfoGenerator. Could you please take a look? @sharadkjaiswal, please take a look.
