### PR TITLE
sunPath Geometry is now shown in Dynamo

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/SunSettings.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/SunSettings.cs
@@ -112,20 +112,6 @@ namespace Revit.Elements
             get { return InternalSunAndShadowSettings as Autodesk.Revit.DB.Element; }
         }
 
-        ///// <summary>
-        /////     Gets the SunPath geometry for the current frame of the solar study.
-        ///// </summary>
-        //public GeometryElement CurrentSunPathGeometry
-        //{
-
-        //    get
-        //    {
-
-        //        var geomOptions = new Autodesk.Revit.DB.Options();
-        //        geomOptions.ComputeReferences = true;
-        //        return InternalSunAndShadowSettings.get_Geometry(geomOptions);
-        //    }
-        //}
 
     }
 }

--- a/src/Libraries/Revit/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/Revit/RevitNodes/RevitNodes.csproj
@@ -161,6 +161,10 @@
     <Compile Include="Transaction\Transaction.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\DynamoCore\DynamoCore.csproj">
+      <Project>{7858fa8c-475f-4b8e-b468-1f8200778cf8}</Project>
+      <Name>DynamoCore</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\NodeServices\NodeServices.csproj">
       <Project>{ef879a10-041d-4c68-83e7-3192685f1bae}</Project>
       <Name>NodeServices</Name>


### PR DESCRIPTION
The current sun path of the view is brought in and converted from revit
geometry to protogeometry. it is also kept up-to-date as the sun path
changes.

The  body of this pull request is a change to Element.Geometry (well InternalGeometry to be more specific) so it handles the SunSettings (sunPath) object. The geometry of the sunPath is view specific and needs a separate set of geometry options passed in,  but this can be done with just a special case similar to FormElement in the same class. Once that is done the rest of the downstream conversion of points, lines works really great (except for the sky dome analema geometry). see images in MAGN-5159.

The rest of the code in this pull request is composed of temporary workarounds to get around geometry failing to convert from revit to protogeometry. it can be removed once MAGN-5159 SunPath surfaces/solids fail to convert from Revit to ProtoGeometry is resolved.
