### PR TITLE
Cross merge to Revit2015

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -516,6 +516,19 @@ namespace Dynamo.Models
             NodeModel node, Guid nodeId, double x, double y,
             bool useDefaultPos, bool transformCoordinates, XmlNode xmlNode = null)
         {
+            // Fix for: 
+            //  http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4024
+            //  http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5045
+            //  http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4767
+            //  http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4946
+            // 
+            // Various derived classes of NodeModel like CodeBlockNode, build 
+            // their internal variables based on the node's GUID. In cases like 
+            // this, a node's GUID must be finalized before variable generation 
+            // logic kicks in.
+            // 
+            node.GUID = nodeId; // Set the node's GUID before anything else.
+
             if (useDefaultPos == false) // Position was specified.
             {
                 node.X = x;
@@ -526,9 +539,6 @@ namespace Dynamo.Models
 
             if (null != xmlNode)
                 node.Load(xmlNode);
-
-            // Override the guid so we can store for connection lookup
-            node.GUID = nodeId;
 
             ModelEventArgs args = null;
             if (!useDefaultPos)

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -214,7 +214,6 @@ b = c[w][x][y][z];";
         }
 
         [Test]
-        [Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_4024()
         {


### PR DESCRIPTION
1. Fix where the guid is set when adding a node.
2. This is based on the fix by Ben:
   https://github.com/DynamoDS/Dynamo/pull/2028
