### PR TITLE
MAGN-3965 File overwrite confirmation dialog hide under main window

### DIFF
--- a/src/DynamoCore/UI/Views/DynamoView.xaml.cs
+++ b/src/DynamoCore/UI/Views/DynamoView.xaml.cs
@@ -1100,6 +1100,7 @@ namespace Dynamo.Controls
         {
             if (e.Data.GetDataPresent(DataFormats.FileDrop))
             {
+                this.Activate();
                 // Note that you can have more than one file.
                 var files = (string[])e.Data.GetData(DataFormats.FileDrop);
 


### PR DESCRIPTION
This fix will activate the main window when a new file is dropped in to Dynamo view. 
Dynamo view will take precedence even if there are multiple monitors.

Before this fix, when a new file is dragged / dropped into Dynamo view, the Save dialog window will not appear on the main window. Instead it hides behind the current active window (which could be Revit or any browser or any other application). So, I explicitly activate the window every time  a new file is dropped in to Dynamic view, and this causes the Save dialog window to appear on the Dynamo view which is now active.
- [x] @Benglin 
