### PR TITLE
[DO NOT MERGE]Option 2: Fix MAGN-2523 Revit Elements not cleaned up after initial failure of the element creation node

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/FamilyInstance.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/FamilyInstance.cs
@@ -45,11 +45,19 @@ namespace Revit.Elements
             //There was a point, rebind to that, and adjust its position
             if (oldFam != null)
             {
-                InternalSetFamilyInstance(oldFam);
-                InternalSetLevel(level);
-                InternalSetFamilySymbol(fs);
-                InternalSetPosition(pos);
-                return;
+                try
+                {
+                    InternalSetFamilyInstance(oldFam);
+                    InternalSetLevel(level);
+                    InternalSetFamilySymbol(fs);
+                    InternalSetPosition(pos);
+                    return;
+                }
+                catch (Exception e)
+                {
+                    var elementManager = ElementIDLifecycleManager<int>.GetInstance();
+                    elementManager.UnRegisterAssociation(Id, this);
+                }
             }
 
             //Phase 2- There was no existing point, create one


### PR DESCRIPTION
When there are exceptions thrown in the constructor, the partly constructed objects are sometimes still added to the life cycle manager and this will make the related Revit elements not deleted.

This submission fixes the issue by attempting to catch the exceptions when rebinding happens. If there are exceptions during the rebinding process, the partly constructed objects will be removed from the life cycle manager. Then the object will be constructed as if it is newly constructed.

@lukechurch 
PTAL
