### PR TITLE
[DO NOT MERGE]Option 3: Fix MAGN-2523 Revit Elements not cleaned up after initial failure of the element creation node

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/FamilyInstance.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/FamilyInstance.cs
@@ -38,41 +38,58 @@ namespace Revit.Elements
         internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, XYZ pos,
             Autodesk.Revit.DB.Level level)
         {
-            //Phase 1 - Check to see if the object exists and should be rebound
-            var oldFam =
-                ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.FamilyInstance>(Document);
-
-            //There was a point, rebind to that, and adjust its position
-            if (oldFam != null)
+            try
             {
-                InternalSetFamilyInstance(oldFam);
-                InternalSetLevel(level);
-                InternalSetFamilySymbol(fs);
-                InternalSetPosition(pos);
-                return;
+                //Phase 1 - Check to see if the object exists and should be rebound
+                var oldFam =
+                    ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.FamilyInstance>(Document);
+
+                //There was a point, rebind to that, and adjust its position
+                if (oldFam != null)
+                {
+                    try
+                    {
+                        InternalSetFamilyInstance(oldFam);
+                        InternalSetLevel(level);
+                        InternalSetFamilySymbol(fs);
+                        InternalSetPosition(pos);
+                        return;
+                    }
+                    catch (Exception e)
+                    {
+                        var elementManager = ElementIDLifecycleManager<int>.GetInstance();
+                        elementManager.UnRegisterAssociation(Id, this);
+                    }
+                }
+
+                //Phase 2- There was no existing point, create one
+                TransactionManager.Instance.EnsureInTransaction(Document);
+
+                Autodesk.Revit.DB.FamilyInstance fi;
+
+                if (Document.IsFamilyDocument)
+                {
+                    fi = Document.FamilyCreate.NewFamilyInstance(pos, fs, level,
+                        Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
+                }
+                else
+                {
+                    fi = Document.Create.NewFamilyInstance(
+                        pos, fs, level, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
+                }
+
+                InternalSetFamilyInstance(fi);
+
+                TransactionManager.Instance.TransactionTaskDone();
+
+                ElementBinder.SetElementForTrace(InternalElement);
             }
-
-            //Phase 2- There was no existing point, create one
-            TransactionManager.Instance.EnsureInTransaction(Document);
-
-            Autodesk.Revit.DB.FamilyInstance fi;
-
-            if (Document.IsFamilyDocument)
+            catch (Exception e)
             {
-                fi = Document.FamilyCreate.NewFamilyInstance(pos, fs, level,
-                    Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
+                var elementManager = ElementIDLifecycleManager<int>.GetInstance();
+                elementManager.UnRegisterAssociation(Id, this);
+                throw e;
             }
-            else
-            {
-                fi = Document.Create.NewFamilyInstance(
-                    pos, fs, level, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
-            }
-
-            InternalSetFamilyInstance(fi);
-
-            TransactionManager.Instance.TransactionTaskDone();
-
-            ElementBinder.SetElementForTrace(InternalElement);
         }
 
         /// <summary>


### PR DESCRIPTION
When there are exceptions thrown in the constructor, the partly constructed objects are sometimes still added to the life cycle manager and this will make the related Revit elements not deleted.

This pull request fixes the issue by catching the exceptions which happen in the rebinding process, if there are exceptions, the object will be constructed as if it is newly constructed. It will also catch all the exceptions which happen when the object is constructed.

@lukechurch 
PTAL
