### PR TITLE
Restored "evaluation completed in..." message

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -623,9 +623,12 @@ namespace Dynamo.Models
                         // Record execution time for update graph task.
                         long start = e.Task.ExecutionStartTime.TickCount;
                         long end = e.Task.ExecutionEndTime.TickCount;
-                        InstrumentationLogger.LogAnonymousTimedEvent("Perf",
-                            e.Task.GetType().Name, new TimeSpan(end - start));
+                        var executionTimeSpan = new TimeSpan(end - start);
 
+                        InstrumentationLogger.LogAnonymousTimedEvent("Perf",
+                            e.Task.GetType().Name, executionTimeSpan);
+
+                        Logger.Log("Evaluation completed in " + executionTimeSpan);
                         ExecutionEvents.OnGraphPostExecution();
                     }
                     break;


### PR DESCRIPTION
This fixes [an issue](https://github.com/DynamoDS/Dynamo/issues/2855) @eproca reported. The old timing information was displayed through `DynamoRunner`, which is now replaced by `DynamoScheduler`. To fix this, I have added the same logging code in `OnAsyncTaskStateChanged` when `State.ExecutionCompleted` is being sent to `DynamoModel`.

Hi @aparajit-pratap, please take a look. Thanks!
