### PR TITLE
Adjust the level name if there is an existing level with the same name

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/InternalUtilities/ElementUtils.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/InternalUtilities/ElementUtils.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Autodesk.DesignScript.Runtime;
+
+namespace Revit.Elements.InternalUtilities
+{
+    [IsVisibleInDynamoLibrary(false)]
+    public class ElementUtils
+    {
+        /// <summary>
+        /// This function checks if the name ends with "(num)". Here num is a integer.
+        /// If yes, it will replace "(num)" with "(num+1)". Here num+1 is the form of the
+        /// evaluated integer. Otherwise, it will append "(1)" at the end of the name.
+        /// For example:
+        /// This function will change the name from "abc(2)" to "abc(3)",
+        /// from "abc" to "abc(1)".
+        /// </summary>
+        /// <param name="name"></param>
+        public static void UpdateLevelName(ref string name)
+        {
+            if (name.EndsWith(")"))
+            {
+                int index = name.LastIndexOf("(");
+                if (index < 0)
+                {
+                    name += "(1)";
+                }
+                else
+                {
+                    int length = name.Length - index - 2;
+                    string strNumber = name.Substring(index + 1, length);
+                    int number = 0;
+                    if (int.TryParse(strNumber, out number))
+                    {
+                        number = number + 1;
+                        name = name.Substring(0, index) + "(" + number.ToString() + ")";
+                    }
+                    else
+                    {
+                        name += "(1)";
+                    }
+                }
+            }
+            else
+            {
+                name += "(1)";
+            }
+        }
+    }
+}

--- a/src/Libraries/Revit/RevitNodes/Elements/Level.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Level.cs
@@ -58,15 +58,7 @@ namespace Revit.Elements
                 return;
             }
 
-            //Phase 2- There was no existing element, create new
-            //Phase 2.1- Check to see whether there is an existing level with the same name
-            var levels = ElementQueries.GetAllLevels();
-            if (levels.Any(x => string.CompareOrdinal(x.Name, name) == 0))
-            {
-                throw new Exception("A level with the specified name already exists");
-            }
-
-            //Phase 2.2 - if there is no existing level of the same name, create a new one
+            //There was no element, create a new one
             TransactionManager.Instance.EnsureInTransaction(Document);
 
             Autodesk.Revit.DB.Level level;
@@ -126,7 +118,17 @@ namespace Revit.Elements
         /// <param name="name"></param>
         private void InternalSetName(string name)
         {
-            if (String.IsNullOrEmpty(name)) return;
+            if (String.IsNullOrEmpty(name) ||
+                string.CompareOrdinal(InternalLevel.Name, name) == 0)
+                return;
+
+            //Check to see whether there is an existing level with the same name
+            var levels = ElementQueries.GetAllLevels();
+            while (levels.Any(x => string.CompareOrdinal(x.Name, name) == 0))
+            {
+                //Update the level name
+                ElementUtils.UpdateLevelName(ref name);
+            }
 
             TransactionManager.Instance.EnsureInTransaction(Document);
             this.InternalLevel.Name = name;

--- a/src/Libraries/Revit/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/Revit/RevitNodes/RevitNodes.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Elements\CurveByPoints.cs" />
     <Compile Include="Elements\CurveElement.cs" />
     <Compile Include="Elements\InternalUtilities\ElementQueries.cs" />
+    <Compile Include="Elements\InternalUtilities\ElementUtils.cs" />
     <Compile Include="Elements\Mullion.cs" />
     <Compile Include="Elements\SunSettings.cs" />
     <Compile Include="Elements\UnknownElement.cs" />

--- a/test/Libraries/Revit/RevitNodesTests/Elements/LevelTests.cs
+++ b/test/Libraries/Revit/RevitNodesTests/Elements/LevelTests.cs
@@ -63,8 +63,16 @@ namespace RevitTestServices.Elements
             Assert.AreEqual(name, level.Name);
 
             //Create a new level with the same name and elevation
-            //Ensure there is a exception thrown
-            Assert.Throws(typeof(System.Exception), ()=>Level.ByElevationAndName(elevation, name));
+            level = Level.ByElevationAndName(elevation, name);
+
+            Assert.AreEqual(elevation, level.Elevation);
+            Assert.AreEqual(name + "(1)", level.Name);
+
+            //Once again create a new level with the same name and elevation
+            level = Level.ByElevationAndName(elevation, name);
+
+            Assert.AreEqual(elevation, level.Elevation);
+            Assert.AreEqual(name + "(2)", level.Name);
 
             //Create a new level with a name of lowercase letters
             //and the same elevation


### PR DESCRIPTION
<h4>Summary</h4>

We can not create a level if there is an existing level with the same name in the document. To bypass the limitation, the name of the new level will be slightly adjusted by appending "(1)" at the end.

@ikeough 
This is implemented based on your comment in one defect.
PTAL
