### PR TITLE
Clear task queue when Scheduler is shutdown

### DIFF
--- a/src/DynamoCore/Core/Threading/DynamoScheduler.cs
+++ b/src/DynamoCore/Core/Threading/DynamoScheduler.cs
@@ -72,9 +72,10 @@ namespace Dynamo.Core.Threading
         /// <summary>
         /// Call this method to properly shutdown the scheduler and its associated
         /// ISchedulerThread. This call will be blocked until the ISchedulerThread
-        /// terminates. Note that if the task queue is not empty at the time this 
-        /// call is made, all the tasks in queue will be executed before shutdown 
-        /// can proceed.
+        /// terminates. Note that the implementation of ISchedulerThread may or may 
+        /// not choose to handle all the remaining AsyncTask in queue when shutdown 
+        /// happens -- DynamoScheduler ensures the tasks in queue are cleared when 
+        /// this call returns.
         /// </summary>
         internal void Shutdown()
         {


### PR DESCRIPTION
Tasks on scheduler thread. In `DynamoScheduler.Shutdown()`, it notifies schedule thread to shutdown as well. Depending on scheduler thread's implementation, it is possible that although scheduler thread have been unavailable, but there are still some pending tasks in the queue. For example, `RevitSchedulerThread` uses Revit's idle event to process tasks, and if it is detached from idle event, tasks would never get a chance to run, so we need to make sure all tasks are cleared. 

@Benglin  please. 
