### PR TITLE
Release event handlers

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -459,6 +459,7 @@ namespace Dynamo.Models
             EngineController = null;
 
             PreferenceSettings.Save();
+            PreferenceSettings.PropertyChanged -= PreferenceSettings_PropertyChanged;
 
             OnCleanup();
 

--- a/src/DynamoCore/UI/Views/DynamoView.xaml.cs
+++ b/src/DynamoCore/UI/Views/DynamoView.xaml.cs
@@ -623,6 +623,7 @@ namespace Dynamo.Controls
             Debug.WriteLine("Dynamo window closed.");
 
             dynamoViewModel.Model.RequestLayoutUpdate -= vm_RequestLayoutUpdate;
+            dynamoViewModel.RequestViewOperation -= DynamoViewModelRequestViewOperation;
 
             //PACKAGE MANAGER
             dynamoViewModel.RequestPackagePublishDialog -= DynamoViewModelRequestRequestPackageManagerPublish;


### PR DESCRIPTION
Although I don't think they are the cause of memory leak, but for the sake of proper cleanup, release them. 

@Benglin please help to review the change. 
