### PR TITLE
Inherit from NotificationObject to avoid memory leak in data binding

### DIFF
--- a/src/DynamoCore/Search/SearchModel.cs
+++ b/src/DynamoCore/Search/SearchModel.cs
@@ -9,10 +9,11 @@ using Dynamo.Nodes.Search;
 using Dynamo.Search.SearchElements;
 using Dynamo.Utilities;
 using Dynamo.DSEngine;
+using Microsoft.Practices.Prism.ViewModel;
 
 namespace Dynamo.Search
 {
-    public class SearchModel
+    public class SearchModel : NotificationObject
     {
         #region Events 
 

--- a/src/DynamoCore/UI/Controls/ShortcutToolbar.xaml.cs
+++ b/src/DynamoCore/UI/Controls/ShortcutToolbar.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Dynamo.UI.Commands;
 using System.Collections.ObjectModel;
 using System.Windows.Controls;
+using Microsoft.Practices.Prism.ViewModel;
 
 namespace Dynamo.UI.Controls
 {
@@ -29,7 +30,7 @@ namespace Dynamo.UI.Controls
         }
     }
 
-    public partial class ShortcutBarItem
+    public partial class ShortcutBarItem : NotificationObject
     {
         private string shortcutToolTip;
         private string imgNormalSource;

--- a/src/DynamoCore/UI/Controls/StartPage.xaml.cs
+++ b/src/DynamoCore/UI/Controls/StartPage.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using Microsoft.Practices.Prism.ViewModel;
 
 namespace Dynamo.UI.Controls
 {
@@ -21,7 +22,7 @@ namespace Dynamo.UI.Controls
     /// See "Action" enumeration below for more details of each item sub-type.
     /// </summary>
     /// 
-    public class StartPageListItem
+    public class StartPageListItem : NotificationObject
     {
         private ImageSource icon = null;
 


### PR DESCRIPTION
This pull request is part of attempt to fix [memory leak on Revit](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3404).

Related pull request:
- [Not register event handler for Dispatcher.ShutdownStarted event](https://github.com/DynamoDS/Dynamo/pull/2888)
- [Clear task queue when Scheduler is shutdown](https://github.com/DynamoDS/Dynamo/pull/2881)

Looking at some retention paths, notice because some objects are referenced from system object, `RevitDynamoModel` is not released (see images attached at the end of comment). 

These objects looks innocent, but according to [this article](http://blogs.msdn.com/b/micmcd/archive/2008/03/07/avoiding-a-wpf-memory-leak-with-databinding-black-magic.aspx), memory could easily be leak due to data binding. The solution is "Anything involved in a databinding should implement `INotifyPropertyChanged`" (:-()

I didn't dig too deep. But inheriting from `NotificationObject` removes these objects on `RevitDynamoModel`'s reference retention path. 

`RevitDynamoModel` is still referenced by other objects, but locally I've fixed it. I'll send the fix in other pull request. 
- [x] @ikeough 
- [x] @Benglin 
- SearchModel

![3](https://cloud.githubusercontent.com/assets/2600379/4823164/04599c60-5f4c-11e4-8ef2-7cb4f04bbb03.png)
- ShortCutBarItem
  
  ![1](https://cloud.githubusercontent.com/assets/2600379/4823165/045ef0de-5f4c-11e4-82c3-5720b93c72c0.png)
- StartPageListItem

![2](https://cloud.githubusercontent.com/assets/2600379/4823166/04681bd2-5f4c-11e4-85d5-51fb17c5cd2c.png)
