### PR TITLE
Fixing installation issue on MSI for 0.7.3 upgrade

### DIFF
--- a/src/DynamoInstall/Product.wxs
+++ b/src/DynamoInstall/Product.wxs
@@ -13,8 +13,8 @@
              InstallScope="perMachine"
              Platform="x64"/>
 
-    <MajorUpgrade
-      Schedule="afterInstallInitialize"
+    <MajorUpgrade AllowSameVersionUpgrades="yes"
+      Schedule="afterInstallValidate"
       DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
 
     <MediaTemplate EmbedCab="yes" />

--- a/src/DynamoInstallActions/CustomAction.cs
+++ b/src/DynamoInstallActions/CustomAction.cs
@@ -17,19 +17,24 @@ namespace DynamoInstallActions
             {
                 // Dynamo 0.7.1 AppId
                 // 6B5FA6CA-9D69-46CF-B517-1F90C64F7C0B
-                string uninstallPath;
-                if (!GetUninstallPathFromRegistry(session, out uninstallPath))
+                string exeUninstallPath, msiUninstallPath = string.Empty;
+                if (!GetUninstallPathFromRegistry(session, out exeUninstallPath) &&
+                    !GetOldMSIUninstallStringFromRegistery(session, out msiUninstallPath))
                 {
                     return ActionResult.NotExecuted;
                 }
 
-                if (!string.IsNullOrEmpty(uninstallPath) && File.Exists(uninstallPath))
+                if (!string.IsNullOrEmpty(exeUninstallPath) && File.Exists(exeUninstallPath))
                 {
-                    Uninstall(session, uninstallPath);
+                    Uninstall(session, exeUninstallPath);
+                }
+                else if (!string.IsNullOrEmpty(msiUninstallPath) && File.Exists(msiUninstallPath))
+                {
+                    UninstallOldMSI(session, msiUninstallPath);
                 }
                 else
                 {
-                    session.Log(string.Format("Dynamo uninstall path: {0}, could not be located.", uninstallPath));
+                    session.Log(string.Format("Dynamo uninstall path: {0}, could not be located.", exeUninstallPath));
                     return ActionResult.NotExecuted;
                 }
 
@@ -41,6 +46,17 @@ namespace DynamoInstallActions
                 session.Log("There was an error uninstalling Dynamo:");
                 session.Log(ex.Message);
                 return ActionResult.Failure;
+            }
+        }
+
+        private static void UninstallOldMSI(Session session, string uninstallPath)
+        {
+            session.Log(string.Format("Uninstalling Old Dynamo MSI 0.7 at {0}", uninstallPath));
+            string options = uninstallPath.Remove(0, 11) + @" \quiet";
+            var proc = Process.Start(uninstallPath, options);
+            if (proc != null)
+            {
+                proc.WaitForExit();
             }
         }
 
@@ -95,6 +111,34 @@ namespace DynamoInstallActions
             session.Log(string.Format("Uninstall key:{0}", uninstallKey));
 
             uninstallPath = Path.GetFullPath(uninstallKey.ToString().Replace(@"""", @""));
+            return true;
+        }
+
+        private static bool GetOldMSIUninstallStringFromRegistery(Session session, out string uninstallString)
+        {
+            const string uninstallPath =
+                @"Software\Microsoft\Windows\CurrentVersion\Uninstall\{6B5FA6CA-9D69-46CF-B517-1F90C64F7C0B}";
+            var key = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+            key = key.OpenSubKey(uninstallPath);
+            if (key == null)
+            {
+                key = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+                key = key.OpenSubKey(uninstallPath);
+            }
+
+            if(key == null)
+            {
+                session.Log("No Dynamo MSI installs could be located in the registry.");
+                {
+                    uninstallString = string.Empty;
+                    return false;
+                }
+            }
+
+            var uninstallKey = key.GetValue("UninstallString");
+            session.Log(string.Format("Uninstall key:{0}", uninstallKey));
+
+            uninstallString = Path.GetFullPath(uninstallKey.ToString().Replace(@"""", @""));
             return true;
         }
     }

--- a/src/Install.sln
+++ b/src/Install.sln
@@ -2,6 +2,9 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "DynamoInstall", "DynamoInstall\DynamoInstall.wixproj", "{C7495640-0D0C-46AB-A5F3-D5BE78F89A0D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{1D5A00DD-9606-4D30-A1F2-CA9BD7B54E34} = {1D5A00DD-9606-4D30-A1F2-CA9BD7B54E34}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamoInstallActions", "DynamoInstallActions\DynamoInstallActions.csproj", "{1D5A00DD-9606-4D30-A1F2-CA9BD7B54E34}"
 EndProject


### PR DESCRIPTION
- Changed product code so that it can be treated as major upgrade and all previous installations done with msi will be uninstalled.
- Change Install execution sequence to execute custom action for uninstall before cost initialization so that if Dynamo is already installed by exe installer on the system then before doing FileCost the previous installation is uninstalled and hence it doesn't compare the file versions for installation.
- For MSI upgrade we had to change the product code to {F295EB3F-AAD2-4514-B466-6F0375AAEEE5}, but the AppId for exe installer is kept same, so that MSI custom action can detect the installation of Dynamo by exe installer.
- Added code to detect 0.7.3 MSI installation and uninstall that if the exe installer for 0.7.3 is being installed.
