### PR TITLE
Fix regressed excel testcase

### DIFF
--- a/src/Libraries/DSOffice/Excel.cs
+++ b/src/Libraries/DSOffice/Excel.cs
@@ -65,8 +65,12 @@ namespace DSOffice
                     throw new Exception("Error setting up communication with Excel.  Try closing any open Excel instances.");
                 }
             }
-            catch (Exception e)
+            catch (NotSupportedException)
             {
+                // An exception "The URI prefix is not recognized" will be
+                // thrown out for the first run, no idea why that happen, so
+                // just swallow this exception and try to create an new excel
+                // instance.
             }
 
             if (excel == null)


### PR DESCRIPTION
When `Marshal.GetActiveObject("Excel.Application")` is called for the first time, a mysterious `System.NotSupportedException` "The URI prefix is not recognized" will be thrown out. Following is stack trace:

```
   at System.Net.WebRequest.Create(Uri requestUri, Boolean useUriBase)
   at MS.Internal.WpfWebRequestHelper.CreateRequest(Uri uri)
   at System.IO.Packaging.PackWebRequest.GetRequest(Boolean allowPseudoRequest)
   at System.IO.Packaging.PackWebRequest.GetResponse()
   at MS.Internal.WpfWebRequestHelper.GetResponse(WebRequest request)
   at MS.Internal.WpfWebRequestHelper.CreateRequestAndGetResponse(Uri uri)
   at MS.Internal.FontCache.FontSource.GetUnmanagedStream()
   at MS.Internal.Text.TextInterface.FontFileStream..ctor(IFontSource fontSource)
   at MS.Internal.Text.TextInterface.FontFileLoader.CreateStreamFromKey(Void* fontFileReferenceKey, UInt32 fontFileReferenceKeySize, IntPtr* fontFileStream)
```

 Unfortunately I have no idea why that happens. :-( As a new excel instance will always be created immediately for the first run, here just swallow this exception.

@aparajit-pratap for you.
