### PR TITLE
Added unit test cases for scheduler

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -250,14 +250,16 @@ namespace Dynamo.Applications.Models
             UnsubscribeTransactionManagerEvents();
         }
 
+#if !ENABLE_DYNAMO_SCHEDULER
+
         protected override void PostShutdownCore(bool shutdownHost)
         {
-#if !ENABLE_DYNAMO_SCHEDULER
             IdlePromise.ClearPromises();
             IdlePromise.Shutdown();
-#endif
             base.PostShutdownCore(shutdownHost);
         }
+
+#endif
 
         public override void ResetEngine(bool markNodesAsDirty = false)
         {


### PR DESCRIPTION
These new test cases are added to verify that `DynamoScheduler` shuts down along with its associated `ISchedulerThread` in a predefined manner. In addition to that, shutting down `DynamoModel` should also properly shutdown its `DynamoScheduler` + `ISchedulerThread`.

These test cases are added to verify the completion of [this internal task](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4686).

Hi @ke-yu, please take a look, thanks!
