### PR TITLE
Fix memory leak: move reivt event handler from RevitDynamoModel to DynamoRevit

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -172,23 +172,11 @@ namespace Dynamo.Applications.Models
 
         private void SubscribeDocumentManagerEvents()
         {
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentClosed +=
-                Application_DocumentClosed;
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened +=
-                Application_DocumentOpened;
-            DocumentManager.Instance.CurrentUIApplication.ViewActivated += Revit_ViewActivated;
-
             DocumentManager.OnLogError += this.Logger.Log;
         }
 
         private void UnsubscribeDocumentManagerEvents()
         {
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentClosed -=
-                Application_DocumentClosed;
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened -=
-                Application_DocumentOpened;
-            DocumentManager.Instance.CurrentUIApplication.ViewActivated -= Revit_ViewActivated;
-
             DocumentManager.OnLogError -= this.Logger.Log;
         }
 
@@ -308,13 +296,11 @@ namespace Dynamo.Applications.Models
         #region Event handlers 
 
         /// <summary>
-        /// Handler for Revit's DocumentOpened event.
-        /// This handler is called when a document is opened, but NOT when
-        /// a document is created from a template.
+        /// Handler Revit's DocumentOpened event.
+        /// It is called when a document is opened, but NOT when a document is 
+        /// created from a template.
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void Application_DocumentOpened(object sender, DocumentOpenedEventArgs e)
+        public void HandleApplicationDocumentOpened()
         {
             // If the current document is null, for instance if there are
             // no documents open, then set the current document, and 
@@ -329,12 +315,19 @@ namespace Dynamo.Applications.Models
         }
 
         /// <summary>
-        /// Handler for Revit's DocumentClosed event.
-        /// This handler is called when a document is closed.
+        /// Handler Revit's DocumentClosing event.
+        /// It is called when a document is closing.
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void Application_DocumentClosed(object sender, DocumentClosedEventArgs e)
+        public void HandleApplicationDocumentClosing(Document doc)
+        {
+            // no-op on revit2014
+        }
+
+        /// <summary>
+        /// Handle Revit's DocumentClosed event.
+        /// It is called when a document is closed.
+        /// </summary>
+        public void HandleApplicationDocumentClosed()
         {
             // If the active UI document is null, it means that all views have been 
             // closed from all document. Clear our reference, present a warning,
@@ -366,13 +359,11 @@ namespace Dynamo.Applications.Models
         }
 
         /// <summary>
-        /// Handler for Revit's ViewActivated event.
-        /// This handler is called when a view is activated. It is called
-        /// after the ViewActivating event.
+        /// Handler Revit's ViewActivated event.
+        /// It is called when a view is activated. It is called after the 
+        /// ViewActivating event.
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void Revit_ViewActivated(object sender, ViewActivatedEventArgs e)
+        public void HandleRevitViewActivated()
         {
             // If there is no active document, then set it to whatever
             // document has just been activated


### PR DESCRIPTION
This is the last pull request for fixing  [memory leak in Revit](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3404).

Other merged pull requests for fixing memory leak:
- [Not register event handler for Dispatcher.ShutdownStarted event](https://github.com/DynamoDS/Dynamo/pull/2888)
- [Clear task queue when Scheduler is shutdown](https://github.com/DynamoDS/Dynamo/pull/2881)
- [Inherit from NotificationObject to avoid memory leak in data binding](https://github.com/DynamoDS/Dynamo/pull/2890)
- [Fix memory leak in NUnit - DynamoCoreTest](https://github.com/DynamoDS/Dynamo/pull/2859)

Memory leak in Revit is because Dynamo's root object `RevitDynamoModel` is still referenced from CLR's system objects or from Revit application's global object after it has been out of scope. 

In Revit, although `RevitDynamoModel` properly unsubscribed Revit's application events (`DocumentOpening`, `DocumentOpened`, `DocumentClosed` and `ViewActivated`) when Dynamo is closed, the reference is not removed. Following reference retention paths are generated by dotMemory, it shows these event handlers are still referencing dead `RevitDynamoModel` instance:

![image001](https://cloud.githubusercontent.com/assets/2600379/4847562/ef828e24-6053-11e4-8a7a-ade5803379b0.png)

I wrote a test app which also proved these event handlers keep reference to the instance that ever subscribes one of these event, so in the pull request I move event handler from `RevitDynamoModel` to `DynamoRevit`. The latter just calls the corresponding function in `RevitDynamoModel` when an event is fired. 

Verified on Revit2015 with dotMemory that `RevitDynamoModel` is no longer leak. 

Primary reviewers:
- [x] @ikeough 
- [ ] @pboyer 
