### PR TITLE
Build fix: Incorrect Hint Path in RevitTestServices.csproj

### DIFF
--- a/test/Libraries/Revit/RevitTestServices/RevitTestServices.csproj
+++ b/test/Libraries/Revit/RevitTestServices/RevitTestServices.csproj
@@ -57,7 +57,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="RevitAPIUI">
-      <HintPath>..\..\..\..\..\..\..\..\..\Program Files\Autodesk\Revit Architecture 2014\RevitAPIUI.dll</HintPath>
+      <HintPath>$(REVITAPI)\RevitAPIUI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
Merging this build fix right in.

@ikeough, just FYI.
