### PR TITLE
Filter hidden classes after detecting namespace collisions in autocomplete

### DIFF
--- a/src/DynamoCore/DSEngine/CodeCompletionServices.cs
+++ b/src/DynamoCore/DSEngine/CodeCompletionServices.cs
@@ -108,13 +108,14 @@ namespace Dynamo.DSEngine.CodeCompletion
             {
                 if (group.Count() > 1)
                 {
-                    completions.AddRange(group.Select(x =>
-                    {
-                        return CompletionData.ConvertMirrorToCompletionData(x, useFullyQualifiedName: true);
-                    }));
+                    completions.AddRange(group.
+                        Where(x => !x.IsHiddenInLibrary).
+                        Select(x =>CompletionData.ConvertMirrorToCompletionData(x, useFullyQualifiedName: true)));
                 }
                 else
-                    completions.AddRange(group.Select(x => CompletionData.ConvertMirrorToCompletionData(x)));
+                    completions.AddRange(group.
+                        Where(x => !x.IsHiddenInLibrary).
+                        Select(x => CompletionData.ConvertMirrorToCompletionData(x)));
             }
 
             // Add matching builtin methods

--- a/src/Engine/ProtoCore/Reflection/Mirror.cs
+++ b/src/Engine/ProtoCore/Reflection/Mirror.cs
@@ -410,11 +410,7 @@ namespace ProtoCore
             public static IEnumerable<ClassMirror> GetClasses(Core core)
             {
                 return core.ClassTable.ClassNodes.Skip((int)PrimitiveType.kMaxPrimitives).
-                    Where(x =>
-                        {
-                            bool hidden = x.ClassAttributes == null ? false : x.ClassAttributes.HiddenInLibrary;
-                            return !hidden && !CoreUtils.StartsWithSingleUnderscore(x.name);
-                        }).
+                    Where(x => !CoreUtils.StartsWithSingleUnderscore(x.name)).
                     Select(x => new ClassMirror(core, x));
             }
 
@@ -548,7 +544,14 @@ namespace ProtoCore
                     }
                     return classNode;
                 }
+            }
 
+            public bool IsHiddenInLibrary
+            {
+                get
+                {
+                    return ClassNode.ClassAttributes == null ? false : ClassNode.ClassAttributes.HiddenInLibrary;
+                }
             }
 
             public ClassMirror(ProtoCore.Type type, ProtoCore.Core core)

--- a/test/Engine/FFITarget/CodeCompletionClass.cs
+++ b/test/Engine/FFITarget/CodeCompletionClass.cs
@@ -99,6 +99,13 @@ namespace FFITarget
             public string PropertyB { get; set; }
             public string PropertyC { get; set; }
         }
+
+        public class AnotherClassWithNameConflict
+        {
+            public static string PropertyA { get; set; }
+            public static string PropertyB { get; set; }
+            public static string PropertyC { get; set; }
+        }
     }
 
     namespace SecondNamespace
@@ -108,6 +115,14 @@ namespace FFITarget
             public string PropertyD { get; set; }
             public string PropertyE { get; set; }
             public string PropertyF { get; set; }
+        }
+
+        [IsVisibleInDynamoLibrary(false)]
+        public class AnotherClassWithNameConflict
+        {
+            public static string PropertyD { get; set; }
+            public static string PropertyE { get; set; }
+            public static string PropertyF { get; set; }
         }
     }
 }


### PR DESCRIPTION
This submission corrects the earlier PR:https://github.com/DynamoDS/Dynamo/pull/2911 to filter classes that were hidden from library. This was causing class name collisions to be examined after filtering out hidden classes, which is incorrect as then collisions with hidden classes are not detected. This is corrected here by first testing for collisions and then filtering out hidden classes by their `IsHiddenInLibrary` property.

@Benglin please review.
