### PR TITLE
Fix for completion while typing - MAGN-5139

### DIFF
--- a/src/DynamoCore/UI/Controls/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCore/UI/Controls/CodeBlockEditor.xaml.cs
@@ -222,7 +222,9 @@ namespace Dynamo.UI.Controls
         {
             try
             {
-                var code = this.InnerTextEditor.Text.Substring(0, this.InnerTextEditor.CaretOffset);
+                int startPos = this.InnerTextEditor.CaretOffset;
+                var code = this.InnerTextEditor.Text.Substring(0, startPos);
+                
                 if (e.Text == ".")
                 {
                     string stringToComplete = CodeCompletionParser.GetStringToComplete(code).Trim('.');
@@ -252,6 +254,11 @@ namespace Dynamo.UI.Controls
                 }
                 else if (completionWindow == null && (char.IsLetterOrDigit(e.Text[0]) || char.Equals(e.Text[0], '_')))
                 {
+                    // Begin completion while typing only if the previous character already typed in
+                    // is a white space or non-alphanumeric character
+                    if (startPos > 1 && char.IsLetterOrDigit(InternalEditor.Document.GetCharAt(startPos - 2)))
+                        return;
+
                     // Autocomplete as you type
                     // complete global methods (builtins), all classes, symbols local to codeblock node
                     string stringToComplete = CodeCompletionParser.GetStringToComplete(code);


### PR DESCRIPTION
This submission fixes an issue in "completion as you type" where if you select an item in the completion window after typing something and then edit the item selected, in the code block, by either doing a backspace on a few characters or by continuing to type immediately after the string, the completion window pops up again. On a subsequent selection of an item from the completion window, the newly selected string is appended to the existing string in the code block which is incorrect behavior. See defect: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5139 for reference.

This fix prevents the completion window from appearing again unless the first string is deleted completely and the user begins typing again. This is the conventional auto-completion behavior in standard IDE's like Visual Studio and prevents unexpected results like the one shown in the defect.

Note: This is a UI related fix and the current autocompletion API-based test fx cannot support testing this behavior.

@Benglin please review.
