### PR TITLE
Fix hard crash of Revit on Dynamo crash

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -396,9 +396,6 @@ namespace Dynamo.Applications
             finally
             {
                 args.Handled = true;
-
-                // KILLDYNSETTINGS - this is suspect
-                revitDynamoModel.Logger.Dispose();
                 DynamoRevitApp.DynamoButton.Enabled = true;
             }
         }


### PR DESCRIPTION
### Issue

Right now, in the majority of cases, a hard crash of Dynamo will also cause a hard crash of Revit.  

In the `Dispatcher` exception in DynamoRevit, we use a reference to `RevitDynamoModel`.  This reference has already been set to `null` in line 452 of `DynamoRevit.`  Therefore, we should avoid referencing it in the finally block inside of this handler.  

In fact, we should avoid doing anything complex in this block.  
### Fix

I removed the erroneous call to `Logger.Dispose` in the finally block.  This is already called `OnDynamoViewClosed`.  
### Reviewers
- [x] @ikeough 
- [x] @Benglin 
