### PR TITLE
Add regression test case

### DIFF
--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -5223,10 +5223,12 @@ a = p.UpdateCount;
 
         [Test]
         [Category("Failure")]
-        public void RegressMAGN5311()
+        public void RegressMAGN5353()
         {
             // This test case tries to verify that when a FFI object is deleted, 
             // the corresponding _Dispose() should be invoked.
+            //
+            // It is for defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5353
             var added = new List<Subtree>();
 
             var guid1 = Guid.NewGuid();


### PR DESCRIPTION
This pull request added a language test case for defect [MAGN-5311: GC: The old element is not deleted when input is switched to another subgrap](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5311)

The following steps demonstrate this issue:
1. Use `Point.ByCoordinates()` node to create a point
2. Delete this node and run
3. In debug mode, verify geometry's Dispose() method is not invoked.

@riteshchandawar for your review. 
