### PR TITLE
Fix in autocomplete for insertion of completion item and closing completion window

### DIFF
--- a/src/DynamoCore/UI/Controls/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCore/UI/Controls/CodeBlockEditor.xaml.cs
@@ -212,7 +212,7 @@ namespace Dynamo.UI.Controls
                     {
                         completionWindow.CompletionList.RequestInsertion(e);
                     }
-                    else if (!char.IsLetterOrDigit(currentChar) && !char.Equals(currentChar, '_'))
+                    else if (!char.IsLetterOrDigit(currentChar) && currentChar != '_')
                     {
                         // In all other cases where what is being typed is not alpha-numeric 
                         // we want to get rid of the completion window 


### PR DESCRIPTION
This is a fix for a regression caused by an earlier PR: https://github.com/DynamoDS/Dynamo/pull/2990

The earlier fix was to allow auto-insertion of the completion item only on certain keystrokes such as Tab, Enter, and '.' 

Since the act of insertion would also close the completion window automatically, after the above change, the completion window would not close on all other keystrokes. This fix adds another condition that ensures the completion window is closed for all other keystrokes that are not alphanumeric characters.

@Benglin sorry for the repeat PR. I should have anticipated this before.
