### PR TITLE
Fix MAGN-5374

### DIFF
--- a/src/Libraries/Revit/RevitNodes/AnalysisDisplay/AbstractAnalysisDisplay.cs
+++ b/src/Libraries/Revit/RevitNodes/AnalysisDisplay/AbstractAnalysisDisplay.cs
@@ -184,7 +184,7 @@ namespace Revit.AnalysisDisplay
                 // then create a new SFM
                 if (sfm.NumberOfMeasurements != numValuesPerAnalysisPoint)
                 {
-                    DocumentManager.Instance.CurrentDBDocument.Delete(sfm);
+                    DocumentManager.Instance.CurrentDBDocument.Delete(sfm.Id);
                     sfm = SpatialFieldManager.CreateSpatialFieldManager(view, (int)numValuesPerAnalysisPoint);
                 }
             }

--- a/test/Libraries/Revit/RevitTestServices/SystemTestBase.cs
+++ b/test/Libraries/Revit/RevitTestServices/SystemTestBase.cs
@@ -136,10 +136,10 @@ namespace RevitTestServices
                 var p1 = new Plane(XYZ.BasisZ, XYZ.Zero);
                 var p2 = new Plane(XYZ.BasisZ, new XYZ(0, 0, 5));
 
-                SketchPlane sp1 = DocumentManager.Instance.CurrentUIDocument.Document.FamilyCreate.NewSketchPlane(p1);
-                SketchPlane sp2 = DocumentManager.Instance.CurrentUIDocument.Document.FamilyCreate.NewSketchPlane(p2);
-                Curve c1 = DocumentManager.Instance.CurrentUIApplication.Application.Create.NewLineBound(XYZ.Zero, new XYZ(1, 0, 0));
-                Curve c2 = DocumentManager.Instance.CurrentUIApplication.Application.Create.NewLineBound(new XYZ(0, 0, 5), new XYZ(1, 0, 5));
+                SketchPlane sp1 = SketchPlane.Create(DocumentManager.Instance.CurrentDBDocument, p1);
+                SketchPlane sp2 = SketchPlane.Create(DocumentManager.Instance.CurrentDBDocument, p2);
+                Curve c1 = Line.CreateBound(XYZ.Zero, new XYZ(1, 0, 0));
+                Curve c2 = Line.CreateBound(new XYZ(0, 0, 5), new XYZ(1, 0, 5));
                 mc1 = DocumentManager.Instance.CurrentUIDocument.Document.FamilyCreate.NewModelCurve(c1, sp1);
                 mc2 = DocumentManager.Instance.CurrentUIDocument.Document.FamilyCreate.NewModelCurve(c2, sp2);
 
@@ -160,8 +160,8 @@ namespace RevitTestServices
 
                 var p1 = new Plane(XYZ.BasisZ, XYZ.Zero);
 
-                SketchPlane sp1 = DocumentManager.Instance.CurrentUIDocument.Document.FamilyCreate.NewSketchPlane(p1);
-                Curve c1 = DocumentManager.Instance.CurrentUIApplication.Application.Create.NewLineBound(XYZ.Zero, new XYZ(1, 0, 0));
+                SketchPlane sp1 = SketchPlane.Create(DocumentManager.Instance.CurrentDBDocument, p1);
+                Curve c1 = Line.CreateBound(XYZ.Zero, new XYZ(1, 0, 0));
                 mc1 = DocumentManager.Instance.CurrentUIDocument.Document.FamilyCreate.NewModelCurve(c1, sp1);
 
                 trans.Commit();


### PR DESCRIPTION
<h6>Summary</h6>


There are some warnings caused by obsoleted functions when building the master branch. The obsoleted functions are:
Autodesk.Revit.Creation.Application.NewLineBound(Autodesk.Revit.DB.XYZ, Autodesk.Revit.DB.XYZ)
Autodesk.Revit.Creation.ItemFactoryBase.NewSketchPlane(Autodesk.Revit.DB.Plane)
Autodesk.Revit.DB.Document.Delete(Autodesk.Revit.DB.Element)

This submission updates the functions to use the newer version:
Use Line.CreateBound instead of Application.NewLineBound
Use SketchPlane.Create instead of FamilyCreate.NewSketchPlane
Use Delete(ElementId) instead of Delete(Element)

@ikeough 
PTAL
