### PR TITLE
Fix regressed test case

### DIFF
--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -1562,7 +1562,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(0, cbn.OutPorts[0].MarginThickness.Top);
 
             Assert.AreEqual("t_1", cbn.OutPorts[1].ToolTipContent);
-            Assert.IsTrue(Math.Abs(cbn.OutPorts[1].MarginThickness.Top - 7 * codeBlockPortHeight) <= tolerance);
+            Assert.IsTrue(Math.Abs(cbn.OutPorts[1].MarginThickness.Top - 3 * codeBlockPortHeight) <= tolerance);
 
         }
 


### PR DESCRIPTION
This pull request fix regressed test case `DynamoCoreUITests.RecordedTestsDSEngine.Defect_MAGN_904`.

This is because a recent change that temporary variable name is shorten (pull request: #3030), therefore in this UI test, the original two long statements no longer occupies 6 lines (each one occupies 3 lines) but only 2 lines, so output port position is shifted up. 

@Benglin please help to review the change.  
