### PR TITLE
Handle more types for List.UniqueItems

### DIFF
--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -844,6 +844,11 @@ namespace DSCore
 
             bool IEqualityComparer<object>.Equals(object x, object y)
             {
+                // If both x and y are null, we can't compare null == null. 
+                // See: http://stackoverflow.com/questions/4730648/c-sharp-nullable-equality-operations-why-does-null-null-resolve-as-false
+                if (ReferenceEquals(x, null) && ReferenceEquals(y, null))
+                    return true;
+
                 return Eq(x as dynamic, y as dynamic);
             }
 

--- a/test/Libraries/CoreNodesTests/ListTests.cs
+++ b/test/Libraries/CoreNodesTests/ListTests.cs
@@ -85,6 +85,20 @@ namespace DSCoreNodesTests
             Assert.AreEqual(new ArrayList { true },
                 List.UniqueItems(new ArrayList { true, true, true, true, true}));
         }
+
+        [Test]
+        public static void UniqueInNullList()
+        {
+            Assert.AreEqual(new ArrayList { null },
+                List.UniqueItems(new ArrayList { null, null, null, null }));
+        }
+
+        [Test]
+        public static void UniqueInCombineList()
+        {
+            Assert.AreEqual(new ArrayList { true, null, 'a', "foo"},
+                List.UniqueItems(new ArrayList { true, true, null, null, 'a', 'a', "foo", "foo" }));
+        }
         #endregion
 
         [Test]


### PR DESCRIPTION
To fix defects
1. [MAGN-4640 List Unique Items for strings?](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4640)
2. [MAGN-5323 List.UniqueItems will not work on lists with null values](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5323)

For null value, we compare them separately with `null`.

For other types that implements `IConvertible`,  we call the corresponding convert to convert object to target type and do comparison. 

Related test cases added. 

@sharadkjaiswal  for you to review. 
