### PR TITLE
Implement Equals() and GetHashCode() for Element

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Element.cs
@@ -182,6 +182,34 @@ namespace Revit.Elements
             return GetType().Name;
         }
 
+        /// <summary>
+        /// Implement Equals() method. 
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        [IsVisibleInDynamoLibrary(false)]
+        public override bool Equals(object obj)
+        {
+            Element otherElement = obj as Element;
+            if (otherElement == null)
+            {
+                return false;
+            }
+
+            return UniqueId.Equals(otherElement.UniqueId);
+        }
+
+        /// <summary>
+        /// Get hash code.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        [IsVisibleInDynamoLibrary(false)]
+        public override int GetHashCode()
+        {
+            return UniqueId.GetHashCode();
+        }
+
         public virtual string ToString(string format, IFormatProvider formatProvider)
         {
             // As a default, return the standard string representation.


### PR DESCRIPTION
This is to fix defect [MAGN-5110 List.UniqueItems does not work for Revit elements](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5110)

Override `Equals()` and `GetHashCode()`. 

![untitled](https://cloud.githubusercontent.com/assets/2600379/5022848/aa529fa4-6b27-11e4-9b4b-e035da6db333.png)

@ikeough , after I override these two methods, `Elements.Equals()` is called in `ElementIDLifecycleManager.RegisterAssociation()/UnRegisterAssociation()`. Is it safe to do comparison based on `Element.UniqueId`?
