### PR TITLE
Fix for regression: MAGN-5427 VM Databridge showing in the UI

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -1244,30 +1244,29 @@ namespace ProtoFFI
 
         public FFIMethodAttributes(MethodInfo method, Dictionary<MethodInfo, Attribute[]> getterAttributes)
         {
+            if (method == null)
+                throw new ArgumentNullException("method");
+
+            FFIClassAttributes baseAttributes = null;
+            Type type = method.DeclaringType;
+            if (!CLRModuleType.TryGetTypeAttributes(type, out baseAttributes))
+            {
+                baseAttributes = new FFIClassAttributes(type);
+                CLRModuleType.SetTypeAttributes(type, baseAttributes);
+            }
+
+            if (null != baseAttributes)
+            {
+                HiddenInLibrary = baseAttributes.HiddenInLibrary;
+            }
+
             Attribute[] atts = null;
             if (getterAttributes.TryGetValue(method, out atts))
             {
                 attributes = atts;
             }
             else
-            {
-
-                if (method == null)
-                    throw new ArgumentNullException("method");
-
-                FFIClassAttributes baseAttributes = null;
-                Type type = method.DeclaringType;
-                if (!CLRModuleType.TryGetTypeAttributes(type, out baseAttributes))
-                {
-                    baseAttributes = new FFIClassAttributes(type);
-                    CLRModuleType.SetTypeAttributes(type, baseAttributes);
-                }
-
-                if (null != baseAttributes)
-                {
-                    HiddenInLibrary = baseAttributes.HiddenInLibrary;
-                }
-
+            {   
                 attributes = method.GetCustomAttributes(false).Cast<Attribute>().ToArray();
             }
             


### PR DESCRIPTION
This is a fix for regression caused by: https://github.com/aparajit-pratap/Dynamo/commit/c4cb901182b7066995e43c9db6e590dc630b91e2

The `HiddenInLibrary` attribute on the type was earlier not being assigned to the getter `MethodInfo`. This has now been fixed.

@sharadkjaiswal please review 
