### PR TITLE
Re-enable two properties on Element.

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Element.cs
@@ -55,7 +55,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get the Name of the Element
         /// </summary>
-        internal string Name
+        public string Name
         {
             get
             {
@@ -92,7 +92,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get the Element Unique Id for this element
         /// </summary>
-        internal string UniqueId
+        public string UniqueId
         {
             get
             {


### PR DESCRIPTION
This PR re-enables two properties that were disabled in an earlier PR. 

Sorry @aparajit-pratap. I should have caught these when they came through. Because these return strings, they're safe, and they are actually used by users. I'm merging this now for 0.7.4, but please double check me.

TBR:
- [ ] @aparajit-pratap 
