### PR TITLE
Make ElementWrapper public to be able to use its APIs in Python scripts

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -15,7 +15,8 @@ namespace Revit.Elements
     /// Element wrapper supplies tools for wrapping Autodesk.Revit.DB.Element types
     /// in their associated Revit.Elements.Element wrapper
     /// </summary>
-    internal static class ElementWrapper
+    [SupressImportIntoVM]
+    public static class ElementWrapper
     {
         /// <summary>
         /// If possible, wrap the element in a DS type


### PR DESCRIPTION
This fix is related to user issue: https://github.com/DynamoDS/Dynamo/issues/2460#issuecomment-63260413

@ikeough @kronz @pboyer please review.
