### PR TITLE
Fix for panning ends active connector

### DIFF
--- a/src/DynamoCore/UI/DragCanvas.cs
+++ b/src/DynamoCore/UI/DragCanvas.cs
@@ -192,17 +192,7 @@ namespace Dynamo.Controls
            if(this.IsMouseCaptured)
                this.ReleaseMouseCapture();
         }
-
-        protected override void OnMouseLeave(MouseEventArgs e)
-        {
-            //if the mouse is released outside the canvas then remove the selection 
-            object dataContext = this.owningWorkspace.DataContext;
-            WorkspaceViewModel wvm = dataContext as WorkspaceViewModel;
-            //if the state is connecting, then do not remove the selection
-            if(!wvm.IsConnecting)
-                wvm.HandleFocusChanged(this, false);
-        }
-
+       
         protected override void OnIsKeyboardFocusWithinChanged(DependencyPropertyChangedEventArgs e)
         {
             // If the focus falls on a node's text box, or a slider's thumb, 


### PR DESCRIPTION
This fix is for panning ends active connector.

If the workspace has an active connection (i.e the state is in connecting mode), then the connector will not be removed even if the mouse is dragged outside the canvas. At the same time, if selection box is moved outside the canvas, then the selection will be removed. 
- [x] @Benglin 
- [x] @aparajit-pratap 
