### PR TITLE
DNM: Fix magn3979 ternary operator should act on each item of a list

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -6800,7 +6800,7 @@ namespace ProtoAssociative
                 // As SSA conversion is enabled, we have got the values of
                 // true and false branch, so it isn't necessary to create 
                 // language blocks.
-                if (core.Options.IsDeltaExecution && core.Options.GenerateSSA)
+                if (core.Options.GenerateSSA)
                 {
                     inlineCall.FormalArguments.Add(inlineConditionalNode.ConditionExpression);
                     inlineCall.FormalArguments.Add(inlineConditionalNode.TrueExpression);

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -777,8 +777,8 @@ namespace ProtoCore.Lang
                     Parameters = new List<KeyValuePair<string, ProtoCore.Type>>
                     {
                         new KeyValuePair<string, ProtoCore.Type>("condition", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeBool, 0)),
-                        new KeyValuePair<string, ProtoCore.Type>("dyn1", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, Constants.kArbitraryRank)),
-                        new KeyValuePair<string, ProtoCore.Type>("dyn2", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, Constants.kArbitraryRank))
+                        new KeyValuePair<string, ProtoCore.Type>("dyn1", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, 0)),
+                        new KeyValuePair<string, ProtoCore.Type>("dyn2", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, 0))
                     },
                     ID = BuiltInMethods.MethodID.kInlineConditional
                 },

--- a/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
@@ -921,7 +921,7 @@ namespace Dynamo.Tests
         public void Test_IFnode_3483_2()
         {
             RunModel(@"core\dsevaluation\ifnode_3483_2.dyn");
-            AssertPreviewValue("70b5aeba-80b7-48cc-a48d-6c755c28555c", new object []{ 1, 1, 1, new object []{ -2, -1, 0, 1, 2 },new object[] { -2, -1, 0, 1, 2 } });
+            AssertPreviewValue("70b5aeba-80b7-48cc-a48d-6c755c28555c", new object []{ 1, 1, 1, 1, 2});
         }
         [Test]
         [Category("RegressionTests")]
@@ -951,7 +951,7 @@ namespace Dynamo.Tests
         public void Test_IfAsFunctionobject_3483()
         {
             RunModel(@"core\dsevaluation\IfAsFunctionobject_3483.dyn");
-            AssertPreviewValue("80d14b69-4796-48c9-a34d-f447abf7b5ba", new object[] {1,1,new double[]{-2,-1,0,1,2},1,1});
+            AssertPreviewValue("80d14b69-4796-48c9-a34d-f447abf7b5ba", new object[] {1, -1, -1, 1});
         }
         
         [Test]

--- a/test/DynamoCoreTests/Nodes/IfTest.cs
+++ b/test/DynamoCoreTests/Nodes/IfTest.cs
@@ -22,11 +22,7 @@ namespace Dynamo.Tests
             RunModel(testFilePath);
 
             AssertPreviewValue("7d6e8c70-3abf-4fc4-864e-948f548e7ba2", 5.0);
-            AssertPreviewValue("d5f5336d-3569-4a88-9a59-5538d6914037",
-                               new object[] { 1, 1, 1, 1, 
-                                              new object[] {-3, -2, -1, 0, 1, 2, 3},
-                                              new object[] {-3, -2, -1, 0, 1, 2, 3},
-                                              new object[] {-3, -2, -1, 0, 1, 2, 3}});
+            AssertPreviewValue("d5f5336d-3569-4a88-9a59-5538d6914037", new object[] { 1, 1, 1, 1, 1, 2, 3});
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/Associative/InlineCondition.cs
+++ b/test/Engine/ProtoTest/TD/Associative/InlineCondition.cs
@@ -561,7 +561,7 @@ x = c > 1 ? a : b;
 test = x;";
             string errmsg = "";//1467290 sprint25: rev 3731 : REGRESSION : Update with inline condition across multiple language blocks is not working as expected";
             thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("x", 1);
+            thisTest.Verify("x", new [] {2, 2});
         }
 
 

--- a/test/Engine/ProtoTest/TD/Associative/InlineCondition.cs
+++ b/test/Engine/ProtoTest/TD/Associative/InlineCondition.cs
@@ -145,9 +145,9 @@ namespace ProtoTest.TD.Associative
             Object[] b = new Object[] { 1, 2, 3, 4 };
             Object[] c = new Object[] { 1, 2, 3 };
             Object[] d = new Object[] { 1, 2 };
-            Object[] b1 = new Object[] { b, b, b, true };
-            Object[] b2 = new Object[] { c, c, c, true };
-            Object[] b3 = new Object[] { d, d, d, c };
+            Object[] b1 = new Object[] { 1, 2, 3, true };
+            Object[] b2 = new Object[] { 1, 2, 3};
+            Object[] b3 = new Object[] { 1, 2};
             thisTest.Verify("b1", b1);
             thisTest.Verify("b2", b2);
             thisTest.Verify("b3", b3);
@@ -177,7 +177,7 @@ namespace ProtoTest.TD.Associative
             // List<Object> b = new List<object>() { 1, 6, 3, 10, 5 };
             // Assert.IsTrue(mirror.CompareArrays("b", b, typeof(System.Int64)));
             List<Object> c = new List<object>() { 4, 6, 8, 10, 12 };
-            List<Object> d = new List<object>() { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            List<Object> d = new List<object>() { 1, 2, 3, 4, 5};
             List<Object> e1 = new List<object>() { 2, 3 };
             Assert.IsTrue(mirror.CompareArrays("c", c, typeof(System.Int64)));
             Assert.IsTrue(mirror.CompareArrays("d", d, typeof(System.Int64)));
@@ -197,7 +197,7 @@ namespace ProtoTest.TD.Associative
 	x_1 = x[1];
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(src);
-            Object[] b1 = new Object[] { new Object[] { 1, 1 }, new Object[] { 1, 1 }, 0, 0 };
+            Object[] b1 = new Object[] { 1, 1};
             thisTest.Verify("x", b1);
         }
 
@@ -249,7 +249,7 @@ number = { 3, -3 };
 ";
             thisTest.VerifyRunScriptSource(src, errmsg);
             Object n1 = null;
-            thisTest.Verify("b", new object[] { new object[] { 2, 4, 6 }, new object[] { 2, 4, 6 }, new object[] { 2, 4, 6 } });
+            thisTest.Verify("b", new object[] { 2, 4, 6 });
             thisTest.Verify("a", 10);
             thisTest.Verify("c", 13);
             thisTest.Verify("d", 53);
@@ -561,7 +561,7 @@ x = c > 1 ? a : b;
 test = x;";
             string errmsg = "";//1467290 sprint25: rev 3731 : REGRESSION : Update with inline condition across multiple language blocks is not working as expected";
             thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("x", 2);
+            thisTest.Verify("x", 1);
         }
 
 
@@ -1174,9 +1174,9 @@ z;
         [Test]
         public void TestInlineConditionReplication()
         {
-            string code = @"x = -2..2; y = (x % 2 == 0) ? (-x) : x;";
+            string code = @"x = -2..2; y = (x % 2 == 0) ? -x : x;";
             thisTest.VerifyRunScriptSource(code, "");
-            thisTest.Verify("y", new object[] { -2, 1, 0, -1, 2 });
+            thisTest.Verify("y", new object[] { 2, -1, 0, 1, -2 });
         }
     }
 }

--- a/test/Engine/ProtoTest/TD/Associative/InlineCondition.cs
+++ b/test/Engine/ProtoTest/TD/Associative/InlineCondition.cs
@@ -1170,5 +1170,13 @@ z;
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("z", new Object[] { 2, 1 });
         }
+
+        [Test]
+        public void TestInlineConditionReplication()
+        {
+            string code = @"x = -2..2; y = (x % 2 == 0) ? (-x) : x;";
+            thisTest.VerifyRunScriptSource(code, "");
+            thisTest.Verify("y", new object[] { -2, 1, 0, -1, 2 });
+        }
     }
 }

--- a/test/Engine/ProtoTest/TD/Associative/Replication.cs
+++ b/test/Engine/ProtoTest/TD/Associative/Replication.cs
@@ -1520,7 +1520,7 @@ list6 = c > a ? 1 : 0; // { 1, 1, 0, 0 }";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             //Assert.Fail("1456751 : Sprint16 : Rev 990 : Inline conditions not working with replication over collections");
             thisTest.Verify("list2", new object[] { 1, 0, 1, 0, 1 });
-            thisTest.Verify("list3", 10);
+            thisTest.Verify("list3", new object[] {10, 10, 10, 10, 10});
             thisTest.Verify("list4", new object[] { 1, 0, 1, 0, 1 });
             thisTest.Verify("list5", new object[] { 0, 0, 0, 1, 1 });
             thisTest.Verify("list6", new object[] { 1, 1, 0, 0 });
@@ -1546,12 +1546,12 @@ c = { 1, 4, 7 };
 list8 = a >= b ? a + c : 10; // { 10, 10, 10 }
 list9 = a < b ? 10 : a + c; // { 10, 10, 10 }";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
-            thisTest.Verify("list3", new object[] { a1, 0, a1, 0 });
-            thisTest.Verify("list4", new object[] { 0, a1, 0, a1 });
+            thisTest.Verify("list3", new object[] { 1, 0, 3, 0 });
+            thisTest.Verify("list4", new object[] { 0, 2, 0, 4 });
             thisTest.Verify("list6", a1);
-            thisTest.Verify("list7", new object[] { -1, -2, -3, -4, -5, -6 });
-            thisTest.Verify("list8", new object[] { 10, 10, a2, a2 });
-            thisTest.Verify("list9", new object[] { 10, 10, a2, a2 });
+            thisTest.Verify("list7", new object[] { -1, -2, -3, -4, -5 });
+            thisTest.Verify("list8", new object[] { 10, 10, 10});
+            thisTest.Verify("list9", new object[] { 10, 10, 10});
         }
 
         [Test]
@@ -1565,7 +1565,7 @@ c = { { 1, 2, 3, 4 }, { 5, 6, 7, 8 }, { 9, 10, 11, 12 } };
 list = a > b ? b + c : a + c; // { { 2, 4, }, { 8, 10 } } ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             //Assert.Fail("1456751 : Sprint16 : Rev 990 : Inline conditions not working with replication over collections");
-            Object[] b1 = new Object[] { new Object[] { new Object[] { new Object[] { 2, 4, 6 }, new Object[] { 9, 11, 13 } }, new Object[] { new Object[] { 2, 4, 6 }, new Object[] { 9, 11, 13 } } }, new Object[] { new Object[] { new Object[] { 2, 4 }, new Object[] { 8, 10 }, new Object[] { 14, 16 } }, new Object[] { new Object[] { 2, 4 }, new Object[] { 8, 10 }, new Object[] { 14, 16 } } } };
+            Object[] b1 = new Object[] { new [] { 2, 4 }, new [] { 8, 10 } }; 
             thisTest.Verify("list", b1);
         }
 
@@ -1575,11 +1575,11 @@ list = a > b ? b + c : a + c; // { { 2, 4, }, { 8, 10 } } ";
         {
             Object[] list2 = { 1, 2, 3, 4 };
             Object[] list3 = { -1, -2, -3, -4, -5, -6 };
-            Object[] list4 = new Object[] { list2, list3, list2, list2, list3 };
-            Object[] list5 = new Object[] { list4, list2, list4, list4, list2 };
+            Object[] list4 = new Object[] { 1, -2, 3, 4 };
+            Object[] list5 = new Object[] { 1, 2, 3, 4 };
             Object[] list6 = { -1, -2, -3, -4, -5 };
-            Object[] list7 = new Object[] { list2, list6, list2, list2, list6 };
-            Object[] list8 = new Object[] { new Object[] { 1, 4, 0 }, new Object[] { 0, 5, 1, 5 }, new Object[] { 0, 5, 1, 5 } };
+            Object[] list7 = new Object[] { 1, -2, 3, 4 };
+            Object[] list8 = new Object[] { 1, 5, 1};
             string code = @"
 list1 = { true, false, true, true, false };
 list2 = { 1, 2, 3, 4 };
@@ -1606,9 +1606,9 @@ list8 = a < c ? b + c : a + c; // { 1, 4, 1 }";
         {
             Object[] list2 = { 1, 2, 3, 4 };
             Object[] list3 = { -1, -2, -3, -4 };
-            Object[] list6 = new Object[] { new Object[] { -4, -1, 2 }, new Object[] { -4, -1, 2 }, new Object[] { 8, 17, 8 } };
-            Object[] list5 = new Object[] { list3, list2, list2, list3 };
-            Object[] list4 = new Object[] { list2, list3, list3, list2 };
+            Object[] list6 = new Object[] { -4, -1, 8 };
+            Object[] list5 = new Object[] { -1, 2, 3, -4};
+            Object[] list4 = new Object[] { 1, -2, -3, 4 };
             string code = @"
 list1 = { true, false, false, true };
 list2 = { 1, 2, 3, 4 };
@@ -3833,7 +3833,7 @@ test = b.a;
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("test", new Object[] { new Object[] { 0, 1 }, new Object[] { 0, 1 } });
+            thisTest.Verify("test", new Object[] { 0, 1});
         }
 
         [Test]
@@ -6206,7 +6206,7 @@ d2;f2;
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
             Object[] v1 = new Object[] { false, false };
-            thisTest.Verify("d2", new Object[] { v1, v1 });
+            thisTest.Verify("d2", v1);
             thisTest.Verify("f2", v1);
 
         }
@@ -6232,7 +6232,7 @@ d2 = [Imperative]
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
             Object[] v1 = new Object[] { false, false };
-            thisTest.Verify("d2", new Object[] { v1, v1 });
+            thisTest.Verify("d2", v1);
         }
 
         [Test]
@@ -6260,7 +6260,7 @@ test2 = a.f2;
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
             Object[] v1 = new Object[] { false, true };
-            thisTest.Verify("test1", new Object[] { new Object[] { 0, 0 }, 1 });
+            thisTest.Verify("test1", new Object[] { 0, 1});
             thisTest.Verify("test2", v1);
         }
 

--- a/test/Engine/ProtoTest/TD/Imperative/IfElseTest.cs
+++ b/test/Engine/ProtoTest/TD/Imperative/IfElseTest.cs
@@ -1829,7 +1829,7 @@ d2;
     //f2 = a2 > b2;	
 }";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
-            Object[] v1 = new Object[] { new Object[] { false, false }, new Object[] { false, false } };
+            Object[] v1 = new Object[] { false, false};
             //Verification 
             thisTest.Verify("d2", v1);
 

--- a/test/Engine/ProtoTest/TD/Imperative/InlineCondition.cs
+++ b/test/Engine/ProtoTest/TD/Imperative/InlineCondition.cs
@@ -524,7 +524,6 @@ f = a <= b || c <= d ? 1 : 0;
 g = foo({ 1, 2 }) > 3+ foo({4,5,6}) ?  1 : 3+ foo({4,5,6});
 i = {1,3} > 2 ? 1: 0;";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
-            Object[][] array = { new Object[] { 7, 8, 9 }, new Object[] { 7, 8, 9 } };
             Object[] array2 = { 0, 1 };
             thisTest.Verify("a", 5.0, 0);
             thisTest.Verify("b", 1, 0);
@@ -532,7 +531,7 @@ i = {1,3} > 2 ? 1: 0;";
             thisTest.Verify("d", 1, 0);
             thisTest.Verify("e1", 0, 0);
             thisTest.Verify("f", 1, 0);
-            thisTest.Verify("g", array, 0);
+            thisTest.Verify("g", new [] {7, 8}, 0);
             thisTest.Verify("i", array2, 0);
         }
 

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestUpdate.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestUpdate.cs
@@ -4075,7 +4075,6 @@ z = 2;";
 
         [Test]
         [Category("SmokeTest")]
-        [Category("Failure")]
         public void T56_Defect_1467342_Inline_Condition_replication()
         {
             // Tracked in: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4088

--- a/test/core/dsevaluation/IfAsFunctionobject_3483.dyn
+++ b/test/core/dsevaluation/IfAsFunctionobject_3483.dyn
@@ -1,21 +1,22 @@
-<Workspace Version="0.7.1.17276" X="-1349.46685950095" Y="-1679.59335706276" zoom="1.09757871883952" Description="" Category="" Name="Home">
+<Workspace Version="0.7.5.3211" X="-1349.46685950095" Y="-1679.59335706276" zoom="1.09757871883952" Description="" Category="" Name="Home">
   <Elements>
-    <DSCoreNodesUI.Logic.If type="DSCoreNodesUI.Logic.If" guid="2bd9e457-4424-49cf-80ef-bfd9c2675188" nickname="If" x="1638.76743349217" y="1797.87964344503" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
-    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="e2a327b4-9b01-4007-b0db-df42ddf85d0b" nickname="Number" x="1476.14117086591" y="1824.5867141521" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    <DSCoreNodesUI.Logic.If type="DSCoreNodesUI.Logic.If" guid="2bd9e457-4424-49cf-80ef-bfd9c2675188" nickname="If" x="1595.03480714283" y="1746.85824603746" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="e2a327b4-9b01-4007-b0db-df42ddf85d0b" nickname="Number" x="1382.29824349128" y="1773.56531674453" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
       <System.Double value="1" />
     </Dynamo.Nodes.DoubleInput>
-    <Dynamo.Nodes.Watch type="Dynamo.Nodes.Watch" guid="80d14b69-4796-48c9-a34d-f447abf7b5ba" nickname="Watch" x="2107.57338777181" y="1935.86369448171" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
-    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="35818966-0193-4878-a7d3-22258fbf8bad" nickname="Number" x="1254.49759222233" y="1942.80460736999" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
-      <System.Double value="-2..2" />
-    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.Watch type="Dynamo.Nodes.Watch" guid="80d14b69-4796-48c9-a34d-f447abf7b5ba" nickname="Watch" x="2023.75252060223" y="1703.53411700082" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
     <DSCore.Map type="DSCore.Map" guid="b4e7ea19-5b26-4e41-a9b5-d74dbef4f5f9" nickname="List.Map" x="1826.42364472733" y="1932.49898442969" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="1b7eabbc-57ff-4378-8c8c-155b091deac2" nickname="Number" x="1381.86807158636" y="1852.56460450388" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="-1" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="f0957fbf-f475-4d41-a977-b441accbb1d5" nickname="Code Block" x="1381.75402375691" y="1960.22325324054" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{true, false, false, true};" ShouldFocus="false" />
   </Elements>
   <Connectors>
     <Dynamo.Models.ConnectorModel start="2bd9e457-4424-49cf-80ef-bfd9c2675188" start_index="0" end="b4e7ea19-5b26-4e41-a9b5-d74dbef4f5f9" end_index="1" portType="0" />
     <Dynamo.Models.ConnectorModel start="e2a327b4-9b01-4007-b0db-df42ddf85d0b" start_index="0" end="2bd9e457-4424-49cf-80ef-bfd9c2675188" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="35818966-0193-4878-a7d3-22258fbf8bad" start_index="0" end="2bd9e457-4424-49cf-80ef-bfd9c2675188" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="35818966-0193-4878-a7d3-22258fbf8bad" start_index="0" end="b4e7ea19-5b26-4e41-a9b5-d74dbef4f5f9" end_index="0" portType="0" />
     <Dynamo.Models.ConnectorModel start="b4e7ea19-5b26-4e41-a9b5-d74dbef4f5f9" start_index="0" end="80d14b69-4796-48c9-a34d-f447abf7b5ba" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="1b7eabbc-57ff-4378-8c8c-155b091deac2" start_index="0" end="2bd9e457-4424-49cf-80ef-bfd9c2675188" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="f0957fbf-f475-4d41-a977-b441accbb1d5" start_index="0" end="b4e7ea19-5b26-4e41-a9b5-d74dbef4f5f9" end_index="0" portType="0" />
   </Connectors>
   <Notes />
 </Workspace>


### PR DESCRIPTION
This pull request fixes defect [MAGN 3979 ternary operator should act on each item of a list](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3979)

In short, inline condition will support replication on all its inputs. Originally it only supports replication on its condition. The new signature of inline condition is

As ``If`` node is compiled to inline condition, now it supports replications on all its inputs as well. 

@lukechurch 
@junmendoza 

please review the changes. 