### PR TITLE
MAGN-5442: Fix crash on search before sync is complete

### DIFF
--- a/src/DynamoCore/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCore/PackageManager/PackageManagerSearchViewModel.cs
@@ -4,7 +4,6 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows.Documents;
 using System.Windows.Input;
 
 using Dynamo.Search;


### PR DESCRIPTION
#### Fix

Before synchronization is complete, users should not be able to search.  This simply causes search to do nothing until sync is done.
#### Reviewers
- [x] @ikeough 
