### PR TITLE
Fix broken test case TestRecordAndDeleteModelsWithEmptyInput

### DIFF
--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -584,10 +584,6 @@ namespace Dynamo.Tests
             models.Add(null);
             workspace.RecordAndDeleteModels(models);
             Assert.AreEqual(false, workspace.CanUndo);
-
-            NodeModel node = ViewModel.Model.Nodes[0];
-            
-
         }
 
         [Test]


### PR DESCRIPTION
Notice test case `Dynamo.Tests.CoreTests.TestRecordAndDeleteModelsWithEmptyInput` is broken. In this test case, the null reference exception is thrown out from this line `NodeModel node = ViewModel.Model.Nodes[0];` which I believe is a copy/paste error (it was added in commit https://github.com/DynamoDS/Dynamo/commit/64a774fc310c0454055dc7c338744e0bc1612ea4). 

@sharadkjaiswal  please review the change. Thanks. 
