### PR TITLE
Fix MAGN-3960 and MAGN-4593

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -550,6 +550,21 @@ namespace Dynamo.Models
             State = ElementState.Dead;
             ArgumentLacing = LacingStrategy.Disabled;
             IsReportingModifications = true;
+
+            Workspace.DynamoModel.PreferenceSettings.PropertyChanged += Preferences_PropertyChanged;
+        }
+
+        public virtual void Preferences_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case "LengthUnit":
+                case "AreaUnit":
+                case "VolumeUnit":
+                    ForceReExecuteOfNode = true;
+                    RequiresRecalc = true;
+                    break;
+            }
         }
 
         /// <summary>

--- a/src/DynamoCore/UI/UIPartials.cs
+++ b/src/DynamoCore/UI/UIPartials.cs
@@ -262,7 +262,7 @@ namespace Dynamo.Nodes
             Workspace.DynamoModel.PreferenceSettings.PropertyChanged += Preferences_PropertyChanged;
         }
 
-        void Preferences_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        public override void Preferences_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/src/Libraries/DynamoUnits/Units.cs
+++ b/src/Libraries/DynamoUnits/Units.cs
@@ -428,12 +428,26 @@ namespace DynamoUnits
         }
  
         public abstract double ConvertToHostUnits();
+
+    }
+
+    public abstract class UIUnit : SIUnit
+    {
+        /// <summary>
+        /// Construct an UIUnit object with a value.
+        /// </summary>
+        /// <param name="value"></param>
+        protected UIUnit(double value) : base (value)
+        {
+        }
+
+        public abstract double ValueInDynamoUIUnits();
     }
 
     /// <summary>
     /// A length stored in meters.
     /// </summary>
-    public class Length : SIUnit, IComparable, IEquatable<Length>
+    public class Length : UIUnit, IComparable, IEquatable<Length>
     {
         //length conversions
         private const double METER_TO_MILLIMETER = 1000;
@@ -476,6 +490,19 @@ namespace DynamoUnits
 
         public static Length FromDouble(double value)
         {
+            return new Length(value);
+        }
+
+        /// <summary>
+        /// The value will be assumed to be in the unit specified in the UI
+        /// and be converted to be the value in meter and a new length will
+        /// be created from it.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static Length FromDoubleInUIUnit(double value)
+        {
+            value /= BaseUnit.UiLengthConversion;
             return new Length(value);
         }
 
@@ -728,12 +755,23 @@ namespace DynamoUnits
 
             return volumeHashCode;
         }
+
+        /// <summary>
+        /// Convert the value from meter to the value in the length unit specified
+        /// in the UI settings
+        /// </summary>
+        /// <returns></returns>
+        [IsVisibleInDynamoLibrary(false)]
+        public override double ValueInDynamoUIUnits()
+        {
+            return Value * BaseUnit.UiLengthConversion;
+        }
     }
 
     /// <summary>
     /// An area stored in square meters.
     /// </summary>
-    public class Area : SIUnit, IComparable, IEquatable<Area>
+    public class Area : UIUnit, IComparable, IEquatable<Area>
     {
         //area conversions
         private const double SQUARE_METERS_TO_SQUARE_MILLIMETERS = 1000000;
@@ -771,6 +809,19 @@ namespace DynamoUnits
 
         public static Area FromDouble(double value)
         {
+            return new Area(value);
+        }
+
+        /// <summary>
+        /// The value will be assumed to be in the unit specified in the UI
+        /// and be converted to be the value in meter*meter and a new area will
+        /// be created from it.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static Area FromDoubleInUiUnit(double value)
+        {
+            value /= BaseUnit.UiAreaConversion;
             return new Area(value);
         }
 
@@ -1016,12 +1067,23 @@ namespace DynamoUnits
 
             return volumeHashCode;
         }
+
+        /// <summary>
+        /// Convert the value from meter*meter to the value in the area unit specified
+        /// in the UI settings
+        /// </summary>
+        /// <returns></returns>
+        [IsVisibleInDynamoLibrary(false)]
+        public override double ValueInDynamoUIUnits()
+        {
+            return Value * BaseUnit.UiAreaConversion;
+        }
     }
 
     /// <summary>
     /// A volume stored in cubic meters.
     /// </summary>
-    public class Volume : SIUnit, IComparable, IEquatable<Volume>
+    public class Volume : UIUnit, IComparable, IEquatable<Volume>
     {
         //volume conversions
         private const double CUBIC_METERS_TO_CUBIC_MILLIMETERS = 1000000000;
@@ -1059,6 +1121,19 @@ namespace DynamoUnits
 
         public static Volume FromDouble(double value)
         {
+            return new Volume(value);
+        }
+
+        /// <summary>
+        /// The value will be assumed to be in the unit specified in the UI
+        /// and be converted to be the value in meter*meter*meter and a new volume will
+        /// be created from it.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static Volume FromDoubleInUiUnit(double value)
+        {
+            value /= BaseUnit.UiVolumeConversion;
             return new Volume(value);
         }
 
@@ -1294,6 +1369,17 @@ namespace DynamoUnits
             var volumeHashCode = Convert.ToInt32(_value);
 
             return volumeHashCode;
+        }
+
+        /// <summary>
+        /// Convert the value from meter*meter*meter to the value in the area unit specified
+        /// in the UI settings
+        /// </summary>
+        /// <returns></returns>
+        [IsVisibleInDynamoLibrary(false)]
+        public override double ValueInDynamoUIUnits()
+        {
+            return Value * BaseUnit.UiVolumeConversion;
         }
     }
 

--- a/src/Libraries/Revit/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Element.cs
@@ -250,13 +250,13 @@ namespace Revit.Elements
                     switch (param.Definition.ParameterType)
                     {
                         case ParameterType.Length:
-                            result = Length.FromFeet(param.AsDouble());
+                            result = Length.FromFeet(param.AsDouble()).ValueInDynamoUIUnits();
                             break;
                         case ParameterType.Area:
-                            result = Area.FromSquareFeet(param.AsDouble());
+                            result = Area.FromSquareFeet(param.AsDouble()).ValueInDynamoUIUnits();
                             break;
                         case ParameterType.Volume:
-                            result = Volume.FromCubicFeet(param.AsDouble());
+                            result = Volume.FromCubicFeet(param.AsDouble()).ValueInDynamoUIUnits();
                             break;
                         default:
                             result = param.AsDouble();
@@ -322,7 +322,7 @@ namespace Revit.Elements
             if (param.StorageType != StorageType.Integer && param.StorageType != StorageType.Double)
                 throw new Exception("The parameter's storage type is not a number.");
 
-            param.Set(value);
+            SetNumericParameterValue(param, value);
         }
 
         private static void SetParameterValue(Autodesk.Revit.DB.Parameter param, Element value)
@@ -338,7 +338,7 @@ namespace Revit.Elements
             if (param.StorageType != StorageType.Integer && param.StorageType != StorageType.Double)
                 throw new Exception("The parameter's storage type is not a number.");
 
-            param.Set(value);
+            SetNumericParameterValue(param, value);
         }
 
         private static void SetParameterValue(Autodesk.Revit.DB.Parameter param, string value)
@@ -363,6 +363,24 @@ namespace Revit.Elements
                 throw new Exception("The parameter's storage type is not an integer.");
 
             param.Set(value.ConvertToHostUnits());
+        }
+
+        /// <summary>
+        /// If the type of the parameter is Length, Area or Volume, the value will be converted to host units
+        /// and then set.
+        /// </summary>
+        /// <param name="param">The parameter</param>
+        /// <param name="value">The value</param>
+        private static void SetNumericParameterValue(Autodesk.Revit.DB.Parameter param, double value)
+        {
+            if (param.Definition.ParameterType == ParameterType.Length)
+                param.Set(Length.FromDoubleInUIUnit(value).ConvertToHostUnits());
+            else if (param.Definition.ParameterType == ParameterType.Area)
+                param.Set(Area.FromDoubleInUiUnit(value).ConvertToHostUnits());
+            else if (param.Definition.ParameterType == ParameterType.Volume)
+                param.Set(Volume.FromDoubleInUiUnit(value).ConvertToHostUnits());
+            else
+                param.Set(value);
         }
 
         #endregion

--- a/src/Libraries/Revit/RevitNodes/GeometryConversion/UnitConverter.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryConversion/UnitConverter.cs
@@ -13,7 +13,7 @@ namespace Revit.GeometryConversion
     {
         public static double DynamoToHostFactor
         {
-            get { return Length.FromDouble(1.0).ConvertToHostUnits(); }
+            get { return Length.FromDoubleInUIUnit(1.0).ConvertToHostUnits(); }
         }
 
         public static double HostToDynamoFactor

--- a/src/Libraries/UnitsUI/UnitsUI.cs
+++ b/src/Libraries/UnitsUI/UnitsUI.cs
@@ -171,7 +171,7 @@ namespace UnitsUI
     {
         public LengthFromString(WorkspaceModel ws) : base(ws)
         {
-            _measure = Length.FromDouble(0.0);
+            _measure = Length.FromDoubleInUIUnit(0.0);
             OutPortData.Add(new PortData("length", "The length. Stored internally as decimal meters."));
             RegisterAllPorts();
         }
@@ -197,7 +197,7 @@ namespace UnitsUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             var doubleNode = AstFactory.BuildDoubleNode(Value);
-            var functionCall = AstFactory.BuildFunctionCall(new Func<double,Length>(Length.FromDouble), new List<AssociativeNode> { doubleNode });
+            var functionCall = AstFactory.BuildFunctionCall(new Func<double, Length>(Length.FromDoubleInUIUnit), new List<AssociativeNode> { doubleNode });
             return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall) };
         }
     }
@@ -211,7 +211,7 @@ namespace UnitsUI
     {
         public AreaFromString(WorkspaceModel workspaceModel) : base(workspaceModel) 
         {
-            _measure = Area.FromDouble(0.0);
+            _measure = Area.FromDoubleInUiUnit(0.0);
             OutPortData.Add(new PortData("area", "The area. Stored internally as decimal meters squared."));
             RegisterAllPorts();
         }
@@ -219,7 +219,7 @@ namespace UnitsUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             var doubleNode = AstFactory.BuildDoubleNode(Value);
-            var functionCall = AstFactory.BuildFunctionCall(new Func<double,Area>(Area.FromDouble), new List<AssociativeNode> { doubleNode });
+            var functionCall = AstFactory.BuildFunctionCall(new Func<double, Area>(Area.FromDoubleInUiUnit), new List<AssociativeNode> { doubleNode });
             return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall) };
         }
     }
@@ -233,7 +233,7 @@ namespace UnitsUI
     {
         public VolumeFromString(WorkspaceModel workspaceModel) : base(workspaceModel)
         {
-            _measure = Volume.FromDouble(0.0);
+            _measure = Volume.FromDoubleInUiUnit(0.0);
             OutPortData.Add(new PortData("volume", "The volume. Stored internally as decimal meters cubed."));
             RegisterAllPorts();
         }
@@ -241,7 +241,7 @@ namespace UnitsUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             var doubleNode = AstFactory.BuildDoubleNode(Value);
-            var functionCall = AstFactory.BuildFunctionCall(new Func<double, Volume>(Volume.FromDouble), new List<AssociativeNode> { doubleNode });
+            var functionCall = AstFactory.BuildFunctionCall(new Func<double, Volume>(Volume.FromDoubleInUiUnit), new List<AssociativeNode> { doubleNode });
             return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall) };
         }
     }

--- a/test/DynamoCoreTests/UnitsOfMeasureTests.cs
+++ b/test/DynamoCoreTests/UnitsOfMeasureTests.cs
@@ -677,9 +677,9 @@ namespace Dynamo.Tests
         [Test]
         public void CanMapOverUnits()
         {
-            var length = Enumerable.Range(1, 5).Select(x => Length.FromDouble(x)).ToList();
-            var area = Enumerable.Range(1, 5).Select(x => Area.FromDouble(x)).ToList();
-            var volume = Enumerable.Range(1, 5).Select(x => Volume.FromDouble(x)).ToList();
+            var length = Enumerable.Range(1, 5).Select(x => Length.FromDoubleInUIUnit(x)).ToList();
+            var area = Enumerable.Range(1, 5).Select(x => Area.FromDoubleInUiUnit(x)).ToList();
+            var volume = Enumerable.Range(1, 5).Select(x => Volume.FromDoubleInUiUnit(x)).ToList();
 
             RunModel(@"core\units\map-numbers-to-units.dyn");
 


### PR DESCRIPTION
<h6>Summary</h6>


This submission is trying to fix two defects: MAGN-3960 and MAGN-4593. For the two functions: SetParameterByName and GetParameterValueByName, GetParameterValueByName returns length, area and volume with a symbolic unit, this is not convenient for users to do downstream calculations, while for SetParameterByName, the int/double value for length, area and volume will be always considered in meters, square meters or cubic meters no matter what is the current settings in the Dynamo settings. But actually the settings can be different.
![image](https://cloud.githubusercontent.com/assets/5584246/5140287/1651a920-71a4-11e4-971d-a34c86a34ce0.png)

@kronz 
I think it is more reasonable to take the int/double values in the unit of the Dynamo settings other than the project unit set in Revit. In this submission, I am following the Dynamo settings. If we want to follow the Revit project unit, I will make corresponding changes. But currently I have not figured out a way to know when the project unit changes in Revit and act correspondingly.

@pboyer 
In this submission, I am keeping the internal value of SIUnit in meter. I added a new derived class UIUnit which will return value according to the current Dynamo unit settings. The method ValueInDynamoUIUnits is for this purpose.

Then for Length, Area and Volume classes, I am deriving from UIUnit so that ValueInDynamoUIUnits can be implemented. This method is then used in the places where it relates to the Dynamo UI settings. Then FromDoubleInUIUnit is implemented to be used in the proper places.

When the unit settings is changed, all nodes will be marked dirty and the graph can be run again. I have added a new event handler in NodeModel.

<h6>New Behaviors</h6>
1. The int/double value to be set or returned from SetParameterByName and GetParameterValueByName is considered to be in the current unit settings in Dynamo for Length, Area and Volume.
2. The int/double value to be set or returned for other nodes will be considered to be in the current unit settings in Dynamo for Length, Area and Volume.
3. When the Length, Area or Volume unit is changed in Dynamo, the graph will run again if "Run Automatically" is on. The output int/double value will change. But the input int/double value will not change.

<h6>Test</h6>

I have run the related test cases under UnitsOfMeasureTests. They are passing.

The following is a series of picture for a graph when I am changing the Dynamo length unit:
a. The length unit is meter:
![image](https://cloud.githubusercontent.com/assets/5584246/5140570/21757a4a-71a7-11e4-97f7-ac8e5c2304c2.png)

b. The length unit is changed to centimeter:
![image](https://cloud.githubusercontent.com/assets/5584246/5140596/40c4fe02-71a7-11e4-8e37-0d90c9a7ba10.png)

c. The length unit is changed to decimal foot:
![image](https://cloud.githubusercontent.com/assets/5584246/5140612/594acf9c-71a7-11e4-9fee-f098ed47a9b9.png)

<h6>Reviewers</h6>
- [ ] @pboyer 
- [ ] @kronz 
