### PR TITLE
MAGN-5488 Dynamo can fail to launch when Kiwi Bonus Tools add-in is installed on Revit 2015

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -100,7 +100,19 @@ namespace Dynamo.Applications
             {
 #if ENABLE_DYNAMO_SCHEDULER
                 extCommandData = commandData;
-                commandData.Application.Idling += OnRevitIdleOnce;
+
+                // create core data models
+                revitDynamoModel = InitializeCoreModel(extCommandData);
+                dynamoViewModel = InitializeCoreViewModel(revitDynamoModel);
+
+                // handle initialization steps after RevitDynamoModel is created.
+                revitDynamoModel.HandlePostInitialization();
+
+                // show the window
+                InitializeCoreView().Show();
+
+                TryOpenWorkspaceInCommandData(extCommandData);
+                SubscribeApplicationEvents(extCommandData);
 #else
 
                 IdlePromise.ExecuteOnIdleAsync(
@@ -147,36 +159,6 @@ namespace Dynamo.Applications
                 revitDynamoModel = value;
             }
         }
-
-#if ENABLE_DYNAMO_SCHEDULER
-
-        /// <summary>
-        /// This method (Application.Idling event handler) is called exactly once
-        /// during the creation of Dynamo Revit plug-in. It is in this call both 
-        /// DynamoScheduler and its RevitSchedulerThread objects are created. All 
-        /// other AsyncTask beyond this point are scheduled through the scheduler.
-        /// </summary>
-        /// 
-        private static void OnRevitIdleOnce(object sender, IdlingEventArgs e)
-        {
-            // We only need to initialize this once, unregister.
-            extCommandData.Application.Idling -= OnRevitIdleOnce;
-
-            // create core data models
-            revitDynamoModel = InitializeCoreModel(extCommandData);
-            dynamoViewModel = InitializeCoreViewModel(revitDynamoModel);
-
-            // handle initialization steps after RevitDynamoModel is created.
-            revitDynamoModel.HandlePostInitialization();
-
-            // show the window
-            InitializeCoreView().Show();
-
-            TryOpenWorkspaceInCommandData(extCommandData);
-            SubscribeApplicationEvents(extCommandData);
-        }
-
-#endif
 
         #region Initialization
 


### PR DESCRIPTION
This pull request fixes the issue where other installed addins will conflict with Dynamo. That is a symptom which is still unexplained by the Revit team. The root cause of the issue is to do with our attempting to register an event handler for Revit's idle event while handling the idle event. The additional hack to do our Dynamo Revit initialization on idle is not required, as the execute method is, by its very nature, safe for making Revit API calls. This PR moves the logic from OnRevitIdleOnce inside the external command's Execute method.

The issue outlined in MAGN-5488 was reproduced in the Revit 2016 branch without other addins installed. This solution fixed the problem there.

PTAL:
- [x] @Benglin 

Merge:
- [ ] Revit2015
