### PR TITLE
Log range expression step 0 warnings at runtime

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -1086,6 +1086,14 @@ namespace ProtoCore.Lang
                     WarningMessage.kInvalidArgumentsInRangeExpression);
                 return StackValue.Null;
             }
+            else if (hasStep 
+                    && (svStep.IsInteger && svStep.opdata == 0) || (svStep.IsDouble && svStep.opdata_d == 0.0))
+            {
+                core.RuntimeStatus.LogWarning(
+                    WarningID.kInvalidArguments,
+                    WarningMessage.kRangeExpressionWithStepSizeZero);
+                return StackValue.Null;
+            }
             else if (!svStep.IsNull && !svStep.IsNumeric)
             {
                 core.RuntimeStatus.LogWarning(

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -61,6 +61,7 @@ namespace ProtoCore
             public const string kInvalidArguments = "Argument is invalid.";
             public const string kInvalidArgumentsInRangeExpression = "The value that used in range expression should be either integer or double.";
             public const string kInvalidAmountInRangeExpression = "The amount in range expression should be an positive integer.";
+            public const string kRangeExpressionWithStepSizeZero = ProtoCore.BuildData.WarningMessage.kRangeExpressionWithStepSizeZero;
             public const string kNoStepSizeInAmountRangeExpression = "No step size is specified in amount range expression.";
             public const string kFileNotFound = "'{0}' doesn't exist.";
             public const string kPropertyNotFound = "Object does not have a property '{0}'.";

--- a/test/Engine/ProtoTest/TD/MultiLangTests/RangeExpressions.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/RangeExpressions.cs
@@ -1879,5 +1879,20 @@ d1;d2;d3;d4;d5;
             thisTest.Verify("x", new object[] { null, null });
             thisTest.VerifyRuntimeWarningCount(2);
         }
+
+
+        [Test]
+        [Category("SmokeTest")]
+        public void TestStepZero()
+        {
+            string src = @"
+a = 0;
+b = 0..10..a;
+";
+            ExecutionMirror mirror = thisTest.RunScriptSource(src);
+            TestFrameWork.VerifyRuntimeWarning(ProtoCore.RuntimeData.WarningID.kInvalidArguments);
+            thisTest.VerifyRuntimeWarningCount(1);
+            thisTest.Verify("b", null);
+        }
     }
 }


### PR DESCRIPTION
Handle warning for range expression with step 0 at runtime.
We should perhaps consider removing the compile time warning for this.
PTAL @lukechurch  @ke-yu 
