### PR TITLE
Fix namespace resolution

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -2249,9 +2249,7 @@ namespace ProtoAssociative
                     // TODO Jun: Move this warning handler to after the SSA transform
                     // http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5221
                     buildStatus.LogSymbolConflictWarning(identList.LeftNode.ToString(), classNames);
-
-                    var leftNode = nodeBuilder.BuildIdentfier(classNames[0]);
-                    rhsIdentList.LeftNode = leftNode;
+                    rhsIdentList = identList;
                 }
                 else
                 {
@@ -3197,12 +3195,6 @@ namespace ProtoAssociative
                             bnode.RightNode = dotCall;
 
                             ProtoCore.Utils.CoreUtils.CopyDebugData(bnode, lhsIdent);
-
-#if SSA_IDENT_LIST
-                            // Set the real lhs (first pointer) of this dot call
-                            dotCall.StaticLHSIdent = firstPointer;
-                            firstPointer = null;
-#endif
 
                             // Update the LHS of the next dotcall
                             //      a = x.y.z

--- a/test/Engine/ProtoTest/DebugTests/NamespaceConflictTest.cs
+++ b/test/Engine/ProtoTest/DebugTests/NamespaceConflictTest.cs
@@ -14,6 +14,7 @@ namespace ProtoTest.DebugTests
 
         [Test]
         [Category("Trace")]
+        [Category("Failure")]
         public void DupImportTest()
         {
             var mirror = thisTest.RunScriptSource(
@@ -42,6 +43,19 @@ aO = a.Foo();
 "
 );
             thisTest.VerifyBuildWarningCount(ProtoCore.BuildData.WarningID.kMultipleSymbolFoundFromName, 1);
+        }
+
+        [Test]
+        public void DupImportTestNamespaceConflict02()
+        {
+            var mirror = thisTest.RunScriptSource(
+@"import(""FFITarget.dll"");
+a = DupTargetTest.DupTargetTest(); 
+p = a;
+"
+);
+            thisTest.VerifyBuildWarningCount(ProtoCore.BuildData.WarningID.kMultipleSymbolFoundFromName, 1);
+            Assert.IsTrue(mirror.GetValue("p").DsasmValue.optype == ProtoCore.DSASM.AddressType.Null);
         }
 
 

--- a/test/Engine/ProtoTest/FFITests/CSFFITest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFITest.cs
@@ -1838,6 +1838,7 @@ p11;
         }
 
         [Test]
+        [Category("Failure")]
         public void TestNamespaceClassResolution()
         {
             // Tracked by http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1947


### PR DESCRIPTION
1. Unresolved calls must not default to any class constructor - this
   regressed from a refactor submission due to inadequate tests.
2. Added namespace resolution test
3. Revert tests failure category removal from previous submission -
   these tests still fail

@aparajit-pratap 
