### PR TITLE
Fix Revit Test failures due to test data restructuring

### DIFF
--- a/test/Libraries/RevitIntegrationTests/RegressionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RegressionTests.cs
@@ -107,7 +107,7 @@ namespace RevitSystemTests
             //fixture, so the initfixture method is not called.
 
             //get the test path
-            string testsLoc = Path.Combine(assDir, @"..\..\..\test\System\revit\");
+            string testsLoc = Path.Combine(assDir, @"..\..\..\test\System\");
             _testPath = Path.GetFullPath(testsLoc);
 
             //get the samples path
@@ -186,7 +186,7 @@ namespace RevitSystemTests
 
             var fi = new FileInfo(Assembly.GetExecutingAssembly().Location);
             string assDir = fi.DirectoryName;
-            string testsLoc = Path.Combine(assDir, @"..\..\..\test\System\revit\Regression\");
+            string testsLoc = Path.Combine(assDir, @"..\..\..\test\System\Regression\");
             var regTestPath = Path.GetFullPath(testsLoc);
 
             var di = new DirectoryInfo(regTestPath);

--- a/test/Libraries/RevitIntegrationTests/SystemTest.cs
+++ b/test/Libraries/RevitIntegrationTests/SystemTest.cs
@@ -26,7 +26,7 @@ namespace RevitSystemTests
             string assDir = fi.DirectoryName;
 
             //get the test path
-            string testsLoc = Path.Combine(assDir, @"..\..\..\..\test\System\revit\");
+            string testsLoc = Path.Combine(assDir, @"..\..\..\..\test\System\");
             workingDirectory = Path.GetFullPath(testsLoc);
 
             //get the samples path


### PR DESCRIPTION
- Now Revit test data is under test\System\ folder
- Updated all test initialization calls to consider this path for revit
  test data.
