### PR TITLE
Fix two failing test cases

### DIFF
--- a/test/System/revit/Samples/IndexedFamilyInstances.dyn
+++ b/test/System/revit/Samples/IndexedFamilyInstances.dyn
@@ -101,7 +101,7 @@
     </Dynamo.Nodes.FamilyInstanceParameterSetter>
     <Dynamo.Nodes.NumberSeq type="Dynamo.Nodes.NumberSeq" guid="da400b3b-2122-489a-a118-3e8e1e0802f7" nickname="Number Sequence" x="1008.38888888889" y="122.663809523809" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
     <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="620de1b6-f21e-468e-84e1-3b6d9ce8debf" nickname="Number" x="838.388888888888" y="122.663809523809" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
-      <System.Double value="0" />
+      <System.Double value="1" />
     </Dynamo.Nodes.DoubleInput>
     <Dynamo.Nodes.Xyz type="Dynamo.Nodes.Xyz" guid="904effa9-e182-4fc8-a070-54fceb9a8ac0" nickname="XYZ" x="1148.38888888889" y="122.663809523809" isVisible="true" isUpstreamVisible="true" lacing="Longest">
       <PortInfo index="0" default="True" />

--- a/test/System/revit/Samples/refgridsliders.dyn
+++ b/test/System/revit/Samples/refgridsliders.dyn
@@ -16,7 +16,7 @@
       <System.Double value="19" min="0" max="50" />
     </Dynamo.Nodes.DoubleSliderInput>
     <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="7d3d4aa4-7a1e-458d-90b1-03f818f3e409" nickname="Number" x="220.636882430989" y="384.161111111111" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
-      <System.Double value="0" />
+      <System.Double value="1" />
     </Dynamo.Nodes.DoubleInput>
     <Dynamo.Nodes.ReferencePtGrid type="Dynamo.Nodes.ReferencePtGrid" guid="28eeac51-501c-406e-a2ee-a38d9998f4f9" nickname="XYZ Grid" x="448.761111111111" y="92.2222222222223" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
     <Dynamo.Nodes.ReferencePointByXyz type="Dynamo.Nodes.ReferencePointByXyz" guid="69dcdcdc-941f-46f9-8e8b-242b61e74e80" nickname="Reference Point" x="699.866666666667" y="92.2222222222223" isVisible="true" isUpstreamVisible="true" lacing="Longest">


### PR DESCRIPTION
<h4>Summary</h4>


There are two failing test cases. The error is caused by the "Number Sequence" node. In one case, it is like:
![image](https://cloud.githubusercontent.com/assets/5584246/5197301/1c3e8580-757b-11e4-873c-e7749218f579.png)

Here the fix is two change the value of the node for the step from 0 to 1.

<h4>Reviewers</h4>

@sharadkjaiswal 
@riteshchandawar 
PTAL
