### PR TITLE
Fixed CBN formatting issues: MAGN-3921, MAGN-3900

### DIFF
--- a/src/DynamoCore/Utilities/CodeBlockUtils.cs
+++ b/src/DynamoCore/Utilities/CodeBlockUtils.cs
@@ -297,7 +297,7 @@ namespace Dynamo.Utilities
 
             // If after all the processing we do not end up with an empty code,
             // then we may need a semi-colon at the end. This is provided if the 
-            // code does not end with a closing curly bracket (in which case a 
+            // code does not end with a comment or string (in which case a 
             // trailing semi-colon is not required).
             // 
             if (!string.IsNullOrEmpty(inputCode) && 


### PR DESCRIPTION
This submission fixes two errors:
1. Semi-colon added after a single line comment if the comment is the last line
2. Semi-colon not added for statements ending with '}' in the last line

@ke-yu please review. Thanks
