### PR TITLE
Added RevitTestConfiguration.tt

### DIFF
--- a/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
+++ b/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
@@ -81,7 +81,7 @@
     </Compile>
     <Compile Include="AdaptiveComponentTests.cs" />
     <Compile Include="AnalysisDisplayTests.cs" />
-	<Compile Include="RevitLibraryTests.cs" />
+    <Compile Include="RevitLibraryTests.cs" />
     <Compile Include="ImportInstanceTests.cs" />
     <Compile Include="SystemTest.cs" />
     <Compile Include="SiteLocationTests.cs" />
@@ -165,7 +165,7 @@
       <Private>False</Private>
     </ProjectReference>
     <Reference Include="SystemTestServices">
-	  <HintPath>$(DYNAMOTESTAPI)\SystemTestServices.dll</HintPath>
+      <HintPath>$(DYNAMOTESTAPI)\SystemTestServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="TestServices">
@@ -183,7 +183,23 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="RevitTestConfiguration.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>RevitTestConfiguration.xml</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="RevitTestConfiguration.xml">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>RevitTestConfiguration.tt</DependentUpon>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>copy /Y "$(ProjectDir)RevitTestConfiguration.xml" "$(OutputPath)"</PreBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/Libraries/RevitIntegrationTests/RevitTestConfiguration.tt
+++ b/test/Libraries/RevitIntegrationTests/RevitTestConfiguration.tt
@@ -1,0 +1,29 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.IO" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".xml" #>
+<?xml version="1.0"?>
+<RevitTestConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<#
+ var templateFileDir = new DirectoryInfo(this.Host.TemplateFile);
+ string basePath = templateFileDir.Parent.Parent.Parent.Parent.FullName;
+ string testDir = Path.Combine(basePath,"test");
+ string workingDirectory = Path.Combine(testDir,"System");
+
+ string docDir = Path.Combine(basePath,"doc");
+ string distribDir = Path.Combine(basePath,"distrib");
+ string samplesPath = Path.Combine(distribDir,"Samples");
+
+ var dynVersion = "0.7";
+ var appData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),"Dynamo",dynVersion);
+ var packagesPath = Path.Combine(appData,"packages");
+ var dynSampleCustomNode = Path.Combine(packagesPath,"Dynamo Sample Custom Nodes");
+ var defPath = Path.Combine(dynSampleCustomNode,"dyf");
+#>
+  <WorkingDirectory><#= workingDirectory #></WorkingDirectory>
+  <SamplesPath><#= samplesPath #></SamplesPath>
+  <DefinitionsPath><#= defPath #></DefinitionsPath>
+</RevitTestConfiguration>

--- a/test/Libraries/RevitIntegrationTests/RevitTestConfiguration.xml
+++ b/test/Libraries/RevitIntegrationTests/RevitTestConfiguration.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0"?>
+<RevitTestConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <WorkingDirectory>C:\Users\t_anhp\Documents\GitHub\Dynamo\test\System</WorkingDirectory>
+  <SamplesPath>C:\Users\t_anhp\Documents\GitHub\Dynamo\distrib\Samples</SamplesPath>
+  <DefinitionsPath>C:\Users\t_anhp\AppData\Roaming\Dynamo\0.7\packages\Dynamo Sample Custom Nodes\dyf</DefinitionsPath>
+</RevitTestConfiguration>


### PR DESCRIPTION
@sharadkjaiswal  I created the T4 template file to generate the RevitTestConfig.xml. However, Path.Combine is not working well in T4. It cannot combine 1 path with @"a\b\c". It just gives me "a\b\c" so I decided to seperate them. Please take a look. Thanks
