### PR TITLE
Fixes RegressionTest Fixture

### DIFF
--- a/test/Libraries/Revit/RevitIntegrationTests/RegressionTests.cs
+++ b/test/Libraries/Revit/RevitIntegrationTests/RegressionTests.cs
@@ -22,16 +22,8 @@ using RevitServices.Transactions;
 namespace RevitSystemTests
 {
     [TestFixture]
-    public class RegressionTest
+    public class RegressionTest : SystemTest
     {
-        protected static Transaction _trans;
-        protected static string _testPath;
-        protected static string _samplesPath;
-        protected static string _defsPath;
-        protected static string _emptyModelPath1;
-        protected static string _emptyModelPath;
-        protected DynamoViewModel ViewModel;
-
         /// <summary>
         /// Automated creation of regression test cases. Opens each workflow
         /// runs it, and checks for errors or warnings. Regression test cases should
@@ -50,8 +42,6 @@ namespace RevitSystemTests
                 var dynamoFilePath = testData.Arguments[0].ToString();
                 var revitFilePath = testData.Arguments[1].ToString();
 
-                Setup();
-
                 //ensure that the incoming arguments are not empty or null
                 //if a dyn file is found in the regression tests directory
                 //and there is no corresponding rfa or rvt, then an empty string
@@ -62,9 +52,15 @@ namespace RevitSystemTests
                 //open the revit model
                 SwapCurrentModel(revitFilePath);
 
+                //Setup should be called after swapping document, so that RevitDynamoModel 
+                //is now associated with swapped model.
+                Setup();
+
                 //open the dyn file
                 ViewModel.OpenCommand.Execute(dynamoFilePath);
-
+                Assert.IsTrue(ViewModel.Model.Nodes.Count > 0);
+                AssertNoDummyNodes();
+                
                 //run the expression and assert that it does not
                 //throw an error
                 Assert.DoesNotThrow(() => ViewModel.Model.RunExpression());
@@ -81,97 +77,12 @@ namespace RevitSystemTests
             {
                 ViewModel.Model.ShutDown(false);
                 ViewModel = null;
-                Teardown();
+                TearDown();
             }
 
             if (exception != null)
             {
                 Assert.Fail(exception.Message);
-            }
-        }
-
-        private void Setup()
-        {
-            var fi = new FileInfo(Assembly.GetExecutingAssembly().Location);
-            string assDir = fi.DirectoryName;
-
-            // Setup the core paths
-            DynamoPathManager.Instance.InitializeCore(Path.GetFullPath(assDir + @"\.."));
-
-            StartDynamo();
-
-            DocumentManager.Instance.CurrentUIApplication.ViewActivating += CurrentUIApplication_ViewActivating;
-
-            //it doesn't make sense to do these steps before every test
-            //but when running from the revit plugin we are not loading the 
-            //fixture, so the initfixture method is not called.
-
-            //get the test path
-            string testsLoc = Path.Combine(assDir, @"..\..\..\test\System\revit\");
-            _testPath = Path.GetFullPath(testsLoc);
-
-            //get the samples path
-            string samplesLoc = Path.Combine(assDir, @"..\..\..\doc\distrib\Samples\");
-            _samplesPath = Path.GetFullPath(samplesLoc);
-
-            //set the custom node loader search path
-            string defsLoc = Path.Combine(DynamoPathManager.Instance.Packages, "Dynamo Sample Custom Nodes", "dyf");
-            _defsPath = Path.GetFullPath(defsLoc);
-
-            _emptyModelPath = Path.Combine(_testPath, "empty.rfa");
-
-            if (DocumentManager.Instance.CurrentUIApplication.Application.VersionNumber.Contains("2014") &&
-                DocumentManager.Instance.CurrentUIApplication.Application.VersionName.Contains("Vasari"))
-            {
-                _emptyModelPath = Path.Combine(_testPath, "emptyV.rfa");
-                _emptyModelPath1 = Path.Combine(_testPath, "emptyV1.rfa");
-            }
-            else
-            {
-                _emptyModelPath = Path.Combine(_testPath, "empty.rfa");
-                _emptyModelPath1 = Path.Combine(_testPath, "empty1.rfa");
-            }
-        }
-
-        private void Teardown()
-        {
-            // Automatic transaction strategy requires that we 
-            // close the transaction if it hasn't been closed by 
-            // by the end of an evaluation. It is possible to 
-            // run the test framework without running Dynamo, so
-            // we ensure that the transaction is closed here.
-            TransactionManager.Instance.ForceCloseTransaction();
-        }
-
-        private void StartDynamo()
-        {
-            try
-            {
-                DynamoRevit.InitializeUnits();
-
-                var model = RevitDynamoModel.Start(
-                    new RevitDynamoModel.StartConfiguration()
-                    {
-                        StartInTestMode = true
-                    });
-
-                this.ViewModel = DynamoViewModel.Start(
-                    new DynamoViewModel.StartConfiguration()
-                    {
-                        DynamoModel = model
-                    });
-
-                // create the transaction manager object
-                TransactionManager.SetupManager(new AutomaticTransactionStrategy());
-
-                // Because the test framework does not work in the idle thread. 
-                // We need to trick Dynamo into believing that it's in the idle
-                // thread already.
-                IdlePromise.InIdleThread = true;
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.StackTrace);
             }
         }
 
@@ -186,7 +97,7 @@ namespace RevitSystemTests
 
             var fi = new FileInfo(Assembly.GetExecutingAssembly().Location);
             string assDir = fi.DirectoryName;
-            string testsLoc = Path.Combine(assDir, @"..\..\..\test\System\revit\Regression\");
+            string testsLoc = Path.Combine(assDir, @"..\..\..\..\test\System\revit\Regression\");
             var regTestPath = Path.GetFullPath(testsLoc);
 
             var di = new DirectoryInfo(regTestPath);
@@ -220,18 +131,6 @@ namespace RevitSystemTests
             
 
             return testParameters;
-        }
-
-        private void SwapCurrentModel(string modelPath)
-        {
-            Document initialDoc = DocumentManager.Instance.CurrentUIApplication.ActiveUIDocument.Document;
-            DocumentManager.Instance.CurrentUIApplication.OpenAndActivateDocument(modelPath);
-            initialDoc.Close(false);
-        }
-
-        void CurrentUIApplication_ViewActivating(object sender, Autodesk.Revit.UI.Events.ViewActivatingEventArgs e)
-        {
-            ((RevitDynamoModel)this.ViewModel.Model).SetRunEnabledBasedOnContext(e.NewActiveView);
         }
     }
 


### PR DESCRIPTION
- So far RegressionTest Fixture was not running properly because
  SetupRevitRegressionTests() was throwing exception and hence the status
  was Test
- RegressionTest is now derived from SystemTest
- SetUp() must be called after calling SwapCurrentModel so that
  RevitDynamoModel initializes DocumentManager with the current active
  revit document.
