### PR TITLE
MAGN-5562 Wrong replication syntax crashes Dynamo hard.

### DIFF
--- a/src/DynamoCore/ViewModels/NodeViewModel.cs
+++ b/src/DynamoCore/ViewModels/NodeViewModel.cs
@@ -612,7 +612,7 @@ namespace Dynamo.ViewModels
                 //is the one passed in
                 foreach (var item in e.OldItems)
                 {
-                    PortViewModel portToRemove = UnSubscribePortEvents(OutPorts.ToList().First(x => x.PortModel == item)); ;                   
+                    PortViewModel portToRemove = UnSubscribePortEvents(InPorts.ToList().First(x => x.PortModel == item)); ;                   
                     InPorts.Remove(portToRemove);
                 }
             }


### PR DESCRIPTION
This PR fixes what appears to be a copy paste error. We should be finding an "in" port in this method, not an "out" port.

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5562

PTAL:
- [x] @ramramps 

Requires Merge:
- [ ] Revit2015
