### PR TITLE
Fix failing test cases related to sun settings

### DIFF
--- a/test/Libraries/Revit/RevitNodesTests/Elements/SunSettingsTests.cs
+++ b/test/Libraries/Revit/RevitNodesTests/Elements/SunSettingsTests.cs
@@ -6,6 +6,8 @@ using RevitServices.Persistence;
 using RevitTestServices;
 
 using RTF.Framework;
+using Revit.GeometryConversion;
+using RevitNodesTests;
 
 namespace RevitNodesTests.Elements
 {
@@ -15,31 +17,27 @@ namespace RevitNodesTests.Elements
         [Test, TestModel(@".\Empty.rvt")]
         public void Current()
         {
-            Assert.AreSame(
-                DocumentManager.Instance.CurrentDBDocument.ActiveView.SunAndShadowSettings,
-                SunSettings.Current());
+            Assert.AreEqual(DocumentManager.Instance.CurrentDBDocument.ActiveView.
+                SunAndShadowSettings.Id, SunSettings.Current().InternalSunAndShadowSettings.Id);
         }
 
         [Test, TestModel(@".\Empty.rvt")]
         public void Direction()
         {
-            Assert.AreEqual(Vector.ByCoordinates(39.898, -28.624, 87.114), SunSettings.Current().SunDirection);
+            Vector.ByCoordinates(39.898058, -28.624325, 87.113678).ShouldBeApproximately(
+                SunSettings.Current().SunDirection);
         }
 
         [Test, TestModel(@".\Empty.rvt")]
         public void Altitude()
         {
-            Assert.AreEqual(
-                DocumentManager.Instance.CurrentDBDocument.ActiveView.SunAndShadowSettings.Altitude,
-                SunSettings.Current().Altitude);
+            SunSettings.Current().Altitude.ShouldBeApproximately(60.591011);
         }
 
         [Test, TestModel(@".\Empty.rvt")]
         public void Azimuth()
         {
-            Assert.AreEqual(
-                DocumentManager.Instance.CurrentDBDocument.ActiveView.SunAndShadowSettings.Azimuth,
-                SunSettings.Current().Azimuth);
+            SunSettings.Current().Azimuth.ShouldBeApproximately(125.657039);
         }
 
         [Test, TestModel(@".\Empty.rvt")]


### PR DESCRIPTION
<h4>Summary</h4>


There are four test cases in SunSettingsTests which are failing:
1). Current: this test case is failing because we need to compare the IDs instead of the two objects.
2). Direction: the precision is not taken into consideration and so it is failing.
3). Altitude: the altitude in comparison is different from what is implemented in Dynamo.
4). Azimuth: the azimuth in comparison is different from what is implemented in Dynamo. 

The fix here for item 1 is to compare the IDs. For the other three, the value will be obtained beforhand and used for comparison.

@ikeough 
@Steell 
PTAL
