### PR TITLE
Fix MAGN-5376 Element.Geometry not working after reopening file.

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Element.cs
@@ -401,6 +401,8 @@ namespace Revit.Elements
         /// <returns></returns>
         internal IEnumerable<Autodesk.Revit.DB.GeometryObject> InternalGeometry(bool useSymbolGeometry = false)
         {
+            DocumentManager.Regenerate();
+
             var thisElement = InternalElement;
 
             var goptions0 = new Options { ComputeReferences = true };


### PR DESCRIPTION
<h4>Summary</h4>


After creating an element, the change may not yet be updated to the database correctly before we are trying to get the internal geometries from it. This submission is fixing the issue by regenerating the document like what is done in some other places.
- [x] @pboyer
  PTAL
