### PR TITLE
Fix for integer slider fix

### DIFF
--- a/src/Libraries/CoreNodesUI/Input/Sliders.cs
+++ b/src/Libraries/CoreNodesUI/Input/Sliders.cs
@@ -355,6 +355,14 @@ namespace Dynamo.Nodes
             {
                 case "Value":
                     Value = ((int)converter.ConvertBack(value, typeof(int), null, null));
+                    if (Value >= Max)
+                    {
+                        this.Max = Value;
+                    }
+                    if (Value <= Min)
+                    {
+                        this.Min = Value;
+                    }
                     return true; // UpdateValueCore handled.
                 case "Max":
                     Max = ((int)converter.ConvertBack(value, typeof(int), null, null));

--- a/test/Libraries/CoreNodesTests/NodeWithUITests.cs
+++ b/test/Libraries/CoreNodesTests/NodeWithUITests.cs
@@ -52,5 +52,23 @@ namespace DSCoreNodesTests
                  -1,
                  sliderNode.Min);
         }
+
+        [Test]
+        [Category("Failure")]
+        public void IntegerSliderMaxValue()
+        {
+            var integerSliderNode = new IntegerSlider(null) { Value = 500 };
+            integerSliderNode.UpdateValue("Value", "1000");
+
+            Assert.AreEqual(
+                 1000,
+                 integerSliderNode.Max);
+
+            integerSliderNode.UpdateValue("Value", "-1");
+
+            Assert.AreEqual(
+                 -1,
+                 integerSliderNode.Min);
+        }
     }
 }


### PR DESCRIPTION
This is the same as Double Slider Fix. 
https://github.com/DynamoDS/Dynamo/pull/2877

In the IntegerSlider : 
if the value entered is greater than Max, then the Max value is updated to the entered value
if the value entered is less than Min, then the Min value is updated to the entered value.
When the node is saved, these new values are saved in .dyn.
- [x] @Steell 
