### PR TITLE
Fix MAGN-3711 Support floor creation for structural types

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/Floor.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Floor.cs
@@ -51,8 +51,16 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            // we assume the floor is not structural here, this may be a bad assumption
-            var floor = Document.Create.NewFloor(curveArray, floorType, level, false);
+            Autodesk.Revit.DB.Floor floor = null;
+            if (floorType.IsFoundationSlab)
+            {
+                floor = Document.Create.NewFoundationSlab(curveArray, floorType, level, false, XYZ.BasisZ);
+            }
+            else
+            {
+                // we assume the floor is not structural here, this may be a bad assumption
+                floor = Document.Create.NewFloor(curveArray, floorType, level, false);
+            }
 
             InternalSetFloor( floor );
 


### PR DESCRIPTION
<h4>Summary</h4>


The floor type of the floor to be created can be a foundation slab or not. There are two different APIs to create two different types of floors. However, originally one API is used for all floor types. This is not correct.

The fix here is to check the floor type and call corresponding API to create the floor.
- [x] @pboyer 
  PTAL
