### PR TITLE
Change the returned object to Element for GetParameterValueByName

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Element.cs
@@ -238,7 +238,9 @@ namespace Revit.Elements
             switch (param.StorageType)
             {
                 case StorageType.ElementId:
-                    result = param.AsElementId();
+                    int id = param.AsElementId().IntegerValue;
+                    var ele = ElementIDLifecycleManager<int>.GetInstance().GetFirstWrapper(id) as Element;
+                    result = ElementSelector.ByElementId(id, ele == null ? true : ele.IsRevitOwned);
                     break;
                 case StorageType.String:
                     result = param.AsString();

--- a/src/Libraries/Revit/RevitServices/Persistence/ElementIDLifecycleManager.cs
+++ b/src/Libraries/Revit/RevitServices/Persistence/ElementIDLifecycleManager.cs
@@ -137,6 +137,23 @@ namespace RevitServices.Persistence
         }
 
         /// <summary>
+        /// Return null if no wrappers are registered with this ID.
+        /// Otherwise, returns the first wrapper.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public object GetFirstWrapper(T id)
+        {
+            List<object> wrappersForGivenId;
+            if (wrappers.TryGetValue(id, out wrappersForGivenId))
+            {
+                if (null != wrappersForGivenId && wrappersForGivenId.Count > 0)
+                    return wrappersForGivenId.First();
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Checks whether an element has been deleted in Revit
         /// </summary>
         /// <param name="id"></param>


### PR DESCRIPTION
<h4>Summary</h4>


When we set a parameter value for an element ID, there is no proper overloaded function. As a result, an exception will be thrown.

In this submission, I am adding an overloaded function to set parameter for an element ID.

@pboyer 
@sharadkjaiswal 
PTAL
