### PR TITLE
Fix MAGN-5376 Element.Geometry not working after reopening file.

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Element.cs
@@ -401,6 +401,8 @@ namespace Revit.Elements
         /// <returns></returns>
         internal IEnumerable<Autodesk.Revit.DB.GeometryObject> InternalGeometry(bool useSymbolGeometry = false)
         {
+            DocumentManager.Regenerate();
+
             var thisElement = InternalElement;
 
             var goptions0 = new Options { ComputeReferences = true };

--- a/src/Libraries/Revit/RevitServices/Persistence/DocumentManager.cs
+++ b/src/Libraries/Revit/RevitServices/Persistence/DocumentManager.cs
@@ -128,10 +128,6 @@ namespace RevitServices.Persistence
                 TransactionManager.Instance.EnsureInTransaction(
                     DocumentManager.Instance.CurrentDBDocument);
                 Instance.CurrentDBDocument.Regenerate();
-                // To ensure the transaction is closed in the idle process
-                // so that the element is updated after this.
-                TransactionManager.Instance.ForceCloseTransaction();
-
 #else
                 IdlePromise.ExecuteOnIdleSync(() =>
                  {

--- a/test/Libraries/Revit/RevitTestServices/RevitNodeTestBase.cs
+++ b/test/Libraries/Revit/RevitTestServices/RevitNodeTestBase.cs
@@ -38,6 +38,9 @@ namespace RevitTestServices
 
             // Tests do not run from idle thread.
             TransactionManager.Instance.DoAssertInIdleThread = false;
+
+            // Start a transaction
+            TransactionManager.Instance.EnsureInTransaction(DocumentManager.Instance.CurrentDBDocument);
         }
 
         public void DisableElementBinder()


### PR DESCRIPTION
<h4>Summary</h4>


I am regenerating the document before attempting to get geometries from elements. This will fix the defect. But because the test cases are running without starting a transaction, I am modifying the test framework to start a transaction in the setup method.

I am removing one call to ForceCloseTransaction in DocumentManager.Regenerate because it will be duplicated with the one call in RevitDynamoModel.OnEvaluationCompleted.

<h4>Reviewers</h4>
- [ ] @pboyer 
