### PR TITLE
Dump library to XML. Added flattened list of nodes

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -3,18 +3,17 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Xml;
+
+using Dynamo.DSEngine;
 using Dynamo.Models;
 using Dynamo.Nodes;
-using System.IO;
-
 using DynamoUtilities;
 
 using Enum = System.Enum;
 using Utils = Dynamo.Nodes.Utilities;
-using DynCmd = Dynamo.ViewModels.DynamoViewModel;
-using Dynamo.DSEngine;
 
 namespace Dynamo.Utilities
 {
@@ -23,13 +22,15 @@ namespace Dynamo.Utilities
     /// </summary>
     public class CustomNodeInfo
     {
-        public CustomNodeInfo(Guid guid, string name, string category, string description, string path)
+        public CustomNodeInfo(Guid guid, string name, string category, string description,
+            string path, string packageName = "")
         {
             Guid = guid;
             Name = name;
             Category = category;
             Description = description;
             Path = path;
+            PackageName = packageName;
         }
 
         public Guid Guid { get; set; }
@@ -37,6 +38,7 @@ namespace Dynamo.Utilities
         public string Category { get; set; }
         public string Description { get; set; }
         public string Path { get; set; }
+        public string PackageName { get; set; }
     }
 
     public delegate void DefinitionLoadHandler(CustomNodeDefinition def);
@@ -163,11 +165,11 @@ namespace Dynamo.Utilities
         public List<CustomNodeInfo> GetInfosFromFolder(string dir)
         {
             return Directory.Exists(dir) ? Directory.EnumerateFiles(dir, "*.dyf")
-                     .Select( AddFileToPath )
+                     .Select(AddFileToPath)
                      .Where(x => x != null)
                      .ToList() : new List<CustomNodeInfo>();
 
-        } 
+        }
 
         /// <summary>
         ///     Removes the custom nodes loaded from a particular folder.
@@ -386,7 +388,7 @@ namespace Dynamo.Utilities
         {
             var compiledNodes = new HashSet<Guid>();
 
-            var enumerator =  LoadedCustomNodes.GetEnumerator();
+            var enumerator = LoadedCustomNodes.GetEnumerator();
             while (enumerator.MoveNext())
             {
                 var guid = (Guid)enumerator.Key;
@@ -632,7 +634,7 @@ namespace Dynamo.Utilities
                 // handle legacy workspace nodes called dynWorkspace
                 // and new workspaces without the dyn prefix
                 XmlNodeList workspaceNodes = xmlDoc.GetElementsByTagName("Workspace");
-                if(workspaceNodes.Count == 0)
+                if (workspaceNodes.Count == 0)
                     workspaceNodes = xmlDoc.GetElementsByTagName("dynWorkspace");
 
                 foreach (XmlNode node in workspaceNodes)
@@ -676,7 +678,7 @@ namespace Dynamo.Utilities
                 if (decision == MigrationManager.Decision.Abort)
                 {
                     Utils.DisplayObsoleteFileMessage(this.dynamoModel, xmlPath, fileVersion, currentVersion);
-                    
+
                     def = null;
                     return false;
                 }

--- a/src/DynamoCore/Core/DynamoLoader.cs
+++ b/src/DynamoCore/Core/DynamoLoader.cs
@@ -308,7 +308,7 @@ namespace Dynamo.Utilities
         /// <summary>
         ///     Load Custom Nodes from the CustomNodeLoader search path and update search
         /// </summary>
-        public List<CustomNodeInfo> LoadPackageCustomNodes(string path, string packageName)
+        public List<CustomNodeInfo> LoadCustomNodesFromPackage(string path, string packageName)
         {
             if (!Directory.Exists(path))
                 return new List<CustomNodeInfo>();

--- a/src/DynamoCore/Core/DynamoLoader.cs
+++ b/src/DynamoCore/Core/DynamoLoader.cs
@@ -308,7 +308,7 @@ namespace Dynamo.Utilities
         /// <summary>
         ///     Load Custom Nodes from the CustomNodeLoader search path and update search
         /// </summary>
-        public List<CustomNodeInfo> LoadCustomNodes(string path)
+        public List<CustomNodeInfo> LoadPackageCustomNodes(string path, string packageName)
         {
             if (!Directory.Exists(path))
                 return new List<CustomNodeInfo>();
@@ -317,9 +317,13 @@ namespace Dynamo.Utilities
             var searchModel = dynamoModel.SearchModel;
 
             var loadedNodes = customNodeLoader.ScanNodeHeadersInDirectory(path).ToList();
-            
+
             // add nodes to search
-            loadedNodes.ForEach(x => searchModel.Add(x));
+            loadedNodes.ForEach(x =>
+            {
+                x.PackageName = packageName;
+                searchModel.Add(x);
+            });
 
             // update search view
             searchModel.OnRequestSync();

--- a/src/DynamoCore/PackageManager/Package.cs
+++ b/src/DynamoCore/PackageManager/Package.cs
@@ -236,7 +236,7 @@ namespace Dynamo.PackageManager
 
         private void LoadCustomNodesIntoDynamo( DynamoLoader loader)
         {
-            loader.LoadCustomNodes(CustomNodeDirectory).ForEach(x => LoadedCustomNodes.Add(x));
+            loader.LoadPackageCustomNodes(CustomNodeDirectory, Name).ForEach(x => LoadedCustomNodes.Add(x));
         }
 
         private void LoadAssembliesIntoDynamo( DynamoLoader loader, ILogger logger, LibraryServices libraryServices)

--- a/src/DynamoCore/PackageManager/Package.cs
+++ b/src/DynamoCore/PackageManager/Package.cs
@@ -236,7 +236,7 @@ namespace Dynamo.PackageManager
 
         private void LoadCustomNodesIntoDynamo( DynamoLoader loader)
         {
-            loader.LoadPackageCustomNodes(CustomNodeDirectory, Name).ForEach(x => LoadedCustomNodes.Add(x));
+            loader.LoadCustomNodesFromPackage(CustomNodeDirectory, Name).ForEach(x => LoadedCustomNodes.Add(x));
         }
 
         private void LoadAssembliesIntoDynamo( DynamoLoader loader, ILogger logger, LibraryServices libraryServices)

--- a/src/DynamoCore/PackageManager/PackageLoader.cs
+++ b/src/DynamoCore/PackageManager/PackageLoader.cs
@@ -188,12 +188,6 @@ namespace Dynamo.PackageManager
             return LocalPackages.FirstOrDefault(ele => ele.ContainsFile(path));
         }
 
-        public IEnumerable<string> GetAllPackagesAssemblies()
-        {
-            return LocalPackages.SelectMany(pkg => pkg.LoadedAssemblies)
-                                .Select(pa => pa.Assembly.Location);
-        }
-
         private static bool hasAttemptedUninstall = false;
 
         internal void DoCachedPackageUninstalls( IPreferences preferences )

--- a/src/DynamoCore/PackageManager/PackageLoader.cs
+++ b/src/DynamoCore/PackageManager/PackageLoader.cs
@@ -188,6 +188,12 @@ namespace Dynamo.PackageManager
             return LocalPackages.FirstOrDefault(ele => ele.ContainsFile(path));
         }
 
+        public IEnumerable<string> GetAllPackagesAssemblies()
+        {
+            return LocalPackages.SelectMany(pkg => pkg.LoadedAssemblies)
+                                .Select(pa => pa.Assembly.Location);
+        }
+
         private static bool hasAttemptedUninstall = false;
 
         internal void DoCachedPackageUninstalls( IPreferences preferences )
@@ -214,6 +220,6 @@ namespace Dynamo.PackageManager
             }
             
             preferences.PackageDirectoriesToUninstall.RemoveAll(pkgDirsRemoved.Contains);
-        }
+        }                
     }
 }

--- a/src/DynamoCore/PackageManager/PackageLoader.cs
+++ b/src/DynamoCore/PackageManager/PackageLoader.cs
@@ -220,6 +220,6 @@ namespace Dynamo.PackageManager
             }
             
             preferences.PackageDirectoriesToUninstall.RemoveAll(pkgDirsRemoved.Contains);
-        }                
+        }
     }
 }

--- a/src/DynamoCore/Search/BrowserInternalElement.cs
+++ b/src/DynamoCore/Search/BrowserInternalElement.cs
@@ -119,8 +119,9 @@ namespace Dynamo.Nodes.Search
             this.OldParent = null;
         }
 
-
         public string FullCategoryName { get; set; }
+
+        public string FullName { get { return FullCategoryName + "." + Name; } }
     }
 }
 

--- a/src/DynamoCore/Search/BrowserInternalElement.cs
+++ b/src/DynamoCore/Search/BrowserInternalElement.cs
@@ -92,6 +92,18 @@ namespace Dynamo.Nodes.Search
             get { return _name; }
         }
 
+        /// <summary>
+        /// Assembly, from which we can get icon for class button.
+        /// </summary>
+        private string assembly;
+        public string Assembly
+        {
+            get { return assembly; }
+
+            // Note: we need setter, when we set resource assembly in NodeSearchElement.
+            set { assembly = value; }
+        }
+
         public BrowserInternalElement()
         {
             this._name = "Default";
@@ -99,9 +111,10 @@ namespace Dynamo.Nodes.Search
             this.OldParent = null;
         }
 
-        public BrowserInternalElement(string name, BrowserItem parent)
+        public BrowserInternalElement(string name, BrowserItem parent, string _assembly = "")
         {
             this._name = name;
+            this.assembly = _assembly;
             this.Parent = parent;
             this.OldParent = null;
         }

--- a/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-using Dynamo.UI.Commands;
 using Dynamo.Utilities;
-using DynCmd = Dynamo.ViewModels.DynamoViewModel;
 
 namespace Dynamo.Search.SearchElements
 {
@@ -15,20 +13,26 @@ namespace Dynamo.Search.SearchElements
         public string Path
         {
             get { return _path; }
-            set { 
-                _path = value; 
-                RaisePropertyChanged("Path"); 
+            set
+            {
+                _path = value;
+                RaisePropertyChanged("Path");
             }
         }
 
+        private string _package;
+        public string Package { get { return _package; } }
+
         public override string Type { get { return "Custom Node"; } }
 
-        public CustomNodeSearchElement(CustomNodeInfo info) : base(info.Name, info.Description, new List<string>())
+        public CustomNodeSearchElement(CustomNodeInfo info)
+            : base(info.Name, info.Description, new List<string>())
         {
             this.Node = null;
             this.FullCategoryName = info.Category;
             this.Guid = info.Guid;
             this._path = info.Path;
+            this._package = info.PackageName;
         }
 
         public override NodeSearchElement Copy()

--- a/src/DynamoCore/Search/SearchElements/DSFunctionNodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/DSFunctionNodeSearchElement.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using DynCmd = Dynamo.ViewModels.DynamoViewModel;
 using Dynamo.DSEngine;
 
 namespace Dynamo.Search.SearchElements
@@ -11,7 +10,8 @@ namespace Dynamo.Search.SearchElements
         private string _displayString;
 
         public DSFunctionNodeSearchElement(string displayString, FunctionDescriptor functionDescriptorItem) :
-            base(displayString, functionDescriptorItem.Description, new List<string> { })
+            base(displayString, functionDescriptorItem.Description, new List<string> { },
+            functionDescriptorItem.DisplayName, functionDescriptorItem.Assembly)
         {
             _displayString = displayString;
             FunctionDescriptor = functionDescriptorItem;

--- a/src/DynamoCore/Search/SearchElements/DSFunctionNodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/DSFunctionNodeSearchElement.cs
@@ -11,7 +11,7 @@ namespace Dynamo.Search.SearchElements
 
         public DSFunctionNodeSearchElement(string displayString, FunctionDescriptor functionDescriptorItem) :
             base(displayString, functionDescriptorItem.Description, new List<string> { },
-            functionDescriptorItem.DisplayName, functionDescriptorItem.Assembly)
+            functionDescriptorItem.Assembly)
         {
             _displayString = displayString;
             FunctionDescriptor = functionDescriptorItem;

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -13,8 +13,6 @@ namespace Dynamo.Search.SearchElements
     /// A search element representing a local node </summary>
     public partial class NodeSearchElement : SearchElementBase, IEquatable<NodeSearchElement>
     {
-        internal readonly string FullName;
-
         #region Properties
 
         /// <summary>
@@ -88,15 +86,14 @@ namespace Dynamo.Search.SearchElements
         /// <param name="description"></param>
         /// <param name="tags"></param>
         /// <param name="fullName"></param>
-        public NodeSearchElement(string name, string description, IEnumerable<string> tags, string fullName = "", string _assembly = "")
+        public NodeSearchElement(string name, string description, IEnumerable<string> tags, string _assembly = "")
         {
             this.Node = null;
             this._name = name;
             this.Weight = 1;
             this.Keywords = String.Join(" ", tags);
             this._type = "Node";
-            this._description = description;
-            this.FullName = fullName;
+            this._description = description;            
             this.Assembly = _assembly;
         }
 

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -13,7 +13,7 @@ namespace Dynamo.Search.SearchElements
     /// A search element representing a local node </summary>
     public partial class NodeSearchElement : SearchElementBase, IEquatable<NodeSearchElement>
     {
-        internal readonly string FullName ;
+        internal readonly string FullName;
 
         #region Properties
 
@@ -88,7 +88,7 @@ namespace Dynamo.Search.SearchElements
         /// <param name="description"></param>
         /// <param name="tags"></param>
         /// <param name="fullName"></param>
-        public NodeSearchElement(string name, string description, IEnumerable<string> tags, string fullName = "")
+        public NodeSearchElement(string name, string description, IEnumerable<string> tags, string fullName = "", string _assembly = "")
         {
             this.Node = null;
             this._name = name;
@@ -97,6 +97,7 @@ namespace Dynamo.Search.SearchElements
             this._type = "Node";
             this._description = description;
             this.FullName = fullName;
+            this.Assembly = _assembly;
         }
 
         public virtual NodeSearchElement Copy()

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -86,15 +86,15 @@ namespace Dynamo.Search.SearchElements
         /// <param name="description"></param>
         /// <param name="tags"></param>
         /// <param name="fullName"></param>
-        public NodeSearchElement(string name, string description, IEnumerable<string> tags, string _assembly = "")
+        public NodeSearchElement(string name, string description, IEnumerable<string> tags, string assembly = "")
         {
             this.Node = null;
             this._name = name;
             this.Weight = 1;
             this.Keywords = String.Join(" ", tags);
             this._type = "Node";
-            this._description = description;            
-            this.Assembly = _assembly;
+            this._description = description;
+            this.Assembly = assembly;
         }
 
         public virtual NodeSearchElement Copy()

--- a/src/DynamoCore/Search/SearchModel.cs
+++ b/src/DynamoCore/Search/SearchModel.cs
@@ -787,6 +787,7 @@ namespace Dynamo.Search
             // Building 'NodesList'
             var parent = XmlHelper.AddNode(document.DocumentElement, "NodesList");
             var assembliesRoot = XmlHelper.AddNode(parent, "Assemblies");
+            var packagesRoot = XmlHelper.AddNode(parent, "Packages");
 
             XmlNode currNode;
 
@@ -812,6 +813,24 @@ namespace Dynamo.Search
                     SpecifyNodeInfo(currNode, currElement as NodeSearchElement);
                 }
             }
+
+            // Adding packages nodes: custom nodes, NodeModel and ZeroTouch assemblies.
+            // Also here are added custom nodes which are not belong to packages
+
+            foreach (var currPackage in DynamoModel.Loader.PackageLoader.LocalPackages)
+            {
+                parent = XmlHelper.AddNode(packagesRoot, "Package");
+                XmlHelper.AddAttribute(parent, "Name", currPackage.Name);
+                XmlHelper.AddAttribute(parent, "VersionName", currPackage.VersionName);
+                //_searchElements.Where(el=>currPackage.LoadedAssemblies.FirstOrDefault)
+                //foreach (var currElement in currPackage.LoadedCustomNodes)
+                //{
+                //    currNode = XmlHelper.AddNode(parent, currElement.GetType().ToString());
+
+                //    SpecifyNodeInfo(currNode, currElement as NodeSearchElement);
+                //}
+            }
+
 
             // Building 'NodesTree'
             parent = XmlHelper.AddNode(document.DocumentElement, "NodesTree");
@@ -853,8 +872,12 @@ namespace Dynamo.Search
         {
             XmlHelper.AddNode(node, "FullName", element.FullName);
             XmlHelper.AddNode(node, "FullCategoryName", element.FullCategoryName);
-            XmlHelper.AddNode(node, "Name", element.Name);            
+            XmlHelper.AddNode(node, "Name", element.Name);
             XmlHelper.AddNode(node, "Description", element.Description);
+
+            var customElement = element as CustomNodeSearchElement;
+            if (customElement != null)
+                XmlHelper.AddNode(node, "Package", customElement.Package);
         }
     }
 }

--- a/src/DynamoCore/Search/SearchModel.cs
+++ b/src/DynamoCore/Search/SearchModel.cs
@@ -603,7 +603,8 @@ namespace Dynamo.Search
                 description = (attribs[0] as NodeDescriptionAttribute).ElementDescription;
             }
 
-            var searchEle = new NodeSearchElement(name, description, tags, t.FullName);
+            var searchEle = new NodeSearchElement(name, description, tags, t.FullName,
+                t.Assembly.GetName().Name + ".dll");
             searchEle.Executed += this.OnExecuted;
 
             attribs = t.GetCustomAttributes(typeof(NodeSearchableAttribute), false);

--- a/src/DynamoCore/Search/SearchModel.cs
+++ b/src/DynamoCore/Search/SearchModel.cs
@@ -814,7 +814,7 @@ namespace Dynamo.Search
 
             IEnumerable<string> assemblyList = nodeModelAssemblies.Union(zeroTouchAssemblies)
                                                                   .OrderBy(a => a);
-            assemblyList = FixRevitAssemblyNames(assemblyList);
+            assemblyList = FixAssemblyNames(assemblyList);
             foreach (var currAssembly in assemblyList)
             {
                 parent = XmlHelper.AddNode(assembliesRoot, "Assembly");
@@ -922,25 +922,21 @@ namespace Dynamo.Search
             XmlHelper.AddNode(node, "Description", element.Description);
         }
 
-        private IEnumerable<string> FixRevitAssemblyNames(IEnumerable<string> assemblyList)
+        private IEnumerable<string> FixAssemblyNames(IEnumerable<string> assemblyList)
         {
             // For nodes which are belongs to preloaded ZeroTouch library Assembly property is
             // specified as library dll filename. But in assemblyList we have full paths 
-            // for those libraries. As result nodes are not added to dump. This method should
-            // replace full names for "RevitNodes.dll" and "SimpleRaaS.dll".
+            // for those libraries. As result nodes are not added to dump. This method fixes it.
+
+            var assembliesToFix = DynamoPathManager.Instance.PreloadLibraries.Where(pl => pl != Path.GetFileName(pl));
+            if (!assembliesToFix.Any())
+                return assemblyList;
+
             var list = assemblyList.ToList();
             for (int i = 0; i < list.Count; i++)
             {
-                if (list[i].Contains("RevitNodes.dll"))
-                {
-                    list[i] = "RevitNodes.dll";
-                    continue;
-                }
-                if (list[i].Contains("SimpleRaaS.dll"))
-                {
-                    list[i] = "SimpleRaaS.dll";
-                    continue;
-                }
+                if (assembliesToFix.Contains(list[i]))
+                    list[i] = Path.GetFileName(list[i]);
             }
 
             return list;

--- a/src/DynamoCore/Search/SearchModel.cs
+++ b/src/DynamoCore/Search/SearchModel.cs
@@ -603,8 +603,11 @@ namespace Dynamo.Search
                 description = (attribs[0] as NodeDescriptionAttribute).ElementDescription;
             }
 
-            var searchEle = new NodeSearchElement(name, description, tags, 
-                t.Assembly.GetName().Name + ".dll");
+            var assemblyName = t.Assembly.GetName().Name + ".dll";
+            if (!DynamoLoader.LoadedAssemblyNames.Contains(assemblyName))
+                assemblyName = t.Assembly.Location;
+
+            var searchEle = new NodeSearchElement(name, description, tags, assemblyName);
             searchEle.Executed += this.OnExecuted;
 
             attribs = t.GetCustomAttributes(typeof(NodeSearchableAttribute), false);

--- a/src/DynamoCore/Search/SearchModel.cs
+++ b/src/DynamoCore/Search/SearchModel.cs
@@ -858,8 +858,6 @@ namespace Dynamo.Search
                     XmlHelper.AddAttribute(element, "Name", child.Name);
                     AddChildrenToXml(element, child.Items);
                 }
-
-                parent.AppendChild(element);
             }
         }
 

--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -274,14 +274,7 @@ namespace Dynamo.Tests
 
             var libraryRoot = document.DocumentElement;
 
-            var nodesListRoot = libraryRoot.SelectSingleNode("NodesList");
-            Assert.IsNotNull(nodesListRoot);
-
-            Assert.IsNotNull(nodesListRoot.SelectSingleNode("Assemblies"));
-            Assert.IsNotNull(nodesListRoot.SelectSingleNode("Packages"));
-            Assert.IsNotNull(nodesListRoot.SelectSingleNode("CustomNodes"));
-            Assert.IsNotNull(nodesListRoot.SelectSingleNode("Specifics"));
-
+            Assert.IsNotNull(libraryRoot.SelectSingleNode("NodesList"));
             Assert.IsNotNull(libraryRoot.SelectSingleNode("NodesTree"));
         }
 
@@ -338,9 +331,7 @@ namespace Dynamo.Tests
             var fgToCompare = libraryServices.GetFunctionGroups(libraryPath);
 
             var document = ViewModel.SearchViewModel.Model.ComposeXmlForLibrary();
-            var assemblyNode = document.DocumentElement.SelectSingleNode(
-                "NodesList/Assemblies/Assembly[@Name='DSOffice.dll']");
-            Assert.IsNotNull(assemblyNode);
+            var nodesList = document.DocumentElement.SelectSingleNode("NodesList");
 
             XmlNode node, subNode;
             foreach (var functionGroup in fgToCompare)
@@ -352,8 +343,8 @@ namespace Dynamo.Tests
                     if (function.IsObsolete || !function.IsVisibleInLibrary || function.Name.Contains("GetType"))
                         continue;
 
-                    node = assemblyNode.SelectSingleNode(string.Format(
-                        "Dynamo.Search.SearchElements.DSFunctionNodeSearchElement[FullName='{0}']",
+                    node = nodesList.SelectSingleNode(string.Format(
+                        "//Dynamo.Search.SearchElements.DSFunctionNodeSearchElement[FullName='{0}']",
                         function.Category + "." + function.Name));
                     Assert.IsNotNull(node);
 
@@ -377,6 +368,10 @@ namespace Dynamo.Tests
                     // For example: 
                     // tests  function.Description: Excel.ReadFromFile (file: FileInfo, sheetName: string): var[][]
                     // normal function.Description: Excel.ReadFromFile (file: var, sheetName: string): var[][]
+
+                    subNode = node.SelectSingleNode("Assembly");
+                    Assert.IsNotNull(subNode);
+                    Assert.AreEqual(function.Assembly, subNode.FirstChild.Value);
                 }
             }
         }
@@ -436,16 +431,14 @@ namespace Dynamo.Tests
             }
 
             var document = ViewModel.SearchViewModel.Model.ComposeXmlForLibrary();
-            var packageNode = document.DocumentElement.SelectSingleNode(string.Format(
-                "NodesList/Packages/Package[@Name='{0}' and @VersionName='{1}']",
-                package.Name, package.VersionName));
-            Assert.IsNotNull(packageNode);
+            var nodesList = document.DocumentElement.SelectSingleNode("NodesList");
+            Assert.IsNotNull(nodesList);
 
             XmlNode node, subNode;
             foreach (var customNode in package.LoadedCustomNodes)
             {
-                node = packageNode.SelectSingleNode(string.Format(
-                    "Dynamo.Search.SearchElements.CustomNodeSearchElement[FullName='{0}']",
+                node = nodesList.SelectSingleNode(string.Format(
+                    "//Dynamo.Search.SearchElements.CustomNodeSearchElement[FullName='{0}']",
                     customNode.Category + "." + customNode.Name));
                 Assert.IsNotNull(node);
 
@@ -462,6 +455,10 @@ namespace Dynamo.Tests
                 subNode = node.SelectSingleNode("Description");
                 Assert.IsNotNull(subNode);
                 Assert.AreEqual(customNode.Description, subNode.FirstChild.Value);
+
+                subNode = node.SelectSingleNode("Package");
+                Assert.IsNotNull(subNode);
+                Assert.AreEqual(customNode.PackageName, subNode.FirstChild.Value);
             }
         }
 


### PR DESCRIPTION
#### Purpose

Currently dump is making a tree of nodes. This PR adds a flattened list of nodes. Node information is saved this list. To link nodes from Tree to nodes of Flattened list `FullName` property is used. Example of new file you can find in attachment of task [MAGN-5542](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5542).

#### Modifications

To populate `Assembly`, `Package` values in dump next changes are needed on Node level.

1. Property `Dynamo.Nodes.Search.BrowserInternalElement.FullName` is specified automatically. Used as unique identifier.
2. Added property `Dynamo.Nodes.Search.BrowserInternalElement.Assembly` to know which assembly is owner of Node.
3. Added property `Dynamo.Nodes.Search.CustomNodeSearchElement.Package` to know to which package custom node is belong to. Can be empty.
4. Added property `Dynamo.Utilities.CustomNodeInfo.PackageName` to specify previous property.

#### Unit tests
![001](https://cloud.githubusercontent.com/assets/8158551/5299233/a094d61a-7bcd-11e4-962f-ee8413fe3fa3.PNG)

#### Additional references

[MAGN-5542](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5542).
[MAGN-5554](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5554).

First PR in "Dump library to XML" series: https://github.com/DynamoDS/Dynamo/pull/3270.

#### Reviewers

@sharadkjaiswal, please, take a look.
@pboyer, could you please take a look? Especially on node changes.
@aparajit-pratap, can your `Dynamo.DynamoLoader.Utilities.DumpLibrarySnapshot` function be removed as the one which is replaced by proposed functionality?