### PR TITLE
Port Snapping defect

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -1205,7 +1205,8 @@ namespace Dynamo.Models
                 ports[ports.Count - 1].extensionEdges = SnapExtensionEdges.Bottom;
                 foreach (PortModel port in ports)
                 {
-                    if (!port.extensionEdges.HasFlag(SnapExtensionEdges.Top | SnapExtensionEdges.Bottom))
+                    if (!port.extensionEdges.HasFlag(SnapExtensionEdges.Top)
+                        && !port.extensionEdges.HasFlag(SnapExtensionEdges.Bottom))
                         port.extensionEdges = SnapExtensionEdges.None;
                 }
             } 

--- a/src/DynamoCore/UI/Converters.cs
+++ b/src/DynamoCore/UI/Converters.cs
@@ -283,9 +283,9 @@ namespace Dynamo.Controls
                 switch (type)
                 {
                     case PortType.INPUT:
-                        thickness = new Thickness(left - 25, top + 3, right + 0, bottom - 10);
+                        thickness = new Thickness(left - 25, top + 3, right + 0, bottom + 3);
                         if (port.extensionEdges.HasFlag(SnapExtensionEdges.Top | SnapExtensionEdges.Bottom))
-                            thickness = new Thickness(left - 25, top - 10, right - 25, bottom - 10);
+                            thickness = new Thickness(left - 25, top - 10, right + 0, bottom - 10);
                         else if (port.extensionEdges.HasFlag(SnapExtensionEdges.Top))
                             thickness = new Thickness(left - 25, top - 10, right + 0, bottom + 3);
                         else if (port.extensionEdges.HasFlag(SnapExtensionEdges.Bottom))


### PR DESCRIPTION
There is a defect with port snapping boundary calculation. 
The defect is mainly with ports with one INPUT or more than 2 INPUT. 

Fixed the boundary calculation and also there was a bug in checking the flag condition. 
- [x] @pboyer 

Merge
- [ ] Revit2015
