### PR TITLE
Product version upgrade to 0.7.6

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
@@ -59,6 +59,6 @@ using System.Runtime.InteropServices;
 <#+
 int MajorVersion = 0;
 int MinorVersion = 7;
-int BuildNumber = 5;
+int BuildNumber = 6;
 int RevisionNumber = ((int)(DateTime.UtcNow - new DateTime(2014,1,1)).TotalDays)*10+((int)DateTime.UtcNow.Hour)/3;
 #>

--- a/src/DynamoInstall/Product.wxs
+++ b/src/DynamoInstall/Product.wxs
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 
-  <Product Id="F295EB3F-AAD2-4514-B466-6F0375AAEEE5"
-           Name="Dynamo 0.7.5"
+  <Product Id="A0A6A915-F284-4CB4-90D3-C1356052D456"
+           Name="Dynamo 0.7.6"
            Language="1033"
-           Version="0.7.5"
+           Version="0.7.6"
            Manufacturer="Dynamo"
            UpgradeCode="733f1d21-d745-47aa-bbb5-4a39b5996e4e">
 

--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -8,16 +8,16 @@ AppCopyright=
 AppPublisherURL=http://www.dynamobim.org
 AppSupportURL=http://www.dynamobim.org
 AppUpdatesURL=http://www.dynamobim.org
-AppVersion=0.7.5
-VersionInfoVersion=0.7.5
+AppVersion=0.7.6
+VersionInfoVersion=0.7.6
 VersionInfoCompany=Dynamo 
-VersionInfoDescription=Dynamo 0.7.5
-VersionInfoTextVersion=Dynamo 0.7.5
+VersionInfoDescription=Dynamo 0.7.6
+VersionInfoTextVersion=Dynamo 0.7.6
 VersionInfoCopyright=
 DefaultDirName={pf64}\Dynamo 0.7
 DefaultGroupName=Dynamo
 OutputDir=Installers
-OutputBaseFilename=InstallDynamo0.7.5
+OutputBaseFilename=InstallDynamo0.7.6
 SetupIconFile=Extra\DynamoInstaller.ico
 Compression=lzma
 SolidCompression=true
@@ -27,7 +27,7 @@ ShowLanguageDialog=auto
 DirExistsWarning=no
 UninstallFilesDir={app}\Uninstall
 UninstallDisplayIcon={app}\DynamoInstaller.ico
-UninstallDisplayName=Dynamo 0.7.5
+UninstallDisplayName=Dynamo 0.7.6
 UsePreviousAppDir=no
 
 [Dirs]
@@ -291,6 +291,11 @@ begin
 
       // Query for 0.7.3 MSI uninstall string.
       sUninstallString := GetUninstallStringForMSI('{F295EB3F-AAD2-4514-B466-6F0375AAEEE5}');
+      if sUninstallString <> '' then
+        UnInstallOldMSI(sUninstallString);
+	  
+	  // Query for 0.7.6 MSI uninstall string.
+      sUninstallString := GetUninstallStringForMSI('{A0A6A915-F284-4CB4-90D3-C1356052D456}');
       if sUninstallString <> '' then
         UnInstallOldMSI(sUninstallString);
 


### PR DESCRIPTION
- Updated BuildNumber to 6 in T4 template AssemblySharedInfo.tt
- Changed the Product Id for msi installer and bumped the version to 0.7.6
- Bumped exe installer version to 0.7.6 and put logic for msi uninstall of 0.7.6
