### PR TITLE
MAGN-5593: Use local reference of RevitDynamoModel in RevitVisualizationManager

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -64,10 +64,9 @@ namespace RevitServices.Threading
         /// when the scheduled DelegateBasedAsyncTask is completed. This parameter
         /// is optional.</param>
         /// 
-        internal static void ExecuteOnIdleAsync(Action p,
+        internal static void ExecuteOnIdleAsync(DynamoScheduler scheduler, Action p,
             AsyncTaskCompletedHandler completionHandler = null)
         {
-            var scheduler = DynamoRevit.RevitDynamoModel.Scheduler;
             var task = new DelegateBasedAsyncTask(scheduler);
 
             task.Initialize(p);

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -277,7 +277,7 @@ namespace Dynamo.Applications.Models
             if (markNodesAsDirty || DynamicRunEnabled)
                 handler = OnResetMarkNodesAsDirty;
 
-            IdlePromise.ExecuteOnIdleAsync(ResetEngineInternal, handler);
+            IdlePromise.ExecuteOnIdleAsync(this.Scheduler, ResetEngineInternal, handler);
         }
 
         /// <summary>

--- a/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
+++ b/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
@@ -70,7 +70,7 @@ namespace Dynamo
 
         private void CleanupVisualizations()
         {
-            RevitServices.Threading.IdlePromise.ExecuteOnIdleAsync(
+            RevitServices.Threading.IdlePromise.ExecuteOnIdleAsync(dynamoModel.Scheduler,
                 () =>
                 {
                     TransactionManager.Instance.EnsureInTransaction(
@@ -128,13 +128,13 @@ namespace Dynamo
 
             Element gStyle = styles.ToElements().FirstOrDefault(x => x.Name == "Dynamo");
 
-            RevitServices.Threading.IdlePromise.ExecuteOnIdleAsync(
+            RevitServices.Threading.IdlePromise.ExecuteOnIdleAsync( dynamoModel.Scheduler,
                 () =>
                 {
                     TransactionManager.Instance.EnsureInTransaction(
                         DocumentManager.Instance.CurrentDBDocument);
 
-                    if (keeperId != ElementId.InvalidElementId && 
+                    if (keeperId != ElementId.InvalidElementId &&   
                         DocumentManager.Instance.CurrentDBDocument.GetElement(keeperId) != null)
                     {
                         DocumentManager.Instance.CurrentUIDocument.Document.Delete(keeperId);


### PR DESCRIPTION
## Issue

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5593

Essentially, a `NullReferenceException` was being thrown from line 69 of DynamoRevit.cs as the `revitDynamoModel` had been set to null.
## Stop-gap

Simply provide a valid reference of `RevitDynamoModel` as one of the arguments to `ExecuteOnIdleAsync`.  All usages of this method are also updated.
## Merge
- [x] Revit2015
- [x] 0.7.5RC
- [x] 0.7.5RC2015
