### PR TITLE
copy arguments should be escaped by quotes

### DIFF
--- a/src/Libraries/Analysis/Analysis.csproj
+++ b/src/Libraries/Analysis/Analysis.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(ProjectDir)Analysis_DynamoCustomization.xml $(OutDir)Analysis_DynamoCustomization.xml</PostBuildEvent>
+    <PostBuildEvent>copy "$(ProjectDir)Analysis_DynamoCustomization.xml" "$(OutDir)Analysis_DynamoCustomization.xml"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
To build successfully solution situated on spaced path (i.e. "d:/dynamo sources/") double quotes are added for `copy` arguments.

![image](https://cloud.githubusercontent.com/assets/8158551/5359355/4c6bebae-7fc5-11e4-8946-0705bef5d04c.png)

@sharadkjaiswal, please, take a look. 