### PR TITLE
Restored version number to the original color

### DIFF
--- a/src/DynamoCoreWpf/Views/AboutWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/AboutWindow.xaml.cs
@@ -24,11 +24,6 @@ namespace Dynamo.UI.Views
             InstallNewUpdate = false;
             PreviewKeyDown += new KeyEventHandler(HandleEsc);
             DataContext = dynamoViewModel;
-
-#if ENABLE_DYNAMO_SCHEDULER
-            // SCHEDULER: Temporary way to tell that scheduler is enabled.
-            VersionNumber.Foreground = new SolidColorBrush(Colors.Yellow);
-#endif
         }
 
         public bool InstallNewUpdate { get; private set; }


### PR DESCRIPTION
Prior to this pull request, the version number on the About Box gets displayed in yellow color when the scheduler is enabled. That was done over a transition period for scheduler before it gets turned on permanently as a way to visually tell if a build has the scheduler enabled or not. Now that scheduler is permanently turned on, it is no longer necessary to do that, therefore the code which did that is removed.

@RodRecker, as requested. Please take a look and if I'm not online to merge this later (when we start allowing submissions), help to merge it for me. Thanks!
