### PR TITLE
Fixed build error

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -4793,7 +4793,7 @@ namespace ProtoAssociative
                 if (ProtoCore.Language.kAssociative == langblock.codeblock.language && !isTopBlock)
                 {
                     // TODO Jun: Move the associative and all common string into some table
-                    buildStatus.LogSyntaxError(StringConstants.invalidNestedImperativeBlock, core.CurrentDSFileName, langblock.line, langblock.col);
+                    buildStatus.LogSyntaxError(StringConstants.invalidNestedAssociativeBlock, core.CurrentDSFileName, langblock.line, langblock.col);
                 }
 
 


### PR DESCRIPTION
This is to fix the build error:
`C:\EC\Dynamo\Dynamo\src\Engine\ProtoAssociative\CodeGen.cs(4796,64,4796,92): error CS0117: 'ProtoAssociative.StringConstants' does not contain a definition for 'invalidNestedImperativeBlock'`
@sharadkjaiswal please take a look. Thanks
