### PR TITLE
MAGN-5620: Fix for UpdateManager's use of MessageBox

### DIFF
--- a/src/DynamoCore/UpdateManager/UpdateManager.cs
+++ b/src/DynamoCore/UpdateManager/UpdateManager.cs
@@ -647,23 +647,10 @@ namespace Dynamo.UpdateManager
 
         public void QuitAndInstallUpdate()
         {
-            OnLog(new LogEventArgs("UpdateNotificationControl-OnInstallButtonClicked", LogLevel.File));
+            OnLog(new LogEventArgs("UpdateManager.QuitAndInstallUpdate-Invoked", LogLevel.File));
 
-            string message = string.Format("An update is available for {0}.\n\n" +
-                "Click OK to close {0} and install\nClick CANCEL to cancel the update.", "Dynamo");
-
-            //SEPARATECORE - fix this
-            //string message = string.Format("An update is available for {0}.\n\n" +
-            //    "Click OK to close {0} and install\nClick CANCEL to cancel the update.", "Dynamo");
-
-            //MessageBoxResult result = MessageBox.Show(message, "Install Dynamo", MessageBoxButton.OKCancel);
-            //bool installUpdate = result == MessageBoxResult.OK;
-
-            //if (installUpdate)
-            //{
-            //    if (ShutdownRequested != null)
-            //        ShutdownRequested(this);
-            //}
+            if (ShutdownRequested != null)
+                ShutdownRequested(this);
         }
 
         public void HostApplicationBeginQuit()

--- a/src/DynamoCoreWpf/Controls/GraphUpdateNotificationControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/GraphUpdateNotificationControl.xaml.cs
@@ -20,7 +20,15 @@ namespace DynamoCore.UI.Controls
         {
             if (DataContext is UpdateManager)
             {
-                UpdateManager.Instance.QuitAndInstallUpdate();
+                var message = string.Format("An update is available for {0}.\n\n" +
+                    "Click OK to close {0} and install\nClick CANCEL to cancel the update.", "Dynamo");
+
+                var result = MessageBox.Show(message, "Install Dynamo", MessageBoxButton.OKCancel);
+
+                if (result == MessageBoxResult.OK)
+                {
+                    UpdateManager.Instance.QuitAndInstallUpdate();
+                }
             }
         }
     }


### PR DESCRIPTION
### Note

As a stop gap, I deactivated the UpdateManager during the core split because of it's usage of MessageBox in DynamoCore.  Turns out it was very easy to fix because there was only one usage of QuitAndInstallUpdate in the project.
### Reviewer
- [x] @ikeough 
