### PR TITLE
Another attempt at fixing flaky NodeViewCustomizationTests

### DIFF
--- a/test/DynamoCoreUITests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreUITests/DynamoTestUIBase.cs
@@ -110,7 +110,7 @@ namespace DynamoCoreUITests
         /// Open a file from the Dynamo test directory
         /// </summary>
         /// <param name="pathInTestsDir">A relative path from the test directory</param>
-        public void Open(string pathInTestsDir)
+        public virtual void Open(string pathInTestsDir)
         {
             string openPath = Path.Combine(GetTestDirectory(ExecutingDirectory), pathInTestsDir);
             ViewModel.OpenCommand.Execute(openPath);
@@ -122,15 +122,10 @@ namespace DynamoCoreUITests
             Run();
         }
 
-        public void AssertWhenDispatcherDone(Action action)
-        {
-            View.Dispatcher.Invoke(DispatcherPriority.SystemIdle, action);
-        }
-
         /// <summary>
         /// Run the current workspace.  Doesn't return until 
         /// </summary>
-        public void Run()
+        public virtual void Run()
         {
             var complete = false;
 


### PR DESCRIPTION
### Issue

The `NodeViewCustomizationTests` seems to fail sporadically on the CI.
### Potential fix

My next best guess is that this failure has to do with the fact that the UI has not been updated after completing a `RecordableCommand` like `Open` or `Run`. 

Here I use the `DispatcherUtils.DoEvents()` to ensure the Dispatcher has emptied it's queue before doing UI assertions.  This class was found in various places on StackOverflow, but probably has its origin in the WPF Application Framework https://waf.codeplex.com/.
### Test runs

I ran the tests 4 times on my machine without failure, but then again, I've never seen them fail like the CI (very frustrating).  
### Reviewers
- [x] @ikeough 
- [x] @Benglin 
