### PR TITLE
MAGN-5461 Add an event for Workspace closed.

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -460,7 +460,7 @@ namespace Dynamo.Models
 
         protected virtual void ShutDownCore(bool shutdownHost)
         {
-            CleanWorkbench();
+            ClearWorkspace();
 
             EngineController.Dispose();
             EngineController = null;
@@ -837,9 +837,11 @@ namespace Dynamo.Models
             return OpenWorkspace(xmlPath);
         }
 
-        internal void CleanWorkbench()
+        internal void ClearWorkspace()
         {
             Logger.Log("Clearing workflow...");
+
+            OnWorkspaceClearing(this, EventArgs.Empty);
 
             //Copy locally
             List<NodeModel> elements = Nodes.ToList();
@@ -879,6 +881,13 @@ namespace Dynamo.Models
                 this.ResetEngine();
 
             CurrentWorkspace.PreloadedTraceData = null;
+
+            //don't save the file path
+            CurrentWorkspace.FileName = "";
+            CurrentWorkspace.HasUnsavedChanges = false;
+            CurrentWorkspace.WorkspaceVersion = AssemblyHelper.GetDynamoVersion();
+
+            OnWorkspaceCleared(this, EventArgs.Empty);
         }
 
         /// <summary>
@@ -976,7 +985,7 @@ namespace Dynamo.Models
         {
             Logger.Log("Opening home workspace " + xmlPath + "...");
 
-            CleanWorkbench();
+            ClearWorkspace();
             MigrationManager.ResetIdentifierIndex();
 
             var sw = new Stopwatch();
@@ -1321,7 +1330,7 @@ namespace Dynamo.Models
                 Logger.Log("There was an error opening the workbench.");
                 Logger.Log(ex);
                 Debug.WriteLine(ex.Message + ":" + ex.StackTrace);
-                CleanWorkbench();
+                ClearWorkspace();
                 return false;
             }
 
@@ -1566,16 +1575,7 @@ namespace Dynamo.Models
         /// <param name="parameter"></param>
         public void Clear(object parameter)
         {
-            OnWorkspaceClearing(this, EventArgs.Empty);
-
-            CleanWorkbench();
-
-            //don't save the file path
-            CurrentWorkspace.FileName = "";
-            CurrentWorkspace.HasUnsavedChanges = false;
-            CurrentWorkspace.WorkspaceVersion = AssemblyHelper.GetDynamoVersion();
-
-            OnWorkspaceCleared(this, EventArgs.Empty);
+            ClearWorkspace();
         }
 
         /// <summary>

--- a/test/DynamoCoreTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreTests/WorkspaceSaving.cs
@@ -59,7 +59,7 @@ namespace Dynamo.Tests
 
             Assert.AreEqual(true, workspace.CanUndo);
             Assert.AreEqual(false, workspace.CanRedo);
-            dynamoModel.CleanWorkbench(); // Clearing current workspace.
+            dynamoModel.ClearWorkspace(); // Clearing current workspace.
 
             // Undo stack should be cleared.
             Assert.AreEqual(false, workspace.CanUndo);


### PR DESCRIPTION
[MAGN-5461](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5461) was originally created to add events for the "closing" of a workspace, at the request of the Robot team. As it turns out, we've got two events, WorkspaceClearing and WorkspaceCleared which already achieve the aim of this issue. This pull request therefore does the following:

- Renames the CleanWorkbench method (from back when I called it a workbench) to ClearWorkspace (which is actually what the method does).
- Moves the WorkspaceClearing and WorkspaceCleared event triggers inside the ClearWorkspace method to ensure that they are always called. There are several places where this method is called and the events were not always being triggered.

PTAL:
- [x] @pboyer 