### PR TITLE
Asynchronously call "RunExpression" in "WorkspaceModel.Modified"

### DIFF
--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -24,9 +24,7 @@ namespace Dynamo.Models
             // shutting down so we check that shutdown has not been requested.
             if (DynamoModel.DynamicRunEnabled && !DynamoModel.ShutdownRequested)
             {
-                //Action run = () => DynamoModel.RunExpression();
-                //Dispatcher.CurrentDispatcher.Invoke(run);
-                DynamoModel.RunExpression();
+                DynamoModel.OnRequestDispatcherBeginInvoke(() => DynamoModel.RunExpression());
             }
         }
     }


### PR DESCRIPTION
This pull request fixes the following test cases:

``` csharp
- DynamoCoreUITests.RecordedTestsDSEngine.Defect_MAGN_4659
- DynamoCoreUITests.RecordedTestsDSEngine.Defect_MAGN_4710
- DynamoCoreUITests.RecordedTestsDSEngine.ErrorInCBN_3872
```

These three tests are run with `Run Automatically` enabled, which means every time `HomeWorkspaceModel.Modified` is called, it immediately triggers a `DynamoModel.RunExpression`. This causes the above test cases to fail because the tests expect the Code Block Nodes in question to be in a `Warning` state but they turned out to be not.

The following code snippet illustrates the reason why this happens:

``` csharp
public string Code
{
    set
    {
        if (code == null || !code.Equals(value))
        {
            // ...

            if (Workspace != null)
                Workspace.Modified(); // Step 1

            // ...

            ClearRuntimeError(); // Step 2

            // ...
        }
    }
}
```
- **Step 1**: `HomeWorkspaceModel.Modified` is called, causing `DynamoModel.RunExpression` to be called immediately, which sets `NodeModel.State` to `Warning`.
- **Step 2**: `ClearRuntimeError` method is called, clearing `NodeModel.State` back to `Dead`.

The regression came from the fact that `DynamoModel.RunExpression` gets called immediately in `Step 1`, when in the old implementation it relies on a `DispatcherTimer` to return at a later time. In that version of the implementation, `ClearRuntimeError` happens before `RunExpression`, which successfully sets the `NodeModel.State` to `Warning` and pass the test. Calling `OnRequestDispatcherBeginInvoke` to execute `RunExpression` asynchronously fixes this issue.

Hi @ikeough, this is for you, feel free to merge :)
