### PR TITLE
Remove LINQ AsParallel() stuff, search goes 200 times faster

### DIFF
--- a/src/DynamoCore/Search/SearchDictionary.cs
+++ b/src/DynamoCore/Search/SearchDictionary.cs
@@ -1,4 +1,5 @@
-﻿using Dynamo.Utilities;
+﻿using System.Diagnostics;
+using Dynamo.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -258,10 +259,10 @@ namespace Dynamo.Search
         {
             var searchDict = new Dictionary<V, double>();
 
-            var _tagDictionary = entryDictionary.AsParallel()
+            var _tagDictionary = entryDictionary
                 .SelectMany(
                     entryAndTags =>
-                        entryAndTags.Value.AsParallel().Select(
+                        entryAndTags.Value.Select(
                             tagAndWeight =>
                                 new
                                 {

--- a/src/DynamoCoreWpf/ViewModels/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/NodeSearchElementViewModel.cs
@@ -51,6 +51,11 @@ namespace Dynamo.Wpf.ViewModels
             get { return Model.IsVisibleInSearch; }
         }
 
+        public bool IsExpanded
+        {
+            get { return true; }
+        }
+
         public bool IsSelected
         {
             get { return isSelected; }


### PR DESCRIPTION
This also fixes an issue where a property was missing, causing cascades of BindingExpression Exceptions.