### PR TITLE
Put testcase RunDSPropertyChangedTest in Failure category

### DIFF
--- a/test/Engine/ProtoTest/EventTests/EventTest.cs
+++ b/test/Engine/ProtoTest/EventTests/EventTest.cs
@@ -10,6 +10,8 @@ using ProtoCore.Lang;
 using ProtoFFI;
 using ProtoScript.Runners;
 using ProtoTestFx.TD;
+using Category = NUnit.Framework.CategoryAttribute;
+
 namespace ProtoTest.EventTests
 {
     public class Foo : INotifyPropertyChanged
@@ -196,6 +198,7 @@ namespace ProtoTest.EventTests
         }
 
         [Test]
+        [Category("Failure")]
         public void RunDSPropertyChangedTest()
         {
             string code =


### PR DESCRIPTION
No idea why this test case passed before because the VM never registered an event handler to DS property change event. Put this test case in Failure category. 

In the long run, we need to remove all property changed related code. The implementation is pretty naive and never work except very basic case. 