### PR TITLE
Fix regressed test case CSFFIDataMarshalingTest.TestDecimals

### DIFF
--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -4187,7 +4187,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		} else if (la.kind == 3) {
 			Get();
 			double value;
-			if (Double.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+			if (Double.TryParse(t.val, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out value))
 			{
 			   node = new ProtoCore.AST.ImperativeAST.DoubleNode(value * sign);
 			}

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -2743,7 +2743,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		} else if (la.kind == 3) {
 			Get();
 			double value;
-			if (Double.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+			if (Double.TryParse(t.val, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out value))
 			{
 			   node = new ProtoCore.AST.AssociativeAST.DoubleNode(value * sign);
 			}

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1951,7 +1951,7 @@ Associative_Number<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
         float   
         (.  
             double value;
-            if (Double.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+            if (Double.TryParse(t.val, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out value))
             {
                 node = new ProtoCore.AST.AssociativeAST.DoubleNode(value * sign);
             }

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -1308,7 +1308,7 @@ Imperative_num<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
         float   
         (.  
             double value;
-            if (Double.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+            if (Double.TryParse(t.val, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out value))
             {
                 node = new ProtoCore.AST.ImperativeAST.DoubleNode(value * sign);
             }


### PR DESCRIPTION
Using ``System.Globalization.NumberStyle.Float`` to parse float value including in scientific notation. 