### PR TITLE
Updated regressed test for formatting of CBN text

### DIFF
--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -1599,8 +1599,7 @@ namespace DynamoCoreUITests
             Assert.AreEqual(0, cbn.OutPorts[0].MarginThickness.Top);
 
             Assert.AreEqual("t_1", cbn.OutPorts[1].ToolTipContent);
-            Assert.IsTrue(Math.Abs(cbn.OutPorts[1].MarginThickness.Top - 3 * codeBlockPortHeight) <= tolerance);
-
+            Assert.AreEqual(0, cbn.OutPorts[1].MarginThickness.Top);
         }
 
         [Test, RequiresSTA]


### PR DESCRIPTION
This fix updates a regressed test case `DynamoCoreUITests.RecordedTestsDSEngine/Defect_MAGN_904' due to [recent change] (https://github.com/DynamoDS/Dynamo/pull/3497) in CBN text formatting that eliminates word wrapping.