### PR TITLE
Fix one test case related to changing the lacing strategy

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -295,6 +295,7 @@ namespace Dynamo.Models
                 {
                     argumentLacing = value;
                     RaisePropertyChanged("ArgumentLacing");
+                    ForceReExecuteOfNode = true;
                     OnAstUpdated();
                 }
             }


### PR DESCRIPTION
<h4>Summary</h4>

When the lacing strategy is changed, the node will not be re-executed when the graph is re-executed. This is because the node is not taken into account for the new run.

This submission makes the fix by setting the ForceReExecuteOfNode property of the node to true.

@Benglin 
PTAL