### PR TITLE
Setup to build with Revit2016

### DIFF
--- a/src/Config/CS.props
+++ b/src/Config/CS.props
@@ -4,9 +4,10 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\$(Platform)\$(Configuration)</OutputPath>
     <NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\extern\NUnit</NunitPath>
-    <REVITAPI  Condition=" '$(REVITAPI)' == '' ">C:\Program Files\Autodesk\Revit Architecture 2015</REVITAPI>
-    <REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit 2015</REVITAPI>
-    <REVIT_VERSION>Revit_2015</REVIT_VERSION>
+    <REVITAPI  Condition=" '$(REVITAPI)' == '' ">C:\Program Files\Autodesk\Revit Architecture 2016</REVITAPI>
+    <REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit 2016</REVITAPI>
+	<REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit Architecture Copernicus</REVITAPI>
+    <REVIT_VERSION>Revit_2016</REVIT_VERSION>
     <BaseIntermediateOutputPath>$(OutputPath)\int\</BaseIntermediateOutputPath>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -19,9 +20,10 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\$(Platform)\$(Configuration)</OutputPath>
     <NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\extern\NUnit</NunitPath>
-    <REVITAPI  Condition=" '$(REVITAPI)' == '' ">C:\Program Files\Autodesk\Revit Architecture 2015</REVITAPI>
-    <REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit 2015</REVITAPI>
-    <REVIT_VERSION>Revit_2015</REVIT_VERSION>
+    <REVITAPI  Condition=" '$(REVITAPI)' == '' ">C:\Program Files\Autodesk\Revit Architecture 2016</REVITAPI>
+    <REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit 2016</REVITAPI>
+	<REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit Architecture Copernicus</REVITAPI>
+    <REVIT_VERSION>Revit_2016</REVIT_VERSION>
     <BaseIntermediateOutputPath>$(OutputPath)\int\</BaseIntermediateOutputPath>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>

--- a/src/DynamoCore/Core/Context.cs
+++ b/src/DynamoCore/Core/Context.cs
@@ -6,6 +6,7 @@
         public const string NONE = "None";
         public const string REVIT_2014 = "Revit 2014";
         public const string REVIT_2015 = "Revit 2015";
+        public const string REVIT_2016 = "Revit 2016";
         public const string VASARI_2014 = "Vasari 2014";
     }
 }

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -146,13 +146,17 @@ namespace Dynamo.Applications
             // Set the LibG folder based on the context.
             // LibG is set to reference the libg_219 folder by default.
             var versionInt = int.Parse(application.ControlledApplication.VersionNumber);
-            if (versionInt > 2014)
+            switch (versionInt)
             {
-                DynamoPathManager.Instance.SetLibGPath("220");
-            }
-            else
-            {
-                DynamoPathManager.Instance.SetLibGPath("219");
+                case 2016:
+                    DynamoPathManager.Instance.SetLibGPath("221");
+                    break;
+                case 2015:
+                    DynamoPathManager.Instance.SetLibGPath("220");
+                    break;
+                default:
+                    DynamoPathManager.Instance.SetLibGPath("219");
+                    break;
             }
         }
 

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -77,7 +77,7 @@ namespace Dynamo.Applications.Models
         {
             // where necessary, assign defaults
             if (string.IsNullOrEmpty(configuration.Context))
-                configuration.Context = Core.Context.REVIT_2015;
+                configuration.Context = Core.Context.REVIT_2016;
             if (string.IsNullOrEmpty(configuration.DynamoCorePath))
             {
                 var asmLocation = Assembly.GetExecutingAssembly().Location;

--- a/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
+++ b/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
@@ -19,6 +19,7 @@ using RevitServices.Transactions;
 using Curve = Autodesk.DesignScript.Geometry.Curve;
 using Point = Autodesk.DesignScript.Geometry.Point;
 using PolyCurve = Autodesk.DesignScript.Geometry.PolyCurve;
+using Surface = Autodesk.DesignScript.Geometry.Surface;
 
 namespace Dynamo
 {

--- a/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
+++ b/src/DynamoRevit/ViewModel/RevitVisualizationManager.cs
@@ -37,7 +37,8 @@ namespace Dynamo
         public RevitVisualizationManager(DynamoModel dynamoModel) : base(dynamoModel)
         {
             if (dynamoModel.Context == Context.VASARI_2014 ||
-                dynamoModel.Context == Context.REVIT_2015)
+                dynamoModel.Context == Context.REVIT_2015 ||
+                dynamoModel.Context == Context.REVIT_2016)
             {
                 AlternateDrawingContextAvailable = true;
                 DrawToAlternateContext = false;

--- a/src/DynamoUtilities/DynamoPathManager.cs
+++ b/src/DynamoUtilities/DynamoPathManager.cs
@@ -413,6 +413,7 @@ namespace DynamoUtilities
         {
             if (PreloadAsmVersion("219", pathManager)) return true;
             if (PreloadAsmVersion("220", pathManager)) return true;
+            if (PreloadAsmVersion("221", pathManager)) return true;
             
             return false;
         }

--- a/src/Libraries/Revit/RevitNodes/AnalysisDisplay/FaceAnalysisDisplay.cs
+++ b/src/Libraries/Revit/RevitNodes/AnalysisDisplay/FaceAnalysisDisplay.cs
@@ -19,6 +19,7 @@ using RevitServices.Transactions;
 
 using UV = Autodesk.Revit.DB.UV;
 using View = Revit.Elements.Views.View;
+using Surface = Autodesk.DesignScript.Geometry.Surface;
 
 namespace Revit.AnalysisDisplay
 {

--- a/src/Libraries/Revit/RevitNodes/Elements/AdaptiveComponent.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/AdaptiveComponent.cs
@@ -13,6 +13,7 @@ using RevitServices.Persistence;
 using RevitServices.Transactions;
 using Point = Autodesk.DesignScript.Geometry.Point;
 using Reference = Autodesk.Revit.DB.Reference;
+using Surface = Autodesk.DesignScript.Geometry.Surface;
 
 namespace Revit.Elements
 {

--- a/src/Libraries/Revit/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/Element.cs
@@ -15,6 +15,7 @@ using RevitServices.Transactions;
 using Color = DSCore.Color;
 using Area = DynamoUnits.Area;
 using Curve = Autodesk.DesignScript.Geometry.Curve;
+using Surface = Autodesk.DesignScript.Geometry.Surface;
 using Face = Autodesk.Revit.DB.Face;
 using Solid = Autodesk.DesignScript.Geometry.Solid;
 

--- a/src/Libraries/Revit/RevitNodes/GeometryConversion/GeometryDebugging.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryConversion/GeometryDebugging.cs
@@ -8,6 +8,7 @@ using Autodesk.Revit.DB;
 
 using Element = Revit.Elements.Element;
 using Face = Autodesk.Revit.DB.Face;
+using Surface = Autodesk.DesignScript.Geometry.Surface;
 
 namespace Revit.GeometryConversion
 {

--- a/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoFace.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoFace.cs
@@ -13,6 +13,7 @@ using Revit.GeometryReferences;
 
 using Edge = Autodesk.Revit.DB.Edge;
 using Face = Autodesk.Revit.DB.Face;
+using Surface = Autodesk.DesignScript.Geometry.Surface;
 
 namespace Revit.GeometryConversion
 {

--- a/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoMesh.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoMesh.cs
@@ -23,10 +23,10 @@ namespace Revit.GeometryConversion
 
         }
 
-        public static Autodesk.DesignScript.Geometry.Mesh[] ToProtoType(this Autodesk.Revit.DB.MeshArray meshArray,
+        public static Autodesk.DesignScript.Geometry.Mesh[] ToProtoType(this IEnumerable<Autodesk.Revit.DB.Mesh> meshArray,
             bool performHostUnitConversion = true)
         {
-            return meshArray.Cast<Autodesk.Revit.DB.Mesh>().Select(x => x.ToProtoType(performHostUnitConversion)).ToArray();
+            return meshArray.Select(x => x.ToProtoType(performHostUnitConversion)).ToArray();
         }
     }
 }

--- a/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoSolid.cs
+++ b/src/Libraries/Revit/RevitNodes/GeometryConversion/RevitToProtoSolid.cs
@@ -13,6 +13,7 @@ using Face = Autodesk.Revit.DB.Face;
 using Point = Autodesk.DesignScript.Geometry.Point;
 using Solid = Autodesk.DesignScript.Geometry.Solid;
 using UV = Autodesk.DesignScript.Geometry.UV;
+using Surface = Autodesk.DesignScript.Geometry.Surface;
 
 namespace Revit.GeometryConversion
 {

--- a/test/Libraries/Revit/RevitIntegrationTests/SelectionTests.cs
+++ b/test/Libraries/Revit/RevitIntegrationTests/SelectionTests.cs
@@ -21,6 +21,7 @@ using RevitServices.Transactions;
 using RTF.Framework;
 
 using ReferencePoint = Revit.Elements.ReferencePoint;
+using Surface = Autodesk.DesignScript.Geometry.Surface;
 
 namespace RevitSystemTests
 {
@@ -47,7 +48,9 @@ namespace RevitSystemTests
             //in the node's items source
             var fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
             fec.OfClass(typeof(Family));
-            int count = fec.ToElements().Cast<Family>().Sum(f => f.Symbols.Cast<FamilySymbol>().Count());
+            var families = fec.ToElements().Cast<Family>();
+            var symbolIds = families.SelectMany(f => f.GetFamilySymbolIds());
+            var count = symbolIds.Count();
 
             var typeSelNode = (FamilyTypes)ViewModel.Model.Nodes.First();
             Assert.AreEqual(typeSelNode.Items.Count, count);


### PR DESCRIPTION
- Updated project config to link to Revit 2016.
- Resolved conflict related to Surface class, Revit2016 also has
introduced surface class.
- MeshArray is updated with IEnumerable<Mesh>
- Use GetFamilySymbolIds instead of Symbols property.