### PR TITLE
Dynamo looks for samples in UI-specific folder

### DIFF
--- a/src/Config/Install.props
+++ b/src/Config/Install.props
@@ -6,7 +6,7 @@
     <DYNAMO_BASE_PATH  Condition=" '$(DYNAMO_BASE_PATH)' == '' ">$(MSBuildProjectDirectory)\..\..</DYNAMO_BASE_PATH>
     <DYNAMO_HARVEST_PATH Condition=" '$(DYNAMO_HARVEST_PATH)' == '' ">$(MSBuildProjectDirectory)\harvest</DYNAMO_HARVEST_PATH>
     <DYNAMO_MIGRATION_NODES_PATH Condition=" '$(DYNAMO_MIGRATION_NODES_PATH)' == '' ">$(DYNAMO_BASE_PATH)\doc\distrib\migration_nodes</DYNAMO_MIGRATION_NODES_PATH>
-    <DYNAMO_SAMPLES_PATH Condition=" '$(DYNAMO_SAMPLES_PATH)' == '' ">$(DYNAMO_BASE_PATH)\doc\distrib\Samples</DYNAMO_SAMPLES_PATH>
+    <DYNAMO_SAMPLES_PATH Condition=" '$(DYNAMO_SAMPLES_PATH)' == '' ">$(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration)\samples</DYNAMO_SAMPLES_PATH>
     <DYNAMO_REVIT_SIGN_TOOLS Condition=" '$(DYNAMO_REVIT_SIGN_TOOLS)' == '' ">$(MSBuildProjectDirectory)\sign</DYNAMO_REVIT_SIGN_TOOLS>
     <BaseIntermediateOutputPath>$(OutputPath)\int\</BaseIntermediateOutputPath>
     <DebugSymbols>true</DebugSymbols>
@@ -22,7 +22,7 @@
     <DYNAMO_BASE_PATH  Condition=" '$(DYNAMO_BASE_PATH)' == '' ">$(MSBuildProjectDirectory)\..\..</DYNAMO_BASE_PATH>
     <DYNAMO_HARVEST_PATH Condition=" '$(DYNAMO_HARVEST_PATH)' == '' ">$(MSBuildProjectDirectory)\harvest</DYNAMO_HARVEST_PATH>
     <DYNAMO_MIGRATION_NODES_PATH Condition=" '$(DYNAMO_MIGRATION_NODES_PATH)' == '' ">$(DYNAMO_BASE_PATH)\doc\distrib\migration_nodes</DYNAMO_MIGRATION_NODES_PATH>
-    <DYNAMO_SAMPLES_PATH Condition=" '$(DYNAMO_SAMPLES_PATH)' == '' ">$(DYNAMO_BASE_PATH)\doc\distrib\Samples</DYNAMO_SAMPLES_PATH>
+    <DYNAMO_SAMPLES_PATH Condition=" '$(DYNAMO_SAMPLES_PATH)' == '' ">$(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration)\samples</DYNAMO_SAMPLES_PATH>
     <DYNAMO_REVIT_SIGN_TOOLS Condition=" '$(DYNAMO_REVIT_SIGN_TOOLS)' == '' ">$(MSBuildProjectDirectory)\sign</DYNAMO_REVIT_SIGN_TOOLS>
     <BaseIntermediateOutputPath>$(OutputPath)\int\</BaseIntermediateOutputPath>
     <DebugType>pdbonly</DebugType>

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -331,6 +331,7 @@ xcopy  /Y "$(SolutionDir)..\doc\distrib\License.rtf" "$(OutputPath)\$(UICulture)
 xcopy  /Y "$(SolutionDir)..\extern\LibG_219\*" "$(OutputPath)libg_219\"
 xcopy  /Y "$(SolutionDir)..\extern\LibG_220\*" "$(OutputPath)libg_220\"
 xcopy /Y "$(SolutionDir)..\extern\SimplexNoise\*" "$(OutputPath)"
+xcopy /Y /e "$(SolutionDir)..\doc\distrib\Samples" "$(OutputPath)samples\$(UICulture)\"
 </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/DynamoInstall/DynamoInstall.wixproj
+++ b/src/DynamoInstall/DynamoInstall.wixproj
@@ -42,7 +42,7 @@
   <Import Project="$(WixTargetsPath)" />
   <PropertyGroup>
     <PreBuildEvent>rd /s /q $(DYNAMO_HARVEST_PATH)
-robocopy $(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration) $(DYNAMO_HARVEST_PATH) -XF %2aTest%2a.dll %2a.pdb TestResult.xml -e -XD int
+robocopy $(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration) $(DYNAMO_HARVEST_PATH) -XF %2aTest%2a.dll %2a.pdb TestResult.xml -e -XD int -XD samples
 
 "C:\Program Files (x86)\WiX Toolset v3.8\bin\heat.exe" dir $(DYNAMO_HARVEST_PATH) -cg RELEASE -gg -scom -sreg -srd -dr DYNAMO_INSTALLDIR -var var.harvest -out "$(ProjectDir)Release.wxs"
 "C:\Program Files (x86)\WiX Toolset v3.8\bin\heat.exe" dir $(DYNAMO_SAMPLES_PATH) -cg SAMPLES -gg -scom -sreg -dr PROGDATA_07 -var var.samples -t "$(ProjectDir)Samples.xsl" -out "$(ProjectDir)Samples.wxs"

--- a/src/DynamoUtilities/DynamoPathManager.cs
+++ b/src/DynamoUtilities/DynamoPathManager.cs
@@ -150,7 +150,8 @@ namespace DynamoUtilities
                 Directory.CreateDirectory(CommonDefinitions);
             }
 
-            CommonSamples = Path.Combine(commonData, /*NXLT*/"samples");
+            var UICulture = System.Globalization.CultureInfo.CurrentUICulture.ToString();
+            CommonSamples = Path.Combine(commonData, /*NXLT*/"samples", UICulture);
             if (!Directory.Exists(CommonSamples))
             {
                 Directory.CreateDirectory(CommonSamples);

--- a/tools/install/CreateInstallers.bat
+++ b/tools/install/CreateInstallers.bat
@@ -53,7 +53,7 @@ rename README.md README.txt
 popd 
 
 robocopy %cwd%\..\..\doc\distrib\migration_nodes %cwd%\temp\definitions /e
-robocopy %cwd%\..\..\doc\distrib\Samples %cwd%\temp\Samples /s
+robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\samples %cwd%\temp\samples /s
 
 "C:\Program Files (x86)\Inno Setup 5\iscc.exe" %cwd%\DynamoInstaller.iss
 rmdir /Q /S %cwd%\temp

--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -55,12 +55,12 @@ Source: temp\bin\nodes\*; DestDir: {app}\nodes; Flags: ignoreversion overwritere
 Source: Extra\IronPython-2.7.3.msi; DestDir: {tmp}; Flags: deleteafterinstall;
 
 ;Revit 2014 / Vasari Beta 3
-Source: temp\bin\Revit_2014\*; DestDir: {app}\Revit_2014; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2014 DynamoForVasariBeta3
-Source: temp\bin\Revit_2014\nodes\*; DestDir: {app}\Revit_2014\nodes; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2014 DynamoForVasariBeta3
+Source: temp\bin\Revit_2014\*; DestDir: {app}\Revit_2014; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly recursesubdirs; Components: DynamoForRevit2014 DynamoForVasariBeta3
+Source: temp\bin\Revit_2014\nodes\*; DestDir: {app}\Revit_2014\nodes; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly recursesubdirs; Components: DynamoForRevit2014 DynamoForVasariBeta3
 
 ;Revit 2015 / Revit 2016
-Source: temp\bin\Revit_2015\*; DestDir: {app}\Revit_2015; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2015 DynamoForRevit2016
-Source: temp\bin\Revit_2015\nodes\*; DestDir: {app}\Revit_2015\nodes; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2015 DynamoForRevit2016
+Source: temp\bin\Revit_2015\*; DestDir: {app}\Revit_2015; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly recursesubdirs; Components: DynamoForRevit2015 DynamoForRevit2016
+Source: temp\bin\Revit_2015\nodes\*; DestDir: {app}\Revit_2015\nodes; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly recursesubdirs; Components: DynamoForRevit2015 DynamoForRevit2016
 
 #include "Localized.iss"
 
@@ -79,7 +79,7 @@ Source: Extra\DynamoInstaller.ico; DestDir: {app}; Flags: ignoreversion overwrit
 Source: temp\bin\UI\*; DestDir: {app}\UI; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 
 ;Samples
-Source: temp\Samples\*.*; DestDir: {commonappdata}\Dynamo\0.7\samples; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoTrainingFiles
+Source: temp\samples\*.*; DestDir: {commonappdata}\Dynamo\0.7\samples; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoTrainingFiles
 
 ;Other Custom Nodes
 Source: temp\definitions\*; DestDir: {commonappdata}\Dynamo\0.7\definitions; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore

--- a/tools/install/Localized.iss
+++ b/tools/install/Localized.iss
@@ -5,41 +5,17 @@
 #define CurrentLanguage "en-US"
 
 ;Localized Resource Files - DynamoCore
-Source: temp\bin\{#CurrentLanguage}\*; DestDir: {app}\{#CurrentLanguage}; Flags: ignoreversion overwritereadonly; Components: DynamoCore
-Source: temp\bin\nodes\{#CurrentLanguage}\*; DestDir: {app}\nodes\{#CurrentLanguage}; Flags: ignoreversion overwritereadonly; Components: DynamoCore
-
-;Revit 2014 / Vasari Beta 3
-Source: temp\bin\Revit_2014\{#CurrentLanguage}\*; DestDir: {app}\Revit_2014\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2014 DynamoForVasariBeta3
-Source: temp\bin\Revit_2014\nodes\{#CurrentLanguage}\*; DestDir: {app}\Revit_2014\nodes\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2014 DynamoForVasariBeta3
-
-;Revit 2015 / Revit 2016
-Source: temp\bin\Revit_2015\{#CurrentLanguage}\*; DestDir: {app}\Revit_2015\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2015 DynamoForRevit2016
-Source: temp\bin\Revit_2015\nodes\{#CurrentLanguage}\*; DestDir: {app}\Revit_2015\nodes\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2015 DynamoForRevit2016
+Source: temp\bin\{#CurrentLanguage}\*; DestDir: {app}\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoCore
+Source: temp\bin\nodes\{#CurrentLanguage}\*; DestDir: {app}\nodes\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoCore
 
 #define CurrentLanguage "de-DE"
 
 ;Localized Resource Files - DynamoCore
-Source: temp\bin\{#CurrentLanguage}\*; DestDir: {app}\{#CurrentLanguage}; Flags: ignoreversion overwritereadonly; Components: DynamoCore
-Source: temp\bin\nodes\{#CurrentLanguage}\*; DestDir: {app}\nodes\{#CurrentLanguage}; Flags: ignoreversion overwritereadonly; Components: DynamoCore
-
-;Revit 2014 / Vasari Beta 3
-Source: temp\bin\Revit_2014\{#CurrentLanguage}\*; DestDir: {app}\Revit_2014\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2014 DynamoForVasariBeta3
-Source: temp\bin\Revit_2014\nodes\{#CurrentLanguage}\*; DestDir: {app}\Revit_2014\nodes\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2014 DynamoForVasariBeta3
-
-;Revit 2015 / Revit 2016
-Source: temp\bin\Revit_2015\{#CurrentLanguage}\*; DestDir: {app}\Revit_2015\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2015 DynamoForRevit2016
-Source: temp\bin\Revit_2015\nodes\{#CurrentLanguage}\*; DestDir: {app}\Revit_2015\nodes\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2015 DynamoForRevit2016
+Source: temp\bin\{#CurrentLanguage}\*; DestDir: {app}\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoCore
+Source: temp\bin\nodes\{#CurrentLanguage}\*; DestDir: {app}\nodes\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoCore
 
 #define CurrentLanguage "ja-JP"
 
 ;Localized Resource Files - DynamoCore
-Source: temp\bin\{#CurrentLanguage}\*; DestDir: {app}\{#CurrentLanguage}; Flags: ignoreversion overwritereadonly; Components: DynamoCore
-Source: temp\bin\nodes\{#CurrentLanguage}\*; DestDir: {app}\nodes\{#CurrentLanguage}; Flags: ignoreversion overwritereadonly; Components: DynamoCore
-
-;Revit 2014 / Vasari Beta 3
-Source: temp\bin\Revit_2014\{#CurrentLanguage}\*; DestDir: {app}\Revit_2014\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2014 DynamoForVasariBeta3
-Source: temp\bin\Revit_2014\nodes\{#CurrentLanguage}\*; DestDir: {app}\Revit_2014\nodes\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2014 DynamoForVasariBeta3
-
-;Revit 2015 / Revit 2016
-Source: temp\bin\Revit_2015\{#CurrentLanguage}\*; DestDir: {app}\Revit_2015\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2015 DynamoForRevit2016
-Source: temp\bin\Revit_2015\nodes\{#CurrentLanguage}\*; DestDir: {app}\Revit_2015\nodes\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoForRevit2015 DynamoForRevit2016
+Source: temp\bin\{#CurrentLanguage}\*; DestDir: {app}\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoCore
+Source: temp\bin\nodes\{#CurrentLanguage}\*; DestDir: {app}\nodes\{#CurrentLanguage}; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly; Components: DynamoCore


### PR DESCRIPTION
Hey @Benglin, please review and merge into localization accordingly
Changes:
- DynamoPathManager to look for samples in the correct folder (samples/en-US , samples/ja-JP etc...)
- while building Dynamo, copy doc/distrib/Samples into bin///samples/en-US
- in the exe installer
   - copy the samples folder (all languages) to %programdata%
- for the msi installer
   - prevent copying the samples folder into C:/Program Files/
   - change the harvest path for the samples folder