### PR TITLE
Fixed various unit test failures due to #3521

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -12,7 +12,7 @@ using Dynamo.Interfaces;
 using Dynamo.Nodes;
 using Dynamo.Selection;
 using Dynamo.Utilities;
-
+using ProtoCore.AST;
 using String = System.String;
 using Utils = Dynamo.Nodes.Utilities;
 using NodeModificationUndoHelper = Dynamo.Core.UndoRedoRecorder.NodeModificationUndoHelper;
@@ -772,27 +772,40 @@ namespace Dynamo.Models
 
         internal void SendModelEvent(Guid modelGuid, string eventName)
         {
-            var model = GetModelInternal(modelGuid) as NodeModel;
-            if (model == null)
-                throw new InvalidOperationException("Unexpected model type");
+            var retrievedModel = GetModelInternal(modelGuid);
+            if (retrievedModel == null)
+                throw new InvalidOperationException("SendModelEvent: Model not found");
 
-            using (new NodeModificationUndoHelper(undoRecorder, model))
+            var handled = false;
+            var nodeModel = retrievedModel as NodeModel;
+            if (nodeModel != null)
             {
-                if (!model.HandleModelEvent(eventName, undoRecorder))
+                using (new NodeModificationUndoHelper(undoRecorder, nodeModel))
                 {
-                    string type = model.GetType().FullName;
-                    string message = string.Format(
-                        "ModelBase.HandleModelEvent call not handled.\n\n" +
-                        "Model type: {0}\n" +
-                        "Model GUID: {1}\n" +
-                        "Event name: {2}",
-                        type, modelGuid, eventName);
-
-                    // All 'HandleModelEvent' calls must be handled by one of 
-                    // the ModelBase derived classes that the 'SendModelEvent'
-                    // is intended for.
-                    throw new InvalidOperationException(message);
+                    handled = nodeModel.HandleModelEvent(eventName, undoRecorder);
                 }
+            }
+            else
+            {
+                // Perform generic undo recording for models other than node.
+                RecordModelForModification(retrievedModel, UndoRecorder);
+                handled = retrievedModel.HandleModelEvent(eventName, undoRecorder);
+            }
+
+            if (!handled) // Method call was not handled by any derived class.
+            {
+                string type = retrievedModel.GetType().FullName;
+                string message = string.Format(
+                    "ModelBase.HandleModelEvent call not handled.\n\n" +
+                    "Model type: {0}\n" +
+                    "Model GUID: {1}\n" +
+                    "Event name: {2}",
+                    type, modelGuid, eventName);
+
+                // All 'HandleModelEvent' calls must be handled by one of 
+                // the ModelBase derived classes that the 'SendModelEvent'
+                // is intended for.
+                throw new InvalidOperationException(message);
             }
 
             HasUnsavedChanges = true;
@@ -800,28 +813,41 @@ namespace Dynamo.Models
 
         internal void UpdateModelValue(Guid modelGuid, string propertyName, string value)
         {
-            var model = GetModelInternal(modelGuid) as NodeModel;
-            if (model == null)
-                throw new InvalidOperationException("Unexpected model type");
+            var retrievedModel = GetModelInternal(modelGuid);
+            if (retrievedModel == null)
+                throw new InvalidOperationException("UpdateModelValue: Model not found");
 
-            using (new NodeModificationUndoHelper(undoRecorder, model))
+            var handled = false;
+            var nodeModel = retrievedModel as NodeModel;
+            if (nodeModel != null)
             {
-                if (!model.UpdateValue(propertyName, value, undoRecorder))
+                using (new NodeModificationUndoHelper(undoRecorder, nodeModel))
                 {
-                    string type = model.GetType().FullName;
-                    string message = string.Format(
-                        "ModelBase.UpdateValue call not handled.\n\n" +
-                        "Model type: {0}\n" +
-                        "Model GUID: {1}\n" +
-                        "Property name: {2}\n" +
-                        "Property value: {3}",
-                        type, modelGuid, propertyName, value);
-
-                    // All 'UpdateValue' calls must be handled by one of the 
-                    // ModelBase derived classes that the 'UpdateModelValue'
-                    // is intended for.
-                    throw new InvalidOperationException(message);
+                    handled = nodeModel.UpdateValue(propertyName, value, undoRecorder);
                 }
+            }
+            else
+            {
+                // Perform generic undo recording for models other than node.
+                RecordModelForModification(retrievedModel, UndoRecorder);
+                handled = retrievedModel.UpdateValue(propertyName, value, undoRecorder);
+            }
+
+            if (!handled) // Method call was not handled by any derived class.
+            {
+                string type = retrievedModel.GetType().FullName;
+                string message = string.Format(
+                    "ModelBase.UpdateValue call not handled.\n\n" +
+                    "Model type: {0}\n" +
+                    "Model GUID: {1}\n" +
+                    "Property name: {2}\n" +
+                    "Property value: {3}",
+                    type, modelGuid, propertyName, value);
+
+                // All 'UpdateValue' calls must be handled by one of the 
+                // ModelBase derived classes that the 'UpdateModelValue'
+                // is intended for.
+                throw new InvalidOperationException(message);
             }
 
             HasUnsavedChanges = true;

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
@@ -429,9 +429,16 @@ namespace Dynamo.UI.Controls
 
         private void CommitChanges(UndoRedoRecorder recorder)
         {
-            nodeViewModel.DynamoViewModel.ExecuteCommand(
-                new DynCmd.UpdateModelValueCommand(nodeModel.GUID,
-                    /*NXLT*/"Code", InnerTextEditor.Text));
+            // Code block editor can lose focus in many scenarios (e.g. switching 
+            // of tabs or application), if there has not been any changes, do not
+            // commit the change.
+            // 
+            if (!nodeModel.Code.Equals(InnerTextEditor.Text))
+            {
+                nodeViewModel.DynamoViewModel.ExecuteCommand(
+                    new DynCmd.UpdateModelValueCommand(nodeModel.GUID,
+                        /*NXLT*/"Code", InnerTextEditor.Text));
+            }
 
             if (createdForNewCodeBlock)
             {

--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -397,7 +397,8 @@ namespace DynamoCoreUITests
                 }
             });
         }
-        [Test]
+
+        [Test, RequiresSTA, Category("Failure")]
         public void Defect_MAGN_1143_CN()
         {
             // modify the name of the input node


### PR DESCRIPTION
This pull request fixes various unit test failures caused by #3521. The following tests now pass:

    Defect_MAGN_2144_CN
    Defect_MAGN_478
    Defect_MAGN_478_DS
    TestUpdateNodeCaptions

The following test has been marked as `Failure`, the test code expects command tagged `FirstRun` and `SecondRun` which do not even exist in the test file `Defect_MAGN_1143_CN.xml`:

    Defect_MAGN_1143_CN
