### PR TITLE
Add a null reference check to avoid attempting to use ViewModel.

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -152,9 +152,8 @@ namespace Dynamo.Views
 
         void OnSelectionCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
+            if (ViewModel == null) return;
             ViewModel.NodeFromSelectionCommand.RaiseCanExecuteChanged();
-            // KILLDYNSETTINGS
-            //ViewModel.NodeToCodeCommand.RaiseCanExecuteChanged();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds a null check for the ViewModel to avoid a tear-down error during visualization manager tests on the CI.