### PR TITLE
Fix FileName not set on Workspaces

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -489,7 +489,7 @@ namespace Dynamo.Utilities
                 nodeGraph.Notes,
                 workspaceInfo.X,
                 workspaceInfo.Y,
-                functionId);
+                functionId, workspaceInfo.FileName);
             
             RegisterCustomNodeWorkspace(newWorkspace);
 
@@ -598,7 +598,7 @@ namespace Dynamo.Utilities
         public WorkspaceModel CreateCustomNode(string name, string category, string description, Guid? functionId = null)
         {
             var newId = functionId ?? Guid.NewGuid();
-            var workspace = new CustomNodeWorkspaceModel(name, category, description, 0, 0, newId, nodeFactory);
+            var workspace = new CustomNodeWorkspaceModel(name, category, description, 0, 0, newId, nodeFactory, string.Empty);
             RegisterCustomNodeWorkspace(workspace);
             return workspace;
         }
@@ -995,7 +995,7 @@ namespace Dynamo.Utilities
                     Enumerable.Empty<NoteModel>(),
                     0,
                     0,
-                    newId);
+                    newId, string.Empty);
 
                 RegisterCustomNodeWorkspace(newWorkspace);
 

--- a/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
@@ -32,7 +32,7 @@ namespace Dynamo.Models
 
         public CustomNodeWorkspaceModel(
             string name, string category, string description, double x, double y, Guid customNodeId,
-            NodeFactory factory, string fileName)
+            NodeFactory factory, string fileName="")
             : this(
                 name,
                 category,
@@ -46,7 +46,7 @@ namespace Dynamo.Models
 
         public CustomNodeWorkspaceModel(
             string name, string category, string description, NodeFactory factory, IEnumerable<NodeModel> e, IEnumerable<NoteModel> n, 
-            double x, double y, Guid customNodeId, string fileName) 
+            double x, double y, Guid customNodeId, string fileName="") 
             : base(name, e, n, x, y, factory, fileName)
         {
             CustomNodeId = customNodeId;

--- a/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
@@ -32,7 +32,7 @@ namespace Dynamo.Models
 
         public CustomNodeWorkspaceModel(
             string name, string category, string description, double x, double y, Guid customNodeId,
-            NodeFactory factory)
+            NodeFactory factory, string fileName)
             : this(
                 name,
                 category,
@@ -42,11 +42,12 @@ namespace Dynamo.Models
                 Enumerable.Empty<NoteModel>(),
                 x,
                 y,
-                customNodeId) { }
+                customNodeId, fileName) { }
 
         public CustomNodeWorkspaceModel(
-            string name, string category, string description, NodeFactory factory, IEnumerable<NodeModel> e, IEnumerable<NoteModel> n, double x, double y, Guid customNodeId) 
-            : base(name, e, n, x, y, factory)
+            string name, string category, string description, NodeFactory factory, IEnumerable<NodeModel> e, IEnumerable<NoteModel> n, 
+            double x, double y, Guid customNodeId, string fileName) 
+            : base(name, e, n, x, y, factory, fileName)
         {
             CustomNodeId = customNodeId;
             HasUnsavedChanges = false;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -788,6 +788,7 @@ namespace Dynamo.Models
                     {
                         AddWorkspace(ws);
                         CurrentWorkspace = ws;
+
                         return;
                     }
                 }
@@ -826,7 +827,7 @@ namespace Dynamo.Models
                 nodeGraph.Notes,
                 workspaceInfo.X,
                 workspaceInfo.Y,
-                DebugSettings.VerboseLogging, IsTestMode);
+                DebugSettings.VerboseLogging, IsTestMode, workspaceInfo.FileName);
 
             RegisterHomeWorkspace(newWorkspace);
             
@@ -900,7 +901,7 @@ namespace Dynamo.Models
                 Scheduler,
                 NodeFactory,
                 DebugSettings.VerboseLogging,
-                IsTestMode);
+                IsTestMode,string.Empty);
 
             RegisterHomeWorkspace(defaultWorkspace);
             AddWorkspace(defaultWorkspace);

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -28,7 +28,7 @@ namespace Dynamo.Models
         public readonly bool VerboseLogging;
 
         public HomeWorkspaceModel(EngineController engine, DynamoScheduler scheduler, 
-            NodeFactory factory, bool verboseLogging, bool isTestMode, string fileName)
+            NodeFactory factory, bool verboseLogging, bool isTestMode, string fileName="")
             : this(
                 engine,
                 scheduler,
@@ -43,7 +43,7 @@ namespace Dynamo.Models
             EngineController engine, DynamoScheduler scheduler, NodeFactory factory,
             IEnumerable<KeyValuePair<Guid, List<string>>> traceData, IEnumerable<NodeModel> e, IEnumerable<NoteModel> n, 
             double x, double y, bool verboseLogging,
-            bool isTestMode, string fileName) : base("Home", e, n, x, y, factory, fileName)
+            bool isTestMode, string fileName="") : base("Home", e, n, x, y, factory, fileName)
         {
             RunEnabled = true;
             PreloadedTraceData = traceData;

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -27,7 +27,8 @@ namespace Dynamo.Models
 
         public readonly bool VerboseLogging;
 
-        public HomeWorkspaceModel(EngineController engine, DynamoScheduler scheduler, NodeFactory factory, bool verboseLogging, bool isTestMode)
+        public HomeWorkspaceModel(EngineController engine, DynamoScheduler scheduler, 
+            NodeFactory factory, bool verboseLogging, bool isTestMode, string fileName)
             : this(
                 engine,
                 scheduler,
@@ -36,12 +37,13 @@ namespace Dynamo.Models
                 Enumerable.Empty<NodeModel>(),
                 Enumerable.Empty<NoteModel>(),
                 0,
-                0, verboseLogging, isTestMode) { }
+                0, verboseLogging, isTestMode, fileName) { }
 
         public HomeWorkspaceModel(
             EngineController engine, DynamoScheduler scheduler, NodeFactory factory,
-            IEnumerable<KeyValuePair<Guid, List<string>>> traceData, IEnumerable<NodeModel> e, IEnumerable<NoteModel> n, double x, double y, bool verboseLogging,
-            bool isTestMode) : base("Home", e, n, x, y, factory)
+            IEnumerable<KeyValuePair<Guid, List<string>>> traceData, IEnumerable<NodeModel> e, IEnumerable<NoteModel> n, 
+            double x, double y, bool verboseLogging,
+            bool isTestMode, string fileName) : base("Home", e, n, x, y, factory, fileName)
         {
             RunEnabled = true;
             PreloadedTraceData = traceData;

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -400,7 +400,7 @@ namespace Dynamo.Models
 
         protected WorkspaceModel(
             string name, IEnumerable<NodeModel> e, IEnumerable<NoteModel> n,
-            double x, double y, NodeFactory factory, string fileName)
+            double x, double y, NodeFactory factory, string fileName="")
         {
             Name = name;
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -400,7 +400,7 @@ namespace Dynamo.Models
 
         protected WorkspaceModel(
             string name, IEnumerable<NodeModel> e, IEnumerable<NoteModel> n,
-            double x, double y, NodeFactory factory)
+            double x, double y, NodeFactory factory, string fileName)
         {
             Name = name;
 
@@ -408,7 +408,7 @@ namespace Dynamo.Models
             notes = new ObservableCollection<NoteModel>(n);
             X = x;
             Y = y;
-
+            FileName = fileName;
             HasUnsavedChanges = false;
             LastSaved = DateTime.Now;
 


### PR DESCRIPTION
This pull request fixes a regression caused by the CoreModularization work where the FileName was not being set on any of the WorkspaceModels. This meant that any workspace you opened, even if it was from a .dyn file, would just say "Home" on the tab, and pressing Ctrl+S (or choosing File > Save), would treat the file as not having been saved previously, and would present the Save As dialogue.

This PR adds a fileName parameter to all WorkspaceModel constructors to ensure that a file name will be supplied at the time of construction. For situations where no file name is set at the time of construction it is possible to pass in string.Empty. The FileName property on the WorkspaceModel is then set using the fileName parameter.

PTAL:
- [ ] @pboyer 