### PR TITLE
change Written Tutorials to Advanced Tutorials in StartPage

### DIFF
--- a/src/DynamoCore/Utilities/Configurations.cs
+++ b/src/DynamoCore/Utilities/Configurations.cs
@@ -22,7 +22,7 @@ namespace Dynamo.UI
         public static string DynamoWikiLink = "https://github.com/DynamoDS/Dynamo/wiki";
         public static string DynamoBimForum = "http://dynamobim.org/forums/forum/dyn/";
         public static string DynamoTeamEmail = "mailto:team@dynamobim.org";
-        public static string DynamoWrittenTutorials = "http://dynamobim.org/learn/#124";
+        public static string DynamoAdvancedTutorials = "http://dynamobim.org/learn/#7570";
         public static string DynamoVideoTutorials = "http://dynamobim.org/learn/#161";
         public static string DynamoMoreSamples = "http://dynamobim.org/learn/#159";
         public static string DynamoDownloadLink = "http://dynamobim.org/download/";

--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -158,9 +158,9 @@ namespace Dynamo.UI.Controls
 
             #region Reference List
 
-            references.Add(new StartPageListItem("Written Tutorials", "icon-reference.png")
+            references.Add(new StartPageListItem("Advanced Tutorials", "icon-reference.png")
             {
-                ContextData = Configurations.DynamoWrittenTutorials,
+                ContextData = Configurations.DynamoAdvancedTutorials,
                 ClickAction = StartPageListItem.Action.ExternalUrl
             });
 


### PR DESCRIPTION
Hi @Benglin, please review and merge.
- I have changed the DynamoWrittenTutorials variable into DynamoAdvancedTutorials as well as the http link in the Configurations.cs file
- String that is displayed to the user on the start page (Written Tutorials) is also changed into Advanced Tutorials 

![startpage](https://cloud.githubusercontent.com/assets/6823427/5733610/b29d5610-9be0-11e4-993b-6701bda65ba0.png)
![magn-4713](https://cloud.githubusercontent.com/assets/6823427/5733616/ba66287c-9be0-11e4-928f-c8d6ddd88062.png)

 