### PR TITLE
Fix port snapping defect

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -324,7 +324,7 @@ namespace Dynamo.Controls
                         if (port.extensionEdges.HasFlag(SnapExtensionEdges.Top | SnapExtensionEdges.Bottom))
                             thickness = new Thickness(left + 0, top - 10, right - 25, bottom - 10);
                         else if (port.extensionEdges.HasFlag(SnapExtensionEdges.Top))
-                            thickness = new Thickness(left - 25, top - 10, right + 0, bottom + 3);
+                            thickness = new Thickness(left + 0, top - 10, right - 25, bottom + 3);
                         else if (port.extensionEdges.HasFlag(SnapExtensionEdges.Bottom))
                             thickness = new Thickness(left + 0, top + 3, right - 25, bottom - 10);
                         break;

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -174,7 +174,6 @@ namespace Dynamo.ViewModels
             // Check if required ports exist
             if (this.activeConnector == null || portVM == null)
                 return false;
-
             //By default the ports will be in snapping mode. But if the connection is not completed,
             //then on mouse leave, the cursor should be pointed as arcselect instead of arcadd.             
             if (!isSnapping)

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -169,11 +169,19 @@ namespace Dynamo.ViewModels
             this.SetActiveConnector(null);
         }
 
-        internal bool CheckActiveConnectorCompatibility(PortViewModel portVM)
+        internal bool CheckActiveConnectorCompatibility(PortViewModel portVM,bool isSnapping = true)
         {
             // Check if required ports exist
             if (this.activeConnector == null || portVM == null)
                 return false;
+
+            //By default the ports will be in snapping mode. But if the connection is not completed,
+            //then on mouse leave, the cursor should be pointed as arcselect instead of arcadd.             
+            if (!isSnapping)
+            {
+                CurrentCursor = CursorLibrary.GetCursor(CursorSet.ArcSelect);
+                return false;
+            }
 
             PortModel srcPortM = this.activeConnector.ActiveStartPort;
             PortModel desPortM = portVM.PortModel;

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -375,7 +375,7 @@ namespace Dynamo.ViewModels
                     this.portViewModel = portViewModel;
                     break;
                 case PortEventType.MouseLeave:
-                     IsSnapping = false;
+                    IsSnapping = this.CheckActiveConnectorCompatibility(portViewModel, false);
                     this.portViewModel = portViewModel;
                     break;
                 case PortEventType.MouseLeftButtonDown:


### PR DESCRIPTION
There are two defects identified in Port snapping. 
1. Ports with many outputs (especially the code block node) have different port snapping region

2. Mouse pointer says ArcAdd, when the mouse pointer is outside snapping region.

This fix addresses both the defects. 
1. Changed the port snapping region boundaries for OUTPUT ports. 
2. On MouseLeave (from snapping region) event, the ports are still ready for connection, and hence the cursor was showing as arc add. Now, this behavior is changed inside the function CheckActiveConnectorCompatibility .

Can you pleas check this Neal? This was already tested, and since this was removed after the refactoring,I added this code. After your test, I will merge this with master.

- [ ] @jnealb 