### PR TITLE
MAGN-5436 Node Migration warning for Read nodes gives incorrect instructions

### DIFF
--- a/src/Libraries/DSOffice/Excel.cs
+++ b/src/Libraries/DSOffice/Excel.cs
@@ -279,7 +279,7 @@ namespace DSOffice
             return ws.Data;
         }
 
-        [Obsolete("Use Excel.ReadFromFile node instead.")]
+        [Obsolete("Use File.FromPath -> Excel.ReadFromFile node instead.")]
         public static object[][] Read(string filePath, string sheetName)
         {
             return ReadFromFile(new FileInfo(filePath), sheetName);


### PR DESCRIPTION
For Excel.Read nodes, change the warning message to
"Use File.FromPath -> Excel.ReadFromFile node instead".

Neal, this is a very simple change involving only Excel.Read. 
- [ ] @jnealb 