### PR TITLE
Fix member names overloading

### DIFF
--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -47,13 +47,13 @@ namespace Dynamo.DSEngine
         /// </summary>
         private string summary;
 
-        public FunctionDescriptor(string name, IEnumerable<TypedParameter> parameters, FunctionType type, bool isOverloaded)
-            : this(null, null, name, parameters, null, type, isOverloaded)
+        public FunctionDescriptor(string name, IEnumerable<TypedParameter> parameters, FunctionType type)
+            : this(null, null, name, parameters, null, type)
         { }
 
         public FunctionDescriptor(
             string assembly, string className, string functionName, IEnumerable<TypedParameter> parameters,
-            string returnType, FunctionType type, bool isOverloaded, bool isVisibleInLibrary = true,
+            string returnType, FunctionType type, bool isVisibleInLibrary = true,
             IEnumerable<string> returnKeys = null, bool isVarArg = false, string obsoleteMsg = "")
             : this(
                 assembly,
@@ -63,7 +63,6 @@ namespace Dynamo.DSEngine
                 parameters,
                 returnType,
                 type,
-                isOverloaded,
                 isVisibleInLibrary,
                 returnKeys,
                 isVarArg,
@@ -71,11 +70,10 @@ namespace Dynamo.DSEngine
 
         public FunctionDescriptor(
             string assembly, string className, string functionName, string summary,
-            IEnumerable<TypedParameter> parameters, string returnType, FunctionType type, bool isOverloaded,
+            IEnumerable<TypedParameter> parameters, string returnType, FunctionType type,
             bool isVisibleInLibrary = true, IEnumerable<string> returnKeys = null, bool isVarArg = false, string obsoleteMsg = "")
         {
             this.summary = summary;
-            IsOverloaded = isOverloaded;
             Assembly = assembly;
             ClassName = className;
             FunctionName = functionName;

--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -100,7 +100,7 @@ namespace Dynamo.DSEngine
             ObsoleteMessage = obsoleteMsg;
         }
 
-        public bool IsOverloaded { get; private set; }
+        public bool IsOverloaded { get; set; }
 
         /// <summary>
         ///     Full path to the assembly the defined this function

--- a/src/DynamoCore/Library/FunctionGroup.cs
+++ b/src/DynamoCore/Library/FunctionGroup.cs
@@ -35,6 +35,13 @@ namespace Dynamo.DSEngine
                 return false;
 
             functions.Add(function);
+
+            if (functions.Count > 1)
+            {
+                functions[0].IsOverloaded = true;
+                functions[functions.Count - 1].IsOverloaded = true;
+            }
+
             return true;
         }
 

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -483,13 +483,12 @@ namespace Dynamo.DSEngine
             };
 
             var functions =
-                ops.Select(op => new FunctionDescriptor(op, args, FunctionType.GenericFunction, false))
+                ops.Select(op => new FunctionDescriptor(op, args, FunctionType.GenericFunction))
                     .Concat(
                         new FunctionDescriptor(
                             Op.GetUnaryOpFunction(UnaryOperator.Not),
                             GetUnaryFuncArgs(),
-                            FunctionType.GenericFunction,
-                            false).AsSingleton());
+                            FunctionType.GenericFunction).AsSingleton());
 
             AddBuiltinFunctions(functions);
         }
@@ -616,8 +615,7 @@ namespace Dynamo.DSEngine
                 procName,
                 arguments,
                 proc.returntype.ToString(),
-                type,
-                false,
+                type,                
                 isVisible,
                 returnKeys,
                 proc.isVarArg,

--- a/src/Libraries/Samples/SampleLibraryUI/SampleLibraryUI.csproj
+++ b/src/Libraries/Samples/SampleLibraryUI/SampleLibraryUI.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{0A4B4EEA-8FAB-4AC8-90D4-27DBC5B0CF2A}</ProjectGuid>
+    <ProjectGuid>{227B776D-8866-49E8-8C93-809CCF86AF12}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SamplesLibraryUI</RootNamespace>

--- a/src/Libraries/Samples/SampleLibraryUI/SampleLibraryUI.csproj
+++ b/src/Libraries/Samples/SampleLibraryUI/SampleLibraryUI.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{227B776D-8866-49E8-8C93-809CCF86AF12}</ProjectGuid>
+    <ProjectGuid>{0A4B4EEA-8FAB-4AC8-90D4-27DBC5B0CF2A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SamplesLibraryUI</RootNamespace>

--- a/test/DynamoCoreTests/XmlDocumentationTests.cs
+++ b/test/DynamoCoreTests/XmlDocumentationTests.cs
@@ -52,8 +52,7 @@ namespace Dynamo.Tests
                 "Translate",
                 parms,
                 "Autodesk.DesignScript.Geometry.Geometry",
-                FunctionType.InstanceMethod,
-                false);
+                FunctionType.InstanceMethod);
 
             parms.ForEach(x => x.Function = funcDesc);
 


### PR DESCRIPTION
#### Purpose

Some overloaded member names doesn't include parameters. For example:
![image](https://cloud.githubusercontent.com/assets/8158551/5767998/6e451b8e-9d15-11e4-9824-23c860358bc9.png)

#### Modifications

The reason of this behavior is in incorrect specification of `FunctionDescriptor.IsOverloaded` property. Parameter `isOverloaded` is removed from `FunctionDescriptor` constructor.

Now the property is specified in `FunctionGroup.AddFunctionDescriptor`.

Result of PR for example:
![capture](https://cloud.githubusercontent.com/assets/8158551/5768104/6c643376-9d16-11e4-8962-e65c766fa211.PNG)

#### Additional references

[MAGN-5827](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5827) Add overloading to name of node

#### Reviewers

@Benglin, please, take a look.