### PR TITLE
Marking Run Automatic test under Failure category

### DIFF
--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -3092,7 +3092,7 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("RegressionTests")]
+        [Category("RegressionTests"), Category("Failure")]
         public void RunAutomatically_On_5068()
         {
             // If Run Automatically On, third file onwards it executes to null


### PR DESCRIPTION
#### Background ####
There have been recent changes to support multiple workspaces in the near future. As a result there has been some change in UI behavior. Previously when `Run Automatic` was turned on, it was applied globally due to which any file when opened subsequently was executed immediately. The following test case tests this very scenario.

Now the `Run Automatic` flag is applied on a per workspace basis due to which, when a new file is opened a new workspace is generated for it with the flag set to `false`. As a result, a new file when opened does not execute even though the flag was set to 'true' prior to opening it.

Since this is more of a UI design issue as to what the new behavior regarding workspaces should be I am marking this test under `Failure` category for the time being.

However I do think there's a [bug in UI binding] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5835) - if the flag is indeed expected to be reset to `false`, the `Run Automatic` checkbox should become unchecked, which it doesn't.

Handing over to:
@kronz 
@mccrone 
@RodRecker 

... for design decisions.