### PR TITLE
Fix MAGN-5831

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -422,7 +422,6 @@ namespace Dynamo.Applications
         {
             var view = (DynamoView)sender;
 
-            revitDynamoModel.RevitServicesUpdater.Dispose();
             DocumentManager.OnLogError -= revitDynamoModel.Logger.Log;
 
             view.Dispatcher.UnhandledException -= Dispatcher_UnhandledException;

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -235,10 +235,7 @@ namespace Dynamo.Applications
 
             revitDynamoModel.ShutdownStarted += (drm) =>
             {
-                lock (idleActions)
-                {
-                    idleActions.Add(DeleteKeeperElement);
-                }
+                AddIdleAction(DeleteKeeperElement);
             };
 
 #else
@@ -426,8 +423,8 @@ namespace Dynamo.Applications
 
             view.Dispatcher.UnhandledException -= Dispatcher_UnhandledException;
             view.Closed -= OnDynamoViewClosed;
-            DocumentManager.Instance.CurrentUIApplication.ViewActivating -=
-                OnApplicationViewActivating;
+            AddIdleAction(() => DocumentManager.Instance.CurrentUIApplication.ViewActivating -=
+                OnApplicationViewActivating);
 
             AppDomain.CurrentDomain.AssemblyResolve -=
                 Analyze.Render.AssemblyHelper.ResolveAssemblies;
@@ -544,5 +541,16 @@ namespace Dynamo.Applications
         }
 
         #endregion
+
+        /// <summary>
+        /// Add an action to run when the application is in the idle state
+        /// </summary>
+        public static void AddIdleAction(Action a)
+        {
+            lock (idleActions)
+            {
+                idleActions.Add(a);
+            }
+        }
     }
 }

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -35,6 +35,7 @@ namespace Dynamo.Applications
         private static readonly string assemblyName = Assembly.GetExecutingAssembly().Location;
         private static ResourceManager res;
         public static ControlledApplication ControlledApplication;
+        public static RevitServicesUpdater RevitServicesUpdater;
         public static List<IUpdater> Updaters = new List<IUpdater>();
         internal static PushButton DynamoButton;
 
@@ -81,6 +82,9 @@ namespace Dynamo.Applications
                 DynamoButton.Image = bitmapSource;
 
                 RegisterAdditionalUpdaters(application);
+                RevitServicesUpdater = new RevitServicesUpdater(DynamoRevitApp.Updaters);
+                
+                SubscribeDocumentChangedEvent();
 
                 return Result.Succeeded;
             }
@@ -94,6 +98,7 @@ namespace Dynamo.Applications
         public Result OnShutdown(UIControlledApplication application)
         {
             UnsubscribeAssemblyResolvingEvent();
+            UnsubscribeDocumentChangedEvent();
 
             return Result.Succeeded;
         }
@@ -168,6 +173,16 @@ namespace Dynamo.Applications
         private void UnsubscribeAssemblyResolvingEvent()
         {
             AppDomain.CurrentDomain.AssemblyResolve -= AssemblyHelper.ResolveAssembly;
+        }
+
+        private void SubscribeDocumentChangedEvent()
+        {
+            ControlledApplication.DocumentChanged += RevitServicesUpdater.ApplicationDocumentChanged;
+        }
+
+        private void UnsubscribeDocumentChangedEvent()
+        {
+            ControlledApplication.DocumentChanged -= RevitServicesUpdater.ApplicationDocumentChanged;
         }
     }
 }

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -222,17 +222,15 @@ namespace Dynamo.Applications.Models
         {
             if (shutdownHost)
             {
-                var uiApplication = DocumentManager.Instance.CurrentUIApplication;
-                uiApplication.Idling += ShutdownRevitHostOnce;
+                DynamoRevit.AddIdleAction(ShutdownRevitHostOnce);
             }
 
             base.PreShutdownCore(shutdownHost);
         }
 
-        private static void ShutdownRevitHostOnce(object sender, IdlingEventArgs idlingEventArgs)
+        private static void ShutdownRevitHostOnce()
         {
             var uiApplication = DocumentManager.Instance.CurrentUIApplication;
-            uiApplication.Idling -= ShutdownRevitHostOnce;
             RevitDynamoModel.ShutdownRevitHost();
         }
 

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -100,7 +100,7 @@ namespace Dynamo.Applications.Models
             string corePath = configuration.DynamoCorePath;
             bool isTestMode = configuration.StartInTestMode;
 
-            RevitServicesUpdater = new RevitServicesUpdater(DynamoRevitApp.ControlledApplication, DynamoRevitApp.Updaters);
+            RevitServicesUpdater = DynamoRevitApp.RevitServicesUpdater;
             SubscribeRevitServicesUpdaterEvents();
 
             InitializeDocumentManager();

--- a/src/Libraries/Revit/RevitServices/Elements/ModelUpdater.cs
+++ b/src/Libraries/Revit/RevitServices/Elements/ModelUpdater.cs
@@ -22,12 +22,10 @@ using RevitServices.Persistence;
 
 namespace RevitServices.Elements
 {
-    public class RevitServicesUpdater : IDisposable
+    public class RevitServicesUpdater
     {
         //TODO: To handle multiple documents, should store unique ids as opposed to ElementIds.
-
-        private readonly ControlledApplication application;
-
+        
         public event ElementUpdateDelegate ElementsAdded;
         public event ElementUpdateDelegateElementId ElementAddedForID;
         public event ElementUpdateDelegate ElementsModified;
@@ -62,12 +60,8 @@ namespace RevitServices.Elements
 
         #endregion
 
-        // constructor takes the AddInId for the add-in associated with this updater
-        public RevitServicesUpdater(/*AddInId id, */ControlledApplication app, IEnumerable<IUpdater> updaters)
+        public RevitServicesUpdater(IEnumerable<IUpdater> updaters)
         {
-            application = app;
-            application.DocumentChanged += ApplicationDocumentChanged;
-
             foreach (var updater in updaters)
             {
                 ((ElementTypeSpecificUpdater)updater).Updated += RevitServicesUpdater_Updated;
@@ -87,11 +81,6 @@ namespace RevitServices.Elements
             var modified = args.Modified.Select(x => doc.GetElement(x).UniqueId).ToList();
             var deleted = args.Deleted;
             ProcessUpdates(doc, modified, deleted, added, addedIds);
-        }
-
-        public void Dispose()
-        {
-            application.DocumentChanged -= ApplicationDocumentChanged;
         }
 
         //TODO: remove once we are using unique ids
@@ -124,7 +113,7 @@ namespace RevitServices.Elements
             OnElementsAdded(doc, addedIds);
         }
 
-        void ApplicationDocumentChanged(object sender, DocumentChangedEventArgs args)
+        public void ApplicationDocumentChanged(object sender, DocumentChangedEventArgs args)
         {
             var doc = args.GetDocument();
             var added = args.GetAddedElementIds().Select(x => doc.GetElement(x).UniqueId);


### PR DESCRIPTION
<h4>Summary</h4>

The cause of this defect is that when we un-register event handler for DocumentChanged during the shutdown process, an exception will be thrown.

This submission makes the change to register/un-register the event handler when the application starts up or shuts down. At the same time, a new public member RevitServicesUpdater is added to DynamoRevitApp. To make RevitServicesUpdater be able to be accessed from the model, the old attribute is reserved in RevitDynamoModel. But instead of creating it, we give it the value from DynamoRevitApp.RevitServicesUpdater.

There are also two more places where exceptions will be thrown. The fix is down in the second commit.

@sharadkjaiswal 
@pboyer 
@Benglin 
PTAL