### PR TITLE
Fix for setting Run Automatic checkbox: MAGN-5835

### DIFF
--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -116,6 +116,12 @@ namespace Dynamo.Models
             EngineController.NodeDeleted(node);
         }
 
+        protected override void ResetWorkspaceCore()
+        {
+            // Reset Run Automatic option to false on resetting the workspace
+            DynamicRunEnabled = false;
+        }
+
         private void LibraryLoaded(object sender, LibraryServices.LibraryLoadedEventArgs e)
         {
             // Mark all nodes as dirty so that AST for the whole graph will be

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -98,7 +98,7 @@ namespace Dynamo.ViewModels
             }
         }
 
-        public virtual bool DynamicRunEnabled
+        public bool DynamicRunEnabled
         {
             get
             {
@@ -889,6 +889,10 @@ namespace Dynamo.ViewModels
         private void WorkspaceRemoved(WorkspaceModel item)
         {
             workspaces.Remove(workspaces.First(x => x.Model == item));
+
+            // If a workspace is removed, reset this property to false 
+            // so that Run Automatic checkbox is unchecked by default
+            DynamicRunEnabled = false;
         }
 
         internal void AddToRecentFiles(string path)
@@ -1426,6 +1430,9 @@ namespace Dynamo.ViewModels
                 Model.CurrentWorkspace = HomeSpace;
 
                 model.ClearCurrentWorkspace();
+
+                // Clear the Run Automatic checkbox by default
+                DynamicRunEnabled = false;
                 return true;
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -890,9 +890,8 @@ namespace Dynamo.ViewModels
         {
             workspaces.Remove(workspaces.First(x => x.Model == item));
 
-            // If a workspace is removed, reset this property to false 
-            // so that Run Automatic checkbox is unchecked by default
-            DynamicRunEnabled = false;
+            // Update the ViewModel property to reflect change in WorkspaceModel
+            RaisePropertyChanged("DynamicRunEnabled");
         }
 
         internal void AddToRecentFiles(string path)
@@ -1431,8 +1430,8 @@ namespace Dynamo.ViewModels
 
                 model.ClearCurrentWorkspace();
 
-                // Clear the Run Automatic checkbox by default
-                DynamicRunEnabled = false;
+                // Update the ViewModel property to reflect change in WorkspaceModel
+                RaisePropertyChanged("DynamicRunEnabled");
                 return true;
             }
 


### PR DESCRIPTION
This submission fixes: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5835

As per the new workspace behavior the `DynamicRunEnabled` property that controls the `Run Automatically` checkbox is a property of the workspace (`WorkspaceModel`) and not globally applied (Refer to PR: https://github.com/DynamoDS/Dynamo/pull/3553). It is therefore reset on opening a new file (workspace) or creating a new home workspace after clearing the existing one. However the UI checkbox bound property, `DynamicRunEnabled` in `DynamoViewModel` was not getting reset along with the action of clearing the existing workspace. This submission fixes this issue.

@Benglin please review.