### PR TITLE
Package uninstalling doesn't remove top category in nodes tree

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -217,7 +217,7 @@ namespace Dynamo.ViewModels
         private void RemoveEntry(NodeSearchElement entry)
         {
             var treeStack = new Stack<NodeCategoryViewModel>();
-            var nameStack = new Stack<string>(entry.Categories);
+            var nameStack = new Stack<string>(entry.Categories.Reverse());
             var target = libraryRoot;
             while (nameStack.Any())
             {


### PR DESCRIPTION
#### Purpose

Currently uninstalling of package doesn't remove node from nodes tree. This PR fixes this issue.

#### Additional references

[MAGN-5848](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5848) Package uninstalling doesn't remove top category in nodes tree

#### Reviewers

@Benglin, please, take a look.