### PR TITLE
Clean up reference counting related code

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -1638,12 +1638,10 @@ namespace ProtoCore.DSASM
                 //
 
                 // Handle deactivated graphnodes
-#if GC_MARK_AND_SWEEP
                 foreach (var symbol in gnode.symbolListWithinExpression)
                 {
                     rmem.SetSymbolValue(symbol, StackValue.Null);
                 }
-#endif
                 gnode.isActive = false;
             }
             return reachableGraphNodes.Count;
@@ -7551,7 +7549,6 @@ namespace ProtoCore.DSASM
             }
         }
 
-        [Conditional("GC_MARK_AND_SWEEP")]
         private void GC()
         {
             var currentFramePointer = rmem.FramePointer;

--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -205,12 +205,6 @@ namespace ProtoCore.DSASM
 
     public class Heap
     {
-        public enum GCStrategies
-        {
-            kReferenceCounting,
-            kMarkAndSweep
-        }
-
         private readonly List<int> freeList = new List<int>();
         private readonly List<HeapElement> heapElements = new List<HeapElement>();
         private bool isGarbageCollecting = false;
@@ -219,17 +213,6 @@ namespace ProtoCore.DSASM
         {
         }
 
-        public GCStrategies GCStrategy
-        {
-            get
-            {
-#if GC_MARK_AND_SWEEP
-                return Heap.GCStrategies.kMarkAndSweep;
-#else
-                return Heap.GCStrategies.kReferenceCounting;
-#endif
-            }
-        }
         public StackValue AllocateString(string str)
         {
             var chs = str.Select(c => StackValue.BuildChar(c)).ToArray();
@@ -285,6 +268,18 @@ namespace ProtoCore.DSASM
             int index = (int)pointer.opdata;
             var heapElement = heapElements[index];
             return heapElement;
+        }
+
+        public bool TryGetHeapElement(StackValue pointer, out HeapElement heapElement)
+        {
+            heapElement = null;
+            int index = (int)pointer.opdata;
+
+            if (index >= 0 && index < heapElements.Count)
+            {
+                heapElement = heapElements[index];
+            }
+            return heapElement != null;
         }
 
         public void Free()

--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -15,11 +15,8 @@ namespace ProtoCore.DSASM
         private const int kInitialSize = 5;
         private const double kReallocFactor = 0.5;
 
-        public bool Active { get; set; }
-        public int Symbol { get; set; }
         private int AllocSize { get; set; }
         public int VisibleSize { get; set; }
-        public int Refcount { get; set; }
         public Dictionary<StackValue, StackValue> Dict;
         public StackValue[] Stack;
         public MetaData MetaData { get; set; }
@@ -31,10 +28,7 @@ namespace ProtoCore.DSASM
 
         public HeapElement(int size, int symbolindex)
         {
-            Active = true;
-            Symbol = symbolindex;
             AllocSize = VisibleSize = size;
-            Refcount = 0;
             Dict = null; 
             Stack = new StackValue[AllocSize];
 
@@ -46,10 +40,7 @@ namespace ProtoCore.DSASM
 
         public HeapElement(StackValue[] arrayElements)
         {
-            Active = true;
-            Symbol = ProtoCore.DSASM.Constants.kInvalidIndex;
             AllocSize = VisibleSize = arrayElements.Length;
-            Refcount = 0;
             Stack = arrayElements;
         }
 
@@ -293,14 +284,6 @@ namespace ProtoCore.DSASM
         {
             int index = (int)pointer.opdata;
             var heapElement = heapElements[index];
-
-            if (!heapElement.Active)
-            {
-#if HEAP_VERIFICATION
-                throw new Exception("Memory corrupted: Access dead memory (E4A2FC59-52DF-4F3B-8CD3-6C9E08F93AC5).");
-#endif
-            }
-
             return heapElement;
         }
 
@@ -505,7 +488,7 @@ namespace ProtoCore.DSASM
         /// <returns> Returns true if the array contains a cycle </returns>
         private bool IsHeapCyclic(HeapElement heapElement, int HeapID)
         {
-            if (heapElement.Active && heapElement.VisibleSize > 0)
+            if (heapElement.VisibleSize > 0)
             {
                 // Traverse each element in the heap
                 foreach (StackValue sv in heapElement.Stack)

--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -416,17 +416,6 @@ namespace ProtoCore
                 //walk over the structure converting each othe elements
 
                 var hpe = core.Heap.GetHeapElement(sv);
-#if GC_REFERENCE_COUNTING
-                var isTemporary = hpe.Active && hpe.Refcount == 0;
-#else
-                var isTemporary = false;
-#endif
-
-                if (targetType.UID == (int)PrimitiveType.kTypeVar && targetType.rank == DSASM.Constants.kArbitraryRank && isTemporary)
-                {
-                    return sv;
-                }
-
                 //Validity.Assert(targetType.rank != -1, "Arbitrary rank array conversion not yet implemented {2EAF557F-62DE-48F0-9BFA-F750BBCDF2CB}");
 
                 //Decrease level of reductions by one

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -84,10 +84,10 @@
     <AssemblyOriginatorKeyFile>ProtoCore.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;GC_MARK_AND_SWEEP</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <DefineConstants>TRACE;GC_MARK_AND_SWEEP</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/test/Engine/ProtoTest/DSASM/HeapMarkSweepTests.cs
+++ b/test/Engine/ProtoTest/DSASM/HeapMarkSweepTests.cs
@@ -8,9 +8,6 @@ using ProtoTestFx.TD;
 using ProtoScript.Runners;
 namespace ProtoTest.DSASM
 {
-
-#if GC_MARK_AND_SWEEP
-
     [TestFixture]
     public class HeapMarkAndSweepTests
     {
@@ -57,11 +54,11 @@ namespace ProtoTest.DSASM
 
             heap.GCMarkAndSweep(new List<StackValue>(), testExecutive);
 
-            var arrayHeapElement = heap.GetHeapElement(array);
-            Assert.IsNull(arrayHeapElement);
+            HeapElement arrayHeapElement;
+            Assert.IsFalse(heap.TryGetHeapElement(array, out arrayHeapElement));
 
-            var strHeapElement = heap.GetHeapElement(str);
-            Assert.IsNull(strHeapElement);
+            HeapElement strHeapElement;
+            Assert.IsFalse(heap.TryGetHeapElement(str, out strHeapElement));
         }
 
         /// <summary>
@@ -100,8 +97,8 @@ namespace ProtoTest.DSASM
 
             heap.GCMarkAndSweep(new List<StackValue>() { array1}, testExecutive);
 
-            var arrayHeapElement = heap.GetHeapElement(array1);
-            Assert.IsNotNull(arrayHeapElement);
+            HeapElement arrayHeapElement;
+            Assert.IsTrue(heap.TryGetHeapElement(array1, out arrayHeapElement));
 
             heap.Free();
         }
@@ -141,8 +138,8 @@ namespace ProtoTest.DSASM
             // non pointer gc root won't retain memory
             heap.GCMarkAndSweep(allTypes, testExecutive);
 
-            var arrayHeapElement = heap.GetHeapElement(array);
-            Assert.IsNull(arrayHeapElement);
+            HeapElement arrayHeapElement;
+            Assert.IsFalse(heap.TryGetHeapElement(array, out arrayHeapElement));
 
             heap.Free();
         }
@@ -161,14 +158,14 @@ namespace ProtoTest.DSASM
 
             heap.GCMarkAndSweep(new List<StackValue>() {}, testExecutive);
 
-            var array1HeapElement = heap.GetHeapElement(array1);
-            Assert.IsNull(array1HeapElement);
+            HeapElement array1HeapElement;
+            Assert.IsFalse(heap.TryGetHeapElement(array1, out array1HeapElement));
 
-            var array2HeapElement = heap.GetHeapElement(array2);
-            Assert.IsNull(array2HeapElement);
+            HeapElement array2HeapElement;
+            Assert.IsFalse(heap.TryGetHeapElement(array2, out array2HeapElement));
 
-            var array3HeapElement = heap.GetHeapElement(array3);
-            Assert.IsNull(array3HeapElement);
+            HeapElement array3HeapElement;
+            Assert.IsFalse(heap.TryGetHeapElement(array3, out array3HeapElement));
         }
 
         /// <summary>
@@ -188,11 +185,11 @@ namespace ProtoTest.DSASM
 
             heap.GCMarkAndSweep(new List<StackValue>() {}, testExecutive);
 
-            var valHeapElement = heap.GetHeapElement(val);
-            Assert.IsNull(valHeapElement);
+            HeapElement valHeapElement;
+            Assert.IsFalse(heap.TryGetHeapElement(val, out valHeapElement));
 
-            var arrayHeapElement = heap.GetHeapElement(array);
-            Assert.IsNull(arrayHeapElement);
+            HeapElement arrayHeapElement;
+            Assert.IsFalse(heap.TryGetHeapElement(array, out arrayHeapElement));
         }
 
         /// <summary>
@@ -208,8 +205,9 @@ namespace ProtoTest.DSASM
             arrayHeapElement.Stack[0] = array;
 
             heap.GCMarkAndSweep(new List<StackValue>() {}, testExecutive);
-            var releasedHeapElement = heap.GetHeapElement(array);
-            Assert.IsNull(releasedHeapElement);
+
+            HeapElement releasedHeapElement;
+            Assert.IsFalse(heap.TryGetHeapElement(array, out releasedHeapElement));
         }
 
         /// <summary>
@@ -227,13 +225,11 @@ namespace ProtoTest.DSASM
 
             heap.GCMarkAndSweep(new List<StackValue>() { }, testExecutive);
 
-            var array1Hpe = heap.GetHeapElement(array1);
-            Assert.IsNull(array1Hpe);
+            HeapElement array1Hpe;
+            Assert.IsFalse(heap.TryGetHeapElement(array1, out array1Hpe));
 
-            var array2Hpe = heap.GetHeapElement(array2);
-            Assert.IsNull(array2Hpe);
+            HeapElement array2Hpe;
+            Assert.IsFalse(heap.TryGetHeapElement(array2, out array2Hpe));
         }
     }
-
-#endif
 }

--- a/test/Engine/ProtoTest/DebugTests/BasicTests.cs
+++ b/test/Engine/ProtoTest/DebugTests/BasicTests.cs
@@ -13943,10 +13943,6 @@ c = 2;
             watchRunner = new ExpressionInterpreterRunner(core);
             mirror = watchRunner.Execute(@"b");
             objExecVal = mirror.GetWatchValue();
-            if (core.Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kReferenceCounting)
-            {
-                Assert.IsTrue((Int64)objExecVal.Payload == -1);
-            }
 
             fsr.StepOver();
             vms = fsr.StepOver();   // a = A.A();
@@ -13968,10 +13964,6 @@ c = 2;
             watchRunner = new ExpressionInterpreterRunner(core);
             mirror = watchRunner.Execute(@"b");
             objExecVal = mirror.GetWatchValue();
-            if (core.Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kReferenceCounting)
-            {
-                Assert.IsTrue((Int64)objExecVal.Payload == -2);
-            }
 
             fsr.StepOver();
             fsr.StepOver();
@@ -14030,10 +14022,6 @@ c = 2;
             watchRunner = new ExpressionInterpreterRunner(core);
             mirror = watchRunner.Execute(@"b");
             objExecVal = mirror.GetWatchValue();
-            if (core.Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kReferenceCounting)
-            {
-                Assert.IsTrue((Int64)objExecVal.Payload == -1);
-            }
 
             vms = fsr.StepOver();   // c = 2;
             vms = fsr.StepOver();   // end of script
@@ -14095,10 +14083,6 @@ c = 2;
             watchRunner = new ExpressionInterpreterRunner(core);
             mirror = watchRunner.Execute(@"b");
             objExecVal = mirror.GetWatchValue();
-            if (core.Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kReferenceCounting)
-            {
-                Assert.IsTrue((Int64)objExecVal.Payload == -1);
-            }
 
             vms = fsr.StepOver();   // c = 2;
             vms = fsr.StepOver();   // end of script
@@ -14213,10 +14197,6 @@ c = 2;
             watchRunner = new ExpressionInterpreterRunner(core);
             mirror = watchRunner.Execute(@"b");
             objExecVal = mirror.GetWatchValue();
-            if (core.Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kReferenceCounting)
-            {
-                Assert.IsTrue((Int64)objExecVal.Payload == -1);
-            }
 
             vms = fsr.StepOver();   // end of script
             watchRunner = new ExpressionInterpreterRunner(core);
@@ -14272,10 +14252,6 @@ c = 2;
             watchRunner = new ExpressionInterpreterRunner(core);
             mirror = watchRunner.Execute(@"b");
             objExecVal = mirror.GetWatchValue();
-            if (core.Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kReferenceCounting)
-            {
-                Assert.IsTrue((Int64)objExecVal.Payload == -1);
-            }
 
             vms = fsr.StepOver();   // end of script
             watchRunner = new ExpressionInterpreterRunner(core);

--- a/test/Engine/ProtoTest/FFITests/CSFFITest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFITest.cs
@@ -1002,11 +1002,6 @@ p11;
                             v = dv.GetValue();
                             ";
             thisTest.RunScriptSource(code);
-            var gcStrategy =  thisTest.SetupTestCore().Heap.GCStrategy;
-            if (gcStrategy == ProtoCore.DSASM.Heap.GCStrategies.kReferenceCounting)
-            {
-                thisTest.Verify("v", 10);
-            }
             // For mark and sweep, the order of object dispose is not defined,
             // so we are not sure if AClass objects or BClass objects will be
             // disposed firstly, hence we can't verify the expected value.
@@ -1050,18 +1045,9 @@ p11;
                             v3 = dv.GetValue();
                             ";
             thisTest.RunScriptSource(code);
-            var gcStrategy =  thisTest.GetTestCore().Heap.GCStrategy;
-            if (gcStrategy == ProtoCore.DSASM.Heap.GCStrategies.kMarkAndSweep)
-            {
                 // For mark and sweep, it is straight, we only need to focus 
                 // on created objects. So the value = 3 + 10 + 20 + 30 = 63.
                 thisTest.Verify("v3", 63);
-            }
-            else
-            {
-                thisTest.Verify("v1", 3); 
-                thisTest.Verify("v2", 23);
-            }
         }
 
         [Test]
@@ -1110,19 +1096,11 @@ p11;
                             ";
 
             thisTest.RunScriptSource(code);
-            var gcStrategy = thisTest.GetTestCore().Heap.GCStrategy;
-            if (gcStrategy == ProtoCore.DSASM.Heap.GCStrategies.kMarkAndSweep)
             {
                 // For mark and sweep, the last object is a2, se the expected
                 // value = 4. But it is very fragile because the order of
                 // disposing is not defined. 
                 thisTest.Verify("v4", 4);
-            }
-            else
-            {
-                thisTest.Verify("v1", 3); 
-                thisTest.Verify("v2", 3); 
-                thisTest.Verify("v3", 16);
             }
         }
 

--- a/test/Engine/ProtoTest/MultiLangTests/GCTest.cs
+++ b/test/Engine/ProtoTest/MultiLangTests/GCTest.cs
@@ -38,16 +38,7 @@ v3 = DisposeVerify.x; // 6
 v4 = DisposeVerify.x;
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code, "", testCasePath);
-            if (thisTest.GetTestCore().Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kMarkAndSweep)
-            {
-                thisTest.Verify("v4", 8);
-            }
-            else
-            {
-                thisTest.Verify("v1", 4);
-                thisTest.Verify("v2", 5);
-                thisTest.Verify("v3", 6);
-            }
+            thisTest.Verify("v4", 8);
         }
 
         [Test]
@@ -93,10 +84,6 @@ v1;
 v2 = DisposeVerify.x; // 3";
             ExecutionMirror mirror = thisTest.RunScriptSource(code, "", testCasePath);
 
-            if (thisTest.GetTestCore().Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kReferenceCounting)
-            {
-                thisTest.Verify("v1", 2);
-            }
             thisTest.Verify("v2", 3);
         }
 
@@ -149,15 +136,7 @@ v2 = DisposeVerify.x; // 4
 }
 v3 = DisposeVerify.x;";
             ExecutionMirror mirror = thisTest.RunScriptSource(code, "", testCasePath);
-            if (thisTest.GetTestCore().Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kMarkAndSweep)
-            {
-                thisTest.Verify("v3", 4);
-            }
-            else
-            {
-                thisTest.Verify("v1", 3);
-                thisTest.Verify("v2", 4);
-            }
+            thisTest.Verify("v3", 4);
         }
 
         [Test]
@@ -193,17 +172,7 @@ v3 = DisposeVerify.x; // 7
 v4 = DisposeVerify.x;
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code, "", testCasePath);
-
-            if (thisTest.GetTestCore().Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kMarkAndSweep)
-            {
                 thisTest.Verify("v4", 7);
-            }
-            else
-            {
-                thisTest.Verify("v1", 4);
-                thisTest.Verify("v2", 4);
-                thisTest.Verify("v3", 7);
-            }
         }
 
         [Test]
@@ -238,16 +207,7 @@ v3 = DisposeVerify.x; // 7
 v4 = DisposeVerify.x;
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code, "", testCasePath);
-            if (thisTest.GetTestCore().Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kMarkAndSweep)
-            {
                 thisTest.Verify("v4", 7);
-            }
-            else
-            {
-                thisTest.Verify("v1", 4);
-                thisTest.Verify("v2", 4);
-                thisTest.Verify("v3", 7);
-            }
         }
 
         [Test]
@@ -291,20 +251,7 @@ v7 = DisposeVerify.x; // 7
 
 v8 = DisposeVerify.x;";
             ExecutionMirror mirror = thisTest.RunScriptSource(code, "", testCasePath);
-            if (thisTest.GetTestCore().Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kMarkAndSweep)
-            {
                 thisTest.Verify("v8", 7);
-            }
-            else
-            {
-                thisTest.Verify("v1", 1);
-                thisTest.Verify("v2", 4);
-                thisTest.Verify("v3", 4);
-                thisTest.Verify("v4", 4);
-                thisTest.Verify("v5", 5);
-                thisTest.Verify("v6", 6);
-                thisTest.Verify("v7", 7);
-            }
         }
 
         [Test]
@@ -352,19 +299,7 @@ v6 = DisposeVerify.x; // 9";
 
             // SSA'd transforms will not GC the temps until end of block
             // However, they must be GC's after every line when in debug setp over
-            if (thisTest.GetTestCore().Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kMarkAndSweep)
-            {
                 thisTest.Verify("v6", 9);
-            }
-            else
-            {
-                thisTest.Verify("v1", 1);
-                thisTest.Verify("v2", 1);
-                thisTest.Verify("v3", 2);
-                thisTest.Verify("v4", 5);
-                thisTest.Verify("v5", 6);
-                thisTest.Verify("v6", 9);
-            }
         }
 
         [Test]
@@ -389,15 +324,7 @@ v2 = DisposeVerify.x; // 4
 }
 v3 = DisposeVerify.x;";
             ExecutionMirror mirror = thisTest.RunScriptSource(code, "", testCasePath);
-            if (thisTest.GetTestCore().Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kMarkAndSweep)
-            {
                 thisTest.Verify("v3", 4);
-            }
-            else
-            {
-                thisTest.Verify("v1", 3);
-                thisTest.Verify("v2", 4);
-            }
         }
 
         [Test]
@@ -456,10 +383,6 @@ v1;
 }
 v2 = DisposeVerify.x; // 4";
             ExecutionMirror mirror = thisTest.RunScriptSource(code, "", testCasePath);
-            if (thisTest.GetTestCore().Heap.GCStrategy == ProtoCore.DSASM.Heap.GCStrategies.kReferenceCounting)
-            {
-                thisTest.Verify("v1", 5);
-            }
             thisTest.Verify("v2", 7);
         }
 

--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -521,18 +521,6 @@ namespace ProtoTestFx.TD
                 else
                 {
                     ProtoCore.DSASM.HeapElement he = testMirror.MirrorTarget.rmem.Heap.GetHeapElement(sv);
-
-                    if (he.Refcount != referencCount)
-                    {
-                        Assert.Fail(String.Format("\t{0}'s reference count is {1}, which is not equal to expected {2}", dsVariable, he.Refcount, referencCount));
-                    }
-                    else if (referencCount > 0)
-                    {
-                        if (!he.Active)
-                        {
-                            Assert.Fail(String.Format("\t{0}'s reference count == {1}, but somehow it is makred as inactive.", dsVariable, referencCount));
-                        }
-                    }
                 }
             }
             catch (NotImplementedException)


### PR DESCRIPTION
This pull request is the followup for reference counting GC code clean up (see https://github.com/DynamoDS/Dynamo/pull/3542):
  1. Remove ``GC_MARK_AND_SWEEP`` and ``GC_REFERENCE_COUNTING`` compilation flags.
  2. Remove dead fields in ``HeapElement``: ``Active``, ``Symbol``, ``RefCount``
  3. Re-enable ``HeapMarkSweepTests``.

@lukechurch , @junmendoza  please review the change. 