### PR TITLE
Removing Failure Category for below three test cases, as now they started passing.

### DIFF
--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -22,7 +22,6 @@ namespace Dynamo.Tests
     internal class CustomNodes : DSEvaluationViewModelUnitTest
     {
         [Test]
-        [Category("Failure")]
         public void CanCollapseNodesAndGetSameResult()
         {
             var model = ViewModel.Model;

--- a/test/Engine/ProtoTest/Associative/MethodsFocusTeam.cs
+++ b/test/Engine/ProtoTest/Associative/MethodsFocusTeam.cs
@@ -1279,7 +1279,6 @@ namespace ProtoTest.Associative
         }
 
         [Test]
-        [Category("Failure")]
         public void TV1467167()
         {
             String code =

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -1845,7 +1845,6 @@ r = Equals(x, {41, 42});
         }
 
         [Test]
-        [Category("Failure")]
         public void TestFunctionOverloadRedefinitionOnUnmodifiedNode02()
         {
             // Tracked in: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4229


### PR DESCRIPTION
Based on email from EC (DynamoCategoryFailure:master) which reports three test are passing from last few submissions.

I am just removing their failure category after verifying locally that they are passing on latest build.

<h3>Reviewer</h3>
- [ ] @Benglin 

@junmendoza : Two of them from Language.

Here is the results on latest build...
![image](https://cloud.githubusercontent.com/assets/5109531/5796739/1c0b40e8-9fe8-11e4-9328-8b27c042103f.png)

