### PR TITLE
Fix MAGN-5839

### DIFF
--- a/src/Libraries/Revit/RevitNodes/Elements/FamilyInstance.cs
+++ b/src/Libraries/Revit/RevitNodes/Elements/FamilyInstance.cs
@@ -57,6 +57,10 @@ namespace Revit.Elements
                 //Phase 2- There was no existing point, create one
                 TransactionManager.Instance.EnsureInTransaction(Document);
 
+                //If the symbol is not active, then activate it
+                if (!fs.IsActive)
+                    fs.Activate();
+
                 Autodesk.Revit.DB.FamilyInstance fi;
 
                 if (Document.IsFamilyDocument)
@@ -104,6 +108,10 @@ namespace Revit.Elements
 
             //Phase 2- There was no existing point, create one
             TransactionManager.Instance.EnsureInTransaction(Document);
+            
+            //If the symbol is not active, then activate it
+            if (!fs.IsActive)
+                fs.Activate();
 
             Autodesk.Revit.DB.FamilyInstance fi;
 


### PR DESCRIPTION
<h4>Summary</h4>

In the case when a family symbol is not active, we need to activate it before using it.

@Benglin 
PTAL