### PR TITLE
Restoring the namespace for sliders

### DIFF
--- a/src/Libraries/CoreNodesUI/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodesUI/Input/DoubleSlider.cs
@@ -8,10 +8,11 @@ using Autodesk.DesignScript.Runtime;
 using Dynamo.Core;
 using Dynamo.Models;
 using Dynamo.Nodes;
+using DSCoreNodesUI.Input;
 
 using ProtoCore.AST.AssociativeAST;
 
-namespace DSCoreNodesUI.Input
+namespace Dynamo.Nodes
 {
     [NodeName("Number Slider")]
     [NodeCategory(BuiltinNodeCategories.CORE_INPUT)]

--- a/src/Libraries/CoreNodesUI/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodesUI/Input/IntegerSlider.cs
@@ -8,10 +8,11 @@ using Autodesk.DesignScript.Runtime;
 using Dynamo.Core;
 using Dynamo.Models;
 using Dynamo.Nodes;
+using DSCoreNodesUI.Input;
 
 using ProtoCore.AST.AssociativeAST;
 
-namespace DSCoreNodesUI.Input
+namespace Dynamo.Nodes
 {
     [NodeName("Integer Slider")]
     [NodeCategory(BuiltinNodeCategories.CORE_INPUT)]

--- a/test/DynamoCoreUITests/SliderTests.cs
+++ b/test/DynamoCoreUITests/SliderTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reflection;
 
 using DSCoreNodesUI.Input;
+using Dynamo.Nodes;
 using NUnit.Framework;
 
 namespace DynamoCoreUITests


### PR DESCRIPTION
- https://github.com/DynamoDS/Dynamo/pull/3482 has moved the sliders to
DSCoreNodesUI.Input and this breaks old dynamo files.
- This submission restores the namespace for sliders to Dynamo.Nodes

*Reviewers:*
@ikeough, I am going ahead and merging this, so that build and test failures are resolved. Feel free to revert it and put a proper solution.
@ke-yu 