### PR TITLE
Fix MAGN-5836

### DIFF
--- a/src/Libraries/CoreNodesUI/Selection.cs
+++ b/src/Libraries/CoreNodesUI/Selection.cs
@@ -114,7 +114,7 @@ namespace Dynamo.Nodes
             OutPortData.Add(new PortData("Elements", "The selected elements."));
             RegisterAllPorts();
 
-            SelectCommand = new DelegateCommand(Select, CanBeginSelect);
+            SelectCommand = new DelegateCommand(InteractivelySelect, CanBeginSelect);
             Prefix = prefix;
 
             State = ElementState.Warning; 
@@ -176,7 +176,7 @@ namespace Dynamo.Nodes
         /// Callback when selection button is clicked. 
         /// Calls the selection action, and stores the ElementId(s) of the selected objects.
         /// </summary>
-        protected virtual void Select(object parameter)
+        protected virtual void InteractivelySelect()
         {
             try
             {


### PR DESCRIPTION
<h4>Summary</h4>

In the ModelBase class which is the base class for the selection classes, a method Select() is defined. As a result, when the select delegate command is called, it will call the one from the base class. This means nothing is done.

In this submission, the method in the derived class is modified and used correctly when creating the delegate command.

@Benglin 
PTAL