### PR TITLE
MAGN-3192 Add test for UpdateManager when using a network requiring login.

### DIFF
--- a/src/DynamoCore/UpdateManager/UpdateManager.cs
+++ b/src/DynamoCore/UpdateManager/UpdateManager.cs
@@ -742,6 +742,11 @@ namespace Dynamo.UpdateManager
 
             var bucketresult = doc.Element(ns + "ListBucketResult");
 
+            if (bucketresult == null)
+            {
+                return null;
+            }
+
             var builds = bucketresult.Descendants(ns + "LastModified").
                 OrderByDescending(x => DateTime.Parse(x.Value)).
                 Where(x => x.Parent.Value.Contains(InstallNameBase) || x.Parent.Value.Contains(OldDailyInstallNameBase)).

--- a/test/DynamoCoreTests/UpdateManagerTests.cs
+++ b/test/DynamoCoreTests/UpdateManagerTests.cs
@@ -247,6 +247,23 @@ namespace Dynamo.Tests
             dateTime = UpdateManager.UpdateManager.GetBuildTimeFromFilePath("DynamoInstall", "DynamoInstall0.7.1.exe");
             Assert.AreEqual(dateTime, DateTime.MinValue);
         }
+
+        [Test, Category("UnitTests")]
+        public void UpdateCheckReturnsNothingWhenGivenBadData()
+        {
+            // Here we simulate some xml that is returned that is well-formed
+            // but not what we are looking for. This is the case often when you
+            // are logging into a network that requires an additional login, like
+            // hotel wi-fi. In this case, the ListBucketResult element will not 
+            // be found in the xml and we'll get null UpdateInfo.
+
+            var updateRequest = new Mock<IAsynchronousRequest>();
+            updateRequest.Setup(ur => ur.Data).Returns(UpdateManagerTestHelpers.badData);
+
+            UpdateManager.UpdateManager.Instance.UpdateDataAvailable(updateRequest.Object);
+
+            Assert.Null(UpdateManager.UpdateManager.Instance.UpdateInfo);
+        }
     }
 
     internal static class UpdateManagerTestHelpers
@@ -323,6 +340,15 @@ namespace Dynamo.Tests
                 "<MaxKeys>1000</MaxKeys>" +
                 "<IsTruncated>true</IsTruncated>" +
                 "</ListBucketResult>";
+
+        public const string badData =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<note>" +
+                "<to> Foo</to>" +
+                "<from>Bar</from>" +
+                "<heading>Reminder</heading>" +
+                "<body>This is some bad xml!</body>" +
+                "</note>";
 
         public static void DoNothing()
         {


### PR DESCRIPTION
This PR addresses [MAGN-3192](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3192), by adding a check that xml returned from a request to our update server is able to be parsed for S3 bucket information. 

## How
- Add a test which mocks well-formed, but senseless, xml returned from the server.
- Adds a null check to guard against attempting to use that xml to get bucket results.

PTAL:
- @pboyer 