### PR TITLE
Fixed an issue with increasing watch node size 

### DIFF
--- a/src/Libraries/DynamoWatch3D/Properties/AssemblyInfo.cs
+++ b/src/Libraries/DynamoWatch3D/Properties/AssemblyInfo.cs
@@ -9,3 +9,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b48c0f05-8716-44d6-9c5e-20ed731a6f0d")]
+[assembly: InternalsVisibleTo("DynamoCoreTests")]

--- a/src/Libraries/DynamoWatch3D/Watch3D.cs
+++ b/src/Libraries/DynamoWatch3D/Watch3D.cs
@@ -48,6 +48,12 @@ namespace Dynamo.Nodes
             View.View.Camera.Position = model.CameraPosition;
             View.View.Camera.LookDirection = model.LookDirection;
 
+            // When user sizes a watch node, only view gets resized. The actual 
+            // NodeModel does not get updated. This is where the view updates the 
+            // model whenever its size is updated.
+            View.SizeChanged += (sender, args) => 
+                model.SetSize(args.NewSize.Width, args.NewSize.Height);
+
             model.RequestUpdateLatestCameraPosition += this.UpdateLatestCameraPosition;
 
             var mi = new MenuItem { Header = "Zoom to Fit" };
@@ -248,9 +254,6 @@ namespace Dynamo.Nodes
 
             var resultAst = new[]
             {
-                //AstFactory.BuildAssignment(
-                //    GetAstIdentifierForOutputIndex(0),
-                //    DataBridge.GenerateBridgeDataAst(GUID.ToString(), inputAstNodes[0])),
                 AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), inputAstNodes[0])
             };
 
@@ -267,8 +270,10 @@ namespace Dynamo.Nodes
             nodeElement.AppendChild(viewElement);
             var viewHelper = new XmlElementHelper(viewElement);
 
-            viewHelper.SetAttribute("width", Width);
-            viewHelper.SetAttribute("height", Height);
+            WatchWidth = Width;
+            WatchHeight = Height;
+            viewHelper.SetAttribute("width", WatchWidth);
+            viewHelper.SetAttribute("height", WatchHeight);
 
             // the view stores the latest position
             OnRequestUpdateLatestCameraPosition();

--- a/test/DynamoCoreTests/CoreUnitTests.cs
+++ b/test/DynamoCoreTests/CoreUnitTests.cs
@@ -1,0 +1,78 @@
+﻿
+using System;
+using System.Windows.Media.Media3D;
+using System.Xml;
+using DSCore.Logic;
+using Dynamo.Models;
+using Dynamo.Nodes;
+using NUnit.Framework;
+
+namespace Dynamo.Tests
+{
+    /// <summary>
+    /// Unit test cases that do not require the whole model, view-model set up
+    /// should be added into this class for quicker test initialization.
+    /// </summary>
+    class CoreUnitTests : UnitTestBase
+    {
+        [Test]
+        [Category("UnitTests")]
+        public void Watch3dSizeStaysConstantBetweenSessions()
+        {
+            var random = new Random();
+            var original = new Watch3D();
+
+            // Update the original node instance.
+            var width = original.Width * (1.0 + random.NextDouble());
+            var height = original.Height * (1.0 + random.NextDouble());
+            original.SetSize(Math.Floor(width), Math.Floor(height));
+
+            original.CameraPosition = new Point3D(10, 20, 30);
+            original.LookDirection = new Vector3D(15, 25, 35);
+
+            // Ensure the serialization survives through file, undo, and copy.
+            var document = new XmlDocument();
+            var fileElement = original.Serialize(document, SaveContext.File);
+            var undoElement = original.Serialize(document, SaveContext.Undo);
+            var copyElement = original.Serialize(document, SaveContext.Copy);
+
+            // Duplicate the node in various save context.
+            var nodeFromFile = new Watch3D();
+            var nodeFromUndo = new Watch3D();
+            var nodeFromCopy = new Watch3D();
+            nodeFromFile.Deserialize(fileElement, SaveContext.File);
+            nodeFromUndo.Deserialize(undoElement, SaveContext.Undo);
+            nodeFromCopy.Deserialize(copyElement, SaveContext.Copy);
+
+            // Making sure we have properties preserved through file operation.
+            Assert.AreEqual(original.WatchWidth, nodeFromFile.WatchWidth);
+            Assert.AreEqual(original.WatchHeight, nodeFromFile.WatchHeight);
+            Assert.AreEqual(original.CameraPosition.X, nodeFromFile.CameraPosition.X);
+            Assert.AreEqual(original.CameraPosition.Y, nodeFromFile.CameraPosition.Y);
+            Assert.AreEqual(original.CameraPosition.Z, nodeFromFile.CameraPosition.Z);
+            Assert.AreEqual(original.LookDirection.X, nodeFromFile.LookDirection.X);
+            Assert.AreEqual(original.LookDirection.Y, nodeFromFile.LookDirection.Y);
+            Assert.AreEqual(original.LookDirection.Z, nodeFromFile.LookDirection.Z);
+
+            // Making sure we have properties preserved through undo operation.
+            Assert.AreEqual(original.WatchWidth, nodeFromUndo.WatchWidth);
+            Assert.AreEqual(original.WatchHeight, nodeFromUndo.WatchHeight);
+            Assert.AreEqual(original.CameraPosition.X, nodeFromUndo.CameraPosition.X);
+            Assert.AreEqual(original.CameraPosition.Y, nodeFromUndo.CameraPosition.Y);
+            Assert.AreEqual(original.CameraPosition.Z, nodeFromUndo.CameraPosition.Z);
+            Assert.AreEqual(original.LookDirection.X, nodeFromUndo.LookDirection.X);
+            Assert.AreEqual(original.LookDirection.Y, nodeFromUndo.LookDirection.Y);
+            Assert.AreEqual(original.LookDirection.Z, nodeFromUndo.LookDirection.Z);
+
+            // Making sure we have properties preserved through copy operation.
+            Assert.AreEqual(original.WatchWidth, nodeFromCopy.WatchWidth);
+            Assert.AreEqual(original.WatchHeight, nodeFromCopy.WatchHeight);
+            Assert.AreEqual(original.CameraPosition.X, nodeFromCopy.CameraPosition.X);
+            Assert.AreEqual(original.CameraPosition.Y, nodeFromCopy.CameraPosition.Y);
+            Assert.AreEqual(original.CameraPosition.Z, nodeFromCopy.CameraPosition.Z);
+            Assert.AreEqual(original.LookDirection.X, nodeFromCopy.LookDirection.X);
+            Assert.AreEqual(original.LookDirection.Y, nodeFromCopy.LookDirection.Y);
+            Assert.AreEqual(original.LookDirection.Z, nodeFromCopy.LookDirection.Z);
+        }
+    }
+}

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -68,6 +68,7 @@
   <ItemGroup>
     <Compile Include="AstBuilderTest.cs" />
     <Compile Include="CodeBlockNodeTests.cs" />
+    <Compile Include="CoreUnitTests.cs" />
     <Compile Include="CustomNodeWorkspaceOpening.cs" />
     <Compile Include="DSEvaluationViewModelTest.cs" />
     <Compile Include="DSFunctionNodeTest.cs" />
@@ -156,6 +157,10 @@
       <Project>{B5F435CB-0D8A-40B1-A4F7-5ECB3CE792A9}</Project>
       <Name>DynamoUtilities</Name>
       <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Libraries\DynamoWatch3D\Watch3D.csproj">
+      <Project>{b9e338ca-6677-4772-b01d-1fceabcdaaab}</Project>
+      <Name>Watch3D</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Libraries\IronPython\IronPythonUI.csproj">
       <Project>{01de9b06-0bcb-4d8a-862e-e8170f5d6b4f}</Project>


### PR DESCRIPTION
Background
-----
Whenever a `Watch3D` node is saved, the dimension value that are stored in DYN file is larger than the actual node size user sees. This issue is being reported by a user: https://github.com/DynamoDS/Dynamo/issues/3573

This is caused by the difference between `NodeModel.Width/Height` and `Watch3D.WatchWidth/WatchHeight` properties. The same problem also happens when user copy-paste a `Watch3D` node after resizing it, because nodes save themselves in the same way for *file*, *undo* and *copy* operations.

Solution
-----
Before saving a `Watch3D` node, updates its `WatchWidth/WatchHeight` properties with the latest value of `Width/Height`. Whenever user resizes the `NodeView`, its updated size must also be set in `NodeModel` so that it is always in-sync.

Unit test
-----
Unit test case `Watch3dSizeStaysConstantBetweenSessions` is added to verify this fix, ensuring that node data survive through `SerializeCore` and `DeserializeCore` method calls.

Reviewer
-----
Hi @pboyer, please have a look at this rather straightforward fix, thanks :)
