### PR TITLE
Fixed crashes due to empty code blocks

### DIFF
--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
@@ -449,7 +449,14 @@ namespace Dynamo.UI.Controls
                 // Pop off the two action groups...
                 // 
                 recorder.PopFromUndoGroup(); // Pop off modification action.
-                recorder.PopFromUndoGroup(); // Pop off creation action.
+
+                // Note that due to various external factors a code block node 
+                // loaded from file may be created empty. In such cases, the 
+                // creation step would not have been recorded (there was no 
+                // explicit creation of the node, it was created from loading 
+                // of a file), and nothing should be popped off of the undo stack.
+                if (recorder.CanUndo)
+                    recorder.PopFromUndoGroup(); // Pop off creation action.
 
                 // ... and record this new node as new creation.
                 using (recorder.BeginActionGroup())
@@ -471,8 +478,15 @@ namespace Dynamo.UI.Controls
             {
                 // If this editing was started due to a new code block node, 
                 // then by this point the creation of the node would have been 
-                // recorded, we need to pop that off the undo stack.
-                recorder.PopFromUndoGroup();
+                // recorded, we need to pop that off the undo stack. Note that 
+                // due to various external factors a code block node loaded 
+                // from file may be created empty. In such cases, the creation 
+                // step would not have been recorded (there was no explicit 
+                // creation of the node, it was created from loading of a file),
+                // and nothing should be popped off of the undo stack.
+                // 
+                if (recorder.CanUndo)
+                    recorder.PopFromUndoGroup(); // Pop off creation action.
 
                 // The empty code block node needs to be removed from workspace.
                 nodeViewModel.WorkspaceViewModel.Model.RemoveNode(nodeModel);


### PR DESCRIPTION
Background
-----
This pull request is meant to fix the following defects (internally tracked):

- [MAGN-5454](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5454) Empty code blocks should be discarded during save
- [MAGN-5915](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5915) Population of CBN can crash application with 7.6 refactor

Analysis
-----
Empty code block nodes can make their ways into a DYN/DYF file in various ways. Intentional or not, empty code blocks that get created while loading such files should not cause Dynamo to crash. The safety net placed here is meant to ensure undo-stack is not being popped beyond its capacity (i.e. no popping off creation action when there was not creation action to begin with).

Reviewer
-----
Hi @aparajit-pratap, PTAL. Thanks!