### PR TITLE
Fix for DS Variable Argument Function node views: MAGN-5920

### DIFF
--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/DSVarArgFunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/DSVarArgFunctionNodeViewCustomization.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using Dynamo.Nodes;
 
 namespace Dynamo.Wpf
 {
@@ -9,6 +12,19 @@ namespace Dynamo.Wpf
     {
         public void CustomizeView(Nodes.DSVarArgFunction nodeModel, Controls.NodeView nodeView)
         {
+            var addButton = new DynamoNodeButton(nodeView.ViewModel.NodeModel, "AddInPort") { Content = "+", Width = 20 };
+            var subButton = new DynamoNodeButton(nodeView.ViewModel.NodeModel, "RemoveInPort") { Content = "-", Width = 20 };
+
+            var wp = new WrapPanel
+            {
+                VerticalAlignment = VerticalAlignment.Top,
+                HorizontalAlignment = HorizontalAlignment.Center
+            };
+
+            wp.Children.Add(addButton);
+            wp.Children.Add(subButton);
+
+            nodeView.inputGrid.Children.Add(wp);
         }
 
         public void Dispose()

--- a/test/DynamoCoreUITests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreUITests/NodeViewCustomizationTests.cs
@@ -275,6 +275,36 @@ namespace DynamoCoreUITests
             Assert.True(nodeView.customNodeBorder0.Visibility == Visibility.Visible);
         }
 
+        [Test]
+        public void DSVarArgFunctionNodeHasButtons()
+        {
+            Open(@"UI\VariableInputNodes.dyn");
+
+            var nodeView = NodeViewWithGuid("0abcef04-75e7-4264-b387-602aad74e34d"); // String.Join node
+
+            var eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
+            Assert.AreEqual(2, eles.Count());
+
+            var inPortGrid = nodeView.inPortGrid;
+            Assert.AreEqual(3, inPortGrid.ChildrenOfType<TextBlock>().Count());
+
+            nodeView = NodeViewWithGuid("2f031397-539e-4df4-bfca-d94d0bd02bc1"); // String.Concat node
+
+            eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
+            Assert.AreEqual(2, eles.Count());
+
+            inPortGrid = nodeView.inPortGrid;
+            Assert.AreEqual(2, inPortGrid.ChildrenOfType<TextBlock>().Count());
+
+            nodeView = NodeViewWithGuid("0cb04cce-1b05-47e0-a73f-ee81af4b7f43"); // List.Join node
+
+            eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
+            Assert.AreEqual(2, eles.Count());
+
+            inPortGrid = nodeView.inPortGrid;
+            Assert.AreEqual(2, inPortGrid.ChildrenOfType<TextBlock>().Count());
+        }
+
         private static class DispatcherUtil
         {
             /// <summary>

--- a/test/UI/VariableInputNodes.dyn
+++ b/test/UI/VariableInputNodes.dyn
@@ -1,0 +1,22 @@
+<Workspace Version="0.7.6.3900" X="844.047480119259" Y="271.551038954673" zoom="0.867977507649016" Name="Home">
+  <Elements>
+    <Dynamo.Nodes.DSVarArgFunction guid="0abcef04-75e7-4264-b387-602aad74e34d" type="Dynamo.Nodes.DSVarArgFunction" nickname="String.Join" x="38.1977284246011" y="159.164504912828" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.String.Join@string,string[]" inputcount="3" />
+    <Dynamo.Nodes.DSVarArgFunction guid="2f031397-539e-4df4-bfca-d94d0bd02bc1" type="Dynamo.Nodes.DSVarArgFunction" nickname="String.Concat" x="-367.342734200311" y="-142.686634881851" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.String.Concat@string[]" inputcount="2" />
+    <Dynamo.Nodes.DSVarArgFunction guid="0cb04cce-1b05-47e0-a73f-ee81af4b7f43" type="Dynamo.Nodes.DSVarArgFunction" nickname="List.Join" x="-596.611348013827" y="212.161269914947" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.Join@var[]..[]" inputcount="2" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="4dc9a834-5b48-4c0e-983d-8c6490cfb32e" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-800" y="155" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{1,2,3};" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="444b0fad-a87b-4038-8a19-d3e00dd71204" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-843" y="270" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{4,5};" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="2d6d94d9-ebff-4856-9455-fb01363657de" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-666" y="-114" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="&quot;dynamo&quot;;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="472a1e46-e924-486c-a3e9-10cbe5bfabb7" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-675" y="34" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="&quot;bim&quot;;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="9b482a38-35e6-488b-a97d-81b0685af24a" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-221" y="95" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="&quot; &quot;;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="4dc9a834-5b48-4c0e-983d-8c6490cfb32e" start_index="0" end="0cb04cce-1b05-47e0-a73f-ee81af4b7f43" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="444b0fad-a87b-4038-8a19-d3e00dd71204" start_index="0" end="0cb04cce-1b05-47e0-a73f-ee81af4b7f43" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="2d6d94d9-ebff-4856-9455-fb01363657de" start_index="0" end="2f031397-539e-4df4-bfca-d94d0bd02bc1" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="2d6d94d9-ebff-4856-9455-fb01363657de" start_index="0" end="0abcef04-75e7-4264-b387-602aad74e34d" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="472a1e46-e924-486c-a3e9-10cbe5bfabb7" start_index="0" end="2f031397-539e-4df4-bfca-d94d0bd02bc1" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="472a1e46-e924-486c-a3e9-10cbe5bfabb7" start_index="0" end="0abcef04-75e7-4264-b387-602aad74e34d" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="9b482a38-35e6-488b-a97d-81b0685af24a" start_index="0" end="0abcef04-75e7-4264-b387-602aad74e34d" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
Hi @pboyer this PR attempts to fix an issue with `DSVarArgFunction` nodes such as `List.Join` and `String.Join` nodes which have [broken views at the moment] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5920). Some analysis showed that the node-view customization for these node types was not implemented (the implementation for `CustomizeView()` was empty). It appears that these node views should be identical to those for `VariableInputNode`s. Therefore a simple solution for me was to simply copy the same customization code from `VariableInputNodeViewCustomization` and stick it into that for `DSVarArgFunctionNodeViewCustomization` instead of trying to mess with all the clever reflection logic and reroute the calls somehow to the `CustomizeView()` implementation for `VariableInputNodeViewCustomization`. Is it as simple as this, I'm not sure? I guess it would have worked naturally if `DSVarArgFunction` node was in the same class hierarchy as `VariableInputNode`, however that is not the case although from a UI standpoint that makes sense. You would obviously be the best person to advise a more appropriate fix for this. Therefore sending it to you for review. Thanks.