### PR TITLE
MAGN-5871 Increase package manager upload size

### DIFF
--- a/src/DynamoCore/PackageManager/PackageManagerClient.cs
+++ b/src/DynamoCore/PackageManager/PackageManagerClient.cs
@@ -116,16 +116,14 @@ namespace Dynamo.PackageManager
 
         #endregion
 
-        //private static readonly string serverUrl = "https://107.20.146.184/";
-        private static readonly string serverUrl = "https://54.225.121.251/";
+        private static readonly string serverUrl = "https://www.dynamopackages.com/";
         
         public PackageManagerClient(string rootPkgDir,  CustomNodeManager customNodeManager)
         {
             this.rootPkgDir = rootPkgDir;
             this.customNodeManager = customNodeManager;
 
-            //Client = new Client(null, "http://107.20.146.184");
-            Client = new Client(null, "http://54.225.121.251");
+            Client = new Client(null, "http://www.dynamopackages.com");
         }
 
         //public bool IsNewestVersion(string packageId, string currentVersion, ref string newerVersion )

--- a/src/DynamoCore/PackageManager/PackageManagerClient.cs
+++ b/src/DynamoCore/PackageManager/PackageManagerClient.cs
@@ -116,14 +116,16 @@ namespace Dynamo.PackageManager
 
         #endregion
 
-        private static readonly string serverUrl = "https://www.dynamopackages.com/";
+        //private static readonly string serverUrl = "https://107.20.146.184/";
+        private static readonly string serverUrl = "https://54.225.121.251/";
         
         public PackageManagerClient(string rootPkgDir,  CustomNodeManager customNodeManager)
         {
             this.rootPkgDir = rootPkgDir;
             this.customNodeManager = customNodeManager;
 
-            Client = new Client(null, "http://www.dynamopackages.com");
+            //Client = new Client(null, "http://107.20.146.184");
+            Client = new Client(null, "http://54.225.121.251");
         }
 
         //public bool IsNewestVersion(string packageId, string currentVersion, ref string newerVersion )

--- a/src/DynamoCore/PackageManager/PackageUploadBuilder.cs
+++ b/src/DynamoCore/PackageManager/PackageUploadBuilder.cs
@@ -67,7 +67,7 @@ namespace Dynamo.PackageManager
                 throw new Exception("Could not compress file.  Is the file in use?");
             }
             
-            if (info.Length > 15 * 1000000) throw new Exception("The package is too large!  The package must be less than 15 MB!");
+            //if (info.Length > 15 * 1000000) throw new Exception("The package is too large!  The package must be less than 15 MB!");
 
             return zipPath;
         }

--- a/src/DynamoCore/PackageManager/PackageUploadBuilder.cs
+++ b/src/DynamoCore/PackageManager/PackageUploadBuilder.cs
@@ -67,7 +67,7 @@ namespace Dynamo.PackageManager
                 throw new Exception("Could not compress file.  Is the file in use?");
             }
             
-            //if (info.Length > 15 * 1000000) throw new Exception("The package is too large!  The package must be less than 15 MB!");
+            if (info.Length > 100 * 1024 * 1024) throw new Exception("The package is too large!  The package must be less than 100 MB!");
 
             return zipPath;
         }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -780,21 +780,10 @@ namespace Dynamo.PackageManager
 
             if (fDialog.ShowDialog() == DialogResult.OK)
             {
-                if (fDialog.FileNames.Length > 1)
+                foreach (var fn in fDialog.FileNames)
                 {
-                    foreach (var fn in fDialog.FileNames)
-                    {
-                        AddFile(fn);
-                    }
+                    AddFile(fn);
                 }
-                else
-                {
-                    AddFile(fDialog.FileName);
-                }
-
-
-                
-                
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -416,7 +416,8 @@ namespace Dynamo.PackageManager
             set
             {
                 customNodeDefinitions = value;
-                Name = CustomNodeDefinitions[0].DisplayName;
+                if (CustomNodeDefinitions != null && CustomNodeDefinitions.Count > 0)
+                    Name = CustomNodeDefinitions[0].DisplayName;
                 UpdateDependencies();
             }
         }
@@ -523,7 +524,7 @@ namespace Dynamo.PackageManager
                 Description = l.Description,
                 Keywords = l.Keywords != null ? String.Join(" ", l.Keywords) : "",
                 CustomNodeDefinitions = defs,
-                Assemblies = l.LoadedAssemblies.ToList(),
+                Assemblies = new List<PackageAssembly>(),
                 Name = l.Name,
                 RepositoryUrl = l.RepositoryUrl ?? "",
                 SiteUrl = l.SiteUrl ?? "",
@@ -531,35 +532,7 @@ namespace Dynamo.PackageManager
                 License = l.License
             };
 
-            // add additional files
-            l.EnumerateAdditionalFiles();
-            foreach (var file in l.AdditionalFiles)
-            {
-                vm.AdditionalFiles.Add(file.Model.FullName);
-            }
-
             var nodeLibraryNames = l.Header.node_libraries;
-
-            // load assemblies into reflection only context
-            foreach (var file in l.EnumerateAssemblyFilesInBinDirectory())
-            {
-                Assembly assem;
-                var result = PackageLoader.TryReflectionOnlyLoadFrom(file, out assem);
-                if (result)
-                {
-                    var isNodeLibrary = nodeLibraryNames == null || nodeLibraryNames.Contains(assem.FullName);
-                    vm.Assemblies.Add(new  PackageAssembly()
-                    {
-                        IsNodeLibrary = isNodeLibrary,
-                        Assembly = assem
-                    });
-                }
-                else
-                {
-                    // if it's not a .NET assembly, we load it as an additional file
-                    vm.AdditionalFiles.Add(file);
-                }
-            }
 
             if (l.VersionName == null) return vm;
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -786,7 +786,8 @@ namespace Dynamo.PackageManager
                 fDialog = new OpenFileDialog()
                 {
                     Filter = "Custom Node, DLL, XML (*.dyf, *.dll, *.xml)|*.dyf;*.dll;*.xml",
-                    Title = "Add Custom Node, Library, or XML file to Package..."
+                    Title = "Add Custom Node, Library, or XML file to Package...",
+                    Multiselect = true
                 };
             }
 
@@ -806,7 +807,21 @@ namespace Dynamo.PackageManager
 
             if (fDialog.ShowDialog() == DialogResult.OK)
             {
-                AddFile(fDialog.FileName);
+                if (fDialog.FileNames.Length > 1)
+                {
+                    foreach (var fn in fDialog.FileNames)
+                    {
+                        AddFile(fn);
+                    }
+                }
+                else
+                {
+                    AddFile(fDialog.FileName);
+                }
+
+
+                
+                
             }
         }
 


### PR DESCRIPTION
This PR removes a client-side limit to the size 

In order to debug uploading large binary packages, I had to fix a crashing bug related to packages containing no custom nodes. This fix is in PublishPackageViewModel line 419-420.

Additionally, the lack of a "Remove file" button in the package manager makes it impossible to remove old DLLs from the package. I've removed the code that automatically adds these DLLs. It make updating a package more laborious, though adds support for zero touch packages which are entirely DLL-based.

@pboyer PTAL