### PR TITLE
correct path of samples directory

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -998,7 +998,8 @@ namespace Dynamo.ViewModels
             {
                 Assembly dynamoAssembly = Assembly.GetExecutingAssembly();
                 string location = Path.GetDirectoryName(dynamoAssembly.Location);
-                string path = Path.Combine(location, "samples");
+                string UICulture = System.Globalization.CultureInfo.CurrentUICulture.ToString();
+                string path = Path.Combine(location, "samples", UICulture);
 
                 if (Directory.Exists(path))
                     _fileDialog.InitialDirectory = path;


### PR DESCRIPTION
The OpenFileDialog refers to the old path of the samples folder when opening Dynamo files.
This patch correct that issue.
@Benglin PTAL