### PR TITLE
Fix defect that double entry is created in Library for new custom node

### DIFF
--- a/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
@@ -191,7 +191,9 @@ namespace Dynamo.Models
             // custom node with a new function id
             if (originalPath != newPath)
             {
-                CustomNodeId = Guid.NewGuid();
+                // If it is a newly created node, no need to generate a new guid
+                if (!string.IsNullOrEmpty(originalPath))
+                    CustomNodeId = Guid.NewGuid();
 
                 // This comes after updating the Id, as if to associate the new name
                 // with the new Id.

--- a/test/DynamoCoreTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreTests/WorkspaceSaving.cs
@@ -522,7 +522,13 @@ namespace Dynamo.Tests
 
             Assert.AreNotEqual(Guid.Empty, initialId);
             Assert.AreNotEqual(Guid.Empty, newDef);
-            Assert.AreNotEqual(initialId, newDef);
+            Assert.AreEqual(initialId, newDef);
+
+            var newPath2 = GetNewFileNameOnTempPath("dyf");
+            workspace.SaveAs(newPath2, ViewModel.Model.EngineController.LiveRunnerCore);
+            var newDef2 = workspace.CustomNodeId;
+            Assert.AreNotEqual(Guid.Empty, newDef2);
+            Assert.AreNotEqual(initialId, newDef2);
         }
 
         [Test]


### PR DESCRIPTION
To fix defect [MAGN-5869 Double entry is created in Library if the custom node is created by adding contents to .dyf file] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5869).

The root cause of this defect is a new GUID is assigned to newly created custom node if it is saved. Custom node gets a new GUID only if it has been saved before and now is saved to a new .dyf file.

@Benglin  please help to review the changes. 