### PR TITLE
Fix crash, issues with additional files in package publish

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -416,7 +416,12 @@ namespace Dynamo.PackageManager
             set
             {
                 customNodeDefinitions = value;
-                Name = CustomNodeDefinitions[0].DisplayName;
+
+                if (customNodeDefinitions.Count > 0 && Name == null)
+                {
+                    Name = CustomNodeDefinitions[0].DisplayName;
+                }
+                
                 UpdateDependencies();
             }
         }
@@ -523,7 +528,6 @@ namespace Dynamo.PackageManager
                 Description = l.Description,
                 Keywords = l.Keywords != null ? String.Join(" ", l.Keywords) : "",
                 CustomNodeDefinitions = defs,
-                Assemblies = l.LoadedAssemblies.ToList(),
                 Name = l.Name,
                 RepositoryUrl = l.RepositoryUrl ?? "",
                 SiteUrl = l.SiteUrl ?? "",


### PR DESCRIPTION
I'm noticing a number of regressions in `PublishPackageViewModel` that indicate that this file was likely not merged correctly in Stephen's branches. I'm going to merge this in to correct the crash. 

@hlp This fixes the bug you discovered as well.