### PR TITLE
Fix defect that save fails to clear the dirty bit for some definitions with 7.6

### DIFF
--- a/src/DynamoCore/Models/ModelBase.cs
+++ b/src/DynamoCore/Models/ModelBase.cs
@@ -251,8 +251,7 @@ namespace Dynamo.Models
 
         public XmlElement Serialize(XmlDocument xmlDocument, SaveContext context)
         {
-            string typeName = GetType().ToString();
-            XmlElement element = xmlDocument.CreateElement(typeName);
+            var element = CreateElement(xmlDocument, context);
             SerializeCore(element, context);
             return element;
         }
@@ -262,6 +261,13 @@ namespace Dynamo.Models
             DeserializeCore(element, context);
         }
 
+        protected virtual XmlElement CreateElement(XmlDocument xmlDocument, SaveContext context)
+        {
+            string typeName = GetType().ToString();
+            XmlElement element = xmlDocument.CreateElement(typeName);
+            return element;
+        }
+        
         protected abstract void SerializeCore(XmlElement element, SaveContext context);
         protected abstract void DeserializeCore(XmlElement nodeElement, SaveContext context);
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -766,7 +766,8 @@ namespace Dynamo.Models
             }
             catch (Exception ex)
             {
-                Debug.WriteLine(ex.Message + " : " + ex.StackTrace);
+                Log(ex.Message);
+                Log(ex.StackTrace);
                 return false;
             }
         }

--- a/src/DynamoCore/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Nodes/DummyNode.cs
@@ -135,23 +135,20 @@ namespace DSCoreNodesUI
                 //instead of saving the dummy node.
                 if (OriginalNodeContent != null)
                 {
-                    XmlElement originalNode = nodeElement.OwnerDocument.CreateElement(OriginalNodeContent.Name);
+                    nodeElement.RemoveAll();
                     foreach (XmlAttribute attribute in OriginalNodeContent.Attributes)
-                        originalNode.SetAttribute(attribute.Name, attribute.Value);
+                        nodeElement.SetAttribute(attribute.Name, attribute.Value);
 
                     //overwrite the guid/x/y value of the original node.
-                    originalNode.SetAttribute("guid", nodeElement.GetAttribute("guid"));
-                    originalNode.SetAttribute("x", nodeElement.GetAttribute("x"));
-                    originalNode.SetAttribute("y", nodeElement.GetAttribute("y"));
+                    nodeElement.SetAttribute("guid", nodeElement.GetAttribute("guid"));
+                    nodeElement.SetAttribute("x", nodeElement.GetAttribute("x"));
+                    nodeElement.SetAttribute("y", nodeElement.GetAttribute("y"));
 
                     for (int i = 0; i < OriginalNodeContent.ChildNodes.Count; i++)
                     {
-                        XmlNode child =
-                            originalNode.OwnerDocument.ImportNode(OriginalNodeContent.ChildNodes[i], true);
-                        originalNode.AppendChild(child.CloneNode(true));
+                        XmlNode child = nodeElement.OwnerDocument.ImportNode(OriginalNodeContent.ChildNodes[i], true);
+                        nodeElement.AppendChild(child.CloneNode(true));
                     }
-
-                    nodeElement.ParentNode.ReplaceChild(originalNode, nodeElement);
                 }
                 else
                 {
@@ -165,6 +162,19 @@ namespace DSCoreNodesUI
         }
 
         #region SerializeCore/DeserializeCore
+
+        protected override XmlElement CreateElement(XmlDocument xmlDocument, SaveContext context)
+        {
+            if (context == SaveContext.File && OriginalNodeContent != null)
+            {
+                XmlElement originalNode = xmlDocument.CreateElement(OriginalNodeContent.Name);
+                return originalNode;
+            }
+            else
+            {
+                return base.CreateElement(xmlDocument, context);
+            }
+        }
 
         protected override void SerializeCore(XmlElement element, SaveContext context)
         {

--- a/test/DynamoCoreTests/UndoRedoRecorderTests.cs
+++ b/test/DynamoCoreTests/UndoRedoRecorderTests.cs
@@ -949,5 +949,22 @@ namespace Dynamo.Tests
             Assert.AreEqual(3, dummyNode.InPorts.Count);
             Assert.AreEqual(2, dummyNode.OutPorts.Count);
         }
+
+        [Test]
+        public void TestDummyNodeSerialization()
+        {
+            var folder = Path.Combine(GetTestDirectory(), @"core\migration\");
+            ViewModel.OpenCommand.Execute(Path.Combine(folder, "dummyNode.dyn"));
+
+            var workspace = ViewModel.Model.CurrentWorkspace;
+            var dummyNode = workspace.Nodes.OfType<DSCoreNodesUI.DummyNode>().FirstOrDefault();
+
+            Assert.IsNotNull(dummyNode);
+            var xmlDocument = new XmlDocument();
+            var element = dummyNode.Serialize(xmlDocument, SaveContext.File);
+
+            // Dummy node should be serialized to its original node
+            Assert.AreEqual(element.Name, "Dynamo.Nodes.DSFunction");
+        }
     }
 }

--- a/test/DynamoCoreTests/UndoRedoRecorderTests.cs
+++ b/test/DynamoCoreTests/UndoRedoRecorderTests.cs
@@ -900,7 +900,6 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [Category("Failure")]
         public void TestDummyNodeInternals00()
         {
             var folder = Path.Combine(GetTestDirectory(), @"core\migration\");
@@ -924,7 +923,6 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [Category("Failure")]
         public void TestDummyNodeInternals01()
         {
             var folder = Path.Combine(GetTestDirectory(), @"core\migration\");

--- a/test/core/migration/DummyNodeSample.dyn
+++ b/test/core/migration/DummyNodeSample.dyn
@@ -1,0 +1,7 @@
+<Workspace Version="0.7.0.20567" X="0" Y="0" zoom="1" Description="" Category="" Name="Home">
+  <Elements>
+    <DSCoreNodesUI.DummyNode type="DSCoreNodesUI.DummyNode" guid="37bffbb9-3438-4c6c-81d6-7b41b5fb5b87" nickname="Point.ByLuck" x="235" y="201.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputCount="3" outputCount="2" legacyNodeName="Point.ByLuck" />
+  </Elements>
+  <Connectors />
+  <Notes />
+</Workspace>

--- a/test/core/migration/dummyNode.dyn
+++ b/test/core/migration/dummyNode.dyn
@@ -1,0 +1,8 @@
+<Workspace Version="0.7.6.3912" X="99.1977448010291" Y="167.824962319859" zoom="0.342081630871005" Name="Home">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="6a5b9043-a953-4909-913d-5616609f8e3b" type="Dynamo.Nodes.DSFunction" nickname="Foo" x="0" y="0" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="FooBar.dll" function="Foo@int" />
+  </Elements>
+  <Connectors>
+  </Connectors>
+</Workspace>


### PR DESCRIPTION
To fix defect [MAGN - 5934 File, Save can fail to clear the dirty bit for some definitions with 7.6] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5934)

This is because of an null reference exception thrown out in saving dummy node. When a dummy node is being serialized, the name of xml element should be its original name (instead of ``DSCoreNodesUI.DummyNode``), this is done through creating a new xml element node and replacing dummy node's xml element in  element parent's children list. But as old xml element hasn't bee added yet, the reference to its parent node is null, therefore null reference exception is thrown out.

I added a virtual fucntion ``CreateElement`` to ``ModelBase`` so that dummy node gets a chance to create different xml element directly, instead of do replacement. 

Also remove two test cases from "Failure" category.

@Benglin , please review the change. 