### PR TITLE
MAGN-5849: Custom node created from selection does not get chance to be saved when exiting Dynamo

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -637,7 +637,7 @@ namespace Dynamo.Core
         /// <param name="currentWorkspace"> The workspace where</param>
         /// <param name="isTestMode"></param>
         /// <param name="args"></param>
-        public WorkspaceModel Collapse(
+        public CustomNodeWorkspaceModel Collapse(
             IEnumerable<NodeModel> selectedNodes, WorkspaceModel currentWorkspace,
             bool isTestMode, FunctionNamePromptEventArgs args)
         {
@@ -1021,6 +1021,8 @@ namespace Dynamo.Core
                     0,
                     0,
                     newId, currentWorkspace.ElementResolver, string.Empty);
+
+                newWorkspace.HasUnsavedChanges = true;
 
                 RegisterCustomNodeWorkspace(newWorkspace);
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -276,10 +276,17 @@ namespace Dynamo.Models
         }
 
         /// <summary>
+        ///     The private collection of visible workspaces in Dynamo
+        /// </summary>
+        private readonly List<WorkspaceModel> _workspaces = new List<WorkspaceModel>();
+
+        /// <summary>
         ///     The collection of visible workspaces in Dynamo
         /// </summary>
-        public readonly List<WorkspaceModel> Workspaces =
-            new List<WorkspaceModel>();
+        public IEnumerable<WorkspaceModel> Workspaces 
+        {
+            get { return _workspaces; } 
+        }
         
         #endregion
 
@@ -896,6 +903,9 @@ namespace Dynamo.Models
 
         #region public methods
 
+        /// <summary>
+        ///     Add a new HomeWorkspace and set as current
+        /// </summary>
         public void AddHomeWorkspace()
         {
             var defaultWorkspace = new HomeWorkspaceModel(
@@ -909,14 +919,23 @@ namespace Dynamo.Models
             AddWorkspace(defaultWorkspace);
             CurrentWorkspace = defaultWorkspace;
         }
-        
+
+        /// <summary>
+        ///     Add a new, visible Custom Node workspace to Dynamo
+        /// </summary>
+        /// <param name="workspace"></param>
+        public void AddCustomNodeWorkspace(CustomNodeWorkspaceModel workspace)
+        {
+            AddWorkspace(workspace);
+        }
+
         /// <summary>
         ///     Remove a workspace from the dynamo model.
         /// </summary>
         /// <param name="workspace"></param>
         public void RemoveWorkspace(WorkspaceModel workspace)
         {
-            if (Workspaces.Remove(workspace))
+            if (_workspaces.Remove(workspace))
             {
                 if (workspace is HomeWorkspaceModel)
                     workspace.Dispose();
@@ -1205,7 +1224,7 @@ namespace Dynamo.Models
                 workspace.MessageLogged -= LogMessage;
             };
 
-            Workspaces.Add(workspace);
+            _workspaces.Add(workspace);
             OnWorkspaceAdded(workspace);
         }
         enum ButtonId

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1215,6 +1215,8 @@ namespace Dynamo.Models
         /// <param name="workspace"></param>
         private void AddWorkspace(WorkspaceModel workspace)
         {
+            if (workspace == null) return;
+            
             Action savedHandler = () => OnWorkspaceSaved(workspace);
             workspace.WorkspaceSaved += savedHandler;
             workspace.MessageLogged += LogMessage;

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -309,7 +309,7 @@ namespace Dynamo.Models
         void SwitchTabImpl(SwitchTabCommand command)
         {
             // We don't attempt to null-check here, we need it to fail fast.
-            CurrentWorkspace = Workspaces[command.TabIndex];
+            CurrentWorkspace = Workspaces.ElementAt(command.TabIndex);
         }
     }
 }

--- a/src/DynamoCore/Utilities/Extensions.cs
+++ b/src/DynamoCore/Utilities/Extensions.cs
@@ -29,6 +29,25 @@ namespace Dynamo.Utilities
     public static class ExtensionMethods
     {
         /// <summary>
+        /// Get the index of an element in an IEnumerable
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source">The IEnumerable</param>
+        /// <param name="value">The value for which the index is sought</param>
+        /// <returns>Zero or greater if in the IEnumerable, otherwise -1</returns>
+        public static int IndexOf<T>(this IEnumerable<T> source, T value)
+        {
+            int index = 0;
+            var comparer = EqualityComparer<T>.Default; // or pass in as a parameter
+            foreach (T item in source)
+            {
+                if (comparer.Equals(item, value)) return index;
+                index++;
+            }
+            return -1;
+        }
+
+        /// <summary>
         ///     Gets all the tags of an ITree.
         /// </summary>
         /// <typeparam name="TNodeTag"></typeparam>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1402,7 +1402,7 @@ namespace Dynamo.ViewModels
             {
                 // If after closing the HOME workspace, and there are no other custom 
                 // workspaces opened at the time, then we should show the start page.
-                this.ShowStartPage = (Model.Workspaces.Count <= 1);
+                this.ShowStartPage = (Model.Workspaces.Count() <= 1);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -966,8 +966,9 @@ namespace Dynamo.ViewModels
             if (!args.Success)
                 return;
 
-            DynamoViewModel.Model.CustomNodeManager.Collapse(
-                selectedNodes, Model, DynamoModel.IsTestMode, args);
+            DynamoViewModel.Model.AddCustomNodeWorkspace(
+                DynamoViewModel.Model.CustomNodeManager.Collapse(
+                    selectedNodes, Model, DynamoModel.IsTestMode, args));
         }
 
         internal void Loaded()

--- a/src/Libraries/Samples/SampleLibraryUI/SampleLibraryUI.csproj
+++ b/src/Libraries/Samples/SampleLibraryUI/SampleLibraryUI.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{227B776D-8866-49E8-8C93-809CCF86AF12}</ProjectGuid>
+    <ProjectGuid>{0A4B4EEA-8FAB-4AC8-90D4-27DBC5B0CF2A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SamplesLibraryUI</RootNamespace>

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -622,6 +622,43 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void CollapsedNodeWOrkspaceIsAddedToDynamoWithUnsavedChanges()
+        {
+            var model = ViewModel.Model;
+
+            NodeModel node;
+            if (!ViewModel.Model.NodeFactory.CreateNodeFromTypeName("Dynamo.Nodes.DoubleInput", out node))
+            {
+                throw new Exception("Failed to create node!");
+            }
+
+            var selectionSet = new[] { node };
+
+            DynamoModel.FunctionNamePromptRequestHandler del = (sender, args) =>
+            {
+                args.Category = "Testing";
+                args.Description = "";
+                args.Name = "__CollapseTest__";
+                args.Success = true;
+            };
+
+            ViewModel.Model.RequestsFunctionNamePrompt += del;
+
+            ViewModel.CurrentSpaceViewModel.CollapseNodes(selectionSet);
+
+            ViewModel.Model.RequestsFunctionNamePrompt += del;
+
+            Assert.IsNotNull(model.CurrentWorkspace.FirstNodeFromWorkspace<Function>());
+
+            Assert.AreEqual(1, model.CurrentWorkspace.Nodes.Count);
+            Assert.AreEqual(2, model.Workspaces.Count());
+
+            var customWorkspace = model.Workspaces.ElementAt(1);
+            Assert.AreEqual("__CollapseTest__", customWorkspace.Name);
+            Assert.IsTrue(customWorkspace.HasUnsavedChanges);
+        }
+
+        [Test]
         public void CollapsedNodeShouldHaveNewIdentfifer()
         {
             var model = ViewModel.Model;

--- a/test/Libraries/NodeServicesTest/DynamoServicesTests.csproj
+++ b/test/Libraries/NodeServicesTest/DynamoServicesTests.csproj
@@ -8,7 +8,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{1B8062D6-941C-4FF5-96FF-F1D6E0D92588}</ProjectGuid>
+    <ProjectGuid>{3E4278F7-60EC-491C-8094-B525C36A51A7}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoServicesTests</RootNamespace>


### PR DESCRIPTION
### Issue 

A custom node created from selection is never added to the workspace collection.  As a result, the user never gets the chance to save it.  

### Fix

Add it to the visible workspace collection!  I also made this collection read only by changing it to an IEnumerable property (as it should be).  

### Tests

I added a test to reproduce. All of the other custom node tests continue to work.  

### Reviewer

@ikeough 