### PR TITLE
Fix defect that button is immediately enabled after initiating long jobs

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -275,6 +275,17 @@ namespace Dynamo.Models
             }
         }
 
+        public bool RunEnabled
+        {
+            get 
+            { 
+                if (CurrentWorkspace == null)
+                    return false;
+                
+                return this.CurrentWorkspace.RunEnabled;
+            }
+        }
+
         /// <summary>
         ///     The collection of visible workspaces in Dynamo
         /// </summary>
@@ -1199,10 +1210,12 @@ namespace Dynamo.Models
             Action savedHandler = () => OnWorkspaceSaved(workspace);
             workspace.WorkspaceSaved += savedHandler;
             workspace.MessageLogged += LogMessage;
+            workspace.PropertyChanged += OnWorkspacePropertyChanged;
             workspace.Disposed += () =>
             {
                 workspace.WorkspaceSaved -= savedHandler;
                 workspace.MessageLogged -= LogMessage;
+                workspace.PropertyChanged -= OnWorkspacePropertyChanged;
             };
 
             Workspaces.Add(workspace);
@@ -1329,6 +1342,12 @@ namespace Dynamo.Models
             }
 
             return args.ClickedButtonId == (int)ButtonId.Proceed;
+        }
+
+        private void OnWorkspacePropertyChanged(object sender, PropertyChangedEventArgs args)
+        {
+            if (args.PropertyName == "RunEnabled")
+                OnPropertyChanged("RunEnabled");
         }
 
         #endregion

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -13,17 +13,6 @@ namespace Dynamo.Models
         public EngineController EngineController { get; private set; }
         private readonly DynamoScheduler scheduler;
 
-        public bool RunEnabled
-        {
-            get { return runEnabled; }
-            set
-            {
-                if (Equals(value, runEnabled)) return;
-                runEnabled = value;
-                RaisePropertyChanged("RunEnabled");
-            }
-        }
-
         public bool DynamicRunEnabled;
 
         public readonly bool VerboseLogging;
@@ -102,8 +91,6 @@ namespace Dynamo.Models
         }
         private IEnumerable<KeyValuePair<Guid, List<string>>> preloadedTraceData;
 
-        private bool runEnabled;
-
         internal bool IsEvaluationPending
         {
             get
@@ -159,6 +146,7 @@ namespace Dynamo.Models
         {
             base.Clear();
             PreloadedTraceData = null;
+            RunEnabled = true;
         }
 
         #region evaluation

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -405,6 +405,17 @@ namespace Dynamo.Models
 
         public ElementResolver ElementResolver { get; private set; }
 
+        private bool runEnabled;
+        public bool RunEnabled
+        {
+            get { return runEnabled; }
+            set
+            {
+                if (Equals(value, runEnabled)) return;
+                runEnabled = value;
+                RaisePropertyChanged("RunEnabled");
+            }
+        }
         #endregion
 
         #region constructors

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -77,11 +77,7 @@ namespace Dynamo.ViewModels
 
         public bool RunEnabled
         {
-            get { return HomeSpace.RunEnabled; }
-            set
-            {
-                HomeSpace.RunEnabled = value;
-            }
+            get { return model.RunEnabled; }
         }
 
         public virtual bool CanRunDynamically
@@ -463,8 +459,6 @@ namespace Dynamo.ViewModels
             var homespace = new WorkspaceViewModel(model.CurrentWorkspace, this);
             workspaces.Add(homespace);
 
-            model.CurrentWorkspace.PropertyChanged += CurrentWorkspace_PropertyChanged;
-
             model.WorkspaceAdded += WorkspaceAdded;
             model.WorkspaceRemoved += WorkspaceRemoved;
             
@@ -794,18 +788,24 @@ namespace Dynamo.ViewModels
 
         void _model_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == "CurrentWorkspace")
+            switch (e.PropertyName)
             {
-                IsAbleToGoHome = !(model.CurrentWorkspace is HomeWorkspaceModel);
-                RaisePropertyChanged("IsAbleToGoHome");
-                RaisePropertyChanged("CurrentSpace");
-                RaisePropertyChanged("BackgroundColor");
-                RaisePropertyChanged("CurrentWorkspaceIndex");
-                RaisePropertyChanged("ViewingHomespace");
-                if (this.PublishCurrentWorkspaceCommand != null)
-                    this.PublishCurrentWorkspaceCommand.RaiseCanExecuteChanged();
-                RaisePropertyChanged("IsPanning");
-                RaisePropertyChanged("IsOrbiting");
+                case "CurrentWorkspace":
+                    IsAbleToGoHome = !(model.CurrentWorkspace is HomeWorkspaceModel);
+                    RaisePropertyChanged("IsAbleToGoHome");
+                    RaisePropertyChanged("CurrentSpace");
+                    RaisePropertyChanged("BackgroundColor");
+                    RaisePropertyChanged("CurrentWorkspaceIndex");
+                    RaisePropertyChanged("ViewingHomespace");
+                    if (this.PublishCurrentWorkspaceCommand != null)
+                        this.PublishCurrentWorkspaceCommand.RaiseCanExecuteChanged();
+                    RaisePropertyChanged("IsPanning");
+                    RaisePropertyChanged("IsOrbiting");
+                    RaisePropertyChanged("RunEnabled");
+                    break; 
+                case "RunEnabled":
+                    RaisePropertyChanged("RunEnabled");
+                    break;
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -809,12 +809,6 @@ namespace Dynamo.ViewModels
             }
         }
 
-        void CurrentWorkspace_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == "RunEnabled")
-                RaisePropertyChanged("RunEnabled");
-        }
-
         private void CleanUp(DynamoModel dynamoModel)
         {
             UnsubscribeAllEvents();

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -739,13 +739,13 @@
                                   Header="{x:Static p:Resources.DynamoViewDebugMenuForceReExecute}"
                                   Command="{Binding ForceRunExpressionCommand}"
                                   CommandParameter="{Binding Path=RunInDebug}"
-                                  IsEnabled="{Binding Path=RunEnabled, Mode=TwoWay}"></MenuItem>
+                                  IsEnabled="{Binding Path=RunEnabled}"></MenuItem>
                         <MenuItem Focusable="False"
                                   Name="MutateTest"
                                   Header="{x:Static p:Resources.DynamoViewDebugMenuRunMutationTest}"
                                   Command="{Binding MutateTestDelegateCommand}"
                                   CommandParameter="{Binding Path=RunInDebug}"
-                                  IsEnabled="{Binding Path=RunEnabled, Mode=TwoWay}"></MenuItem>
+                                  IsEnabled="{Binding Path=RunEnabled}"></MenuItem>
                         <MenuItem Focusable="False"
                                   Name="CheckDailyBuilds"
                                   Header="{x:Static p:Resources.DynamoViewDebugMenuCheckDailyBuild}"
@@ -1570,7 +1570,7 @@
                                 Command="{Binding RunExpressionCommand}"
                                 CommandParameter="{Binding Path=RunInDebug}"
                                 ToolTip="{x:Static p:Resources.DynamoViewRunButtonTooltip}"
-                                IsEnabled="{Binding Path=RunEnabled, Mode=TwoWay}"
+                                IsEnabled="{Binding Path=RunEnabled}"
                                 Focusable="False" />
 
                         <Button Name="cancelButton"


### PR DESCRIPTION
This pull request is identical to PR https://github.com/DynamoDS/Dynamo/pull/3594, somehow the original one can't be merged automatically by github.

The problem happens when loading a dyn file and run it. 

Run button's ``IsEnabled`` binds to view model's ``RunEnabled`` which gets its value from home workspace model's ``RunEnabled``. View model registers property change event for model's current workspace model in its constructor, so that if home workspace's ``RunEnabled`` is updated, Run button will be enabled/disabled accordingly. But that means view model never handles property change event if current workspace model is changed, for example, loading a new .dyn file. 

As the owner of workspace model is model, it is not good idea that view model directly handle events from workspace model. Instead, view model monitors model's property changed event. Therefore if ``RunEnable`` property is changed, the event handling chain is home workspace model -> model -> view model -> Run button. 

@Benglin  please review the change...