### PR TITLE
Fix workspace swtiching issues (magn-5919, magn-6022)

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -152,12 +152,15 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                var index = model.Workspaces.IndexOf(model.CurrentWorkspace);
+                var viewModel = workspaces.FirstOrDefault(vm => vm.Model == model.CurrentWorkspace);
+                var index = workspaces.IndexOf(viewModel);
                 return index;
             }
             set
             {
-                if (model.Workspaces.IndexOf(model.CurrentWorkspace) != value)
+                var viewModel = workspaces.FirstOrDefault(vm => vm.Model == model.CurrentWorkspace);
+                var index = workspaces.IndexOf(viewModel);
+                if (index != value)
                     this.ExecuteCommand(new DynamoModel.SwitchTabCommand(value));
             }
         }
@@ -596,7 +599,6 @@ namespace Dynamo.ViewModels
             DynamoModel.RequestDispatcherBeginInvoke -= TryDispatcherBeginInvoke;
             DynamoModel.RequestDispatcherInvoke -= TryDispatcherInvoke;
         }
-
         #endregion
 
         private void InitializeAutomationSettings(string commandFilePath)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -86,20 +86,11 @@ namespace Dynamo.Views
         void OnWorkspaceViewLoaded(object sender, RoutedEventArgs e)
         {
             DynamoSelection.Instance.Selection.CollectionChanged += new NotifyCollectionChangedEventHandler(OnSelectionCollectionChanged);
-
-            ViewModel.DragSelectionStarted += OnViewModelDragSelectionStarted;
-            ViewModel.DragSelectionEnded += OnViewModelDragSelectionEnded;
         }
 
         void OnWorkspaceViewUnloaded(object sender, RoutedEventArgs e)
         {
             DynamoSelection.Instance.Selection.CollectionChanged -= new NotifyCollectionChangedEventHandler(OnSelectionCollectionChanged);
-
-            if (ViewModel != null)
-            {
-                ViewModel.DragSelectionStarted -= OnViewModelDragSelectionStarted;
-                ViewModel.DragSelectionEnded -= OnViewModelDragSelectionEnded;
-            }
         }
 
         /// <summary>
@@ -185,6 +176,8 @@ namespace Dynamo.Views
                 oldViewModel.RequestAddViewToOuterCanvas -= vm_RequestAddViewToOuterCanvas;
                 oldViewModel.WorkspacePropertyEditRequested -= VmOnWorkspacePropertyEditRequested;
                 oldViewModel.RequestSelectionBoxUpdate -= VmOnRequestSelectionBoxUpdate;
+                oldViewModel.DragSelectionStarted -= OnViewModelDragSelectionStarted;
+                oldViewModel.DragSelectionEnded -= OnViewModelDragSelectionEnded;
             }
 
             if (ViewModel != null)
@@ -200,8 +193,19 @@ namespace Dynamo.Views
                 ViewModel.RequestAddViewToOuterCanvas += vm_RequestAddViewToOuterCanvas;
                 ViewModel.WorkspacePropertyEditRequested += VmOnWorkspacePropertyEditRequested;
                 ViewModel.RequestSelectionBoxUpdate += VmOnRequestSelectionBoxUpdate;
+                ViewModel.DragSelectionStarted += OnViewModelDragSelectionStarted;
+                ViewModel.DragSelectionEnded += OnViewModelDragSelectionEnded;
 
                 ViewModel.Loaded();
+            }
+        }
+
+        private void OnRemovingWorkspaceViewModel(WorkspaceViewModel workspaceViewModel)
+        {
+            if (ViewModel == workspaceViewModel)
+            {
+                ViewModel.DragSelectionStarted -= OnViewModelDragSelectionStarted;
+                ViewModel.DragSelectionEnded -= OnViewModelDragSelectionEnded;
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -200,15 +200,6 @@ namespace Dynamo.Views
             }
         }
 
-        private void OnRemovingWorkspaceViewModel(WorkspaceViewModel workspaceViewModel)
-        {
-            if (ViewModel == workspaceViewModel)
-            {
-                ViewModel.DragSelectionStarted -= OnViewModelDragSelectionStarted;
-                ViewModel.DragSelectionEnded -= OnViewModelDragSelectionEnded;
-            }
-        }
-
         private void VmOnWorkspacePropertyEditRequested(WorkspaceModel workspace)
         {
             var customNodeWs = workspace as CustomNodeWorkspaceModel;


### PR DESCRIPTION
This pull request tries to fix two issues when switching workspace:
* [MAGN-5919 Regression: open custom node and then open dyn mess up workspace] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5919)
* [MAGN-6022 Closing a custom workspace without saving it crashes Dynamo upon creating new node] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6022)

``DynamoViewModel`` has a list of ``WorkspaceViewModel``, and ``DynamoModel`` has a list of ``WorkspaceModel``. When switching workspace on the UI or closing a workspace, ``WorkspaceView`` needs to load the corresponding ``WorkspaceViewModel``, it is done through getting/setting the dependency property ``DynamoViewModel.CurrentWorkspaceIndex``: internally it uses the index of current ``WorkspaceModel`` in the workspace model list in ``DynamoModel`` as the index of current ``WorkspaceViewModel`` in workspace viewmodel list:

```
...
get
{
    var index = model.Workspaces.IndexOf(model.CurrentWorkspace);
    return index;
}
```
But this assumption is incorrect because viewmodels/models in these two lists are not exactly 1-1 mapped, therefore wrong index is returned and worksapce is messed up. Instead, here we have to return the index of workspace view model whose model is the current workspace model.

The other issue is null reference exception thrown out when clicking on home workspace after closing custom workspace. That is because an event handler is invoked on a already removed ``WorkspaceViewModel`` (which was for custom node). 

``WorkspaceView`` registers two event handlers for ``WorkspaceViewModel``'s two event:  ``DragSelectionStarted`` and ``DragSelectionEnded``. Normally, when a workspace view model is removed, the view should unregister these two event handlers -- previously it is done in view's unloaded event. But it is too late -- at that moment view's data context (workspace view model) has already been set to null. The workflow of closing a tab on the UI is:
1. ``DynamoModel.RemoveWorkspace()``
2. ``DynamoViewModel.WorkspaceRemoved()``
    -- here view's data context is cleared
3. ...
4. ``WorkspaceView.Unloaded()``

So the fix is to move event handler registration/unregistration in ``WorkspaceView.OnWorkspaceViewDataContextChanged``.

- [ ] @Benglin 
- [x] @pboyer 

please help to review the change. 

