### PR TITLE
fixing MAGN-5392

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -177,7 +177,9 @@
                 <dynui:DynamoToolTip AttachmentSide="Top"
                                      Style="{DynamicResource ResourceKey=SLightToolTip}">
                     <Grid>
-                        <TextBlock Text="{Binding Path=Description}"></TextBlock>
+                        <TextBlock MaxWidth="320"
+                                   TextWrapping="Wrap"
+                                   Text="{Binding Path=Description}"></TextBlock>
                     </Grid>
                 </dynui:DynamoToolTip>
             </Rectangle.ToolTip>


### PR DESCRIPTION
This patch adds text wrapping for node tooltip.
Before:
![2015-01-23_1220](https://cloud.githubusercontent.com/assets/10401664/5950808/bc618c2e-a799-11e4-8a3e-33c43610890b.png)

After:
![node](https://cloud.githubusercontent.com/assets/10401664/5950785/7ee41b0a-a799-11e4-8e36-7359355683bc.png)

PTAL @Benglin 