### PR TITLE
Fix for MAGN-6048 [CRASH] while CBN was deleted during Edit mode

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -867,9 +867,7 @@ namespace Dynamo.Models
 
             var retrievedModels = GetModelsInternal(modelGuids);
             if (!retrievedModels.Any())
-            {
-                return;
-            }
+                throw new InvalidOperationException("UpdateModelValue: Model not found");
 
             var updateValueParams = new UpdateValueParams(propertyName, value, ElementResolver);
             using (new ModelModificationUndoHelper(undoRecorder, retrievedModels))

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -867,7 +867,9 @@ namespace Dynamo.Models
 
             var retrievedModels = GetModelsInternal(modelGuids);
             if (!retrievedModels.Any())
-                throw new InvalidOperationException("UpdateModelValue: Model not found");
+            {
+                return;
+            }
 
             var updateValueParams = new UpdateValueParams(propertyName, value, ElementResolver);
             using (new ModelModificationUndoHelper(undoRecorder, retrievedModels))

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/CodeBlockNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/CodeBlockNodeViewCustomization.cs
@@ -14,7 +14,7 @@ namespace Dynamo.Wpf
     {
         public void CustomizeView(CodeBlockNodeModel model, NodeView nodeView)
         {
-            var cbe = new CodeBlockEditor(nodeView.ViewModel);
+            var cbe = new CodeBlockEditor(nodeView);
 
             nodeView.inputGrid.Children.Add(cbe);
             Grid.SetColumn(cbe, 0);

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
@@ -1,4 +1,5 @@
 ﻿﻿using System.Diagnostics;
+﻿using Dynamo.Controls;
 ﻿using Dynamo.Core;
 ﻿using Dynamo.Nodes;
 using Dynamo.Utilities;
@@ -32,20 +33,22 @@ namespace Dynamo.UI.Controls
         private readonly CodeBlockNodeModel nodeModel;
         private CompletionWindow completionWindow;
         private CodeBlockMethodInsightWindow insightWindow;
+        private bool isDisposed;
 
         public CodeBlockEditor()
         {
             InitializeComponent();
         }
 
-        public CodeBlockEditor(NodeViewModel nodeViewModel)
+        public CodeBlockEditor(NodeView nodeView)
         {
             InitializeComponent();
 
-            this.nodeViewModel = nodeViewModel;
+            this.nodeViewModel = nodeView.ViewModel;
             this.dynamoViewModel = nodeViewModel.DynamoViewModel;
             this.DataContext = nodeViewModel.NodeModel;
             this.nodeModel = nodeViewModel.NodeModel as CodeBlockNodeModel;
+            
             if (nodeModel == null)
             {
                 throw new InvalidOperationException(
@@ -60,6 +63,7 @@ namespace Dynamo.UI.Controls
             // Register text editing events            
             this.InnerTextEditor.TextChanged += InnerTextEditor_TextChanged;
             this.InnerTextEditor.TextArea.LostFocus += TextArea_LostFocus;
+            nodeView.Unloaded += (obj, args) => isDisposed = true;
 
             // the code block should not be in focus upon undo/redo actions on node
             if (this.nodeModel.ShouldFocus)
@@ -134,6 +138,7 @@ namespace Dynamo.UI.Controls
                 target.Code = (string)args.NewValue;
             })
         );
+        
         #endregion
 
         #region Syntax highlighting helper methods
@@ -384,6 +389,9 @@ namespace Dynamo.UI.Controls
         /// <param name="e"></param>
         void TextArea_LostFocus(object sender, RoutedEventArgs e)
         {
+            if(isDisposed)
+                return;
+
             InnerTextEditor.TextArea.ClearSelection();
             var recorder = nodeViewModel.WorkspaceViewModel.Model.UndoRecorder;
 


### PR DESCRIPTION
The issue here is that the node is deleted before it loses focus. The event handler for "lost focus" raises a command to update the `NodeModel`. This `UpdateModelValue()` function expects a non-empty list of `NodeModel`s. Since this function is called after deletion of the node, `UpdateModelValue` throws an exception complaining it isn't able to find any node and hence the crash. 

The fix is to detect when the `View` is being unloaded (via the `NodeView.Unloaded` event) and mark the `View` (`CodeBlockEditor` in this case) as being deleted (`isDisposed` field is set to `true`). Then we check for this condition in the `lost_focus` callback and skip updating the node if it's `true`.

@Benglin please review