### PR TITLE
Restored code that was replaced during modularization

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -47,6 +47,7 @@ namespace Dynamo.Models
         private bool isUpdated;
         private MirrorData cachedMirrorData;
         private readonly object cachedMirrorDataMutex = new object();
+
         // Input and output port related data members.
         private ObservableCollection<PortModel> inPorts = new ObservableCollection<PortModel>();
         private ObservableCollection<PortModel> outPorts = new ObservableCollection<PortModel>();
@@ -353,7 +354,20 @@ namespace Dynamo.Models
             }
         }
 
-        public MirrorData GetCachedValueFromEngine(EngineController engine)
+        /// <summary>
+        /// WARNING: This method is meant for unit test only. It directly accesses
+        /// the EngineController for the mirror data without waiting for any 
+        /// possible execution to complete (which, in single-threaded nature of 
+        /// unit test, is an okay thing to do). The right way to get the cached 
+        /// value for a NodeModel is by going through its RequestValueUpdateAsync
+        /// method).
+        /// </summary>
+        /// <param name="engine">Instance of EngineController from which the node
+        /// value is to be retrieved.</param>
+        /// <returns>Returns the MirrorData if the node's value is computed, or 
+        /// null otherwise.</returns>
+        /// 
+        internal MirrorData GetCachedValueFromEngine(EngineController engine)
         {
             if (cachedMirrorData != null)
                 return cachedMirrorData;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -190,9 +190,7 @@ namespace Dynamo.Controls
                     return;
                 }
 
-                previewControl.BindToDataSource(
-                    ViewModel.NodeLogic.GetCachedValueFromEngine(
-                        ViewModel.DynamoViewModel.EngineController));
+                previewControl.BindToDataSource(ViewModel.NodeModel.CachedValue);
             }));
         }
 
@@ -373,9 +371,7 @@ namespace Dynamo.Controls
             if (PreviewControl.IsHidden)
             {
                 if (PreviewControl.IsDataBound == false)
-                    PreviewControl.BindToDataSource(
-                        ViewModel.NodeLogic.GetCachedValueFromEngine(
-                            ViewModel.DynamoViewModel.EngineController));
+                    PreviewControl.BindToDataSource(ViewModel.NodeModel.CachedValue);
 
                 PreviewControl.TransitionToState(PreviewControl.State.Condensed);
             }


### PR DESCRIPTION
This pull request restores the original code that dealt with `CachedValue`. It got replaced accidentally by [the merge into core modularization branch](https://github.com/Benglin/Dynamo/commit/b5a6319a5b76ca7cc78b582200aedddec9deb89d). It also added warning statement to `GetCachedValueFromEngine` method, making its intent clearer to anyone who think about using it.

Hi @ke-yu, see if you get a chance to look at this. Thanks!