### PR TITLE
Fix for failing unit tests

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -127,6 +127,10 @@ namespace Dynamo.Core
                     Properties.Resources.UnableToCreateCustomNodeID + id + "\"",
                     WarningLevel.Moderate);
                 info = new CustomNodeInfo(id, nickname ?? "", "", "", "");
+            }
+
+            if (def == null)
+            {
                 def = CustomNodeDefinition.MakeProxy(id, info.Name);
             }
 


### PR DESCRIPTION
### Issue

Part of the changes I introduced in #3646 was to prevent a custom node instance from being created with a null `CustomNodeDefinition`.  This is necessary as much of the undo/redo logic depends on having a valid `CustomNodeDefinition`.  The new validation code I introduced would throw an exception in such a case.  

It turns out that, at this point in the code in `CustomNodeManager`, a definition can still be null at this point.  This can be the case when the dyf files are being scanned from a directory upon opening a dyn file.  I missed this because I actually ran all of the custom node tests AFTER I introduced the validation code.  :(  

The tests that previous failed relied on directory scanning for dyf files.  This fixes all of those tests.

### Reviewer 

@ikeough 