### PR TITLE
MAGN-6138 Empty CBN cannot be re-position - Missed in code re factoring process

### DIFF
--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -242,22 +242,19 @@ namespace Dynamo.Nodes
 
             value = CodeBlockUtils.FormatUserText(value);
 
-            if (!value.Equals(Code))
-                SetCodeContent(value);
-
-            ////Since an empty Code Block Node should not exist, this checks for such instances.
-            //// If an empty Code Block Node is found, it is deleted. Since the creation and deletion of 
-            //// an empty Code Block Node should not be recorded, this method also checks and removes
-            //// any unwanted recordings
-            //if (value == "")
-            //{
-            //    Code = "";
-            //}
-            //else
-            //{
-            //    if (!value.Equals(Code))
-            //        SetCodeContent(value);
-            //}
+            //Since an empty Code Block Node should not exist, this checks for such instances.
+            // If an empty Code Block Node is found, it is deleted. Since the creation and deletion of 
+            // an empty Code Block Node should not be recorded, this method also checks and removes
+            // any unwanted recordings
+            if (value == "")
+            {
+                Code = "";
+            }
+            else
+            {
+                if (!value.Equals(Code))
+                    SetCodeContent(value);
+            }
             return true;
         }
 

--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -242,19 +242,22 @@ namespace Dynamo.Nodes
 
             value = CodeBlockUtils.FormatUserText(value);
 
-            //Since an empty Code Block Node should not exist, this checks for such instances.
-            // If an empty Code Block Node is found, it is deleted. Since the creation and deletion of 
-            // an empty Code Block Node should not be recorded, this method also checks and removes
-            // any unwanted recordings
-            if (value == "")
-            {
-                Code = "";
-            }
-            else
-            {
-                if (!value.Equals(Code))
-                    SetCodeContent(value);
-            }
+            if (!value.Equals(Code))
+                SetCodeContent(value);
+
+            ////Since an empty Code Block Node should not exist, this checks for such instances.
+            //// If an empty Code Block Node is found, it is deleted. Since the creation and deletion of 
+            //// an empty Code Block Node should not be recorded, this method also checks and removes
+            //// any unwanted recordings
+            //if (value == "")
+            //{
+            //    Code = "";
+            //}
+            //else
+            //{
+            //    if (!value.Equals(Code))
+            //        SetCodeContent(value);
+            //}
             return true;
         }
 

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
@@ -472,7 +472,7 @@ namespace Dynamo.UI.Controls
             }
         }
 
-        private void DiscardChangesAndOptionallyRemoveNode(UndoRedoRecorder recorder,bool removeCodeBlockNode = false)
+        private void DiscardChangesAndOptionallyRemoveNode(UndoRedoRecorder recorder)
         {
             if (!string.IsNullOrEmpty(InnerTextEditor.Text))
             {
@@ -495,18 +495,15 @@ namespace Dynamo.UI.Controls
                     recorder.PopFromUndoGroup(); // Pop off creation action.
 
                 // The empty code block node needs to be removed from workspace.
-                //Fix - MAGN - 6138 - Do not remove empty code block when clicked outside.
-                if(removeCodeBlockNode)
-                    nodeViewModel.WorkspaceViewModel.Model.RemoveNode(nodeModel);
+                //Fix - MAGN - 6138 - Do not remove empty code block when clicked outside.               
+                //nodeViewModel.WorkspaceViewModel.Model.RemoveNode(nodeModel);
             }
             else
             {
                 // If the editing was started for an existing code block node,
                 // and user deletes the text contents, it should be restored to 
                 // the original codes.
-                InnerTextEditor.Text = nodeModel.Code;
-                if (removeCodeBlockNode)
-                    nodeViewModel.WorkspaceViewModel.Model.RemoveNode(nodeModel);
+                InnerTextEditor.Text = nodeModel.Code;               
             }
         }
 

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
@@ -425,6 +425,12 @@ namespace Dynamo.UI.Controls
                 OnRequestReturnFocusToSearch();
             else
                 this.InnerTextEditor.Text = (DataContext as CodeBlockNodeModel).Code;
+
+            if (text == "")
+            {
+                var recorder = nodeViewModel.WorkspaceViewModel.Model.UndoRecorder;
+                DiscardChangesAndOptionallyRemoveNode(recorder,true);
+            }
         }
 
         private void CommitChanges(UndoRedoRecorder recorder)
@@ -466,7 +472,7 @@ namespace Dynamo.UI.Controls
             }
         }
 
-        private void DiscardChangesAndOptionallyRemoveNode(UndoRedoRecorder recorder)
+        private void DiscardChangesAndOptionallyRemoveNode(UndoRedoRecorder recorder,bool removeCodeBlockNode = false)
         {
             if (!string.IsNullOrEmpty(InnerTextEditor.Text))
             {
@@ -489,7 +495,9 @@ namespace Dynamo.UI.Controls
                     recorder.PopFromUndoGroup(); // Pop off creation action.
 
                 // The empty code block node needs to be removed from workspace.
-                nodeViewModel.WorkspaceViewModel.Model.RemoveNode(nodeModel);
+                //Fix - MAGN - 6138 - Do not remove empty code block when clicked outside.
+                if(removeCodeBlockNode)
+                    nodeViewModel.WorkspaceViewModel.Model.RemoveNode(nodeModel);
             }
             else
             {
@@ -497,6 +505,8 @@ namespace Dynamo.UI.Controls
                 // and user deletes the text contents, it should be restored to 
                 // the original codes.
                 InnerTextEditor.Text = nodeModel.Code;
+                if (removeCodeBlockNode)
+                    nodeViewModel.WorkspaceViewModel.Model.RemoveNode(nodeModel);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
@@ -428,8 +428,8 @@ namespace Dynamo.UI.Controls
 
             if (text == "")
             {
-                var recorder = nodeViewModel.WorkspaceViewModel.Model.UndoRecorder;
-                DiscardChangesAndOptionallyRemoveNode(recorder,true);
+                nodeViewModel.DynamoViewModel.ExecuteCommand(
+                   new DynCmd.DeleteModelCommand(nodeModel.GUID));
             }
         }
 

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
@@ -492,11 +492,7 @@ namespace Dynamo.UI.Controls
                 // and nothing should be popped off of the undo stack.
                 // 
                 if (recorder.CanUndo)
-                    recorder.PopFromUndoGroup(); // Pop off creation action.
-
-                // The empty code block node needs to be removed from workspace.
-                //Fix - MAGN - 6138 - Do not remove empty code block when clicked outside.               
-                //nodeViewModel.WorkspaceViewModel.Model.RemoveNode(nodeModel);
+                    recorder.PopFromUndoGroup(); // Pop off creation action.               
             }
             else
             {

--- a/src/Libraries/Samples/SampleLibraryUI/SampleLibraryUI.csproj
+++ b/src/Libraries/Samples/SampleLibraryUI/SampleLibraryUI.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{227B776D-8866-49E8-8C93-809CCF86AF12}</ProjectGuid>
+    <ProjectGuid>{0A4B4EEA-8FAB-4AC8-90D4-27DBC5B0CF2A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SamplesLibraryUI</RootNamespace>


### PR DESCRIPTION
This feature was implemented in 0.7.5 and this was missed in the code refactoring process. 

This fix performs the below action :

Defers the deletion of empty code block
Deletes an empty CBN, only if Esc key is pressed inside that CBN
Enables creation of multiple CBN.
Records the deletion of an empty CBN. This helps the user to undo the deletion of that empty CBN.

- [x] @pboyer 