### PR TITLE
MAGN-6096 Revit nodes, when unavailable, show as "Legacy Node", not as "Dummy" node.

### DIFF
--- a/src/DynamoCore/Models/NodeLoaders/ZeroTouchNodeLoader.cs
+++ b/src/DynamoCore/Models/NodeLoaders/ZeroTouchNodeLoader.cs
@@ -6,6 +6,7 @@ using System.Xml;
 using DSCoreNodesUI;
 using Dynamo.DSEngine;
 using Dynamo.Nodes;
+using Dynamo.Utilities;
 
 namespace Dynamo.Models.NodeLoaders
 {
@@ -70,13 +71,20 @@ namespace Dynamo.Models.NodeLoaders
             if (null == descriptor)
             {
                 var inputcount = DetermineFunctionInputCount(nodeElement);
-                return new DummyNode(
+
+                var dummy = new DummyNode(
                     inputcount,
                     1,
                     nickname,
                     nodeElement,
                     assembly,
                     DummyNode.Nature.Unresolved);
+
+                var helper = new XmlElementHelper(nodeElement);
+                dummy.X = helper.ReadDouble("x", 0.0);
+                dummy.Y = helper.ReadDouble("y", 0.0);
+
+                return dummy;
             }
 
             DSFunctionBase result;

--- a/src/DynamoCore/Models/NodeLoaders/ZeroTouchNodeLoader.cs
+++ b/src/DynamoCore/Models/NodeLoaders/ZeroTouchNodeLoader.cs
@@ -72,19 +72,13 @@ namespace Dynamo.Models.NodeLoaders
             {
                 var inputcount = DetermineFunctionInputCount(nodeElement);
 
-                var dummy = new DummyNode(
+                return new DummyNode(
                     inputcount,
                     1,
                     nickname,
                     nodeElement,
                     assembly,
                     DummyNode.Nature.Unresolved);
-
-                var helper = new XmlElementHelper(nodeElement);
-                dummy.X = helper.ReadDouble("x", 0.0);
-                dummy.Y = helper.ReadDouble("y", 0.0);
-
-                return dummy;
             }
 
             DSFunctionBase result;

--- a/src/DynamoCore/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Nodes/DummyNode.cs
@@ -2,6 +2,7 @@
 using System.Xml;
 using Autodesk.DesignScript.Runtime;
 using Dynamo.Models;
+using Dynamo.Utilities;
 
 namespace DSCoreNodesUI
 {
@@ -23,8 +24,7 @@ namespace DSCoreNodesUI
             LegacyNodeName = "DSCoreNodesUI.DummyNode";
             LegacyAssembly = string.Empty;
             NodeNature = Nature.Unresolved;
-            Description = GetDescription(); 
-            
+            Description = GetDescription();
             ShouldDisplayPreviewCore = false;
         }
 
@@ -42,6 +42,10 @@ namespace DSCoreNodesUI
             ShouldDisplayPreviewCore = false;
 
             UpdatePorts();
+
+            var helper = new XmlElementHelper(originalElement);
+            X = helper.ReadDouble("x", 0.0);
+            Y = helper.ReadDouble("y", 0.0);
         }
 
         private void LoadNode(XmlNode nodeElement)

--- a/src/DynamoCore/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Nodes/DummyNode.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Xml;
 using Autodesk.DesignScript.Runtime;
 using Dynamo.Models;
@@ -36,6 +33,7 @@ namespace DSCoreNodesUI
             InputCount = inputCount;
             OutputCount = outputCount;
             LegacyNodeName = legacyName;
+            NickName = legacyName;
             OriginalNodeContent = originalElement;
             LegacyAssembly = legacyAssembly;
             NodeNature = nodeNature;

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DummyNode.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DummyNode.cs
@@ -14,7 +14,7 @@ namespace Dynamo.Wpf.Nodes
             if (model.NodeNature == DummyNode.Nature.Unresolved)
                 fileName = "MissingNode.png";
 
-            var src = @"/DSCoreNodesWpf;component/Resources/" + fileName;
+            var src = @"/CoreNodeModelsWpf;component/Resources/" + fileName;
 
             Image dummyNodeImage = new Image()
             {


### PR DESCRIPTION
This PR fixes a regression with DummyNodes, detailed in [MAGN-6096](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6096). 

- The resource path string for the unresolved node image was incorrect due to the renaming of CoreNodeModelsWpf. When the resource could not be found, the dummy node image was not applied to the nodes. The resource path has been updated to reference the renamed assembly.
- NodeModel types that could not be resolved through the migration manager created the proper Dummy node, but ZT types that could not be resolved by the ZeroTouchNodeLoader, created a DummyNode object, but did not set its location. Dummy nodes were placed at the origin and were not immediately visible to the user as most graphs are zoomed to their original content. The X and Y coordinates are now read from the node's original xml element and applied to properly position the dummy node.
- Dummy nodes created during a failure to resolve a ZT type were incorrectly nicknamed "Legacy Node". The nickname of the node is now set in the DummyNode constructor.

![image](https://cloud.githubusercontent.com/assets/1139788/6015261/8f58ecfe-ab27-11e4-81c0-418ea6b058ba.png)


PTAL:
- [x] @pboyer 