### PR TITLE
MAGN-5931: Insert pasted elements at the current workspace offset

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1022,6 +1022,10 @@ namespace Dynamo.Models
         /// </summary>
         public void Paste()
         {
+            //clear the selection so we can put the
+            //paste contents in
+            DynamoSelection.Instance.ClearSelection();
+
             //make a lookup table to store the guids of the
             //old nodes and the guids of their pasted versions
             var nodeLookup = new Dictionary<Guid, NodeModel>();
@@ -1030,15 +1034,27 @@ namespace Dynamo.Models
             //creations can be recorded in the undo recorder.
             var createdModels = new List<ModelBase>();
 
-            //clear the selection so we can put the
-            //paste contents in
-            DynamoSelection.Instance.ClearSelection();
-
             var nodes = ClipBoard.OfType<NodeModel>();
             var connectors = ClipBoard.OfType<ConnectorModel>();
+            var notes = ClipBoard.OfType<NoteModel>();
+
+            var minX = Double.MaxValue;
+            var minY = Double.MaxValue;
+
+            // Create the new NoteModel's
+            var newNoteModels = new List<NoteModel>();
+            foreach (var note in notes)
+            {
+                newNoteModels.Add(new NoteModel(note.X, note.Y, note.Text, Guid.NewGuid()));
+
+                minX = Math.Min(note.X, minX);
+                minY = Math.Min(note.Y, minY);
+            }
 
             var xmlDoc = new XmlDocument();
 
+            // Create the new NodeModel's
+            var newNodeModels = new List<NodeModel>();
             foreach (var node in nodes)
             {
                 NodeModel newNode;
@@ -1049,7 +1065,7 @@ namespace Dynamo.Models
                         ? (node as Symbol).InputSymbol
                         : (node as Output).Symbol);
                     var code = (string.IsNullOrEmpty(symbol) ? "x" : symbol) + ";";
-                    newNode = new CodeBlockNodeModel(code, node.X, node.Y + 100, LibraryServices);
+                    newNode = new CodeBlockNodeModel(code, node.X, node.Y, LibraryServices);
                 }
                 else
                 {
@@ -1061,12 +1077,49 @@ namespace Dynamo.Models
                 if (!string.IsNullOrEmpty(node.NickName))
                     newNode.NickName = node.NickName;
 
-                CurrentWorkspace.AddNode(newNode, false);
-                createdModels.Add(newNode);
                 nodeLookup.Add(node.GUID, newNode);
+
+                newNodeModels.Add( newNode );
+
+                minX = Math.Min(node.X, minX);
+                minY = Math.Min(node.Y, minY);
             }
 
+            // Move all of the notes and nodes such that they are aligned with
+            // the top left of the workspace
+            var workspaceX = -CurrentWorkspace.X / CurrentWorkspace.Zoom;
+            var workspaceY = -CurrentWorkspace.Y / CurrentWorkspace.Zoom;
+
+            // Provide a small offset when pasting so duplicate pastes aren't directly on top of each other
+            CurrentWorkspace.IncrementPasteOffset();
+
+            var shiftX = workspaceX - minX + CurrentWorkspace.CurrentPasteOffset;
+            var shiftY = workspaceY - minY + CurrentWorkspace.CurrentPasteOffset;
+
+            foreach (var model in newNodeModels.Concat<ModelBase>(newNoteModels))
+            {
+                model.X = model.X + shiftX;
+                model.Y = model.Y + shiftY;
+            }
+
+            // Add the new NodeModel's to the Workspace
+            foreach (var newNode in newNodeModels)
+            {
+                CurrentWorkspace.AddNode(newNode, false);
+                createdModels.Add(newNode);
+                AddToSelection(newNode);
+            }
+
+            // TODO: is this required?
             OnRequestLayoutUpdate(this, EventArgs.Empty);
+
+            // Add the new NoteModel's to the Workspace
+            foreach (var newNote in newNoteModels)
+            {
+                CurrentWorkspace.AddNote(newNote, false);
+                createdModels.Add(newNote);
+                AddToSelection(newNote);
+            }
 
             NodeModel start;
             NodeModel end;
@@ -1090,29 +1143,6 @@ namespace Dynamo.Models
                     ConnectorModel.Make(startNode, endNode, c.Start.Index, c.End.Index);
 
             createdModels.AddRange(newConnectors);
-
-            //process the queue again to create the connectors
-            //DynamoCommands.ProcessCommandQueue();
-
-            var notes = ClipBoard.OfType<NoteModel>();
-
-            var newNotes = from note in notes
-                           let newGUID = Guid.NewGuid()
-                           let sameSpace =
-                               CurrentWorkspace.Notes.Any(x => x.GUID == note.GUID)
-                           let newX = sameSpace ? note.X + 20 : note.X
-                           let newY = sameSpace ? note.Y + 20 : note.Y
-                           select new NoteModel(newX, newY, note.Text, newGUID);
-
-            foreach (var newNote in newNotes)
-            {
-                CurrentWorkspace.AddNote(newNote, false);
-                createdModels.Add(newNote);
-                AddToSelection(newNote);
-            }
-
-            foreach (var de in nodeLookup.Values)
-                AddToSelection(de);
 
             // Record models that are created as part of the command.
             CurrentWorkspace.RecordCreatedModels(createdModels);

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -21,11 +21,31 @@ namespace Dynamo.Models
 {
     public abstract class WorkspaceModel : NotificationObject, ILocatable, IUndoRedoRecorderClient, ILogSource, IDisposable
     {
+
         public const double ZOOM_MAXIMUM = 4.0;
         public const double ZOOM_MINIMUM = 0.01;
 
-        #region private members
-        
+        #region private/internal members
+
+        /// <summary>
+        ///     The offset of the elements in the current paste operation
+        /// </summary>
+        private int currentPasteOffset = 0;
+        internal int CurrentPasteOffset
+        {
+            get { return currentPasteOffset; }
+        }
+
+        /// <summary>
+        ///     The step to offset elements between subsequent paste operations
+        /// </summary>
+        internal static readonly int PASTE_OFFSET_STEP = 10;
+
+        /// <summary>
+        ///     The maximum paste offset before reset
+        /// </summary>
+        internal static readonly int PASTE_OFFSET_MAX = 60;
+
         private string fileName;
         private string name;
         private double height = 100;
@@ -660,6 +680,14 @@ namespace Dynamo.Models
         public void ReportPosition()
         {
             RaisePropertyChanged("Position");
+        }
+
+        /// <summary>
+        ///     Increment the current paste offset to prevent overlapping pasted elements
+        /// </summary>
+        internal void IncrementPasteOffset()
+        {
+            this.currentPasteOffset = (this.currentPasteOffset + PASTE_OFFSET_STEP) % PASTE_OFFSET_MAX;
         }
 
         #endregion


### PR DESCRIPTION
### Issue

Currently, when users paste content into a workspace, the original position of the pasted content determines the new location.  

This is problematic for several reasons:

1.  It results in the new content being pasted, confusingly, directly atop the old content.  
2.  It doesn't reflect the current workspace offset.  As a result, a user that has panned significantly will have their pasted content offscreen.  
3.  Two workspaces seldomly have the same offset.  This causes 2 to occur when copying between workspaces.

### Fix 

Use the current workspace offset in order to determine the location of the new content.  In this pull request, the top left corner of the copied content is determined and all of the pasted content is shifted so as to consistently place the pasted content in view.  

Further, a small offset is introduced between subsequent paste operations in order to prevent issue 1 when  copying repeatedly.

### Reviewer

- [ ] @ikeough 