### PR TITLE
Remove WorkspaceModel.OnWorkspaceSaved from its WorkspaceSaved handler

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -457,8 +457,6 @@ namespace Dynamo.Models
             HasUnsavedChanges = false;
             LastSaved = DateTime.Now;
 
-            WorkspaceSaved += OnWorkspaceSaved;       
-
             WorkspaceVersion = AssemblyHelper.GetDynamoVersion();
             undoRecorder = new UndoRedoRecorder(this);
 


### PR DESCRIPTION
Dyanmo crashes on [saving custom node](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6221). That is because ``WorkspaceModel.OnWorkspaceSaved`` was added to ``WorkspaceModel.WorkspaceSaved`` event handler which causes infinite loop at saving. This PR reverted this change. 

@Benglin Please review the change. 