### PR TITLE
MAGN-5591 Integer slider int overflow can set slider max to 0

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -43,6 +43,10 @@ namespace DSCoreNodesUI.Input
             set
             {
                 base.Value = value;
+                if (base.Value > Int32.MaxValue)
+                    base.Value = Int32.MaxValue;
+                if (base.Value < Int32.MinValue)
+                    base.Value = Int32.MinValue;
                 RaisePropertyChanged("Value");
             }
         }

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -77,7 +77,8 @@
                             IsSnapToTickEnabled="true" 
                             Grid.Column="2" 
                             Thumb.DragStarted="Slider_OnDragStarted"
-                            Thumb.DragCompleted="Slider_OnDragCompleted"/>
+                            Thumb.DragCompleted="Slider_OnDragCompleted"                            
+                            Validation.ErrorTemplate="{x:Null}"/>
 
         </Grid>
 

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -78,7 +78,7 @@
                             Grid.Column="2" 
                             Thumb.DragStarted="Slider_OnDragStarted"
                             Thumb.DragCompleted="Slider_OnDragCompleted"                            
-                            Validation.ErrorTemplate="{x:Null}"/>
+                            />
 
         </Grid>
 

--- a/test/DynamoCoreUITests/SliderTests.cs
+++ b/test/DynamoCoreUITests/SliderTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Reflection;
 
 using DSCoreNodesUI.Input;
-
+using Dynamo.Models;
 using NUnit.Framework;
 using DoubleSlider = DSCoreNodesUI.Input.DoubleSlider;
 
@@ -79,5 +79,54 @@ namespace DynamoCoreUITests
             var slider = new IntegerSlider();
             Assert.NotNull(slider);
         }
+
+        [Test]
+        public void SliderCanNotBeSetGreaterThanMaxIntValue()
+        {
+            var slider = new IntegerSlider();
+            Assert.NotNull(slider);
+
+            var param = new UpdateValueParams("Value", "2147483648");
+            slider.UpdateValue(param);
+
+            Assert.AreEqual(slider.Value, Int32.MaxValue);
+        }
+
+        [Test]
+        public void  SliderCanNotBeSetLessThanMinIntValue()
+        {
+            var slider = new IntegerSlider();
+            Assert.NotNull(slider);
+
+            var param = new UpdateValueParams("Value", "-2147483649");
+            slider.UpdateValue(param);
+
+            Assert.AreEqual(slider.Value, Int32.MinValue);
+        }
+
+        [Test]
+        public void SliderMaxResetsToIntMax()
+        {
+            var slider = new IntegerSlider();
+            Assert.NotNull(slider);
+
+            var param = new UpdateValueParams("Max", "2147483648");
+            slider.UpdateValue(param);
+
+            Assert.AreEqual(slider.Max, Int32.MaxValue);
+        }
+
+        [Test]
+        public void SliderMinResetsToIntMin()
+        {
+            var slider = new IntegerSlider();
+            Assert.NotNull(slider);
+
+            var param = new UpdateValueParams("Min", "-2147483649");
+            slider.UpdateValue(param);
+
+            Assert.AreEqual(slider.Min, Int32.MinValue);
+        }
+
     }
 }


### PR DESCRIPTION
When the slider is dragged to a value greater than Integer Max, the value does not set to Integer max and there is a red border appearing over the slider.

This fix will remove the red border (which is actually a validation border on the slider) and make the slider value equal to Integer Max (when it reaches a value greater than the Integer Max).

- [ ] @ikeough 