### PR TITLE
Add anew a possibility to create proxy custom node by request from Flood

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -78,34 +78,44 @@ namespace Dynamo.Models
                     {
                         Guid customNodeId; // To be used in the event it's a custom node we're making.
 
-                    // Then, we have to figure out what kind of node to make, based on the name.
+                        if (command is CreateProxyNodeCommand)
+                        {
+                            var proxyCommand = command as CreateProxyNodeCommand;
 
-                    // First, we check for a DSFunction by looking for a FunctionDescriptor
-                    var functionItem = LibraryServices.GetFunctionDescriptor(name);
-                    if (functionItem != null)
-                    {
-                        node = (functionItem.IsVarArg)
-                            ? new DSVarArgFunction(functionItem) as NodeModel
-                            : new DSFunction(functionItem);
-                        node.GUID = nodeId;
-                    }
-                    // If that didn't work, let's try using the NodeFactory
-                    else if (NodeFactory.CreateNodeFromTypeName(name, out node))
-                    {
-                        node.GUID = nodeId;
-                    }
-                    // And if that didn't work, then it must be a custom node.
-                    else if (Guid.TryParse(name, out customNodeId))
-                    {
-                        node = CustomNodeManager.CreateCustomNodeInstance(customNodeId);
-                        node.GUID = nodeId;
-                    }
-                    // We're out of ideas, log an error.
-                    else
-                    {
-                        Logger.LogError("Could not create instance of node with name: " + name);
-                        return;
-                    }
+                            node = NodeFactory.CreateProxyNodeInstance(nodeId, name, 
+                                proxyCommand.NickName, proxyCommand.Inputs, proxyCommand.Outputs);
+                        }
+                        else
+                        {
+                            // Then, we have to figure out what kind of node to make, based on the name.
+
+                            // First, we check for a DSFunction by looking for a FunctionDescriptor
+                            var functionItem = LibraryServices.GetFunctionDescriptor(name);
+                            if (functionItem != null)
+                            {
+                                node = (functionItem.IsVarArg)
+                                    ? new DSVarArgFunction(functionItem) as NodeModel
+                                    : new DSFunction(functionItem);
+                                node.GUID = nodeId;
+                            }
+                            // If that didn't work, let's try using the NodeFactory
+                            else if (NodeFactory.CreateNodeFromTypeName(name, out node))
+                            {
+                                node.GUID = nodeId;
+                            }
+                            // And if that didn't work, then it must be a custom node.
+                            else if (Guid.TryParse(name, out customNodeId))
+                            {
+                                node = CustomNodeManager.CreateCustomNodeInstance(customNodeId);
+                                node.GUID = nodeId;
+                            }
+                            // We're out of ideas, log an error.
+                            else
+                            {
+                                Logger.LogError("Could not create instance of node with name: " + name);
+                                return;
+                            }
+                        }
                     }
                 }
             }

--- a/src/DynamoCore/Models/NodeFactory.cs
+++ b/src/DynamoCore/Models/NodeFactory.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Xml;
 using DSCoreNodesUI;
 using Dynamo.Interfaces;
+using Dynamo.Models.NodeLoaders;
+using Dynamo.Nodes;
 using Dynamo.Utilities;
 
 namespace Dynamo.Models
@@ -107,6 +109,35 @@ namespace Dynamo.Models
         public bool AddTypeFactoryAndLoader<T>() where T : NodeModel
         {
             return AddTypeFactoryAndLoader(typeof(T));
+        }
+
+        /// A proxy custom node is a custom node without its definition loaded 
+        /// in Dynamo. The creation of a proxy custom node relies on information 
+        /// provided by the caller since the definition is not readily available 
+        /// for reading. The actual definition may become available at a later 
+        /// time by means of user uploading the definition.
+        /// </summary>
+        /// <param name="id">Identifier of the custom node instance.</param>
+        /// <param name="name">The name represents the GUID of the custom node 
+        /// definition that is used for creating the custom node instance.</param>
+        /// <param name="nickName">The display name of the custom node.</param>
+        /// <param name="inputs">Number of input ports.</param>
+        /// <param name="outputs">Number of output ports.</param>
+        /// <returns>Returns the custom node instance if creation was successful, 
+        /// or null otherwise.</returns>
+        internal NodeModel CreateProxyNodeInstance(Guid id, string name, string nickName, int inputs, int outputs)
+        {
+            Guid guid;
+            INodeLoader<NodeModel> data;
+            if (!Guid.TryParse(name, out guid) || !GetNodeSourceFromType(typeof(Function), out data))
+            {
+                return null;
+            }
+
+
+            // create an instance of Function node 
+            var result = (data as CustomNodeLoader).CreateProxyNode(guid, nickName, id, inputs, outputs);
+            return result;
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/NodeLoaders/CustomNodeLoader.cs
+++ b/src/DynamoCore/Models/NodeLoaders/CustomNodeLoader.cs
@@ -42,5 +42,13 @@ namespace Dynamo.Models.NodeLoaders
             node.Deserialize(nodeElement, context);
             return node;
         }
+
+        public Function CreateProxyNode(Guid funcId, string nickname, Guid nodeId, int inputNum, int outputNum)
+        {
+            var node = customNodeManager.CreateCustomNodeInstance(funcId, nickname, isTestMode);
+            // create its definition and add inputs and outputs
+            node.LoadNode(nodeId, inputNum, outputNum);
+            return node;
+        }
     }
 }

--- a/src/DynamoCore/Nodes/Custom Nodes/Function.cs
+++ b/src/DynamoCore/Nodes/Custom Nodes/Function.cs
@@ -81,6 +81,60 @@ namespace Dynamo.Nodes
             }
             element.AppendChild(outEl);
         }
+        
+        /// <summary>
+        /// Create a definition for custom node and add inputs and outputs
+        /// </summary>
+        /// <param name="funcID">ID of the definition</param>
+        /// <param name="inputs">Number of inputs</param>
+        /// <param name="outputs">Number of outputs</param>
+        internal void LoadNode(Guid nodeId, int inputs, int outputs)
+        {
+            GUID = nodeId;
+            
+            // make the custom node instance be in sync 
+            // with its definition if it's needed
+            if (!Controller.IsInSyncWithNode(this))
+            {
+                Controller.SyncNodeWithDefinition(this);
+            }
+            else
+            {
+                PortData data;
+                if (outputs > -1)
+                {
+                    // create outputs for the node
+                    for (int i = 0; i < outputs; i++)
+                    {
+                        data = new PortData("", "Output #" + (i + 1));
+                        if (OutPortData.Count > i)
+                            OutPortData[i] = data;
+                        else
+                            OutPortData.Add(data);
+                    }
+                }
+
+                if (inputs > -1)
+                {
+                    // create inputs for the node
+                    for (int i = 0; i < inputs; i++)
+                    {
+                        data = new PortData("", "Input #" + (i + 1));
+                        if (InPortData.Count > i)
+                            InPortData[i] = data;
+                        else
+                            InPortData.Add(data);
+                    }
+                }
+
+                RegisterAllPorts();
+            }
+
+            //argument lacing on functions should be set to disabled
+            //by default in the constructor, but for any workflow saved
+            //before this was the case, we need to ensure it here.
+            ArgumentLacing = LacingStrategy.Disabled;
+        }
 
         protected override void DeserializeCore(XmlElement nodeElement, SaveContext context)
         {


### PR DESCRIPTION
Proxy custom node is custom node instance without a corresponding workspace, so Dynamo isn't able to do all proper computation with it. Currently Dynamo can create a proxy node during opening a file but sometimes Flood may need to create such node as well