### PR TITLE
Add "Group" property for every search element during library dump process

### DIFF
--- a/src/DynamoCore/Search/NodeSearchModel.cs
+++ b/src/DynamoCore/Search/NodeSearchModel.cs
@@ -61,6 +61,7 @@ namespace Dynamo.Search
             var element = XmlHelper.AddNode(parent, entry.GetType().ToString());
             XmlHelper.AddNode(element, "FullCategoryName", entry.FullCategoryName);
             XmlHelper.AddNode(element, "Name", entry.Name);
+            XmlHelper.AddNode(element, "Group", entry.Group.ToString());
             XmlHelper.AddNode(element, "Description", entry.Description);
         }
 

--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -289,11 +289,18 @@ namespace Dynamo.Tests
                     if (function.IsObsolete || !function.IsVisibleInLibrary || function.FunctionName.Contains("GetType"))
                         continue;
 
+                    var category = function.Category;
+                    var group = SearchElementGroup.Action;
+                    category = ViewModel.SearchViewModel.Model.ProcessNodeCategory(category, ref group);
+
                     node = document.SelectSingleNode(string.Format(
-                        "//{0}[FullCategoryName='{1}' and Name='{2}']", 
-                        typeof(ZeroTouchSearchElement).FullName,
-                        function.Category, function.FunctionName));
+                        "//{0}[FullCategoryName='{1}' and Name='{2}']",
+                        typeof(ZeroTouchSearchElement).FullName, category, function.FunctionName));
                     Assert.IsNotNull(node);
+
+                    subNode = node.SelectSingleNode("Group");
+                    Assert.IsNotNull(subNode.FirstChild);
+                    Assert.AreEqual(group.ToString(), subNode.FirstChild.Value);
 
                     // 'FullCategoryName' is already checked.
                     // 'Name' is already checked.


### PR DESCRIPTION
#### Purpose

Add `Group` property for every search element during library dump process. We need this because `FullCategoryName` of element doesn't contain this kind information.

Additionally `Dynamo.Tests.LibraryTests.DumpLibraryToXmlZeroTouchTest` is fixed.

#### Unit test
![capture](https://cloud.githubusercontent.com/assets/8158551/6098514/bf689ae0-afe9-11e4-9058-81aa8da6db87.PNG)

#### Additional references

[MAGN-6245](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6245) Add "Group" property for every search element 

#### Reviewers

@Benglin, please, take a look.