### PR TITLE
Fixed unit test failure in "Defect_MAGN_520_DS"

### DIFF
--- a/test/core/recorded/Defect_MAGN_520_DS.xml
+++ b/test/core/recorded/Defect_MAGN_520_DS.xml
@@ -1,4 +1,4 @@
-<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="1000">
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
   <CreateNodeCommand NodeId="03107ea4-75db-4826-a12d-9ebf4f23f65c" NodeName="+@," X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
   <CreateNodeCommand NodeId="70c28589-855c-45cf-9ec3-bbf25d478a0d" NodeName="-@," X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
   <CreateNodeCommand NodeId="bdb376ca-a02d-4c6e-94fd-67142a0361e0" NodeName="*@," X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />

--- a/test/core/recorded/Defect_MAGN_520_DS.xml
+++ b/test/core/recorded/Defect_MAGN_520_DS.xml
@@ -1,4 +1,4 @@
-<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="1000">
   <CreateNodeCommand NodeId="03107ea4-75db-4826-a12d-9ebf4f23f65c" NodeName="+@," X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
   <CreateNodeCommand NodeId="70c28589-855c-45cf-9ec3-bbf25d478a0d" NodeName="-@," X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
   <CreateNodeCommand NodeId="bdb376ca-a02d-4c6e-94fd-67142a0361e0" NodeName="*@," X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
@@ -16,6 +16,6 @@
   <DragSelectionCommand X="298" Y="219" DragOperation="0" />
   <DragSelectionCommand X="241" Y="208" DragOperation="1" />
   <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
-  <SelectInRegionCommand X="151" Y="355" Width="507" Height="191" IsCrossSelection="false" />
+  <SelectInRegionCommand X="151" Y="355" Width="640" Height="191" IsCrossSelection="false" />
   <DeleteModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" />
 </Commands>


### PR DESCRIPTION
There are supposed to be two nodes selected with the `SelectInRegionCommand` command, but due to the new width of Library UI, this command ends up with selecting only one node, subsequently failing the test. The fix is to increase the horizontal region in which selection is made, which selects also the other node that was left out.

@vmoyseenko, thanks for checking this out. I'm merging this in to fix the build issue.