### PR TITLE
[DUI] Node Description are shown even after clearing search result.

### DIFF
--- a/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
@@ -200,7 +200,8 @@ namespace Dynamo.Search
                 case Key.Down:
                 case Key.Up:
                 case Key.Enter:
-                    librarySearchView.SelectNext(e.Key);
+                    if (viewModel.CurrentMode == SearchViewModel.ViewMode.LibrarySearchView)
+                        librarySearchView.SelectNext(e.Key);
                     break;
             }
         }

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -18,9 +18,10 @@ namespace Dynamo.UI.Views
     /// </summary>
     public partial class LibrarySearchView : UserControl
     {
-        private ListBoxItem HighlightedItem;
-
         public UIElement SearchTextBox;
+        private ListBoxItem HighlightedItem;
+        private SearchViewModel viewModel;
+
 
         public LibrarySearchView()
         {
@@ -31,8 +32,19 @@ namespace Dynamo.UI.Views
 
         private void OnLibrarySearchViewLoaded(object sender, RoutedEventArgs e)
         {
-            (DataContext as SearchViewModel).SearchTextChanged +=
-                (s, eInner) => topResultPanel.BringIntoView();
+            viewModel = DataContext as SearchViewModel;
+            viewModel.SearchTextChanged += OnSearchTextBoxKeyDown;
+        }
+
+        private void OnSearchTextBoxKeyDown(object sender, EventArgs e)
+        {
+            topResultPanel.BringIntoView();
+
+            if (string.IsNullOrEmpty(viewModel.SearchText))
+            {
+                UpdateHighlightedItem(null);
+                libraryToolTipPopup.SetDataContext(null, true);
+            }
         }
 
         #region MethodButton
@@ -108,10 +120,8 @@ namespace Dynamo.UI.Views
 
         private void OnNoMatchFoundButtonClick(object sender, RoutedEventArgs e)
         {
-            var searchViewModel = this.DataContext as SearchViewModel;
-
             // Clear SearchText in ViewModel, as result search textbox clears as well.
-            searchViewModel.SearchText = "";
+            viewModel.SearchText = "";
         }
 
         private void OnMemberGroupNameMouseDown(object sender, MouseButtonEventArgs e)
@@ -616,8 +626,7 @@ namespace Dynamo.UI.Views
         private void OnTopResultTargetUpdated(object sender, DataTransferEventArgs e)
         {
             // If we turn to regular view, we have to hide tooltip immediately.
-            if ((DataContext as SearchViewModel).CurrentMode !=
-                SearchViewModel.ViewMode.LibrarySearchView)
+            if (viewModel.CurrentMode != SearchViewModel.ViewMode.LibrarySearchView)
             {
                 libraryToolTipPopup.SetDataContext(null, true);
                 UpdateHighlightedItem(null);

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -36,6 +36,9 @@ namespace Dynamo.UI.Views
             viewModel.SearchTextChanged += OnSearchTextBoxKeyDown;
         }
 
+        // Changing text content of the search box should always bring up the 
+        // "top result" (since there is no search term). Also, any possible tool-tip
+        // that is displayed and highlighted item should be dismissed right away.
         private void OnSearchTextBoxKeyDown(object sender, EventArgs e)
         {
             topResultPanel.BringIntoView();


### PR DESCRIPTION
#### Purpose

1. Enter `s` to search.
2. Clear it with `ESC`.
3. Enter down button.
 
You will see tooltip connected with item of `SearchLibraryView` which is not active now. This PR fixes this bug.

#### Modifications

When `SearchText` is empty we make `HighlighteItem` as `null` and closing ToolTip.

#### Additional references

[MAGN-6196](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6196)  [DUI] Node Description are shown even after clearing search result.

#### Reviewers

@Benglin, please, take a look.