### PR TITLE
DUI: Provisioning of default icons does not work in all cases 

### DIFF
--- a/src/DynamoCore/Library/LibraryCustomization.cs
+++ b/src/DynamoCore/Library/LibraryCustomization.cs
@@ -106,7 +106,7 @@ namespace Dynamo.DSEngine
         /// <summary>
         /// Resources assembly. Assembly where icons are saved.
         /// </summary>
-        public Assembly ResAssembly { get { return resourceAssembly; } }
+        public Assembly ResourceAssembly { get { return resourceAssembly; } }
 
         internal LibraryCustomization(Assembly resAssembly, XDocument document)
         {

--- a/src/DynamoCore/Library/LibraryCustomization.cs
+++ b/src/DynamoCore/Library/LibraryCustomization.cs
@@ -103,7 +103,10 @@ namespace Dynamo.DSEngine
         private readonly Assembly resourceAssembly;
         private readonly XDocument xmlDocument;
 
-        public Assembly Assembly { get { return resourceAssembly; } }
+        /// <summary>
+        /// Resources assembly. Assembly where icons are saved.
+        /// </summary>
+        public Assembly ResAssembly { get { return resourceAssembly; } }
 
         internal LibraryCustomization(Assembly resAssembly, XDocument document)
         {

--- a/src/DynamoCoreWpf/Services/IconServices.cs
+++ b/src/DynamoCoreWpf/Services/IconServices.cs
@@ -21,7 +21,9 @@ namespace Dynamo.Wpf.Services
             if (libraryCustomization == null)
                 return null;
 
-            var assembly = libraryCustomization.Assembly;
+            var assembly = libraryCustomization.ResAssembly;
+            if (assembly == null)
+                return null;
 
             if (!warehouses.ContainsKey(assembly))
                 warehouses[assembly] = new IconWarehouse(assembly);

--- a/src/DynamoCoreWpf/Services/IconServices.cs
+++ b/src/DynamoCoreWpf/Services/IconServices.cs
@@ -21,7 +21,7 @@ namespace Dynamo.Wpf.Services
             if (libraryCustomization == null)
                 return null;
 
-            var assembly = libraryCustomization.ResAssembly;
+            var assembly = libraryCustomization.ResourceAssembly;
             if (assembly == null)
                 return null;
 


### PR DESCRIPTION
#### Purpose

For nodes which are added to tree from DLLs during importing of package or importing library no icons are shown. This PR fixes it.

To show icons for custom libraries (not core libraries) it should be organized in special way. Together with main dll `.resources` dll should be distributed.

#### Additional references

[MAGN-6214](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6214) DUI: Provisioning of default icons does not work in all cases 

#### Reviewers

@Benglin, please, take a look.
