### PR TITLE
DUI: Search results should be the same in New Library UI and Old Library UI

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -636,7 +636,6 @@ namespace Dynamo.ViewModels
 
             var foundNodes = Search(query);
 
-            UpdateTopResult();
             RaisePropertyChanged("SearchRootCategories");
 
             SearchResults = new ObservableCollection<NodeSearchElementViewModel>(foundNodes);
@@ -686,6 +685,12 @@ namespace Dynamo.ViewModels
 
                 category.AddMemberToGroup(elementVM);
             }
+
+            // Update top result before we do not sort categories.
+            if (searchRootCategories.Any())
+                UpdateTopResult(searchRootCategories.FirstOrDefault().MemberGroups.FirstOrDefault());
+            else
+                UpdateTopResult(null);
 
             // Order found categories by name.
             searchRootCategories = new ObservableCollection<SearchCategory>(searchRootCategories.OrderBy(x => x.Name));
@@ -797,20 +802,16 @@ namespace Dynamo.ViewModels
 
         }
 
-        private void UpdateTopResult()
+        private void UpdateTopResult(SearchMemberGroup memberGroup)
         {
-            if (!SearchRootCategories.Any())
+            if (memberGroup == null)
             {
                 TopResult = null;
-
                 return;
             }
 
-            // If SearchRootCategories has at least 1 element, it has at least 1 member. 
-            var firstMemberGroup = SearchRootCategories.First().MemberGroups.First();
-
-            var topMemberGroup = new SearchMemberGroup(firstMemberGroup.FullyQualifiedName);
-            topMemberGroup.AddMember(firstMemberGroup.Members.First());
+            var topMemberGroup = new SearchMemberGroup(memberGroup.FullyQualifiedName);
+            topMemberGroup.AddMember(memberGroup.Members.First());
 
             TopResult = topMemberGroup;
         }


### PR DESCRIPTION
#### Purpose

For Top Result should be used first found search element before sorting. Now we are using first sorted item. This PR fixes it.

#### Modifications

We take first item in `SearchRootCategories` before sorting.

Some examples of old implementation (left) and new implementation (right).
![capture](https://cloud.githubusercontent.com/assets/8158551/6129185/0ccfc7c0-b145-11e4-8595-bc7d42000146.PNG)

![capture](https://cloud.githubusercontent.com/assets/8158551/6129198/260d9c26-b145-11e4-86ed-b418fc5f9a86.PNG)

![capture](https://cloud.githubusercontent.com/assets/8158551/6129221/512e9dce-b145-11e4-9f24-3519c10f92f9.PNG)

#### Additional references

[MAGN-6051](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6051) DUI: Search results should be the same in New Library UI and Old Library UI

#### Reviewers

@Benglin, please, take a look.