### PR TITLE
Rework WpfUtilities.FindChildren using WpfUtilities.ChildrenOfType as example 

### DIFF
--- a/src/DynamoCoreWpf/Utilities/WpfUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/WpfUtilities.cs
@@ -71,50 +71,5 @@ namespace Dynamo.Utilities
                 }
             }
         }
-
-        //TODO (Vladimir): take a look on ChildrenOfType method and try to rework 
-        //                 FindChildren method in that manner.
-        //                 http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6202
-
-        /// <summary>
-        /// Call this method to find child elements in a visual tree of a specific type,
-        /// given the parent visual element.
-        /// </summary>
-        /// <param name="parent">The parent visual element from which child visual elements 
-        /// are to be located.</param>
-        /// <typeparam name="T">The type of child visual element to look for.</typeparam>
-        /// <param name="childName">The name of child element to look for. This value can 
-        /// be an empty string if child element name is not a search criteria.</param>
-        /// <param name="foundChildren">A list of child elements that match the search criteria, 
-        /// or an empty list if none is found.</param>
-        /// 
-        public static void FindChildren<T>(DependencyObject parent, string childName, List<T> foundChildren)
-           where T : DependencyObject
-        {
-            if (parent == null) return;
-            if (foundChildren == null) return;
-
-            int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
-            for (int i = 0; i < childrenCount; i++)
-            {
-                var child = VisualTreeHelper.GetChild(parent, i);
-
-                T childType = child as T;
-                if (childType == null)
-                {
-                    FindChildren<T>(child, childName, foundChildren);
-                }
-                else if (!string.IsNullOrEmpty(childName))
-                {
-                    var frameworkElement = child as FrameworkElement;
-                    if (frameworkElement != null && frameworkElement.Name == childName)
-                        foundChildren.Add((T)child);
-                }
-                else
-                {
-                    foundChildren.Add((T)child);
-                }
-            }
-        }
     }
 }

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -82,7 +82,7 @@ namespace Dynamo.UI.Views
             var expanderContent = (sender as FrameworkElement);
             expanderContent.BringIntoView(new Rect(0.0, 0.0, 100.0, 20.0));
 
-            var buttons = WpfUtilities.ChildOfType<ListView>(expanderContent);
+            var buttons = expanderContent.ChildOfType<ListView>();
             if (buttons != null)
                 buttons.UnselectAll();
 
@@ -118,9 +118,8 @@ namespace Dynamo.UI.Views
             if (!(categoryButton.DataContext is RootNodeCategoryViewModel))
                 return;
 
-            var wrapPanels = new List<LibraryWrapPanel>();
-            WpfUtilities.FindChildren<LibraryWrapPanel>(categoryButton, string.Empty, wrapPanels);
-            if (wrapPanels.Count == 0)
+            var wrapPanels = categoryButton.ChildrenOfType<LibraryWrapPanel>();
+            if (!wrapPanels.Any())
                 return;
 
             var selectedElement = e.OriginalSource as FrameworkElement;


### PR DESCRIPTION
#### Purpose

After rework of method I have noticed that we can use another existing function. Refactored function was deleted...

#### Additional references

[MAGN-6202](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6202) Rework WpfUtilities.FindChildren using WpfUtilities.ChildrenOfType as example 

#### Reviewers

@Benglin, please, take a look.