### PR TITLE
DUI: Rename icon resource files 

### DIFF
--- a/src/DynamoCore/Library/LibraryCustomization.cs
+++ b/src/DynamoCore/Library/LibraryCustomization.cs
@@ -85,7 +85,7 @@ namespace Dynamo.DSEngine
             try
             {
                 var fn = Path.GetFileNameWithoutExtension(assemblyLocation);
-                resourceAssemblyPath = fn + Configurations.ResourcesDLL;
+                resourceAssemblyPath = fn + Configurations.IconResourcesDLL;
 
                 return DynamoPathManager.Instance.ResolveLibraryPath(ref resourceAssemblyPath);
             }

--- a/src/DynamoCore/Utilities/Configurations.cs
+++ b/src/DynamoCore/Utilities/Configurations.cs
@@ -185,7 +185,7 @@ namespace Dynamo.UI
 
         public const string SmallIconPostfix = ".Small";
         public const string LargeIconPostfix = ".Large";
-        public const string ResourcesDLL = ".resources.dll";
+        public const string IconResourcesDLL = ".customization.dll";
         public const string DefaultIcon = "DefaultIcon";
         public const string DefaultCustomNodeIcon = "DefaultCustomNode";
         public const string DefaultAssembly = "DynamoCore";

--- a/src/DynamoIcons/DynamoIcons.csproj
+++ b/src/DynamoIcons/DynamoIcons.csproj
@@ -48,27 +48,27 @@
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
     </GetReferenceAssemblyPaths>
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DSCoreNodesImages.resx" OutputResources="$(ProjectDir)DSCoreNodesImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)DSCoreNodesImages.resources" OutputAssembly="$(OutDir)DSCoreNodes.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DSCoreNodesImages.resources" OutputAssembly="$(OutDir)DSCoreNodes.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DSCoreNodesUIImages.resx" OutputResources="$(ProjectDir)DSCoreNodesUIImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)DSCoreNodesUIImages.resources" OutputAssembly="$(OutDir)DSCoreNodesUI.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DSCoreNodesUIImages.resources" OutputAssembly="$(OutDir)DSCoreNodesUI.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DSOfficeImages.resx" OutputResources="$(ProjectDir)DSOfficeImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)DSOfficeImages.resources" OutputAssembly="$(OutDir)DSOffice.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DSOfficeImages.resources" OutputAssembly="$(OutDir)DSOffice.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DSIronPythonNodeImages.resx" OutputResources="$(ProjectDir)DSIronPythonNodeImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)DSIronPythonNodeImages.resources" OutputAssembly="$(OutDir)DSIronPythonNode.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DSIronPythonNodeImages.resources" OutputAssembly="$(OutDir)DSIronPythonNode.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)TessellationImages.resx" OutputResources="$(ProjectDir)TessellationImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)TessellationImages.resources" OutputAssembly="$(OutDir)Tessellation.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)TessellationImages.resources" OutputAssembly="$(OutDir)Tessellation.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DynamoWatch3DImages.resx" OutputResources="$(ProjectDir)DynamoWatch3DImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)DynamoWatch3DImages.resources" OutputAssembly="$(OutDir)DynamoWatch3D.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DynamoWatch3DImages.resources" OutputAssembly="$(OutDir)DynamoWatch3D.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)ProtoGeometryImages.resx" OutputResources="$(ProjectDir)ProtoGeometryImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)ProtoGeometryImages.resources" OutputAssembly="$(OutDir)ProtoGeometry.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)ProtoGeometryImages.resources" OutputAssembly="$(OutDir)ProtoGeometry.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DynamoCoreImages.resx" OutputResources="$(ProjectDir)DynamoCoreImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)DynamoCoreImages.resources" OutputAssembly="$(OutDir)DynamoCore.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DynamoCoreImages.resources" OutputAssembly="$(OutDir)DynamoCore.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)UnitsUIImages.resx" OutputResources="$(ProjectDir)UnitsUIImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)UnitsUIImages.resources" OutputAssembly="$(OutDir)UnitsUI.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)UnitsUIImages.resources" OutputAssembly="$(OutDir)UnitsUI.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DynamoUnitsImages.resx" OutputResources="$(ProjectDir)DynamoUnitsImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)DynamoUnitsImages.resources" OutputAssembly="$(OutDir)DynamoUnits.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DynamoUnitsImages.resources" OutputAssembly="$(OutDir)DynamoUnits.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)AnalysisImages.resx" OutputResources="$(ProjectDir)AnalysisImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)AnalysisImages.resources" OutputAssembly="$(OutDir)Analysis.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)AnalysisImages.resources" OutputAssembly="$(OutDir)Analysis.customization.dll" />
   </Target>
   <Target Name="AfterBuild">
     <ItemGroup>


### PR DESCRIPTION
#### Purpose

To avoid confusion of users icon dlls are renamed from `*.resources.dll` to `*.customization.dll`

#### Additional references

[MAGN-6310](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6310) DUI: Rename icon resource files

#### Reviewers

@Benglin, please, take a look.