### PR TITLE
MAGN-5916 Delete key can fail to delete CBN with 7.6 refactor

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -318,13 +318,9 @@ namespace Dynamo.Controls
         {
             if (ViewModel == null) return;
 
-            if ((ViewModel.NodeLogic is CodeBlockNodeModel) == false)
-            {
-                // Do not return focus to search if this is a code block node.
-                var view = WpfUtilities.FindUpVisualTree<DynamoView>(this);
-                ViewModel.DynamoViewModel.ReturnFocusToSearch();
-                view.mainGrid.Focus();
-            }
+            var view = WpfUtilities.FindUpVisualTree<DynamoView>(this);
+            ViewModel.DynamoViewModel.ReturnFocusToSearch();
+            view.mainGrid.Focus();
 
             Guid nodeGuid = ViewModel.NodeModel.GUID;
             ViewModel.DynamoViewModel.ExecuteCommand(


### PR DESCRIPTION
**Issue** 
 When there are multiple codeblock nodes, and if any one of the codeblock node has the focus, then you cannot delete any of the codeblock nodes.

**Fix**
 After this fix, the CBN's will  behave like other nodes (say Number node). Clicking on any of the CBN will return the focus to the search. So, the CBN's can be deleted from the workspace. 

- [ ] @pboyer 