### PR TITLE
Remove full signature of member in description

### DIFF
--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -170,7 +170,7 @@ namespace Dynamo.DSEngine
         /// </summary>
         public string Description
         {
-            get { return !String.IsNullOrEmpty(Summary) ? Summary + "\n\n" + Signature : Signature; }
+            get { return !String.IsNullOrEmpty(Summary) ? Summary : string.Empty; }
         }
 
         /// <summary>


### PR DESCRIPTION
#### Purpose

Remove signature from description for `ZeroTouch` libraries.
![untitled1](https://cloud.githubusercontent.com/assets/8158551/6193049/6005fbd0-b3c0-11e4-87b8-b36a88536a95.png)

#### Additional references

[MAGN-6317](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6317) Remove full signature of member in description

#### Reviewers

@Benglin, please, take a look.