### PR TITLE
Fix crash in switching workspace when still editing code block node

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -279,7 +279,8 @@ namespace Dynamo.Models
 
         void UpdateModelValueImpl(UpdateModelValueCommand command)
         {
-            CurrentWorkspace.UpdateModelValue(command.ModelGuids,
+            var targetWorkspace = command.TargetWorkspace ?? CurrentWorkspace;
+            targetWorkspace.UpdateModelValue(command.ModelGuids,
                 command.Name, command.Value);
         }
 

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -279,7 +279,10 @@ namespace Dynamo.Models
 
         void UpdateModelValueImpl(UpdateModelValueCommand command)
         {
-            var targetWorkspace = command.TargetWorkspace ?? CurrentWorkspace;
+            WorkspaceModel targetWorkspace  = CurrentWorkspace;
+            if (!command.WorkspaceGuid.Equals(System.Guid.Empty))
+                targetWorkspace = Workspaces.FirstOrDefault(w => w.Guid.Equals(command.WorkspaceGuid));
+
             targetWorkspace.UpdateModelValue(command.ModelGuids,
                 command.Name, command.Value);
         }

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -921,19 +921,31 @@ namespace Dynamo.Models
         public class UpdateModelValueCommand : RecordableCommand
         {
             private readonly List<Guid> modelGuids;
-            private WorkspaceModel workspaceModel;
 
             #region Public Class Methods
 
+            /// <summary>
+            /// </summary>
+            /// <param name="modelGuid"></param>
+            /// <param name="name"></param>
+            /// <param name="value"></param>
+            /// <param name="workspaceModel">If workspace model is null, this command will be sent to the current workspace</param>
             public UpdateModelValueCommand(Guid modelGuid, string name, string value, WorkspaceModel workspaceModel = null)
                 : this(new[] {modelGuid}, name, value, workspaceModel)
             {
             }
 
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name="modelGuids"></param>
+            /// <param name="name"></param>
+            /// <param name="value"></param>
+            /// <param name="workspaceModel">If workspace model is null, this command will be sent to the current workspace</param>
             public UpdateModelValueCommand(IEnumerable<Guid> modelGuids, string name, string value, WorkspaceModel workspaceModel = null)
             {
                 this.modelGuids = new List<Guid>(modelGuids);
-                this.workspaceModel = workspaceModel;
+                TargetWorkspace = workspaceModel;
                 Name = name;
                 Value = value;
             }
@@ -967,18 +979,12 @@ namespace Dynamo.Models
 
             #endregion
 
-            #region Public Properties
-            public WorkspaceModel TargetWorkspace
-            {
-                get { return workspaceModel; }
-            }
-            #endregion
-
             #region Public Command Properties
 
             internal IEnumerable<Guid> ModelGuids { get { return modelGuids; } }
             internal string Name { get; private set; }
             internal string Value { get; private set; }
+            internal WorkspaceModel TargetWorkspace { get; private set; } 
 
             #endregion
 

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -921,17 +921,19 @@ namespace Dynamo.Models
         public class UpdateModelValueCommand : RecordableCommand
         {
             private readonly List<Guid> modelGuids;
+            private WorkspaceModel workspaceModel;
 
             #region Public Class Methods
 
-            public UpdateModelValueCommand(Guid modelGuid, string name, string value)
-                : this(new[] {modelGuid}, name, value)
+            public UpdateModelValueCommand(Guid modelGuid, string name, string value, WorkspaceModel workspaceModel = null)
+                : this(new[] {modelGuid}, name, value, workspaceModel)
             {
             }
 
-            public UpdateModelValueCommand(IEnumerable<Guid> modelGuids, string name, string value)
+            public UpdateModelValueCommand(IEnumerable<Guid> modelGuids, string name, string value, WorkspaceModel workspaceModel = null)
             {
                 this.modelGuids = new List<Guid>(modelGuids);
+                this.workspaceModel = workspaceModel;
                 Name = name;
                 Value = value;
             }
@@ -963,6 +965,13 @@ namespace Dynamo.Models
                 }
             }
 
+            #endregion
+
+            #region Public Properties
+            public WorkspaceModel TargetWorkspace
+            {
+                get { return workspaceModel; }
+            }
             #endregion
 
             #region Public Command Properties

--- a/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
+++ b/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
@@ -221,8 +221,8 @@ namespace Dynamo.Nodes
                         string propName = expr.ParentBinding.Path.Path;
                         nvm.DynamoViewModel.ExecuteCommand(
                             new DynamoModel.UpdateModelValueCommand(
-                                nvm.NodeModel.GUID, propName, Text,
-                                nodeViewModel.WorkspaceViewModel.Model));
+                                nodeViewModel.WorkspaceViewModel.Model.Guid,
+                                nvm.NodeModel.GUID, propName, Text));
                     }
                 }
 

--- a/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
+++ b/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
@@ -221,7 +221,8 @@ namespace Dynamo.Nodes
                         string propName = expr.ParentBinding.Path.Path;
                         nvm.DynamoViewModel.ExecuteCommand(
                             new DynamoModel.UpdateModelValueCommand(
-                                nvm.NodeModel.GUID, propName, Text));
+                                nvm.NodeModel.GUID, propName, Text,
+                                nodeViewModel.WorkspaceViewModel.Model));
                     }
                 }
 

--- a/src/DynamoCoreWpf/TestInfrastructure/CodeBlockNodeMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/CodeBlockNodeMutator.cs
@@ -169,7 +169,7 @@ namespace Dynamo.TestInfrastructure
                         }
                     }
 
-                    var cmd = new DynamoModel.UpdateModelValueCommand(node.GUID, "Code", replacement);
+                    var cmd = new DynamoModel.UpdateModelValueCommand(System.Guid.Empty, node.GUID, "Code", replacement);
 
                     this.DynamoViewModel.ExecuteCommand(cmd);
                 }));

--- a/src/DynamoCoreWpf/TestInfrastructure/DirectoryPathMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/DirectoryPathMutator.cs
@@ -122,7 +122,7 @@ namespace Dynamo.TestInfrastructure
             DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
             {
                 DynamoModel.UpdateModelValueCommand updateValue =
-                    new DynamoModel.UpdateModelValueCommand(node.GUID, "Value", assemblyPath);
+                    new DynamoModel.UpdateModelValueCommand(System.Guid.Empty, node.GUID, "Value", assemblyPath);
 
                 DynamoViewModel.ExecuteCommand(updateValue);
             }));

--- a/src/DynamoCoreWpf/TestInfrastructure/DoubleSliderMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/DoubleSliderMutator.cs
@@ -141,7 +141,7 @@ namespace Dynamo.TestInfrastructure
                 DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
                 {
                     DynamoModel.UpdateModelValueCommand updateValue =
-                        new DynamoModel.UpdateModelValueCommand(node.GUID, "Value", value);
+                        new DynamoModel.UpdateModelValueCommand(System.Guid.Empty, node.GUID, "Value", value);
                     DynamoViewModel.ExecuteCommand(updateValue);
                 }));
 

--- a/src/DynamoCoreWpf/TestInfrastructure/FilePathMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/FilePathMutator.cs
@@ -121,7 +121,7 @@ namespace Dynamo.TestInfrastructure
             DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
             {
                 DynamoModel.UpdateModelValueCommand updateValue =
-                    new DynamoModel.UpdateModelValueCommand(node.GUID, "Value", assemblyPath);
+                    new DynamoModel.UpdateModelValueCommand(System.Guid.Empty, node.GUID, "Value", assemblyPath);
 
                 DynamoViewModel.ExecuteCommand(updateValue);
             }));

--- a/src/DynamoCoreWpf/TestInfrastructure/IntegerSliderMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/IntegerSliderMutator.cs
@@ -145,7 +145,7 @@ namespace Dynamo.TestInfrastructure
                 DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
                 {
                     DynamoModel.UpdateModelValueCommand updateValue =
-                        new DynamoModel.UpdateModelValueCommand(node.GUID, "Value", value);
+                        new DynamoModel.UpdateModelValueCommand(System.Guid.Empty, node.GUID, "Value", value);
                     DynamoViewModel.ExecuteCommand(updateValue);
                 }));
 

--- a/src/DynamoCoreWpf/TestInfrastructure/NumberInputMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/NumberInputMutator.cs
@@ -115,7 +115,7 @@ namespace Dynamo.TestInfrastructure
             DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
             {
                 DynamoModel.UpdateModelValueCommand updateValue =
-                    new DynamoModel.UpdateModelValueCommand(node.GUID, "Value", value);
+                    new DynamoModel.UpdateModelValueCommand(System.Guid.Empty, node.GUID, "Value", value);
 
                 DynamoViewModel.ExecuteCommand(updateValue);
             }));

--- a/src/DynamoCoreWpf/TestInfrastructure/StringInputMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/StringInputMutator.cs
@@ -120,7 +120,7 @@ namespace Dynamo.TestInfrastructure
             DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
             {
                 DynamoModel.UpdateModelValueCommand updateValue =
-                    new DynamoModel.UpdateModelValueCommand(node.GUID, "Value", value);
+                    new DynamoModel.UpdateModelValueCommand(System.Guid.Empty, node.GUID, "Value", value);
 
                 DynamoViewModel.ExecuteCommand(updateValue);
             }));

--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
@@ -55,7 +55,7 @@ namespace Dynamo.UI.Prompts
 
                 dynamoViewModel.ExecuteCommand(
                     new DynCmd.UpdateModelValueCommand(
-                        model.GUID, propName, editText.Text));
+                        System.Guid.Empty, model.GUID, propName, editText.Text));
             }
 
             this.DialogResult = true;

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -551,7 +551,7 @@ namespace Dynamo.ViewModels
         {           
             this.DynamoViewModel.ExecuteCommand(
               new DynamoModel.UpdateModelValueCommand(
-                    this.NodeModel.GUID, "ArgumentLacing", param.ToString()));
+                    System.Guid.Empty, this.NodeModel.GUID, "ArgumentLacing", param.ToString()));
           
             DynamoViewModel.UndoCommand.RaiseCanExecuteChanged();
             DynamoViewModel.RedoCommand.RaiseCanExecuteChanged();

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
@@ -450,9 +450,10 @@ namespace Dynamo.UI.Controls
             if (!nodeModel.Code.Equals(InnerTextEditor.Text))
             {
                 nodeViewModel.DynamoViewModel.ExecuteCommand(
-                    new DynCmd.UpdateModelValueCommand(nodeModel.GUID,
-                        "Code", InnerTextEditor.Text,
-                        nodeViewModel.WorkspaceViewModel.Model));
+                    new DynCmd.UpdateModelValueCommand(
+                        nodeViewModel.WorkspaceViewModel.Model.Guid,
+                        nodeModel.GUID,
+                        "Code", InnerTextEditor.Text));
             }
 
             if (createdForNewCodeBlock)

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
@@ -451,7 +451,8 @@ namespace Dynamo.UI.Controls
             {
                 nodeViewModel.DynamoViewModel.ExecuteCommand(
                     new DynCmd.UpdateModelValueCommand(nodeModel.GUID,
-                        "Code", InnerTextEditor.Text));
+                        "Code", InnerTextEditor.Text,
+                        nodeViewModel.WorkspaceViewModel.Model));
             }
 
             if (createdForNewCodeBlock)

--- a/src/DynamoCoreWpf/Views/Input/ParameterEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Input/ParameterEditor.xaml.cs
@@ -182,8 +182,8 @@ namespace Dynamo.UI.Controls
             nodeViewModel.DynamoViewModel.ExecuteCommand(
                 new DynCmd.UpdateModelValueCommand(
                     nodeViewModel.NodeModel.GUID, "InputSymbol",
-                    InnerTextEditor.Text));
-
+                    InnerTextEditor.Text,
+                    nodeViewModel.WorkspaceViewModel.Model));
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Input/ParameterEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Input/ParameterEditor.xaml.cs
@@ -181,9 +181,9 @@ namespace Dynamo.UI.Controls
 
             nodeViewModel.DynamoViewModel.ExecuteCommand(
                 new DynCmd.UpdateModelValueCommand(
+                    nodeViewModel.WorkspaceViewModel.Model.Guid,
                     nodeViewModel.NodeModel.GUID, "InputSymbol",
-                    InnerTextEditor.Text,
-                    nodeViewModel.WorkspaceViewModel.Model));
+                    InnerTextEditor.Text));
         }
 
         /// <summary>

--- a/src/Libraries/IronPython/ScriptEditorWindow.xaml.cs
+++ b/src/Libraries/IronPython/ScriptEditorWindow.xaml.cs
@@ -129,7 +129,7 @@ namespace DSIronPythonNode
             if (DialogResult.HasValue && (DialogResult.Value))
             {
                 var command = new DynamoModel.UpdateModelValueCommand(
-                    boundNodeId, propertyName, editText.Text);
+                    System.Guid.Empty, boundNodeId, propertyName, editText.Text);
 
                 dynamoViewModel.ExecuteCommand(command);
             }

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -772,7 +772,7 @@ b = c[w][x][y][z];";
 
         private void UpdateCodeBlockNodeContent(CodeBlockNodeModel cbn, string value)
         {
-            var command = new DynCmd.UpdateModelValueCommand(cbn.GUID, "Code", value);
+            var command = new DynCmd.UpdateModelValueCommand(System.Guid.Empty, cbn.GUID, "Code", value);
             ViewModel.ExecuteCommand(command);
         }
     }

--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -68,7 +68,7 @@ namespace Dynamo.Tests
 
         private void UpdateCodeBlockNodeContent(CodeBlockNodeModel cbn, string value)
         {
-            var command = new DynCmd.UpdateModelValueCommand(cbn.GUID, "Code", value);
+            var command = new DynCmd.UpdateModelValueCommand(System.Guid.Empty, cbn.GUID, "Code", value);
             ViewModel.ExecuteCommand(command);
         }
 

--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -271,7 +271,7 @@ namespace DynamoCoreUITests
             string name = randomizer.Next().ToString();
             string value = randomizer.Next().ToString();
 
-            var cmdOne = new DynamoModel.UpdateModelValueCommand(modelGuid, name, value);
+            var cmdOne = new DynamoModel.UpdateModelValueCommand(System.Guid.Empty, modelGuid, name, value);
             var cmdTwo = DuplicateAndCompare(cmdOne);
 
             Assert.IsTrue(cmdOne.ModelGuids.SequenceEqual(cmdTwo.ModelGuids));
@@ -295,7 +295,7 @@ namespace DynamoCoreUITests
             string name = randomizer.Next().ToString();
             string value = randomizer.Next().ToString();
 
-            var cmdOne = new DynamoModel.UpdateModelValueCommand(modelGuids, name, value);
+            var cmdOne = new DynamoModel.UpdateModelValueCommand(System.Guid.Empty, modelGuids, name, value);
             var cmdTwo = DuplicateAndCompare(cmdOne);
 
             Assert.IsTrue(cmdOne.ModelGuids.SequenceEqual(cmdTwo.ModelGuids));

--- a/test/Libraries/DynamoPythonTests/PythonEditTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEditTests.cs
@@ -129,7 +129,7 @@ namespace Dynamo.Tests
         private void UpdatePythonNodeContent(ModelBase pythonNode, string value)
         {
             var command = new DynCmd.UpdateModelValueCommand(
-                pythonNode.GUID, "ScriptContent", value);
+                System.Guid.Empty, pythonNode.GUID, "ScriptContent", value);
 
             ViewModel.ExecuteCommand(command);
         }


### PR DESCRIPTION
This PR tries to fix defect [MAGN-6236 Navigating between workspaces after typing in an incomplete statement in any input node( CBN/Input/Number node) crashes Dynamo](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6236).

That is because when switching workspace, we need to commit the change for code block node. Internally, we use ``UpdateModelValueCommand`` which consequently update the value of node that in **current workspace model**:
```
void UpdateModelValueImpl(UpdateModelValueCommand command)
{
    CurrentWorkspace.UpdateModelValue(command.ModelGuids, ...
}
```
As the workspace has been switched to the other one, ``UpdateModelValue`` will fail. 

The fix is to save the target workspace model in ``UpdateModelValueCommand``. But this fix is not ideal : it won't supported in recordable framework because workspace model information is not serialized. A way to fix it is to use workspace's GUID instead of keeping a reference to workspace in ``UpdateModelValueCommand`` so that GUID could be serialized, but this solution has problem in deserialization -- right now the recordable framework doesn't the GUID of workspace when it is serializing the commands, neither capturing GUID of home workspace, so here we still use direct reference to workspace model in the command. 

  - [ ] @Benglin    