### PR TITLE
Get the next graphnode to be executed

### DIFF
--- a/src/Engine/ProtoCore/AssociativeGraph.cs
+++ b/src/Engine/ProtoCore/AssociativeGraph.cs
@@ -1296,32 +1296,14 @@ namespace ProtoCore.AssociativeGraph
             {
                 foreach (GraphNode gnode in gnodeList)
                 {
-                    if (gnode.isActive && gnode.isDirty && gnode.updateBlock.startpc >= pc)
-                    {
-                        return gnode;
-                    }
-                }
-            }
-            return null;
-        }
-
-        /// <summary>
-        /// Gets the first dirty graphnode
-        /// </summary>
-        /// <param name="pc"></param>
-        /// <param name="classIndex"></param>
-        /// <param name="procIndex"></param>
-        /// <returns></returns>
-        public GraphNode GetFirstDirtyGraphNode(int classIndex, int procIndex)
-        {
-            List<GraphNode> gnodeList = GetGraphNodesAtScope(classIndex, procIndex);
-            if (gnodeList != null && gnodeList.Count > 0)
-            {
-                foreach (GraphNode gnode in gnodeList)
-                {
                     if (gnode.isActive && gnode.isDirty)
                     {
-                        return gnode;
+                        bool isFirstDirtyNode = pc == Constants.kInvalidIndex;
+                        bool isFirstDirtyNodeAfterPC = pc != Constants.kInvalidIndex && gnode.updateBlock.startpc >= pc;
+                        if (isFirstDirtyNode || isFirstDirtyNodeAfterPC)
+                        {
+                            return gnode;
+                        }
                     }
                 }
             }

--- a/src/Engine/ProtoCore/AssociativeGraph.cs
+++ b/src/Engine/ProtoCore/AssociativeGraph.cs
@@ -1305,6 +1305,28 @@ namespace ProtoCore.AssociativeGraph
             return null;
         }
 
+        /// <summary>
+        /// Gets the first dirty graphnode
+        /// </summary>
+        /// <param name="pc"></param>
+        /// <param name="classIndex"></param>
+        /// <param name="procIndex"></param>
+        /// <returns></returns>
+        public GraphNode GetFirstDirtyGraphNode(int classIndex, int procIndex)
+        {
+            List<GraphNode> gnodeList = GetGraphNodesAtScope(classIndex, procIndex);
+            if (gnodeList != null && gnodeList.Count > 0)
+            {
+                foreach (GraphNode gnode in gnodeList)
+                {
+                    if (gnode.isActive && gnode.isDirty)
+                    {
+                        return gnode;
+                    }
+                }
+            }
+            return null;
+        }
 
         private ulong GetGraphNodeKey(int classIndex, int procIndex)
         {

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -6966,7 +6966,7 @@ namespace ProtoCore.DSASM
                 else
                 {
                     // Allow immediate update if we are in a local scope.
-                    nextGraphNode = istream.dependencyGraph.GetFirstDirtyGraphNode(ci, fi);
+                    nextGraphNode = istream.dependencyGraph.GetFirstDirtyGraphNode(Constants.kInvalidIndex, ci, fi);
                 }
             }
             else

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -6928,22 +6928,7 @@ namespace ProtoCore.DSASM
             {
                 // Go to the next pc
                 pc++;
-
-                // Given the next pc, get the next graphnode to execute and mark it clean
-                if (runtimeCore.Options.IsDeltaExecution)
-                {
-                    // On delta execution, it is possible that the next graphnode is clean
-                    // Retrieve the next dirty graphnode given the pc
-                    // Associative update is handled when ApplyUpdate = true
-                    Properties.executingGraphNode = istream.dependencyGraph.GetFirstDirtyGraphNode(pc, ci, fi);
-                }
-                else
-                {
-                    // On normal execution, just retrieve the graphnode associated with pc
-                    // Associative update is handled in jdep
-                    Properties.executingGraphNode = istream.dependencyGraph.GetGraphNode(pc, ci, fi);
-                }
-
+                Properties.executingGraphNode = GetNextGraphNodeToExecute(pc, ci, fi);
                 if (Properties.executingGraphNode != null)
                 {
                     Properties.executingGraphNode.isDirty = false;
@@ -6952,6 +6937,45 @@ namespace ProtoCore.DSASM
             }
             GC();
             return;
+        }
+
+        /// <summary>
+        /// Get the next graphnode to execute given the current next pc and scope
+        /// </summary>
+        /// <param name="pc"></param>
+        /// <param name="ci"></param>
+        /// <param name="fi"></param>
+        private AssociativeGraph.GraphNode GetNextGraphNodeToExecute(int nextPC, int ci, int fi)
+        {
+            AssociativeGraph.GraphNode nextGraphNode = null;
+
+            // Given the next pc, get the next graphnode to execute and mark it clean
+            if (runtimeCore.Options.IsDeltaExecution)
+            {
+                if (IsGlobalScope())
+                {
+                    // At the global scope, no associative update occurs. Dirty nodes are accumulated and only executed on ApplyUpdate
+                    // This behavior conforms to the Transaction Update design
+                    // https://docs.google.com/a/adsk-oss.com/document/d/1v-eV16hzeBINKKY-F8sa6b0s_Q4Fafih1uOus8hYyD8
+
+                    // On delta execution, it is possible that the next graphnode is clean
+                    // Retrieve the next dirty graphnode given the pc
+                    // Associative update is handled when ApplyUpdate = true
+                    nextGraphNode = istream.dependencyGraph.GetFirstDirtyGraphNode(nextPC, ci, fi);
+                }
+                else
+                {
+                    // Allow immediate update if we are in a local scope.
+                    nextGraphNode = istream.dependencyGraph.GetFirstDirtyGraphNode(ci, fi);
+                }
+            }
+            else
+            {
+                // On normal execution, just retrieve the graphnode associated with pc
+                // Associative update is handled in jdep
+                nextGraphNode = istream.dependencyGraph.GetGraphNode(nextPC, ci, fi);
+            }
+            return nextGraphNode;
         }
 
         private void JDEP_Handler(Instruction instruction)

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -5444,6 +5444,33 @@ a = p.UpdateCount;
             astLiveRunner.UpdateGraph(syncData);
             AssertValue("y", 1);
         }
+
+        [Test]
+        public void TestAssociativeupdateWithinFunction01()
+        {
+            // Test that there are no warnings because the unbound variable is resolved downstream
+            string code =
+            @"
+def f()
+{
+	a = 1;
+	b = a;
+	a = 10;
+	return = b;
+}
+x = f();
+            ";
+
+            Guid guid = System.Guid.NewGuid();
+
+            List<Subtree> added = new List<Subtree>();
+            added.Add(CreateSubTreeFromCode(guid, code));
+
+            var syncData = new GraphSyncData(null, added, null);
+            astLiveRunner.UpdateGraph(syncData);
+
+            AssertValue("x", 10);
+        }
     }
 
 }


### PR DESCRIPTION
@ke-yu  PTAL

1. On live-execution, associative update is only allowed on non-global
scope.
2. On the global scope, associative update is handled by the
Applyupdate. This conforms to the Transaction update behavior.
3. Added assoc update behavior on local scope for live-execution

Pls see this doc for the Transaction update behavior
https://docs.google.com/a/adsk-oss.com/document/d/1v-eV16hzeBINKKY-F8sa6b0s_Q4Fafih1uOus8hYyD8