### PR TITLE
DUI: When Dynamo is behind a number of other windows, the tooltips pop up to obscure other windows

### DIFF
--- a/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
+++ b/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
@@ -350,6 +350,7 @@ namespace Dynamo.UI.Controls
         private DispatcherTimer dispatcherTimer = new DispatcherTimer();
         private DispatcherTimer showTimer = new DispatcherTimer();
         private object nextDataContext;
+        private DynamoView mainDynamoWindow;
 
         public LibraryToolTipPopup()
         {
@@ -368,7 +369,7 @@ namespace Dynamo.UI.Controls
         // If we try to load it before, we will get null.
         private void LoadMainDynamoWindow(object sender, RoutedEventArgs e)
         {
-            var mainDynamoWindow = WpfUtilities.FindUpVisualTree<DynamoView>(this);
+            mainDynamoWindow = WpfUtilities.FindUpVisualTree<DynamoView>(this);
             if (mainDynamoWindow == null)
                 return;
 
@@ -383,6 +384,9 @@ namespace Dynamo.UI.Controls
 
         public void SetDataContext(object dataContext, bool closeImmediately = false)
         {
+            // If Dynamo window is not active, we should not show as well as hide tooltip or do any other staff.
+            if (!mainDynamoWindow.IsActive) return;
+
             if (dataContext == null)
             {
                 if (closeImmediately)


### PR DESCRIPTION
Open Dynamo, open a web browser or other application to partly obscure the Dynamo window, hover over the partially obscured Dynamo library.  Tooltips will pop out and obscure the top level window.  See image.
![2015-02-03_0750](https://cloud.githubusercontent.com/assets/8158404/6212706/e320a416-b5f0-11e4-83ad-4dda23fc0f98.png)

Reviewers
@Benglin ,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-6217](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6217#) DUI:  When Dynamo is behind a number of other windows, the tooltips pop up to obscure other windows