### PR TITLE
Provide support for description for Built-in methods

### DIFF
--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -442,12 +442,17 @@ namespace Dynamo.DSEngine
                                                                     argType))
                                                         let visibleInLibrary =
                                                             (method.MethodAttribute == null
-                                                                || !method.MethodAttribute.HiddenInLibrary)
+                                                                || !method.MethodAttribute
+                                                                    .HiddenInLibrary)
+                                                        let description =
+                                                            (method.MethodAttribute != null
+                                                                ? method.MethodAttribute.Description : String.Empty)
                                                         select
                                                             new FunctionDescriptor(
                                                                 null,
                                                                 null,
                                                                 method.name,
+                                                                description,
                                                                 arguments,
                                                                 method.returntype,
                                                                 FunctionType.GenericFunction,

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -167,7 +167,8 @@ namespace ProtoCore.Lang
                     {
                         new KeyValuePair<string, ProtoCore.Type>("array", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, Constants.kArbitraryRank))
                     },
-                    ID = BuiltInMethods.MethodID.kCount
+                    ID = BuiltInMethods.MethodID.kCount,
+                    MethodAttributes = new MethodAttributes(){Description = "Returns number of items in the specified list."}
                 },
 
                 new BuiltInMethod

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -1268,6 +1268,11 @@ namespace ProtoCore.AST.AssociativeAST
         public string ObsoleteMessage { get; protected set; }
         public bool IsObsolete { get { return !string.IsNullOrEmpty(ObsoleteMessage); } }
         
+        /// <summary>
+        /// Gets/Sets description for the method.
+        /// </summary>
+        public string Description { get; set; }
+        
         public MethodAttributes(bool hiddenInLibrary = false, string msg = "")
         {
             HiddenInLibrary = hiddenInLibrary;


### PR DESCRIPTION
- Added Description property to MethodAttributes class to hold
description for the method.
- BuiltInMethods can be now created with MethodAttribute instance with
Description.
- LibraryServices queries Description property from MethodAttribute of
method and populates summary of corresponding FunctionDescriptor
instance to show Description for built-in methods in library UI.