### PR TITLE
Fixes input/output parameters on node tooltip

### DIFF
--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -91,21 +91,21 @@ namespace Dynamo.DSEngine
                     });
             }
 
+            var inputParameters = new List<Tuple<string, string>>();
+            //Add instance parameter as one of the inputs for instance method as well as properties.
+            if(type == FunctionType.InstanceMethod || type == FunctionType.InstanceProperty)
+                inputParameters.Add(Tuple.Create(UnqualifedClassName.ToLower(), UnqualifedClassName));
+
             if (Parameters.Any())
             {
-                InputParameters = Parameters.Select(
-                    par =>
-                    {
-                        return Tuple.Create<string, string>(par.Name, par.DisplayTypeName);
-                    }
-                    );
-            }
-            else
-            {
-                InputParameters = new List<Tuple<string, string>>();
+                inputParameters.AddRange(Parameters.Select(
+                    par => Tuple.Create(par.Name, par.DisplayTypeName)));
             }
 
-            ReturnType = returnType.ToShortString();
+            InputParameters = inputParameters;
+            
+            //Not sure why returnType for constructors are var[]..[], use UnqualifiedClassName
+            ReturnType = (type == FunctionType.Constructor) ? UnqualifedClassName : returnType.ToShortString();
             Type = type;
             ReturnKeys = returnKeys ?? new List<string>();
             IsVarArg = isVarArg;


### PR DESCRIPTION
This submission fixes following two issues:
- Input parameters on instance methods and properties don't contain
information about this instance.
- The output type for Constructor is shown as var[]..[]
- Fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4672 & http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6356