### PR TITLE
MAGN-6361 Running 7.6 in French Windows "Select Model Element" does not present a UI button

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/Properties/AssemblyInfo.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -6,14 +7,8 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("CoreNodeModelsWpf")]
-
 [assembly: AssemblyCulture("")]
-
-
-
+[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8a24e7a0-5c03-4fe3-bfce-7c4c6858c19a")]
-
-
-
 [assembly: InternalsVisibleTo("DynamoCoreUITests")]


### PR DESCRIPTION
For computers' whose region was set to something other than english, resources could not be found because the assembly attribute had not been set to specify where the system should look if a resource for the current ui culture could not be found. This PR adds the NeutralResourcesLanguage attribute, that has been added to other assemblies, to the CoreNodeModelsWpf assembly. This will cause users's systems in foreign locales to fall back to using the "en-US" resources when resources are not available for their culture.

FYI:
@jnealb @RodRecker 