### PR TITLE
Fix issue that license and samples are missing in other locales

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -390,6 +390,10 @@ namespace Dynamo.ViewModels
                 string rootModuleDirectory = System.IO.Path.GetDirectoryName(executingAssemblyPathName);
                 var language = System.Threading.Thread.CurrentThread.CurrentUICulture.ToString();
                 var licensePath = System.IO.Path.Combine(rootModuleDirectory, language, "License.rtf");
+                // Fall back to en-US folder
+                if (!File.Exists(licensePath))
+                    licensePath = System.IO.Path.Combine(rootModuleDirectory, "en-US", "License.rtf");
+
                 return licensePath;
             }
         }

--- a/src/DynamoUtilities/DynamoPathManager.cs
+++ b/src/DynamoUtilities/DynamoPathManager.cs
@@ -148,7 +148,12 @@ namespace DynamoUtilities
             CommonSamples = Path.Combine(commonData, "samples", UICulture);
             if (!Directory.Exists(CommonSamples))
             {
-                Directory.CreateDirectory(CommonSamples);
+                var neturalCommonSamples = Path.Combine(commonData, "samples", "en-US");
+
+                if (Directory.Exists(neturalCommonSamples))
+                    CommonSamples = neturalCommonSamples;
+                else
+                    Directory.CreateDirectory(CommonSamples);
             }
 
             if (Nodes == null)


### PR DESCRIPTION
In the code we use current UI culture (note it is different from system locale. UI culture depends on which language version that Revit is running) to decide the folder of license and samples . As license.rtf and samples haven't been localized yet, they are in default en-US folder, therefore Dynamo fails to load them from other locale folder, for example, from zh-CN folder.

Tested with Chinese Revit 2015. 

@sharadkjaiswal for your review. 