### PR TITLE
Update tooltip content for PortModel if function definition is updated

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -1142,7 +1142,7 @@ namespace Dynamo.Models
                             p.UsingDefaultValue = true;
                             p.DefaultValueEnabled = true;
                         }
-
+                        p.ToolTipContent = data.ToolTipString;
                         return p;
                     }
 

--- a/src/DynamoCore/Models/PortModel.cs
+++ b/src/DynamoCore/Models/PortModel.cs
@@ -91,7 +91,7 @@ namespace Dynamo.Models
             }
         }
 
-        public string ToolTipContent { get; set; }
+        public string ToolTipContent { get; internal set; }
 
         public string DefaultValueTip
         {

--- a/src/DynamoCore/Models/PortModel.cs
+++ b/src/DynamoCore/Models/PortModel.cs
@@ -91,7 +91,7 @@ namespace Dynamo.Models
             }
         }
 
-        public string ToolTipContent { get; private set; }
+        public string ToolTipContent { get; set; }
 
         public string DefaultValueTip
         {


### PR DESCRIPTION
To fix [defect MAGN-6325 Parameter types not updated on custom node tool tip when set](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6325)

`PortModel.ToolTipContent` needs to be in sync with `PortData.ToolTip`.

@pboyer , please review the change.