### PR TITLE
DUI: Shorten the tool tip description for long texts

### DIFF
--- a/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
+++ b/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
@@ -11,6 +11,10 @@
              Background="Transparent">
     <UserControl.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.SidebarGridDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+            
             <controls:FullyQualifiedNameToDisplayConverter x:Key="FullyQualifiedNameToDisplayConverter" />
             <controls:InOutParamTypeConverter x:Key="InOutParamTypeConverter" />
             <controls:NullValueToCollapsedConverter x:Key="NullValueToCollapsedConverter" />
@@ -21,155 +25,6 @@
             <controls:BooleanToBrushConverter x:Key="DescriptionToColorConverter"
                                               TrueBrush="#cccccc"
                                               FalseBrush="#666666" />
-
-            <!-- Region ScrollBar Template-->
-
-            <ControlTemplate x:Key="ScrollViewerControlTemplate"
-                             TargetType="{x:Type ScrollViewer}">
-                <Grid x:Name="Grid"
-                      Background="{TemplateBinding Background}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-                    <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
-                                            CanContentScroll="{TemplateBinding CanContentScroll}"
-                                            CanHorizontallyScroll="False"
-                                            CanVerticallyScroll="True"
-                                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                                            Content="{TemplateBinding Content}"
-                                            Grid.RowSpan="2"
-                                            Margin="{TemplateBinding Padding}"
-                                            Grid.ColumnSpan="2" />
-                    <ScrollBar x:Name="PART_VerticalScrollBar"
-                               AutomationProperties.AutomationId="VerticalScrollBar"
-                               Cursor="Arrow"
-                               Grid.Column="1"
-                               Maximum="{TemplateBinding ScrollableHeight}"
-                               Minimum="0"
-                               Grid.Row="0"
-                               Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-                               Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                               ViewportSize="{TemplateBinding ViewportHeight}"
-                               Width="10" />
-                </Grid>
-            </ControlTemplate>
-
-            <!--EndRegion-->
-
-            <!-- Region ScrollBar Styles-->
-
-            <Style x:Key="VerticalThumb"
-                   TargetType="{x:Type Thumb}">
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type Thumb}">
-                            <Grid>
-                                <Rectangle HorizontalAlignment="Stretch"
-                                           VerticalAlignment="Stretch"
-                                           Width="Auto"
-                                           Height="Auto"
-                                           Fill="Transparent" />
-                                <Border x:Name="Rectangle1"
-                                        HorizontalAlignment="Stretch"
-                                        VerticalAlignment="Stretch"
-                                        Width="5"
-                                        Height="Auto"
-                                        Background="#aaaaaa"
-                                        Opacity="0.5"
-                                        CornerRadius="2" />
-                            </Grid>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-            <Style x:Key="ScrollViewerStyle"
-                   TargetType="ScrollViewer">
-                <Setter Property="VerticalScrollBarVisibility"
-                        Value="Hidden" />
-                <Style.Triggers>
-                    <Trigger Property="IsMouseOver"
-                             Value="true">
-                        <Setter Property="VerticalScrollBarVisibility"
-                                Value="Auto" />
-                    </Trigger>
-                </Style.Triggers>
-            </Style>
-
-            <Style TargetType="{x:Type ScrollBar}">
-                <Setter Property="Stylus.IsPressAndHoldEnabled"
-                        Value="false" />
-                <Setter Property="Stylus.IsFlicksEnabled"
-                        Value="false" />
-                <Setter Property="Foreground"
-                        Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                <Setter Property="Width"
-                        Value="10" />
-                <Setter Property="MinWidth"
-                        Value="10" />
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type ScrollBar}">
-                            <Grid x:Name="Bg"
-                                  SnapsToDevicePixels="true"
-                                  Background="Transparent">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="0.00001*" />
-                                </Grid.RowDefinitions>
-                                <Track x:Name="PART_Track"
-                                       IsDirectionReversed="true"
-                                       IsEnabled="{TemplateBinding IsMouseOver}">
-                                    <Track.Thumb>
-                                        <Thumb Style="{DynamicResource VerticalThumb}"
-                                               Width="6" />
-                                    </Track.Thumb>
-                                </Track>
-                            </Grid>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-                <Style.Triggers>
-                    <Trigger Property="Orientation"
-                             Value="Horizontal">
-                        <Setter Property="Width"
-                                Value="Auto" />
-                        <Setter Property="MinWidth"
-                                Value="0" />
-                        <Setter Property="Height"
-                                Value="10" />
-                        <Setter Property="MinHeight"
-                                Value="10" />
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="{x:Type ScrollBar}">
-                                    <Grid x:Name="Bg"
-                                          SnapsToDevicePixels="true"
-                                          Background="#7FA7A7A7">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="0.00001*" />
-                                        </Grid.ColumnDefinitions>
-                                        <Track x:Name="PART_Track"
-                                               IsEnabled="{TemplateBinding IsMouseOver}">
-                                            <Track.Thumb>
-                                                <Thumb Style="{DynamicResource HorizontalThumb}"
-                                                       Height="6" />
-                                            </Track.Thumb>
-                                        </Track>
-                                    </Grid>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Trigger>
-                </Style.Triggers>
-            </Style>
-
-            <!--EndRegion-->
-
         </ResourceDictionary>
     </UserControl.Resources>
     <Border CornerRadius="5"
@@ -199,8 +54,8 @@
                     <ColumnDefinition Width="96"></ColumnDefinition>
                 </Grid.ColumnDefinitions>
 
-                <ScrollViewer Template="{DynamicResource ScrollViewerControlTemplate}"
-                              Style="{StaticResource ScrollViewerStyle}"
+                <ScrollViewer Template="{DynamicResource TooltipScrollViewerControlTemplate}"
+                              Style="{DynamicResource LibraryScrollViewerStyle}"
                               CanContentScroll="True">
                     <TextBlock Text="{Binding Path=Description}"
                                FontSize="13"

--- a/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
+++ b/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
@@ -21,6 +21,155 @@
             <controls:BooleanToBrushConverter x:Key="DescriptionToColorConverter"
                                               TrueBrush="#cccccc"
                                               FalseBrush="#666666" />
+
+            <!-- Region ScrollBar Template-->
+
+            <ControlTemplate x:Key="ScrollViewerControlTemplate"
+                             TargetType="{x:Type ScrollViewer}">
+                <Grid x:Name="Grid"
+                      Background="{TemplateBinding Background}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
+                                            CanContentScroll="{TemplateBinding CanContentScroll}"
+                                            CanHorizontallyScroll="False"
+                                            CanVerticallyScroll="True"
+                                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                                            Content="{TemplateBinding Content}"
+                                            Grid.RowSpan="2"
+                                            Margin="{TemplateBinding Padding}"
+                                            Grid.ColumnSpan="2" />
+                    <ScrollBar x:Name="PART_VerticalScrollBar"
+                               AutomationProperties.AutomationId="VerticalScrollBar"
+                               Cursor="Arrow"
+                               Grid.Column="1"
+                               Maximum="{TemplateBinding ScrollableHeight}"
+                               Minimum="0"
+                               Grid.Row="0"
+                               Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                               Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
+                               ViewportSize="{TemplateBinding ViewportHeight}"
+                               Width="10" />
+                </Grid>
+            </ControlTemplate>
+
+            <!--EndRegion-->
+
+            <!-- Region ScrollBar Styles-->
+
+            <Style x:Key="VerticalThumb"
+                   TargetType="{x:Type Thumb}">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type Thumb}">
+                            <Grid>
+                                <Rectangle HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Stretch"
+                                           Width="Auto"
+                                           Height="Auto"
+                                           Fill="Transparent" />
+                                <Border x:Name="Rectangle1"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Stretch"
+                                        Width="5"
+                                        Height="Auto"
+                                        Background="#aaaaaa"
+                                        Opacity="0.5"
+                                        CornerRadius="2" />
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style x:Key="ScrollViewerStyle"
+                   TargetType="ScrollViewer">
+                <Setter Property="VerticalScrollBarVisibility"
+                        Value="Hidden" />
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver"
+                             Value="true">
+                        <Setter Property="VerticalScrollBarVisibility"
+                                Value="Auto" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="{x:Type ScrollBar}">
+                <Setter Property="Stylus.IsPressAndHoldEnabled"
+                        Value="false" />
+                <Setter Property="Stylus.IsFlicksEnabled"
+                        Value="false" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                <Setter Property="Width"
+                        Value="10" />
+                <Setter Property="MinWidth"
+                        Value="10" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type ScrollBar}">
+                            <Grid x:Name="Bg"
+                                  SnapsToDevicePixels="true"
+                                  Background="Transparent">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="0.00001*" />
+                                </Grid.RowDefinitions>
+                                <Track x:Name="PART_Track"
+                                       IsDirectionReversed="true"
+                                       IsEnabled="{TemplateBinding IsMouseOver}">
+                                    <Track.Thumb>
+                                        <Thumb Style="{DynamicResource VerticalThumb}"
+                                               Width="6" />
+                                    </Track.Thumb>
+                                </Track>
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <Trigger Property="Orientation"
+                             Value="Horizontal">
+                        <Setter Property="Width"
+                                Value="Auto" />
+                        <Setter Property="MinWidth"
+                                Value="0" />
+                        <Setter Property="Height"
+                                Value="10" />
+                        <Setter Property="MinHeight"
+                                Value="10" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type ScrollBar}">
+                                    <Grid x:Name="Bg"
+                                          SnapsToDevicePixels="true"
+                                          Background="#7FA7A7A7">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="0.00001*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Track x:Name="PART_Track"
+                                               IsEnabled="{TemplateBinding IsMouseOver}">
+                                            <Track.Thumb>
+                                                <Thumb Style="{DynamicResource HorizontalThumb}"
+                                                       Height="6" />
+                                            </Track.Thumb>
+                                        </Track>
+                                    </Grid>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <!--EndRegion-->
+
         </ResourceDictionary>
     </UserControl.Resources>
     <Border CornerRadius="5"
@@ -29,7 +178,7 @@
             Padding="10">
         <Grid Width="325">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="96"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
@@ -49,15 +198,21 @@
                     <ColumnDefinition Width="*"></ColumnDefinition>
                     <ColumnDefinition Width="96"></ColumnDefinition>
                 </Grid.ColumnDefinitions>
-                <TextBlock Text="{Binding Path=Description}"
-                           FontSize="13"
-                           Margin="0,0,10,0"
-                           TextWrapping="WrapWithOverflow">
-                    <TextBlock.Foreground>
-                        <Binding Path="HasDescription"
-                                 Converter="{StaticResource DescriptionToColorConverter}" />
-                    </TextBlock.Foreground>
-                </TextBlock>
+
+                <ScrollViewer Template="{DynamicResource ScrollViewerControlTemplate}"
+                              Style="{StaticResource ScrollViewerStyle}"
+                              CanContentScroll="True">
+                    <TextBlock Text="{Binding Path=Description}"
+                               FontSize="13"
+                               Margin="0,0,10,0"
+                               TextWrapping="WrapWithOverflow">
+                        <TextBlock.Foreground>
+                            <Binding Path="HasDescription"
+                                     Converter="{StaticResource DescriptionToColorConverter}" />
+                        </TextBlock.Foreground>
+                    </TextBlock>
+                </ScrollViewer>
+
                 <Image Grid.Column="1"
                        Height="96"
                        Width="96"

--- a/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
+++ b/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
@@ -54,7 +54,7 @@
                     <ColumnDefinition Width="96"></ColumnDefinition>
                 </Grid.ColumnDefinitions>
 
-                <ScrollViewer Template="{DynamicResource TooltipScrollViewerControlTemplate}"
+                <ScrollViewer Template="{DynamicResource LibraryScrollViewerControlTemplate}"
                               Style="{DynamicResource LibraryScrollViewerStyle}"
                               CanContentScroll="True">
                     <TextBlock Text="{Binding Path=Description}"

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -951,6 +951,11 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <None Include="UI\Themes\Modern\SidebarGridStyleDictionary.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <Page Include="Views\About\AboutWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/DynamoCoreWpf/UI/SharedResourceDictionary.cs
+++ b/src/DynamoCoreWpf/UI/SharedResourceDictionary.cs
@@ -63,6 +63,7 @@ namespace Dynamo.UI
         private static ResourceDictionary _toolbarStyleDictionary;
         private static ResourceDictionary _connectorsDictionary;
         private static ResourceDictionary _portsDictionary;
+        private static ResourceDictionary _sidebarGridDictionary;
 
         public static string ThemesDirectory 
         {
@@ -116,6 +117,11 @@ namespace Dynamo.UI
         public static Uri PortsDictionaryUri
         {
             get { return new Uri(Path.Combine(ThemesDirectory, "Ports.xaml")); }
+        }
+
+        public static Uri SidebarGridDictionaryUri
+        {
+            get { return new Uri(Path.Combine(ThemesDirectory, "SidebarGridStyleDictionary.xaml")); }
         }
 
         public static ResourceDictionary DynamoModernDictionary
@@ -186,6 +192,14 @@ namespace Dynamo.UI
         {
             get {
                 return _portsDictionary ?? (_portsDictionary = new ResourceDictionary() {Source = PortsDictionaryUri});
+            }
+        }
+
+        public static ResourceDictionary SidebarGrid
+        {
+            get
+            {
+                return _sidebarGridDictionary ?? (_sidebarGridDictionary = new ResourceDictionary() { Source = SidebarGridDictionaryUri });
             }
         }
     }

--- a/src/DynamoCoreWpf/UI/Themes/Modern/SidebarGridStyleDictionary.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/SidebarGridStyleDictionary.xaml
@@ -3,7 +3,6 @@
 
     <!-- Region Control Templates-->
 
-
     <!-- Region LibraryView + LibrarySearchView-->
 
     <ControlTemplate x:Key="LibraryThumbTemplate"
@@ -37,7 +36,7 @@
                    IsDirectionReversed="true"
                    IsEnabled="{TemplateBinding IsMouseOver}">
                 <Track.Thumb>
-                    <Thumb Style="{DynamicResource LibraryVerticalThumb}" />
+                    <Thumb Template="{StaticResource LibraryThumbTemplate}" />
                 </Track.Thumb>
             </Track>
         </Grid>
@@ -81,83 +80,6 @@
 
     <!--EndRegion-->
 
-    <!-- Region TooltipWindow -->
-
-    <ControlTemplate x:Key="TooltipThumbTemplate"
-                     TargetType="{x:Type Thumb}">
-        <Grid>
-            <Rectangle HorizontalAlignment="Stretch"
-                       VerticalAlignment="Stretch"
-                       Width="Auto"
-                       Height="Auto"
-                       Fill="Transparent" />
-            <Border x:Name="Rectangle1"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    Width="5"
-                    Height="Auto"
-                    Background="#aaaaaa"
-                    Opacity="0.5"
-                    CornerRadius="2" />
-        </Grid>
-    </ControlTemplate>
-
-    <ControlTemplate x:Key="TooltipScrollBarTemplate"
-                     TargetType="{x:Type ScrollBar}">
-        <Grid x:Name="Bg"
-              SnapsToDevicePixels="true"
-              Background="Transparent">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="0.00001*" />
-            </Grid.RowDefinitions>
-            <Track x:Name="PART_Track"
-                   IsDirectionReversed="true"
-                   IsEnabled="{TemplateBinding IsMouseOver}">
-                <Track.Thumb>
-                    <Thumb Style="{DynamicResource TooltipVerticalThumb}" />
-                </Track.Thumb>
-            </Track>
-        </Grid>
-    </ControlTemplate>
-
-    <ControlTemplate x:Key="TooltipScrollViewerControlTemplate"
-                     TargetType="{x:Type ScrollViewer}">
-        <Grid x:Name="Grid"
-              Background="{TemplateBinding Background}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
-                                    CanContentScroll="{TemplateBinding CanContentScroll}"
-                                    CanHorizontallyScroll="False"
-                                    CanVerticallyScroll="True"
-                                    ContentTemplate="{TemplateBinding ContentTemplate}"
-                                    Content="{TemplateBinding Content}"
-                                    Grid.RowSpan="2"
-                                    Margin="{TemplateBinding Padding}"
-                                    Grid.ColumnSpan="2" />
-            <ScrollBar x:Name="PART_VerticalScrollBar"
-                       AutomationProperties.AutomationId="VerticalScrollBar"
-                       Cursor="Arrow"
-                       Grid.Column="1"
-                       Maximum="{TemplateBinding ScrollableHeight}"
-                       Minimum="0"
-                       Grid.Row="0"
-                       Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-                       Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                       ViewportSize="{TemplateBinding ViewportHeight}"
-                       Width="5"
-                       Style="{DynamicResource TooltipScrollBarStyle}" />
-        </Grid>
-    </ControlTemplate>
-
-    <!--EndRegion-->
-
     <!--EndRegion-->
 
     <!-- Region Styles-->
@@ -188,29 +110,6 @@
                 Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
         <Setter Property="Template"
                 Value="{StaticResource LibraryScrollBarTemplate}" />
-    </Style>
-
-    <Style x:Key="LibraryVerticalThumb"
-           TargetType="{x:Type Thumb}">
-        <Setter Property="Template"
-                Value="{StaticResource LibraryThumbTemplate}" />
-    </Style>
-
-    <!--EndRegion-->
-
-    <!-- Region TooltipWindow -->
-
-    <Style x:Key="TooltipScrollBarStyle"
-           TargetType="{x:Type ScrollBar}"
-           BasedOn="{StaticResource LibraryScrollBarStyle}">
-        <Setter Property="Template"
-                Value="{StaticResource TooltipScrollBarTemplate}" />
-    </Style>
-
-    <Style x:Key="TooltipVerticalThumb"
-           TargetType="{x:Type Thumb}">
-        <Setter Property="Template"
-                Value="{StaticResource TooltipThumbTemplate}" />
     </Style>
 
     <!--EndRegion-->

--- a/src/DynamoCoreWpf/UI/Themes/Modern/SidebarGridStyleDictionary.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/SidebarGridStyleDictionary.xaml
@@ -1,0 +1,245 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Region ImageSources-->
+    <BitmapImage x:Key="CollapseStateNormal"
+                 UriSource="/DynamoCoreWpf;component/UI/Images/collapsestate_normal.png"/>
+    <BitmapImage x:Key="CollapseStateHover"
+                 UriSource="/DynamoCoreWpf;component/UI/Images/collapsestate_hover.png" />
+    <BitmapImage x:Key="ExpandStateHover"
+                 UriSource="/DynamoCoreWpf;component/UI/Images/expandstate_hover.png" />
+    <BitmapImage x:Key="ExpandStateNormal"
+                 UriSource="/DynamoCoreWpf;component/UI/Images/expandstate_normal.png" />
+
+    <!--EndRegion-->
+
+    <!-- Region Control Templates-->
+
+    <!-- Region Scrolling-->
+
+    <!-- Region LibraryView + LibrarySearchView-->
+
+    <ControlTemplate x:Key="LibraryThumbTemplate"
+                     TargetType="{x:Type Thumb}">
+        <Grid>
+            <Rectangle HorizontalAlignment="Stretch"
+                       VerticalAlignment="Stretch"
+                       Width="Auto"
+                       Height="Auto"
+                       Fill="Transparent" />
+            <Border x:Name="Rectangle1"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Width="7"
+                    Height="Auto"
+                    Background="#aaaaaa"
+                    Opacity="0.5"
+                    CornerRadius="2" />
+        </Grid>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="LibraryScrollBarTemplate"
+                     TargetType="{x:Type ScrollBar}">
+        <Grid x:Name="Bg"
+              SnapsToDevicePixels="true"
+              Background="Transparent">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="0.00001*" />
+            </Grid.RowDefinitions>
+            <Track x:Name="PART_Track"
+                   IsDirectionReversed="true"
+                   IsEnabled="{TemplateBinding IsMouseOver}">
+                <Track.Thumb>
+                    <Thumb Style="{DynamicResource LibraryVerticalThumb}" />
+                </Track.Thumb>
+            </Track>
+        </Grid>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="LibraryScrollViewerControlTemplate"
+                     TargetType="{x:Type ScrollViewer}">
+        <Grid x:Name="Grid"
+              Background="{TemplateBinding Background}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
+                                    CanContentScroll="{TemplateBinding CanContentScroll}"
+                                    CanHorizontallyScroll="False"
+                                    CanVerticallyScroll="True"
+                                    ContentTemplate="{TemplateBinding ContentTemplate}"
+                                    Content="{TemplateBinding Content}"
+                                    Grid.RowSpan="2"
+                                    Margin="{TemplateBinding Padding}"
+                                    Grid.ColumnSpan="2" />
+            <ScrollBar x:Name="PART_VerticalScrollBar"
+                       AutomationProperties.AutomationId="VerticalScrollBar"
+                       Cursor="Arrow"
+                       Grid.Column="1"
+                       Maximum="{TemplateBinding ScrollableHeight}"
+                       Minimum="0"
+                       Grid.Row="0"
+                       Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                       Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
+                       ViewportSize="{TemplateBinding ViewportHeight}"
+                       Width="8"
+                       Style="{DynamicResource LibraryScrollBarStyle}" />
+        </Grid>
+    </ControlTemplate>
+
+    <!--EndRegion-->
+
+    <!-- Region TooltipWindow -->
+
+    <ControlTemplate x:Key="TooltipThumbTemplate"
+                     TargetType="{x:Type Thumb}">
+        <Grid>
+            <Rectangle HorizontalAlignment="Stretch"
+                       VerticalAlignment="Stretch"
+                       Width="Auto"
+                       Height="Auto"
+                       Fill="Transparent" />
+            <Border x:Name="Rectangle1"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Width="5"
+                    Height="Auto"
+                    Background="#aaaaaa"
+                    Opacity="0.5"
+                    CornerRadius="2" />
+        </Grid>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="TooltipScrollBarTemplate"
+                     TargetType="{x:Type ScrollBar}">
+        <Grid x:Name="Bg"
+              SnapsToDevicePixels="true"
+              Background="Transparent">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="0.00001*" />
+            </Grid.RowDefinitions>
+            <Track x:Name="PART_Track"
+                   IsDirectionReversed="true"
+                   IsEnabled="{TemplateBinding IsMouseOver}">
+                <Track.Thumb>
+                    <Thumb Style="{DynamicResource TooltipVerticalThumb}" />
+                </Track.Thumb>
+            </Track>
+        </Grid>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="TooltipScrollViewerControlTemplate"
+                     TargetType="{x:Type ScrollViewer}">
+        <Grid x:Name="Grid"
+              Background="{TemplateBinding Background}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
+                                    CanContentScroll="{TemplateBinding CanContentScroll}"
+                                    CanHorizontallyScroll="False"
+                                    CanVerticallyScroll="True"
+                                    ContentTemplate="{TemplateBinding ContentTemplate}"
+                                    Content="{TemplateBinding Content}"
+                                    Grid.RowSpan="2"
+                                    Margin="{TemplateBinding Padding}"
+                                    Grid.ColumnSpan="2" />
+            <ScrollBar x:Name="PART_VerticalScrollBar"
+                       AutomationProperties.AutomationId="VerticalScrollBar"
+                       Cursor="Arrow"
+                       Grid.Column="1"
+                       Maximum="{TemplateBinding ScrollableHeight}"
+                       Minimum="0"
+                       Grid.Row="0"
+                       Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                       Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
+                       ViewportSize="{TemplateBinding ViewportHeight}"
+                       Width="5"
+                       Style="{DynamicResource TooltipScrollBarStyle}" />
+        </Grid>
+    </ControlTemplate>
+
+    <!--EndRegion-->
+
+    <!--EndRegion-->
+
+    <!-- Region Expansion-->
+
+
+    <!--EndRegion-->
+
+    <!--EndRegion-->
+
+
+    <!-- Region Styles-->
+
+    <!-- Region Scrolling-->
+
+    <!-- Region LibraryView + LibrarySearchView-->
+
+    <!--Hide scrollbar, when mouse is not over.-->
+    <Style x:Key="LibraryScrollViewerStyle"
+           TargetType="ScrollViewer">
+        <Setter Property="VerticalScrollBarVisibility"
+                Value="Hidden" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver"
+                     Value="true">
+                <Setter Property="VerticalScrollBarVisibility"
+                        Value="Auto" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="LibraryScrollBarStyle"
+           TargetType="{x:Type ScrollBar}">
+        <Setter Property="Stylus.IsPressAndHoldEnabled"
+                Value="false" />
+        <Setter Property="Stylus.IsFlicksEnabled"
+                Value="false" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+        <Setter Property="Template"
+                Value="{StaticResource LibraryScrollBarTemplate}" />
+    </Style>
+
+    <Style x:Key="LibraryVerticalThumb"
+           TargetType="{x:Type Thumb}">
+        <Setter Property="Template"
+                Value="{StaticResource LibraryThumbTemplate}"/>
+    </Style>
+
+    <!--EndRegion-->
+
+    <!-- Region TooltipWindow -->
+
+    <Style x:Key="TooltipScrollBarStyle"
+           TargetType="{x:Type ScrollBar}"
+           BasedOn="{StaticResource LibraryScrollBarStyle}">
+        <Setter Property="Template"
+                Value="{StaticResource TooltipScrollBarTemplate}" />
+    </Style>
+
+    <Style x:Key="TooltipVerticalThumb"
+           TargetType="{x:Type Thumb}">
+        <Setter Property="Template"
+                Value="{StaticResource TooltipThumbTemplate}" />
+    </Style>
+
+    <!--EndRegion-->
+
+    <!--EndRegion-->
+
+    <!--EndRegion-->
+
+</ResourceDictionary>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/SidebarGridStyleDictionary.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/SidebarGridStyleDictionary.xaml
@@ -1,21 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <!-- Region ImageSources-->
-    <BitmapImage x:Key="CollapseStateNormal"
-                 UriSource="/DynamoCoreWpf;component/UI/Images/collapsestate_normal.png"/>
-    <BitmapImage x:Key="CollapseStateHover"
-                 UriSource="/DynamoCoreWpf;component/UI/Images/collapsestate_hover.png" />
-    <BitmapImage x:Key="ExpandStateHover"
-                 UriSource="/DynamoCoreWpf;component/UI/Images/expandstate_hover.png" />
-    <BitmapImage x:Key="ExpandStateNormal"
-                 UriSource="/DynamoCoreWpf;component/UI/Images/expandstate_normal.png" />
-
-    <!--EndRegion-->
-
     <!-- Region Control Templates-->
 
-    <!-- Region Scrolling-->
 
     <!-- Region LibraryView + LibrarySearchView-->
 
@@ -173,17 +160,7 @@
 
     <!--EndRegion-->
 
-    <!-- Region Expansion-->
-
-
-    <!--EndRegion-->
-
-    <!--EndRegion-->
-
-
     <!-- Region Styles-->
-
-    <!-- Region Scrolling-->
 
     <!-- Region LibraryView + LibrarySearchView-->
 
@@ -216,7 +193,7 @@
     <Style x:Key="LibraryVerticalThumb"
            TargetType="{x:Type Thumb}">
         <Setter Property="Template"
-                Value="{StaticResource LibraryThumbTemplate}"/>
+                Value="{StaticResource LibraryThumbTemplate}" />
     </Style>
 
     <!--EndRegion-->
@@ -235,8 +212,6 @@
         <Setter Property="Template"
                 Value="{StaticResource TooltipThumbTemplate}" />
     </Style>
-
-    <!--EndRegion-->
 
     <!--EndRegion-->
 

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -5,10 +5,16 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:controls="clr-namespace:Dynamo.Controls"
              xmlns:uicontrols="clr-namespace:Dynamo.UI.Controls"
+             xmlns:ui="clr-namespace:Dynamo.UI"
              mc:Ignorable="d"
              d:DesignHeight="525"
              d:DesignWidth="350">
     <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.SidebarGridDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+
         <!-- Region Expander Templates -->
 
         <ControlTemplate x:Key="CategoryExpanderButtonTemplate"
@@ -365,158 +371,15 @@
                                               ClassDetailsTemplate="{StaticResource ClassDetailsDataTemplate}" />
         <!--EndRegion-->
 
-        <!-- Region ScrollBar -->
-
-        <ControlTemplate x:Key="ScrollViewerControlTemplate"
-                         TargetType="{x:Type ScrollViewer}">
-            <Grid x:Name="Grid"
-                  Background="{TemplateBinding Background}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
-                                        CanContentScroll="{TemplateBinding CanContentScroll}"
-                                        CanHorizontallyScroll="False"
-                                        CanVerticallyScroll="True"
-                                        ContentTemplate="{TemplateBinding ContentTemplate}"
-                                        Content="{TemplateBinding Content}"
-                                        Grid.RowSpan="2"
-                                        Margin="{TemplateBinding Padding}"
-                                        Grid.ColumnSpan="2" />
-                <ScrollBar x:Name="PART_VerticalScrollBar"
-                           AutomationProperties.AutomationId="VerticalScrollBar"
-                           Cursor="Arrow"
-                           Grid.Column="1"
-                           Maximum="{TemplateBinding ScrollableHeight}"
-                           Minimum="0"
-                           Grid.Row="0"
-                           Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-                           Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                           ViewportSize="{TemplateBinding ViewportHeight}"
-                           Width="8" />
-            </Grid>
-        </ControlTemplate>
-
-        <Style x:Key="VerticalThumb"
-               TargetType="{x:Type Thumb}">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type Thumb}">
-                        <Grid>
-                            <Rectangle HorizontalAlignment="Stretch"
-                                       VerticalAlignment="Stretch"
-                                       Width="Auto"
-                                       Height="Auto"
-                                       Fill="Transparent" />
-                            <Border x:Name="Rectangle1"
-                                    HorizontalAlignment="Stretch"
-                                    VerticalAlignment="Stretch"
-                                    Width="7"
-                                    Height="Auto"
-                                    Background="#aaaaaa"
-                                    Opacity="0.5"
-                                    CornerRadius="2" />
-                        </Grid>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-
-        <Style TargetType="{x:Type ScrollBar}">
-            <Setter Property="Stylus.IsPressAndHoldEnabled"
-                    Value="false" />
-            <Setter Property="Stylus.IsFlicksEnabled"
-                    Value="false" />
-            <Setter Property="Foreground"
-                    Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-            <Setter Property="Width"
-                    Value="10" />
-            <Setter Property="MinWidth"
-                    Value="10" />
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type ScrollBar}">
-                        <Grid x:Name="Bg"
-                              SnapsToDevicePixels="true"
-                              Background="Transparent">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="0.00001*" />
-                            </Grid.RowDefinitions>
-                            <Track x:Name="PART_Track"
-                                   IsDirectionReversed="true"
-                                   IsEnabled="{TemplateBinding IsMouseOver}">
-                                <Track.Thumb>
-                                    <Thumb Style="{DynamicResource VerticalThumb}"
-                                           Width="8" />
-                                </Track.Thumb>
-                            </Track>
-                        </Grid>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            <Style.Triggers>
-                <Trigger Property="Orientation"
-                         Value="Horizontal">
-                    <Setter Property="Width"
-                            Value="Auto" />
-                    <Setter Property="MinWidth"
-                            Value="0" />
-                    <Setter Property="Height"
-                            Value="10" />
-                    <Setter Property="MinHeight"
-                            Value="10" />
-                    <Setter Property="Template">
-                        <Setter.Value>
-                            <ControlTemplate TargetType="{x:Type ScrollBar}">
-                                <Grid x:Name="Bg"
-                                      SnapsToDevicePixels="true"
-                                      Background="#7FA7A7A7">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="0.00001*" />
-                                    </Grid.ColumnDefinitions>
-                                    <Track x:Name="PART_Track"
-                                           IsEnabled="{TemplateBinding IsMouseOver}">
-                                        <Track.Thumb>
-                                            <Thumb Style="{DynamicResource HorizontalThumb}"
-                                                   Height="8" />
-                                        </Track.Thumb>
-                                    </Track>
-                                </Grid>
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-
-        <!--Hide scrollbar, when mouse is not over.-->
-        <Style x:Key="ScrollLibraryViewerStyle"
-               TargetType="ScrollViewer">
-            <Setter Property="VerticalScrollBarVisibility"
-                    Value="Hidden" />
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver"
-                         Value="true">
-                    <Setter Property="VerticalScrollBarVisibility"
-                            Value="Auto" />
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-
-        <!--EndRegion-->
+        </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
         <ScrollViewer CanContentScroll="True"
                       PreviewMouseWheel="OnPreviewMouseWheel"
                       Background="#333333"
                       Name="ScrollLibraryViewer"
-                      Template="{DynamicResource ScrollViewerControlTemplate}"
-                      Style="{StaticResource ScrollLibraryViewerStyle}">
+                      Template="{DynamicResource LibraryScrollViewerControlTemplate}"
+                      Style="{DynamicResource LibraryScrollViewerStyle}">
             <Grid KeyDown="OnMainGridKeyDown">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml
@@ -14,6 +14,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.MenuStyleDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.SidebarGridDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
 
             <!-- Region Converters -->
@@ -30,136 +31,6 @@
             <controls:FullCategoryNameToMarginConverter x:Key="FullCategoryNameToMarginConverter" />
             <controls:IntToVisibilityConverter x:Key="IntToVisibilityConverter" />
             <controls:LibraryTreeItemsHostVisibilityConverter x:Key="LibraryTreeItemsHostVisibilityConverter" />
-
-            <!--EndRegion-->
-
-            <!-- Region Expander Templates -->
-
-            <ControlTemplate x:Key="CategoryExpanderButtonTemplate"
-                             TargetType="{x:Type ToggleButton}">
-                <Border x:Name="ExpanderButtonBorder"
-                        Background="#282828"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        Padding="8,0,0,0">
-                    <Grid MinHeight="27"
-                          MinWidth="66"
-                          Margin="0,0,0,2">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-
-                        <Image x:Name="ExpandCollapseStateIcon"
-                               Source="/DynamoCoreWpf;component/UI/Images/collapsestate_normal.png"
-                               Width="16"
-                               Height="16"
-                               VerticalAlignment="Center" />
-                        <ContentPresenter x:Name="HeaderContent"
-                                          Grid.Column="1"
-                                          ContentSource="Content"
-                                          VerticalAlignment="Center"
-                                          TextBlock.FontSize="13"
-                                          TextBlock.Foreground="#989898"
-                                          Margin="8,0,0,0" />
-                    </Grid>
-                </Border>
-                <ControlTemplate.Triggers>
-
-                    <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsMouseOver"
-                                       Value="True" />
-                            <Condition Property="IsChecked"
-                                       Value="False" />
-                        </MultiTrigger.Conditions>
-                        <MultiTrigger.Setters>
-                            <Setter Property="Source"
-                                    TargetName="ExpandCollapseStateIcon"
-                                    Value="/DynamoCoreWpf;component/UI/Images/collapsestate_hover.png" />
-                            <Setter Property="Background"
-                                    TargetName="ExpanderButtonBorder"
-                                    Value="#222222" />
-                        </MultiTrigger.Setters>
-                    </MultiTrigger>
-
-                    <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsMouseOver"
-                                       Value="True" />
-                            <Condition Property="IsChecked"
-                                       Value="True" />
-                        </MultiTrigger.Conditions>
-                        <MultiTrigger.Setters>
-                            <Setter Property="Source"
-                                    TargetName="ExpandCollapseStateIcon"
-                                    Value="/DynamoCoreWpf;component/UI/Images/expandstate_hover.png" />
-                            <Setter Property="TextBlock.FontWeight"
-                                    TargetName="HeaderContent"
-                                    Value="Semibold" />
-                            <Setter Property="TextBlock.Foreground"
-                                    TargetName="HeaderContent"
-                                    Value="#bbbbbb" />
-                            <Setter Property="Background"
-                                    TargetName="ExpanderButtonBorder"
-                                    Value="#222222" />
-                        </MultiTrigger.Setters>
-                    </MultiTrigger>
-
-                    <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsMouseOver"
-                                       Value="False" />
-                            <Condition Property="IsChecked"
-                                       Value="True" />
-                        </MultiTrigger.Conditions>
-                        <MultiTrigger.Setters>
-                            <Setter Property="Source"
-                                    TargetName="ExpandCollapseStateIcon"
-                                    Value="/DynamoCoreWpf;component/UI/Images/expandstate_normal.png" />
-                            <Setter Property="TextBlock.FontWeight"
-                                    TargetName="HeaderContent"
-                                    Value="Semibold" />
-                            <Setter Property="TextBlock.Foreground"
-                                    TargetName="HeaderContent"
-                                    Value="#bbbbbb" />
-                        </MultiTrigger.Setters>
-                    </MultiTrigger>
-
-                </ControlTemplate.Triggers>
-            </ControlTemplate>
-
-            <ControlTemplate x:Key="CategoryExpanderTemplate"
-                             TargetType="{x:Type Expander}">
-                <DockPanel Background="#2F2F2F">
-                    <ToggleButton x:Name="ExpanderButton"
-                                  DockPanel.Dock="Top"
-                                  Template="{StaticResource CategoryExpanderButtonTemplate}"
-                                  Content="{TemplateBinding Header}"
-                                  IsChecked="{Binding Path=IsExpanded, RelativeSource={RelativeSource TemplatedParent}}"
-                                  OverridesDefaultStyle="True"
-                                  Height="27"
-                                  BorderBrush="#353535"
-                                  BorderThickness="0,0,0,1" />
-
-                    <ContentPresenter x:Name="ExpanderContent"
-                                      Visibility="Collapsed"
-                                      DockPanel.Dock="Bottom">
-                        <ContentPresenter.Width>
-                            <Binding Path="ActualWidth"
-                                     RelativeSource="{RelativeSource FindAncestor, AncestorType=ListView}" />
-                        </ContentPresenter.Width>
-                    </ContentPresenter>
-                </DockPanel>
-                <ControlTemplate.Triggers>
-                    <Trigger Property="IsExpanded"
-                             Value="True">
-                        <Setter TargetName="ExpanderContent"
-                                Property="Visibility"
-                                Value="Visible" />
-                    </Trigger>
-                </ControlTemplate.Triggers>
-            </ControlTemplate>
 
             <!--EndRegion-->
 
@@ -379,45 +250,6 @@
                                                   MemberTemplate="{StaticResource MemberControlTemplate}"
                                                   SubclassesTemplate="{StaticResource SubclassesTemplate}"
                                                   NestedCategoryTemplate="{StaticResource NestedCategoryTemplate}" />
-
-            <!--EndRegion-->
-
-            <!-- Region ScrollBar Template-->
-
-            <ControlTemplate x:Key="ScrollViewerControlTemplate"
-                             TargetType="{x:Type ScrollViewer}">
-                <Grid x:Name="Grid"
-                      Background="{TemplateBinding Background}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-                    <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
-                                            CanContentScroll="{TemplateBinding CanContentScroll}"
-                                            CanHorizontallyScroll="False"
-                                            CanVerticallyScroll="True"
-                                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                                            Content="{TemplateBinding Content}"
-                                            Grid.RowSpan="2"
-                                            Margin="{TemplateBinding Padding}"
-                                            Grid.ColumnSpan="2" />
-                    <ScrollBar x:Name="PART_VerticalScrollBar"
-                               AutomationProperties.AutomationId="VerticalScrollBar"
-                               Cursor="Arrow"
-                               Grid.Column="1"
-                               Maximum="{TemplateBinding ScrollableHeight}"
-                               Minimum="0"
-                               Grid.Row="0"
-                               Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-                               Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                               ViewportSize="{TemplateBinding ViewportHeight}"
-                               Width="8" />
-                </Grid>
-            </ControlTemplate>
 
             <!--EndRegion-->
 
@@ -779,112 +611,6 @@
                 </Style.Resources>
             </Style>
 
-            <Style x:Key="VerticalThumb"
-                   TargetType="{x:Type Thumb}">
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type Thumb}">
-                            <Grid>
-                                <Rectangle HorizontalAlignment="Stretch"
-                                           VerticalAlignment="Stretch"
-                                           Width="Auto"
-                                           Height="Auto"
-                                           Fill="Transparent" />
-                                <Border x:Name="Rectangle1"
-                                        HorizontalAlignment="Stretch"
-                                        VerticalAlignment="Stretch"
-                                        Width="7"
-                                        Height="Auto"
-                                        Background="#aaaaaa"
-                                        Opacity="0.5"
-                                        CornerRadius="2" />
-                            </Grid>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-            <Style TargetType="{x:Type ScrollBar}">
-                <Setter Property="Stylus.IsPressAndHoldEnabled"
-                        Value="false" />
-                <Setter Property="Stylus.IsFlicksEnabled"
-                        Value="false" />
-                <Setter Property="Foreground"
-                        Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                <Setter Property="Width"
-                        Value="10" />
-                <Setter Property="MinWidth"
-                        Value="10" />
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type ScrollBar}">
-                            <Grid x:Name="Bg"
-                                  SnapsToDevicePixels="true"
-                                  Background="Transparent">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="0.00001*" />
-                                </Grid.RowDefinitions>
-                                <Track x:Name="PART_Track"
-                                       IsDirectionReversed="true"
-                                       IsEnabled="{TemplateBinding IsMouseOver}">
-                                    <Track.Thumb>
-                                        <Thumb Style="{DynamicResource VerticalThumb}"
-                                               Width="8" />
-                                    </Track.Thumb>
-                                </Track>
-                            </Grid>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-                <Style.Triggers>
-                    <Trigger Property="Orientation"
-                             Value="Horizontal">
-                        <Setter Property="Width"
-                                Value="Auto" />
-                        <Setter Property="MinWidth"
-                                Value="0" />
-                        <Setter Property="Height"
-                                Value="10" />
-                        <Setter Property="MinHeight"
-                                Value="10" />
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="{x:Type ScrollBar}">
-                                    <Grid x:Name="Bg"
-                                          SnapsToDevicePixels="true"
-                                          Background="#7FA7A7A7">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="0.00001*" />
-                                        </Grid.ColumnDefinitions>
-                                        <Track x:Name="PART_Track"
-                                               IsEnabled="{TemplateBinding IsMouseOver}">
-                                            <Track.Thumb>
-                                                <Thumb Style="{DynamicResource HorizontalThumb}"
-                                                       Height="8" />
-                                            </Track.Thumb>
-                                        </Track>
-                                    </Grid>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Trigger>
-                </Style.Triggers>
-            </Style>
-
-            <!--Hide scrollbar, when mouse is not over.-->
-            <Style x:Key="ScrollLibraryViewerStyle"
-                   TargetType="ScrollViewer">
-                <Setter Property="VerticalScrollBarVisibility"
-                        Value="Hidden" />
-                <Style.Triggers>
-                    <Trigger Property="IsMouseOver"
-                             Value="true">
-                        <Setter Property="VerticalScrollBarVisibility"
-                                Value="Auto" />
-                    </Trigger>
-                </Style.Triggers>
-            </Style>
-
             <!--EndRegion-->
 
         </ResourceDictionary>
@@ -894,8 +620,8 @@
                       PreviewMouseWheel="OnPreviewMouseWheel"
                       Background="Transparent"
                       Name="ScrollLibraryViewer"
-                      Template="{DynamicResource ScrollViewerControlTemplate}"
-                      Style="{StaticResource ScrollLibraryViewerStyle}">
+                      Template="{DynamicResource LibraryScrollViewerControlTemplate}"
+                      Style="{DynamicResource LibraryScrollViewerStyle}">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -57,6 +57,13 @@ namespace Dynamo.UI.Views
             }
 
             // 2 case.
+            // If mouse is not over this control, but it handles event.
+            // This means user scroll inside of tooltip. We do not need change something,
+            // we also do not set Handled to true, because tooltip's scrollviewer will handle this event.
+            if (!(sender as UIElement).IsMouseOver)
+                return;
+
+            // 3 case.
             // User uses just mouse wheel. That means user wants to scroll down LibraryView.
             // So, we just change VerticalOffset, and there is no need to go further and change something.
             // Set Handled to true.

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -46,27 +46,26 @@ namespace Dynamo.UI.Views
         /// </summary>
         private void OnPreviewMouseWheel(object sender, MouseWheelEventArgs e)
         {
-            // 1 case. 
-            // User presses Shift and uses mouse wheel. That means user tries to 
-            // scroll horizontally to the right side, to see the whole long name of node.
-            // So, we go further, in scrollbar, that is under this one, that's why Handled is false.
+            // Case 1: User scrolls the mouse wheel when Shift key is being held down. This 
+            // action triggers a horizontal scroll on the library view (so that lengthy names 
+            // can be revealed). Setting 'Handled' to 'false' allows the underlying scroll bar
+            // to handle the mouse wheel event.
             if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
             {
                 e.Handled = false;
                 return;
             }
 
-            // 2 case.
-            // If mouse is not over this control, but it handles event.
-            // This means user scroll inside of tooltip. We do not need change something,
-            // we also do not set Handled to true, because tooltip's scrollviewer will handle this event.
+            // Case 2: If the mouse is outside of the library view, but mouse wheel messages 
+            // get sent to it anyway. In such case there is nothing to change here. The 'Handled'
+            // is not set to 'true' here because the mouse wheel messages should be routed to the 
+            // ScrollViewer on tool-tip for further processing.
             if (!(sender as UIElement).IsMouseOver)
                 return;
 
-            // 3 case.
-            // User uses just mouse wheel. That means user wants to scroll down LibraryView.
-            // So, we just change VerticalOffset, and there is no need to go further and change something.
-            // Set Handled to true.
+            // Case 3: Mouse wheel without any modifier keys, it scrolls the library view 
+            // vertically. In this case 'VerticalOffset' is updated, 'Handled' is also set 
+            // so that mouse wheel message routing ends here.
             ScrollViewer scv = (ScrollViewer)sender;
             scv.ScrollToVerticalOffset(scv.VerticalOffset - e.Delta);
             e.Handled = true;


### PR DESCRIPTION
If description is too long, we use scrollviewer to show it.

Before:
![image](https://cloud.githubusercontent.com/assets/8158404/6263649/21282336-b823-11e4-9bce-20af2279ab5b.png)

After:
![image](https://cloud.githubusercontent.com/assets/8158404/6263654/30ae5988-b823-11e4-8554-b6de525eb2be.png)

Reviewers
@Benglin ,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-6211](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6211) [DUI]Shorten the tool tip description for long texts