### PR TITLE
DUI: After entering space in Library shouldn't start search

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -147,7 +147,7 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                return string.IsNullOrEmpty(SearchText) ? ViewMode.LibraryView :
+                return string.IsNullOrEmpty(SearchText.Trim()) ? ViewMode.LibraryView :
                     ViewMode.LibrarySearchView;
             }
         }
@@ -617,7 +617,8 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal void SearchAndUpdateResults()
         {
-            SearchAndUpdateResults(SearchText);
+            if (!String.IsNullOrEmpty(SearchText.Trim()))
+                SearchAndUpdateResults(SearchText);
         }
 
         /// <summary>


### PR DESCRIPTION
1. Launch Dynamo (with Library UI build)
2. Press space bar in search.
 * You will notice it will search for IsNull which is wrong,
3. Now press one more space it will search again 
4. Now press one more space and it will search again.
5. Now press Esc key to clear the search.
 * Tool tip will stay there unless you click on canvas multiple time.
Couldn't reproduce 5th.

Reviewers
@Benglin ,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-6235](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6235) [DUI] After entering space in Library shouldn't start search. IN master it doesn't