### PR TITLE
MAGN-6364 7.6 does not provide any files under Help, Samples with French Revit

### DIFF
--- a/src/DynamoUtilities/DynamoPathManager.cs
+++ b/src/DynamoUtilities/DynamoPathManager.cs
@@ -146,14 +146,20 @@ namespace DynamoUtilities
 
             var UICulture = System.Globalization.CultureInfo.CurrentUICulture.ToString();
             CommonSamples = Path.Combine(commonData, "samples", UICulture);
-            if (!Directory.Exists(CommonSamples))
+
+            // If the localized samples directory does not exist
+            // then fall back to using the en-US samples folder. Do an
+            // additional check whether the localized folder is available
+            // but is empty.
+            var di = new DirectoryInfo(CommonSamples);
+            if (!Directory.Exists(CommonSamples)
+                || !di.GetDirectories().Any() 
+                || !di.GetFiles().Any())
             {
                 var neturalCommonSamples = Path.Combine(commonData, "samples", "en-US");
 
                 if (Directory.Exists(neturalCommonSamples))
                     CommonSamples = neturalCommonSamples;
-                else
-                    Directory.CreateDirectory(CommonSamples);
             }
 
             if (Nodes == null)


### PR DESCRIPTION
The [original fix for this error](https://github.com/DynamoDS/Dynamo/pull/3775), created a new, empty, samples for for the locale, if one could not be found. But an empty folder doesn't do much good, and has the same bad behavior as before, with the samples missing from the Start page and the Help menu. This pull request augments the original change to do two things:

- It checks to see whether there is a samples for the locale, and if so, it checks to see whether it has files and folders. If the folder for the locale exists, but is empty, it falls back to using en-US.
- It removes the creation of an empty folder for the locale.

This has been tested to work on a German machine where the de-DE samples folder was not available.


PTAL:
- [x] @ke-yu 

FYI:
@jnealb This will continue to malfunction in a Debug environment as we do not have localized sample content when building from source.