### PR TITLE
MAGN-6069 Re-enable hardware acceleration in Revit 2015 and 2016

### DIFF
--- a/src/DynamoCore/Core/PreferenceSettings.cs
+++ b/src/DynamoCore/Core/PreferenceSettings.cs
@@ -27,7 +27,7 @@ namespace Dynamo
         private VolumeUnit volumeUnit;
         private string numberFormat;
         private string lastUpdateDownloadPath;
-
+        
         // Variables of the settings that will be persistent
 
         #region Collect Information Settings
@@ -36,12 +36,34 @@ namespace Dynamo
         public bool IsAnalyticsReportingApproved { get; set; }
         #endregion
 
+        /// <summary>
+        /// The width of the library pane.
+        /// </summary>
         public int LibraryWidth { get; set; }
+
+        /// <summary>
+        /// The height of the console display.
+        /// </summary>
         public int ConsoleHeight { get; set; }
+
+        /// <summary>
+        /// Should connectors be visible?
+        /// </summary>
         public bool ShowConnector { get; set; }
+
+        /// <summary>
+        /// The types of connector: Bezier or Polyline.
+        /// </summary>
         public ConnectorType ConnectorType { get; set; }
+
+        /// <summary>
+        /// Should the background 3D preview be shown?
+        /// </summary>
         public bool FullscreenWatchShowing { get; set; }
 
+        /// <summary>
+        /// The decimal precision used to display numbers.
+        /// </summary>
         public string NumberFormat
         {
             get { return numberFormat; }
@@ -52,6 +74,26 @@ namespace Dynamo
             }
         }
 
+        /// <summary>
+        /// The maximum number of recent file paths to be saved.
+        /// </summary>
+        public int MaxNumRecentFiles
+        {
+            get { return 10; }
+            set { }
+        }
+
+        /// <summary>
+        /// A list of recently opened file paths.
+        /// </summary>
+        public List<string> RecentFiles { get; set; }
+
+        /// <summary>
+        /// A list of packages used by the Package Manager to determine
+        /// which packages are marked for deletion.
+        /// </summary>
+        public List<string> PackageDirectoriesToUninstall { get; set; }
+
         public LengthUnit LengthUnit
         {
             get { return lengthUnit; }
@@ -61,16 +103,6 @@ namespace Dynamo
                 RaisePropertyChanged("LengthUnit");
             }
         }
-
-        public int MaxNumRecentFiles
-        {
-            get { return 10; }
-            set { }
-        }
-
-        public List<string> RecentFiles { get; set; }
-
-        public List<string> PackageDirectoriesToUninstall { get; set; }
 
         public AreaUnit AreaUnit
         {
@@ -92,16 +124,30 @@ namespace Dynamo
             }
         }
 
+        /// <summary>
+        /// The last X coordinate of the Dynamo window.
+        /// </summary>
         public double WindowX { get; set; }
+
+        /// <summary>
+        /// The last Y coordinate of the Dynamo window.
+        /// </summary>
         public double WindowY { get; set; }
+
+        /// <summary>
+        /// The last width of the Dynamo window.
+        /// </summary>
         public double WindowW { get; set; }
+
+        /// <summary>
+        /// The last height of the Dynamo window.
+        /// </summary>
         public double WindowH { get; set; }
 
-        public string LastUpdateDownloadPath
-        {
-            get { return lastUpdateDownloadPath; }
-            set { lastUpdateDownloadPath = !File.Exists(value) ? "" : value; }
-        }
+        /// <summary>
+        /// Should Dynamo use hardware acceleration if it is supported?
+        /// </summary>
+        public bool UseHardwareAcceleration { get; set; }
 
         public PreferenceSettings()
         {
@@ -124,7 +170,7 @@ namespace Dynamo
             VolumeUnit = VolumeUnit.CubicMeter;
             PackageDirectoriesToUninstall = new List<string>();
             NumberFormat = "f3";
-            LastUpdateDownloadPath = "";
+            UseHardwareAcceleration = true;
         }
 
         /// <summary>

--- a/src/DynamoCore/Interfaces/IPreferences.cs
+++ b/src/DynamoCore/Interfaces/IPreferences.cs
@@ -21,7 +21,6 @@ namespace Dynamo.Interfaces
         double WindowY { get; set; }
         double WindowH { get; set; }
         double WindowW { get; set; }
-        string LastUpdateDownloadPath { get; set; }
         int MaxNumRecentFiles { get; set; }
         List<string> RecentFiles { get; set; }
         List<string> PackageDirectoriesToUninstall { get; set; }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Diagnostics;
+using System.Windows.Interop;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using Dynamo.Core;
@@ -56,6 +57,13 @@ namespace Dynamo.Controls
 
         public DynamoView(DynamoViewModel dynamoViewModel)
         {
+            // Revit2015+ has disabled hardware acceleration for WPF to
+            // avoid issues with rendering certain elements in the Revit UI. 
+            // Here we get it back, by setting the ProcessRenderMode to Default,
+            // signifying that we want to use hardware rendering if it's 
+            // available.
+            RenderOptions.ProcessRenderMode = RenderMode.Default;
+
             this.dynamoViewModel = dynamoViewModel;
             this.dynamoViewModel.UIDispatcher = Dispatcher;
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1,5 +1,3 @@
-//#define __NO_SAMPLES_MENU
-
 using System;
 using System.ComponentModel;
 using System.IO;
@@ -20,7 +18,6 @@ using Dynamo.PackageManager.UI;
 using Dynamo.Search;
 using Dynamo.Selection;
 using Dynamo.UI;
-using Dynamo.UI.Views;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf;
@@ -42,15 +39,10 @@ namespace Dynamo.Controls
     /// </summary>
     public partial class DynamoView : Window
     {
-        public const int CANVAS_OFFSET_Y = 0;
-        public const int CANVAS_OFFSET_X = 0;
-
         private readonly NodeViewCustomizationLibrary nodeViewCustomizationLibrary;
-
-        internal DynamoViewModel dynamoViewModel = null;
-        private Stopwatch _timer = null;
-        private StartPageViewModel startPage = null;
-
+        private DynamoViewModel dynamoViewModel;
+        private Stopwatch _timer;
+        private StartPageViewModel startPage;
         private int tabSlidingWindowStart, tabSlidingWindowEnd;
 
         DispatcherTimer _workspaceResizeTimer = new DispatcherTimer { Interval = new TimeSpan(0, 0, 0, 0, 500), IsEnabled = false };
@@ -62,8 +54,9 @@ namespace Dynamo.Controls
             // Here we get it back, by setting the ProcessRenderMode to Default,
             // signifying that we want to use hardware rendering if it's 
             // available.
-            RenderOptions.ProcessRenderMode = RenderMode.Default;
-
+            RenderOptions.ProcessRenderMode = dynamoViewModel.Model.PreferenceSettings.UseHardwareAcceleration ? 
+                RenderMode.Default : RenderMode.SoftwareOnly;
+            
             this.dynamoViewModel = dynamoViewModel;
             this.dynamoViewModel.UIDispatcher = Dispatcher;
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -49,11 +49,11 @@ namespace Dynamo.Controls
 
         public DynamoView(DynamoViewModel dynamoViewModel)
         {
-            // Revit2015+ has disabled hardware acceleration for WPF to
-            // avoid issues with rendering certain elements in the Revit UI. 
-            // Here we get it back, by setting the ProcessRenderMode to Default,
-            // signifying that we want to use hardware rendering if it's 
-            // available.
+            // The user's choice to enable hardware acceleration is now saved in
+            // the Dynamo preferences. It is set to true by default. 
+            // When the view is constructed, we enable or disable hardware acceleration based on that preference. 
+            //This preference is not exposed in the UI and can be used to debug hardware issues only
+            // by modifying the preferences xml.
             RenderOptions.ProcessRenderMode = dynamoViewModel.Model.PreferenceSettings.UseHardwareAcceleration ? 
                 RenderMode.Default : RenderMode.SoftwareOnly;
             


### PR DESCRIPTION
During initialization of the DynamoView, we set the `RenderProcessMode` to `RenderMode.Default` to signify that we want to use hardware acceleration if it is available. This logic is added to DynamoView so that it is only triggered when the view is loaded.

Revit 2015+ have disabled hardware acceleration for all of WPF including Dynamo. This causes performance degradation for users of Dynamo on Revit 2015 and beyond. Because the [Revit hardware specifications](http://knowledge.autodesk.com/support/revit-products/troubleshooting/caas/sfdcarticles/sfdcarticles/System-requirements-for-Autodesk-Revit-2015-products.html) clearly state that your machine should have a DirectX11, Shader Model 3, compliant video card, all computers using Dynamo on Revit should support hardware acceleration.

PTAL:
- [ ] @lukechurch Because you've already tested this for me :)

FYI:
@jnealb This requires hardware testing, and testing using virtualization (i.e. Parallels).