### PR TITLE
Fix crash in editing recursive custom node

### DIFF
--- a/src/DynamoCore/Nodes/Custom Nodes/CustomNodeController.cs
+++ b/src/DynamoCore/Nodes/Custom Nodes/CustomNodeController.cs
@@ -140,7 +140,10 @@ namespace Dynamo.Nodes
                 var paramNames = model.InPortData.Select(p => p.NickName);
                 if (!Definition.DisplayParameters.SequenceEqual(paramNames))
                     return false;
+            }
 
+            if (Definition.Parameters != null)
+            {
                 var defParamTypes = Definition.Parameters.Select(p => p.Type.ToShortString());
                 var paramTypes = model.InPortData.Select(p => p.ToolTipString);
                 if (!defParamTypes.SequenceEqual(paramTypes))

--- a/src/DynamoCore/Nodes/Custom Nodes/CustomNodeController.cs
+++ b/src/DynamoCore/Nodes/Custom Nodes/CustomNodeController.cs
@@ -135,11 +135,10 @@ namespace Dynamo.Nodes
             if (Definition == null)
                 return true;
 
-            if (Definition.Parameters != null)
+            if (Definition.DisplayParameters != null)
             {
-                var defParamNames = Definition.Parameters.Select(p => p.Name);
                 var paramNames = model.InPortData.Select(p => p.NickName);
-                if (!defParamNames.SequenceEqual(paramNames))
+                if (!Definition.DisplayParameters.SequenceEqual(paramNames))
                     return false;
 
                 var defParamTypes = Definition.Parameters.Select(p => p.Type.ToShortString());


### PR DESCRIPTION
To fix defect [MAGN-6415 Creating Nested custom node crashes Dynamo even before I press Run](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6415).

This is because editing a custom node will cause custom node definition to be updated, which consequently updates all custom node instances. But because the function that is for checking if a custom node instance is in sync with its definition `IsInSyncWithNode()` always returns false, the custom node instance will be updated, which consequently cause custom node definition to be updated, and then stack overflow. 

In `IsInSyncWithNode()`, it compares `Defintion.Parameters` with mode's inports' names. But we should use `Definition.DisplayParameters`, which is user friendly name, instead of `Definition.Parameters`, which is real parameter name with GUID embeded into it. 

@Benglin please help to review it.