### PR TITLE
DUI:  Fix BindingExpression errors and warnings for Library UI views

### DIFF
--- a/src/DynamoCoreWpf/Controls/AddonsTreeView.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/AddonsTreeView.xaml.cs
@@ -13,6 +13,10 @@ namespace Dynamo.UI.Controls
         public AddonsTreeView()
         {
             InitializeComponent();
+
+            // In future DataContext will be set SearchViewModel in binding, but for now set it to null. 
+            // Therefore we can escape errors in VS Output.
+            this.DataContext = null;
         }
 
         private void OnPopupMouseLeave(object sender, System.Windows.Input.MouseEventArgs e)

--- a/src/DynamoCoreWpf/Controls/AddonsTreeView.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/AddonsTreeView.xaml.cs
@@ -14,8 +14,9 @@ namespace Dynamo.UI.Controls
         {
             InitializeComponent();
 
-            // In future DataContext will be set SearchViewModel in binding, but for now set it to null. 
-            // Therefore we can escape errors in VS Output.
+            // Invalidate the DataContext here because it will be set at a later 
+            // time through data binding expression. This way debugger will not 
+            // display warnings for missing properties.
             this.DataContext = null;
         }
 

--- a/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
+++ b/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
@@ -356,6 +356,7 @@ namespace Dynamo.UI.Controls
             this.Placement = PlacementMode.Custom;
             this.AllowsTransparency = true;
             this.CustomPopupPlacementCallback = PlacementCallback;
+            this.DataContext = null;
             this.Child = tooltip;
             this.dispatcherTimer.Interval = new TimeSpan(0, 0, 0, 0, 500);
             this.dispatcherTimer.Tick += CloseLibraryToolTipPopup;

--- a/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
@@ -42,6 +42,7 @@ namespace Dynamo.Search
             viewModel = searchViewModel;
             this.dynamoViewModel = dynamoViewModel;
 
+            DataContext = viewModel;
             InitializeComponent();
             Loaded += OnSearchViewLoaded;
             Unloaded += OnSearchViewUnloaded;
@@ -69,8 +70,6 @@ namespace Dynamo.Search
 
         private void OnSearchViewLoaded(object sender, RoutedEventArgs e)
         {
-            DataContext = viewModel;
-
             MouseEnter += OnSearchViewMouseEnter;
             MouseLeave += OnSearchViewMouseLeave;
 

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -746,13 +746,13 @@
                         </Style>
                     </ListView.ItemContainerStyle>
                 </ListView>
-                <uicontrols:AddonsTreeView Grid.Row="2"
+                <!--<uicontrols:AddonsTreeView Grid.Row="2"
                                            DataContext="{Binding}">
                     <uicontrols:AddonsTreeView.Visibility>
                         <Binding Path="SearchAddonsVisibility"
                                  Converter="{StaticResource BoolToVisibilityCollapsedConverter}" />
                     </uicontrols:AddonsTreeView.Visibility>
-                </uicontrols:AddonsTreeView>
+                </uicontrols:AddonsTreeView>-->
             </Grid>
         </ScrollViewer>
 

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -26,8 +26,10 @@ namespace Dynamo.UI.Views
         public LibrarySearchView()
         {
             InitializeComponent();
-            // In future DataContext will be set SearchViewModel in binding, but for now set it to null. 
-            // Therefore we can escape errors in VS Output.
+
+            // Invalidate the DataContext here because it will be set at a later 
+            // time through data binding expression. This way debugger will not 
+            // display warnings for missing properties.
             this.DataContext = null;
 
             Loaded += OnLibrarySearchViewLoaded;

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -26,6 +26,9 @@ namespace Dynamo.UI.Views
         public LibrarySearchView()
         {
             InitializeComponent();
+            // In future DataContext will be set SearchViewModel in binding, but for now set it to null. 
+            // Therefore we can escape errors in VS Output.
+            this.DataContext = null;
 
             Loaded += OnLibrarySearchViewLoaded;
         }

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml
@@ -914,12 +914,12 @@
                     </TreeView.Template>
                 </TreeView>
                 <!-- Do not remove. Possibly Addons TreeView will be return later. -->
-                <uicontrols:AddonsTreeView Grid.Row="1"
+                <!--<uicontrols:AddonsTreeView Grid.Row="1"
                                            DataContext="{Binding}">
                     <uicontrols:AddonsTreeView.Visibility>
                         Collapsed
                     </uicontrols:AddonsTreeView.Visibility>
-                </uicontrols:AddonsTreeView>
+                </uicontrols:AddonsTreeView>-->
                 <Button Grid.Row="2"
                         Height="23"
                         HorizontalAlignment="Center"

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -40,8 +40,9 @@ namespace Dynamo.UI.Views
         {
             InitializeComponent();
 
-            // In future DataContext will be set SearchViewModel in binding, but for now set it to null. 
-            // Therefore we can escape errors in VS Output.
+            // Invalidate the DataContext here because it will be set at a later 
+            // time through data binding expression. This way debugger will not 
+            // display warnings for missing properties.
             this.DataContext = null;
         }
 

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -39,6 +39,10 @@ namespace Dynamo.UI.Views
         public LibraryView()
         {
             InitializeComponent();
+
+            // In future DataContext will be set SearchViewModel in binding, but for now set it to null. 
+            // Therefore we can escape errors in VS Output.
+            this.DataContext = null;
         }
 
         /// <summary>


### PR DESCRIPTION
# Reason of errors
DataContext of LibraryView and LibrarySearchView is set in binding. Like this: DataContext="{Binding}" . The problem is next: DataContext by default is set from parent element. That's why we see binding error like this:
![image](https://cloud.githubusercontent.com/assets/8158404/6348633/43824eb0-bc2a-11e4-9743-451f41aa0e05.png)

System.Windows.Data Error: 40 : BindingExpression path error: 'FullName' property not found on 'object' ''ClassInformationViewModel' (HashCode=42515625)'. BindingExpression:Path=FullName; DataItem='ClassInformationViewModel' (HashCode=42515625); target element is 'TextBlock' (Name='code'); target property is 'Text' (type 'String')

# How to fix
I can offer 2 solutions.
1. Set DataContext during initialization to null, so that LibraryView doesn't inherit it from DynamoViewModel/ClassInformationViewModel or any other DataContext, that located above. (that I've done)
2. Give needed DataContext in constructor, but in this case I have to rewrite initialization of LibraryView and LibrarySearchView and LibraryContainerView as well.

# Reviewers
@Benglin , please take a look, are you ok with this fix?

Link to YouTrack:
[MAGN-6273](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6273) Fix BindingExpression errors and warnings for Library UI views