### PR TITLE
Fix incorrect usage of String.Join (MAGN-6381)

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1400,7 +1400,7 @@ namespace Dynamo.Models
             document.AppendChild(document.CreateElement("Workspace"));
 
             //This is only used for computing relative offsets, it's not actually created
-            string virtualFileName = Path.GetTempPath() + "DynamoTemp.dyn";
+            string virtualFileName = Path.Combine(Path.GetTempPath(), "DynamoTemp.dyn");
             Utils.SetDocumentXmlPath(document, virtualFileName);
 
             if (!PopulateXmlDocument(document))

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1400,7 +1400,7 @@ namespace Dynamo.Models
             document.AppendChild(document.CreateElement("Workspace"));
 
             //This is only used for computing relative offsets, it's not actually created
-            string virtualFileName = String.Join(Path.GetTempPath(), "DynamoTemp.dyn");
+            string virtualFileName = Path.GetTempPath() + "DynamoTemp.dyn";
             Utils.SetDocumentXmlPath(document, virtualFileName);
 
             if (!PopulateXmlDocument(document))


### PR DESCRIPTION
This seems to have been broken in the refactor, this method is used to generate a synthetic file name for the XML generator.
For this, as we only have one TempPath, there isn't any real value here beyond just appending them.

@pboyer PTAL

I've verified every other use of String.Join it in our code base, the others are correct.
