### PR TITLE
Fix broken testcases TestCustomNodeDefaultValue and TestFunctionNode

### DIFF
--- a/src/DynamoCore/Nodes/Custom Nodes/Function.cs
+++ b/src/DynamoCore/Nodes/Custom Nodes/Function.cs
@@ -96,13 +96,12 @@ namespace Dynamo.Nodes
             if (descNode != null && descNode.Attributes != null)
                 Description = descNode.Attributes["value"].Value;
 
-            if (!Controller.IsInSyncWithNode(this))
+            if (Controller.Definition != null && !Controller.IsInSyncWithNode(this))
             {
                 Controller.SyncNodeWithDefinition(this);
                 OnNodeModified();
+                return;
             }
-            else
-            {
                 foreach (XmlNode subNode in childNodes)
                 {
                     if (subNode.Name.Equals("Outputs"))
@@ -162,7 +161,6 @@ namespace Dynamo.Nodes
                 }
 
                 RegisterAllPorts();
-            }
         }
 
         #endregion

--- a/src/DynamoCore/Nodes/Custom Nodes/Function.cs
+++ b/src/DynamoCore/Nodes/Custom Nodes/Function.cs
@@ -100,7 +100,6 @@ namespace Dynamo.Nodes
             {
                 Controller.SyncNodeWithDefinition(this);
                 OnNodeModified();
-                return;
             }
             else if (Controller.Definition == null || Controller.Definition.IsProxy)
             {

--- a/src/DynamoCore/Nodes/Custom Nodes/Function.cs
+++ b/src/DynamoCore/Nodes/Custom Nodes/Function.cs
@@ -249,19 +249,6 @@ namespace Dynamo.Nodes
                     }
                     else
                     {
-                        if (identifierNode.datatype.UID == Constants.kInvalidIndex)
-                        {
-                            string warningMessage = String.Format(
-                                Properties.Resources.WarningCannotFindType, 
-                                identifierNode.datatype.Name);
-                            this.Warning(warningMessage);
-                        }
-                        else
-                        {
-                            nickName = identifierNode.Value;
-                            type = identifierNode.datatype;
-                        }
-
                         if (defaultValueNode != null)
                         {
                             TypeSwitch.Do(
@@ -271,6 +258,23 @@ namespace Dynamo.Nodes
                                 TypeSwitch.Case<BooleanNode>(n => defaultValue = n.Value),
                                 TypeSwitch.Case<StringNode>(n => defaultValue = n.value),
                                 TypeSwitch.Default(() => defaultValue = null));
+                        }
+
+                        if (identifierNode.datatype.UID == Constants.kInvalidIndex)
+                        {
+                            string warningMessage = String.Format(
+                                Properties.Resources.WarningCannotFindType, 
+                                identifierNode.datatype.Name);
+                            this.Warning(warningMessage);
+                        }
+                        else
+                        {
+                            // Default value not supported or invalid, so use the original
+                            // input as nickName. For example, "y = f(x)"
+                            if (defaultValueNode == null || defaultValue != null)
+                                nickName = identifierNode.Value;
+
+                            type = identifierNode.datatype;
                         }
                     }
                 }

--- a/src/DynamoCore/Nodes/Custom Nodes/Function.cs
+++ b/src/DynamoCore/Nodes/Custom Nodes/Function.cs
@@ -96,12 +96,14 @@ namespace Dynamo.Nodes
             if (descNode != null && descNode.Attributes != null)
                 Description = descNode.Attributes["value"].Value;
 
-            if (Controller.Definition != null && !Controller.IsInSyncWithNode(this))
+            if (!Controller.IsInSyncWithNode(this))
             {
                 Controller.SyncNodeWithDefinition(this);
                 OnNodeModified();
                 return;
             }
+            else if (Controller.Definition == null || Controller.Definition.IsProxy)
+            {
                 foreach (XmlNode subNode in childNodes)
                 {
                     if (subNode.Name.Equals("Outputs"))
@@ -161,6 +163,7 @@ namespace Dynamo.Nodes
                 }
 
                 RegisterAllPorts();
+            }
         }
 
         #endregion

--- a/test/DynamoCoreTests/UndoRedoRecorderTests.cs
+++ b/test/DynamoCoreTests/UndoRedoRecorderTests.cs
@@ -877,7 +877,7 @@ namespace Dynamo.Tests
             Assert.AreEqual("07e6b150-d902-4abb-8103-79193552eee7", graphNode.Definition.FunctionId.ToString());
             Assert.AreEqual("GraphFunction", graphNode.NickName);
             Assert.AreEqual(4, graphNode.InPortData.Count);
-            Assert.AreEqual("y", graphNode.InPortData[3].NickName);
+            Assert.AreEqual("y = f(x)", graphNode.InPortData[3].NickName);
 
             //Serialize node and then change values
             XmlDocument xmlDoc = new XmlDocument();
@@ -896,7 +896,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(534.75, graphNode.X);
             Assert.AreEqual(4, graphNode.InPortData.Count);
             Assert.AreEqual("GraphFunction", graphNode.NickName);
-            Assert.AreEqual("y", graphNode.InPortData[3].NickName);
+            Assert.AreEqual("y = f(x)", graphNode.InPortData[3].NickName);
         }
 
         [Test]


### PR DESCRIPTION
Test case `TestCustomNodeDefaultValue` is broken because the custom node instance, which is deserialized from xml file, is not in sync with its function definition. The .dyn file doesn't contain default value for the custom node instance, the value should be from function definition.

Test case `TestFunctionNode` is broken because for expression `y = f(x)` in input parameter, we extract `y` as input parameter name and `f(x)` as default value, although the latter format hasn't been supported yet. For this case, we should use the whole string, i.e., `y = f(x)` as its input parameter. 

@Benglin :-)