### PR TITLE
Fix regression that switching worksapce command cannot be recorded

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -179,7 +179,8 @@ namespace Dynamo.ViewModels
                     currentWorkspaceViewModel = viewModel;
 
                     // Keep DynamoModel.CurrentWorkspace update-to-date
-                    model.CurrentWorkspace = currentWorkspaceViewModel.Model;
+                    int modelIndex = model.Workspaces.IndexOf(currentWorkspaceViewModel.Model);
+                    this.ExecuteCommand(new DynamoModel.SwitchTabCommand(modelIndex));
                 }
             }
         }


### PR DESCRIPTION
This is regression caused by my PR #3736, where `DynamoModel.CurrentWorkspace` is directly set in `DynamoViewModel.CurrentWorkspaceIndex`'s setter. Instead, we should use recordable command `SwichTabCommand` to do that.

@Benglin , sorry for dragging you to the review again...