### PR TITLE
MAGN-6314 : Change Length / Volume / Area From String node for new system

### DIFF
--- a/src/Libraries/DynamoUnits/Units.cs
+++ b/src/Libraries/DynamoUnits/Units.cs
@@ -436,8 +436,6 @@ namespace DynamoUnits
     /// </summary>
     public class Length : SIUnit, IComparable, IEquatable<Length>
     {
-        internal LengthUnit UnitSystem { get; set; }
-
         //length conversions
         private const double METER_TO_MILLIMETER = 1000;
         private const double METER_TO_CENTIMETER = 100;

--- a/src/Libraries/DynamoUnits/Units.cs
+++ b/src/Libraries/DynamoUnits/Units.cs
@@ -241,8 +241,8 @@ namespace DynamoUnits
         /// </summary>
         public double Value
         {
-            get { return _value; }
-            set { _value = value; }
+            get { return _value * UiLengthConversion; }
+            set { _value = value / UiLengthConversion; }
         }
 
         /// <summary>
@@ -431,10 +431,13 @@ namespace DynamoUnits
     }
 
     /// <summary>
-    /// A length stored in meters.
+    /// A length stored in meters. This length can represent any unit type, but internally this 
+    /// is stored as meters to make algorithms simpler.
     /// </summary>
     public class Length : SIUnit, IComparable, IEquatable<Length>
     {
+        internal LengthUnit UnitSystem { get; set; }
+
         //length conversions
         private const double METER_TO_MILLIMETER = 1000;
         private const double METER_TO_CENTIMETER = 100;
@@ -627,6 +630,11 @@ namespace DynamoUnits
             double fractionalInch = 0.0;
             double feet, inch, m, cm, mm, numerator, denominator;
             Utils.ParseLengthFromString(value, out feet, out inch, out m, out cm, out mm, out numerator, out denominator);
+
+            if (m != 0 || cm != 0 || mm != 0)
+                LengthUnit = LengthUnit.Meter;
+            else
+                LengthUnit = LengthUnit.DecimalFoot;
 
             if (denominator != 0)
                 fractionalInch = numerator / denominator;
@@ -928,6 +936,11 @@ namespace DynamoUnits
             double sq_mm, sq_cm, sq_m, sq_in, sq_ft;
             Utils.ParseAreaFromString(value, out sq_in, out sq_ft, out sq_mm, out sq_cm, out sq_m);
 
+            if (sq_mm != 0 || sq_cm != 0 || sq_m != 0)
+                AreaUnit = AreaUnit.SquareMeter;
+            else
+                AreaUnit = AreaUnit.SquareFoot;
+
             total += sq_mm / ToSquareMillimeters;
             total += sq_cm / ToSquareCentimeters;
             total += sq_m;
@@ -1206,6 +1219,11 @@ namespace DynamoUnits
 
             double cu_mm, cu_cm, cu_m, cu_in, cu_ft;
             Utils.ParseVolumeFromString(value, out cu_in, out cu_ft, out cu_mm, out cu_cm, out cu_m);
+
+            if (cu_mm != 0 || cu_cm != 0 || cu_m != 0)
+                VolumeUnit = VolumeUnit.CubicMeter;
+            else
+                VolumeUnit = VolumeUnit.CubicFoot;
 
             total += cu_mm / ToCubicMillimeter;
             total += cu_cm / ToCubicCentimeter;

--- a/src/Libraries/UnitsUI/UnitsUI.cs
+++ b/src/Libraries/UnitsUI/UnitsUI.cs
@@ -236,8 +236,7 @@ namespace UnitsUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             var doubleNode = AstFactory.BuildDoubleNode(Value);
-            var functionCall = AstFactory.BuildFunctionCall(new Func<double,Length>(Length.FromDouble), new List<AssociativeNode> { doubleNode });
-            return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall) };
+            return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), doubleNode) };
         }
     }
 
@@ -267,8 +266,7 @@ namespace UnitsUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             var doubleNode = AstFactory.BuildDoubleNode(Value);
-            var functionCall = AstFactory.BuildFunctionCall(new Func<double,Area>(Area.FromDouble), new List<AssociativeNode> { doubleNode });
-            return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall) };
+            return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), doubleNode) };
         }
     }
 
@@ -298,8 +296,7 @@ namespace UnitsUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             var doubleNode = AstFactory.BuildDoubleNode(Value);
-            var functionCall = AstFactory.BuildFunctionCall(new Func<double, Volume>(Volume.FromDouble), new List<AssociativeNode> { doubleNode });
-            return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall) };
+            return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), doubleNode) };
         }
     }
 


### PR DESCRIPTION
This PR fixes MAGN-6314, making the From String nodes act according to the new unit system.

The change was relatively minimal. The AST builder for the UI node now returns a double, not a SIUnit type, and the SIUnit type now returns a converted value based on the backing UI unit. I chose to implement this on top of SIUnit, rather than ripping out that code or replacing it because:
- The PR is minimal, and leaves behind a lot of useful unit logic
- Algorithms inside the unit node can assume the internal number is a meter. This makes the From String algorithms simpler

Note: I am proposing to make the SIUnit node internal, keeping the logic around for us, but not for the users. I haven't made that change here as we'll need to sync up with whoever is doing MAGN-6142

@ikeough PTAL
