### PR TITLE
Update broken test case TestBuiltInMethodSignatureCompletion

### DIFF
--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -1040,7 +1040,7 @@ b = c[w][x][y][z];";
             {
                 Assert.AreEqual(functionName, overload.Text);
             }
-            Assert.AreEqual("Count : int (array : [])", overloads.ElementAt(0).Stub);
+            Assert.AreEqual("Count : int (list : [])", overloads.ElementAt(0).Stub);
 
         }
 


### PR DESCRIPTION
The name of parameter in builtin function `Count()` was change from `array` to `list` in [this commit](https://github.com/DynamoDS/Dynamo/commit/9a2cef641ab7bee708082771856f78cc0f109823), but test case `TestBuiltInMethodSignatureCompletion` still tries to compare the code completion result with old name `Count :int (array : [])`. 

Update the expected value of this test case. 