### PR TITLE
DUI: Fix SearchModel failing tests

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -314,6 +314,7 @@ namespace Dynamo.ViewModels
             {
                 var parent = treeStack.Pop();
                 parent.SubCategories.Remove(target);
+                parent.Items.Remove(target);
 
                 // Check to see if all items under "parent" are removed, leaving behind only one 
                 // entry that is "ClassInformationViewModel" (a class used to show StandardPanel).


### PR DESCRIPTION
I couldn't find failed tests in SearchModelTests.
![image](https://cloud.githubusercontent.com/assets/8158404/6388982/3ee2fcfe-bda8-11e4-87db-acfa6bbe49a3.png)

But I found them in SearchViewModelTests.
![image](https://cloud.githubusercontent.com/assets/8158404/6389065/060c8eee-bda9-11e4-85d9-d8d54e6936a0.png)
PopulateSearchTextWithSelectedResultReturnsExpectedResult has category "Failure", that's why I didn't fix it.

But in two other... There fix is needed, but not in test. SearchVM does delete SubCategory, but doesn't delete Item. But it should. If we delete SubCategory, we must delete it from items as well.

Now tests run properly.
![image](https://cloud.githubusercontent.com/assets/8158404/6389111/8f745e5a-bda9-11e4-933f-e33641f33773.png)

Reviewers
@Benglin , please take a look, are you ok with this fix?

Link to YouTrack:
[MAGN-5668](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5668) DUI: Fix SearchModel failing tests