### PR TITLE
DUI: Expanding Built in Functions Category first time after launch jumps to the end of list.

### DIFF
--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -80,7 +80,6 @@ namespace Dynamo.UI.Views
         {
             BringIntoViewCount++;
             var expanderContent = (sender as FrameworkElement);
-            expanderContent.BringIntoView(new Rect(0.0, 0.0, 100.0, 20.0));
 
             var buttons = expanderContent.ChildOfType<ListView>();
             if (buttons != null)


### PR DESCRIPTION
1. Launch Dynamo.
2. Click on Built In Functions category.
 * You will notice that it jumps to the end of list. It should behave just like Geometry category.

Reviewers
@Benglin , please take a look.

Link to YouTrack:
[MAGN-6441](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6441) [DUI] Expanding Built in Functions Category first time after launch jumps to the end of list.