### PR TITLE
DUI: hide code text in tooltip

### DIFF
--- a/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
+++ b/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
@@ -150,6 +150,7 @@
                 </ListBox.ItemTemplate>
             </ListBox>
 
+            <!--Here is code text and copy icon. Do not remove it. We may use it in future. -->
             <!--<Grid Grid.Row="5"
                   Grid.ColumnSpan="3">
                 <Grid.RowDefinitions>
@@ -214,7 +215,7 @@
                     </Image>
                 </StackPanel>-->
 
-                <!--<TextBlock Grid.Row="3"
+            <!--<TextBlock Grid.Row="3"
                                Grid.Column="0"
                                FontSize="10"
                                Margin="0,0,0,10">

--- a/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
+++ b/src/DynamoCoreWpf/Controls/TooltipWindow.xaml
@@ -150,7 +150,7 @@
                 </ListBox.ItemTemplate>
             </ListBox>
 
-            <Grid Grid.Row="5"
+            <!--<Grid Grid.Row="5"
                   Grid.ColumnSpan="3">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*"></RowDefinition>
@@ -212,7 +212,7 @@
                             </Style>
                         </Image.Style>
                     </Image>
-                </StackPanel>
+                </StackPanel>-->
 
                 <!--<TextBlock Grid.Row="3"
                                Grid.Column="0"
@@ -240,7 +240,7 @@
                             Web Reference
                         </Hyperlink>
                     </TextBlock>-->
-            </Grid>
+            <!--</Grid>-->
         </Grid>
     </Border>
 </UserControl>

--- a/src/DynamoCoreWpf/Controls/TooltipWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/TooltipWindow.xaml.cs
@@ -18,7 +18,7 @@ namespace Dynamo.UI.Controls
 
         public void CopyIconMouseClick(object sender, MouseButtonEventArgs e)
         {
-            Clipboard.SetText(code.Text);
+            //Clipboard.SetText(code.Text);
         }
 
         private void RequestNavigate(object sender, RequestNavigateEventArgs e)


### PR DESCRIPTION
As EB wrote: The decision for now is to hide this.
I've comented it. Maybe in future EB will propose something better. But for now let's leave it as comment.

Reviewers
@Benglin , please take a look.

Link to YouTrack:
[MAGN-6215](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6215) DUI: copy/paste the DS syntax of a given node in the library mistakenly identifying custom nodes as targets