### PR TITLE
Removed redundant "LibraryServices" calls

### DIFF
--- a/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
@@ -16,22 +16,6 @@ namespace Dynamo.Tests
 {
     public class DSEvaluationViewModelUnitTest : DynamoViewModelUnitTest
     {
-        protected LibraryServices libraryServices = null;
-        protected ProtoCore.Core libraryServicesCore = null;
-
-        public override void Init()
-        {
-            base.Init();
-
-            var options = new ProtoCore.Options();
-            options.RootModulePathName = string.Empty;
-            libraryServicesCore = new ProtoCore.Core(options);
-            libraryServicesCore.Compilers.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Compiler(libraryServicesCore));
-            libraryServicesCore.Compilers.Add(ProtoCore.Language.kImperative, new ProtoImperative.Compiler(libraryServicesCore));
-
-            libraryServices = new LibraryServices(libraryServicesCore);
-        }
-
         public void OpenModel(string relativeFilePath)
         {
             string openPath = Path.Combine(GetTestDirectory(), relativeFilePath);
@@ -225,13 +209,6 @@ namespace Dynamo.Tests
 
         public override void Cleanup()
         {
-            if (libraryServicesCore != null)
-            {
-                libraryServicesCore.__TempCoreHostForRefactoring.Cleanup();
-                libraryServicesCore = null;
-            }
-            libraryServices = null;
-
             base.Cleanup();
             DynamoUtilities.DynamoPathManager.DestroyInstance();
         }

--- a/test/DynamoCoreTests/DSLibraryTest.cs
+++ b/test/DynamoCoreTests/DSLibraryTest.cs
@@ -11,10 +11,13 @@ namespace Dynamo.Tests
     [Category("DSExecution")]
     class DSLibraryTest : DSEvaluationViewModelUnitTest
     {
+        private LibraryServices libraryServices;
+
         [SetUp]
         public override void Init()
         {
             base.Init();
+            libraryServices = ViewModel.Model.LibraryServices;
         }
 
         [Test]

--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -14,12 +14,16 @@ namespace Dynamo.Tests
     [TestFixture]
     class LibraryTests : DSEvaluationViewModelUnitTest
     {
+        private LibraryServices libraryServices;
+
         protected static bool LibraryLoaded { get; set; }
 
         [SetUp]
         public override void Init()
         {
             base.Init();
+
+            libraryServices = ViewModel.Model.LibraryServices;
             RegisterEvents();
         }
 


### PR DESCRIPTION
Background
-----
Redundant `LibraryServices` creation has been removed from `DSEvaluationViewModelUnitTest` (subsequently, all derived classes). In `DSEvaluationViewModelUnitTest` class, an instance of `LibraryServices` is always created as part of `DynamoModel` construction process, and removed as part of `DynamoModel.Dispose` call. There is no need to create another `LibraryServices` in addition to that.

Changes
-----
1. `LibraryServices` creation in `DSEvaluationViewModelUnitTest.Init` is removed.
2. `LibraryServices` destruction is `DSEvaluationViewModelUnitTest.Cleanup` is removed.
3. Derived classes that rely on `DSEvaluationViewModelUnitTest.libraryServices` are now redirected to use `DynamoModel.LibraryServices` property instead.

Hi @ikeough, please have a look, as far as I can see tests are passing on my side. Thanks!