### PR TITLE
Reintroduce failed test cases

### DIFF
--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -1124,7 +1124,6 @@ namespace DynamoCoreUITests
         }
         
         [Test, RequiresSTA]
-        [Category("Failure")]
         public void ErrorInCBN_3872()
         {
             // add a new line of code in a CBN in warning stage and see if the warning persists
@@ -3063,7 +3062,6 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_4710()
         {
@@ -3106,7 +3104,6 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_4659()
         {
@@ -3149,7 +3146,6 @@ namespace DynamoCoreUITests
         }
 
         [Test, RequiresSTA]
-        [Category("Failure")]
         [Category("RegressionTests")]
         public void RunAutomatically_On_5068()
         {


### PR DESCRIPTION
Now that a new build is being posted, I'm reverted the change that suppressed these failed test cases. Thanks to @pboyer for helping with the previous merge anyway :)