### PR TITLE
Update the installation path for Sample and Definitions

### DIFF
--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -83,10 +83,10 @@ Source: Extra\DynamoInstaller.ico; DestDir: {app}; Flags: ignoreversion overwrit
 Source: temp\bin\UI\*; DestDir: {app}\UI; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 
 ;Samples
-Source: temp\samples\*.*; DestDir: {commonappdata}\Dynamo\0.7\samples; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoTrainingFiles
+Source: temp\samples\*.*; DestDir: {commonappdata}\Dynamo\0.8\samples; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoTrainingFiles
 
 ;Other Custom Nodes
-Source: temp\definitions\*; DestDir: {commonappdata}\Dynamo\0.7\definitions; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
+Source: temp\definitions\*; DestDir: {commonappdata}\Dynamo\0.8\definitions; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 
 [UninstallDelete]
 Type: files; Name: "{commonappdata}\Autodesk\Revit\Addins\2014\Dynamo071.addin"


### PR DESCRIPTION
- Update the installation path for Sample and Definitions to 0.8 from
0.7
- This is a partial fix for
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6542 to ensure that
the components installed with exe installer, installs the components to
correct folder.