### PR TITLE
MAGN-6543 With 0.8 the Cuboid, Sphere and Circle nodes do not render properly with a list of points

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
@@ -122,7 +122,6 @@ namespace Dynamo.Core.Threading
 
             var labelMap = new List<string>();
             var count = 0;
-
             
             foreach (var mirrorData in data)
             {


### PR DESCRIPTION
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6543

The GetGraphicItems method was marked obsolete some time ago. With recent refactoring of the engine, the use of GetPointersRecursively in this method began to throw null reference exceptions. The inability to get graphic items for a preview identifier caused all geometry generation to fail. This pull request removes the call to GetGraphicItems in favor of a checking whether the CLR object returned in the MirrorData is of type IGraphicItem.

VisualizationManager tests are returned to health after this fix.

PTAL:
- [ ] @lukechurch 

FYI:
@junmendoza  
@jnealb 