### PR TITLE
Units closeout

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.7.6.4256")]
+[assembly: AssemblyVersion("0.7.6.4270")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.7.6.4256")]
+[assembly: AssemblyFileVersion("0.7.6.4270")]

--- a/src/Libraries/DynamoConversions/DynamoConversions.csproj
+++ b/src/Libraries/DynamoConversions/DynamoConversions.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C5ADC05B-34E8-47BF-8E78-9C7BF96418C2}</ProjectGuid>
+    <ProjectGuid>{67CF6CF2-CD6A-442C-BABE-864F896DD8EA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoConversions</RootNamespace>

--- a/src/Libraries/DynamoUnits/Units.cs
+++ b/src/Libraries/DynamoUnits/Units.cs
@@ -632,7 +632,13 @@ namespace DynamoUnits
             if (m != 0 || cm != 0 || mm != 0)
                 LengthUnit = LengthUnit.Meter;
             else
-                LengthUnit = LengthUnit.DecimalFoot;
+            {
+                if (value.Contains("'") || value.Contains("\""))
+                    LengthUnit = LengthUnit.FractionalFoot;
+                else
+                    LengthUnit = LengthUnit.DecimalFoot;
+            }
+                
 
             if (denominator != 0)
                 fractionalInch = numerator / denominator;

--- a/src/Libraries/UnitsUI/UnitsUI.cs
+++ b/src/Libraries/UnitsUI/UnitsUI.cs
@@ -201,7 +201,7 @@ namespace UnitsUI
         }
     }
 
-    [NodeName("Length From String")]
+    [NodeName("Number from Feet and Inches")]
     [NodeCategory("Units.Length.Create")]
     [NodeDescription("LengthFromStringDescription",typeof(UnitsUI.Properties.Resources))]
     [NodeSearchTags("LengthFromStringSearchTags", typeof(UnitsUI.Properties.Resources))]

--- a/src/Libraries/UnitsUI/UnitsUI.cs
+++ b/src/Libraries/UnitsUI/UnitsUI.cs
@@ -254,6 +254,7 @@ namespace UnitsUI
     [NodeDescription("AreaFromStringDescription",typeof(UnitsUI.Properties.Resources))]
     [NodeSearchTags("AreaFromStringSearchTags", typeof(UnitsUI.Properties.Resources))]
     [IsDesignScriptCompatible]
+    [NodeDeprecatedAttribute]
     public class AreaFromString : MeasurementInputBase
     {
         public AreaFromString()
@@ -284,6 +285,7 @@ namespace UnitsUI
     [NodeDescription("VolumeFromStringDescription",typeof(UnitsUI.Properties.Resources))]
     [NodeSearchTags("VolumeFromStringSearchTags", typeof(UnitsUI.Properties.Resources))]
     [IsDesignScriptCompatible]
+    [NodeDeprecatedAttribute]
     public class VolumeFromString : MeasurementInputBase
     {
         public VolumeFromString()


### PR DESCRIPTION
This PR cleans up two remaining tasks for the Units epic, generated in a discussion with Lilli and Ian:

1. Deprecates the AreaFromString and VolumeFromString nodes
2. Renames 'Length from String' to 'Number from Feet and Inches'
3. The Number from Feet and Inches node now keeps displaying numbers in quote feet and inches if that was the original input

@ikeough PTAL