### PR TITLE
Fix crash that modulo crashes 

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -5409,7 +5409,17 @@ namespace ProtoCore.DSASM
             {
                 if (opdata1.IsInteger && opdata2.IsInteger)
                 {
-                    opdata2 = StackValue.BuildInt(opdata2.RawIntValue % opdata1.RawIntValue);
+                    long lhs = opdata2.RawIntValue;
+                    long rhs = opdata1.RawIntValue;
+                    if (rhs == 0)
+                    {
+                        runtimeCore.RuntimeStatus.LogWarning(WarningID.kReplicationWarning, Resources.ModuloByZero);
+                        opdata2 = StackValue.Null;
+                    }
+                    else
+                    {
+                        opdata2 = StackValue.BuildInt(lhs % rhs);
+                    }
                 }
                 else
                 {

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -5413,7 +5413,7 @@ namespace ProtoCore.DSASM
                     long rhs = opdata1.RawIntValue;
                     if (rhs == 0)
                     {
-                        runtimeCore.RuntimeStatus.LogWarning(WarningID.kReplicationWarning, Resources.ModuloByZero);
+                        runtimeCore.RuntimeStatus.LogWarning(WarningID.kModuloByZero, Resources.ModuloByZero);
                         opdata2 = StackValue.Null;
                     }
                     else

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -934,6 +934,15 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Integer modulo by zero.
+        /// </summary>
+        public static string ModuloByZero {
+            get {
+                return ResourceManager.GetString("ModuloByZero", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No constructors for Attribute &apos;{0}&apos; takes {1} arguments.
         /// </summary>
         public static string NoConstructorForAttribute {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -486,4 +486,7 @@
   <data name="ValidForImperativeBlockOnly" xml:space="preserve">
     <value>'{0}' statement can only be used in imperative language block</value>
   </data>
+  <data name="ModuloByZero" xml:space="preserve">
+    <value>Integer modulo by zero</value>
+  </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -486,4 +486,7 @@
   <data name="UseListJoinNode" xml:space="preserve">
     <value>Use List.Join node instead</value>
   </data>
+  <data name="ModuloByZero" xml:space="preserve">
+    <value>Integer modulo by zero</value>
+  </data>
 </root>

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -32,7 +32,8 @@ namespace ProtoCore
             kTypeConvertionCauseInfoLoss,
             kTypeMismatch,
             kReplicationWarning,
-            kInvalidIndexing
+            kInvalidIndexing,
+            kModuloByZero
         }
 
         public struct WarningEntry

--- a/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using NUnit.Framework;
 using ProtoCore.DSASM.Mirror;
 using ProtoCore.Lang;
@@ -1721,6 +1722,23 @@ x4 = 0..#5..10;
             string code = @"a = 5.2 % 2.3;";
             var mirror = thisTest.RunScriptSource(code);
             mirror.Verify("a", 0.6);
+        }
+
+        [Test]
+        public void ModuloByZero()
+        {
+            string code =
+@"
+a = 2 % 0;
+b = 2.1 % 0;
+";
+
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("a", null);
+            thisTest.Verify("b", double.NaN);
+
+            var warnings = thisTest.GetTestRuntimeCore().RuntimeStatus.Warnings;
+            Assert.IsTrue(warnings.Any(w => w.ID == ProtoCore.Runtime.WarningID.kModuloByZero));
         }
 
         [Test]


### PR DESCRIPTION
To fix [MAGN-5856 Modulo node crashes with division by zero](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5856).

Throw a warning "Integer modulo by zero" for this case and returns a null. 

@junmendoza please review the change. 