### PR TITLE
Fix for MAGN-5636: Issue with pre-compilation of typed identifier statements

### DIFF
--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -31,6 +31,7 @@ namespace Dynamo.Nodes
         private readonly List<Statement> codeStatements = new List<Statement>();
         private string code = string.Empty;
         private List<string> inputIdentifiers = new List<string>();
+        private List<string> inputPortNames = new List<string>();
         private readonly List<string> tempVariables = new List<string>();
         private string previewVariable;
         private readonly LibraryServices libraryServices;
@@ -430,9 +431,20 @@ namespace Dynamo.Nodes
                 }
 
                 if (parseParam.UnboundIdentifiers != null)
-                    inputIdentifiers = new List<string>(parseParam.UnboundIdentifiers);
+                {
+                    inputIdentifiers = new List<string>();
+                    inputPortNames = new List<string>();
+                    foreach (var kvp in parseParam.UnboundIdentifiers)
+                    {
+                        inputIdentifiers.Add(kvp.Value);
+                        inputPortNames.Add(kvp.Key);
+                    }
+                }
                 else
+                {
                     inputIdentifiers.Clear();
+                    inputPortNames.Clear();                    
+                }
             }
             catch (Exception e)
             {
@@ -514,7 +526,7 @@ namespace Dynamo.Nodes
         private void SetInputPorts()
         {
             // Generate input port data list from the unbound identifiers.
-            var inportData = CodeBlockUtils.GenerateInputPortData(inputIdentifiers);
+            var inportData = CodeBlockUtils.GenerateInputPortData(inputPortNames);
             foreach (var portData in inportData)
                 InPortData.Add(portData);
         }

--- a/src/DynamoCore/Nodes/Custom Nodes/Function.cs
+++ b/src/DynamoCore/Nodes/Custom Nodes/Function.cs
@@ -328,23 +328,12 @@ namespace Dynamo.Nodes
             identifier = null;
             defaultValue = null;
 
-            // workaround: there is an issue in parsing "x:int" format unless 
-            // we create the other parser specially for it. We change it to 
-            // "x:int = dummy;" for parsing. 
             var parseString = InputSymbol;
 
             // if it has default value, then append ';'
-            if (InputSymbol.Contains("="))
-            {
-                parseString += ";";
-            }
-            else
-            {
-                String dummyExpression = "{0}=dummy;";
-                parseString = string.Format(dummyExpression, parseString);
-            }
-
-            ParseParam parseParam = new ParseParam(this.GUID, parseString);
+            parseString += ";";
+            
+            var parseParam = new ParseParam(this.GUID, parseString);
 
             if (EngineController.CompilationServices.PreCompileCodeBlock(ref parseParam) &&
                 parseParam.ParsedNodes != null &&

--- a/src/Engine/ProtoCore/CompilerUtils.cs
+++ b/src/Engine/ProtoCore/CompilerUtils.cs
@@ -94,7 +94,6 @@ namespace ProtoCore.Utils
     public class ParseParam
     {
         private List<string> temporaries = null;
-        //private List<string> unboundIdentifiers = null;
         private Dictionary<string, string> unboundIdentifiers;
         private List<ProtoCore.AST.Node> parsedNodes = null;
         private List<ProtoCore.BuildData.ErrorEntry> errors = null;
@@ -119,8 +118,6 @@ namespace ProtoCore.Utils
             if (this.unboundIdentifiers == null)
                 this.unboundIdentifiers = new Dictionary<string, string>();
 
-            //if (!this.unboundIdentifiers.Contains(identifier))
-            //    this.unboundIdentifiers.Add(identifier);
             if (!this.unboundIdentifiers.ContainsKey(displayName))
                 this.unboundIdentifiers.Add(displayName, identifier);
         }

--- a/src/Engine/ProtoCore/DSASM/DSasmDefs.cs
+++ b/src/Engine/ProtoCore/DSASM/DSasmDefs.cs
@@ -454,6 +454,7 @@ namespace ProtoCore.DSASM
         public const char kLongestPostfix = 'L';
         public const string kDoubleUnderscores = "__";
         public const string kSingleUnderscore = "_";
+        public const string kTempVarForTypedIdentifier = "%tTypedIdent";
     }
 
     public enum MemoryRegion

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -433,6 +433,13 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class TypedIdentifierNode : IdentifierNode
     {
+        public TypedIdentifierNode()
+        {
+        }
+
+        public TypedIdentifierNode(IdentifierNode rhs)
+            : base(rhs) {}
+
         public override string ToString()
         {
             return base.ToString() + " : " + datatype;

--- a/src/Engine/ProtoCore/Utils/NodeUtils.cs
+++ b/src/Engine/ProtoCore/Utils/NodeUtils.cs
@@ -1,4 +1,6 @@
 ﻿
+using ProtoCore.AST.AssociativeAST;
+
 namespace ProtoCore.Utils
 {
     public static class NodeUtils
@@ -24,6 +26,9 @@ namespace ProtoCore.Utils
         {
             if (rhsNode is ProtoCore.AST.AssociativeAST.IdentifierNode)
             {
+                if(rhsNode is TypedIdentifierNode)
+                    return new ProtoCore.AST.AssociativeAST.TypedIdentifierNode(rhsNode as ProtoCore.AST.AssociativeAST.IdentifierNode);
+
                 return new ProtoCore.AST.AssociativeAST.IdentifierNode(rhsNode as ProtoCore.AST.AssociativeAST.IdentifierNode);
             }
             else if (rhsNode is ProtoCore.AST.AssociativeAST.IdentifierListNode)


### PR DESCRIPTION
### Background ###
Non-assignment statements such as `a : Point;` were not being compiled properly and the type information for these identifiers was lost. While the parser spits out the correct AST's (`TypedIdentifierNode`), these were being mutated during the pre-compilation stage which caused the type information to be lost. This caused problems in `Input` node used with custom nodes. This has now been fixed in the pre-compilation step. 

For example, `a : int;` would be converted to `tempVar = a;` such that the code block node would have both an input (`a`) as well as an output port (`tempVar`), however the type information of `a` would be lost.

### Solution ###
`a : Point;` is now converted into something equivalent to `a : Point = %tTypedIdent;` so that the type information is preserved. The `%tTypedIdent` is simply a placeholder for an identifier so that the node would have an input port assigned to it.

This also fixes the following scenarios. Now the warnings related to type mismatch are generated properly as expected:
![image](https://cloud.githubusercontent.com/assets/5710686/6521091/b19d2a34-c40c-11e4-88d8-f31ea9e21802.png)

![image](https://cloud.githubusercontent.com/assets/5710686/6521072/73e26f9c-c40c-11e4-9231-05a3eff319a2.png)


Reviewers:
@junmendoza 
@ke-yu 