### PR TITLE
Add core to the runtimemirror

### DIFF
--- a/src/Engine/ProtoCore/Reflection/Mirror.cs
+++ b/src/Engine/ProtoCore/Reflection/Mirror.cs
@@ -82,8 +82,8 @@ namespace ProtoCore
                 this.mirrorData = mirrorData;
             }
 
-            public RuntimeMirror(string varname, int blockDecl, ProtoCore.RuntimeCore runtimeCore)
-                : base(runtimeCore)
+            public RuntimeMirror(string varname, int blockDecl, ProtoCore.RuntimeCore runtimeCore, ProtoCore.Core staticCore = null)
+                : base(runtimeCore, staticCore)
             {
                 TargetExecutive = runtimeCore.CurrentExecutive.CurrentDSASMExec;
                 deprecateThisMirror = new DSASM.Mirror.ExecutionMirror(TargetExecutive, runtimeCore);
@@ -94,7 +94,7 @@ namespace ProtoCore
                 blockDeclaration = blockDecl;
                 StackValue svData = deprecateThisMirror.GetValue(variableName, blockDeclaration).DsasmValue;
 
-                mirrorData = new MirrorData(this.runtimeCore, svData);
+                mirrorData = new MirrorData(staticCore, this.runtimeCore, svData);
             }
 
             /// <summary>

--- a/src/Engine/ProtoCore/Reflection/MirrorData.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorData.cs
@@ -50,8 +50,9 @@ namespace ProtoCore
             /// Takes a runtime core object to read runtime data
             /// </summary>
             /// <param name="sv"></param>
-            public MirrorData(ProtoCore.RuntimeCore runtimeCore, StackValue sv)
+            public MirrorData(ProtoCore.Core core, ProtoCore.RuntimeCore runtimeCore, StackValue sv)
             {
+                this.core = core;
                 this.runtimeCore = runtimeCore;
                 svData = sv;
             }
@@ -158,7 +159,7 @@ namespace ProtoCore
                 if (!this.IsCollection)
                     return null;
 
-                return ArrayUtils.GetValues(svData, runtimeCore).Select(x => new MirrorData(this.runtimeCore, x)).ToList();
+                return ArrayUtils.GetValues(svData, runtimeCore).Select(x => new MirrorData(this.core, this.runtimeCore, x)).ToList();
             }
 
             /// <summary>

--- a/src/Engine/ProtoCore/Reflection/Reflection.cs
+++ b/src/Engine/ProtoCore/Reflection/Reflection.cs
@@ -11,9 +11,9 @@ namespace ProtoCore
             ///  Returns a runtime mirror that can be reflected upon
             /// </summary>
             /// <returns></returns>
-            public static RuntimeMirror Reflect(string varname, int blockDecl, ProtoCore.RuntimeCore runtimeCore)
+            public static RuntimeMirror Reflect(string varname, int blockDecl, ProtoCore.RuntimeCore runtimeCore, ProtoCore.Core core)
             {
-                return new RuntimeMirror(varname, blockDecl, runtimeCore);
+                return new RuntimeMirror(varname, blockDecl, runtimeCore, core);
             }
 
             

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1297,7 +1297,7 @@ namespace ProtoScript.Runners
                     {
                         //return GetWatchValue(nodeName);
                         const int blockID = 0;
-                        ProtoCore.Mirror.RuntimeMirror runtimeMirror = ProtoCore.Mirror.Reflection.Reflect(nodeName, blockID, runtimeCore);
+                        ProtoCore.Mirror.RuntimeMirror runtimeMirror = ProtoCore.Mirror.Reflection.Reflect(nodeName, blockID, runtimeCore, runnerCore);
                         return runtimeMirror;
                     }
                 }


### PR DESCRIPTION
@ke-yu @aparajit-pratap PTAL


The UI also uses the runtime mirror for inspecting class information. It
should then hold a reference to the core in order to inspect class and
function information