### PR TITLE
Fix regressed test case RunAutomatically_On_5068

### DIFF
--- a/test/core/recorded/var2.dyn
+++ b/test/core/recorded/var2.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="0.7.2.9691" X="0" Y="0" zoom="1" Description="" Category="" Name="Home">
+<Workspace Version="0.7.2.9691" X="0" Y="0" zoom="1" Description="" RunType="Automatic" Category="" Name="Home">
   <Elements>
     <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="22318709-d001-45c0-afde-f9a7ff94ed39" nickname="+" x="691" y="404.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="+@," />
     <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="e9c9a45b-e5fb-4b16-b2ba-e5e08a7048c8" nickname="Code Block" x="308" y="414" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="1;" ShouldFocus="false" />

--- a/test/core/recorded/var3.dyn
+++ b/test/core/recorded/var3.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="0.7.2.9691" X="440.832449136614" Y="371.970016254834" zoom="1.01250925112211" Description="" Category="" Name="Home">
+<Workspace Version="0.7.2.9691" X="440.832449136614" Y="371.970016254834" zoom="1.01250925112211" RunType="Automatic" Description="" Category="" Name="Home">
   <Elements>
     <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="a383d8d7-328b-4515-9e8f-836a2b62341a" nickname="Code Block" x="-9" y="-14" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0..10..1;" ShouldFocus="false" />
   </Elements>


### PR DESCRIPTION
This test case tries to run some .dyn files in Run Automatically mode (by setting `HomeworkSpace.RunSettings.RunType` to `RunType.Automatic` in `CodeBlockNodetests.RunCommandFileFile()`). 

But these files never run in automatic mode because `RunType` now is serialized to .dyn file, when .dyn file is deserialized, the default `RunType` would be set to `RunType.Manual` if .dyn file doesn't contain `RunType` attribute. Then the test fails to verify some values as the graph hasn't been run yet. 

I add `RunType` attribute to these test .dyn files. 

@Benglin , @ikeough , please review the fix. 
