### PR TITLE
Set the dirty flag when the slider is clicked

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -77,7 +77,8 @@
                             IsSnapToTickEnabled="true" 
                             Grid.Column="2" 
                             Thumb.DragStarted="Slider_OnDragStarted"
-                            Thumb.DragCompleted="Slider_OnDragCompleted"                            
+                            Thumb.DragCompleted="Slider_OnDragCompleted"   
+                            MouseMove="Slider_OnMouseMove"
                             />
 
         </Grid>

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
@@ -44,8 +44,7 @@ namespace Dynamo.Wpf.Controls
 
         private void Slider_OnDragCompleted(object sender, DragCompletedEventArgs e)
         {
-            nodeModel.MarkNodeAsModified(true);
-            ui.ViewModel.WorkspaceViewModel.HasUnsavedChanges = true;
+            nodeModel.MarkNodeAsModified(true);           
         }
 
         protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
@@ -54,6 +53,14 @@ namespace Dynamo.Wpf.Controls
             base.OnPreviewMouseLeftButtonDown(e);
             if (e.OriginalSource is Rectangle)
                 WorkspaceModel.RecordModelForModification(nodeModel, undoRecorder);
+        }
+
+        private void Slider_OnMouseMove(object sender, MouseEventArgs e)
+        {
+            if (e.LeftButton == MouseButtonState.Pressed)
+            {
+                ui.ViewModel.WorkspaceViewModel.HasUnsavedChanges = true;
+            }
         }
 
         #endregion


### PR DESCRIPTION
**Issue**:
   Dirty flag is not set when the Slider is clicked inside (instead of a Drag).

**Fix**:
  Added a mousemove function and check for Button Pressed property. Setting the dirty flag to true when the click happened inside the slider thumb.

- [x] @ikeough 