### PR TITLE
MAGN-6416 When there are too many Nodes in Graph, it doesn't show input and output ports on Nodes.

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -54,11 +54,6 @@
                 </ContextMenu>
             </Grid.ContextMenu>
 
-            <Grid.Width>
-                <Binding Path="ActualWidth"
-                         RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type ItemsControl}}" />
-            </Grid.Width>
-
             <Grid.ToolTip>
                 <dynui:DynamoToolTip AttachmentSide="{Binding Path=PortType, Converter={StaticResource PortToAttachmentConverter}}"
                          Style="{DynamicResource ResourceKey=SLightToolTip}">


### PR DESCRIPTION
**Issue**:
  Too many nodes in the graph or if the zoom is below a certain threshold, the ports does not show up.

**Fix**:
  Removed the redundant "ActualWidth" setting on the ports grid. Ports Grid width inherit from InportsGrid width on NodeView. 

- [x] @pboyer 