### PR TITLE
More memory leak fixes

### DIFF
--- a/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
+++ b/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
@@ -43,35 +43,7 @@ namespace ProtoFFI
             {
                 return Assembly.LoadFrom(name);
             }
-            else
-            {
-                string assemblyName = System.IO.Path.GetFileNameWithoutExtension(name);
-                byte[] publicKeyToekn;
-
-                if (GACGeometryKeyTokens.TryGetValue(assemblyName, out publicKeyToekn))
-                {
-                    AssemblyName an = new AssemblyName();
-                    an.Name = assemblyName;
-                    an.SetPublicKeyToken(publicKeyToekn);
-                    an.Version = mExecutingAssemblyName.Version;
-                    an.CultureInfo = mExecutingAssemblyName.CultureInfo;
-                    an.ProcessorArchitecture = mExecutingAssemblyName.ProcessorArchitecture;
-                    System.Diagnostics.Debug.Write("Assembly: " + assemblyName + "," + an.Version.ToString() + " is in GAC.");
-                    return Assembly.Load(an);
-                }
-            }
             throw new System.IO.FileNotFoundException();
-        }
-
-        public bool IsInternalGacAssembly(string moduleName)
-        {
-            if (string.IsNullOrEmpty(moduleName))
-            {
-                return false;
-            }
-
-            string assemblyName = System.IO.Path.GetFileNameWithoutExtension(moduleName);
-            return GACGeometryKeyTokens.ContainsKey(assemblyName);
         }
 
         public IExecutionSession GetSession(RuntimeCore runtimeCore)

--- a/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
+++ b/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
@@ -80,7 +80,7 @@ namespace ProtoFFI
 
         private void OnDispose(RuntimeCore sender)
         {
-            if (null == mSessions)
+            if (mSessions == null)
                 return;
 
             FFIExecutionSession session = null;
@@ -94,7 +94,6 @@ namespace ProtoFFI
                     sender.ExecutionEvent -= OnExecutionEvent;
                 }
                 mSelf = null;
-
             }
 
         }

--- a/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
+++ b/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
@@ -121,7 +121,10 @@ namespace ProtoFFI
                     sender.Dispose -= OnDispose;
                     sender.ExecutionEvent -= OnExecutionEvent;
                 }
+                mSelf = null;
+
             }
+
         }
 
         private void OnExecutionEvent(object sender, ExecutionStateEventArgs e)

--- a/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
+++ b/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
@@ -14,13 +14,6 @@ namespace ProtoFFI
         {
         }
 
-        private static Dictionary<string, byte[]> GACGeometryKeyTokens = new Dictionary<string, byte[]>()
-        {
-            /* {"ProtoGeometry", new byte[] { 0xD5, 0x24, 0x30, 0x4D, 0xAF, 0x1F, 0x8B, 0x35}}, */
-        };
-
-        private AssemblyName mExecutingAssemblyName = Assembly.GetExecutingAssembly().GetName();
-
         Dictionary<RuntimeCore, FFIExecutionSession> mSessions = new Dictionary<RuntimeCore, FFIExecutionSession>();
         ExtensionAppLoader mApploader = new ExtensionAppLoader();
 

--- a/src/Engine/ProtoCore/FFI/ImportModuleHandler.cs
+++ b/src/Engine/ProtoCore/FFI/ImportModuleHandler.cs
@@ -59,12 +59,9 @@ namespace ProtoFFI
 
             if (modulePathFileName == null || !File.Exists(modulePathFileName))
             {
-                if (!FFIExecutionManager.Instance.IsInternalGacAssembly(moduleName))
-                {
-                    System.Diagnostics.Debug.Write(@"Cannot import file: '" + modulePathFileName);
-                    _coreObj.LogWarning(ProtoCore.BuildData.WarningID.kFileNotFound, string.Format(Resources.kFileNotFound, modulePathFileName));
-                    return null;
-                }
+                System.Diagnostics.Debug.Write(@"Cannot import file: '" + modulePathFileName);
+                _coreObj.LogWarning(ProtoCore.BuildData.WarningID.kFileNotFound, string.Format(Resources.kFileNotFound, modulePathFileName));
+                return null;
             }
 
             node.ModulePathFileName = modulePathFileName;


### PR DESCRIPTION
TBR @sharadkjaiswal @junmendoza @ke-yu 

The FFIManager was leaking on each session as it never cleaned up its instance. @sharadkjaiswal this needs fixing, can you confirm that my fix is safe?

This removes about another 30Mb/test of memory leakage.

GACGeometryKeyTokens was an empty dictionary that nothing was added to. Consequently the contains checks would also ways be false. I propagated false through the call graph and pruned the resultant dead code.

TBR to allow CI recovery
