### PR TITLE
Fix repeated calls to Library Services

### DIFF
--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -301,6 +301,8 @@ namespace Dynamo.DSEngine
                     return false;
                 }
 
+                LoadLibraryMigrations(library);
+
                 var loadedClasses = classTable.ClassNodes.Skip(classNumber);
                 foreach (var classNode in loadedClasses)
                 {
@@ -318,12 +320,12 @@ namespace Dynamo.DSEngine
                 OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(library, e.Message));
                 return false;
             }
-
             OnLibraryLoaded(new LibraryLoadedEventArgs(library));
             return true;
         }
 
-        private void ParseLibraryMigrations(string library)
+
+        private void LoadLibraryMigrations(string library)
         {
             string fullLibraryName = library;
 
@@ -376,7 +378,6 @@ namespace Dynamo.DSEngine
             if (null == library || null == functions)
                 throw new ArgumentNullException();
 
-            ParseLibraryMigrations(library);
 
             Dictionary<string, FunctionGroup> fptrs;
             if (!importedFunctionGroups.TryGetValue(library, out fptrs))
@@ -501,14 +502,23 @@ namespace Dynamo.DSEngine
         /// </summary>
         private void PopulatePreloadLibraries()
         {
+            HashSet<String> librariesThatNeedMigrationLoading = new HashSet<string>();
+
             foreach (ClassNode classNode in LibraryManagementCore.ClassTable.ClassNodes)
             {
                 if (classNode.IsImportedClass && !string.IsNullOrEmpty(classNode.ExternLib))
                 {
                     string library = Path.GetFileName(classNode.ExternLib);
                     ImportClass(library, classNode);
+                    librariesThatNeedMigrationLoading.Add(library);
                 }
             }
+
+            foreach (String library in librariesThatNeedMigrationLoading)
+            {
+                LoadLibraryMigrations(library);
+            }
+
         }
 
         private void ImportProcedure(string library, ProcedureNode proc)


### PR DESCRIPTION
Library loading was making multiple thousand IO calls un-necessarily. It was loading the migration XML for everything method rather than every library.

TBR for test fixes @ke-yu @sharadkjaiswal 