### PR TITLE
Removed obsolete test case 

### DIFF
--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -230,39 +230,6 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
-        public void LibraryLoaded_PrecompileCBN_ShowConflictWarnings()
-        {
-            var model = ViewModel.Model;
-
-            // Create the initial code block node.
-            var codeBlockNodeOne = CreateCodeBlockNode();
-            UpdateCodeBlockNodeContent(codeBlockNodeOne, "Point.ByCoordinates();");
-
-            // We should have one code block node by now.
-            Assert.AreEqual(1, model.CurrentWorkspace.Nodes.Count());
-
-            // Run 
-            Assert.DoesNotThrow(() => ViewModel.HomeSpace.Run());
-
-            string libraryPath = "FFITarget.dll";
-
-            var libraryServices = ViewModel.Model.EngineController.LibraryServices;
-
-            // All we need to do here is to ensure that the target has been loaded
-            // at some point, so if it's already thre, don't try and reload it
-            if (!libraryServices.IsLibraryLoaded(libraryPath))
-            {
-                libraryServices.ImportLibrary(libraryPath);
-            }
-
-            // Assert that once a library with classname conflicts is loaded the CBN
-            // displays the warning
-            Assert.IsTrue(codeBlockNodeOne.ToolTipText.Contains(string.Format(
-                ProtoCore.Properties.Resources.kMultipleSymbolFoundFromName, "Point", "")));
-        }
-
-        [Test]
-        [Category("UnitTests")]
         public void DumpLibraryToXmlZeroTouchTest()
         {
             LibraryLoaded = false;


### PR DESCRIPTION
This is no longer required once the namespace collision changes go in shortly.