### PR TITLE
MAGN-6382 Preview bubbles do not display numbers correctly

### DIFF
--- a/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
+++ b/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
@@ -98,7 +98,7 @@ namespace Dynamo.Interfaces
             return new WatchViewModel(visualizationManager, value.ToString(preferences.NumberFormat, CultureInfo.InvariantCulture), tag);
         }
 
-        private WatchViewModel ProcessThing(int value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
+        private WatchViewModel ProcessThing(long value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
             return new WatchViewModel(visualizationManager, value.ToString(CultureInfo.InvariantCulture), tag);
         }


### PR DESCRIPTION
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6382

Watch processing logic IS the same for both the PreviewControl (under node preview) and the Watch. But, in both places it was wrong :) The `Process` methods used to handle integer values for watch were using `int`, but the data was `long`. Dynamic dispatch used the only `Process` method with a suitable cast. This turned out to be `double`. By converting that method to use `long`, instead of `int`, we get the appropriate behavior.

Interestingly, the compact view of the PreviewControl showed the correct representation of integers because it doesn't use the `Process` methods. It uses the `MirrorData.StringData` property which was correctly formatted.

Integers:
![image](https://cloud.githubusercontent.com/assets/1139788/6520318/93902148-c378-11e4-820a-c6b4f7ad0070.png)

Doubles:
![image](https://cloud.githubusercontent.com/assets/1139788/6520323/a1335068-c378-11e4-9bf5-887750b05edc.png)

PTAL @lukechurch, because you gave this to me :)