### PR TITLE
Introduce NodeModified, RequestRun methods to WorkspaceModel

### DIFF
--- a/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
@@ -153,9 +153,9 @@ namespace Dynamo.Models
         }
         private string description;
 
-        protected override void OnNodesModified()
+        protected override void RequestRun()
         {
-            base.OnNodesModified();
+            base.RequestRun();
             HasUnsavedChanges = true;
             OnDefinitionUpdated();
         }

--- a/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
@@ -153,7 +153,7 @@ namespace Dynamo.Models
         }
         private string description;
 
-        public override void OnNodesModified()
+        protected override void OnNodesModified()
         {
             base.OnNodesModified();
             HasUnsavedChanges = true;

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -134,9 +134,9 @@ namespace Dynamo.Models
             MarkNodesAsModified(Nodes);
         }
 
-        protected override void OnNodesModified()
+        protected override void RequestRun()
         {
-            base.OnNodesModified();
+            base.RequestRun();
 
             if (RunSettings.RunType != RunType.Manual)
             {
@@ -148,9 +148,9 @@ namespace Dynamo.Models
         {
             base.OnNodeModified(node);
 
-            if (!silenceNodeModifications && RunSettings.RunType != RunType.Manual)
+            if (!silenceNodeModifications)
             {
-                Run();
+                RequestRun();
             }
         }
 
@@ -209,7 +209,7 @@ namespace Dynamo.Models
                 nodeToUpdate.MarkNodeAsModified(true);
             }
 
-            OnNodesModified();
+            RequestRun();
         }
 
         /// <summary>
@@ -277,16 +277,21 @@ namespace Dynamo.Models
         /// Mark all nodes as modified. 
         /// </summary>
         /// <param name="nodes"></param>
-        public void MarkNodesAsModified(IEnumerable<NodeModel> nodes)
+        /// <param name="forceExecute"></param>
+        public void MarkNodesAsModified(IEnumerable<NodeModel> nodes, bool forceExecute = false)
         {
             if (nodes == null)
                 throw new ArgumentNullException("nodes");
 
             foreach (var node in nodes)
-                node.MarkNodeAsModified();
+            {
+                node.MarkNodeAsModified(forceExecute);
+            } 
 
             if (nodes.Any())
-                OnNodesModified();
+            {
+                RequestRun();
+            } 
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -184,7 +184,7 @@ namespace Dynamo.Models
                 pulseMaker = new PulseMaker();
             }
 
-            pulseMaker.RunStarted += pulseMaker_RunStarted;
+            pulseMaker.RunStarted += PulseMakerRunStarted;
             EvaluationCompleted += pulseMaker.OnRunExpressionCompleted;
 
             if (pulseMaker.TimerPeriod != 0)
@@ -196,25 +196,10 @@ namespace Dynamo.Models
             pulseMaker.Start(milliseconds);
         }
 
-        private void pulseMaker_RunStarted()
+        private void PulseMakerRunStarted()
         {
             var nodesToUpdate = Nodes.Where(n => n.EnablePeriodicUpdate);
-            MarkNodesAsModifiedAndUpdate(nodesToUpdate);
-        }
-
-        private void MarkNodesAsModifiedAndUpdate(object state)
-        {
-            var nodesToUpdate = state as IEnumerable<NodeModel>;
-
-            if (nodesToUpdate == null) return;
-
-            // Dirty selective nodes so they get included for evaluation.
-            foreach (var nodeToUpdate in nodesToUpdate)
-            {
-                nodeToUpdate.MarkNodeAsModified(true);
-            }
-
-            RequestRun();
+            MarkNodesAsModified(nodesToUpdate, true);
         }
 
         /// <summary>
@@ -225,7 +210,7 @@ namespace Dynamo.Models
         {
             if (pulseMaker == null || (pulseMaker.TimerPeriod == 0)) return;
 
-            pulseMaker.RunStarted -= pulseMaker_RunStarted;
+            pulseMaker.RunStarted -= PulseMakerRunStarted;
             EvaluationCompleted -= pulseMaker.OnRunExpressionCompleted;
             pulseMaker.Stop();
         }
@@ -279,10 +264,10 @@ namespace Dynamo.Models
         }
 
         /// <summary>
-        /// Mark all nodes as modified. 
+        /// Mark the input nodes as modified
         /// </summary>
-        /// <param name="nodes"></param>
-        /// <param name="forceExecute"></param>
+        /// <param name="nodes">The nodes to modify</param>
+        /// <param name="forceExecute">The argument to NodeModel.MarkNodeAsModified</param>
         public void MarkNodesAsModified(IEnumerable<NodeModel> nodes, bool forceExecute = false)
         {
             if (nodes == null)

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -134,6 +134,11 @@ namespace Dynamo.Models
             MarkNodesAsModified(Nodes);
         }
 
+        /// <summary>
+        ///     Invoked when a change to the workspace that requires re-execution
+        ///     has taken place.  If in run-automatic, a new run will take place,
+        ///     otherwise nothing will happen.
+        /// </summary>
         protected override void RequestRun()
         {
             base.RequestRun();
@@ -144,9 +149,9 @@ namespace Dynamo.Models
             }
         }
 
-        protected override void OnNodeModified(NodeModel node)
+        protected override void NodeModified(NodeModel node)
         {
-            base.OnNodeModified(node);
+            base.NodeModified(node);
 
             if (!silenceNodeModifications)
             {

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -620,11 +620,11 @@ namespace Dynamo.Models
         /// <summary>
         ///     Event fired when the node's DesignScript AST should be recompiled
         /// </summary>
-        public event Action<NodeModel> NodeModified;
+        public event Action<NodeModel> Modified;
         public virtual void OnNodeModified(bool forceExecute = false)
         {
             MarkNodeAsModified(forceExecute);
-            var handler = NodeModified;
+            var handler = Modified;
             if (handler != null) handler(this);
         }
 

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -618,14 +618,14 @@ namespace Dynamo.Models
         #region Modification Reporting
 
         /// <summary>
-        ///     Event fired when the DesignScript AST produced by this node has changed.
+        ///     Event fired when the node's DesignScript AST should be recompiled
         /// </summary>
-        public event Action NodeModified;
+        public event Action<NodeModel> NodeModified;
         public virtual void OnNodeModified(bool forceExecute = false)
         {
             MarkNodeAsModified(forceExecute);
             var handler = NodeModified;
-            if (handler != null) handler();
+            if (handler != null) handler(this);
         }
 
         #endregion

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -579,7 +579,7 @@ namespace Dynamo.Models
             OnNodeAdded(node);
             HasUnsavedChanges = true;
 
-            OnNodesModified();
+            RequestRun();
         }
 
         private void RegisterNode(NodeModel node)
@@ -589,9 +589,11 @@ namespace Dynamo.Models
         }
 
         /// <summary>
-        ///     Indicates that the collection of nodes in this workspace has changed
+        ///     Invoked when a change to the workspace that requires re-execution
+        ///     has taken place.  If in run-automatic, a new run will take place,
+        ///     otherwise nothing will happen.
         /// </summary>
-        protected virtual void OnNodesModified()
+        protected virtual void RequestRun()
         {
             
         }
@@ -996,7 +998,7 @@ namespace Dynamo.Models
             DynamoSelection.Instance.ClearSelection();
             DynamoSelection.Instance.Selection.Add(codeBlockNode);
 
-            OnNodesModified();
+            RequestRun();
         }
 
         #endregion
@@ -1155,7 +1157,7 @@ namespace Dynamo.Models
                     }
                 }
 
-                OnNodesModified();
+                RequestRun();
 
             } // Conclude the deletion.
         }

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -584,15 +584,10 @@ namespace Dynamo.Models
 
         private void RegisterNode(NodeModel node)
         {
-            node.NodeModified += OnNodeModified;
+            node.Modified += NodeModified;
             node.ConnectorAdded += OnConnectorAdded;
         }
 
-        /// <summary>
-        ///     Invoked when a change to the workspace that requires re-execution
-        ///     has taken place.  If in run-automatic, a new run will take place,
-        ///     otherwise nothing will happen.
-        /// </summary>
         protected virtual void RequestRun()
         {
             
@@ -601,7 +596,7 @@ namespace Dynamo.Models
         /// <summary>
         ///     Indicates that the AST for a node in this workspace requires recompilation
         /// </summary>
-        protected virtual void OnNodeModified(NodeModel node)
+        protected virtual void NodeModified(NodeModel node)
         {
 
         }
@@ -621,7 +616,7 @@ namespace Dynamo.Models
         protected void DisposeNode(NodeModel model)
         {
             model.ConnectorAdded -= OnConnectorAdded;
-            model.NodeModified -= OnNodeModified;
+            model.Modified -= NodeModified;
             OnNodeRemoved(model);
         }
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -258,6 +258,8 @@ namespace Dynamo.Models
 
         /// <summary>
         ///     All of the nodes currently in the workspace.
+        /// 
+        ///     TODO(Peter): This should be an IEnumerable of nodes to prevent modification from the outside - MAGN-6580
         /// </summary>
         public ObservableCollection<NodeModel> Nodes { get { return nodes; } }
 
@@ -276,8 +278,11 @@ namespace Dynamo.Models
 
         /// <summary>
         ///     All of the notes currently in the workspace.
+        /// 
+        ///     TODO(Peter): This should be an IEnumerable of notes to prevent modification from the outside - MAGN-6580
         /// </summary>
         public ObservableCollection<NoteModel> Notes { get { return notes; } }
+
         /// <summary>
         ///     Path to the file this workspace is associated with. If null or empty, this workspace has never been saved.
         /// </summary>
@@ -570,27 +575,6 @@ namespace Dynamo.Models
                 OnRequestNodeCentered(this, args);
             }
 
-            //var cbn = node as CodeBlockNodeModel;
-            //if (cbn != null)
-            //{
-            //    var firstChange = true;
-            //    PropertyChangedEventHandler codeChangedHandler = (sender, args) =>
-            //    {
-            //        if (args.PropertyName != "Code") return;
-                    
-            //        if (string.IsNullOrWhiteSpace(cbn.Code))
-            //        {
-            //            if (firstChange)
-            //                RemoveNode(cbn);
-            //            else
-            //                RecordAndDeleteModels(new List<ModelBase> { cbn });
-            //        }
-            //        firstChange = false;
-            //    };
-            //    cbn.PropertyChanged += codeChangedHandler;
-            //    cbn.Disposed += () => { cbn.PropertyChanged -= codeChangedHandler; };
-            //}
-
             nodes.Add(node);
             OnNodeAdded(node);
             HasUnsavedChanges = true;
@@ -600,16 +584,24 @@ namespace Dynamo.Models
 
         private void RegisterNode(NodeModel node)
         {
-            node.NodeModified += OnNodesModified;
+            node.NodeModified += OnNodeModified;
             node.ConnectorAdded += OnConnectorAdded;
         }
 
         /// <summary>
-        ///     Indicates that this workspace's DesignScript AST has been updated.
+        ///     Indicates that the collection of nodes in this workspace has changed
         /// </summary>
-        public virtual void OnNodesModified()
+        protected virtual void OnNodesModified()
         {
             
+        }
+
+        /// <summary>
+        ///     Indicates that the AST for a node in this workspace requires recompilation
+        /// </summary>
+        protected virtual void OnNodeModified(NodeModel node)
+        {
+
         }
 
         /// <summary>
@@ -627,7 +619,7 @@ namespace Dynamo.Models
         protected void DisposeNode(NodeModel model)
         {
             model.ConnectorAdded -= OnConnectorAdded;
-            model.NodeModified -= OnNodesModified;
+            model.NodeModified -= OnNodeModified;
             OnNodeRemoved(model);
         }
 


### PR DESCRIPTION
### Issue

This fixes the regression in MAGN-6548 and introduces some basic refactorings to clarify what these methods should do.  

Basically, adding a node invoked the old `OnNodesModified` method on `WorkspaceModel`, which implicitly meant that the AST for the whole workspace needed regen.  Because a run had yet to take place, `silenceNodeModifications` prevented this from causing a run.

### Fix 

`AddNode` should invoke the new method `RequestRun`, which will cause a run only if the workspace is in run auto.

`NodeModel.Modified` (refactored here) should have the same behavior as before.  

### Reviewer

- [x] @ikeough 