### PR TITLE
MAGN-5727 Clicking on custom UI drops active connector.

### DIFF
--- a/src/DynamoCoreWpf/Controls/DragCanvas.cs
+++ b/src/DynamoCoreWpf/Controls/DragCanvas.cs
@@ -204,7 +204,9 @@ namespace Dynamo.Controls
             WorkspaceViewModel wvm = dataContext as WorkspaceViewModel;
             // when there is a connection on a dynamonodebutton, then the connection should not be cancelled
             if (wvm != null && !wvm.CheckActiveConnectorCompatibility(wvm.portViewModel))
-                wvm.HandleFocusChanged(this, ((bool)e.NewValue));
+            {
+                wvm.HandleFocusChanged(this, ((bool) e.NewValue));
+            }
             base.OnIsKeyboardFocusWithinChanged(e);
         }
 

--- a/src/DynamoCoreWpf/Controls/DragCanvas.cs
+++ b/src/DynamoCoreWpf/Controls/DragCanvas.cs
@@ -199,10 +199,12 @@ namespace Dynamo.Controls
             // this method will be called with "e.NewValue" sets to "true". 
             // In such cases the state machine should be notified, and any 
             // connection that is in progress should be cancelled off.
-            // 
+            
             object dataContext = this.owningWorkspace.DataContext;
             WorkspaceViewModel wvm = dataContext as WorkspaceViewModel;
-            wvm.HandleFocusChanged(this, ((bool)e.NewValue));
+            // when there is a connection on a dynamonodebutton, then the connection should not be cancelled
+            if (wvm != null && !wvm.CheckActiveConnectorCompatibility(wvm.portViewModel))
+                wvm.HandleFocusChanged(this, ((bool)e.NewValue));
             base.OnIsKeyboardFocusWithinChanged(e);
         }
 


### PR DESCRIPTION
**Issue**:
   Say you have a node List.Create, and you have an active connection, clicking + or - will drop the active connection.

**Fix**:
   Check whether there is an active connection on LostFocus event and if so, don't drop the connection.
I checked this with codeblock nodes and other nodes. This change worked good.

- [x] @pboyer 