### PR TITLE
More minor improvements to the Watch node

### DIFF
--- a/src/DynamoCore/Properties/AssemblyInfo.cs
+++ b/src/DynamoCore/Properties/AssemblyInfo.cs
@@ -13,3 +13,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("DynamoRevitDS")]
 [assembly: InternalsVisibleTo("DynamoMSOfficeTests")]
 [assembly: InternalsVisibleTo("DSCoreNodesUI")]
+[assembly: InternalsVisibleTo("CoreNodeModelsWpf")]

--- a/src/Libraries/CoreNodeModels/Watch.cs
+++ b/src/Libraries/CoreNodeModels/Watch.cs
@@ -19,6 +19,12 @@ namespace Dynamo.Nodes
         public event Action<Object> EvaluationComplete;
         public new object CachedValue;
 
+        /// <summary>
+        ///     Has the Watch node been run once?  If not, the CachedValue
+        ///     is technically not accurate.
+        /// </summary>
+        public bool HasRunOnce { get; private set; }
+
         public Watch()
         {
             InPortData.Add(new PortData("", "Node to evaluate."));
@@ -29,6 +35,7 @@ namespace Dynamo.Nodes
             ArgumentLacing = LacingStrategy.Disabled;
 
             ShouldDisplayPreviewCore = false;
+            HasRunOnce = false;
         }
 
         protected override void OnBuilt()
@@ -46,6 +53,7 @@ namespace Dynamo.Nodes
         private void OnEvaluationComplete(object obj)
         {
             this.CachedValue = obj;
+            this.HasRunOnce = true;
 
             if (EvaluationComplete != null)
             {


### PR DESCRIPTION
After I made some minor fixes to Watch, I realize that it has some incorrect behavior.  

1.  When placing a Watch node in manual mode, the preview value reads "null".  That's because we didn't check if the node has an input value.  Now, before updating the preview value, we check if the node is partially applied.  If so, we clear the preview and move on.
2.  When the Watch node has yet to be run, the `CachedValue` is technically incorrect.  Here I set a simple flag, `HasRunOnce` to check if it has been run yet.  
3.  It's possible that getting the `WatchViewModel` will cause a data race.  Here we use the scheduler to ensure that we're not accessing this data while the engine is writing to it.

### Reviewer

- [x] @ikeough 

