### PR TITLE
Consolidated FunctionDescriptor constructors

### DIFF
--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -38,6 +38,29 @@ namespace Dynamo.DSEngine
         string FunctionName { get; }
     }
 
+    public class FunctionDescriptorParams
+    {
+        public FunctionDescriptorParams()
+        {
+            IsVisibleInLibrary = true;
+            Parameters = new List<TypedParameter>();
+            ReturnKeys = new List<string>();
+            ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar);
+        }
+
+        public string Assembly { get; set; }
+        public string ClassName { get; set; }
+        public string FunctionName { get; set; }
+        public string Summary { get; set; }
+        public string ObsoleteMsg { get; set; }
+        public IEnumerable<TypedParameter> Parameters { get; set; }
+        public ProtoCore.Type ReturnType { get; set; }
+        public FunctionType FunctionType { get; set; }
+        public bool IsVisibleInLibrary { get; set; }
+        public IEnumerable<string> ReturnKeys { get; set; }
+        public bool IsVarArg { get; set; }
+    }
+
     /// <summary>
     ///     Describe a DesignScript function in a imported library
     /// </summary>
@@ -48,49 +71,21 @@ namespace Dynamo.DSEngine
         /// </summary>
         private string summary;
 
-        public FunctionDescriptor(string name, IEnumerable<TypedParameter> parameters, FunctionType type)
-            : this(null, null, name, parameters, TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar), type)
-        { }
-
-        public FunctionDescriptor(
-            string assembly, string className, string functionName, IEnumerable<TypedParameter> parameters,
-            ProtoCore.Type returnType, FunctionType type, bool isVisibleInLibrary = true,
-            IEnumerable<string> returnKeys = null, bool isVarArg = false, string obsoleteMsg = "")
-            : this(
-                assembly,
-                className,
-                functionName,
-                null,
-                parameters,
-                returnType,
-                type,
-                isVisibleInLibrary,
-                returnKeys,
-                isVarArg,
-                obsoleteMsg) { }
-
-        public FunctionDescriptor(
-            string assembly, string className, string functionName, string summary,
-            IEnumerable<TypedParameter> parameters, ProtoCore.Type returnType, FunctionType type,
-            bool isVisibleInLibrary = true, IEnumerable<string> returnKeys = null, bool isVarArg = false, string obsoleteMsg = "")
+        public FunctionDescriptor(FunctionDescriptorParams funcDescParams)
         {
-            this.summary = summary;
-            Assembly = assembly;
-            ClassName = className;
-            FunctionName = functionName;
+            summary = funcDescParams.Summary;
+            Assembly = funcDescParams.Assembly;
+            ClassName = funcDescParams.ClassName;
+            FunctionName = funcDescParams.FunctionName;
 
-            if (parameters == null)
-                Parameters = new List<TypedParameter>();
-            else
-            {
-                Parameters = parameters.Select(
-                    x =>
-                    {
-                        x.Function = this;
-                        return x;
-                    });
-            }
+            Parameters = funcDescParams.Parameters.Select(
+                x =>
+                {
+                    x.Function = this;
+                    return x;
+                });
 
+            var type = funcDescParams.FunctionType;
             var inputParameters = new List<Tuple<string, string>>();
             //Add instance parameter as one of the inputs for instance method as well as properties.
             if(type == FunctionType.InstanceMethod || type == FunctionType.InstanceProperty)
@@ -105,12 +100,15 @@ namespace Dynamo.DSEngine
             InputParameters = inputParameters;
             
             //Not sure why returnType for constructors are var[]..[], use UnqualifiedClassName
-            ReturnType = (type == FunctionType.Constructor) ? UnqualifedClassName : returnType.ToShortString();
+            ReturnType = (type == FunctionType.Constructor) ?
+                UnqualifedClassName :
+                funcDescParams.ReturnType.ToShortString();
+
             Type = type;
-            ReturnKeys = returnKeys ?? new List<string>();
-            IsVarArg = isVarArg;
-            IsVisibleInLibrary = isVisibleInLibrary;
-            ObsoleteMessage = obsoleteMsg;
+            ReturnKeys = funcDescParams.ReturnKeys;
+            IsVarArg = funcDescParams.IsVarArg;
+            IsVisibleInLibrary = funcDescParams.IsVisibleInLibrary;
+            ObsoleteMessage = funcDescParams.ObsoleteMsg;
         }
 
         public bool IsOverloaded { get; set; }

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -446,15 +446,15 @@ namespace Dynamo.DSEngine
                                                         let description = 
                                                             (method.MethodAttribute != null ? method.MethodAttribute.Description :String.Empty)
                                                         select
-                                                            new FunctionDescriptor(
-                                                                null,
-                                                                null,
-                                                                method.name,
-                                                                description,
-                                                                arguments,
-                                                                method.returntype,
-                                                                FunctionType.GenericFunction,
-                                                                visibleInLibrary);
+                                                            new FunctionDescriptor(new FunctionDescriptorParams
+                                                            {
+                                                                FunctionName = method.name,
+                                                                Summary = description,
+                                                                Parameters = arguments,
+                                                                ReturnType = method.returntype,
+                                                                FunctionType = FunctionType.GenericFunction,
+                                                                IsVisibleInLibrary = visibleInLibrary
+                                                            });
 
             AddBuiltinFunctions(functions);
         }
@@ -487,12 +487,18 @@ namespace Dynamo.DSEngine
             };
 
             var functions =
-                ops.Select(op => new FunctionDescriptor(op, args, FunctionType.GenericFunction))
-                    .Concat(
-                        new FunctionDescriptor(
-                            Op.GetUnaryOpFunction(UnaryOperator.Not),
-                            GetUnaryFuncArgs(),
-                            FunctionType.GenericFunction).AsSingleton());
+                ops.Select(op => new FunctionDescriptor(new FunctionDescriptorParams
+                {
+                    FunctionName = op,
+                    Parameters = args,
+                    FunctionType = FunctionType.GenericFunction
+                }))
+                .Concat(new FunctionDescriptor(new FunctionDescriptorParams
+                {
+                    FunctionName = Op.GetUnaryOpFunction(UnaryOperator.Not),
+                    Parameters = GetUnaryFuncArgs(),
+                    FunctionType = FunctionType.GenericFunction
+                }).AsSingleton());
 
             AddBuiltinFunctions(functions);
         }
@@ -622,17 +628,19 @@ namespace Dynamo.DSEngine
                     obsoleteMessage = proc.MethodAttribute.ObsoleteMessage;
             }
 
-            var function = new FunctionDescriptor(
-                library,
-                className,
-                procName,
-                arguments,
-                proc.returntype,
-                type,
-                isVisible,
-                returnKeys,
-                proc.isVarArg,
-                obsoleteMessage);
+            var function = new FunctionDescriptor(new FunctionDescriptorParams
+            {
+                Assembly = library,
+                ClassName = className,
+                FunctionName = procName,
+                Parameters = arguments,
+                ReturnType = proc.returntype,
+                FunctionType = type,
+                IsVisibleInLibrary = isVisible,
+                ReturnKeys = returnKeys,
+                IsVarArg = proc.isVarArg,
+                ObsoleteMsg = obsoleteMessage
+            });
 
             AddImportedFunctions(library, new[] { function });
         }

--- a/test/DynamoCoreTests/TypedParametersToStringTests.cs
+++ b/test/DynamoCoreTests/TypedParametersToStringTests.cs
@@ -20,50 +20,68 @@ namespace Dynamo.Tests
             //6. Empty string(a: int)
 
             // 1 case
-            List<TypedParameter> parameters1 = new List<TypedParameter>();
+            var parameters1 = new List<TypedParameter>();
             parameters1.Add(new TypedParameter("x", new ProtoCore.Type { Name = "double" }));
             parameters1.Add(new TypedParameter("y", new ProtoCore.Type { Name = "double" }));
-            FunctionDescriptor functionItem1 = new FunctionDescriptor("Foo", parameters1, FunctionType.GenericFunction);
+            var functionItem1 = new FunctionDescriptor(new FunctionDescriptorParams
+            {
+                FunctionName = "Foo", Parameters = parameters1, FunctionType = FunctionType.GenericFunction
+            });
 
             System.Console.WriteLine(functionItem1.Parameters.Count());
             Assert.AreEqual("Foo.double-double", Utils.TypedParametersToString(functionItem1));
 
             //2 case
-            List<TypedParameter> parameters2 = new List<TypedParameter>();
+            var parameters2 = new List<TypedParameter>();
             parameters2.Add(new TypedParameter("point", new ProtoCore.Type { Name = "Point" }));
-            FunctionDescriptor functionItem2 = new FunctionDescriptor("Foo", parameters2, FunctionType.GenericFunction);
+            var functionItem2 = new FunctionDescriptor(new FunctionDescriptorParams
+            {
+                FunctionName = "Foo", Parameters = parameters2, FunctionType = FunctionType.GenericFunction
+            });
 
             Assert.AreEqual("Foo.Point", Utils.TypedParametersToString(functionItem2));
 
             //3 case
-            List<TypedParameter> parameters3 = new List<TypedParameter>();
+            var parameters3 = new List<TypedParameter>();
             parameters3.Add(new TypedParameter("a", new ProtoCore.Type { Name = "bool [ ] [ ] " }));
             parameters3.Add(new TypedParameter("b", new ProtoCore.Type { Name = "var[]" }));
             parameters3.Add(new TypedParameter("c", new ProtoCore.Type { Name = "double[][]" }));
-            FunctionDescriptor functionItem3 = new FunctionDescriptor("Foo", parameters3, FunctionType.GenericFunction);
+            var functionItem3 = new FunctionDescriptor(new FunctionDescriptorParams
+            {
+                FunctionName = "Foo", Parameters = parameters3, FunctionType = FunctionType.GenericFunction
+            });
 
             Assert.AreEqual("Foo.bool2-var1-double2", Utils.TypedParametersToString(functionItem3));
 
             //4 case
-            List<TypedParameter> parameters4 = new List<TypedParameter>();
+            var parameters4 = new List<TypedParameter>();
             parameters4.Add(new TypedParameter("arr", new ProtoCore.Type { Name = "var[]..[]" }));
             parameters4.Add(new TypedParameter("a", new ProtoCore.Type { Name = "int" }));
-            FunctionDescriptor functionItem4 = new FunctionDescriptor("Foo", parameters4, FunctionType.GenericFunction);
+            var functionItem4 = new FunctionDescriptor(new FunctionDescriptorParams
+            {
+                FunctionName = "Foo", Parameters = parameters4, FunctionType = FunctionType.GenericFunction
+            });
 
             Assert.AreEqual("Foo.varN-int", Utils.TypedParametersToString(functionItem4));
 
             //5 case
-            List<TypedParameter> parameters5 = new List<TypedParameter>();
+            var parameters5 = new List<TypedParameter>();
             parameters5.Add(new TypedParameter("a", new ProtoCore.Type { Name = "Autodesk.DesignScript.Geometry.Circle" }));
             parameters5.Add(new TypedParameter("b", new ProtoCore.Type { Name = "Xxxx.Yyy.Curve" }));
-            FunctionDescriptor functionItem5 = new FunctionDescriptor("Foo", parameters5, FunctionType.GenericFunction);
+            var functionItem5 = new FunctionDescriptor(new FunctionDescriptorParams
+            {
+                FunctionName = "Foo", Parameters = parameters5, FunctionType = FunctionType.GenericFunction
+            });
 
             Assert.AreEqual("Foo.Circle-Curve", Utils.TypedParametersToString(functionItem5));
 
             //6 case
-            List<TypedParameter> parameters6 = new List<TypedParameter>();
+            var parameters6 = new List<TypedParameter>();
             parameters6.Add(new TypedParameter("a", new ProtoCore.Type { Name = "int" }));
-            FunctionDescriptor functionItem6 = new FunctionDescriptor("", parameters6, FunctionType.GenericFunction);
+            var functionItem6 = new FunctionDescriptor(new FunctionDescriptorParams
+            {
+                FunctionName = "", Parameters = parameters6, FunctionType = FunctionType.GenericFunction
+            });
 
             Assert.AreEqual(".int", Utils.TypedParametersToString(functionItem6));
         }

--- a/test/DynamoCoreTests/XmlDocumentationTests.cs
+++ b/test/DynamoCoreTests/XmlDocumentationTests.cs
@@ -47,13 +47,15 @@ namespace Dynamo.Tests
                 new TypedParameter("zTranslation", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeDouble, 0))
             };
 
-            var funcDesc = new FunctionDescriptor(
-                "ProtoGeometry.dll",
-                "Autodesk.DesignScript.Geometry.Geometry",
-                "Translate",
-                parms,
-                TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar),
-                FunctionType.InstanceMethod);
+            var funcDesc = new FunctionDescriptor(new FunctionDescriptorParams
+            {
+                Assembly = "ProtoGeometry.dll",
+                ClassName = "Autodesk.DesignScript.Geometry.Geometry",
+                FunctionName = "Translate",
+                Parameters = parms,
+                ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar),
+                FunctionType = FunctionType.InstanceMethod
+            });
 
             parms.ForEach(x => x.Function = funcDesc);
 


### PR DESCRIPTION
`FunctionDescriptor` constructors are... not so pretty, to say the least. The bulk of arguments, some having default values while others don't, make dealing with `FunctionDescriptor` error-prone and tedious. This PR consolidates all of them into one that takes a single argument `FunctionDescriptorParams`, and updates all other callers.

Just in case either one of you get online, @ke-yu @aparajit-pratap, please help to take a look at this, thanks!

Note: There is [another sibling pull request](https://github.com/DynamoDS/Dynamo/pull/3917) if you happen to see this.