### PR TITLE
Test Fixes

### DIFF
--- a/src/DynamoCore/Core/Threading/AggregateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/AggregateRenderPackageAsyncTask.cs
@@ -93,7 +93,6 @@ namespace Dynamo.Core.Threading
                 duplicatedNodeReferences = gathered;
             }
 
-            Debug.WriteLine(string.Format("Aggregation task initialized for {0}", nodeModel == null?"null":nodeModel.GUID.ToString()));
             return duplicatedNodeReferences.Any();
         }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -339,6 +339,7 @@ namespace Dynamo.Models
             OnCleanup();
             
             DynamoSelection.DestroyInstance();
+            DynamoPathManager.DestroyInstance();
 
             InstrumentationLogger.End();
 

--- a/src/DynamoCore/Models/RunSettings.cs
+++ b/src/DynamoCore/Models/RunSettings.cs
@@ -98,9 +98,6 @@ namespace Dynamo.Models
 
         private void RaisePropertyChangeWithDebug(string propertyName)
         {
-#if DEBUG
-            Debug.WriteLine(string.Format("{0} property change raised on the RunSettings object.", propertyName));
-#endif
             RaisePropertyChanged(propertyName);
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2114,7 +2114,6 @@ namespace Dynamo.ViewModels
 
         public void GetBranchVisualization(object parameters)
         {
-            Debug.WriteLine("Requesting branch update for background preview.");
             VisualizationManager.RequestBranchUpdate(null);
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -99,7 +99,6 @@ namespace Dynamo.Wpf.ViewModels.Core
             // If any property changes on the run settings object
             // Raise a property change notification for the RunSettingsViewModel
             // property
-            Debug.WriteLine(string.Format("{0} property change handled on the WorkspaceViewModel object.", e.PropertyName));
             RaisePropertyChanged("RunSettingsViewModel");
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -290,7 +290,6 @@ namespace Dynamo.ViewModels
             // If any property changes on the run settings object
             // Raise a property change notification for the RunSettingsViewModel
             // property
-            Debug.WriteLine(string.Format("{0} property change handled on the WorkspaceViewModel object.", e.PropertyName));
             RaisePropertyChanged("RunSettingsViewModel");
         }
 

--- a/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
@@ -250,7 +250,6 @@ namespace Dynamo.Wpf.ViewModels
         /// <param name="e"></param>
         void Model_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            Debug.WriteLine(string.Format("{0} property change handled on the RunSettingsViewModel object.", e.PropertyName));
             switch (e.PropertyName)
             {
                 case "RunEnabled":

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -174,8 +174,6 @@ namespace Dynamo.Controls
         {
             dynamoViewModel.Model.PreferenceSettings.WindowW = e.NewSize.Width;
             dynamoViewModel.Model.PreferenceSettings.WindowH = e.NewSize.Height;
-
-            Debug.WriteLine("Resizing window to {0}:{1}", e.NewSize.Width, e.NewSize.Height);
         }
 
         void InitializeLogin()
@@ -716,8 +714,6 @@ namespace Dynamo.Controls
 
         private void WindowClosed(object sender, EventArgs e)
         {
-            Debug.WriteLine("Dynamo window closed.");
-
             dynamoViewModel.Model.RequestLayoutUpdate -= vm_RequestLayoutUpdate;
             dynamoViewModel.RequestViewOperation -= DynamoViewModelRequestViewOperation;
 
@@ -1168,8 +1164,6 @@ namespace Dynamo.Controls
             if (dynamoViewModel == null)
                 return;
             dynamoViewModel.WorkspaceActualSize(border.ActualWidth, border.ActualHeight);
-
-            Debug.WriteLine("Resizing workspace children.");
         }
 
         private void Window_PreviewMouseDown(object sender, MouseButtonEventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -84,8 +84,6 @@ namespace Dynamo.Controls
 
         private void OnNodeViewUnloaded(object sender, RoutedEventArgs e)
         {
-            Debug.WriteLine("Node view unloaded.");
-
             ViewModel.NodeLogic.DispatchedToUI -= NodeLogic_DispatchedToUI;
             ViewModel.RequestShowNodeHelp -= ViewModel_RequestShowNodeHelp;
             ViewModel.RequestShowNodeRename -= ViewModel_RequestShowNodeRename;
@@ -108,7 +106,6 @@ namespace Dynamo.Controls
                 var size = new double[] { ActualWidth, nodeBorder.ActualHeight };
                 if (ViewModel.SetModelSizeCommand.CanExecute(size))
                 {
-                    //Debug.WriteLine(string.Format("Updating {2} node size {0}:{1}", size[0], size[1], ViewModel.NodeLogic.GetType().ToString()));
                     ViewModel.SetModelSizeCommand.Execute(size);
                 }
             }

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -217,8 +217,6 @@ namespace Dynamo.Controls
 
         private void OnViewUnloaded(object sender, RoutedEventArgs e)
         {
-            Debug.WriteLine("Watch 3D view unloaded.");
-
             var vm = DataContext as IWatchViewModel;
             if (vm != null)
             {
@@ -420,8 +418,6 @@ namespace Dynamo.Controls
             {
                 return;
             }
-
-            Debug.WriteLine(string.Format("Rendering visuals for {0}", e.Id));
 
             var sw = new Stopwatch();
             sw.Start();

--- a/src/DynamoCoreWpf/VisualizationManager/VisualizationManager.cs
+++ b/src/DynamoCoreWpf/VisualizationManager/VisualizationManager.cs
@@ -57,7 +57,6 @@ namespace Dynamo
             get { return updatingPaused; }
             internal set
             {
-                Debug.WriteLine("Updating paused = " + value.ToString());
                 updatingPaused = value;
             }
         }
@@ -576,8 +575,6 @@ namespace Dynamo
             var rps = new List<RenderPackage>();
             rps.AddRange(task.NormalRenderPackages.Cast<RenderPackage>());
             rps.AddRange(task.SelectedRenderPackages.Cast<RenderPackage>());
-
-            Debug.WriteLine("Render aggregation complete for {0}", task.NodeId);
 
             var e = new VisualizationEventArgs(rps, task.NodeId, -1);
             OnResultsReadyToVisualize(this, e);

--- a/src/DynamoUtilities/DynamoPathManager.cs
+++ b/src/DynamoUtilities/DynamoPathManager.cs
@@ -84,7 +84,7 @@ namespace DynamoUtilities
             get { return instance ?? (instance = new DynamoPathManager()); }
         }
 
-        internal static void DestroyInstance()
+        public static void DestroyInstance()
         {
             instance = null;
         }

--- a/src/Libraries/DynamoWatch3D/Watch3D.cs
+++ b/src/Libraries/DynamoWatch3D/Watch3D.cs
@@ -338,7 +338,6 @@ namespace Dynamo.Nodes
 
         public void GetBranchVisualization(object parameters)
         {
-            Debug.WriteLine(string.Format("Requesting branch update for {0}", GUID));
             ViewModel.VisualizationManager.RequestBranchUpdate(this);
         }
 

--- a/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
@@ -206,11 +206,6 @@ namespace Dynamo.Tests
             }
         }
 
-        public override void Cleanup()
-        {
-            base.Cleanup();
-            DynamoUtilities.DynamoPathManager.DestroyInstance();
-        }
     }
 
     [Category("DSExecution")]

--- a/test/DynamoCoreTests/DSLibraryTest.cs
+++ b/test/DynamoCoreTests/DSLibraryTest.cs
@@ -14,9 +14,9 @@ namespace Dynamo.Tests
         private LibraryServices libraryServices;
 
         [SetUp]
-        public override void Init()
+        public override void Setup()
         {
-            base.Init();
+            base.Setup();
             libraryServices = ViewModel.Model.LibraryServices;
         }
 

--- a/test/DynamoCoreTests/DynamoViewModelUnitTest.cs
+++ b/test/DynamoCoreTests/DynamoViewModelUnitTest.cs
@@ -26,9 +26,10 @@ namespace Dynamo.Tests
         protected DynamoViewModel ViewModel;
         private DynamoShapeManager.Preloader preloader;
 
-        public override void Init()
+        [SetUp]
+        public override void Setup()
         {
-            base.Init();
+            base.Setup();
             StartDynamo();
         }
 
@@ -94,7 +95,6 @@ namespace Dynamo.Tests
         {
             var assemblyPath = Assembly.GetExecutingAssembly().Location;
             var assemblyFolder = Path.GetDirectoryName(assemblyPath);
-            DynamoPathManager.Instance.InitializeCore(assemblyFolder);
 
             preloader = new Preloader(assemblyFolder);
             preloader.Preload();

--- a/test/DynamoCoreTests/DynamoViewModelUnitTest.cs
+++ b/test/DynamoCoreTests/DynamoViewModelUnitTest.cs
@@ -39,8 +39,12 @@ namespace Dynamo.Tests
                 preloader = null;
                 DynamoSelection.Instance.ClearSelection();
 
+                if (ViewModel == null)
+                    return;
+
                 var shutdownParams = new DynamoViewModel.ShutdownParams(
-                    shutdownHost: false, allowCancellation: false);
+                    shutdownHost: false,
+                    allowCancellation: false);
 
                 ViewModel.PerformShutdownSequence(shutdownParams);
                 ViewModel.RequestUserSaveWorkflow -= RequestUserSaveWorkflow;

--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -19,9 +19,9 @@ namespace Dynamo.Tests
         protected static bool LibraryLoaded { get; set; }
 
         [SetUp]
-        public override void Init()
+        public override void Setup()
         {
-            base.Init();
+            base.Setup();
 
             libraryServices = ViewModel.Model.LibraryServices;
             RegisterEvents();

--- a/test/DynamoCoreTests/SchedulerTests.cs
+++ b/test/DynamoCoreTests/SchedulerTests.cs
@@ -1192,9 +1192,10 @@ namespace Dynamo
 
         #region Test Setup, TearDown, Helper Methods
 
-        public override void Init()
+        [SetUp]
+        public override void Setup()
         {
-            base.Init();
+            base.Setup();
             StartDynamo();
 
             FakeAsyncTaskData.ResetSerialNumber();

--- a/test/DynamoCoreTests/UnitTestBase.cs
+++ b/test/DynamoCoreTests/UnitTestBase.cs
@@ -13,7 +13,7 @@ namespace Dynamo
         protected string TempFolder { get; private set; }
 
         [SetUp]
-        public virtual void Init()
+        public virtual void Setup()
         {
             SetupDirectories();
         }

--- a/test/DynamoCoreTests/UnitTestBase.cs
+++ b/test/DynamoCoreTests/UnitTestBase.cs
@@ -65,9 +65,12 @@ namespace Dynamo
             string tempPath = Path.GetTempPath();
 
             TempFolder = Path.Combine(tempPath, "dynamoTmp\\" + Guid.NewGuid().ToString("N"));
-
+            
             if (!Directory.Exists(TempFolder))
                 Directory.CreateDirectory(TempFolder);
+
+            // Setup Temp PreferenceSetting Location for testing
+            PreferenceSettings.DynamoTestPath = Path.Combine(TempFolder, "UserPreferenceTest.xml");
         }
     }
 }

--- a/test/DynamoCoreTests/UnitsOfMeasureTests.cs
+++ b/test/DynamoCoreTests/UnitsOfMeasureTests.cs
@@ -9,7 +9,7 @@ namespace Dynamo.Tests
     internal class UnitsOfMeasureTests : UnitTestBase
     {
         [SetUp]
-        public void Setup()
+        public override void Setup()
         {
             BaseUnit.NumberFormat = "f4";
         }

--- a/test/DynamoCoreUITests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreUITests/CodeBlockNodeTests.cs
@@ -34,7 +34,7 @@ namespace DynamoCoreUITests
         protected WorkspaceModel workspace = null;
         protected WorkspaceViewModel workspaceViewModel = null;
 
-        public override void Init()
+        public override void Setup()
         {
             // We do not call "base.Init()" here because we want to be able 
             // to create our own copy of Controller here with command file path.

--- a/test/DynamoCoreUITests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreUITests/NodeViewCustomizationTests.cs
@@ -247,7 +247,7 @@ namespace DynamoCoreUITests
             Assert.Greater(img.ActualHeight, 10);
         }
 
-        [Test, Category("Failure")]
+        [Test]
         public void Watch3DContainsExpectedGeometry()
         {
             OpenAndRun(@"UI\WatchUINodes.dyn");

--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -53,13 +53,6 @@ namespace DynamoCoreUITests
         [SetUp]
         public override void Setup()
         {
-            // We do not call "base.Init()" here because we want to be able 
-            // to create our own copy of DynamoModel here with command file path.
-        }
-
-        [SetUp]
-        public void Start()
-        {
             // Fixed seed randomizer for predictability.
             randomizer = new System.Random(123456);
             SetupDirectories();
@@ -1779,7 +1772,7 @@ namespace DynamoCoreUITests
 
             // Reset current test case
             Exit();
-            Start();
+            Setup();
 
             // Run playback is recorded in command file
             RunCommandsFromFile("TestCBNOperationWithNodeToCode.xml");
@@ -1787,7 +1780,7 @@ namespace DynamoCoreUITests
 
             // Reset current test case
             Exit();
-            Start();
+            Setup();
 
             // Run playback is recorded in command file
             RunCommandsFromFile("TestCBNOperationWithNodeToCodeUndo.xml");
@@ -1885,7 +1878,7 @@ namespace DynamoCoreUITests
             AssertValue("p_d4d53e201514434983e17cb5c533a3e0", 0);
             
             Exit();
-            Start();
+            Setup();
             
             // redefine function - test if the CBN reexecuted
             RunCommandsFromFile("Function_redef01a.xml");
@@ -1908,7 +1901,7 @@ namespace DynamoCoreUITests
             AssertValue("p_c9827e41855647f68e9d6c600a2e45ee", 0);
 
             Exit();
-            Start();
+            Setup();
 
             // redefine function call - CBN with function definition is not expected to be executed
             RunCommandsFromFile("Function_redef02a.xml");
@@ -1931,7 +1924,7 @@ namespace DynamoCoreUITests
             AssertValue("d_f34e01e225e446349eb8e815e8ee580d", 1);
 
             Exit();
-            Start();
+            Setup();
 
             // redefine function call - CBN with function definition is not expected to be executed
             RunCommandsFromFile("Function_redef03a.xml");
@@ -1953,7 +1946,7 @@ namespace DynamoCoreUITests
             AssertValue("b_9b638b99d63145838b82662a60cdf6bc", 0);
             
             Exit();
-            Start();
+            Setup();
             
             // redefine function call - change type of argument
             RunCommandsFromFile("Function_redef04a.xml");

--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -50,12 +50,11 @@ namespace DynamoCoreUITests
         protected double tolerance = 1e-6;
         protected double codeBlockPortHeight = Configurations.CodeBlockPortHeightInPixels;
 
-        public override void Init()
+        [SetUp]
+        public override void Setup()
         {
             // We do not call "base.Init()" here because we want to be able 
-            // to create our own copy of Controller here with command file path.
-            DynamoPathManager.Instance.InitializeCore(
-              Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+            // to create our own copy of DynamoModel here with command file path.
         }
 
         [SetUp]

--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -53,6 +53,11 @@ namespace DynamoCoreUITests
         [SetUp]
         public override void Setup()
         {
+            // We do not call "base.Init()" here because we want to be able 
+            // to create our own copy of Controller here with command file path.
+            DynamoPathManager.Instance.InitializeCore(
+              Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+
             // Fixed seed randomizer for predictability.
             randomizer = new System.Random(123456);
             SetupDirectories();

--- a/test/DynamoCoreUITests/UpdateManagerUITests.cs
+++ b/test/DynamoCoreUITests/UpdateManagerUITests.cs
@@ -22,7 +22,8 @@ using Moq;
 namespace DynamoCoreUITests
 {
     [TestFixture]
-    public class UpdateManagerUITests : SystemTestBase
+    public class 
+        UpdateManagerUITests : SystemTestBase
     {
         private const string DOWNLOAD_SOURCE_PATH_S = "http://downloadsourcepath/";
         private const string SIGNATURE_SOURCE_PATH_S = "http://SignatureSourcePath/";
@@ -46,34 +47,6 @@ namespace DynamoCoreUITests
             return um_mock;
         }
 
-        private void Init()
-        {
-            AppDomain.CurrentDomain.AssemblyResolve += AssemblyHelper.ResolveAssembly;
-
-            var corePath =
-                    Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-
-            Model = DynamoModel.Start(
-                new DynamoModel.StartConfiguration()
-                {
-                    StartInTestMode = true,
-                    DynamoCorePath = corePath
-                });
-
-            ViewModel = DynamoViewModel.Start(
-                new DynamoViewModel.StartConfiguration()
-                {
-                    DynamoModel = Model
-                });
-
-            //create the view
-            View = new DynamoView(ViewModel);
-            View.Show();                             
-
-            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
-            CreateTemporaryFolder();
-        }
-
         [SetUp]
         public override void Setup()
         {
@@ -87,8 +60,8 @@ namespace DynamoCoreUITests
             const string availableVersion = "9.9.9.9";
             const string productVersion = "1.1.1.1";
             MockUpdateManager(availableVersion, productVersion);
-            
-            Init();
+
+            base.Setup();
 
             var stb = (ShortcutToolbar)View.shortcutBarGrid.Children[0];
             var sbgrid = (Grid)stb.FindName("ShortcutToolbarGrid");
@@ -104,7 +77,7 @@ namespace DynamoCoreUITests
             const string productVersion = "9.9.9.9";
             MockUpdateManager(availableVersion, productVersion);
 
-            Init();
+            base.Setup();
 
             var stb = (ShortcutToolbar)View.shortcutBarGrid.Children[0];
             var sbgrid = (Grid)stb.FindName("ShortcutToolbarGrid");
@@ -120,7 +93,7 @@ namespace DynamoCoreUITests
             const string productVersion = "9.9.9.9";
             MockUpdateManager(availableVersion, productVersion);
 
-            Init();
+            base.Setup();
 
             var stb = (ShortcutToolbar)View.shortcutBarGrid.Children[0];
             var sbgrid = (Grid)stb.FindName("ShortcutToolbarGrid");

--- a/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
+++ b/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
@@ -17,9 +17,9 @@ namespace Dynamo.Tests
     public class ExcelTests : DynamoViewModelUnitTest
     {
         [SetUp]
-        public override void Init()
+        public override void Setup()
         {
-            base.Init();
+            base.Setup();
 
             // In unit-test scenario we are redirecting 'PreferenceSettings' to 
             // load from a non-existing preference XML file. That way each test 


### PR DESCRIPTION
Recorded tests were a twisted mess of redundant Setup methods. They're model is pretty messed up, inheriting from DynamoViewModelUnitTestBase, but not using any of the setup logic from the same. Things were being double initialized. Shutdown was being called multiple times. Etc. Recorded tests needs a re-design. The changes here are just to reduce some of the confusion when looking at this hierarchy of classes and to remove some of the duplicate initialization and shutdown calls.

FYI @lukechurch @jnealb 