### PR TITLE
MAGN-5525 Pressing ESC while writing a CBN should not irretrievably delete all the text

### DIFF
--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
@@ -431,9 +431,7 @@ namespace Dynamo.UI.Controls
           
             if (cb == null || cb.Code != null && text.Equals(cb.Code))
                 OnRequestReturnFocusToSearch();
-            else
-                this.InnerTextEditor.Text = (DataContext as CodeBlockNodeModel).Code;
-
+            
             if (text == "")
             {
                 nodeViewModel.DynamoViewModel.ExecuteCommand(


### PR DESCRIPTION
**Issue**:
 Pressing ESC key inside Codeblock deletes all the text.

**Fix**:
 After the fixes for empty CBN to exist in a workspace, it is irrelevant to set the editor value to code. Codeblock text editor value will not be set unless it is populated. When esc is pressed before that, the editor value is set to null. This is removed as part of this fix.

- [x] @pboyer 