### PR TITLE
Fix for type system resolution error

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -538,6 +538,52 @@ namespace ProtoCore
 
             #endregion
 
+            #region Case 1a: Replicate only according to the replication guides, but with a sub-typing match
+
+            {
+                log.AppendLine("Case 1a: Replication guides + auto-replication + no cases");
+
+
+                List<ReplicationInstruction> replicationOption = replicationControl.Instructions;
+                    ReplicationControl rc = new ReplicationControl() { Instructions = replicationOption };
+
+                    log.AppendLine("Attempting replication control: " + rc);
+
+                    List<List<StackValue>> reducedParams = Replicator.ComputeAllReducedParams(arguments,
+                                                                                              rc.Instructions, runtimeCore);
+                    int resolutionFailures;
+
+                    Dictionary<FunctionEndPoint, int> lookups = funcGroup.GetExactMatchStatistics(
+                        context, reducedParams, stackFrame, runtimeCore,
+                        out resolutionFailures);
+
+
+                    if (resolutionFailures == 0)
+                    {
+
+                        log.AppendLine("Resolution succeeded against FEP Cluster");
+                        foreach (FunctionEndPoint fep in lookups.Keys)
+                            log.AppendLine("\t - " + fep);
+
+                        List<FunctionEndPoint> feps = new List<FunctionEndPoint>();
+                        feps.AddRange(lookups.Keys);
+
+                        //log.AppendLine("Resolution completed in " + sw.ElapsedMilliseconds + "ms");
+                        if (runtimeCore.Options.DumpFunctionResolverLogic)
+                            runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
+
+                        //Otherwise we have a cluster of FEPs that can be used to dispatch the array
+                        resolvesFeps = feps;
+                        replicationInstructions = rc.Instructions;
+
+                        return;
+                    }
+                }
+            
+
+            #endregion
+
+
             #region Case 2: Replication with no type cast
 
             {

--- a/src/Engine/ProtoCore/Lang/FunctionGroup.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionGroup.cs
@@ -121,7 +121,6 @@ namespace ProtoCore
 
             List<List<StackValue>> allReducedParamSVs = Replicator.ComputeAllReducedParams(formalParams, replicationInstructions, runtimeCore);
 
-            List<StackValue> reducedParamSVs = allReducedParamSVs[0];
             
             //@TODO(Luke): Need to add type statistics checks to the below if it is an array to stop int[] matching char[]
             
@@ -133,6 +132,9 @@ namespace ProtoCore
             foreach (FunctionEndPoint fep in FunctionEndPoints)
             {
                 var proc = fep.procedureNode;
+
+
+
 
                 // Member functions are overloaded with thisptr as the first
                 // parameter, so if member function replicates on the left hand
@@ -148,10 +150,19 @@ namespace ProtoCore
                     continue;
                 }
 
-                if (fep.DoesTypeDeepMatch(reducedParamSVs, runtimeCore))
+                bool typesOK = true;
+                foreach (List<StackValue> reducedParamSVs in allReducedParamSVs)
                 {
-                    ret.Add(fep);
+                    if (!fep.DoesTypeDeepMatch(reducedParamSVs, runtimeCore))
+                    {
+                        typesOK = false;
+                        break;
+                    }
                 }
+
+                if (typesOK)
+                    ret.Add(fep);
+
             }
 
             return ret;

--- a/test/Engine/ProtoTest/Associative/MethodResolution.cs
+++ b/test/Engine/ProtoTest/Associative/MethodResolution.cs
@@ -313,5 +313,57 @@ namespace ProtoTest.Associative
             thisTest.VerifyRunScriptSource(code, error);
             thisTest.Verify("z", null);
         }
+
+
+        [Test]
+        public void TestArraySubtypeDispatch1D()
+        {
+            string code = @"def foo(val : int){    return = true;}def foo(val : double){    return = false;}r1 = foo({1, 2});   // r1 = {true, true}
+r2 = foo({1.0, 2.0});   // r1 = {false, false}
+r3 = foo({1, 2.0});
+";
+            string error = "";
+            thisTest.VerifyRunScriptSource(code, error);
+            thisTest.Verify("r1", new object[] { true, true });
+            thisTest.Verify("r2", new object[] { false, false });
+            thisTest.Verify("r3", new object[] { true, false });
+        }
+
+        [Test]
+        public void TestArraySubtypeDispatch1D_R1()
+        {
+            string code = @"def foo(val : int){    return = true;}def foo(val : double){    return = false;}r1 = foo({1, 2}<1>);   // r1 = {true, true}
+r2 = foo({1.0, 2.0}<1>);   // r1 = {false, false}
+r3 = foo({1, 2.0}<1>);
+";
+            string error = "";
+            thisTest.VerifyRunScriptSource(code, error);
+            thisTest.Verify("r1", new object[] { true, true });
+            thisTest.Verify("r2", new object[] { false, false });
+            thisTest.Verify("r3", new object[] { true, false });
+        }
+
+        [Test]
+        public void MAGN5729_Repro()
+        {
+            string code = @"def foo(val : int){    return = true;}def foo(val : double){    return = false;}r3 = foo({1, 2.0}<1>);
+";
+            string error = "";
+            thisTest.VerifyRunScriptSource(code, error);
+            thisTest.Verify("r3", new object[] { true, false });
+        }
+
+
+        [Test]
+        public void MAGN5729_Repro_Simple()
+        {
+            string code = @"def foo(val : int){    return = true;}def foo(val : double){    return = false;}r3 = foo({1, 2.0});
+";
+            string error = "";
+            thisTest.VerifyRunScriptSource(code, error);
+            thisTest.Verify("r3", new object[] { true, false });
+        }
+
+
     }
 }


### PR DESCRIPTION
This is PR 1/2

This fixes the functionality of when a replication is forced over a hetreo-type array with multiple exact matches e.g.

{0, 1.0}<1> dispatching correctly to an int and double 

PR 2/2 will reunify case 1 and 1a, and generalise to do testing of cases 3,4 and 5 under partially replication guide forced conditions

Regression tests running now, I will only merge if they're clean.

@junmendoza 
