### PR TITLE
Fixed language parser for typed identifiers and updated ATG files: MAGN-6596

### DIFF
--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -2164,13 +2164,30 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			NodeUtils.SetNodeLocation(typedVar, t);
 			
 			Expect(51);
-			Expect(1);
-			int type = core.TypeSystem.GetType(t.val); 
+			//Expect(1);
+            string ident = string.Empty;
+            int type = ProtoCore.DSASM.Constants.kInvalidIndex;
+		    if (la.kind == 1)
+		    {
+		        if (IsIdentList())
+		        {
+                    Associative_IdentifierList(out node);
+                    ident = node.ToString();
+		        }
+		        else
+		        {
+                    Expect(1);
+		            ident = t.val;
+		        }
+		    }
+		    //int type = core.TypeSystem.GetType(t.val); 
+            type = core.TypeSystem.GetType(ident);
 			if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
 			{
 			   var unknownType = new ProtoCore.Type();
 			   unknownType.UID = ProtoCore.DSASM.Constants.kInvalidIndex;
-			   unknownType.Name = t.val; 
+			   //unknownType.Name = t.val; 
+               unknownType.Name = ident; 
 			   typedVar.datatype = unknownType;
 			}
 			else

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -2164,37 +2164,35 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			NodeUtils.SetNodeLocation(typedVar, t);
 			
 			Expect(51);
-			//Expect(1);
-            string ident = string.Empty;
-            int type = ProtoCore.DSASM.Constants.kInvalidIndex;
-		    if (la.kind == 1)
-		    {
-		        if (IsIdentList())
-		        {
-                    Associative_IdentifierList(out node);
-                    ident = node.ToString();
-		        }
-		        else
-		        {
-                    Expect(1);
-		            ident = t.val;
-		        }
-		    }
-		    //int type = core.TypeSystem.GetType(t.val); 
-            type = core.TypeSystem.GetType(ident);
-			if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
+			string ident = string.Empty;
+			int type = ProtoCore.DSASM.Constants.kInvalidIndex;
+			if (la.kind == 1)
 			{
-			   var unknownType = new ProtoCore.Type();
-			   unknownType.UID = ProtoCore.DSASM.Constants.kInvalidIndex;
-			   //unknownType.Name = t.val; 
-               unknownType.Name = ident; 
-			   typedVar.datatype = unknownType;
+			if (IsIdentList())
+			{
+			Associative_IdentifierList(out node);
+			ident = node.ToString();
 			}
 			else
 			{
-			   typedVar.datatype = core.TypeSystem.BuildTypeObject(type, 0);
-			}
 			
+			Expect(1);
+			ident = t.val;
+			}
+			}
+			type = core.TypeSystem.GetType(ident);
+			                  if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
+			                  {
+			                      var unknownType = new ProtoCore.Type();
+			                      unknownType.UID = ProtoCore.DSASM.Constants.kInvalidIndex;
+			                      unknownType.Name = ident; 
+			                      typedVar.datatype = unknownType;
+			                  }
+			                  else
+			                  {
+			                      typedVar.datatype = core.TypeSystem.BuildTypeObject(type, 0);
+			                  }
+			              
 			if (la.kind == 8) {
 				var datatype = typedVar.datatype; 
 				Get();

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -84,9 +84,9 @@ Hydrogen<out Node codeBlockNode>
 
   
                            (. if (la.val == "if")
-                                 SynErr(String.Format(Resources.useInlineConditional, la.val)); .)
+                                 SynErr(String.Format(Resources.UseInlineConditional, la.val)); .)
                            (. if ((la.val == "for")||(la.val == "while"))
-                                 SynErr(String.Format(Resources.validForImperativeBlockOnly, la.val)); .)
+                                 SynErr(String.Format(Resources.ValidForImperativeBlockOnly, la.val)); .)
                            (. 
                                 codeBlockNode = codeblock;
 
@@ -121,7 +121,7 @@ Import_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
         [kw_prefix ident] 
                             (. 
                                 if (la.kind != _endline)
-                                   SynErr(Resources.semiColonExpected);
+                                   SynErr(Resources.SemiColonExpected);
                             .)
         endline
     (.
@@ -159,7 +159,7 @@ Import_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 
 //------------------------------------------------------------------------
 Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>      
-=  SYNC                     (. if (!IsFullClosure()) SynErr(Resources.closeBracketExpected); .)
+=  SYNC                     (. if (!IsFullClosure()) SynErr(Resources.CloseBracketExpected); .)
                             (. node = null; .)
 (
 	IF(IsNonAssignmentStatement())
@@ -183,7 +183,7 @@ Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
             kw_break 
                 (. 
                     if (la.val != ";")
-                        SynErr(Resources.semiColonExpected);  
+                        SynErr(Resources.SemiColonExpected);  
                 .)
             endline
         )      (. node = new ProtoCore.AST.AssociativeAST.BreakNode(); .)
@@ -192,7 +192,7 @@ Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
             kw_continue 
                 (. 
                     if (la.val != ";")
-                        SynErr(Resources.semiColonExpected); 
+                        SynErr(Resources.SemiColonExpected); 
                 .)
             endline
         )   (. node = new ProtoCore.AST.AssociativeAST.ContinueNode(); .)
@@ -209,7 +209,7 @@ Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
             (
                 (. 
                     if (la.val != ";")
-                        SynErr(Resources.semiColonExpected);
+                        SynErr(Resources.SemiColonExpected);
                 .)
                 endline   
             )      
@@ -226,12 +226,12 @@ Associative_ThrowStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode node
                                 (. throwNode.expression = expression; .)
                                 (. 
                                     if (la.val != ";")
-                                        SynErr(Resources.semiColonExpected);  
+                                        SynErr(Resources.SemiColonExpected);  
                                 .)
         
                                 (. 
                                     if (la.val != ";")
-                                        SynErr(Resources.semiColonExpected); 
+                                        SynErr(Resources.SemiColonExpected); 
                                 .)
     endline
                                 (. node = throwNode; .)
@@ -246,9 +246,9 @@ Associative_StatementList<.out List<ProtoCore.AST.AssociativeAST.AssociativeNode
 }    
     (.         
         if (la.val == "if")
-            SynErr(String.Format(Resources.useInlineConditional, la.val)); 
+            SynErr(String.Format(Resources.UseInlineConditional, la.val)); 
         if ((la.val == "for")||(la.val == "while"))
-             SynErr(String.Format(Resources.validForImperativeBlockOnly, la.val));
+             SynErr(String.Format(Resources.ValidForImperativeBlockOnly, la.val));
     .)
 .
 
@@ -315,7 +315,7 @@ Associative_classdecl<.out ProtoCore.AST.AssociativeAST.AssociativeNode node, Li
 
                                                 (. 
                                                    if (la.val != ";")
-                                                       SynErr(Resources.semiColonExpected);  
+                                                       SynErr(Resources.SemiColonExpected);  
                                                 .)
                                                 endline
                                                 (. NodeUtils.SetNodeEndLocation(varnode, t); .)
@@ -351,7 +351,7 @@ Associative_LanguageBlock<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
                                             }
                                             else {
                                                 langblock.codeblock.language = ProtoCore.Language.kInvalid;
-                                                errors.SemErr(t.line, t.col, String.Format(Resources.invalidLanguageBlockIdentifier, t.val));
+                                                errors.SemErr(t.line, t.col, String.Format(Resources.InvalidLanguageBlockIdentifier, t.val));
                                             }
                                         .)
     {
@@ -461,7 +461,7 @@ Associative_BaseConstructorCall<out ProtoCore.AST.AssociativeAST.AssociativeNode
                                     (. 
                                        if (la.val != "base")
                                        {
-                                           SynErr(Resources.baseIsExpectedToCallBaseConstructor); 
+                                           SynErr(Resources.BaseIsExpectedToCallBaseConstructor); 
                                        }
                                        else
                                        {
@@ -866,7 +866,7 @@ Associative_FunctionalMethodBodySingleLine<out ProtoCore.AST.AssociativeAST.Asso
 
                                         (. 
                                             if (la.val != ";")
-                                                SynErr(Resources.semiColonExpected);  
+                                                SynErr(Resources.SemiColonExpected);  
                                         .)
     endline
 .
@@ -1055,14 +1055,30 @@ Associative_DecoratedIdentifier<out ProtoCore.AST.AssociativeAST.AssociativeNode
                         .)
         ':'
 
-        ident
                         (. 
-                            int type = core.TypeSystem.GetType(t.val); 
+                            string ident = string.Empty;
+							int type = ProtoCore.DSASM.Constants.kInvalidIndex;
+							if (la.kind == 1)
+							{
+								if (IsIdentList())
+								{
+									Associative_IdentifierList(out node);
+									ident = node.ToString();
+								}
+								else
+								{
+						.)
+		ident
+						(.
+									ident = t.val;
+								}
+							}
+							type = core.TypeSystem.GetType(ident);
                             if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
                             {
                                 var unknownType = new ProtoCore.Type();
                                 unknownType.UID = ProtoCore.DSASM.Constants.kInvalidIndex;
-                                unknownType.Name = t.val; 
+                                unknownType.Name = ident; 
                                 typedVar.datatype = unknownType;
                             }
                             else
@@ -1132,7 +1148,7 @@ Associative_NonAssignmentStatement<out ProtoCore.AST.AssociativeAST.AssociativeN
                     
                     (. 
                         if (la.val != ";")
-                            SynErr(Resources.semiColonExpected);  
+                            SynErr(Resources.SemiColonExpected);  
                     .)
 		endline				
 					(. NodeUtils.SetNodeEndLocation(node, t); .)
@@ -1181,7 +1197,7 @@ Associative_FunctionCallStatement<out ProtoCore.AST.AssociativeAST.AssociativeNo
                     
                     (. 
                         if (la.val != ";")
-                            SynErr(Resources.semiColonExpected);  
+                            SynErr(Resources.SemiColonExpected);  
                     .)
 		endline				
 					(. NodeUtils.SetNodeEndLocation(node, t); .)
@@ -1286,7 +1302,7 @@ Associative_FunctionalStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode
                         Associative_Expression<out rightNode> 
                                 (.
                                     if (la.val == "=") 
-                                        SynErr(String.Format(Resources.invalidSymbol, la.val));
+                                        SynErr(String.Format(Resources.InvalidSymbol, la.val));
 
                                     ProtoCore.AST.AssociativeAST.IdentifierNode identifier = null;
                                 .)
@@ -1310,7 +1326,7 @@ Associative_FunctionalStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode
 
                                 (. 
                                     if (la.val != ";")
-                                        SynErr(Resources.semiColonExpected); 
+                                        SynErr(Resources.SemiColonExpected); 
                                 .)
 
                         SYNC endline (. NodeUtils.SetNodeEndLocation(elementNode, t); .)
@@ -1334,7 +1350,7 @@ Associative_FunctionalStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode
                             Associative_Expression<out rightNode>
                             (.
                                     if (la.val == "=") 
-                                        SynErr(String.Format(Resources.invalidSymbol, la.val));
+                                        SynErr(String.Format(Resources.InvalidSymbol, la.val));
 
                                     identifier = null;
                             .)
@@ -1368,7 +1384,7 @@ Associative_FunctionalStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode
 
                                 (. 
                                     if (la.val != ";")
-                                        SynErr(Resources.semiColonExpected); 
+                                        SynErr(Resources.SemiColonExpected); 
                                 .)
 
                             SYNC endline (. NodeUtils.SetNodeEndLocation(elementNode, t); .)
@@ -1414,7 +1430,7 @@ Associative_FunctionalStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode
 
                                 (. 
                                     if (la.kind != _endline)
-                                       SynErr(Resources.semiColonExpected);
+                                       SynErr(Resources.SemiColonExpected);
                                 .)
                     endline				
                                 (. NodeUtils.SetNodeEndLocation(expressionNode, t); node = expressionNode; .)
@@ -1443,7 +1459,7 @@ Associative_FunctionalStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode
         )
         |
         (
-            (. SynErr(Resources.semiColonExpected); .)
+            (. SynErr(Resources.SemiColonExpected); .)
         )
     )
 )
@@ -1978,7 +1994,7 @@ Associative_Char<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
     char
             (. 
                 if (t.val.Length <= 2) {
-                    errors.SemErr(t.line, t.col, Resources.emptyCharacterLiteral);
+                    errors.SemErr(t.line, t.col, Resources.EmptyCharacterLiteral);
                 }
 
                 node = new ProtoCore.AST.AssociativeAST.CharNode() 
@@ -2065,7 +2081,7 @@ Associative_Ident<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
                 int ltype = (0 == String.Compare(t.val, "return")) ? (int)ProtoCore.PrimitiveType.kTypeReturn : (int)ProtoCore.PrimitiveType.kTypeVar;
                 if (ltype == (int)ProtoCore.PrimitiveType.kTypeReturn && la.val != "=")
                 {
-                     SynErr(String.Format(Resources.invalidReturnStatement, la.val));
+                     SynErr(String.Format(Resources.InvalidReturnStatement, la.val));
                 }
                 
                 var = ProtoCore.Utils.CoreUtils.BuildAssocIdentifier(core, t.val, (ProtoCore.PrimitiveType)ltype);
@@ -2130,7 +2146,7 @@ Associative_NameReference<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
         (                               (.
                                             if (isLeft)
                                             {
-                                               errors.SemErr(la.line, la.col, Resources.functionCallCannotBeAtLeftSide);
+                                               errors.SemErr(la.line, la.col, Resources.FunctionCallCannotBeAtLeftSide);
                                             } 
                                         .)
             Associative_FunctionCall<out node>  
@@ -2705,7 +2721,7 @@ Associative_FunctionCall<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 
 Associative_Arguments<.out List<ProtoCore.AST.AssociativeAST.AssociativeNode> nodes.>
 =                                           
-    '('										(. if (!IsFullClosure()) SynErr(Resources.closeBracketExpected); .)
+    '('										(. if (!IsFullClosure()) SynErr(Resources.CloseBracketExpected); .)
                                             (. nodes = new List<ProtoCore.AST.AssociativeAST.AssociativeNode>(); .)
         [
                                             (. ProtoCore.AST.AssociativeAST.AssociativeNode t; .)

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -54,7 +54,7 @@ Imperative_languageblock<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                                             }
                                             else {
                                                 langblock.codeblock.language = ProtoCore.Language.kInvalid; 
-                                                errors.SemErr(t.line, t.col, String.Format(Resources.invalidLanguageBlockIdentifier, t.val));
+                                                errors.SemErr(t.line, t.col, String.Format(Resources.InvalidLanguageBlockIdentifier, t.val));
                                             }
                                         .)
     {
@@ -147,7 +147,7 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
             kw_break 
             (.
                 if (la.kind != _endline)
-                    SynErr(Resources.semiColonExpected);
+                    SynErr(Resources.SemiColonExpected);
             .)
             endline
         )     (. node = new ProtoCore.AST.ImperativeAST.BreakNode(); NodeUtils.SetNodeLocation(node, t); .)
@@ -156,7 +156,7 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
             kw_continue 
             (.
                 if (la.kind != _endline)
-                   SynErr(Resources.semiColonExpected);
+                   SynErr(Resources.SemiColonExpected);
             .)
             endline
         )  (. node = new ProtoCore.AST.ImperativeAST.ContinueNode(); NodeUtils.SetNodeLocation(node, t); .)
@@ -169,7 +169,7 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
             Imperative_expr<out node> 
             (.
                 if (la.kind != _endline)
-                   SynErr(Resources.semiColonExpected);
+                   SynErr(Resources.SemiColonExpected);
             .)
             endline
         )
@@ -177,7 +177,7 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
         (
             (.
                 if (la.kind != _endline)
-                   SynErr(Resources.semiColonExpected);
+                   SynErr(Resources.SemiColonExpected);
             .)
             endline 
         )
@@ -193,7 +193,7 @@ Imperative_ThrowStatement<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                                 (. throwNode.expression = expression; .)
                                 (.
                                     if (la.kind != _endline)
-                                       SynErr(Resources.semiColonExpected);
+                                       SynErr(Resources.SemiColonExpected);
                                 .)
     endline
                                 (. node = throwNode; .)
@@ -380,7 +380,7 @@ Imperative_assignstmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                             Imperative_expr<out rhsNode>        
                             (.
                                 if (la.kind != _endline)
-                                   SynErr(Resources.semiColonExpected);
+                                   SynErr(Resources.SemiColonExpected);
                             .)
                             endline
                         )
@@ -782,7 +782,7 @@ Imperative_Char<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
 =
     char            (. 
                         if (t.val.Length <= 2) {
-                            errors.SemErr(t.line, t.col, Resources.emptyCharacterLiteral);
+                            errors.SemErr(t.line, t.col, Resources.EmptyCharacterLiteral);
                         }
 
                         node = new ProtoCore.AST.ImperativeAST.CharNode() 
@@ -892,7 +892,7 @@ Imperative_Ident<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                     int ltype = (0 == String.Compare(t.val, "return")) ? (int)ProtoCore.PrimitiveType.kTypeReturn : (int)ProtoCore.PrimitiveType.kTypeVar;
                     if (ltype == (int)ProtoCore.PrimitiveType.kTypeReturn && la.val != "=")
                     {
-                        SynErr(String.Format(Resources.invalidReturnStatement, la.val)); 
+                        SynErr(String.Format(Resources.InvalidReturnStatement, la.val)); 
                     }        
                     var = BuildImperativeIdentifier(t.val, (ProtoCore.PrimitiveType)ltype);
                     NodeUtils.SetNodeLocation(var, t);
@@ -1244,7 +1244,7 @@ Imperative_functionalMethodBodySingleStatement<.out List<ProtoCore.AST.Imperativ
 
                                         (.
                                             if (la.kind != _endline)
-                                               SynErr(Resources.semiColonExpected);
+                                               SynErr(Resources.SemiColonExpected);
                                         .)
     endline
 .

--- a/src/Engine/ProtoCore/Parser/atg/Start.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Start.atg
@@ -468,7 +468,7 @@ COMPILER DesignScriptParser
         if (File.Exists(filePath))
             return filePath;
 
-        SemErr(String.Format(Resources.noSuchFileOrDirectoryToImport,fileName));
+        SemErr(String.Format(Resources.NoSuchFileOrDirectoryToImport,fileName));
         return null;
     }
 

--- a/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM.Mirror;
 using ProtoCore.Lang;
 using ProtoTest.TD;
@@ -2582,6 +2583,43 @@ r = foo(3);";
             ProtoCore.AST.Node s2Root = ProtoCore.Utils.ParserUtils.Parse(s2);
             bool areEqual = s1Root.Equals(s2Root);
             Assert.AreEqual(areEqual, true);
+        }
+
+        [Test]
+        public void ParseTypedIdentifier_AstNode()
+        {
+            string s1 = "a : A;";
+            string s2 = "a : A = null;";
+            string s3 = "a : A.B.C;";
+            string s4 = "a : A.B.C = null;";
+            
+            var s1Root = ProtoCore.Utils.ParserUtils.Parse(s1) as CodeBlockNode;
+            Assert.IsNotNull(s1Root);
+            var typedNode = s1Root.Body[0] as TypedIdentifierNode;
+            Assert.IsNotNull(typedNode);
+            Assert.AreEqual("A", typedNode.datatype.Name);
+
+            s1Root = ProtoCore.Utils.ParserUtils.Parse(s2) as CodeBlockNode;
+            Assert.IsNotNull(s1Root);
+            var ben = s1Root.Body[0] as BinaryExpressionNode;
+            Assert.IsNotNull(ben);
+            typedNode = ben.LeftNode as TypedIdentifierNode;
+            Assert.IsNotNull(typedNode);
+            Assert.AreEqual("A", typedNode.datatype.Name);
+
+            s1Root = ProtoCore.Utils.ParserUtils.Parse(s3) as CodeBlockNode;
+            Assert.IsNotNull(s1Root);
+            typedNode = s1Root.Body[0] as TypedIdentifierNode;
+            Assert.IsNotNull(typedNode);
+            Assert.AreEqual("A.B.C", typedNode.datatype.Name);
+
+            s1Root = ProtoCore.Utils.ParserUtils.Parse(s4) as CodeBlockNode;
+            Assert.IsNotNull(s1Root);
+            ben = s1Root.Body[0] as BinaryExpressionNode;
+            Assert.IsNotNull(ben);
+            typedNode = ben.LeftNode as TypedIdentifierNode;
+            Assert.IsNotNull(typedNode);
+            Assert.AreEqual("A.B.C", typedNode.datatype.Name);
         }
 
         [Test]


### PR DESCRIPTION
Statements such as these:
```
a : Autodesk.Point; // AND
a : Autodesk.Geometry.Point = Point.ByCoordinates();
```
were failing in the parser. This is now fixed

@junmendoza PTAL