### PR TITLE
Copy the OriginalASTID to the SSA nodes

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -3527,7 +3527,7 @@ namespace ProtoAssociative
                                 ssaNode.exprUID = ssaID;
                                 ssaNode.ssaExprID = ssaExprID;
                                 ssaNode.guid = bnode.guid;
-                                ssaNode.OriginalAstID = bnode.ID;
+                                ssaNode.OriginalAstID = bnode.OriginalAstID;
                                 NodeUtils.SetNodeLocation(ssaNode, node, node);
                             }
 


### PR DESCRIPTION
@ke-yu  PTAL
This fixes the cyclic bug.

As discussed, the cycle is due to static analysis of the code. 
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5477

The bug is because the static analyzer is testing cycle between graphnodes that were already deleted.
This fix assigns the correct astID so the ChagneSetApplier correctly marks the deleted astnodes as inactive