### PR TITLE
DUI: Close ToolTip after click on member

### DIFF
--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -166,7 +166,7 @@ namespace Dynamo.UI.Views
         // here to ignore the immediate mouse-enter event.
         private void OnExpanderButtonMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
-            if ((sender as Button).DataContext is NodeSearchElement)
+            if ((sender as Button).DataContext is NodeCategoryViewModel)
             {
                 libraryToolTipPopup.SetDataContext(null, true);
                 ignoreMouseEnter = true;


### PR DESCRIPTION
This works fine on top of members under the classes but not on members like under builtin function.

This code was written a long time ago. And I assume, that we have just forgot to use `NodeCategoryViewModel` instead of `NodeSearchElement`.

Reviewers
@Benglin , please take a look.

Link to YouTrack:
[MAGN-5605](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5605) DUI: Close ToolTip after click on member