### PR TITLE
DUI: Node tooltip "No description available" in other color

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -107,7 +107,7 @@ namespace Dynamo.Wpf.ViewModels
 
         public bool HasDescription
         {
-            get { return (!string.IsNullOrEmpty(Model.Description)); }
+            get { return (!Model.Description.Equals(Dynamo.UI.Configurations.NoDescriptionAvailable)); }
         }
 
         public NodeCategoryViewModel Category { get; set; }


### PR DESCRIPTION
It was made before, when there wasn't any view model. We used to check empty string. Now we need to check for `NoDescriptionAvailable`.

Reviewers
@Benglin , please take a look.

Link to YouTrack:
[MAGN-6618](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6618) DUI Node tooltip that says "No description available" needs different color