### PR TITLE
Add CustomNodeworkspaceModel.NodeModified()

### DIFF
--- a/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
@@ -164,6 +164,12 @@ namespace Dynamo.Models
             OnDefinitionUpdated();
         }
 
+        protected override void NodeModified(NodeModel node)
+        {
+            base.NodeModified(node);
+            RequestRun();
+        }
+
         public event Action InfoChanged;
         protected virtual void OnInfoChanged()
         {


### PR DESCRIPTION
Custom node now is broken because `CustomNodeWorkspaceModel.NodeModified` is changed to `CustomNodeWorkspaceModel.RequestRun()` which is only triggered when a node is added to custom workspace, but not when a node *is modified*. Add `CustomNodeWorkspaceModel.NodeModified` back so that the modification of a node can trigger custom node recompilation. 

@pboyer please review the change. 

@monikaprabhu please verify when it gets merged. 