### PR TITLE
MAGN-6100 Mouse clicks are sometimes thrown away with 7.6 refactor

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -296,13 +296,14 @@ namespace Dynamo.Controls
         }
     }
 
-    public class SnapRegionMarginConverter : IValueConverter
+    public class SnapRegionMarginConverter : IMultiValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter,
+        public object Convert(object[] values, Type targetType, object parameter,
           CultureInfo culture)
         {
             Thickness thickness = new Thickness(0, 0, 0, 0);
-            PortModel port = value as PortModel;
+            var actualWidth = (double)values[0];
+            PortModel port = values[1] as PortModel;
             if (port != null)
             {
                 PortType type = port.PortType;
@@ -313,33 +314,33 @@ namespace Dynamo.Controls
                 switch (type)
                 {
                     case PortType.Input:
-                        thickness = new Thickness(left - 25, top + 3, right + 0, bottom + 3);
+                        thickness = new Thickness(left - 25, top + 3, right + actualWidth, bottom + 3);
                         if (port.extensionEdges.HasFlag(SnapExtensionEdges.Top | SnapExtensionEdges.Bottom))
-                            thickness = new Thickness(left - 25, top - 10, right + 0, bottom - 10);
+                            thickness = new Thickness(left - 25, top - 10, right + actualWidth, bottom - 10);
                         else if (port.extensionEdges.HasFlag(SnapExtensionEdges.Top))
-                            thickness = new Thickness(left - 25, top - 10, right + 0, bottom + 3);
+                            thickness = new Thickness(left - 25, top - 10, right + actualWidth, bottom + 3);
                         else if (port.extensionEdges.HasFlag(SnapExtensionEdges.Bottom))
-                            thickness = new Thickness(left - 25, top + 3, right + 0, bottom - 10);
+                            thickness = new Thickness(left - 25, top + 3, right + actualWidth, bottom - 10);
                         break;
 
                     case PortType.Output:
-                        thickness = new Thickness(left + 0, top + 3, right - 25, bottom + 3);
+                        thickness = new Thickness(left + actualWidth, top + 3, right - 25, bottom + 3);
                         if (port.extensionEdges.HasFlag(SnapExtensionEdges.Top | SnapExtensionEdges.Bottom))
-                            thickness = new Thickness(left + 0, top - 10, right - 25, bottom - 10);
+                            thickness = new Thickness(left + actualWidth, top - 10, right - 25, bottom - 10);
                         else if (port.extensionEdges.HasFlag(SnapExtensionEdges.Top))
-                            thickness = new Thickness(left + 0, top - 10, right - 25, bottom + 3);
+                            thickness = new Thickness(left + actualWidth, top - 10, right - 25, bottom + 3);
                         else if (port.extensionEdges.HasFlag(SnapExtensionEdges.Bottom))
-                            thickness = new Thickness(left + 0, top + 3, right - 25, bottom - 10);
+                            thickness = new Thickness(left + actualWidth, top + 3, right - 25, bottom - 10);
                         break;
                 }
             }
             return thickness;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter,
+        public object[] ConvertBack(object value, Type[] targetType, object parameter,
          CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return null;
         }
     }
 

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -77,10 +77,8 @@
                as no mouse events are generated.This happens only for codeblock node. 
             -->
             <Rectangle Fill="Transparent"                                      
-                       SnapsToDevicePixels="True"
-                       MinWidth="26"                       
-                       IsHitTestVisible="True"                      
-                       Margin ="{Binding Path=PortModel, Converter={StaticResource SnapRegionMarginConverter}}">              
+                       SnapsToDevicePixels="True"                                         
+                       IsHitTestVisible="True">                                                         
                 <interactivity:Interaction.Triggers>
                     <views:HandlingEventTrigger EventName="MouseEnter">
                         <interactivity:InvokeCommandAction Command="{Binding Path=MouseEnterCommand}" CommandParameter="{Binding}" />
@@ -91,7 +89,13 @@
                     <views:HandlingEventTrigger EventName="MouseLeftButtonDown">
                         <interactivity:InvokeCommandAction Command="{Binding Path=MouseLeftButtonDownCommand}" CommandParameter="{Binding}" />
                     </views:HandlingEventTrigger>
-                </interactivity:Interaction.Triggers>               
+                </interactivity:Interaction.Triggers>
+                <Rectangle.Margin>
+                    <MultiBinding Converter="{StaticResource SnapRegionMarginConverter}">
+                        <Binding ElementName="portNameTb" Path="ActualWidth"/>
+                        <Binding Path="PortModel"/>
+                    </MultiBinding>
+                </Rectangle.Margin>
             </Rectangle>
             <Rectangle Name="highlightOverlay"
                        Fill="White"


### PR DESCRIPTION
**Issue**
    Mouse clicks are thrown away when clicked on the node.

**Cause**
    The snap region was constructed to cover the entire ports and extend the top,right,left and bottom based on the port type and location. So clicking in that region does not select the nodes. For the user, this looks like mouse clicks are thrown away. 

**Fix**
    After the fix the port snap region does not cover the entire port. Instead the right or left parameter has been reduced to have the width of the textblock inside the port. This creates the snap region to be outside the ports and hence clicking anywhere in the node actually selects the node.

- [x] @pboyer 