### PR TITLE
Error handling for invalid default argument

### DIFF
--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -89,7 +89,7 @@ namespace Dynamo.DSEngine
                 {
                     x.Function = this;
                     return x;
-                });
+                }).ToList();
 
             var type = funcDescParams.FunctionType;
             var inputParameters = new List<Tuple<string, string>>();

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -699,7 +699,16 @@ namespace Dynamo.DSEngine
             LibraryManagementCore.ParsingMode = ProtoCore.ParseMode.AllowNonAssignment;
             LibraryManagementCore.IsParsingCodeBlockNode = true;
 
-            var astNode = ParserUtils.ParseWithCore(defaultExpression + ";", LibraryManagementCore);
+            ProtoCore.AST.Node astNode = null ;
+            try
+            {
+                astNode = ParserUtils.ParseWithCore(defaultExpression + ";", LibraryManagementCore);
+            }
+            catch (ProtoCore.BuildHaltException ex)
+            {
+                Log("Failed to parse default argument attribute \"" + defaultExpression + "\" for parameter: " + arg.Name);
+            }
+
             if (astNode != null)
             {
                 var cbn = astNode as CodeBlockNode;
@@ -780,14 +789,15 @@ namespace Dynamo.DSEngine
                 }
             }
 
-            IEnumerable<TypedParameter> arguments = proc.argInfoList.Zip(
+            List<TypedParameter> arguments = proc.argInfoList.Zip(
                 proc.argTypeList,
                 (arg, argType) =>
                 {
                     AssociativeNode defaultArgumentNode;
                     // Default argument specified by DefaultArgumentAttribute
                     // takes higher priority
-                    if (!TryGetDefaultArgumentFromAttribute(arg, out defaultArgumentNode) && arg.IsDefault)
+                    if (!TryGetDefaultArgumentFromAttribute(arg, out defaultArgumentNode) 
+                        && arg.IsDefault)
                     {
                         var binaryExpr = arg.DefaultExpression as BinaryExpressionNode;
                         if (binaryExpr != null)
@@ -797,7 +807,7 @@ namespace Dynamo.DSEngine
                     }
 
                     return new TypedParameter(arg.Name, argType, defaultArgumentNode);
-                });
+                }).ToList();
 
             IEnumerable<string> returnKeys = null;
             if (proc.MethodAttribute != null)

--- a/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
@@ -1113,6 +1113,19 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void TestDefaulArgumentAttributeNegative()
+        {
+            // This is to test FFITarget.TestData.MultiplyBy3NonParsableDefaultArgument() whose
+            // DefaultArgumentAttribute is invalid. In this case, we should make sure that
+            // no default argument is used, even null. So this function should be compiled to
+            // a function object and Apply() should work on it. 
+            DynamoUtilities.DynamoPathManager.Instance.AddPreloadLibrary("FFITarget.dll");
+            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\default_values\invalidDefaultArgument.dyn");
+            RunModel(dynFilePath);
+            AssertPreviewValue("1b2fa812-960d-424c-b679-8b850abe2e26", 12);
+        }
+
+        [Test]
         public void TestDefaultValueAttributeForDummyLine()
         {
             DynamoUtilities.DynamoPathManager.Instance.AddPreloadLibrary("FFITarget.dll");

--- a/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
@@ -1119,7 +1119,6 @@ namespace Dynamo.Tests
             // DefaultArgumentAttribute is invalid. In this case, we should make sure that
             // no default argument is used, even null. So this function should be compiled to
             // a function object and Apply() should work on it. 
-            DynamoUtilities.DynamoPathManager.Instance.AddPreloadLibrary("FFITarget.dll");
             var dynFilePath = Path.Combine(GetTestDirectory(), @"core\default_values\invalidDefaultArgument.dyn");
             RunModel(dynFilePath);
             AssertPreviewValue("1b2fa812-960d-424c-b679-8b850abe2e26", 12);

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -475,6 +475,18 @@ namespace FFITarget
         {
             return radius * radius * Math.PI;
         }
+
+        public static int MultiplyBy2WithWrongDefaultArgument(
+            [DefaultArgumentAttribute("TestData.NonExistFunction()")] int x)
+        {
+            return x * 2;
+        }
+
+        public static int MultiplyBy3NonParsableDefaultArgument(
+           [DefaultArgumentAttribute("%!48asfasd4")] int x)
+        {
+            return x * 3;
+        }
     }
 
     internal class InternalClass

--- a/test/core/default_values/invalidDefaultArgument.dyn
+++ b/test/core/default_values/invalidDefaultArgument.dyn
@@ -1,0 +1,13 @@
+<Workspace Version="0.8.0.710" X="0" Y="0" zoom="1" Name="Home" RunType="Manual" RunPeriod="100">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="693a0aec-795e-4a53-ab86-6a68906578d6" type="Dynamo.Nodes.DSFunction" nickname="TestData.MultiplyBy3NonParsableDefaultArgument" x="295.5" y="353" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="FFITarget.dll" function="FFITarget.TestData.MultiplyBy3NonParsableDefaultArgument@int" />
+    <DSCoreNodesUI.HigherOrder.ApplyFunction guid="1b2fa812-960d-424c-b679-8b850abe2e26" type="DSCoreNodesUI.HigherOrder.ApplyFunction" nickname="Function.Apply" x="704.5" y="404" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="54ade611-400c-476a-a2a6-c1e27ba07fca" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="466" y="477" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="4;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="693a0aec-795e-4a53-ab86-6a68906578d6" start_index="0" end="1b2fa812-960d-424c-b679-8b850abe2e26" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="54ade611-400c-476a-a2a6-c1e27ba07fca" start_index="0" end="1b2fa812-960d-424c-b679-8b850abe2e26" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
This PR is for task [MAGN 6507: Error handling for default argument when importing zero touch library](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6507).

If the default argument expression specified in `DefaultArgumentAttribute` is invalid, we should treat the parameter without any default argument. Negative test cases added.

@Benglin  please help to review the change. 