### PR TITLE
DUI: Location Category shouldn't be under Units category.

### DIFF
--- a/src/Libraries/DynamoUnits/DynamoUnits_DynamoCustomization.xml
+++ b/src/Libraries/DynamoUnits/DynamoUnits_DynamoCustomization.xml
@@ -5,7 +5,7 @@
     </assembly>
     <namespaces>
         <namespace name="DynamoUnits">
-            <category>Core.Units</category>
+            <category>Core</category>
         </namespace>
     </namespaces>
 </doc>


### PR DESCRIPTION
NB!!!
Units.Volume, Units.Area have NodeDeprecatedAttribute.That's why they are invisible in Dynamo. Is it right behavior?
_________________________

Units should have only three nodes which are related to Units and Location should be a different category.

Before:
![image](https://cloud.githubusercontent.com/assets/8158404/6638112/1d9d5f6e-c98b-11e4-971c-7862a7ae9eb7.png)

After:
![image](https://cloud.githubusercontent.com/assets/8158404/6638119/398e28ac-c98b-11e4-8f58-9ca7ad6a42e1.png)

Reviewers
@Benglin , please take a look.

Link to YouTrack:
[MAGN-6645](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6645) [DUI] Location Category shouldn't be under Units category.