### PR TITLE
Fix for opening a file with proxy custom node inside

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -1462,9 +1462,12 @@ namespace Dynamo.Models
                 if (subNode.Name == "PortInfo")
                 {
                     int index = int.Parse(subNode.Attributes["index"].Value);
-                    portInfoProcessed.Add(index);
-                    bool def = bool.Parse(subNode.Attributes["default"].Value);
-                    inPorts[index].UsingDefaultValue = def;
+                    if (index < InPorts.Count)
+                    {
+                        portInfoProcessed.Add(index);
+                        bool def = bool.Parse(subNode.Attributes["default"].Value);
+                        inPorts[index].UsingDefaultValue = def;
+                    }
                 }
             }
 

--- a/src/DynamoCore/Nodes/Custom Nodes/Function.cs
+++ b/src/DynamoCore/Nodes/Custom Nodes/Function.cs
@@ -140,17 +140,7 @@ namespace Dynamo.Nodes
 
         protected override void DeserializeCore(XmlElement nodeElement, SaveContext context)
         {
-            base.DeserializeCore(nodeElement, context); //Base implementation must be called
-
             List<XmlNode> childNodes = nodeElement.ChildNodes.Cast<XmlNode>().ToList();
-
-            XmlNode nameNode = childNodes.LastOrDefault(subNode => subNode.Name.Equals("Name"));
-            if (nameNode != null && nameNode.Attributes != null)
-                NickName = nameNode.Attributes["value"].Value;
-
-            XmlNode descNode = childNodes.LastOrDefault(subNode => subNode.Name.Equals("Description"));
-            if (descNode != null && descNode.Attributes != null)
-                Description = descNode.Attributes["value"].Value;
 
             if (!Controller.IsInSyncWithNode(this))
             {
@@ -219,6 +209,16 @@ namespace Dynamo.Nodes
 
                 RegisterAllPorts();
             }
+
+            base.DeserializeCore(nodeElement, context); //Base implementation must be called
+
+            XmlNode nameNode = childNodes.LastOrDefault(subNode => subNode.Name.Equals("Name"));
+            if (nameNode != null && nameNode.Attributes != null)
+                NickName = nameNode.Attributes["value"].Value;
+
+            XmlNode descNode = childNodes.LastOrDefault(subNode => subNode.Name.Equals("Description"));
+            if (descNode != null && descNode.Attributes != null)
+                Description = descNode.Attributes["value"].Value;
         }
 
         #endregion


### PR DESCRIPTION
Base implementation of `DeserializeCore` uses ports of a node which are not added yet if the node is a proxy custom node. So this adding should be done before calling `base.DeserializeCore`.

I have got an error during opening a workspace which contains custom node instance with port info:
````
<Dynamo.Nodes.Function guid="8146efc7-9512-3bb3-c1ed-3242d9b65e07" type="Dynamo.Nodes.Function"
nickname="D" x="4644" y="4322" isVisible="true" isUpstreamVisible="true" lacing="Longest">
      <PortInfo index="0" default="True" />
      <PortInfo index="1" default="True" />
      <ID value="78a4e34c-93d8-d558-e47c-4ff9b1da1dac" />
      <Name value="D" />
      <Description value="" />
      <Inputs>
        <Input value="" />
        <Input value="" />
      </Inputs>
      <Outputs>
        <Output value="" />
      </Outputs>
    </Dynamo.Nodes.Function>
````