### PR TITLE
Fix the bug on ShowExecutionPreview when the node is in error state

### DIFF
--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -21,11 +21,6 @@ namespace Dynamo.Models
         private bool graphExecuted;              
         public readonly bool VerboseLogging;
        
-        /// <summary>        
-        /// This is used to compute the delta state of the nodes.       
-        /// </summary>        
-        public bool ShowRunPreview { get; set; }
-
         /// <summary>
         ///     Before the Workspace has been built the first time, we do not respond to 
         ///     NodeModification events.
@@ -164,10 +159,6 @@ namespace Dynamo.Models
             {
                 RequestRun();
             }
-
-            //Find the next executing nodes on when Run-Auto is not set 
-            if (RunSettings.RunType == RunType.Manual)
-                GetExecutingNodes();
         }
 
         /// <summary>
@@ -443,7 +434,7 @@ namespace Dynamo.Models
             if (handler != null) handler(this, e);
         }
 
-        public void GetExecutingNodes()
+        public void GetExecutingNodes(bool ShowRunPreview)
         {
             var task = new PreviewGraphAsyncTask(scheduler, VerboseLogging);
                         

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -434,12 +434,18 @@ namespace Dynamo.Models
             if (handler != null) handler(this, e);
         }
 
-        public void GetExecutingNodes(bool ShowRunPreview)
+        /// <summary>
+        /// This function gets the set of nodes that will get executed in the next run.
+        /// This function will be called when the nodes are modified or when showrunpreview is set
+        /// the executing nodes will be sent via SetNodeDeltaState event.
+        /// </summary>
+        /// <param name="showRunPreview">This parameter controls the delta state computation </param>
+        public void GetExecutingNodes(bool showRunPreview)
         {
             var task = new PreviewGraphAsyncTask(scheduler, VerboseLogging);
                         
             //The Graph is executed and Show node execution is checked on the Settings menu
-            if (graphExecuted && ShowRunPreview)
+            if (graphExecuted && showRunPreview)
             {
                 if (task.Initialize(EngineController, this) != null)
                 {

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -20,6 +20,13 @@ namespace Dynamo.Models
 
         private bool graphExecuted;              
         public readonly bool VerboseLogging;
+       
+        /// <summary>
+        /// This is set from Dynamoviewmodel. This is required here otherwise 
+        /// preview graph will run under every context that affects some of the test.
+        /// Also preview graph should run only when showrunpreview is set to true.
+        /// </summary>        
+        public bool ShowRunPreview { get; set; }
 
         /// <summary>
         ///     Before the Workspace has been built the first time, we do not respond to 
@@ -443,7 +450,7 @@ namespace Dynamo.Models
             var task = new PreviewGraphAsyncTask(scheduler, VerboseLogging);
                         
             //The Graph is executed and Show node execution is checked on the Debug menu
-            if (graphExecuted)
+            if (graphExecuted && ShowRunPreview)
             {
                 if (task.Initialize(EngineController, this) != null)
                 {

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -21,10 +21,8 @@ namespace Dynamo.Models
         private bool graphExecuted;              
         public readonly bool VerboseLogging;
        
-        /// <summary>
-        /// This is set from Dynamoviewmodel. This is required here otherwise 
-        /// preview graph will run under every context that affects some of the test.
-        /// Also preview graph should run only when showrunpreview is set to true.
+        /// <summary>        
+        /// This is used to compute the delta state of the nodes.       
         /// </summary>        
         public bool ShowRunPreview { get; set; }
 
@@ -449,7 +447,7 @@ namespace Dynamo.Models
         {
             var task = new PreviewGraphAsyncTask(scheduler, VerboseLogging);
                         
-            //The Graph is executed and Show node execution is checked on the Debug menu
+            //The Graph is executed and Show node execution is checked on the Settings menu
             if (graphExecuted && ShowRunPreview)
             {
                 if (task.Initialize(EngineController, this) != null)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -442,10 +442,10 @@ namespace Dynamo.ViewModels
         private bool showRunPreview;
         public bool ShowRunPreview
         {
-            get { return showRunPreview; }
+            get { return HomeSpace.ShowRunPreview; }
             set
             {
-                showRunPreview = value;
+                HomeSpace.ShowRunPreview = value;
                 HomeSpace.GetExecutingNodes();
                 RaisePropertyChanged("ShowRunPreview");              
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -442,11 +442,11 @@ namespace Dynamo.ViewModels
         private bool showRunPreview;
         public bool ShowRunPreview
         {
-            get { return HomeSpace.ShowRunPreview; }
+            get { return showRunPreview; }
             set
             {
-                HomeSpace.ShowRunPreview = value;
-                HomeSpace.GetExecutingNodes();
+                showRunPreview = value;
+                HomeSpace.GetExecutingNodes(showRunPreview);
                 RaisePropertyChanged("ShowRunPreview");              
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -66,6 +66,17 @@ namespace Dynamo.Wpf.ViewModels.Core
             hwm.SetNodeDeltaState +=hwm_SetNodeDeltaState;
         }
 
+        /// <summary>
+        /// When a node is modified, this calls the executing nodes on Homeworkspace
+        /// to compute the delta state.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        public override void OnNodeModified(NodeModel obj)
+        {
+            if (DynamoViewModel.HomeSpace.RunSettings.RunType == RunType.Manual)
+                DynamoViewModel.HomeSpace.GetExecutingNodes(DynamoViewModel.ShowRunPreview);
+        }
+
         private void hwm_SetNodeDeltaState(object sender, DeltaComputeStateEventArgs e)
         {
             var nodeGuids = e.NodeGuidList;

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -100,13 +100,13 @@ namespace Dynamo.Wpf.ViewModels.Core
                 {
                     if (nodeViewModel.NodeModel.GUID == t)
                     {
-                        nodeViewModel.ShowExecutionPreview = nodeViewModel.DynamoViewModel.ShowRunPreview && true;
+                        nodeViewModel.ShowExecutionPreview = nodeViewModel.DynamoViewModel.ShowRunPreview;
                         nodeViewModel.IsNodeAddedRecently = false;
                     }
                 }
                 /* Color the recently added nodes */
                 if (nodeViewModel.IsNodeAddedRecently && !nodeViewModel.ShowExecutionPreview)
-                    nodeViewModel.ShowExecutionPreview = true;
+                    nodeViewModel.ShowExecutionPreview = nodeViewModel.DynamoViewModel.ShowRunPreview;
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -90,24 +90,26 @@ namespace Dynamo.Wpf.ViewModels.Core
                         nodeViewModel.ShowExecutionPreview = false;
                         nodeViewModel.IsNodeAddedRecently = false;
                     }
-                }
-                
+                }                
             }
 
-            foreach (var nodeViewModel in Nodes)
+            foreach (Guid t in nodeGuids)
             {
-                foreach (Guid t in nodeGuids)
+                var nodeViewModel = Nodes.FirstOrDefault(x => x.NodeModel.GUID == t);
+                if (nodeViewModel != null)
                 {
-                    if (nodeViewModel.NodeModel.GUID == t)
-                    {
-                        nodeViewModel.ShowExecutionPreview = nodeViewModel.DynamoViewModel.ShowRunPreview;
-                        nodeViewModel.IsNodeAddedRecently = false;
-                    }
-                }
-                /* Color the recently added nodes */
-                if (nodeViewModel.IsNodeAddedRecently && !nodeViewModel.ShowExecutionPreview)
                     nodeViewModel.ShowExecutionPreview = nodeViewModel.DynamoViewModel.ShowRunPreview;
+                    nodeViewModel.IsNodeAddedRecently = false;
+                }
             }
+
+            /* Color the recently added nodes */
+            var addedNodes = Nodes.Where(x => x.IsNodeAddedRecently).ToList();
+            foreach (var nodes in addedNodes)
+            {
+                if (nodes.ShowExecutionPreview)
+                    nodes.ShowExecutionPreview = nodes.DynamoViewModel.ShowRunPreview;
+            }           
         }
 
         void hwm_EvaluationCompleted(object sender, EvaluationCompletedEventArgs e)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Data;
-
+using Dynamo.Controls;
 using Dynamo.Models;
 using Dynamo.Selection;
 using Dynamo.UI;
@@ -351,7 +351,8 @@ namespace Dynamo.ViewModels
                             var node = item as NodeModel;
 
                             var nodeViewModel = new NodeViewModel(this, node);
-                            nodeViewModel.SnapInputEvent +=nodeViewModel_SnapInputEvent;                          
+                            nodeViewModel.SnapInputEvent +=nodeViewModel_SnapInputEvent;  
+                            nodeViewModel.NodeLogic.Modified +=OnNodeModified;
                             _nodes.Add(nodeViewModel);
                             Errors.Add(nodeViewModel.ErrorBubble);
                             nodeViewModel.UpdateBubbleContent();
@@ -376,6 +377,16 @@ namespace Dynamo.ViewModels
             if (RunSettingsViewModel == null) return;
 
             CheckAndSetPeriodicRunCapability();
+        }
+
+        /// <summary>
+        /// This is required here to compute the nodes delta state.
+        /// This is overriden in HomeWorkspaceViewModel
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        public virtual void OnNodeModified(NodeModel obj)
+        {
+            
         }
 
         internal void CheckAndSetPeriodicRunCapability()

--- a/src/Libraries/DynamoConversions/DynamoConversions.csproj
+++ b/src/Libraries/DynamoConversions/DynamoConversions.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{67CF6CF2-CD6A-442C-BABE-864F896DD8EA}</ProjectGuid>
+    <ProjectGuid>{C5ADC05B-34E8-47BF-8E78-9C7BF96418C2}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoConversions</RootNamespace>


### PR DESCRIPTION
**Issue** 
   When the node is in error state, ShowExecutionPreview was set on Nodes.

**Fix**
   The ShowExecutionPreview was set to True / False, ideally it should set to the value of ShowRunPreview. 

-  [x] @ikeough 