### PR TITLE
MAGN-6625 "Convert between Units" node gives the "Warning: Null value cannot be cast to double" message at population time with Automatic

### DIFF
--- a/src/Libraries/CoreNodeModels/DynamoConvert.cs
+++ b/src/Libraries/CoreNodeModels/DynamoConvert.cs
@@ -104,8 +104,9 @@ namespace DSCoreNodesUI
       
         public DynamoConvert()
         {           
-            SelectedMetricConversion = ConversionMetricUnit.Length;           
-            InPortData.Add(new PortData("", "A numeric value for conversion."));
+            SelectedMetricConversion = ConversionMetricUnit.Length;  
+            AssociativeNode defaultNode = new DoubleNode(0.0);
+            InPortData.Add(new PortData("", "A numeric value for conversion.", defaultNode));
             OutPortData.Add(new PortData("", "A converted numeric value."));
 
             ShouldDisplayPreviewCore = true;


### PR DESCRIPTION
**Issue**
  The convert between units node does not have a default inport node. So there is a warning message when this node is placed on the graph.

**Fix**
      Add a default double node to inport. That way, the inport will get the value as 0 every time.

- [x] @pboyer 