### PR TITLE
User better character for unit toggle button in DynamoConverterControl

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoConverterControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoConverterControl.xaml
@@ -39,7 +39,9 @@
 
             <Button Name="DirectionButton"
                 Grid.Column="1"
-                Content="="  
+                Content="⇄"  
+                FontWeight="Bold"
+                FontSize="13"
                 Height ="{x:Static ui2:Configurations.PortHeightInPixels}"
                 Width="40" Command="{Binding ToggleButtonClick}"/>
 


### PR DESCRIPTION
I have no idea why we're using the equal sign for something that SWITCHES two things.  

- [x] @lukechurch  

Before:

![beforeconverter](https://cloud.githubusercontent.com/assets/916345/6645037/510f9d18-c98f-11e4-88c0-ab7ee278771d.PNG)

After:

![useswitch](https://cloud.githubusercontent.com/assets/916345/6645039/54206348-c98f-11e4-9186-c88997cf722f.PNG)
