### PR TITLE
Make node be temporarily silent for node modification event. 

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -590,6 +590,8 @@ namespace Dynamo.Models
             IsSelected = false;
             State = ElementState.Dead;
             ArgumentLacing = LacingStrategy.Disabled;
+
+            RaisesModificationEvents = true;
         }
 
         public virtual void Dispose()
@@ -624,11 +626,11 @@ namespace Dynamo.Models
         #region Modification Reporting
 
         /// <summary>
-        ///     Indicate if the node should respond to Modified event. It
-        ///     always should be false, unless is temporarily set to true to 
+        ///     Indicate if the node should respond to NodeModified event. It
+        ///     always should be true, unless is temporarily set to false to 
         ///     avoid flood of Modified event. 
         /// </summary>
-        public bool BeSilentForNodeModification { get; set; }
+        public bool RaisesModificationEvents { get; set; }
 
         /// <summary>
         ///     Event fired when the node's DesignScript AST should be recompiled
@@ -636,7 +638,7 @@ namespace Dynamo.Models
         public event Action<NodeModel> Modified;
         public virtual void OnNodeModified(bool forceExecute = false)
         {
-            if (BeSilentForNodeModification)
+            if (!RaisesModificationEvents)
                 return;
 
             MarkNodeAsModified(forceExecute);           

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -624,11 +624,21 @@ namespace Dynamo.Models
         #region Modification Reporting
 
         /// <summary>
+        ///     Indicate if the node should respond to Modified event. It
+        ///     always should be false, unless is temporarily set to true to 
+        ///     avoid flood of Modified event. 
+        /// </summary>
+        public bool BeSilentForNodeModification { get; set; }
+
+        /// <summary>
         ///     Event fired when the node's DesignScript AST should be recompiled
         /// </summary>
         public event Action<NodeModel> Modified;
         public virtual void OnNodeModified(bool forceExecute = false)
         {
+            if (BeSilentForNodeModification)
+                return;
+
             MarkNodeAsModified(forceExecute);           
             var handler = Modified;
             if (handler != null) handler(this);

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1141,8 +1141,8 @@ namespace Dynamo.Models
                         var node = model as NodeModel;
                         Debug.Assert(Nodes.Contains(node));
 
-                        bool silentFlag = node.BeSilentForNodeModification;
-                        node.BeSilentForNodeModification = true;
+                        bool silentFlag = node.RaisesModificationEvents;
+                        node.RaisesModificationEvents = false;
 
                         // Note that AllConnectors is duplicated as a separate list 
                         // by calling its "ToList" method. This is the because the 
@@ -1154,7 +1154,7 @@ namespace Dynamo.Models
                             undoRecorder.RecordDeletionForUndo(conn);
                         }
 
-                        node.BeSilentForNodeModification = silentFlag;
+                        node.RaisesModificationEvents = silentFlag;
 
                         // Take a snapshot of the node before it goes away.
                         undoRecorder.RecordDeletionForUndo(node);

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1141,15 +1141,20 @@ namespace Dynamo.Models
                         var node = model as NodeModel;
                         Debug.Assert(Nodes.Contains(node));
 
+                        bool silentFlag = node.BeSilentForNodeModification;
+                        node.BeSilentForNodeModification = true;
+
                         // Note that AllConnectors is duplicated as a separate list 
                         // by calling its "ToList" method. This is the because the 
                         // "Connectors.Remove" will modify "AllConnectors", causing 
                         // the Enumerator in this "foreach" to become invalid.
                         foreach (var conn in node.AllConnectors.ToList())
                         {
-                            conn.Delete(true);
+                            conn.Delete();
                             undoRecorder.RecordDeletionForUndo(conn);
                         }
+
+                        node.BeSilentForNodeModification = silentFlag;
 
                         // Take a snapshot of the node before it goes away.
                         undoRecorder.RecordDeletionForUndo(node);


### PR DESCRIPTION
This is to fix [a regression] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-887) about after deleting a node that connected to default argument of a function node, function node won't use default argument any more. 

When a node is deleted, all its connectors get deleted, and for each connector, all nodes that the connector connects to will be marked as modified, which consequently will run the graph in run auto mode, so the graph will run multiple times. To avoid unnecessary runs, in [this commit] (https://github.com/DynamoDS/Dynamo/commit/d95ef7b650439b0feb4a21a7db412722efe7507d) we remove node silently. But as nodes that the connector connects to are not in dirty state, they won't be re-compiled and still try to get value from deleted node, which is `null`, instead of using default argument. 

In other word, suppose before deletion, the graph is compiled to:
```
    node_to_be_deleted = ....;
    x = func_node(node_to_be_deleted);
```
Ideally after deleting node, the graph should be re-compiled to:
```
    node_to_be_deleted = null;
    x= func_node(default_argument);
```
so that default argument will be used. But as ``func_node`` is still clean, the re-compilation doesn't happen.

In this PR, we add a property `BeSilentForNodeModification` to `NodeModel` to temporarily make node be silent for node modified events. 

@ikeough please review the change. Thanks!