### PR TITLE
Preserve type alias from user typed code for typed identifiers

### DIFF
--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -174,7 +174,7 @@ namespace ProtoCore.Namespace
                     typedNode.datatype.UID < (int) PrimitiveType.kMaxPrimitives)
                     return;
 
-                var identListNode = CoreUtils.CreateNodeFromString(typedNode.datatype.Name);
+                var identListNode = CoreUtils.CreateNodeFromString(typedNode.TypeAlias);
 
                 // Rewrite node with resolved name
                 if (resolvedNames.Any())

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -433,6 +433,8 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class TypedIdentifierNode : IdentifierNode
     {
+        public string TypeAlias { get; set; }
+
         public TypedIdentifierNode()
         {
         }

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -2194,6 +2194,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 				strIdent = t.val; 
 			} else SynErr(98);
 			type = core.TypeSystem.GetType(strIdent);
+			typedVar.TypeAlias = strIdent;
 			if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
 			{
 			var unknownType = new ProtoCore.Type();

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1100,6 +1100,7 @@ Associative_DecoratedIdentifier<out ProtoCore.AST.AssociativeAST.AssociativeNode
 				)
 				(.
 						type = core.TypeSystem.GetType(strIdent);
+						typedVar.TypeAlias = strIdent;
 						if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
 						{
 							var unknownType = new ProtoCore.Type();


### PR DESCRIPTION
The string typed in user supplied code for the type of a typed identifier must be cached in order to be used by the `ElementResolver` for it to be persisted to the resolution map. A new property has been added for this purpose to the `TypedIdentifierNode` class called `TypeAlias` to store this string. Although it is not used in the core language and only by code block nodes, this was the simplest solution I could think of since this information can only be provided by the parser.

@junmendoza  PTAL