### PR TITLE
Don't use ToList() on Package.node_libraries

### DIFF
--- a/src/DynamoCore/PackageManager/Package.cs
+++ b/src/DynamoCore/PackageManager/Package.cs
@@ -318,8 +318,9 @@ namespace Dynamo.PackageManager
             if (!Directory.Exists(BinaryDirectory))
                 return assemblies;
 
-            // use the pkg header to determine which assemblies to load and prevent multiple enumeration
-            var nodeLibraries = Header.node_libraries.ToList();
+            // Use the pkg header to determine which assemblies to load and prevent multiple enumeration
+            // In earlier packages, this field could be null, which is correctly handled by IsNodeLibrary
+            var nodeLibraries = Header.node_libraries;
             
             foreach (var assemFile in (new DirectoryInfo(BinaryDirectory)).EnumerateFiles("*.dll"))
             {


### PR DESCRIPTION
### Issue

Aparajit noticed an exception being thrown in this method due to some of my recent changes.  For older packages, the node_libraries field may be null.  Thus, we can't use `ToList` on it.  This optimization is unnecessary anyways.

### Fix 

Don't use `ToList`!

### Reviewer

- [x] @aparajit-pratap 