### PR TITLE
Make ImportFromCSV more tolerant of leading or trailing whitespace

### DIFF
--- a/src/Engine/ProtoCore/Utils/FileUtils.cs
+++ b/src/Engine/ProtoCore/Utils/FileUtils.cs
@@ -22,6 +22,10 @@ namespace ProtoCore.Utils
         /// file name when failed to loate the given file</returns>
         public static string GetDSFullPathName(string fileName, Options options = null)
         {
+            // trim white space chars
+            var trimChars = new[] {'\n','\t','\r',' '};
+            fileName = fileName.Trim(trimChars);
+
             //1.  First search at .exe module directory, in case files of the same name exists in the following directories.
             //    The .exe module directory is of highest priority.
             //    CodeBase is used here because Assembly.Location does not work quite well when the module is shallow-copied in nunit test.

--- a/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
+++ b/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
@@ -322,6 +322,17 @@ namespace ProtoTest.Associative
         }
 
         [Test]
+        //Test "LoadCSV"
+        public void BIM24_LoadCSV()
+        {
+            // ensure that white space is trimmed from the path
+            String code =
+@"a = ""\n \r\t../../../test/Engine/ProtoTest/ImportFiles/CSV/Set1/test1.csv\r\r\n "";b = ImportFromCSV(a);x = b[0][2];";
+            ExecutionMirror mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("x", 3.0);
+        }
+
+        [Test]
         //Test "Count"
         public void BIM24_Count()
         {


### PR DESCRIPTION
### Issue

`ImportFromCSV` crashes when a user supplies a path with leading or trailing carriage returns.  http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6388

### Fix

Make the `GetDSFullPathName` resistant to such issues. 

### Results

![tolerantcsv](https://cloud.githubusercontent.com/assets/916345/6691179/7e25be7c-cc9b-11e4-8e02-7bf9e942546a.PNG)

### Reviewer

- [ ] @lukechurch 