### PR TITLE
update IPathResolver to allow customized data location

### DIFF
--- a/src/DynamoCore/Core/PathManager.cs
+++ b/src/DynamoCore/Core/PathManager.cs
@@ -291,7 +291,7 @@ namespace Dynamo.Core
 
         private string GetUserDataFolder(IPathResolver pathResolver)
         {
-            if (pathResolver != null && pathResolver.UserDataRootFolder != string.Empty)
+            if (pathResolver != null && !string.IsNullOrEmpty(pathResolver.UserDataRootFolder))
                 return GetDynamoDataFolder(pathResolver.UserDataRootFolder);
 
             var folder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
@@ -300,7 +300,7 @@ namespace Dynamo.Core
 
         private string GetCommonDataFolder(IPathResolver pathResolver)
         {
-            if (pathResolver != null && pathResolver.CommonDataRootFolder != string.Empty)
+            if (pathResolver != null && !string.IsNullOrEmpty(pathResolver.CommonDataRootFolder))
                 return GetDynamoDataFolder(pathResolver.CommonDataRootFolder);
 
             var folder = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);

--- a/src/DynamoCore/Core/PathManager.cs
+++ b/src/DynamoCore/Core/PathManager.cs
@@ -201,7 +201,7 @@ namespace Dynamo.Core
             }
 
             // Current user specific directories.
-            userDataDir = GetUserDataFolder();
+            userDataDir = GetUserDataFolder(pathResolver);
 
             userDefinitions = Path.Combine(userDataDir, DefinitionsDirectoryName);
             logDirectory = Path.Combine(userDataDir, LogsDirectoryName);
@@ -209,7 +209,7 @@ namespace Dynamo.Core
             preferenceFilePath = Path.Combine(userDataDir, PreferenceSettingsFileName);
 
             // Common directories.
-            commonDataDir = GetCommonDataFolder();
+            commonDataDir = GetCommonDataFolder(pathResolver);
 
             commonDefinitions = Path.Combine(commonDataDir, DefinitionsDirectoryName);
             samplesDirectory = GetSamplesFolder(commonDataDir);
@@ -289,21 +289,27 @@ namespace Dynamo.Core
             }
         }
 
-        private string GetUserDataFolder()
+        private string GetUserDataFolder(IPathResolver pathResolver)
         {
-            var folder = Environment.SpecialFolder.ApplicationData;
-            return GetDynamoDataFolder(folder);
+            if (pathResolver != null && pathResolver.UserDataRootFolder != string.Empty)
+                return GetDynamoDataFolder(pathResolver.UserDataRootFolder);
+
+            var folder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            return GetDynamoDataFolder(Path.Combine(folder, "Dynamo"));
         }
 
-        private string GetCommonDataFolder()
+        private string GetCommonDataFolder(IPathResolver pathResolver)
         {
-            var folder = Environment.SpecialFolder.CommonApplicationData;
-            return GetDynamoDataFolder(folder);
+            if (pathResolver != null && pathResolver.CommonDataRootFolder != string.Empty)
+                return GetDynamoDataFolder(pathResolver.CommonDataRootFolder);
+
+            var folder = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            return GetDynamoDataFolder(Path.Combine(folder, "Dynamo"));
         }
 
-        private string GetDynamoDataFolder(Environment.SpecialFolder folder)
+        private string GetDynamoDataFolder(string folder)
         {
-            return Path.Combine(Environment.GetFolderPath(folder), "Dynamo",
+            return Path.Combine(folder,
                 String.Format("{0}.{1}", majorFileVersion, minorFileVersion));
         }
 

--- a/src/DynamoCore/Interfaces/IPathResolver.cs
+++ b/src/DynamoCore/Interfaces/IPathResolver.cs
@@ -34,10 +34,9 @@ namespace Dynamo.Interfaces
         /// <summary>
         /// This property represents the root folder where user specific data files 
         /// are stored. If this property returns a null or empty string, then 
-        /// PathManager falls back to using "%ProgramData%\Dynamo". If this property
-        /// returns a string that does not represent a valid folder, a 
-        /// DirectoryNotFoundException is thrown. Note that this path should not 
-        /// include the version number as it will be appended by PathManager.
+        /// PathManager falls back to using "%ProgramData%\Dynamo". Note that this 
+        /// path should not include the version number as it will be appended by
+        /// PathManager.
         /// </summary>
         string UserDataRootFolder { get; }
 
@@ -45,10 +44,8 @@ namespace Dynamo.Interfaces
         /// This property represents the root folder where application common data 
         /// files (i.e. shared among all users on the same machine) are stored. If 
         /// this property returns a null or empty string, then PathManager falls 
-        /// back to using "%AppData%\Dynamo". If this property returns a string 
-        /// that does not represent a valid folder, a DirectoryNotFoundException 
-        /// is thrown. Note that this path should not include the version number 
-        /// as it will be appended by PathManager.
+        /// back to using "%AppData%\Dynamo". Note that this path should not 
+        /// include the version number as it will be appended by PathManager.
         /// </summary>
         string CommonDataRootFolder { get; }
     }

--- a/src/DynamoCore/Interfaces/IPathResolver.cs
+++ b/src/DynamoCore/Interfaces/IPathResolver.cs
@@ -32,21 +32,23 @@ namespace Dynamo.Interfaces
         IEnumerable<string> PreloadedLibraryPaths { get; }
 
         /// <summary>
-        /// This property represents the root folder where user specific data
-        /// files are stored. If this property returns a null or empty string,
-        /// then PathManager falls back to using %ProgramData%\Dynamo\%version%.
-        /// If this property returns a string that does not represent a valid 
-        /// folder, a DirectoryNotFoundException is thrown.
+        /// This property represents the root folder where user specific data files 
+        /// are stored. If this property returns a null or empty string, then 
+        /// PathManager falls back to using "%ProgramData%\Dynamo". If this property
+        /// returns a string that does not represent a valid folder, a 
+        /// DirectoryNotFoundException is thrown. Note that this path should not 
+        /// include the version number as it will be appended by PathManager.
         /// </summary>
         string UserDataRootFolder { get; }
 
         /// <summary>
-        /// This property represents the root folder where application common 
-        /// data files (i.e. shared among all users on the same machine) are 
-        /// stored. If this property returns a null or empty string, then 
-        /// PathManager falls back to using %AppData%\Dynamo\%version%. If 
-        /// this property returns a string that does not represent a valid 
-        /// folder, a DirectoryNotFoundException is thrown.
+        /// This property represents the root folder where application common data 
+        /// files (i.e. shared among all users on the same machine) are stored. If 
+        /// this property returns a null or empty string, then PathManager falls 
+        /// back to using "%AppData%\Dynamo". If this property returns a string 
+        /// that does not represent a valid folder, a DirectoryNotFoundException 
+        /// is thrown. Note that this path should not include the version number 
+        /// as it will be appended by PathManager.
         /// </summary>
         string CommonDataRootFolder { get; }
     }

--- a/src/DynamoCore/Interfaces/IPathResolver.cs
+++ b/src/DynamoCore/Interfaces/IPathResolver.cs
@@ -30,6 +30,25 @@ namespace Dynamo.Interfaces
         /// null.
         /// </summary>
         IEnumerable<string> PreloadedLibraryPaths { get; }
+
+        /// <summary>
+        /// This property represents the root folder where user specific data
+        /// files are stored. If this property returns a null or empty string,
+        /// then PathManager falls back to using %ProgramData%\Dynamo\%version%.
+        /// If this property returns a string that does not represent a valid 
+        /// folder, a DirectoryNotFoundException is thrown.
+        /// </summary>
+        string UserDataRootFolder { get; }
+
+        /// <summary>
+        /// This property represents the root folder where application common 
+        /// data files (i.e. shared among all users on the same machine) are 
+        /// stored. If this property returns a null or empty string, then 
+        /// PathManager falls back to using %AppData%\Dynamo\%version%. If 
+        /// this property returns a string that does not represent a valid 
+        /// folder, a DirectoryNotFoundException is thrown.
+        /// </summary>
+        string CommonDataRootFolder { get; }
     }
 
     public interface IPathManager

--- a/src/DynamoCore/Interfaces/IPathResolver.cs
+++ b/src/DynamoCore/Interfaces/IPathResolver.cs
@@ -34,9 +34,12 @@ namespace Dynamo.Interfaces
         /// <summary>
         /// This property represents the root folder where user specific data files 
         /// are stored. If this property returns a null or empty string, then 
-        /// PathManager falls back to using "%ProgramData%\Dynamo". Note that this 
-        /// path should not include the version number as it will be appended by
-        /// PathManager.
+        /// PathManager falls back to using "%ProgramData%\Dynamo". If this property
+        /// returns a string that does not represent an existing folder, PathManager 
+        /// will attempt to create a new directory. If the property does not represent
+        /// a valid path string, an exception will be thrown by the underlying system 
+        /// IO API invoked. Note that this path should not include the version number 
+        /// as it will be appended by PathManager.
         /// </summary>
         string UserDataRootFolder { get; }
 
@@ -44,8 +47,12 @@ namespace Dynamo.Interfaces
         /// This property represents the root folder where application common data 
         /// files (i.e. shared among all users on the same machine) are stored. If 
         /// this property returns a null or empty string, then PathManager falls 
-        /// back to using "%AppData%\Dynamo". Note that this path should not 
-        /// include the version number as it will be appended by PathManager.
+        /// back to using "%AppData%\Dynamo". If this property returns a string 
+        /// that does not represent an existing folder, PathManager will attempt 
+        /// to create a new directory. If the property does not represent a valid 
+        /// path string, an exception will be thrown by the underlying system IO 
+        /// API invoked. Note that this path should not include the version number 
+        /// as it will be appended by PathManager.
         /// </summary>
         string CommonDataRootFolder { get; }
     }

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -48,6 +48,16 @@ namespace DynamoSandbox
         {
             get { return preloadedLibraryPaths; }
         }
+
+        public string UserDataRootFolder 
+        {
+            get { return string.Empty; }
+        }
+
+        public string CommonDataRootFolder
+        { 
+            get { return string.Empty; }
+        }
     }
 
     internal class Program

--- a/test/Libraries/TestServices/TestPathResolver.cs
+++ b/test/Libraries/TestServices/TestPathResolver.cs
@@ -38,5 +38,15 @@ namespace TestServices
         {
             get { return preloadedLibraryPaths; }
         }
+
+        public string UserDataRootFolder
+        {
+            get { return string.Empty; }
+        }
+
+        public string CommonDataRootFolder
+        {
+            get { return string.Empty; }
+        }
     }
 }


### PR DESCRIPTION
This patch addresses MAGN-6605
Changes:
- Update IPathResolver to include location of customized user 
- Update TestPathResolver and PathResolver classes to the new interface
- Modify PathManager to accept customized locations for user data


@Benglin PTAL