### PR TITLE
Fix defect that String node is not able to handle some Unicode strings

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1582,13 +1582,13 @@ namespace Dynamo.Controls
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             //source -> target
-            return value == null ? "" : HttpUtility.HtmlDecode(value.ToString());
+            return value == null ? "" : value.ToString(); 
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             //target -> source
-            return HttpUtility.HtmlEncode(value.ToString());
+            return value.ToString();
         }
     }
 

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -37,7 +37,7 @@ namespace Dynamo.Nodes
 
             if (name == "Value")
             {
-                Value = HttpUtility.HtmlEncode(value);
+                Value = value; 
                 return true; // UpdateValueCore handled.
             }
 
@@ -48,21 +48,13 @@ namespace Dynamo.Nodes
             return base.UpdateValueCore(updateValueParams);
         }
 
-        protected override string SerializeValue()
-        {
-            return HttpUtility.HtmlEncode(Value);
-        }
-
-        protected override string DeserializeValue(string val)
-        {
-            return HttpUtility.HtmlDecode(val);
-        }
-
         protected override void SerializeCore(XmlElement nodeElement, SaveContext context)
         {
             base.SerializeCore(nodeElement, context);
             XmlElement outEl = nodeElement.OwnerDocument.CreateElement(typeof(string).FullName);
-            outEl.SetAttribute("value", SerializeValue().ToString(CultureInfo.InvariantCulture));
+
+            var helper = new XmlElementHelper(outEl);
+            helper.SetAttribute("value", SerializeValue());
             nodeElement.AppendChild(outEl);
         }
 

--- a/src/Libraries/CoreNodeModels/Input/String.cs
+++ b/src/Libraries/CoreNodeModels/Input/String.cs
@@ -18,7 +18,7 @@ namespace DSCoreNodesUI
             string value = updateValueParams.PropertyValue;
             if (name == "Value")
             {
-                Value = HttpUtility.HtmlEncode(value);
+                Value = value; 
                 return true;
             }
 

--- a/test/DynamoCoreTests/UnicodeTest.cs
+++ b/test/DynamoCoreTests/UnicodeTest.cs
@@ -28,8 +28,8 @@ namespace Dynamo.Tests
         [Test]
         public void TestUnicodeInStringNode()
         {
-            RunModel(@"core\unicode_test\unicodeInCBN.dyn");
-            AssertPreviewValue("2ac4c6a7-83a1-4775-b8f4-7fa9001d33f7", "<\"äö&amp;üß\">");
+            RunModel(@"core\unicode_test\unicodeInStringNode.dyn");
+            AssertPreviewValue("2ac4c6a7-83a1-4775-b8f4-7fa9001d33f7", "<\"äö&üß\">");
         }
 
         [Test]

--- a/test/DynamoCoreTests/UnicodeTest.cs
+++ b/test/DynamoCoreTests/UnicodeTest.cs
@@ -26,6 +26,13 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void TestUnicodeInStringNode()
+        {
+            RunModel(@"core\unicode_test\unicodeInCBN.dyn");
+            AssertPreviewValue("2ac4c6a7-83a1-4775-b8f4-7fa9001d33f7", "<\"äö&amp;üß\">");
+        }
+
+        [Test]
         public void TestUnicodeInIronPython()
         {
             RunModel(@"core\unicode_test\unicodeInIronPython.dyn");

--- a/test/core/unicode_test/unicodeInStringNode.dyn
+++ b/test/core/unicode_test/unicodeInStringNode.dyn
@@ -1,0 +1,14 @@
+<Workspace Version="0.8.0.762" X="-470.999549014225" Y="-234.633819254866" zoom="2.05668026833428" Name="Home" RunType="Automatic" RunPeriod="100">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.StringInput guid="4cdbea90-286d-4395-86c7-58bcea5f17bc" type="Dynamo.Nodes.StringInput" nickname="String" x="294.401591051291" y="275.909450478924" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.String>&lt;"äö&amp;üß"&gt;</System.String>
+      <System.String value="&lt;&quot;äö&amp;üß&quot;&gt;" />
+    </Dynamo.Nodes.StringInput>
+    <Dynamo.Nodes.Watch guid="2ac4c6a7-83a1-4775-b8f4-7fa9001d33f7" type="Dynamo.Nodes.Watch" nickname="Watch" x="573.658210440436" y="278.587683872462" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="4cdbea90-286d-4395-86c7-58bcea5f17bc" start_index="0" end="2ac4c6a7-83a1-4775-b8f4-7fa9001d33f7" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
This PR is to address defect [MAGN-5791] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5791#) that `String` node is not able to handle some unicode strings.

That's because internally we use `HttpUtility.HtmlEncode()` and `HttpUtlity.HtmlDecode()` to encode/decode string value in html encoding format. It is not necessary because 1) internally, including the language engine, we always use UTF-16 format for strings 2) when do serialization/deserialization, `XmlElement.SetAttribute()` and `XmlElement.GetAttribute()` will properly encode/decode string in UTF-8 format, and also escape the string (i.e., characters `<`, `>`, `"`, `&`, `'` will be converted to `&lt;`, `&gt;`, `quot;`, `&amp;`, `&apos;`). 

Regression test case `TestUnicodeInStringNode` added.

@sharadkjaiswal  please help to review the change. 