### PR TITLE
Fix crash when calling GetKeys() non-array object

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -418,13 +418,14 @@ namespace ProtoCore.Lang
                 case BuiltInMethods.MethodID.kGetKeys:
                     {
                         StackValue array = formalParameters[0];
-                        StackValue[] result = ArrayUtils.GetKeys(array, runtimeCore);
-                        if (null == result)
+                        if (!array.IsArray)
                         {
+                            runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, Resources.kArrayOverIndexed);
                             ret = StackValue.Null;
                         }
                         else
                         {
+                            var result = ArrayUtils.GetKeys(array, runtimeCore);
                             ret = rmem.Heap.AllocateArray(result, null);
                         }
                         break;
@@ -434,6 +435,7 @@ namespace ProtoCore.Lang
                         StackValue array = formalParameters[0];
                         if (!array.IsArray)
                         {
+                            runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, Resources.kArrayOverIndexed);
                             ret = StackValue.Null;
                         }
                         else

--- a/test/DynamoCoreTests/DSFunctionNodeTest.cs
+++ b/test/DynamoCoreTests/DSFunctionNodeTest.cs
@@ -95,5 +95,17 @@ namespace Dynamo.Tests
             var value = (Int64)mirror.GetData().Data;
             Assert.AreEqual(value, 10);
         }
+
+        [Test, Category("RegressionTests")]
+        public void TestGetKeys()
+        {
+            var model = ViewModel.Model;
+
+            string openPath = Path.Combine(GetTestDirectory(), @"core\dsfunction\GetKeys.dyn");
+            ViewModel.OpenCommand.Execute(openPath);
+
+            // no crash
+            Assert.DoesNotThrow(() => ViewModel.HomeSpace.Run());
+        }
     }
 }

--- a/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
+++ b/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
@@ -830,6 +830,16 @@ r = __TryGetValueFromNestedDictionaries(a, ""nonexist"");
             var mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("r", null);
         }
+
+        [Test]
+        public void TestGetKeysFromNonArray()
+        {
+            string code = @"
+x = 1;
+k = GetKeys(x);";
+            var mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("k", null);
+        }
     }
 
     class MathematicalFunctionMethodsTest

--- a/test/core/dsfunction/GetKeys.dyn
+++ b/test/core/dsfunction/GetKeys.dyn
@@ -1,0 +1,11 @@
+<Workspace Version="0.8.0.742" X="0" Y="0" zoom="1" Name="Home" RunType="Manual" RunPeriod="100">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="fd5b7765-9882-4468-92d4-399fbc64da08" type="Dynamo.Nodes.DSFunction" nickname="GetKeys" x="309.6" y="362" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="GetKeys@var[]..[]" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="32daa21e-47ab-409c-bfc3-2039f68ad3ed" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="99.2" y="314.2" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="1;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="32daa21e-47ab-409c-bfc3-2039f68ad3ed" start_index="0" end="fd5b7765-9882-4468-92d4-399fbc64da08" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
This PR is to fix [crash when calling `GetKeys()` on non-array object] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6684), and [this issue] (https://github.com/DynamoDS/Dynamo/issues/3989).

We need to do checking and log a warning before getting keys on a non-array object. 

@junmendoza PTAL.