### PR TITLE
Test fix.

### DIFF
--- a/src/DynamoCore/Nodes/NodeCategories.cs
+++ b/src/DynamoCore/Nodes/NodeCategories.cs
@@ -173,7 +173,7 @@ namespace Dynamo.Nodes
                                             s[s.Count - 2],
                                             s[s.Count - 1]
                                         };
-                    catName = String.Join(" " + Configurations.ShortenedCategoryDelimiter + " ", s);
+                    catName = String.Join(Configurations.ShortenedCategoryDelimiter, s);
                 }
             }
 

--- a/test/DynamoCoreTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreTests/SearchViewModelTests.cs
@@ -71,8 +71,8 @@ namespace Dynamo.Tests
             categoryName = "Cat1 Cat" + Configurations.CategoryDelimiterString + "Cat2 Cat" +
                                     Configurations.CategoryDelimiterString + "Cat3";
             result = Nodes.Utilities.ShortenCategoryName(categoryName);
-            Assert.AreEqual("Cat1 Cat " + Configurations.ShortenedCategoryDelimiter + " Cat2 Cat " +
-                                      Configurations.ShortenedCategoryDelimiter + " Cat3", result);
+            Assert.AreEqual("Cat1 Cat" + Configurations.ShortenedCategoryDelimiter + "Cat2 Cat" +
+                                      Configurations.ShortenedCategoryDelimiter + "Cat3", result);
 
             categoryName = "TenSymbol" + Configurations.CategoryDelimiterString +
                            "TenSymbol" + Configurations.CategoryDelimiterString +
@@ -81,11 +81,11 @@ namespace Dynamo.Tests
                            "TenSymbol" + Configurations.CategoryDelimiterString +
                            "MoreSymbols";
             result = Nodes.Utilities.ShortenCategoryName(categoryName);
-            Assert.AreEqual("TenSymbol " + Configurations.ShortenedCategoryDelimiter +
-                           " ... " + Configurations.ShortenedCategoryDelimiter +
-                           " TenSymbol " + Configurations.ShortenedCategoryDelimiter +
-                           " TenSymbol " + Configurations.ShortenedCategoryDelimiter +
-                           " MoreSymbols", result);
+            Assert.AreEqual("TenSymbol" + Configurations.ShortenedCategoryDelimiter +
+                           "..." + Configurations.ShortenedCategoryDelimiter +
+                           "TenSymbol" + Configurations.ShortenedCategoryDelimiter +
+                           "TenSymbol" + Configurations.ShortenedCategoryDelimiter +
+                           "MoreSymbols", result);
         }
 
         #region InsertEntry tests

--- a/test/DynamoCoreTests/WorkspaceOpeningTests.cs
+++ b/test/DynamoCoreTests/WorkspaceOpeningTests.cs
@@ -56,7 +56,7 @@ namespace Dynamo
 
         private WorkspaceModel OpenWorkspaceFromSampleFile()
         {
-            var examplePath = Path.Combine(GetSampleDirectory(), @"Basics\Basics_Basic01.dyn");
+            var examplePath = Path.Combine(GetSampleDirectory(), @"en-US\Basics\Basics_Basic01.dyn");
             ViewModel.Model.OpenFileFromPath(examplePath);
             return ViewModel.Model.CurrentWorkspace;
         }


### PR DESCRIPTION
In [this PR](https://github.com/DynamoDS/Dynamo/pull/4010)  `CategoryDelimiterWithSpaces` was removed. Tests left with extra spaces.

Reviewers
@Benglin , please take a look.