### PR TITLE
User shouldn't see option to submit package without an AuthProvider

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -115,7 +115,7 @@ namespace Dynamo.ViewModels
 
         public bool CanPublishCurrentWorkspace(object m)
         {
-            return DynamoViewModel.Model.CurrentWorkspace is CustomNodeWorkspaceModel;
+            return DynamoViewModel.Model.CurrentWorkspace is CustomNodeWorkspaceModel && HasAuthProvider;
         }
 
         public void PublishNewPackage(object m)
@@ -170,7 +170,7 @@ namespace Dynamo.ViewModels
         public bool CanPublishSelectedNodes(object m)
         {
             return DynamoSelection.Instance.Selection.Count > 0 &&
-                   DynamoSelection.Instance.Selection.All(x => x is Function);
+                   DynamoSelection.Instance.Selection.All(x => x is Function) && HasAuthProvider;;
         }
 
         private void ShowNodePublishInfo()
@@ -204,7 +204,6 @@ namespace Dynamo.ViewModels
 
             DynamoViewModel.OnRequestPackagePublishDialog(newPkgVm);
         }
-
 
         public List<PackageManagerSearchElement> ListAll()
         {


### PR DESCRIPTION
This is a minor regression I noticed, likely due to the work on standalone authentication.  The issue is that the user erroneously sees certain options like "Publish Custom Node as Package" as enabled when there's no way for them to login.   

- [x] @ramramps