### PR TITLE
MAGN-6704: Override FarPlaneDistance in Watch3DView

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml
@@ -108,6 +108,10 @@
                          Converter="{StaticResource BackgroundPreviewGestureConverter}"
                          ConverterParameter="IsOrbiting" />
             </HelixToolkit:HelixViewport3D.RotateGesture2>
+            <HelixToolkit:HelixViewport3D.Camera>
+                <PerspectiveCamera FarPlaneDistance="5000000" UpDirection="0,0,1" Position="10,10,10" LookDirection="-1,-1,-1">
+                </PerspectiveCamera>
+            </HelixToolkit:HelixViewport3D.Camera>
             <ModelVisual3D>
                 <HelixToolkit:LightVisual3D>
                     <HelixToolkit:DefaultLights>


### PR DESCRIPTION
### Issue

When Revit users have a model in mm, they can easily have quite gigantic models.  

### Fix

I overrode the `Camera` in `Watch3DView` with a much larger `FarPlaneDistance` of 5,000,000 units.  This will enclose a building that is 5280 ft = 1,609,344 mm.  

### Screenshots

Before (immediately after zoom extent operation):

![beforedist](https://cloud.githubusercontent.com/assets/916345/6713768/f1d1578a-cd6a-11e4-935d-de324e38fe1e.PNG)

After (immediately after zoom extent operation): 

![image](https://cloud.githubusercontent.com/assets/916345/6713805/1abe9f54-cd6b-11e4-99aa-e7749a86a134.png)

### Reviewer

- [x] @ikeough 