### PR TITLE
MAGN-6621 Convert node not working and throwing error "Dereferencing a non-pointer"

### DIFF
--- a/src/DynamoCore/Core/PathManager.cs
+++ b/src/DynamoCore/Core/PathManager.cs
@@ -228,6 +228,7 @@ namespace Dynamo.Core
                 "DSIronPython.dll",
                 "FunctionObject.ds",
                 "Optimize.ds",
+                "DynamoConversions.dll",
                 "DynamoUnits.dll",
                 "Tessellation.dll",
                 "Analysis.dll"


### PR DESCRIPTION
**Issue**:
  DynamoConversions.dll was not loaded in preloadedlibraries.

**Fix**
   Added DynamoConversions.dll in PreloadedLibraries.

- [x] @pboyer 