### PR TITLE
Cleanup DynamoCoreUITests to avoid duplicate test cases

### DIFF
--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -28,12 +28,11 @@ namespace DynamoCoreUITests
 {
     public delegate void CommandCallback(string commandTag);
 
-    [TestFixture]
-    public class RecordedTests : DSEvaluationViewModelUnitTest
+    public class RecordedUnitTestBase : DSEvaluationViewModelUnitTest
     {
         #region Generic Set-up Routines and Data Members
 
-        private System.Random randomizer = null;
+        protected System.Random randomizer = null;
         private IEnumerable<string> customNodesToBeLoaded = null;
         private CommandCallback commandCallback = null;
 
@@ -47,7 +46,6 @@ namespace DynamoCoreUITests
         protected double tolerance = 1e-6;
         protected double codeBlockPortHeight = Configurations.CodeBlockPortHeightInPixels;
 
-        [SetUp]
         public override void Setup()
         {
             // Fixed seed randomizer for predictability.
@@ -60,8 +58,7 @@ namespace DynamoCoreUITests
             // base.Init();
         }
 
-        [TearDown]
-        protected void Exit()
+        public void Exit()
         {
             commandCallback = null;
             if (this.ViewModel != null)
@@ -86,6 +83,195 @@ namespace DynamoCoreUITests
         }
 
         #endregion
+
+        #region Private Helper Methods
+
+        protected ModelBase GetNode(string guid)
+        {
+            Guid id = Guid.Parse(guid);
+            return ViewModel.Model.CurrentWorkspace.GetModelInternal(id);
+        }
+
+        /// <summary>
+        /// Call this method to load custom nodes from their file paths. This 
+        /// call, if made, must precede the call to RunCommandsFromFile. This 
+        /// call cannot be made more than once for a single test case. If more 
+        /// than one custom node files are needed for the test case, they must 
+        /// be specified in the same call.
+        /// </summary>
+        /// <param name="customNodeFilePaths">And array of custom node file paths.
+        /// This array cannot be null or empty.</param>
+        /// 
+        protected void LoadCustomNodes(string[] customNodeFilePaths)
+        {
+            if (customNodeFilePaths == null || (customNodeFilePaths.Length <= 0))
+            {
+                var message = "Argument must be one or more valid file paths";
+                throw new ArgumentException(message);
+            }
+
+            if (this.customNodesToBeLoaded != null)
+                throw new InvalidOperationException("LoadCustomNodes called twice");
+
+            if (this.ViewModel != null)
+            {
+                var message = "'LoadCustomNodes' should be called before 'RunCommandsFromFile'";
+                throw new InvalidOperationException(message);
+            }
+
+            var fileList = new List<string>();
+            foreach (var customNodeFilePath in customNodeFilePaths)
+            {
+                if (File.Exists(customNodeFilePath) != false)
+                {
+                    fileList.Add(customNodeFilePath);
+                    continue;
+                }
+
+                var message = "Custom node file not found";
+                throw new System.IO.FileNotFoundException(message, customNodeFilePath);
+            }
+
+            this.customNodesToBeLoaded = fileList;
+        }
+
+        protected void RunCommandsFromFile(string commandFileName,
+            bool autoRun = false, CommandCallback commandCallback = null)
+        {
+            string commandFilePath = SystemTestBase.GetTestDirectory(ExecutingDirectory);
+            commandFilePath = Path.Combine(commandFilePath, @"core\recorded\");
+            commandFilePath = Path.Combine(commandFilePath, commandFileName);
+
+            if (this.ViewModel != null)
+            {
+                var message = "Multiple DynamoViewModel instances detected!";
+                throw new InvalidOperationException(message);
+            }
+
+            var geometryFactoryPath = string.Empty;
+            if (preloadGeometry && (preloader == null))
+            {
+                var assemblyPath = Assembly.GetExecutingAssembly().Location;
+                preloader = new Preloader(Path.GetDirectoryName(assemblyPath));
+                preloader.Preload();
+
+                geometryFactoryPath = preloader.GeometryFactoryPath;
+                preloadGeometry = false;
+            }
+
+            var model = DynamoModel.Start(
+                new DynamoModel.DefaultStartConfiguration()
+                {
+                    StartInTestMode = true,
+                    PathResolver = pathResolver,
+                    GeometryFactoryPath = geometryFactoryPath
+                });
+
+            pathResolver = null; // Invalidate path resolver after specified.
+
+            // Create the DynamoViewModel to control the view
+            this.ViewModel = DynamoViewModel.Start(
+                new DynamoViewModel.StartConfiguration()
+                {
+                    CommandFilePath = commandFilePath,
+                    DynamoModel = model
+                });
+
+            ViewModel.HomeSpace.RunSettings.RunType = autoRun ?
+                RunType.Automatic :
+                RunType.Manual;
+
+            // Load all custom nodes if there is any specified for this test.
+            if (this.customNodesToBeLoaded != null)
+            {
+                foreach (var customNode in this.customNodesToBeLoaded)
+                {
+                    CustomNodeInfo info;
+                    if (!ViewModel.Model.CustomNodeManager.AddUninitializedCustomNode(customNode, true, out info))
+                    {
+                        throw new System.IO.FileFormatException(string.Format(
+                            "Failed to load custom node: {0}", customNode));
+                    }
+                }
+            }
+
+            RegisterCommandCallback(commandCallback);
+
+            // Create the view.
+            dynamoView = new DynamoView(this.ViewModel);
+            dynamoView.ShowDialog();
+
+            Assert.IsNotNull(this.ViewModel);
+            Assert.IsNotNull(this.ViewModel.Model);
+            Assert.IsNotNull(this.ViewModel.Model.CurrentWorkspace);
+            workspace = this.ViewModel.Model.CurrentWorkspace;
+            workspaceViewModel = this.ViewModel.CurrentSpaceViewModel;
+        }
+
+        private void RegisterCommandCallback(CommandCallback commandCallback)
+        {
+            if (commandCallback == null)
+                return;
+
+            if (this.commandCallback != null)
+                throw new InvalidOperationException("RunCommandsFromFile called twice");
+
+            this.commandCallback = commandCallback;
+            var automation = this.ViewModel.Automation;
+            automation.PlaybackStateChanged += OnAutomationPlaybackStateChanged;
+        }
+
+        private void OnAutomationPlaybackStateChanged(object sender, PlaybackStateChangedEventArgs e)
+        {
+            if (e.OldState == AutomationSettings.State.Paused)
+            {
+                if (e.NewState == AutomationSettings.State.Playing)
+                {
+                    // Call back to the delegate registered by the test case. We
+                    // only handle command transition from Paused to Playing. Note 
+                    // that "commandCallback" is not checked against "null" value 
+                    // because "OnAutomationPlaybackStateChanged" would not have 
+                    // been called if the "commandCallback" was not registered.
+                    // 
+                    this.commandCallback(e.NewTag);
+                }
+            }
+        }
+
+        protected CmdType DuplicateAndCompare<CmdType>(CmdType command)
+            where CmdType : DynamoModel.RecordableCommand
+        {
+            Assert.IsNotNull(command); // Ensure we have an input command.
+
+            // Serialize the command into an XmlElement.
+            XmlDocument xmlDocument = new XmlDocument();
+            XmlElement element = command.Serialize(xmlDocument);
+            Assert.IsNotNull(element);
+
+            // Deserialized the XmlElement into a new instance of the command.
+            var duplicate = DynamoModel.RecordableCommand.Deserialize(element);
+            Assert.IsNotNull(duplicate);
+            Assert.IsTrue(duplicate is CmdType);
+            return duplicate as CmdType;
+        }
+
+        #endregion
+    }
+
+    [TestFixture]
+    public class RecordedTests : RecordedUnitTestBase
+    {
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            base.Exit();
+        }
 
         #region Recorded Test Cases for Command Framework
 
@@ -448,15 +634,11 @@ namespace DynamoCoreUITests
                     Assert.AreEqual(1, customWorkspace.Nodes.Count);
 
                     var node = GetNode("6cec1997-ed61-4277-a1a8-3f3e4eb4321d") as NodeModel;
-
-
                 }
                 else if (commandTag == "SecondRun")
                 {
-
                     Assert.IsNotNull(workspaces);
                     Assert.AreEqual(2, workspaces.Count());
-
 
                     Assert.AreEqual(2, workspace.Connectors.Count());
                     Assert.AreEqual(1, workspace.Nodes.Count);
@@ -464,13 +646,7 @@ namespace DynamoCoreUITests
                     Assert.IsNotNull(customWorkspace);
                     Assert.AreEqual(2, customWorkspace.Connectors.Count());
                     Assert.AreEqual(1, customWorkspace.Nodes.Count);
-
-
-
-
                 }
-
-
             });
         }
         [Test]
@@ -624,184 +800,23 @@ namespace DynamoCoreUITests
         }
 
         #endregion
-
-        #region Private Helper Methods
-
-        protected ModelBase GetNode(string guid)
-        {
-            Guid id = Guid.Parse(guid);
-            return ViewModel.Model.CurrentWorkspace.GetModelInternal(id);
-        }
-
-        /// <summary>
-        /// Call this method to load custom nodes from their file paths. This 
-        /// call, if made, must precede the call to RunCommandsFromFile. This 
-        /// call cannot be made more than once for a single test case. If more 
-        /// than one custom node files are needed for the test case, they must 
-        /// be specified in the same call.
-        /// </summary>
-        /// <param name="customNodeFilePaths">And array of custom node file paths.
-        /// This array cannot be null or empty.</param>
-        /// 
-        protected void LoadCustomNodes(string[] customNodeFilePaths)
-        {
-            if (customNodeFilePaths == null || (customNodeFilePaths.Length <= 0))
-            {
-                var message = "Argument must be one or more valid file paths";
-                throw new ArgumentException(message);
-            }
-
-            if (this.customNodesToBeLoaded != null)
-                throw new InvalidOperationException("LoadCustomNodes called twice");
-
-            if (this.ViewModel != null)
-            {
-                var message = "'LoadCustomNodes' should be called before 'RunCommandsFromFile'";
-                throw new InvalidOperationException(message);
-            }
-
-            var fileList = new List<string>();
-            foreach (var customNodeFilePath in customNodeFilePaths)
-            {
-                if (File.Exists(customNodeFilePath) != false)
-                {
-                    fileList.Add(customNodeFilePath);
-                    continue;
-                }
-
-                var message = "Custom node file not found";
-                throw new System.IO.FileNotFoundException(message, customNodeFilePath);
-            }
-
-            this.customNodesToBeLoaded = fileList;
-        }
-
-        protected void RunCommandsFromFile(string commandFileName,
-            bool autoRun = false, CommandCallback commandCallback = null)
-        {
-            string commandFilePath = SystemTestBase.GetTestDirectory(ExecutingDirectory);
-            commandFilePath = Path.Combine(commandFilePath, @"core\recorded\");
-            commandFilePath = Path.Combine(commandFilePath, commandFileName);
-
-            if (this.ViewModel != null)
-            {
-                var message = "Multiple DynamoViewModel instances detected!";
-                throw new InvalidOperationException(message);
-            }
-
-            var geometryFactoryPath = string.Empty;
-            if (preloadGeometry && (preloader == null))
-            {
-                var assemblyPath = Assembly.GetExecutingAssembly().Location;
-                preloader = new Preloader(Path.GetDirectoryName(assemblyPath));
-                preloader.Preload();
-
-                geometryFactoryPath = preloader.GeometryFactoryPath;
-                preloadGeometry = false;
-            }
-
-            var model = DynamoModel.Start(
-                new DynamoModel.DefaultStartConfiguration()
-                {
-                    StartInTestMode = true,
-                    PathResolver = pathResolver,
-                    GeometryFactoryPath = geometryFactoryPath
-                });
-
-            pathResolver = null; // Invalidate path resolver after specified.
-
-            // Create the DynamoViewModel to control the view
-            this.ViewModel = DynamoViewModel.Start(
-                new DynamoViewModel.StartConfiguration()
-                {
-                    CommandFilePath = commandFilePath,
-                    DynamoModel = model
-                });
-
-            ViewModel.HomeSpace.RunSettings.RunType = autoRun ? 
-                RunType.Automatic : 
-                RunType.Manual;
-
-            // Load all custom nodes if there is any specified for this test.
-            if (this.customNodesToBeLoaded != null)
-            {
-                foreach (var customNode in this.customNodesToBeLoaded)
-                {
-                    CustomNodeInfo info;
-                    if (!ViewModel.Model.CustomNodeManager.AddUninitializedCustomNode(customNode, true, out info))
-                    {
-                        throw new System.IO.FileFormatException(string.Format(
-                            "Failed to load custom node: {0}", customNode));
-                    }
-                }
-            }
-
-            RegisterCommandCallback(commandCallback);
-
-            // Create the view.
-            dynamoView = new DynamoView(this.ViewModel);
-            dynamoView.ShowDialog();
-
-            Assert.IsNotNull(this.ViewModel);
-            Assert.IsNotNull(this.ViewModel.Model);
-            Assert.IsNotNull(this.ViewModel.Model.CurrentWorkspace);
-            workspace = this.ViewModel.Model.CurrentWorkspace;
-            workspaceViewModel = this.ViewModel.CurrentSpaceViewModel;
-        }
-
-        private void RegisterCommandCallback(CommandCallback commandCallback)
-        {
-            if (commandCallback == null)
-                return;
-
-            if (this.commandCallback != null)
-                throw new InvalidOperationException("RunCommandsFromFile called twice");
-
-            this.commandCallback = commandCallback;
-            var automation = this.ViewModel.Automation;
-            automation.PlaybackStateChanged += OnAutomationPlaybackStateChanged;
-        }
-
-        private void OnAutomationPlaybackStateChanged(object sender, PlaybackStateChangedEventArgs e)
-        {
-            if (e.OldState == AutomationSettings.State.Paused)
-            {
-                if (e.NewState == AutomationSettings.State.Playing)
-                {
-                    // Call back to the delegate registered by the test case. We
-                    // only handle command transition from Paused to Playing. Note 
-                    // that "commandCallback" is not checked against "null" value 
-                    // because "OnAutomationPlaybackStateChanged" would not have 
-                    // been called if the "commandCallback" was not registered.
-                    // 
-                    this.commandCallback(e.NewTag);
-                }
-            }
-        }
-
-        private CmdType DuplicateAndCompare<CmdType>(CmdType command)
-            where CmdType : DynamoModel.RecordableCommand
-        {
-            Assert.IsNotNull(command); // Ensure we have an input command.
-
-            // Serialize the command into an XmlElement.
-            XmlDocument xmlDocument = new XmlDocument();
-            XmlElement element = command.Serialize(xmlDocument);
-            Assert.IsNotNull(element);
-
-            // Deserialized the XmlElement into a new instance of the command.
-            var duplicate = DynamoModel.RecordableCommand.Deserialize(element);
-            Assert.IsNotNull(duplicate);
-            Assert.IsTrue(duplicate is CmdType);
-            return duplicate as CmdType;
-        }
-
-        #endregion
     }
 
-    
-    class RecordedTestsDSEngine : RecordedTests
+
+    class RecordedTestsDSEngine : RecordedUnitTestBase
     {
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            base.Exit();
+        }
+
         #region Basic CodeBlockNode Test Cases
 
         [Test, RequiresSTA, Category("Failure")]

--- a/test/DynamoCoreUITests/RecordedTests.cs
+++ b/test/DynamoCoreUITests/RecordedTests.cs
@@ -78,8 +78,6 @@ namespace DynamoCoreUITests
             }
 
             preloader = null; // Invalid preloader object for the test.
-
-            GC.Collect();
         }
 
         #endregion


### PR DESCRIPTION
`RecordedTestsDSEgnine` inherits from `RecordedTests`, therefore a bunch of test cases in `RecordedTests` are included in `RecordedTestsDSEngine` and get run twice.

This PR creates a base class `RecordedUITestsBase` and inherits from this base class.

@Benglin  for your review.