### PR TITLE
Added batch scripts to copy localizable resources

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -324,28 +324,17 @@ limitations under the License.
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(SolutionDir)..\extern\DesignScript\*" "$(OutputPath)"
-copy "$(SolutionDir)..\doc\distrib\License.rtf" "$(OutputPath)\$(UICulture)\License.rtf"
-copy "$(SolutionDir)..\tools\install\extra\InstallASMForDynamo.exe" "$(OutputPath)\InstallASMForDynamo.exe"
-IF NOT EXIST "$(OutputPath)\dll" "$(OutputPath)\InstallASMForDynamo.exe" /SILENT /SUPPRESSMSGBOXES</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
-    <PostBuildEvent>mkdir "$(OutputPath)\dll"
-copy /Y "$(SolutionDir)..\extern\LibG\x64\Release\*" "$(OutputPath)\dll"
-</PostBuildEvent>
-    <PostBuildEvent>xcopy /Y "$(SolutionDir)..\extern\ProtoGeometry\*" "$(OutputPath)"
+    <PostBuildEvent>copy /Y "$(SolutionDir)..\README.md" "$(OutputPath)README.txt"
+xcopy  /Y "$(SolutionDir)..\doc\distrib\License.rtf" "$(OutputPath)"
+xcopy /Y "$(SolutionDir)..\extern\ProtoGeometry\*" "$(OutputPath)"
 xcopy /Y "$(SolutionDir)..\extern\ProtoGeometry\ProtoGeometry.xml" "$(OutputPath)\$(UICulture)"
 xcopy /Y /e "$(SolutionDir)..\extern\ProtoGeometry\$(UICulture)\*" "$(OutputPath)\$(UICulture)"
-xcopy  /Y /e "$(SolutionDir)..\extern\ProtoGeometry\libg_locale\*" "$(OutputPath)libg_locale\"
-xcopy  /Y "$(SolutionDir)..\doc\distrib\License.rtf" "$(OutputPath)\$(UICulture)"
-xcopy  /Y "$(SolutionDir)..\extern\LibG_219\*" "$(OutputPath)libg_219\"
-xcopy  /Y "$(SolutionDir)..\extern\LibG_220\*" "$(OutputPath)libg_220\"
-xcopy  /Y "$(SolutionDir)..\extern\LibG_221\*" "$(OutputPath)libg_221\"
+xcopy /Y /e "$(SolutionDir)..\extern\ProtoGeometry\libg_locale\*" "$(OutputPath)libg_locale\"
+xcopy /Y "$(SolutionDir)..\extern\LibG_219\*" "$(OutputPath)libg_219\"
+xcopy /Y "$(SolutionDir)..\extern\LibG_220\*" "$(OutputPath)libg_220\"
+xcopy /Y "$(SolutionDir)..\extern\LibG_221\*" "$(OutputPath)libg_221\"
 xcopy /Y "$(SolutionDir)..\extern\SimplexNoise\*" "$(OutputPath)"
-xcopy /Y /e "$(SolutionDir)..\doc\distrib\Samples\*" "$(OutputPath)samples\"
-copy /Y $(SolutionDir)..\README.md $(OutputPath)$(UICulture)\README.txt</PostBuildEvent>
+xcopy /Y /e "$(SolutionDir)..\doc\distrib\Samples\*" "$(OutputPath)samples\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -385,13 +385,7 @@ namespace Dynamo.ViewModels
             {
                 string executingAssemblyPathName = System.Reflection.Assembly.GetExecutingAssembly().Location;
                 string rootModuleDirectory = System.IO.Path.GetDirectoryName(executingAssemblyPathName);
-                var language = System.Threading.Thread.CurrentThread.CurrentUICulture.ToString();
-                var licensePath = System.IO.Path.Combine(rootModuleDirectory, language, "License.rtf");
-                // Fall back to en-US folder
-                if (!File.Exists(licensePath))
-                    licensePath = System.IO.Path.Combine(rootModuleDirectory, "en-US", "License.rtf");
-
-                return licensePath;
+                return System.IO.Path.Combine(rootModuleDirectory, "License.rtf");
             }
         }
 

--- a/src/DynamoInstall/DynamoInstall.wixproj
+++ b/src/DynamoInstall/DynamoInstall.wixproj
@@ -49,7 +49,7 @@ robocopy $(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration) $(DYNAMO_HARVEST_PATH) 
 "%25WIX%25bin\heat.exe" dir $(DYNAMO_MIGRATION_NODES_PATH) -cg DEFINITIONS -gg -scom -sreg -dr PROGDATA -var var.definitions -t "$(ProjectDir)Definitions.xsl" -out "$(ProjectDir)Definitions.wxs"</PreBuildEvent>
   </PropertyGroup>
   <Target Name="BeforeBuild">
-    <GetAssemblyIdentity AssemblyFiles="$(DYNAMO_HARVEST_PATH)\DynamoCore.dll">
+    <GetAssemblyIdentity AssemblyFiles="$(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration)\DynamoCore.dll">
       <Output TaskParameter="Assemblies" ItemName="AssemblyVersions" />
     </GetAssemblyIdentity>
     <CreateProperty Value="%(AssemblyVersions.Version)">

--- a/tools/install/CreateInstallers.bat
+++ b/tools/install/CreateInstallers.bat
@@ -8,6 +8,7 @@ set OPT_Platform=AnyCPU
 IF /I "%2"=="x64" set OPT_Platform=x64
 IF /I "%2"=="x86" set OPT_Platform=x86
 
+robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION% %cwd%\temp\bin License.rtf README.txt
 robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION% %cwd%\temp\bin *.exe *.dll *.xml *.config *.cer -XF *Tests.dll
 
 IF EXIST %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\Revit_2014 (
@@ -39,7 +40,6 @@ XmlDocumentationsUtility.exe %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\
 
 REM Localized resource assemblies
 for %%L in (cs-CZ, de-DE, en-US, es-ES, fr-FR, it-IT, ja-JP, ko-KR, pl-PL, pt-BR, ru-RU, zh-CN, zh-TW) do (
-    robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\%%L %cwd%\temp\bin\lang\%%L License.rtf README.txt
     robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\%%L %cwd%\temp\bin\lang\%%L *.dll *.xml /e
 )
 
@@ -47,4 +47,4 @@ robocopy %cwd%\..\..\doc\distrib\migration_nodes %cwd%\temp\definitions /e
 robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\samples %cwd%\temp\samples /s
 
 "C:\Program Files (x86)\Inno Setup 5\iscc.exe" %cwd%\DynamoInstaller.iss
-rmdir /Q /S %cwd%\temp
+rem rmdir /Q /S %cwd%\temp

--- a/tools/install/CreateInstallers.bat
+++ b/tools/install/CreateInstallers.bat
@@ -47,4 +47,4 @@ robocopy %cwd%\..\..\doc\distrib\migration_nodes %cwd%\temp\definitions /e
 robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\samples %cwd%\temp\samples /s
 
 "C:\Program Files (x86)\Inno Setup 5\iscc.exe" %cwd%\DynamoInstaller.iss
-rem rmdir /Q /S %cwd%\temp
+rmdir /Q /S %cwd%\temp

--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -70,6 +70,7 @@ Source: temp\bin\*; DestDir: {app}; Flags: ignoreversion overwritereadonly; Comp
 Source: temp\bin\nodes\*; DestDir: {app}\nodes; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 Source: temp\bin\lang\*; DestDir: {app}\; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 Source: Extra\IronPython-2.7.3.msi; DestDir: {tmp}; Flags: deleteafterinstall;
+Source: temp\bin\README.txt; DestDir: {app}\; Flags: onlyifdoesntexist isreadme ignoreversion; Components: DynamoCore
 
 ;Revit 2014
 Source: temp\bin\Revit_2014\*; DestDir: {app}\Revit_2014; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly recursesubdirs; Components: DynamoForRevit2014

--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -70,7 +70,6 @@ Source: temp\bin\*; DestDir: {app}; Flags: ignoreversion overwritereadonly; Comp
 Source: temp\bin\nodes\*; DestDir: {app}\nodes; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 Source: temp\bin\lang\*; DestDir: {app}\; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 Source: Extra\IronPython-2.7.3.msi; DestDir: {tmp}; Flags: deleteafterinstall;
-Source: temp\bin\lang\{#locale}\README.txt; DestDir: {app}\{#locale}\; Flags: onlyifdoesntexist isreadme ignoreversion; Components: DynamoCore
 
 ;Revit 2014
 Source: temp\bin\Revit_2014\*; DestDir: {app}\Revit_2014; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly recursesubdirs; Components: DynamoForRevit2014

--- a/tools/install/ExtractResources-DEBUG.bat
+++ b/tools/install/ExtractResources-DEBUG.bat
@@ -1,0 +1,1 @@
+%~dp0\ExtractResources.bat Debug

--- a/tools/install/ExtractResources-RELEASE.bat
+++ b/tools/install/ExtractResources-RELEASE.bat
@@ -1,0 +1,1 @@
+%~dp0\ExtractResources.bat Release

--- a/tools/install/ExtractResources.bat
+++ b/tools/install/ExtractResources.bat
@@ -1,4 +1,4 @@
-echo off
+@echo off
 set cwd=%~dp0
 echo %cwd%
 
@@ -11,8 +11,14 @@ IF /I "%2"=="x86" set OPT_Platform=x86
 
 set binroot=%cwd%..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\
 set wwlroot=%binroot%wwl\
-echo %binroot%
-echo %wwlroot%
+
+echo .
+echo -------------------------------------------------------------------------------
+echo BIN folder: %binroot%
+echo WWL folder: %wwlroot%
+echo -------------------------------------------------------------------------------
+echo .
+rd /s/q %wwlroot%
 mkdir %wwlroot%
 
 robocopy "%binroot%\en-US"                    "%wwlroot%\en-US"                  *.resources.dll *.xml

--- a/tools/install/ExtractResources.bat
+++ b/tools/install/ExtractResources.bat
@@ -1,0 +1,36 @@
+echo off
+set cwd=%~dp0
+echo %cwd%
+
+set OPT_CONFIGURATION=Release
+IF /I "%1"=="Debug" set OPT_CONFIGURATION=Debug
+
+set OPT_Platform=AnyCPU
+IF /I "%2"=="x64" set OPT_Platform=x64
+IF /I "%2"=="x86" set OPT_Platform=x86
+
+set binroot=%cwd%..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\
+set wwlroot=%binroot%wwl\
+echo %binroot%
+echo %wwlroot%
+mkdir %wwlroot%
+
+robocopy "%binroot%\en-US"                    "%wwlroot%\en-US"                  *.resources.dll *.xml
+robocopy "%binroot%\libg_locale"              "%wwlroot%\libg_locale"            /e
+robocopy "%binroot%\nodes\en-US"              "%wwlroot%\nodes\en-US"            *.resources.dll *.xml
+robocopy "%binroot%\samples\en-US"            "%wwlroot%\samples\en-US"          /e
+
+IF EXIST "%binroot%\Revit_2014" (
+robocopy "%binroot%\Revit_2014\en-US"         "%wwlroot%\Revit_2014\en-US"       *.resources.dll *.xml
+robocopy "%binroot%\Revit_2014\nodes\en-US"   "%wwlroot%\Revit_2014\nodes\en-US" *.resources.dll *.xml
+)
+
+IF EXIST "%binroot%\Revit_2015" (
+robocopy "%binroot%\Revit_2015\en-US"         "%wwlroot%\Revit_2015\en-US"       *.resources.dll *.xml
+robocopy "%binroot%\Revit_2015\nodes\en-US"   "%wwlroot%\Revit_2015\nodes\en-US" *.resources.dll *.xml
+)
+
+IF EXIST "%binroot%\Revit_2016" (
+robocopy "%binroot%\Revit_2016\en-US"         "%wwlroot%\Revit_2016\en-US"       *.resources.dll *.xml
+robocopy "%binroot%\Revit_2016\nodes\en-US"   "%wwlroot%\Revit_2016\nodes\en-US" *.resources.dll *.xml
+)


### PR DESCRIPTION
Background
-----
This pull request introduces `ExtractResources.bat` to copy only localizable resource files to a predefined `bin\AnyCPU\Debug\wwl` or `bin\AnyCPU\Release\wwl` folders (depending on the build flavor).

This is the structure of resulting `wwl` folder:

    wwl\en-US                           (*.resources.dll, *.xml)
    wwl\libg_locale\en_US\LC_MESSAGES   (*.mo, *.po)
    wwl\nodes\en-US                     (*.resources.dll)
    wwl\samples\en-US                   (sample dyn files)

    wwl\Revit_2014\en-US                (*.resources.dll, *.xml)
    wwl\Revit_2014\nodes\en-US          (*.resources.dll)

    wwl\Revit_2015\en-US                (*.resources.dll, *.xml)
    wwl\Revit_2015\nodes\en-US          (*.resources.dll)

    wwl\Revit_2016\en-US                (*.resources.dll, *.xml)
    wwl\Revit_2016\nodes\en-US          (*.resources.dll)


Also note that both `README.txt` and `License.rtf` files are moved out of `en-US` folder into `bin` folder, as they are no longer localizable.

Hi @nguyen-binh-minh, please take a look. Thanks!