### PR TITLE
Explicitly copy files under "libg_locale\en_US"

### DIFF
--- a/tools/install/ExtractResources.bat
+++ b/tools/install/ExtractResources.bat
@@ -22,7 +22,7 @@ rd /s/q %wwlroot%
 mkdir %wwlroot%
 
 robocopy "%binroot%\en-US"                    "%wwlroot%\en-US"                  *.resources.dll *.xml
-robocopy "%binroot%\libg_locale"              "%wwlroot%\libg_locale"            /e
+robocopy "%binroot%\libg_locale\en_US"        "%wwlroot%\libg_locale\en_US"      /e
 robocopy "%binroot%\nodes\en-US"              "%wwlroot%\nodes\en-US"            *.resources.dll *.xml
 robocopy "%binroot%\samples\en-US"            "%wwlroot%\samples\en-US"          /e
 


### PR DESCRIPTION
`ExtractResources.bat` is used to extract only localizable resources for World Wide Localization team, therefore it should not be copying languages other than `en_US`. This pull request updates the script to copy just files under `libg_locale\en_US` folder.

For more details, please see [a previous pull request](https://github.com/DynamoDS/Dynamo/pull/4041).

Hi @nguyen-binh-minh, I'm merging this in as the build machine will start using it soon. Please take a look later. Thanks!