### PR TITLE
DNM: Load package binaries with Assembly.Load(byte[]) in order to prevent file lock

### DIFF
--- a/src/DynamoCore/PackageManager/PackageLoader.cs
+++ b/src/DynamoCore/PackageManager/PackageLoader.cs
@@ -129,11 +129,12 @@ namespace Dynamo.PackageManager
         /// <param name="filename">The filename of a DLL</param>
         /// <param name="assem">out Assembly - the passed value does not matter and will only be set if loading succeeds</param>
         /// <returns>Returns true if success, false if BadImageFormatException (i.e. not a managed assembly)</returns>
-        internal static bool TryLoadFrom(string filename, out Assembly assem)
+        internal static bool TryLoad(string filename, out Assembly assem)
         {
             try
             {
-                assem = Assembly.LoadFrom(filename);
+                var raw = File.ReadAllBytes(filename);
+                assem = Assembly.Load(raw);
                 return true;
             }
             catch (BadImageFormatException)

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -881,7 +881,7 @@ namespace Dynamo.PackageManager
 
                 // we're not sure if this is a managed assembly or not
                 // we try to load it, if it fails - we add it as an additional file
-                var result = PackageLoader.TryLoadFrom(filename, out assem);
+                var result = PackageLoader.TryLoad(filename, out assem);
                 if (result)
                 {
                     Assemblies.Add(new PackageAssembly()

--- a/src/Engine/ProtoCore/Properties/AssemblyInfo.cs
+++ b/src/Engine/ProtoCore/Properties/AssemblyInfo.cs
@@ -12,4 +12,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyKeyFile("ProtoCore.snk")]
 [assembly: InternalsVisibleTo("ProtoTest")]
 [assembly: InternalsVisibleTo("ProtoTestFx")]
+[assembly: InternalsVisibleTo("DynamoCore")]
 


### PR DESCRIPTION
FYI: @lukechurch @sharadkjaiswal 

### Issue

When a package author loads their package, they want to be able to continue to modify the files in that package when publishing.

However, they can't.  `Assembly.Load(string)` and `Assembly.LoadFrom(string)` lock the assembly files.

Therefore, in order to update a managed DLL part of their package, they are forced to turn off Dynamo, manually modify their package files, and then restart Dynamo.  :(

### Fix 

In order to fix this, we need to load the assembly without locking the file.  This requires `Assembly.Load(byte[])`.  

But, today there is no way to specify this in the DS language, nor through the `LibraryServices` API.    

In this PR, as a stop-gap (this is 0.8.0 release show-stopper - MAGN-6643), I've added an internal API to cache a loaded `Assembly` (potentially loaded with this mechanism) in `FFIExecutionManager.`

There's more work to do here, but this works.
