### PR TITLE
Inject root folder to GetASMInstallations

### DIFF
--- a/src/Tools/DynamoShapeManager/Preloader.cs
+++ b/src/Tools/DynamoShapeManager/Preloader.cs
@@ -88,7 +88,7 @@ namespace DynamoShapeManager
             var versionList = versions.ToList();
 
             shapeManagerPath = string.Empty; // Folder that contains ASM binaries.
-            version = Utilities.GetInstalledAsmVersion(versionList, ref shapeManagerPath);
+            version = Utilities.GetInstalledAsmVersion(versionList, ref shapeManagerPath, rootFolder);
             
             var libGFolderName = string.Format("libg_{0}", ((int) version));
             preloaderLocation = Path.Combine(rootFolder, libGFolderName);

--- a/src/Tools/DynamoShapeManager/Preloader.cs
+++ b/src/Tools/DynamoShapeManager/Preloader.cs
@@ -68,11 +68,11 @@ namespace DynamoShapeManager
         /// Constructs a preloader object to help preload a specific version of 
         /// shape manager.
         /// </summary>
-        /// <param name="rootFolder">Full path of the directory that contains 
-        /// LibG_xxx folder, where 'xxx' represents the library version. In a 
-        /// typical setup this would be the same directory that contains Dynamo 
-        /// core modules. This must represent a valid directory.
-        /// </param>
+        /// <param name="rootFolder">This method makes use of DynamoInstallDetective
+        /// to determine the installation location of various Autodesk products. This 
+        /// argument is not optional and must represent the full path to the folder 
+        /// which contains DynamoInstallDetective.dll. An exception is thrown if the 
+        /// assembly cannot be located.</param>
         /// <param name="versions">A list of version numbers to check for in order 
         /// of preference. This argument cannot be null or empty.</param>
         /// 

--- a/src/Tools/DynamoShapeManager/Preloader.cs
+++ b/src/Tools/DynamoShapeManager/Preloader.cs
@@ -68,11 +68,11 @@ namespace DynamoShapeManager
         /// Constructs a preloader object to help preload a specific version of 
         /// shape manager.
         /// </summary>
-        /// <param name="rootFolder">This method makes use of DynamoInstallDetective
-        /// to determine the installation location of various Autodesk products. This 
-        /// argument is not optional and must represent the full path to the folder 
-        /// which contains DynamoInstallDetective.dll. An exception is thrown if the 
-        /// assembly cannot be located.</param>
+        /// <param name="rootFolder">Full path of the directory that contains 
+        /// LibG_xxx folder, where 'xxx' represents the library version. In a 
+        /// typical setup this would be the same directory that contains Dynamo 
+        /// core modules. This must represent a valid directory.
+        /// </param>
         /// <param name="versions">A list of version numbers to check for in order 
         /// of preference. This argument cannot be null or empty.</param>
         /// 

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -146,7 +146,12 @@ namespace DynamoShapeManager
 
         private static IEnumerable GetAsmInstallations(string rootFolder)
         {
-            var assembly = Assembly.LoadFrom(Path.Combine(rootFolder, "DynamoInstallDetective.dll"));
+            var assemblyPath = Path.Combine(Path.Combine(rootFolder, "DynamoInstallDetective.dll"));
+            if (!File.Exists(assemblyPath))
+                throw new FileNotFoundException(assemblyPath);
+
+            var assembly = Assembly.LoadFrom(assemblyPath);
+
             var type = assembly.GetType("DynamoInstallDetective.Utilities");
 
             var installationsMethod = type.GetMethod(

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -28,7 +28,7 @@ namespace DynamoShapeManager
         /// <returns>Returns LibraryVersion of ASM if any installed ASM is found, 
         /// or None otherwise.</returns>
         /// 
-        public static LibraryVersion GetInstalledAsmVersion(List<LibraryVersion> versions, ref string location)
+        public static LibraryVersion GetInstalledAsmVersion(List<LibraryVersion> versions, ref string location, string rootFolder)
         {
             if ((versions == null) || versions.Count <= 0)
                 throw new ArgumentNullException("versions");
@@ -39,7 +39,7 @@ namespace DynamoShapeManager
 
             try
             {
-                var installations = GetAsmInstallations();
+                var installations = GetAsmInstallations(rootFolder);
 
                 foreach (KeyValuePair<string, Tuple<int,int,int,int>> install in installations)
                 {
@@ -144,10 +144,9 @@ namespace DynamoShapeManager
             return assemblyPath;
         }
 
-        private static IEnumerable GetAsmInstallations()
+        private static IEnumerable GetAsmInstallations(string rootFolder)
         {
-            string installDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var assembly = Assembly.LoadFrom(Path.Combine(installDir, "DynamoInstallDetective.dll"));
+            var assembly = Assembly.LoadFrom(Path.Combine(rootFolder, "DynamoInstallDetective.dll"));
             var type = assembly.GetType("DynamoInstallDetective.Utilities");
 
             var installationsMethod = type.GetMethod(

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -25,11 +25,20 @@ namespace DynamoShapeManager
         /// of preference. This argument cannot be null or empty.</param>
         /// <param name="location">The full path of the directory in which targeted
         /// ASM binaries are found. This argument cannot be null.</param>
+        /// <param name="rootFolder">This method makes use of DynamoInstallDetective
+        /// to determine the installation location of various Autodesk products. This 
+        /// argument is not optional and must represent the full path to the folder 
+        /// which contains DynamoInstallDetective.dll. An exception is thrown if the 
+        /// assembly cannot be located.</param>
         /// <returns>Returns LibraryVersion of ASM if any installed ASM is found, 
         /// or None otherwise.</returns>
         /// 
         public static LibraryVersion GetInstalledAsmVersion(List<LibraryVersion> versions, ref string location, string rootFolder)
         {
+            if (string.IsNullOrEmpty(rootFolder))
+                throw new ArgumentNullException("rootFolder");
+            if (!Directory.Exists(rootFolder))
+                throw new DirectoryNotFoundException(rootFolder);
             if ((versions == null) || versions.Count <= 0)
                 throw new ArgumentNullException("versions");
             if (location == null)


### PR DESCRIPTION
This PR injects the root folder into the GetASMInstallations method. This is required to correctly set the root folder for testing environments where the executing assembly is not in the dynamo root folder. Without this fix, tests which use the TestServices.dll.config file are unable to load libG and return the error that the directory including `libG_0` can't be found (which is another problem that we return this incorrect path instead of throwing an exception).

Requires cherry-pick:
- RC8.0

PTAL:
@Benglin (Because you are the master of paths.)
@sharadkjaiswal (Because you are the install detective.)