### PR TITLE
Short namespace heuristics for Autocomplete

### DIFF
--- a/src/DynamoCore/DSEngine/CodeCompletionServices.cs
+++ b/src/DynamoCore/DSEngine/CodeCompletionServices.cs
@@ -20,10 +20,8 @@ namespace Dynamo.DSEngine.CodeCompletion
         public static string[] KeywordList = {Keyword.Def, 
                                         Keyword.If, Keyword.Elseif, Keyword.Else, 
                                         Keyword.While, Keyword.For, Keyword.In, Keyword.Continue,  
-                                        Keyword.Int, Keyword.Double, Keyword.String, Keyword.Bool, Keyword.Char, 
-                                        Keyword.Void, Keyword.Null, Keyword.Var, 
                                         Keyword.True, Keyword.False, 
-                                        Keyword.Return, Keyword.Static,
+                                        Keyword.Static,
                                         Keyword.Associative, Keyword.Imperative};
 
 
@@ -99,48 +97,13 @@ namespace Dynamo.DSEngine.CodeCompletion
         /// <returns> list of classes, global methods and properties that match with string being completed </returns>
         internal IEnumerable<CompletionData> SearchCompletions(string stringToComplete, Guid guid, ElementResolver resolver = null)
         {
-            List<CompletionData> completions = new List<CompletionData>();
-
+            var completions = new List<CompletionData>();
+            
             // Add matching DS keywords
             completions.AddRange(KeywordList.Where(x => x.ToLower().Contains(stringToComplete.ToLower())).
                 Select(x => new CompletionData(x, CompletionData.CompletionType.Keyword)));
 
-            // Add matching Classes
-            var groups = StaticMirror.GetClasses(core).
-                Where(x => x.Alias.ToLower().Contains(stringToComplete.ToLower())).
-                    GroupBy(x => x.Alias);
-
-            foreach (var group in groups)
-            {
-                // For those class names that have collisions, use shorter names
-                if (group.Count() > 1)
-                {
-                    // For colliding namespaces, compute shortest unique names for each
-                    var namespaces = @group.Select(x => new Symbol(x.ClassName)).ToList();
-                    var shortNames = Symbol.GetShortestUniqueNames(namespaces);
-                    Debug.Assert(shortNames.Count() == group.Count());
-
-                    // Update class mirror (group) Alias with short name computed above
-                    for (int i = 0; i < group.Count(); i++)
-                    {
-                        var cm = group.ElementAt(i);
-                        cm.Alias = shortNames.ElementAt(i).Value;
-                    }
-
-                    completions.AddRange(group.
-                        Where(x => !x.IsHiddenInLibrary).
-                        Select(
-                            x =>
-                                CompletionData.ConvertMirrorToCompletionData(x, useShorterName: true,
-                                    resolver: resolver)));
-                }
-                else
-                {
-                    completions.AddRange(group.
-                        Where(x => !x.IsHiddenInLibrary).
-                        Select(x => CompletionData.ConvertMirrorToCompletionData(x)));
-                }
-            }
+            AddTypesToCompletionData(stringToComplete, completions, resolver);
 
             // Add matching builtin methods
             completions.AddRange(StaticMirror.GetBuiltInMethods(core).
@@ -160,26 +123,8 @@ namespace Dynamo.DSEngine.CodeCompletion
         internal IEnumerable<CompletionData> SearchTypes(string stringToComplete, ElementResolver resolver = null)
         {
             var completions = new List<CompletionData>();
-            var partialName = stringToComplete.ToLower();
-
-            // Add matching Classes
-            var classMirrorGroups = 
-                    StaticMirror.GetAllTypes(core)
-                                .Where(x => !x.IsHiddenInLibrary && x.Alias.ToLower().StartsWith(partialName))
-                                .GroupBy(x => x.Alias);
-
-            // For those class names that have collisions (same alias), list 
-            // their fully qualified names in completion window.
-            foreach (var classMirrorGroup in classMirrorGroups)
-            {
-                bool useFullyQualifiedName = classMirrorGroup.Count() > 1;
-                foreach (var classMirror in classMirrorGroup)
-                {
-                    var completionData = CompletionData.ConvertMirrorToCompletionData(
-                        classMirror, useFullyQualifiedName, resolver);
-                    completions.Add(completionData);
-                }
-            }
+            
+            AddTypesToCompletionData(stringToComplete, completions, resolver);
 
             return completions;
         }
@@ -235,6 +180,40 @@ namespace Dynamo.DSEngine.CodeCompletion
                 }
             }
             return candidates.Select(x => CompletionData.ConvertMirrorToCompletionData(x));
+        }
+
+        private void AddTypesToCompletionData(string stringToComplete, List<CompletionData> completions, ElementResolver resolver)
+        {
+            var partialName = stringToComplete.ToLower();
+            // Add matching Classes
+            var classMirrorGroups = StaticMirror.GetAllTypes(core).
+                Where(x => !x.IsHiddenInLibrary && x.Alias.ToLower().Contains(partialName)).
+                    GroupBy(x => x.Alias);
+
+            foreach (var classMirrorGroup in classMirrorGroups)
+            {
+                // For those class names that have collisions, use shorter names
+                bool useShorterName = classMirrorGroup.Count() > 1;
+                if (useShorterName)
+                {
+                    // For colliding namespaces, compute shortest unique names for each
+                    var namespaces = classMirrorGroup.Select(x => new Symbol(x.ClassName)).ToList();
+                    var shortNames = Symbol.GetShortestUniqueNames(namespaces);
+                    Debug.Assert(shortNames.Count() == classMirrorGroup.Count());
+
+                    // Update class mirror (group) Alias with short name computed above
+                    for (int i = 0; i < classMirrorGroup.Count(); i++)
+                    {
+                        var cm = classMirrorGroup.ElementAt(i);
+                        cm.Alias = shortNames.ElementAt(i).Value;
+                    }
+                }
+                completions.AddRange(classMirrorGroup.
+                        Select(
+                            x =>
+                                CompletionData.ConvertMirrorToCompletionData(x, useShorterName,
+                                    resolver: resolver)));
+            }
         }
 
         private ClassMirror GetClassType(string className)

--- a/src/Engine/ProtoCore/DSDefinitions.cs
+++ b/src/Engine/ProtoCore/DSDefinitions.cs
@@ -44,6 +44,7 @@
         public const string Dispose = "_Dispose";
         public const string GetType = "GetType";
         public const string Invalid = "__invalid";
+        public const string PointerReserved = "pointer_reserved";
         public static string[] KeywordList = {Native, Class, Constructor, Def, External, Extend, Heap,
                                         If, Elseif, Else, While, For, Import, From, Break,
                                         Continue, Return, Int, Double, String, Bool, Var,

--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -139,7 +139,7 @@ namespace ProtoCore
                 primitiveTypeNames[PrimitiveType.kTypeVoid] = DSDefinitions.Keyword.Void;
                 primitiveTypeNames[PrimitiveType.kTypeArray] = DSDefinitions.Keyword.Array;
                 primitiveTypeNames[PrimitiveType.kTypeHostEntityID] = "hostentityid";
-                primitiveTypeNames[PrimitiveType.kTypePointer] = "pointer_reserved";
+                primitiveTypeNames[PrimitiveType.kTypePointer] = DSDefinitions.Keyword.PointerReserved;
                 primitiveTypeNames[PrimitiveType.kTypeFunctionPointer] = DSDefinitions.Keyword.FunctionPointer;
                 primitiveTypeNames[PrimitiveType.kTypeReturn] = "return_reserved";
             }
@@ -279,7 +279,7 @@ namespace ProtoCore
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeHostEntityID);
             //
             //
-            cnode = new ClassNode { name = "pointer_reserved", size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.PointerReserved, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
             // if convert operator to method call, without the following statement, 
             // a = b.c + d.e will fail, b.c and d.e are resolved as pointer and _add method requires two integer
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);

--- a/src/Engine/ProtoCore/Namespace/SymbolTable.cs
+++ b/src/Engine/ProtoCore/Namespace/SymbolTable.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 namespace ProtoCore.Namespace
 {
+    // Reference: http://www.interact-sw.co.uk/iangblog/2004/09/16/permuterate
     public static class PermuteUtils
     {
         /// <summary>

--- a/src/Engine/ProtoCore/Reflection/Mirror.cs
+++ b/src/Engine/ProtoCore/Reflection/Mirror.cs
@@ -524,12 +524,9 @@ namespace ProtoCore
             {
                 get
                 {
-                    if (alias == null)
-                    {
-                        alias = ClassName.Split('.').Last();
-                    }
-                    return alias;
+                    return alias ?? (alias = ClassName.Split('.').Last());
                 }
+                set { alias = value; }
             }
 
             private LibraryMirror libraryMirror = null;

--- a/src/Engine/ProtoCore/Reflection/Mirror.cs
+++ b/src/Engine/ProtoCore/Reflection/Mirror.cs
@@ -416,8 +416,11 @@ namespace ProtoCore
 
             public static IEnumerable<ClassMirror> GetAllTypes(Core core)
             {
+                // TODO: Get rid of keyword "PointerReserved" and PrimitiveType.kTypePointer
+                // if not used in the language: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6752
                 return core.ClassTable.ClassNodes.
-                    Where(x => !CoreUtils.StartsWithSingleUnderscore(x.name)).
+                    Where(x => !CoreUtils.StartsWithSingleUnderscore(x.name)
+                    && x.name != DSDefinitions.Keyword.PointerReserved).
                     Select(x => new ClassMirror(core, x));
             }
 

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -1190,8 +1190,9 @@ b = c[w][x][y][z];";
             // Expected 4 completion items
             Assert.AreEqual(4, completions.Count());
 
-            string[] expected = {"DummyPoint", "FFITarget.DesignScript.Point",
-                                    "FFITarget.Dynamo.Point", "UnknownPoint"};
+            string[] expectedValues = {"DummyPoint", "DesignScript.Point",
+                                    "Dynamo.Point", "UnknownPoint"};
+            var expected = expectedValues.OrderBy(x => x);
             var actual = completions.Select(x => x.Text).OrderBy(x => x);
 
             Assert.AreEqual(expected, actual);
@@ -1250,7 +1251,7 @@ b = c[w][x][y][z];";
             // Expected 1 completion items
             Assert.AreEqual(1, completions.Count());
 
-            string[] expected = { "FFITarget.FirstNamespace.AnotherClassWithNameConflict" };
+            string[] expected = { "AnotherClassWithNameConflict" };
             var actual = completions.Select(x => x.Text).OrderBy(x => x);
 
             Assert.AreEqual(expected, actual);

--- a/test/Engine/ProtoTest/NameSpaceTests.cs
+++ b/test/Engine/ProtoTest/NameSpaceTests.cs
@@ -169,5 +169,25 @@ namespace ProtoTest
             Assert.AreEqual("E.E", shortNamespaces[namespaceList[1]]);
             Assert.AreEqual("C.B.E", shortNamespaces[namespaceList[2]]);
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void GetShortestUniqueNamespaces_FromComplexNamespaceList2()
+        {
+            var namespaceList = new List<Symbol>
+            {
+                new Symbol("A.B.C.D.E"),
+                new Symbol("B.X.Y.A.C.E.E"),
+                new Symbol("X.Y.A.C.B.E"),
+                new Symbol("X.Y.B.C.E")
+            };
+            var shortNamespaces = Symbol.GetShortestUniqueNames(namespaceList);
+
+            Assert.AreEqual(4, shortNamespaces.Count);
+            Assert.AreEqual("D.E", shortNamespaces[namespaceList[0]]);
+            Assert.AreEqual("E.E", shortNamespaces[namespaceList[1]]);
+            Assert.AreEqual("C.B.E", shortNamespaces[namespaceList[2]]);
+            Assert.AreEqual("X.B.C.E", shortNamespaces[namespaceList[3]]);
+        }
     }
 }

--- a/test/Engine/ProtoTest/NameSpaceTests.cs
+++ b/test/Engine/ProtoTest/NameSpaceTests.cs
@@ -135,5 +135,39 @@ namespace ProtoTest
             Assert.IsFalse(table.TryGetUniqueSymbol("Com.Point", out symbol));
             Assert.IsFalse(table.TryGetUniqueSymbol("Point", out symbol));
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void GetShortestUniqueNamespaces_FromNamespaceList()
+        {
+            var namespaceList = new List<Symbol>
+            {
+                new Symbol("Autodesk.DesignScript.Geometry.Point"),
+                new Symbol("Rhino.Geometry.Point")
+            };
+            var shortNamespaces = Symbol.GetShortestUniqueNames(namespaceList);
+
+            Assert.AreEqual(2, shortNamespaces.Count);
+            Assert.AreEqual("Autodesk.Point", shortNamespaces[namespaceList[0]]);
+            Assert.AreEqual("Rhino.Point", shortNamespaces[namespaceList[1]]);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void GetShortestUniqueNamespaces_FromComplexNamespaceList()
+        {
+            var namespaceList = new List<Symbol>
+            {
+                new Symbol("A.B.C.D.E"),
+                new Symbol("X.Y.A.B.E.C.E"),
+                new Symbol("X.Y.A.C.B.E")
+            };
+            var shortNamespaces = Symbol.GetShortestUniqueNames(namespaceList);
+
+            Assert.AreEqual(3, shortNamespaces.Count);
+            Assert.AreEqual("D.E", shortNamespaces[namespaceList[0]]);
+            Assert.AreEqual("E.E", shortNamespaces[namespaceList[1]]);
+            Assert.AreEqual("C.B.E", shortNamespaces[namespaceList[2]]);
+        }
     }
 }


### PR DESCRIPTION
When there are namespace collisions, i.e. the same class name belonging to more than one namespace that are imported into Dynamo (via Import Library, Package manager, etc.), auto-complete would display the conflicting classes with their fully qualified names in order to distinguish them uniquely. For example:
```
Autodesk.DS.Geometry.Point
Rhino.Geometry.Point
FFITarget.Dynamo.Point
```
This submission enhances this experience by displaying the shortest possible names, such that they can still be resolved uniquely. So for the same example above, auto-complete now displays:
```
Autodesk.Point
Rhino.Point
FFITarget.Point
```
The core algorithm basically computes all possible in-order permutations of the individual namespaces in the long name and checks for which of these permutations, starting with the shortest, resolves uniquely. These shortest names are then fed into auto-complete to display instead of the fully qualified names used earlier.

Note that in the case of an existing resolution map in the namespace resolver, where there could be existing mappings to map say `Point` to `Autodesk.DS.Geometry.Point`, auto-complete will refer to the resolver as well. Thus in the same example above, it will display:
```
Point
Rhino.Point
FFITarget.Point
```
Unfortunately in the case of namespace collisions, users will need to get in the habit of seeing at least one namespace preceding the class name. We cannot get rid of them entirely.

Reviewers:
@Benglin 
@junmendoza 