### PR TITLE
DNM:  "Shadow Copy" Package Assemblies

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.0.781")]
+[assembly: AssemblyVersion("0.8.0.786")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.0.781")]
+[assembly: AssemblyFileVersion("0.8.0.786")]

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -411,7 +411,6 @@ namespace Dynamo.Models
 
             return new DynamoModel(configuration);
         }
-
         
         protected DynamoModel(IStartConfiguration config)
         {

--- a/src/DynamoCore/PackageManager/PackageLoader.cs
+++ b/src/DynamoCore/PackageManager/PackageLoader.cs
@@ -4,6 +4,8 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
 using Dynamo.Core;
 using Dynamo.DSEngine;
 using Dynamo.Interfaces;
@@ -48,7 +50,14 @@ namespace Dynamo.PackageManager
             if (pathManager != null)
             {
                 foreach (var pkg in LocalPackages)
+                {
+                    pkg.ShadowCopyAssemblies(pathManager);
+                } 
+
+                foreach (var pkg in LocalPackages)
+                {
                     pathManager.AddResolutionPath(pkg.BinaryDirectory);
+                }    
             }
 
             foreach (var pkg in LocalPackages)


### PR DESCRIPTION
### Issue

When a package author loads their package, they want to be able to continue to modify the files in that package when publishing.

However, they can't.  `Assembly.Load(string)` and `Assembly.LoadFrom(string)` lock the assembly files.

Therefore, in order to update a managed DLL part of their package, they are forced to turn off Dynamo, manually modify their package files, and then restart Dynamo.  :(

### Fix

Copy the package assemblies in order to prevent the file lock.  "Shadow copying" is a term that I borrowed, but should be considered distinct from the way the term is used in the context of CLR `AppDomain`'s.  In this PR, I am NOT suggesting modifying `AppDomain` startup behavior, but simply copying package assemblies to a separate temp location for loading into Dynamo.

This is my first attempt, which I've decided is a hack:  

https://github.com/DynamoDS/Dynamo/pull/4056

### Reviewer

- [ ] @lukechurch 