### PR TITLE
Prevent update of already loaded package assemblies during active session

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2711,6 +2711,24 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while Dynamo is not running and try again..
+        /// </summary>
+        public static string PackageDuplicateAssemblyWarning {
+            get {
+                return ResourceManager.GetString("PackageDuplicateAssemblyWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot update assembly!.
+        /// </summary>
+        public static string PackageDuplicateAssemblyWarningTitle {
+            get {
+                return ResourceManager.GetString("PackageDuplicateAssemblyWarningTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package Manager Website.
         /// </summary>
         public static string PackageManagerWebSiteButton {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1560,4 +1560,10 @@ Many thanks!</value>
   <data name="Watch3DViewContextMenuZoomToFit" xml:space="preserve">
     <value>_Zoom to Fit</value>
   </data>
+  <data name="PackageDuplicateAssemblyWarning" xml:space="preserve">
+    <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while Dynamo is not running and try again.  </value>
+  </data>
+  <data name="PackageDuplicateAssemblyWarningTitle" xml:space="preserve">
+    <value>Cannot update assembly!</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1564,6 +1564,6 @@ Many thanks!</value>
     <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while Dynamo is not running and try again.  </value>
   </data>
   <data name="PackageDuplicateAssemblyWarningTitle" xml:space="preserve">
-    <value>Cannot update assembly!</value>
+    <value>Cannot update assembly</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1564,6 +1564,6 @@ Do you want to install the latest Dynamo update?</value>
     <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while Dynamo is not running and try again.</value>
   </data>
   <data name="PackageDuplicateAssemblyWarningTitle" xml:space="preserve">
-    <value>Cannot update assembly!</value>
+    <value>Cannot update assembly</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1560,4 +1560,10 @@ Do you want to install the latest Dynamo update?</value>
   <data name="RunStartedMessage" xml:space="preserve">
     <value>Run started...</value>
   </data>
+  <data name="PackageDuplicateAssemblyWarning" xml:space="preserve">
+    <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while Dynamo is not running and try again.</value>
+  </data>
+  <data name="PackageDuplicateAssemblyWarningTitle" xml:space="preserve">
+    <value>Cannot update assembly!</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -550,6 +550,7 @@ namespace Dynamo.PackageManager
             {
                 Assembly assem;
                 var result = PackageLoader.TryReflectionOnlyLoadFrom(file, out assem);
+
                 if (result)
                 {
                     var isNodeLibrary = nodeLibraryNames == null || nodeLibraryNames.Contains(assem.FullName);
@@ -884,6 +885,19 @@ namespace Dynamo.PackageManager
                 var result = PackageLoader.TryLoadFrom(filename, out assem);
                 if (result)
                 {
+                    var assemName = assem.GetName().Name;
+
+                    // The user has attempted to load an existing dll from another path. This is not allowed 
+                    // as the existing assembly cannot be modified while Dynamo is active.
+                    if (this.Assemblies.Any(x => assemName == x.Assembly.GetName().Name))
+                    {
+                        MessageBox.Show(Resources.PackageDuplicateAssemblyWarning, 
+                                        Resources.PackageDuplicateAssemblyWarningTitle, 
+                                        MessageBoxButtons.OK, 
+                                        MessageBoxIcon.Stop);
+                        return; // skip loading assembly
+                    }
+
                     Assemblies.Add(new PackageAssembly()
                     {
                         Assembly = assem,


### PR DESCRIPTION
### Issue

A user should not be able to update an already loaded package assembly during an active session.  The user might try to do this by using the "Add" button when submitting a new package version.  As the assembly cannot be overwritten, the user can end up with the odd situation where they submit a new package but the assemblies are unchanged.

### Fix

After consider multiple options, including byte-array loading of package assemblies or shadow copying, the best option is to just tell the user that this behavior is not allowed and direct them to modify the package assemblies while Dynamo is not active.

![stop](https://cloud.githubusercontent.com/assets/916345/6790132/efb9af5a-d17b-11e4-9aa2-799b943ccfd0.PNG)

### Reviewer

- [ ] @lukechurch 