### PR TITLE
Some margin changes and color changes for making library UI more uniform

### DIFF
--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml
@@ -42,7 +42,7 @@
                             Orientation="Horizontal"
                             VerticalAlignment="Center">
                     <Image Margin="16,0,16,0"
-                           Height="32"
+                           Height="36"
                            Width="32"
                            HorizontalAlignment="Left"
                            VerticalAlignment="Center"
@@ -53,14 +53,12 @@
                                VerticalAlignment="Center"
                                Text="{Binding Name}"
                                Margin="5,0,0,0"
-                               Foreground="#989898"
+                               Foreground="#CCCCCC"
                                FontSize="13" />
                     <StackPanel.Style>
                         <Style TargetType="{x:Type StackPanel}">
                             <Setter Property="Background"
                                     Value="Transparent" />
-                            <Setter Property="Margin"
-                                    Value="3,0,0,0" />
                             <Setter Property="Width">
                                 <Setter.Value>
                                     <Binding Path="ActualWidth"
@@ -89,7 +87,7 @@
                 <StackPanel Orientation="Vertical"
                             Width="72"
                             Height="72">
-                    <Border Padding="0">
+                    <Border Padding="2, 7, 2, 7">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="32" />
@@ -108,11 +106,13 @@
                             <TextBlock HorizontalAlignment="Center"
                                        VerticalAlignment="Top"
                                        TextAlignment="Center"
-                                       Foreground="#989898"
+                                       Foreground="#AAAAAA"
                                        Grid.Row="1"
                                        Grid.Column="0"
                                        Grid.ColumnSpan="3"
-                                       FontSize="13">
+                                       FontSize="13"
+                                       LineStackingStrategy="BlockLineHeight"
+                                       LineHeight="14px">
                                 <TextBlock.Text>
                                     <Binding Path="Name"
                                              Converter="{StaticResource FullyQualifiedNameToDisplayConverter}"
@@ -147,7 +147,7 @@
             <DataTemplate x:Key="SubclassesTemplate">
                 <ListView Name="SubCategoryListView"
                           ItemTemplateSelector="{StaticResource ClassObjectTemplateSelector}"
-                          Background="#2F2F2F"
+                          Background="#353535"
                           BorderThickness="0"
                           ScrollViewer.HorizontalScrollBarVisibility="Hidden"
                           ScrollViewer.VerticalScrollBarVisibility="Hidden"
@@ -286,7 +286,7 @@
                                     <Image x:Name="ExpandCollapseStateIcon"
                                            Source="/DynamoCoreWpf;component/UI/Images/collapsestate_normal.png"
                                            Width="16"
-                                           Height="16"
+                                           Height="32"
                                            VerticalAlignment="Center" />
                                     <ContentPresenter x:Name="HeaderContent"
                                                       Grid.Column="1"
@@ -492,7 +492,7 @@
                                         </Border>
 
                                         <Border Grid.Row="1"
-                                                Background="#2F2F2F">
+                                                Background="#353535">
                                             <ItemsPresenter x:Name="ItemsHost">
                                                 <ItemsPresenter.Visibility>
                                                     <Binding Converter="{StaticResource LibraryTreeItemsHostVisibilityConverter}" />
@@ -533,7 +533,7 @@
                                                                  Converter="{StaticResource RootElementToBoolConverter}" />
                                                     </DataTrigger.Binding>
                                                     <Setter Property="Background"
-                                                            Value="#2F2F2F" />
+                                                            Value="#353535" />
                                                     <Setter Property="Padding"
                                                             Value="0,0,0,0" />
                                                 </DataTrigger>


### PR DESCRIPTION
Before / After
![library margins](https://cloud.githubusercontent.com/assets/4365353/6796365/bf5b84e4-d22c-11e4-94cf-aea09583dcec.png)


1. Removed the extra margins that were floating around
2. Unified size for all click targets in library UI
3. (a) Vertically centered the class icon and name without changing the 72px by 72px size, (b)Made the line height smaller - this is to make sure the icons and names appear closer to each other
4. Unified the background color to make the library UI appear brighter.