### PR TITLE
MAGN-6748 webrequest does not clear error after intial "url cannot be null"

### DIFF
--- a/src/DynamoCore/Models/RunSettings.cs
+++ b/src/DynamoCore/Models/RunSettings.cs
@@ -80,7 +80,7 @@ namespace Dynamo.Models
 
         public RunSettings()
         {
-            RunPeriod = 100;
+            RunPeriod = 500;
             RunType = RunType.Manual;
             RunEnabled = true;
         }

--- a/src/Libraries/CoreNodeModels/WebRequest.cs
+++ b/src/Libraries/CoreNodeModels/WebRequest.cs
@@ -9,16 +9,11 @@ using DSCoreNodesUI.Properties;
 namespace DSCoreNodesUI
 {
     [NodeName("Web Request")]
-    [NodeDescription("WebRequestDescription", typeof(DSCoreNodesUI.Properties.Resources))]
+    [NodeDescription("WebRequestDescription", typeof(Resources))]
     [NodeCategory(BuiltinNodeCategories.CORE_STRINGS)]
     [IsDesignScriptCompatible]
     public class WebRequest : NodeModel
     {
-        protected override ExecutionHints GetExecutionHintsCore()
-        {
-            return ExecutionHints.ForceExecute;
-        }
-
         public WebRequest()
         {
             InPortData.Add(new PortData("url", Resources.WebRequestPortDataUrlToolTip));

--- a/src/Libraries/CoreNodes/Web.cs
+++ b/src/Libraries/CoreNodes/Web.cs
@@ -9,14 +9,24 @@ namespace DSCore
     {
         public static string WebRequestByUrl(string url)
         {
-            if (url == null)
+            if (string.IsNullOrEmpty(url))
             {
                 throw new ArgumentException("The url cannot be null.");
             }
 
+            Uri uriResult;
+            var result = Uri.TryCreate(url, UriKind.Absolute, out uriResult)
+                          && (uriResult.Scheme == Uri.UriSchemeHttp
+                              || uriResult.Scheme == Uri.UriSchemeHttps);
+
+            if (!result)
+            {
+                throw new UriFormatException("The specified url is invalid.");
+            }
+
             //send a webrequest to the URL
             // Initialize the WebRequest.
-            var myRequest = System.Net.WebRequest.Create(url);
+            var myRequest = System.Net.WebRequest.Create(uriResult);
 
             string responseFromServer;
 

--- a/test/Libraries/CoreNodesTests/WebTests.cs
+++ b/test/Libraries/CoreNodesTests/WebTests.cs
@@ -21,5 +21,12 @@ namespace DSCoreNodesTests
         {
             Assert.Throws<UriFormatException>(()=>Web.WebRequestByUrl("ThisIsNotAUrl"));
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WebRequest_EmptyUrl()
+        {
+            Assert.Throws<ArgumentException>(() => Web.WebRequestByUrl(""));
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the issues pertaining to the Web Request node not clearing its warning message.

The Web Request node has previously included a call to `OnNodeModified` and an override of the `ExecutionHints` property. Neither of these were necessary, and both have been removed. The overriding of `ExecutionHints` was causing the node to not properly clear its warning, so although the node was executing correctly the initial "null url" warning would still be on the node.

The internal method used by this node, `WebRequestByUrl` has been further hardened to check the incoming url to see whether it is a valid url. 

FYI:
@pboyer 

I'm merging this get it into Neal's hands for testing.

Requires Merge:
- [ ] RC0.8.0