### PR TITLE
Use temp path from UnitTestBase in LibraryTests

### DIFF
--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -7,6 +7,7 @@ using Dynamo.Nodes;
 using Dynamo.Search;
 using Dynamo.Search.SearchElements;
 using NUnit.Framework;
+using TestServices;
 using DynCmd = Dynamo.Models.DynamoModel;
 using Dynamo.ViewModels;
 using ProtoCore;
@@ -15,31 +16,33 @@ using Dynamo.Core;
 namespace Dynamo.Tests
 {
     [TestFixture]
-    class LibraryTests 
+    class LibraryTests : UnitTestBase
     {
         private LibraryServices libraryServices;
         private ProtoCore.Core libraryCore;
-        private PathManager pathManager = new PathManager(new PathManagerParams());
 
         protected static bool LibraryLoaded { get; set; }
 
-        [SetUp]
-        public void Setup()
+        public override void Setup()
         {
+            base.Setup();
+
             libraryCore = new ProtoCore.Core(new Options { RootCustomPropertyFilterPathName = string.Empty });
             libraryCore.Compilers.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Compiler(libraryCore));
             libraryCore.Compilers.Add(ProtoCore.Language.kImperative, new ProtoImperative.Compiler(libraryCore));
             libraryCore.ParsingMode = ParseMode.AllowNonAssignment;
+
+            var pathManager = new PathManager(new PathManagerParams());
             libraryServices = new LibraryServices(libraryCore, pathManager);
 
             RegisterEvents();
         }
 
-        [TearDown]
-        public void Cleanup()
+        public override void Cleanup()
         {
             UnRegisterEvents();
             libraryServices.Dispose();
+            base.Cleanup();
         }
 
         private void RegisterEvents()
@@ -109,12 +112,8 @@ namespace Dynamo.Tests
         {
             LibraryLoaded = false;
 
-            string libraryPath = "FFITarget.dll";
-
-            string tempPath = Path.GetTempPath();
-            var uniqueDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
-            var tempDirectory = uniqueDirectory.FullName;
-            string tempLibraryPath = Path.Combine(tempDirectory, libraryPath);
+            const string libraryPath = "FFITarget.dll";
+            string tempLibraryPath = Path.Combine(TempFolder, libraryPath);
 
             File.Copy(libraryPath, tempLibraryPath);
 
@@ -139,11 +138,8 @@ namespace Dynamo.Tests
                 "</priorNameHint>" + System.Environment.NewLine +
                 "</migrations>" + System.Environment.NewLine;
 
-            string tempPath = Path.GetTempPath();
-            var uniqueDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
-            var tempDirectory = uniqueDirectory.FullName;
-            string tempLibraryPath = Path.Combine(tempDirectory, libraryPath);
-            string tempBadXMLPath = Path.Combine(tempDirectory, badXMLPath);
+            string tempLibraryPath = Path.Combine(TempFolder, libraryPath);
+            string tempBadXMLPath = Path.Combine(TempFolder, badXMLPath);
 
             File.Copy(libraryPath, tempLibraryPath);
 
@@ -173,11 +169,8 @@ namespace Dynamo.Tests
                 "</priorNameHint>" + System.Environment.NewLine +
                 "</migrations>" + System.Environment.NewLine;
 
-            string tempPath = Path.GetTempPath();
-            var uniqueDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
-            var tempDirectory = uniqueDirectory.FullName;
-            string tempLibraryPath = Path.Combine(tempDirectory, libraryPath);
-            string tempBadXMLPath = Path.Combine(tempDirectory, badXMLPath);
+            string tempLibraryPath = Path.Combine(TempFolder, libraryPath);
+            string tempBadXMLPath = Path.Combine(TempFolder, badXMLPath);
 
             File.Copy(libraryPath, tempLibraryPath);
 
@@ -196,7 +189,7 @@ namespace Dynamo.Tests
         {
             LibraryLoaded = false;
 
-            string libraryPath = "FFITarget.dll";
+            const string libraryPath = "FFITarget.dll";
 
             // All we need to do here is to ensure that the target has been loaded
             // at some point, so if it's already thre, don't try and reload it


### PR DESCRIPTION
`LibraryTests` makes temporary folders that it does not destroy after use, causing temporary folder count to increase. This pull request changes that by using `UnitTestBase.TempFolder`, allowing `UnitTestBase` clean-up routine to correctly destroy the temporary folder (just like all other tests).

All tests under `LibraryTests` are passing as expected after this change.

Hi @nguyen-binh-minh, please have a look, thanks!