### PR TITLE
Prevent crashing dyn files from reopening in automatic run mode

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -985,6 +985,11 @@ namespace Dynamo.Models
         {
             var nodeGraph = NodeGraph.LoadGraphFromXml(xmlDoc, NodeFactory);
 
+            if (workspaceInfo.RunType == RunType.Automatic && !workspaceInfo.HasRunWithoutCrash)
+            {
+                workspaceInfo.RunType = RunType.Manual;
+            }
+
             var newWorkspace = new HomeWorkspaceModel(
                 EngineController,
                 Scheduler,

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -985,11 +985,6 @@ namespace Dynamo.Models
         {
             var nodeGraph = NodeGraph.LoadGraphFromXml(xmlDoc, NodeFactory);
 
-            if (workspaceInfo.RunType == RunType.Automatic && !workspaceInfo.HasRunWithoutCrash)
-            {
-                workspaceInfo.RunType = RunType.Manual;
-            }
-
             var newWorkspace = new HomeWorkspaceModel(
                 EngineController,
                 Scheduler,

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -25,6 +25,8 @@ namespace Dynamo.Models
         public bool IsTestMode { get; set; }
 
         /// <summary>
+        ///     Indicates whether a run has completed successfully.   
+        /// 
         ///     This flag is critical to ensuring that broken run auto files
         ///     are not left in run-auto if the file causes a crash.  
         /// </summary>
@@ -72,6 +74,14 @@ namespace Dynamo.Models
             : base(e, n, info, factory)
         {
             EvaluationCount = 0;
+
+            // This protects the user from a file that might have crashed during
+            // its last run.  As a side effect, this also causes all files set to
+            // run auto, but the HasRunWithoutCrash flag to run manually.
+            if (info.RunType == RunType.Automatic && !info.HasRunWithoutCrash)
+            {
+                info.RunType = RunType.Manual;
+            }
 
             RunSettings = new RunSettings(info.RunType, info.RunPeriod);
 

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -77,7 +77,7 @@ namespace Dynamo.Models
 
             // This protects the user from a file that might have crashed during
             // its last run.  As a side effect, this also causes all files set to
-            // run auto, but the HasRunWithoutCrash flag to run manually.
+            // run auto but lacking the HasRunWithoutCrash flag to run manually.
             if (info.RunType == RunType.Automatic && !info.HasRunWithoutCrash)
             {
                 info.RunType = RunType.Manual;

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -27,8 +27,8 @@ namespace Dynamo.Models
         /// <summary>
         ///     Indicates whether a run has completed successfully.   
         /// 
-        ///     This flag is critical to ensuring that broken run auto files
-        ///     are not left in run-auto if the file causes a crash.  
+        ///     This flag is critical to ensuring that crashing run-auto files
+        ///     are not left in run-auto upon reopening.  
         /// </summary>
         public bool HasRunWithoutCrash { get; private set; }
 

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -19,13 +19,24 @@ namespace Dynamo.Models
         private readonly bool verboseLogging;
         private bool graphExecuted;
 
-        public readonly bool VerboseLogging;
-       
+        /// <summary>
+        ///     Flag specifying if this workspace is operating in "test mode".
+        /// </summary>
+        public bool IsTestMode { get; set; }
+
+        /// <summary>
+        ///     This flag is critical to ensuring that broken run auto files
+        ///     are not left in run-auto if the file causes a crash.  
+        /// </summary>
+        public bool HasRunWithoutCrash { get; private set; }
+
         /// <summary>
         ///     Before the Workspace has been built the first time, we do not respond to 
         ///     NodeModification events.
         /// </summary>
         private bool silenceNodeModifications = true;
+   
+        public readonly bool VerboseLogging;
 
         public RunSettings RunSettings { get; protected set; }
        
@@ -87,19 +98,8 @@ namespace Dynamo.Models
         }
 
         /// <summary>
-        /// This does not belong here, period. It is here simply because there is 
-        /// currently no better place to put it. A DYN file is loaded by DynamoModel,
-        /// subsequently populating WorkspaceModel, along the way, the trace data 
-        /// gets preloaded with the file. The best place for this cached data is in 
-        /// the EngineController (or even LiveRunner), but the engine gets reset in 
-        /// a rather nondeterministic way (for example, when Revit idle thread 
-        /// decides it is time to execute a pre-scheduled engine reset). And it gets 
-        /// done more than once during file open. So that's out. The second best 
-        /// place to store this information is then the WorkspaceModel, where file 
-        /// loading is SUPPOSED TO BE done. As of now we let DynamoModel sets the 
-        /// loaded data (since it deals with loading DYN file), but in near future,
-        /// the file loading mechanism will be completely moved into WorkspaceModel,
-        /// that's the time we removed this property setter below.
+        /// In near future, the file loading mechanism will be completely moved 
+        /// into WorkspaceModel, that's the time we removed this property setter below.
         /// </summary>
         internal IEnumerable<KeyValuePair<Guid, List<string>>> PreloadedTraceData
         {
@@ -185,8 +185,6 @@ namespace Dynamo.Models
         /// </summary>
         /// <param name="milliseconds">The desired amount of time between two 
         /// evaluations in milliseconds.</param>
-        /// <param name="context">A synchronization context belonging to the 
-        /// thread on which you want PulseMaker callbacks to execute.</param>
         public void StartPeriodicEvaluation(int milliseconds)
         {
             if (pulseMaker == null)
@@ -236,6 +234,7 @@ namespace Dynamo.Models
 
             root.SetAttribute("RunType", RunSettings.RunType.ToString());
             root.SetAttribute("RunPeriod", RunSettings.RunPeriod.ToString(CultureInfo.InvariantCulture));
+            root.SetAttribute("HasRunWithoutCrash", HasRunWithoutCrash.ToString(CultureInfo.InvariantCulture));
 
             return true;
         }
@@ -364,11 +363,6 @@ namespace Dynamo.Models
         }
 
         /// <summary>
-        ///     Flag specifying if this workspace is operating in "test mode".
-        /// </summary>
-        public bool IsTestMode { get; set; }
-
-        /// <summary>
         /// This method is typically called from the main application thread (as 
         /// a result of user actions such as button click or node UI changes) to
         /// schedule an update of the graph. This call may or may not represent 
@@ -376,11 +370,10 @@ namespace Dynamo.Models
         /// in actual graph update (e.g. moving of node on UI), the update task 
         /// will not be scheduled for execution.
         /// </summary>
-        /// <param name="state">Any state that passed to this method by the 
-        /// running context.</param>
         public void Run()
         {
             graphExecuted = true;
+
             // When Dynamo is shut down, the workspace is cleared, which results
             // in Modified() being called. But, we don't want to run when we are
             // shutting down so we check whether an engine controller is available.
@@ -426,6 +419,8 @@ namespace Dynamo.Models
         public event EventHandler<EventArgs> EvaluationStarted;
         public virtual void OnEvaluationStarted(EventArgs e)
         {
+            this.HasRunWithoutCrash = false;
+
             var handler = EvaluationStarted;
             if (handler != null) handler(this, e);
         }
@@ -433,6 +428,8 @@ namespace Dynamo.Models
         public event EventHandler<EvaluationCompletedEventArgs> EvaluationCompleted;
         public virtual void OnEvaluationCompleted(EvaluationCompletedEventArgs e)
         {
+            this.HasRunWithoutCrash = true;
+
             var handler = EvaluationCompleted;
             if (handler != null) handler(this, e);
         }

--- a/src/DynamoCore/Models/WorkspaceInfo.cs
+++ b/src/DynamoCore/Models/WorkspaceInfo.cs
@@ -33,6 +33,7 @@ namespace Dynamo.Models
                 string version = "";
                 var runType = RunType.Manual;
                 int runPeriod = 100;
+                bool hasRunWithoutCrash = false;
 
                 var topNode = xmlDoc.GetElementsByTagName("Workspace");
 
@@ -61,6 +62,8 @@ namespace Dynamo.Models
                             category = att.Value;
                         else if (att.Name.Equals("Description"))
                             description = att.Value;
+                        else if (att.Name.Equals("HasRunWithoutCrash"))
+                            hasRunWithoutCrash = bool.Parse(att.Value);
                         else if (att.Name.Equals("Version"))
                             version = att.Value;
                         else if (att.Name.Equals("RunType"))
@@ -95,7 +98,8 @@ namespace Dynamo.Models
                     Description = description,
                     Version = version,
                     RunType  = runType,
-                    RunPeriod = runPeriod
+                    RunPeriod = runPeriod,
+                    HasRunWithoutCrash = hasRunWithoutCrash
                 };
                 return true;
             }
@@ -125,6 +129,7 @@ namespace Dynamo.Models
         public string FileName { get; internal set; }
         public RunType RunType { get; internal set; }
         public int RunPeriod { get; internal set; }
+        public bool HasRunWithoutCrash { get; internal set; }
         public bool IsCustomNodeWorkspace
         {
             get { return !string.IsNullOrEmpty(ID); }

--- a/test/DynamoCoreTests/CrashProtectionTests.cs
+++ b/test/DynamoCoreTests/CrashProtectionTests.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Dynamo.Models;
+using NUnit.Framework;
+
+namespace Dynamo.Tests
+{
+    [TestFixture]
+    public class CrashProtectionTests : DynamoModelTestBase
+    {
+        private readonly string crashProtDir = @"core\crashProtection";
+
+        #region Helpers
+
+        private void AssertManual(HomeWorkspaceModel ws)
+        {
+            Assert.AreEqual(RunType.Manual, ws.RunSettings.RunType);
+        }
+
+        private void AssertAuto(HomeWorkspaceModel ws)
+        {
+            Assert.AreEqual(RunType.Automatic, ws.RunSettings.RunType);
+        }
+
+        #endregion
+
+        [Test]
+        public void RunAutoFileWithoutFlagOpensInManual()
+        {
+            //For files what have never been opened, HasRunWithoutCrash defaults to false 
+            //    -> So, all non-marked files will open in manual even if run auto is on
+
+            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runAutoNoCrashFlag.dyn");
+
+            AssertManual(ws);
+        }
+
+        [Test]
+        public void RunAutoFileWithTrueFlagOpensInAuto()
+        {
+            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runAutoTrueCrashFlag.dyn");
+
+            AssertAuto(ws);
+        }
+
+
+        [Test]
+        public void RunAutoFileWithFalseFlagOpensInManual()
+        {
+            //On open file, if run auto & HasRunWithoutCrash = false, set to run manual
+            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runAutoFalseCrashFlag.dyn");
+
+            AssertManual(ws);
+        }
+
+        [Test]
+        public void RunAutoFileWithSuccessfulRunSavesFlag()
+        {
+            //On save, if run auto & HasRunWithoutCrash = true, this should be saved
+            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runAutoFalseCrashFlag.dyn");
+
+            // We do a run so HasRunWithoutCrash is set to true.  Otherwise, the test
+            // assertion is not valid.
+            BeginRun();
+            EmptyScheduler();
+
+            Assert.True(ws.HasRunWithoutCrash);
+
+            // set to auto, we expect this to be maintained in the re-opened file
+            ws.RunSettings.RunType = RunType.Automatic;
+
+            // save the file to a temp location
+            var tp = Path.Combine(TempFolder, "tempCrashProtection.dyn");
+            ws.SaveAs(tp, CurrentDynamoModel.EngineController.LiveRunnerCore);
+
+            // open the file
+            var nws = Open<HomeWorkspaceModel>(tp);
+
+            AssertAuto(nws);
+        }
+
+        [Test]
+        public void FlagIsFalseWhenEvaluationStarted()
+        {
+            //On run start, HasRunWithoutCrash = false
+            //    - This makes sure that if the user has modifies the file during a run that causes a crash, there 
+            //        file is not erroneously marked as having run without crash. 
+            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runManual.dyn");
+
+            // We do a run so HasRunWithoutCrash is set to true.  Otherwise, the test
+            // assertion is not valid.
+            BeginRun();
+            EmptyScheduler();
+
+            Assert.True(ws.HasRunWithoutCrash);
+
+            // Update the number input to ensure another run takes place
+            var n = ws.Nodes.OfType<Nodes.DoubleInput>().First();
+            CurrentDynamoModel.ExecuteCommand(
+                new DynamoModel.UpdateModelValueCommand(n.GUID, "Value", "3.0"));
+
+            // We'll need this flag to ensure the run is completed even when
+            // done async
+            var assertionComplete = false;
+            ws.EvaluationStarted += (e, a) =>
+            {
+                Assert.False(ws.HasRunWithoutCrash);
+                assertionComplete = true;
+            };
+
+            // Do the next run
+            BeginRun();
+            EmptyScheduler();
+
+            if (!assertionComplete)
+            {
+                Assert.Fail("The assertion was not evaluated!");
+            }
+        }
+
+        [Test]
+        public void FlagIsSetToTrueAfterRunSuccessfullyCompletes()
+        {
+            //On run complete, HasRunWithoutCrash = true
+            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runManual.dyn");
+
+            Assert.False(ws.HasRunWithoutCrash);
+
+            // We'll need this flag to ensure the run is completed even when
+            // done async
+            var assertionComplete = false;
+            ws.EvaluationCompleted += (e, a) =>
+            {
+                Assert.True(ws.HasRunWithoutCrash);
+                assertionComplete = true;
+            };
+
+            BeginRun();
+            EmptyScheduler();
+
+            if (!assertionComplete)
+            {
+                Assert.Fail("The assertion was not evaluated!");
+            }
+        }
+
+    }
+}

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -11,7 +11,7 @@
     <ProjectGuid>{472084ED-1067-4B2C-8737-3839A6143EB2}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Dynamo</RootNamespace>
+    <RootNamespace>Dynamo.Tests</RootNamespace>
     <AssemblyName>DynamoCoreTests</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -68,6 +68,8 @@
   <ItemGroup>
     <Compile Include="AstBuilderTest.cs" />
     <Compile Include="ConverterTests.cs" />
+    <Compile Include="CrashProtectionTests.cs" />
+    <Compile Include="DynamoModelTestBase.cs" />
     <Compile Include="MessageLogTests.cs" />
     <Compile Include="IconsTests.cs" />
     <Compile Include="NodeConstructionTests.cs" />

--- a/test/DynamoCoreTests/DynamoModelTestBase.cs
+++ b/test/DynamoCoreTests/DynamoModelTestBase.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Dynamo.Models;
+using Dynamo.Selection;
+using Dynamo.Tests;
+using Dynamo.ViewModels;
+using DynamoShapeManager;
+using NUnit.Framework;
+using ProtoCore.Mirror;
+using TestServices;
+
+namespace Dynamo
+{
+    public class DynamoModelTestBase : UnitTestBase
+    {
+        protected DynamoModel CurrentDynamoModel { get; private set; }
+
+        protected Preloader preloader;
+        protected TestPathResolver pathResolver;
+
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+            StartDynamo();
+        }
+
+        public override void Cleanup()
+        {
+            try
+            {
+                preloader = null;
+                DynamoSelection.Instance.ClearSelection();
+
+                if (this.CurrentDynamoModel == null)
+                    return;
+
+                this.CurrentDynamoModel.ShutDown(false);
+                this.CurrentDynamoModel = null;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.StackTrace);
+            }
+
+            base.Cleanup();
+        }
+
+        protected virtual void StartDynamo()
+        {
+            var assemblyPath = Assembly.GetExecutingAssembly().Location;
+            preloader = new Preloader(Path.GetDirectoryName(assemblyPath));
+            preloader.Preload();
+
+            this.CurrentDynamoModel = DynamoModel.Start(
+                new DynamoModel.DefaultStartConfiguration()
+                {
+                    PathResolver = pathResolver,
+                    StartInTestMode = true,
+                    GeometryFactoryPath = preloader.GeometryFactoryPath
+                });
+        }
+
+        protected T Open<T>(params string[] relativePathParts) where T : WorkspaceModel
+        {
+            var path = Path.Combine(relativePathParts);
+            CurrentDynamoModel.ExecuteCommand(new DynamoModel.OpenFileCommand(path));
+            return CurrentDynamoModel.CurrentWorkspace as T;
+        }
+
+        protected void BeginRun()
+        {
+            CurrentDynamoModel.ExecuteCommand(new DynamoModel.RunCancelCommand(false, false));
+        }
+
+        protected void EmptyScheduler()
+        {
+            while (CurrentDynamoModel.Scheduler.ProcessNextTask(false))
+            {
+
+            }
+        }
+
+        protected void AssertNoDummyNodes()
+        {
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+
+            var dummyNodes = nodes.OfType<DSCoreNodesUI.DummyNode>();
+            string logs = string.Empty;
+            foreach (var node in dummyNodes)
+            {
+                logs += string.Format("{0} is a {1} node\n", node.NickName, node.NodeNature);
+            }
+
+            double dummyNodesCount = dummyNodes.Count();
+            if (dummyNodesCount >= 1)
+            {
+                Assert.Fail(logs + "Number of dummy nodes found in Sample: " + dummyNodesCount);
+            }
+        }
+
+        protected IEnumerable<object> GetPreviewValues()
+        {
+            List<object> objects = new List<object>();
+            foreach(var node in CurrentDynamoModel.CurrentWorkspace.Nodes)
+            {
+                objects.Add(GetPreviewValue(node.GUID));
+            }
+            return objects;
+        }
+
+        protected void AssertNullValues()
+        {
+            foreach (var node in CurrentDynamoModel.CurrentWorkspace.Nodes)
+            {
+                string varname = GetVarName(node.GUID);
+                var mirror = GetRuntimeMirror(varname);
+                Assert.IsNull(mirror);
+            }
+            
+        }
+
+        protected object GetPreviewValue(System.Guid guid)
+        {
+            string varname = GetVarName(guid);
+            var mirror = GetRuntimeMirror(varname);
+            Assert.IsNotNull(mirror);
+
+            return mirror.GetData().Data;
+        }
+
+        protected string GetVarName(System.Guid guid)
+        {
+            var model = CurrentDynamoModel;
+            var node = model.CurrentWorkspace.NodeFromWorkspace(guid);
+            Assert.IsNotNull(node);
+
+            int outportCount = node.OutPorts.Count;
+            Assert.IsTrue(outportCount > 0);
+
+            if(outportCount > 1) 
+                return node.AstIdentifierBase; 
+            else 
+                return node.GetAstIdentifierForOutputIndex(0).Value;
+
+        }
+
+        protected string GetVarName(string guid)
+        {
+            var model = CurrentDynamoModel;
+            var node = model.CurrentWorkspace.NodeFromWorkspace(guid);
+            Assert.IsNotNull(node);
+
+            int outportCount = node.OutPorts.Count;
+            Assert.IsTrue(outportCount > 0);
+
+            if (outportCount > 1) 
+                return node.AstIdentifierBase; 
+            else 
+                return node.GetAstIdentifierForOutputIndex(0).Value;
+
+        }
+
+        /// <summary>
+        ///     Used to reflect on runtime data such as values of a variable
+        /// </summary>
+        protected RuntimeMirror GetRuntimeMirror(string varName)
+        {
+            RuntimeMirror mirror = null;
+            Assert.DoesNotThrow(() => mirror = CurrentDynamoModel.EngineController.GetMirror(varName));
+            return mirror;
+        }
+
+        /// <summary>
+        ///     Used to reflect on static data such as classes and class members
+        /// </summary>
+        protected ClassMirror GetClassMirror(string className)
+        {
+            ProtoCore.Core core = CurrentDynamoModel.EngineController.LiveRunnerCore;
+            var classMirror = new ClassMirror(className, core);
+            return classMirror;
+        }
+
+    }
+}

--- a/test/DynamoCoreTests/DynamoViewModelUnitTest.cs
+++ b/test/DynamoCoreTests/DynamoViewModelUnitTest.cs
@@ -16,14 +16,20 @@ using TestServices;
 namespace Dynamo.Tests
 {
     /// <summary>
-    /// The DynamoViewModelUnitTests constructs the DynamoModel
-    /// and the DynamoViewModel, but does not construct the view.
-    /// You can use this class to create tests which ensure that the 
-    /// ViewModel and the Model are communicating properly.
+    /// 
+    ///     The DynamoViewModelUnitTests constructs the DynamoModel
+    ///     and the DynamoViewModel, but does not construct the view.
+    ///     You can use this class to create tests which ensure that the 
+    ///     ViewModel and the Model are communicating properly.
+    /// 
+    ///     WARNING! You should think twice about using this class!  It's
+    ///     often a better alternative to use DynamoModelTestBase or,
+    ///     better yet, use an even lighter weight class.  
+    ///
     /// </summary>
-    public class DynamoViewModelUnitTest : DynamoModelTestBase
+    public class DynamoViewModelUnitTest : UnitTestBase
     {
-        protected DynamoViewModel ViewModel { get; private set; }
+        protected DynamoViewModel ViewModel;
         protected Preloader preloader;
         protected TestPathResolver pathResolver;
 
@@ -90,14 +96,24 @@ namespace Dynamo.Tests
             }
         }
 
-        protected override void StartDynamo()
+        protected void StartDynamo()
         {
-            base.StartDynamo();
+            var assemblyPath = Assembly.GetExecutingAssembly().Location;
+            preloader = new Preloader(Path.GetDirectoryName(assemblyPath));
+            preloader.Preload();
+
+            var model = DynamoModel.Start(
+                new DynamoModel.DefaultStartConfiguration()
+                {
+                    PathResolver = pathResolver,
+                    StartInTestMode = true,
+                    GeometryFactoryPath = preloader.GeometryFactoryPath
+                });
 
             this.ViewModel = DynamoViewModel.Start(
                 new DynamoViewModel.StartConfiguration()
                 {
-                    DynamoModel = CurrentDynamoModel
+                    DynamoModel = model
                 });
 
             this.ViewModel.RequestUserSaveWorkflow += RequestUserSaveWorkflow;
@@ -124,6 +140,110 @@ namespace Dynamo.Tests
                 var runResult = this.ViewModel.Model.CurrentWorkspace.NodeFromWorkspace(test.Key).CachedValue.Data;
                 Assert.AreEqual(test.Value, runResult);
             }
+        }
+
+        protected void AssertNoDummyNodes()
+        {
+            var nodes = ViewModel.Model.CurrentWorkspace.Nodes;
+
+            var dummyNodes = nodes.OfType<DSCoreNodesUI.DummyNode>();
+            string logs = string.Empty;
+            foreach (var node in dummyNodes)
+            {
+                logs += string.Format("{0} is a {1} node\n", node.NickName, node.NodeNature);
+            }
+
+            double dummyNodesCount = dummyNodes.Count();
+            if (dummyNodesCount >= 1)
+            {
+                Assert.Fail(logs + "Number of dummy nodes found in Sample: " + dummyNodesCount);
+            }
+        }
+
+        protected IEnumerable<object> GetPreviewValues()
+        {
+            List<object> objects = new List<object>();
+            foreach (var node in ViewModel.Model.CurrentWorkspace.Nodes)
+            {
+                objects.Add(GetPreviewValue(node.GUID));
+            }
+            return objects;
+        }
+
+        protected void AssertNullValues()
+        {
+            foreach (var node in ViewModel.Model.CurrentWorkspace.Nodes)
+            {
+                string varname = GetVarName(node.GUID);
+                var mirror = GetRuntimeMirror(varname);
+                Assert.IsNull(mirror);
+            }
+
+        }
+
+        protected object GetPreviewValue(System.Guid guid)
+        {
+            string varname = GetVarName(guid);
+            var mirror = GetRuntimeMirror(varname);
+            Assert.IsNotNull(mirror);
+
+            return mirror.GetData().Data;
+        }
+
+        protected string GetVarName(System.Guid guid)
+        {
+            var model = ViewModel.Model;
+            var node = model.CurrentWorkspace.NodeFromWorkspace(guid);
+            Assert.IsNotNull(node);
+
+            int outportCount = node.OutPorts.Count;
+            Assert.IsTrue(outportCount > 0);
+
+            if (outportCount > 1)
+                return node.AstIdentifierBase;
+            else
+                return node.GetAstIdentifierForOutputIndex(0).Value;
+
+        }
+
+        protected string GetVarName(string guid)
+        {
+            var model = ViewModel.Model;
+            var node = model.CurrentWorkspace.NodeFromWorkspace(guid);
+            Assert.IsNotNull(node);
+
+            int outportCount = node.OutPorts.Count;
+            Assert.IsTrue(outportCount > 0);
+
+            if (outportCount > 1)
+                return node.AstIdentifierBase;
+            else
+                return node.GetAstIdentifierForOutputIndex(0).Value;
+
+        }
+
+        /// <summary>
+        /// Used to reflect on runtime data such as values of a variable
+        /// </summary>
+        /// <param name="varName"></param>
+        /// <returns></returns>
+        protected RuntimeMirror GetRuntimeMirror(string varName)
+        {
+            RuntimeMirror mirror = null;
+            Assert.DoesNotThrow(() => mirror = ViewModel.Model.EngineController.GetMirror(varName));
+            return mirror;
+        }
+
+        /// <summary>
+        /// Used to reflect on static data such as classes and class members
+        /// </summary>
+        /// <param name="varName"></param>
+        /// <returns></returns>
+        protected ClassMirror GetClassMirror(string className)
+        {
+            ProtoCore.Core core = ViewModel.Model.EngineController.LiveRunnerCore;
+            var classMirror = new ClassMirror(className, core);
+            return classMirror;
         }
 
     }

--- a/test/DynamoCoreTests/DynamoViewModelUnitTest.cs
+++ b/test/DynamoCoreTests/DynamoViewModelUnitTest.cs
@@ -21,9 +21,9 @@ namespace Dynamo.Tests
     /// You can use this class to create tests which ensure that the 
     /// ViewModel and the Model are communicating properly.
     /// </summary>
-    public class DynamoViewModelUnitTest : UnitTestBase
+    public class DynamoViewModelUnitTest : DynamoModelTestBase
     {
-        protected DynamoViewModel ViewModel;
+        protected DynamoViewModel ViewModel { get; private set; }
         protected Preloader preloader;
         protected TestPathResolver pathResolver;
 
@@ -90,24 +90,14 @@ namespace Dynamo.Tests
             }
         }
 
-        protected void StartDynamo()
+        protected override void StartDynamo()
         {
-            var assemblyPath = Assembly.GetExecutingAssembly().Location;
-            preloader = new Preloader(Path.GetDirectoryName(assemblyPath));
-            preloader.Preload();
-
-            var model = DynamoModel.Start(
-                new DynamoModel.DefaultStartConfiguration()
-                {
-                    PathResolver = pathResolver,
-                    StartInTestMode = true,
-                    GeometryFactoryPath = preloader.GeometryFactoryPath
-                });
+            base.StartDynamo();
 
             this.ViewModel = DynamoViewModel.Start(
                 new DynamoViewModel.StartConfiguration()
                 {
-                    DynamoModel = model
+                    DynamoModel = CurrentDynamoModel
                 });
 
             this.ViewModel.RequestUserSaveWorkflow += RequestUserSaveWorkflow;
@@ -134,110 +124,6 @@ namespace Dynamo.Tests
                 var runResult = this.ViewModel.Model.CurrentWorkspace.NodeFromWorkspace(test.Key).CachedValue.Data;
                 Assert.AreEqual(test.Value, runResult);
             }
-        }
-
-        protected void AssertNoDummyNodes()
-        {
-            var nodes = ViewModel.Model.CurrentWorkspace.Nodes;
-
-            var dummyNodes = nodes.OfType<DSCoreNodesUI.DummyNode>();
-            string logs = string.Empty;
-            foreach (var node in dummyNodes)
-            {
-                logs += string.Format("{0} is a {1} node\n", node.NickName, node.NodeNature);
-            }
-
-            double dummyNodesCount = dummyNodes.Count();
-            if (dummyNodesCount >= 1)
-            {
-                Assert.Fail(logs + "Number of dummy nodes found in Sample: " + dummyNodesCount);
-            }
-        }
-
-        protected IEnumerable<object> GetPreviewValues()
-        {
-            List<object> objects = new List<object>();
-            foreach(var node in ViewModel.Model.CurrentWorkspace.Nodes)
-            {
-                objects.Add(GetPreviewValue(node.GUID));
-            }
-            return objects;
-        }
-
-        protected void AssertNullValues()
-        {
-            foreach (var node in ViewModel.Model.CurrentWorkspace.Nodes)
-            {
-                string varname = GetVarName(node.GUID);
-                var mirror = GetRuntimeMirror(varname);
-                Assert.IsNull(mirror);
-            }
-            
-        }
-
-        protected object GetPreviewValue(System.Guid guid)
-        {
-            string varname = GetVarName(guid);
-            var mirror = GetRuntimeMirror(varname);
-            Assert.IsNotNull(mirror);
-
-            return mirror.GetData().Data;
-        }
-
-        protected string GetVarName(System.Guid guid)
-        {
-            var model = ViewModel.Model;
-            var node = model.CurrentWorkspace.NodeFromWorkspace(guid);
-            Assert.IsNotNull(node);
-
-            int outportCount = node.OutPorts.Count;
-            Assert.IsTrue(outportCount > 0);
-
-            if(outportCount > 1) 
-                return node.AstIdentifierBase; 
-            else 
-                return node.GetAstIdentifierForOutputIndex(0).Value;
-
-        }
-
-        protected string GetVarName(string guid)
-        {
-            var model = ViewModel.Model;
-            var node = model.CurrentWorkspace.NodeFromWorkspace(guid);
-            Assert.IsNotNull(node);
-
-            int outportCount = node.OutPorts.Count;
-            Assert.IsTrue(outportCount > 0);
-
-            if (outportCount > 1) 
-                return node.AstIdentifierBase; 
-            else 
-                return node.GetAstIdentifierForOutputIndex(0).Value;
-
-        }
-
-        /// <summary>
-        /// Used to reflect on runtime data such as values of a variable
-        /// </summary>
-        /// <param name="varName"></param>
-        /// <returns></returns>
-        protected RuntimeMirror GetRuntimeMirror(string varName)
-        {
-            RuntimeMirror mirror = null;
-            Assert.DoesNotThrow(() => mirror = ViewModel.Model.EngineController.GetMirror(varName));
-            return mirror;
-        }
-
-        /// <summary>
-        /// Used to reflect on static data such as classes and class members
-        /// </summary>
-        /// <param name="varName"></param>
-        /// <returns></returns>
-        protected ClassMirror GetClassMirror(string className)
-        {
-            ProtoCore.Core core = ViewModel.Model.EngineController.LiveRunnerCore;
-            var classMirror = new ClassMirror(className, core);
-            return classMirror;
         }
 
     }

--- a/test/core/crashProtection/runAutoFalseCrashFlag.dyn
+++ b/test/core/crashProtection/runAutoFalseCrashFlag.dyn
@@ -1,0 +1,14 @@
+<Workspace Version="0.8.1.835" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="100" HasRunWithoutCrash="False">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DoubleInput guid="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="283.5" y="225.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="1" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DSFunction guid="6c46c7f8-9625-4deb-8d99-f90780428e74" type="Dynamo.Nodes.DSFunction" nickname="+" x="516.5" y="196.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="+@var[]..[],var[]..[]" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" start_index="0" end="6c46c7f8-9625-4deb-8d99-f90780428e74" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" start_index="0" end="6c46c7f8-9625-4deb-8d99-f90780428e74" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>

--- a/test/core/crashProtection/runAutoNoCrashFlag.dyn
+++ b/test/core/crashProtection/runAutoNoCrashFlag.dyn
@@ -1,0 +1,14 @@
+<Workspace Version="0.8.1.835" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="100">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DoubleInput guid="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="283.5" y="225.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="1" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DSFunction guid="6c46c7f8-9625-4deb-8d99-f90780428e74" type="Dynamo.Nodes.DSFunction" nickname="+" x="516.5" y="196.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="+@var[]..[],var[]..[]" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" start_index="0" end="6c46c7f8-9625-4deb-8d99-f90780428e74" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" start_index="0" end="6c46c7f8-9625-4deb-8d99-f90780428e74" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>

--- a/test/core/crashProtection/runAutoTrueCrashFlag.dyn
+++ b/test/core/crashProtection/runAutoTrueCrashFlag.dyn
@@ -1,0 +1,14 @@
+<Workspace Version="0.8.1.835" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="100" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DoubleInput guid="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="283.5" y="225.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="1" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DSFunction guid="6c46c7f8-9625-4deb-8d99-f90780428e74" type="Dynamo.Nodes.DSFunction" nickname="+" x="516.5" y="196.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="+@var[]..[],var[]..[]" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" start_index="0" end="6c46c7f8-9625-4deb-8d99-f90780428e74" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" start_index="0" end="6c46c7f8-9625-4deb-8d99-f90780428e74" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>

--- a/test/core/crashProtection/runManual.dyn
+++ b/test/core/crashProtection/runManual.dyn
@@ -1,0 +1,14 @@
+<Workspace Version="0.8.1.835" X="0" Y="0" zoom="1" Name="Home" RunType="Manual" RunPeriod="100" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DoubleInput guid="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="283.5" y="225.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="1" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DSFunction guid="6c46c7f8-9625-4deb-8d99-f90780428e74" type="Dynamo.Nodes.DSFunction" nickname="+" x="516.5" y="196.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="+@var[]..[],var[]..[]" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" start_index="0" end="6c46c7f8-9625-4deb-8d99-f90780428e74" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="87c82c81-c93b-4ebc-b4f1-1ce2239b3c6f" start_index="0" end="6c46c7f8-9625-4deb-8d99-f90780428e74" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
### Issue

We need to prevent files that cause a crash from being reopened with run auto.  This would cause Dynamo to immediately crash on opening the file, effectively preventing the user from ever accessing the file again.

### Fix

Introduce a simple flag, `HasRunWithoutCrash`.  There are several state transitions for this flag, encoded in a new unit test file `CrashProtectionTests`. 

* For files what have never been opened, `HasRunWithoutCrash = false`
	- *So, all files from previous version of Dynamo will open in manual!*
* On run start, `HasRunWithoutCrash = false` is immediately set
	- This makes sure that if the user has modifies the file during a run that causes a crash, there 
	  file is not erroneously marked as having run without crash. 
* On run complete, `HasRunWithoutCrash = true`
* On open file, if run auto & `HasRunWithoutCrash = false`, set to run manual
* On save, if run auto & `HasRunWithoutCrash = true`, ensure that is saved to the file

### Reviewer

- [ ] @lukechurch 