### PR TITLE
add missing RevitAddinUtility.dll to installer

### DIFF
--- a/src/DynamoInstall/DynamoInstall.wixproj
+++ b/src/DynamoInstall/DynamoInstall.wixproj
@@ -47,6 +47,8 @@
   <PropertyGroup>
     <PreBuildEvent>rd /s /q $(DYNAMO_HARVEST_PATH)
 robocopy $(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration) $(DYNAMO_HARVEST_PATH) -XF %2aTest%2a.dll %2a.pdb TestResult.xml -e -XD int -XD samples
+copy $(DYNAMO_BASE_PATH)\tools\install\Extra\DynamoAddinGenerator.exe $(DYNAMO_HARVEST_PATH)\DynamoAddinGenerator.exe
+copy $(DYNAMO_BASE_PATH)\tools\install\Extra\RevitAddinUtility.dll $(DYNAMO_HARVEST_PATH)\RevitAddinUtility.dll
 
 "%25WIX%25bin\heat.exe" dir $(DYNAMO_HARVEST_PATH) -cg RELEASE -gg -scom -sreg -srd -dr DYNAMO_INSTALLDIR -var var.harvest -out "$(ProjectDir)Release.wxs"
 "%25WIX%25bin\heat.exe" dir $(DYNAMO_SAMPLES_PATH) -cg SAMPLES -gg -scom -sreg -dr PROGDATA -var var.samples -t "$(ProjectDir)Samples.xsl" -out "$(ProjectDir)Samples.wxs"

--- a/src/DynamoInstall/Product.wxs
+++ b/src/DynamoInstall/Product.wxs
@@ -28,10 +28,10 @@
     <CustomAction Id="UninstallDynamo" Return="check" Execute="deferred" Impersonate="no"
               BinaryKey="DynamoInstallActions.CA.dll" DllEntry="UninstallDynamo" />
     
-    <CustomAction Id="RemoveShortcut.SetProperty" Return="check" Property="RemoveShortcut"
+    <!--<CustomAction Id="RemoveShortcut.SetProperty" Return="check" Property="RemoveShortcut"
                   Value="Major=$(var.Major);Minor=$(var.Minor);Rev=$(var.Rev);Dir=[ApplicationProgramsFolder]" />
     <CustomAction Id="RemoveShortcut" Return="ignore" Execute="deferred" Impersonate="no"
-              BinaryKey="DynamoInstallActions.CA.dll" DllEntry="RemoveShortcut" />
+              BinaryKey="DynamoInstallActions.CA.dll" DllEntry="RemoveShortcut" />-->
     
     <CustomAction Id="GenerateRevitAddin.SetProperty" Property="GenerateRevitAddin" 
                   Value="&quot;[DYNAMO_INSTALLDIR]DynamoAddinGenerator.exe&quot; &quot;[DYNAMO_INSTALLDIR]&quot;" />
@@ -44,8 +44,8 @@
     <InstallExecuteSequence>
       <Custom Action="UninstallDynamo.SetProperty" Before="UninstallDynamo">NOT Installed</Custom>
       <Custom Action="UninstallDynamo" After="InstallInitialize">NOT Installed</Custom>
-      <Custom Action="RemoveShortcut.SetProperty" Before="RemoveShortcut">Installed</Custom>
-      <Custom Action="RemoveShortcut" After="InstallInitialize">Installed</Custom>
+      <!--<Custom Action="RemoveShortcut.SetProperty" Before="RemoveShortcut">Installed</Custom>
+      <Custom Action="RemoveShortcut" After="InstallInitialize">Installed</Custom>-->
       <Custom Action="GenerateRevitAddin.SetProperty" Before="GenerateRevitAddin">NOT Installed</Custom>
       <Custom Action="GenerateRevitAddin" Before="InstallFinalize">NOT Installed</Custom>
       <Custom Action="RemoveRevitAddin.SetProperty" Before="RemoveRevitAddin">Installed</Custom>
@@ -67,7 +67,6 @@
       <ComponentGroupRef Id="DEFINITIONS"/>
       <ComponentRef Id="ApplicationShortcut" />
       <ComponentRef Id="ProductRegistry" />
-      <ComponentGroupRef Id="AddinGenerator" />
       <Feature Id="DYNAMO_CORE_SAMPLES"
              Title="Sample Content"
              Level="1" >
@@ -104,7 +103,7 @@
 
     <!-- Install a shortcut in the Start menu -->
     <DirectoryRef Id="ApplicationProgramsFolder">
-      <Component Id="ApplicationShortcut" Guid="d7575401-f8ba-488f-b5e4-5ad24dbc4b10" Win64="yes">
+      <Component Id="ApplicationShortcut" Win64="yes">
         <Shortcut Id="ApplicationStartMenuShortcut"
                   Name="Dynamo $(var.Major).$(var.Minor).$(var.Rev)"
                   Description="Dynamo Sandbox"
@@ -119,7 +118,7 @@
     </DirectoryRef>
 
     <DirectoryRef Id="TARGETDIR">
-      <Component Id="ProductRegistry" Guid="*" Win64="yes">
+      <Component Id="ProductRegistry" Win64="yes">
         <RegistryKey Root="HKLM"
                      Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(var.ProductName) $(var.Major).$(var.Minor)"
                      ForceDeleteOnUninstall="yes">
@@ -141,12 +140,6 @@
         <RemoveFolder Id="RemoveDynamoAppDataDir" Directory="DYNAMO_APPDATA" On="uninstall" />
       </Component>
     </DirectoryRef>
-
-    <ComponentGroup Id="AddinGenerator">
-      <Component Id="DynamoAddinGenerator.exe" Directory="DYNAMO_INSTALLDIR" Guid="{8BD3DEB8-531C-4967-BD8A-C821BA85891A}">
-        <File Id="DynamoAddinGenerator.exe" KeyPath="yes" Source="$(var.base)\tools\install\Extra\DynamoAddinGenerator.exe" />
-      </Component>
-    </ComponentGroup>
 
   </Fragment>
 


### PR DESCRIPTION
**Changes**

* Add RevitAddinUtility.dll to the installer. When DynamoAddinGenerator is launched and RevitAddinUtility.dll is not present, DynamoAddinGenerator would crash and no Revit addin is created.
* Remove GUID from shortcut component since shortcut is not a shared component and it should have auto-generated GUID

This change should be cherry-picked for RC0.8.0
@sharadkjaiswal PTAL