### PR TITLE
Fixed a test which shows dialog and wait for user input

### DIFF
--- a/test/Libraries/WorlflowTests/DynamoSamples.cs
+++ b/test/Libraries/WorlflowTests/DynamoSamples.cs
@@ -1,11 +1,10 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using Autodesk.DesignScript.Geometry;
 using NUnit.Framework;
-using Dynamo.Utilities;
 using Dynamo.Models;
 using System.Collections.Generic;
 using System.Linq;
-using Autodesk.DesignScript.Geometry;
 
 namespace Dynamo.Tests
 {
@@ -538,7 +537,7 @@ namespace Dynamo.Tests
 
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
-            string resultPath = GetSampleDirectory() + "Data\\icosohedron_points.csv";
+            string resultPath = Path.Combine(TempFolder, "icosohedron_points.csv");
             // Although old path is a hard coded but that is not going to change 
             // because it is saved in DYN which we have added in Samples folder.
             filename.Value = filename.Value.Replace

--- a/test/Libraries/WorlflowTests/WorkflowTests.csproj
+++ b/test/Libraries/WorlflowTests/WorkflowTests.csproj
@@ -41,8 +41,7 @@
     </Reference>
     <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\bin\AnyCPU\Debug\ProtoGeometry.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\extern\ProtoGeometry\ProtoGeometry.dll</HintPath>
     </Reference>
     <Reference Include="ProtoInterface, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
The test `ImportExport_Data_To_Excel` results in a dialog that asks if `icosohedron_points.csv` in samples folder should be overwritten. The reason for that was because the file already exists. This pull request updates that by using `UnitTestBase.TempFolder` property, which guaranteed the file to always be non-existence.

The pull request also updated `WorkflowTests.csproj` to reference `ProtoGeometry.dll` in `extern` folder rather than in `bin\AnyCPU\Debug`, because that will not work for `Release` build.

Hi @riteshchandawar, since you're familiar with this test, I'm making you a reviewer. Thanks!