### PR TITLE
posting msi installer to the same location where the exe installer is

### DIFF
--- a/src/DynamoInstall/DynamoInstall.wixproj
+++ b/src/DynamoInstall/DynamoInstall.wixproj
@@ -9,7 +9,7 @@
     <ProductVersion>3.8</ProductVersion>
     <ProjectGuid>c7495640-0d0c-46ab-a5f3-d5be78f89a0d</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>DynamoCore</OutputName>
+    <OutputName>DynamoInstall</OutputName>
     <OutputType>Package</OutputType>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
@@ -82,4 +82,7 @@ copy $(DYNAMO_BASE_PATH)\tools\install\Extra\RevitAddinUtility.dll $(DYNAMO_HARV
   </Target>
   <Target Name="AfterBuild">
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy $(OutputPath)$(OutputName).msi  $(DYNAMO_BASE_PATH)\tools\install\Installers\ /y</PostBuildEvent>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
**Changes**
- Rename output file to *DynamoInstall.msi* since it contains not only core program but Revit addins as well
- Post the output msi to the folder containing the exe installer

@sharadkjaiswal @Benglin PTAL