### PR TITLE
Revert "Dui imported dll missing description"

### DIFF
--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -164,7 +164,7 @@ namespace Dynamo.DSEngine
             {
                 case FunctionType.Constructor:
                     // XML documentation uses slightly different constructor names
-                    memberName = member.ClassName + ".#ctor";
+                    memberName = memberName.Replace(".ctor", "#ctor");
                     goto case FunctionType.InstanceMethod;
 
                 case FunctionType.InstanceMethod: 

--- a/test/DynamoCoreTests/XmlDocumentationTests.cs
+++ b/test/DynamoCoreTests/XmlDocumentationTests.cs
@@ -34,12 +34,6 @@ namespace Dynamo.Tests
             </search>
             <returns>Transformed Geometry.</returns>
         </member>
-        <member name=""M:Namespace.Class.#ctor(System.String)"">
-            <summary>
-            Description string constructor.
-            </summary>
-            <param name=""str"">String parameter.</param>
-        </member>
     </members>
 </doc>
 ");
@@ -64,26 +58,6 @@ namespace Dynamo.Tests
             });
 
             parms.ForEach(x => x.UpdateFunctionDescriptor(funcDesc, null));
-
-            return funcDesc;
-        }
-
-        private static FunctionDescriptor GetConstructorMethod()
-        {
-            var parm = new List<TypedParameter>()
-            {
-                new TypedParameter("str", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeString,0))
-            };
-
-            var funcDesc = new FunctionDescriptor(new FunctionDescriptorParams
-            {
-                Assembly = "ProtoGeometry.dll",
-                ClassName = "Namespace.Class",
-                FunctionName = "Class",
-                Parameters = parm,
-                ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar),
-                FunctionType = FunctionType.Constructor
-            });
 
             return funcDesc;
         }
@@ -125,16 +99,6 @@ namespace Dynamo.Tests
             var descript = paramX.GetDescription(SampleDocument);
 
             Assert.AreEqual("Displacement along X-axis.", descript);
-        }
-
-        [Test]
-        [Category("UnitTests")]
-        public static void GetSummary_FunctionDescriptorXDocument_CanFindSummaryForConstructorMethod()
-        {
-            var method = GetConstructorMethod();
-            var summary = method.GetSummary(SampleDocument);
-
-            Assert.AreEqual("Description string constructor.", summary);
         }
     }
 }


### PR DESCRIPTION
Reverts DynamoDS/Dynamo#4031
These changes influence search results.

Reviewers
@Benglin , please take a look.
@ramramps , please take a look.

Link to YouTrack:
[MAGN-6577](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6577) [DUI] Imported dlls are missing description even though the source has the descriptions
[MAGN-6770](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6770) Point.ByCoordinates is not listed when typing "point" at the Library Search