### PR TITLE
Add loaded nodes to loaded assemblies collection.

### DIFF
--- a/src/DynamoCore/Core/NodeModelAssemblyLoader.cs
+++ b/src/DynamoCore/Core/NodeModelAssemblyLoader.cs
@@ -134,8 +134,7 @@ namespace Dynamo.Utilities
                     }
 
                     LoadNodesFromAssembly(assembly, context, result, result2);
-                    loadedAssemblies.Add(assembly);
-                    OnAssemblyLoaded(assembly);
+                    
                 }
                 catch (BadImageFormatException)
                 {
@@ -245,6 +244,9 @@ namespace Dynamo.Utilities
                     Log(e);
                 }
             }
+
+            loadedAssemblies.Add(assembly);
+            OnAssemblyLoaded(assembly);
         }
 
         #endregion


### PR DESCRIPTION
This PR continues the work of #4081. 

While testing [MAGN-6721](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6721), I realized that node view customizations were not being loaded for node models in packages. Specifically, the node view customization for the `HelloDynamo` class in `SampleLibraryUI`.

Upon investigation, it was found that the node view customizations were not applied for certain node models because those node models' assemblies had not been put into the `NodeModelAssemblyLoader.LoadedAssemblies` collection.   This is because the new `DynamoModel.LoadNodeLibrary` method calls `NodeModelAssemblyLoader.LoadNodesFromAssembly` method, but didn't then add the assembly to this collection or raise an event that the node was loaded.

When the `DynamoView` was later loaded and proceeded to apply the node view customizations it did so for only those assemblies that had been added to the `LoadedAssemblies` collection mentioned above. So, for any nodes loaded using the new method, customization loading was just skipped.

Because every method of node model loading eventually calls the `NodeModelAssemblyLoader.LoadNodesFromAssembly`method, in this PR I move the calls to add the assembly to the collection and raise the event inside that method.

Node view customizations now load for packages :) 
![image](https://cloud.githubusercontent.com/assets/1139788/6858307/af429df0-d3ca-11e4-9c16-9f3d16ca9a58.png)

PTAL:
- [ ] @pboyer (Because you know what I'm talkin' about.)

Requires Merge:
- [ ] RC0.8.0_master