### PR TITLE
Fix excel tests

### DIFF
--- a/test/DynamoCoreTests/AstBuildFailTest.cs
+++ b/test/DynamoCoreTests/AstBuildFailTest.cs
@@ -20,7 +20,7 @@ namespace Dynamo.Tests
             // when it is compiled to AST node. Verify the exception won't
             // crash Dynamo, and the state of node should be AstBuildBroken
             var model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\astbuilder\buildAstException.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\astbuilder\buildAstException.dyn");
             RunModel(openPath);
 
             var node = model.CurrentWorkspace.NodeFromWorkspace("c0e4b4ef-49f2-4bbc-9cbe-a8cc651ac17e");

--- a/test/DynamoCoreTests/AstBuilderTest.cs
+++ b/test/DynamoCoreTests/AstBuilderTest.cs
@@ -42,7 +42,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\astbuilder\complex.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\astbuilder\complex.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             AstBuilder builder = new AstBuilder(null);
@@ -61,7 +61,7 @@ namespace Dynamo.Tests
             //
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\astbuilder\cyclic.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\astbuilder\cyclic.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             var sortedNodes = AstBuilder.TopologicalSort(model.CurrentWorkspace.Nodes);
@@ -80,7 +80,7 @@ namespace Dynamo.Tests
             //      +----> 4
             // 
             var model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\astbuilder\multioutputs.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\astbuilder\multioutputs.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             var nodes = model.CurrentWorkspace.Nodes.ToList();
 
@@ -120,7 +120,7 @@ namespace Dynamo.Tests
             //   3 ----+
             // 
             var model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\astbuilder\multiinputs.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\astbuilder\multiinputs.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             var nodes = model.CurrentWorkspace.Nodes.ToList();
 
@@ -159,7 +159,7 @@ namespace Dynamo.Tests
             //  2 ----> 3 ----> 1
             // 
             var model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\astbuilder\tri.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\astbuilder\tri.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             var nodes = model.CurrentWorkspace.Nodes.ToList();
 
@@ -195,7 +195,7 @@ namespace Dynamo.Tests
             // 1 <---- 2 <----> 3 <---- 4
             //
             var model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\astbuilder\linear.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\astbuilder\linear.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             var nodes = model.CurrentWorkspace.Nodes.ToList();
 
@@ -239,7 +239,7 @@ namespace Dynamo.Tests
             // 
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\astbuilder\complex.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\astbuilder\complex.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             var nodes = model.CurrentWorkspace.Nodes.ToList();

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -334,7 +334,7 @@ b = c[w][x][y][z];";
         [Category("RegressionTests")]
         public void Defect_MAGN_784()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\dsevaluation\Defect_MAGN_784.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\dsevaluation\Defect_MAGN_784.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             Assert.IsFalse(ViewModel.Model.CurrentWorkspace.CanUndo);
@@ -821,7 +821,7 @@ b = c[w][x][y][z];";
         [Test]
         public void TypedIdentifier_AssignedToDifferentType_ThrowsWarning2()
         {
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
                 @"core\dsevaluation\typedIdentifier_warning.dyn");
 
             var dynamoModel = ViewModel.Model;

--- a/test/DynamoCoreTests/CoreDynTests.cs
+++ b/test/DynamoCoreTests/CoreDynTests.cs
@@ -22,7 +22,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\map_reduce_filter\map_reduce_filter.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\map_reduce_filter\map_reduce_filter.dyn");
             RunModel(openPath);
 
 
@@ -68,7 +68,7 @@ namespace Dynamo.Tests
         public void MultipleOutputs()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\multiout");
+            var examplePath = Path.Combine(TestDirectory, @"core\multiout");
 
             string openPath = Path.Combine(examplePath, "multi.dyn");
             RunModel(openPath);
@@ -87,7 +87,7 @@ namespace Dynamo.Tests
         public void PartialApplicationWithMultipleOutputs()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\multiout");
+            var examplePath = Path.Combine(TestDirectory, @"core\multiout");
 
             string openPath = Path.Combine(examplePath, "partial-multi.dyn");
             RunModel(openPath);
@@ -102,7 +102,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\sequence\sequence.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\sequence\sequence.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             // check all the nodes and connectors are loaded
@@ -126,7 +126,7 @@ namespace Dynamo.Tests
         public void Sorting()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\sorting\");
+            var examplePath = Path.Combine(TestDirectory, @"core\sorting\");
 
             string openPath = Path.Combine(examplePath, "sorting.dyn");
             ViewModel.OpenCommand.Execute(openPath);
@@ -155,7 +155,7 @@ namespace Dynamo.Tests
         public void Add()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Add.dyn");
             RunModel(openPath);
@@ -168,7 +168,7 @@ namespace Dynamo.Tests
         public void Subtract()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Subtract.dyn");
             RunModel(openPath);
@@ -181,7 +181,7 @@ namespace Dynamo.Tests
         public void Multiply()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Multiply.dyn");
             RunModel(openPath);
@@ -194,7 +194,7 @@ namespace Dynamo.Tests
         public void Divide()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Divide.dyn");
             RunModel(openPath);
@@ -207,7 +207,7 @@ namespace Dynamo.Tests
         public void Modulo()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Modulo.dyn");
             RunModel(openPath);
@@ -220,7 +220,7 @@ namespace Dynamo.Tests
         public void Ceiling()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Ceiling.dyn");
             RunModel(openPath);
@@ -233,7 +233,7 @@ namespace Dynamo.Tests
         public void Floor()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Floor.dyn");
             RunModel(openPath);
@@ -246,7 +246,7 @@ namespace Dynamo.Tests
         public void Power()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Power.dyn");
             RunModel(openPath);
@@ -259,7 +259,7 @@ namespace Dynamo.Tests
         public void Round()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Round.dyn");
             RunModel(openPath);
@@ -272,7 +272,7 @@ namespace Dynamo.Tests
         public void Sine()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Sine.dyn");
             RunModel(openPath);
@@ -285,7 +285,7 @@ namespace Dynamo.Tests
         public void Cosine()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Cosine.dyn");
             RunModel(openPath);
@@ -297,7 +297,7 @@ namespace Dynamo.Tests
         [Test]
         public void OpeningDynWithDyfMissingIsOkayAndRunsOkay()
         {
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\CASE");
+            var examplePath = Path.Combine(TestDirectory, @"core\CASE");
             string openPath = Path.Combine(examplePath, "case_flip_matrix.dyn");
 
             RunModel(openPath);
@@ -309,7 +309,7 @@ namespace Dynamo.Tests
         public void Tangent()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math");
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
 
             string openPath = Path.Combine(examplePath, "Tangent.dyn");
             RunModel(openPath);
@@ -322,7 +322,7 @@ namespace Dynamo.Tests
         public void StringInputNodeWorksWithSpecialCharacters()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core");
+            var examplePath = Path.Combine(TestDirectory, @"core");
             string openPath = Path.Combine(examplePath, "StringInputTest.dyn");
             RunModel(openPath);
 
@@ -335,7 +335,7 @@ namespace Dynamo.Tests
         [Test]
         public void Repeat()
         {
-            var examplePath = Path.Combine(GetTestDirectory(), @"core");
+            var examplePath = Path.Combine(TestDirectory, @"core");
             string openPath = Path.Combine(examplePath, "RepeatTest.dyn");
 
             //open and run the expression
@@ -356,7 +356,7 @@ namespace Dynamo.Tests
         [Test]
         public void RepeatFail()
         {
-            var examplePath = Path.Combine(GetTestDirectory(), @"core");
+            var examplePath = Path.Combine(TestDirectory, @"core");
             string openPath = Path.Combine(examplePath, "RepeatTest.dyn");
 
             //open and run the expression
@@ -375,7 +375,7 @@ namespace Dynamo.Tests
         public void ReadImageFile()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\files");
+            var examplePath = Path.Combine(TestDirectory, @"core\files");
 
             string openPath = Path.Combine(examplePath, "readImageFileTest.dyn");
             ViewModel.OpenCommand.Execute(openPath);
@@ -393,7 +393,7 @@ namespace Dynamo.Tests
         public void TestExportToCSVFile()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\files");
+            var examplePath = Path.Combine(TestDirectory, @"core\files");
 
             string openPath = Path.Combine(examplePath, "TestExportToCSVFile.dyn");
             ViewModel.OpenCommand.Execute(openPath);
@@ -418,7 +418,7 @@ namespace Dynamo.Tests
         public void TestExportToCSVFile_Negativ()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\files");
+            var examplePath = Path.Combine(TestDirectory, @"core\files");
 
             string openPath = Path.Combine(examplePath, "TestExportToCSVFile_Negative.dyn");
             ViewModel.OpenCommand.Execute(openPath);
@@ -430,7 +430,7 @@ namespace Dynamo.Tests
         public void UsingDefaultValue()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\default_values");
+            var examplePath = Path.Combine(TestDirectory, @"core\default_values");
 
             string openPath = Path.Combine(examplePath, "take-every-default.dyn");
             RunModel(openPath);
@@ -460,7 +460,7 @@ namespace Dynamo.Tests
         public void Formula()
         {
             var model = ViewModel.Model;
-            var exPath = Path.Combine(GetTestDirectory(), @"core\formula");
+            var exPath = Path.Combine(TestDirectory, @"core\formula");
 
             ViewModel.OpenCommand.Execute(Path.Combine(exPath, "formula-test.dyn"));
 
@@ -482,7 +482,7 @@ namespace Dynamo.Tests
         [Test]
         public void AndNode()
         {
-            var exPath = Path.Combine(GetTestDirectory(), @"core\customast");
+            var exPath = Path.Combine(TestDirectory, @"core\customast");
 
             RunModel(Path.Combine(exPath, @"and-test.dyn"));
 
@@ -493,7 +493,7 @@ namespace Dynamo.Tests
         public void OrNode()
         {
             var model = ViewModel.Model;
-            var exPath = Path.Combine(GetTestDirectory(), @"core\customast");
+            var exPath = Path.Combine(TestDirectory, @"core\customast");
 
             RunModel(Path.Combine(exPath, @"or-test.dyn"));
 
@@ -503,7 +503,7 @@ namespace Dynamo.Tests
         [Test]
         public void IfNode()
         {
-            var exPath = Path.Combine(GetTestDirectory(), @"core\customast");
+            var exPath = Path.Combine(TestDirectory, @"core\customast");
 
             RunModel(Path.Combine(exPath, @"if-test.dyn"));
 
@@ -514,7 +514,7 @@ namespace Dynamo.Tests
         public void PerformAllNode()
         {
             var model = ViewModel.Model;
-            var exPath = Path.Combine(GetTestDirectory(), @"core\customast");
+            var exPath = Path.Combine(TestDirectory, @"core\customast");
 
             ViewModel.OpenCommand.Execute(Path.Combine(exPath, @"begin-test.dyn"));
 
@@ -537,7 +537,7 @@ namespace Dynamo.Tests
         [Test]
         public void Constants()
         {
-            var exPath = Path.Combine(GetTestDirectory(), @"core\customast");
+            var exPath = Path.Combine(TestDirectory, @"core\customast");
 
             RunModel(Path.Combine(exPath, @"constants-test.dyn"));
 
@@ -547,7 +547,7 @@ namespace Dynamo.Tests
         [Test]
         public void Thunks()
         {
-            var exPath = Path.Combine(GetTestDirectory(), @"core\customast");
+            var exPath = Path.Combine(TestDirectory, @"core\customast");
 
             RunModel(Path.Combine(exPath, @"thunk-test.dyn"));
 
@@ -557,7 +557,7 @@ namespace Dynamo.Tests
         [Test]
         public void MultithreadingWithFutureAndNow()
         {
-            var exPath = Path.Combine(GetTestDirectory(), @"core\multithreading");
+            var exPath = Path.Combine(TestDirectory, @"core\multithreading");
 
             RunModel(Path.Combine(exPath, @"multithread-test.dyn"));
 
@@ -567,7 +567,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestNumber_RangeExpr01()
         {
-            var exPath = Path.Combine(GetTestDirectory(), @"core\number");
+            var exPath = Path.Combine(TestDirectory, @"core\number");
 
             RunModel(Path.Combine(exPath, @"TestNumber_RangeExpr01.dyn"));
 
@@ -579,7 +579,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestNumber_RangeExpr02()
         {
-            var exPath = Path.Combine(GetTestDirectory(), @"core\number");
+            var exPath = Path.Combine(TestDirectory, @"core\number");
 
             RunModel(Path.Combine(exPath, @"TestNumber_RangeExpr02.dyn"));
 
@@ -601,7 +601,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestNumber_RangeExpr03()
         {
-            var exPath = Path.Combine(GetTestDirectory(), @"core\number");
+            var exPath = Path.Combine(TestDirectory, @"core\number");
 
             RunModel(Path.Combine(exPath, @"TestNumber_RangeExpr03.dyn"));
 
@@ -613,7 +613,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestNumber_RangeExpr04()
         {
-            var exPath = Path.Combine(GetTestDirectory(), @"core\number");
+            var exPath = Path.Combine(TestDirectory, @"core\number");
 
             RunModel(Path.Combine(exPath, @"TestNumber_RangeExpr04.dyn"));
 

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -25,7 +25,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanOpenGoodFile()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\multiplicationAndAdd\multiplicationAndAdd.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\multiplicationAndAdd\multiplicationAndAdd.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             Assert.AreEqual(5, ViewModel.CurrentSpace.Nodes.Count);
@@ -375,7 +375,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestFileDirtyOnLacingChange()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\LacingTest.dyn");            
+            string openPath = Path.Combine(TestDirectory, @"core\LacingTest.dyn");            
             ViewModel.OpenCommand.Execute(openPath);
 
             WorkspaceModel workspace = ViewModel.CurrentSpace;            
@@ -608,7 +608,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanOpenDSVarArgFunctionFile()
         {
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
                 @"core\dsfunction\dsvarargfunction.dyn");
 
             var dynamoModel = ViewModel.Model;
@@ -676,7 +676,7 @@ namespace Dynamo.Tests
         [Test]
         public void NodesHaveCorrectLocationsIndpendentOfCulture()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\nodeLocationTest.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\nodeLocationTest.dyn");
 
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("es-AR");
             ViewModel.OpenCommand.Execute(openPath);

--- a/test/DynamoCoreTests/CrashProtectionTests.cs
+++ b/test/DynamoCoreTests/CrashProtectionTests.cs
@@ -33,7 +33,7 @@ namespace Dynamo.Tests
             //For files what have never been opened, HasRunWithoutCrash defaults to false 
             //    -> So, all non-marked files will open in manual even if run auto is on
 
-            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runAutoNoCrashFlag.dyn");
+            var ws = Open<HomeWorkspaceModel>(TestDirectory, crashProtDir, "runAutoNoCrashFlag.dyn");
 
             AssertManual(ws);
         }
@@ -41,7 +41,7 @@ namespace Dynamo.Tests
         [Test]
         public void RunAutoFileWithTrueFlagOpensInAuto()
         {
-            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runAutoTrueCrashFlag.dyn");
+            var ws = Open<HomeWorkspaceModel>(TestDirectory, crashProtDir, "runAutoTrueCrashFlag.dyn");
 
             AssertAuto(ws);
         }
@@ -51,7 +51,7 @@ namespace Dynamo.Tests
         public void RunAutoFileWithFalseFlagOpensInManual()
         {
             //On open file, if run auto & HasRunWithoutCrash = false, set to run manual
-            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runAutoFalseCrashFlag.dyn");
+            var ws = Open<HomeWorkspaceModel>(TestDirectory, crashProtDir, "runAutoFalseCrashFlag.dyn");
 
             AssertManual(ws);
         }
@@ -60,7 +60,7 @@ namespace Dynamo.Tests
         public void RunAutoFileWithSuccessfulRunSavesFlag()
         {
             //On save, if run auto & HasRunWithoutCrash = true, this should be saved
-            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runAutoFalseCrashFlag.dyn");
+            var ws = Open<HomeWorkspaceModel>(TestDirectory, crashProtDir, "runAutoFalseCrashFlag.dyn");
 
             // We do a run so HasRunWithoutCrash is set to true.  Otherwise, the test
             // assertion is not valid.
@@ -88,7 +88,7 @@ namespace Dynamo.Tests
             //On run start, HasRunWithoutCrash = false
             //    - This makes sure that if the user has modifies the file during a run that causes a crash, there 
             //        file is not erroneously marked as having run without crash. 
-            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runManual.dyn");
+            var ws = Open<HomeWorkspaceModel>(TestDirectory, crashProtDir, "runManual.dyn");
 
             // We do a run so HasRunWithoutCrash is set to true.  Otherwise, the test
             // assertion is not valid.
@@ -125,7 +125,7 @@ namespace Dynamo.Tests
         public void FlagIsSetToTrueAfterRunSuccessfullyCompletes()
         {
             //On run complete, HasRunWithoutCrash = true
-            var ws = Open<HomeWorkspaceModel>(GetTestDirectory(), crashProtDir, "runManual.dyn");
+            var ws = Open<HomeWorkspaceModel>(TestDirectory, crashProtDir, "runManual.dyn");
 
             Assert.False(ws.HasRunWithoutCrash);
 

--- a/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
+++ b/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
@@ -13,7 +13,7 @@ namespace Dynamo.Tests
     {
         public void OpenTestFile(string folder, string fileName)
         {
-            var examplePath = Path.Combine(GetTestDirectory(), folder, fileName);
+            var examplePath = Path.Combine(TestDirectory, folder, fileName);
             ViewModel.OpenCommand.Execute(examplePath);
         }
 
@@ -46,7 +46,7 @@ namespace Dynamo.Tests
         public void CanOpenCustomNodeWorkspace()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\combine", "Sequence2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\combine", "Sequence2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
             var nodeWorkspace = model.Workspaces.FirstOrDefault(x => x is CustomNodeWorkspaceModel);
@@ -57,7 +57,7 @@ namespace Dynamo.Tests
         [Test]
         public void CustomNodeWorkspaceIsAddedToSearchOnOpening()
         {
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\combine", "Sequence2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\combine", "Sequence2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
             
             var res = ViewModel.Model.SearchModel.Search("Sequence2");

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -25,7 +25,7 @@ namespace Dynamo.Tests
         public void CanCollapseNodesAndGetSameResult()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\collapse\");
+            var examplePath = Path.Combine(TestDirectory, @"core\collapse\");
 
             string openPath = Path.Combine(examplePath, "collapse.dyn");
             ViewModel.OpenCommand.Execute(openPath);
@@ -81,7 +81,7 @@ namespace Dynamo.Tests
         public void CanCollapseNodesWithDefaultValues()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\collapse\");
+            var examplePath = Path.Combine(TestDirectory, @"core\collapse\");
 
             string openPath = Path.Combine(examplePath, "collapse-defaults.dyn");
             RunModel(openPath);
@@ -127,7 +127,7 @@ namespace Dynamo.Tests
         {
         //   http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5603
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\collapse\");
+            var examplePath = Path.Combine(TestDirectory, @"core\collapse\");
 
             string openPath = Path.Combine(examplePath, "collapse-function.dyn");
             RunModel(openPath);
@@ -171,7 +171,7 @@ namespace Dynamo.Tests
         public void CanCollapseAndUndoRedo()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\collapse\");
+            var examplePath = Path.Combine(TestDirectory, @"core\collapse\");
             ViewModel.OpenCommand.Execute(Path.Combine(examplePath, "collapse-number-chain.dyn"));
 
             // Ensure all the nodes we are looking for are actually there.
@@ -295,7 +295,7 @@ namespace Dynamo.Tests
         public void GitHub_461_DeleteNodesFromCustomNodeWorkspaceAfterCollapse()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\collapse\");
+            var examplePath = Path.Combine(TestDirectory, @"core\collapse\");
 
             string openPath = Path.Combine(examplePath, "collapse.dyn");
             ViewModel.OpenCommand.Execute(openPath);
@@ -346,7 +346,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\reduce_and_recursion\");
+            var examplePath = Path.Combine(TestDirectory, @"core\reduce_and_recursion\");
 
             string openPath = Path.Combine(examplePath, "reduce-example.dyn");
             ViewModel.OpenCommand.Execute(openPath);
@@ -371,7 +371,7 @@ namespace Dynamo.Tests
         public void FilterWithCustomNode()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\filter\");
+            var examplePath = Path.Combine(TestDirectory, @"core\filter\");
 
             CustomNodeInfo info;
             Assert.IsTrue(ViewModel.Model.CustomNodeManager.AddUninitializedCustomNode(Path.Combine(examplePath, "IsOdd.dyf"), true, out info));
@@ -406,7 +406,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanEvaluateCustomNodeWithDuplicateInputs()
         {
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\duplicate-input.dyn");
+            var examplePath = Path.Combine(TestDirectory, @"core\CustomNodes\duplicate-input.dyn");
             ViewModel.OpenCommand.Execute(examplePath);
             ViewModel.HomeSpace.Run();
 
@@ -574,7 +574,7 @@ namespace Dynamo.Tests
         public void MultipleOutputs()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\multiout");
+            var examplePath = Path.Combine(TestDirectory, @"core\multiout");
 
             string openPath = Path.Combine(examplePath, "multi-custom.dyn");
             ViewModel.OpenCommand.Execute(openPath);
@@ -601,7 +601,7 @@ namespace Dynamo.Tests
         public void PartialApplicationWithMultipleOutputs()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\multiout");
+            var examplePath = Path.Combine(TestDirectory, @"core\multiout");
 
             string openPath = Path.Combine(examplePath, "partial-multi-custom.dyn");
             ViewModel.OpenCommand.Execute(openPath);
@@ -662,7 +662,7 @@ namespace Dynamo.Tests
         public void CollapsedNodeShouldHaveNewIdentfifer()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\collapse\");
+            var examplePath = Path.Combine(TestDirectory, @"core\collapse\");
             ViewModel.OpenCommand.Execute(Path.Combine(examplePath, "collapse-newname.dyn"));
 
             // Convert a DSFunction node Point.ByCoordinates to custom node.
@@ -710,7 +710,7 @@ namespace Dynamo.Tests
             // Dyn file contains a proxy custom node. Evaluating the whole graph
             // should evaluate all nodes except those proxy custom node instance. 
             var model = ViewModel.Model;
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\missing_custom_node.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\CustomNodes\missing_custom_node.dyn");
 
             ViewModel.OpenCommand.Execute(dynFilePath);
             ViewModel.HomeSpace.Run();
@@ -725,7 +725,7 @@ namespace Dynamo.Tests
             // Custom node's signature is add(x:int, y:int)
             // Test type conversion happens.
             var model = ViewModel.Model;
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\TestTypeConversion.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\CustomNodes\TestTypeConversion.dyn");
 
             ViewModel.OpenCommand.Execute(dynFilePath);
             ViewModel.HomeSpace.Run();
@@ -739,7 +739,7 @@ namespace Dynamo.Tests
         {
             // Test lacing works ofr custom node. 
             var model = ViewModel.Model;
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\TestLacing.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\CustomNodes\TestLacing.dyn");
             ViewModel.OpenCommand.Execute(dynFilePath);
             
             var instance = model.CurrentWorkspace.Nodes.OfType<Function>().First();
@@ -760,7 +760,7 @@ namespace Dynamo.Tests
         {
             // Test custom node default value works
             var model = ViewModel.Model;
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\TestDefaultValue.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\CustomNodes\TestDefaultValue.dyn");
 
             ViewModel.OpenCommand.Execute(dynFilePath);
             ViewModel.HomeSpace.Run();
@@ -773,7 +773,7 @@ namespace Dynamo.Tests
         {
             // Custom node has invalid type, which should be captured by Input node
             var model = ViewModel.Model;
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\invalidType.dyf");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\CustomNodes\invalidType.dyf");
 
             ViewModel.OpenCommand.Execute(dynFilePath);
 
@@ -787,7 +787,7 @@ namespace Dynamo.Tests
             // Custom node has invalid input like "x = f(x)", but the evalution should continue
             // so that old custom node won't be broken
             var model = ViewModel.Model;
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\TestInvalidInput.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\CustomNodes\TestInvalidInput.dyn");
             ViewModel.OpenCommand.Execute(dynFilePath);
             ViewModel.HomeSpace.Run();
 
@@ -799,7 +799,7 @@ namespace Dynamo.Tests
         public void TestCustomNodeFromCollapsedNodeHasTypes()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\");
+            var examplePath = Path.Combine(TestDirectory, @"core\CustomNodes\");
             ViewModel.OpenCommand.Execute(Path.Combine(examplePath, "simpleGeometry.dyn"));
 
             // Convert a DSFunction node Line.ByStartPointEndPoint to custom node.
@@ -828,7 +828,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestCustomNodeInSyncWithDefinition()
         {
-            var basePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\");
+            var basePath = Path.Combine(TestDirectory, @"core\CustomNodes\");
 
             var model = ViewModel.Model;
             ViewModel.OpenCommand.Execute(Path.Combine(basePath, "testCustomNodeSync.dyn"));

--- a/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
@@ -14,13 +14,13 @@ namespace Dynamo.Tests
     {
         public void OpenModel(string relativeFilePath)
         {
-            string openPath = Path.Combine(GetTestDirectory(), relativeFilePath);
+            string openPath = Path.Combine(TestDirectory, relativeFilePath);
             ViewModel.OpenCommand.Execute(openPath);
         }
 
         public void OpenSampleModel(string relativeFilePath)
         {
-            string openPath = Path.Combine(GetSampleDirectory(), relativeFilePath);
+            string openPath = Path.Combine(SampleDirectory, relativeFilePath);
             ViewModel.OpenCommand.Execute(openPath);
         }
 
@@ -1047,7 +1047,7 @@ namespace Dynamo.Tests
         {
             // Regression test case for
             // http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5233
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\default_values\defaultValueInFunctionObject.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\default_values\defaultValueInFunctionObject.dyn");
 
             RunModel(dynFilePath);
 
@@ -1061,7 +1061,7 @@ namespace Dynamo.Tests
             //http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3132
             // test for run time warning is thrown or not 
 
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\dsfunction\RunTimeWarning_3132.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\dsfunction\RunTimeWarning_3132.dyn");
 
             RunModel(dynFilePath);
             var guid = System.Guid.Parse("88f376fa-634b-422e-b853-6afa8af8d286");
@@ -1076,7 +1076,7 @@ namespace Dynamo.Tests
             //http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5233
             //List.map with default arguments 
 
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\list\List_Map_DefaultArg5233.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\list\List_Map_DefaultArg5233.dyn");
             RunModel(dynFilePath);
             AssertPreviewValue("6a0207d9-78d7-4fd3-829f-d19644acdc1b", new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
         }
@@ -1084,7 +1084,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestListCombineRegress5561()
         {
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\dsevaluation\regress5561.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\dsevaluation\regress5561.dyn");
             RunModel(dynFilePath);
             AssertPreviewValue("4fb0a4ef-8151-4e5f-a2e6-9c3fcd2c1e8f", new object[] { "1foo", null });
         }
@@ -1092,7 +1092,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestMod()
         {
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\dsfunction\modDoesntWork.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\dsfunction\modDoesntWork.dyn");
             RunModel(dynFilePath);
             AssertPreviewValue("77c95ace-e4f1-4119-87fc-7163f9b3b8b0", true);
             AssertPreviewValue("21f58def-725d-41c9-abc7-063cc3642420", true);
@@ -1102,7 +1102,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestDefaultValueAttribute()
         {
-            var dynFilePath = Path.Combine(GetTestDirectory(),
+            var dynFilePath = Path.Combine(TestDirectory,
                 @"core\default_values\defaultValueAttributeTest.dyn");
 
             RunModel(dynFilePath);
@@ -1116,7 +1116,7 @@ namespace Dynamo.Tests
             // DefaultArgumentAttribute is invalid. In this case, we should make sure that
             // no default argument is used, even null. So this function should be compiled to
             // a function object and Apply() should work on it. 
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\default_values\invalidDefaultArgument.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\default_values\invalidDefaultArgument.dyn");
             RunModel(dynFilePath);
             AssertPreviewValue("1b2fa812-960d-424c-b679-8b850abe2e26", 12);
         }
@@ -1124,7 +1124,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestDefaultValueAttributeForDummyLine()
         {
-            var dynFilePath = Path.Combine(GetTestDirectory(), 
+            var dynFilePath = Path.Combine(TestDirectory, 
                 @"core\default_values\defaultValueAttributeForDummyLine.dyn");
 
             RunModel(dynFilePath);
@@ -1139,7 +1139,7 @@ namespace Dynamo.Tests
         public void CustomNodeNoInput01()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\");
+            var examplePath = Path.Combine(TestDirectory, @"core\CustomNodes\");
 
             CustomNodeInfo info;
             Assert.IsTrue(
@@ -1164,7 +1164,7 @@ namespace Dynamo.Tests
         public void CustomNodeWithInput02()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\");
+            var examplePath = Path.Combine(TestDirectory, @"core\CustomNodes\");
 
             CustomNodeInfo info;
             Assert.IsTrue(
@@ -1186,7 +1186,7 @@ namespace Dynamo.Tests
         [Test]
         public void CustomNodeWithCBNAndGeometry()
         {
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\");
+            var examplePath = Path.Combine(TestDirectory, @"core\CustomNodes\");
 
             CustomNodeInfo info;
             Assert.IsTrue(
@@ -1206,7 +1206,7 @@ namespace Dynamo.Tests
         [Test]
         public void CustomNodeMultipleInGraph()
         {
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\");
+            var examplePath = Path.Combine(TestDirectory, @"core\CustomNodes\");
 
             var dyfPath = Path.Combine(examplePath, "Poly.dyf");
             CustomNodeInfo info;
@@ -1222,7 +1222,7 @@ namespace Dynamo.Tests
         [Test]
         public void CustomNodeConditional()
         {
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\");
+            var examplePath = Path.Combine(TestDirectory, @"core\CustomNodes\");
 
             CustomNodeInfo info;
             Assert.IsTrue(
@@ -1247,7 +1247,7 @@ namespace Dynamo.Tests
             // which cannot be found, so foo.dyf would be a proxy custom node,
             // as opening a dyn file will compile all custom nodes, the 
             // compilation of that proxy custom node should have any problem.
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\");
+            var examplePath = Path.Combine(TestDirectory, @"core\CustomNodes\");
 
             CustomNodeInfo info;
             Assert.IsTrue(
@@ -1264,7 +1264,7 @@ namespace Dynamo.Tests
             // Test nested custom node: run and reset engine and re-run.
             // Original defect: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4837
 
-            var dynFilePath = Path.Combine(GetTestDirectory(), @"core\CustomNodes\Regress_Magn_4837.dyn");
+            var dynFilePath = Path.Combine(TestDirectory, @"core\CustomNodes\Regress_Magn_4837.dyn");
 
             RunModel(dynFilePath);
  

--- a/test/DynamoCoreTests/DSFunctionNodeTest.cs
+++ b/test/DynamoCoreTests/DSFunctionNodeTest.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\dsfunction\dsfunctions.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\dsfunction\dsfunctions.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             
             // check all the nodes and connectors are loaded
@@ -32,7 +32,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\dsfunction\add.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\dsfunction\add.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             Assert.DoesNotThrow(() => ViewModel.HomeSpace.Run());
@@ -52,7 +52,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\dsfunction\abs.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\dsfunction\abs.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             Assert.DoesNotThrow(() => ViewModel.HomeSpace.Run());
@@ -80,7 +80,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\dsfunction\count.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\dsfunction\count.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             Assert.DoesNotThrow(() => ViewModel.HomeSpace.Run());
@@ -101,7 +101,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\dsfunction\GetKeys.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\dsfunction\GetKeys.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             // no crash

--- a/test/DynamoCoreTests/DSLibraryTest.cs
+++ b/test/DynamoCoreTests/DSLibraryTest.cs
@@ -37,7 +37,7 @@ namespace Dynamo.Tests
             libraryServices.LibraryLoaded += (sender, e) => libraryLoaded = true;
             libraryServices.LibraryLoadFailed += (sender, e) => Assert.Fail("Failed to load library: " + e.LibraryPath); 
 
-            string libraryPath = Path.Combine(GetTestDirectory(), @"core\library\Dummy.ds");
+            string libraryPath = Path.Combine(TestDirectory, @"core\library\Dummy.ds");
             libraryServices.ImportLibrary(libraryPath);
             Assert.IsTrue(libraryLoaded);
 
@@ -54,7 +54,7 @@ namespace Dynamo.Tests
             libraryServices.LibraryLoaded += (sender, e) => libraryLoaded = true;
 
             // library should be able to load
-            string libraryPath = Path.Combine(GetTestDirectory(), @"core\library\Test.ds");
+            string libraryPath = Path.Combine(TestDirectory, @"core\library\Test.ds");
             libraryServices.ImportLibrary(libraryPath);
             Assert.IsTrue(libraryLoaded);
 

--- a/test/DynamoCoreTests/DynamoDefects.cs
+++ b/test/DynamoCoreTests/DynamoDefects.cs
@@ -22,7 +22,7 @@ namespace Dynamo.Tests
         [Test, Category("RegressionTests")]
         public void T01_Defect_MAGN_110()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_110.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_110.dyn");
             RunModel(openPath);
             Dictionary<int, object> validationData = new Dictionary<int, object>()
             {
@@ -35,7 +35,7 @@ namespace Dynamo.Tests
         [Test, Category("RegressionTests")]
         public void Defect_MAGN_942_Equal()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_942_Equal.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_942_Equal.dyn");
             RunModel(openPath);
 
             Dictionary<int, object> validationData = new Dictionary<int, object>()
@@ -52,7 +52,7 @@ namespace Dynamo.Tests
         public void Defect_MAGN_942_GreaterThan()
         {
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_942_GreaterThan.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_942_GreaterThan.dyn");
             RunModel(openPath);
 
             Dictionary<int, object> validationData = new Dictionary<int, object>()
@@ -70,7 +70,7 @@ namespace Dynamo.Tests
         [Test, Category("RegressionTests")]
         public void Defect_MAGN_942_GreaterThanOrEqual()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_942_GreaterThanOrEqual.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_942_GreaterThanOrEqual.dyn");
             RunModel(openPath);
 
             Dictionary<int, object> validationData = new Dictionary<int, object>()
@@ -89,7 +89,7 @@ namespace Dynamo.Tests
         public void Defect_MAGN_942_LessThan()
         {
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_942_LessThan.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_942_LessThan.dyn");
             RunModel(openPath);
 
             AssertPreviewValue("7ec8271d-be03-4d53-ae78-b94c4db484e1", new int[] { 1, 1, 1, 1, 1 });
@@ -98,7 +98,7 @@ namespace Dynamo.Tests
         [Test, Category("RegressionTests")]
         public void Defect_MAGN_942_LessThanOrEqual()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_942_LessThanOrEqual.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_942_LessThanOrEqual.dyn");
             RunModel(openPath);
 
             AssertPreviewValue("6adba162-ef10-4664-9c9c-d0280a56a52a", new int[] { 0, 1, 1, 1, 0, 1 });
@@ -110,7 +110,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1206
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_1206.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_1206.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             ViewModel.HomeSpace.Run();
@@ -124,7 +124,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2566
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_2566.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_2566.dyn");
             RunModel(openPath);
 
              // check all the nodes and connectors are loaded
@@ -152,7 +152,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3256
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_3256.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_3256.dyn");
             RunModel(openPath);
 
             // check all the nodes and connectors are loaded
@@ -170,7 +170,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3646
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_3646.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_3646.dyn");
             RunModel(openPath);
 
             // check all the nodes and connectors are loaded
@@ -189,7 +189,7 @@ namespace Dynamo.Tests
             // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3648
 
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_3648.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_3648.dyn");
 
             OpenModel(openPath);
 
@@ -214,7 +214,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2169
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_2169.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_2169.dyn");
             RunModel(openPath);
             var cbn = model.CurrentWorkspace.NodeFromWorkspace
                 ("ff354c76-cbcc-4903-a88a-89184905dba0");
@@ -228,7 +228,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3468
             var model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_3468.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_3468.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             Assert.DoesNotThrow(() => ViewModel.HomeSpace.Run());
@@ -239,7 +239,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2264
             var model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_2264.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_2264.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             Assert.DoesNotThrow(() => ViewModel.HomeSpace.Run());
@@ -250,7 +250,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1292
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_1292.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_1292.dyn");
             RunModel(openPath);
             var listContainsItemNode = model.CurrentWorkspace.NodeFromWorkspace
                 ("3011fcbe-00d5-42e6-84c8-55bdf38b6a3b");
@@ -264,7 +264,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1905
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_1905.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_1905.dyn");
             RunModel(openPath);
             AssertPreviewValue("c4b9077d-3e6c-40b9-a715-078083e29655", 11);
             BoolSelector b = model.CurrentWorkspace.NodeFromWorkspace
@@ -279,7 +279,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3726
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_3726.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_3726.dyn");
             RunModel(openPath);
 
             // check all the nodes and connectors are loaded
@@ -297,7 +297,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-847
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_847.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_847.dyn");
             RunModel(openPath);
             AssertPreviewCount("2ea813c4-7729-45b5-b23b-d7a3377f0b31", 4);
             DoubleInput doubleInput = model.CurrentWorkspace.NodeFromWorkspace
@@ -313,7 +313,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3548
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_3548.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_3548.dyn");
             RunModel(openPath);
             var point = model.CurrentWorkspace.NodeFromWorkspace
                 ("a3da7834-f56f-4e73-b8f1-56796b6c37b3");
@@ -327,7 +327,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4105
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_4105.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_4105.dyn");
             RunModel(openPath);
             AssertPreviewCount("1499d976-e7d5-486f-89bf-bc050eac4489", 4);
         }
@@ -337,7 +337,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2555
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_2555.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_2555.dyn");
             RunModel(openPath);
             var geometryTranslateNode = model.CurrentWorkspace.NodeFromWorkspace
                 ("f49e3857-2a08-4a1f-83ac-89f64b24a592");
@@ -351,7 +351,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1971
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_1971.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_1971.dyn");
             RunModel(openPath);
             var pythonNode = model.CurrentWorkspace.NodeFromWorkspace
                 ("768780b5-0902-4756-93dc-2d6a8690df53");
@@ -365,7 +365,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4046
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_4046.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_4046.dyn");
             RunModel(openPath);
             AssertPreviewCount("354ec30b-b13f-4399-beb2-a68753c09bfc", 1);
             IntegerSlider integerInput = model.CurrentWorkspace.NodeFromWorkspace
@@ -383,7 +383,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3998
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_3998.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_3998.dyn");
             RunModel(openPath);
             AssertPreviewCount("7e825844-c428-4067-a916-11ff14bc0715", 100);
         }
@@ -392,7 +392,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2607
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_2607.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_2607.dyn");
             RunModel(openPath);
             AssertPreviewValue("99975a42-f887-4b99-9b0a-e36513d2bd6d", 12);
             IntegerSlider input = model.CurrentWorkspace.NodeFromWorkspace
@@ -407,7 +407,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1968
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_1968.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_1968.dyn");
             RunModel(openPath);
             int[] listResult = new int[] { 0, 1, 2 };
             AssertPreviewValue("522e092c-4493-4959-9b89-a02d045070cc", listResult);
@@ -418,7 +418,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4364
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Defect_MAGN_4364.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Defect_MAGN_4364.dyn");
 
             RunModel(openPath);
 
@@ -452,7 +452,7 @@ namespace Dynamo.Tests
             // http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3420
             
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\Bool_Case_3420.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\Bool_Case_3420.dyn");
             RunModel(openPath);
             
             
@@ -471,7 +471,7 @@ namespace Dynamo.Tests
             // http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5173
             
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\DynamoDefects\VMFailOnCBN_5173.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\DynamoDefects\VMFailOnCBN_5173.dyn");
             Assert.DoesNotThrow(() => ViewModel.HomeSpace.Run());
 
             
@@ -482,7 +482,7 @@ namespace Dynamo.Tests
         {
             //Detail steps are here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5561
             DynamoModel model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), 
+            string openPath = Path.Combine(TestDirectory, 
                         @"core\DynamoDefects\5561_ListCombineCrash_AddingArrayToSingleItem.dyn");
             RunModel(openPath);
 

--- a/test/DynamoCoreTests/ExecutionIntervalTests.cs
+++ b/test/DynamoCoreTests/ExecutionIntervalTests.cs
@@ -17,7 +17,7 @@ namespace Dynamo.Tests
         {
             Assert.Inconclusive("To be fixed once Execution Interval is implemented.");
 
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\executioninterval\");
+            var examplePath = Path.Combine(TestDirectory, @"core\executioninterval\");
 
             string openPath = Path.Combine(examplePath, "pause.dyn");
             ViewModel.OpenCommand.Execute(openPath);

--- a/test/DynamoCoreTests/FileReading.cs
+++ b/test/DynamoCoreTests/FileReading.cs
@@ -10,8 +10,8 @@ namespace Dynamo.Tests
     [TestFixture]
     class FileReadingTests : DynamoViewModelUnitTest
     {
-        string localDynamoStringTestFloder { get { return Path.Combine(GetTestDirectory(), "core", "files"); } }
-        string localDynamoFileTestFloder { get { return Path.Combine(GetTestDirectory(), "core", "files", "future files"); } }
+        string localDynamoStringTestFloder { get { return Path.Combine(TestDirectory, "core", "files"); } }
+        string localDynamoFileTestFloder { get { return Path.Combine(TestDirectory, "core", "files", "future files"); } }
 
         [Test]
         public void CanOpenADynFileFromBefore6_0()

--- a/test/DynamoCoreTests/LibraryCustomizationTests.cs
+++ b/test/DynamoCoreTests/LibraryCustomizationTests.cs
@@ -14,7 +14,7 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void CanLoadValidLibraryCustomization()
         {
-            var fn = Path.Combine(GetTestDirectory(), @"core/library/ProtoGeometry.dll");
+            var fn = Path.Combine(TestDirectory, @"core/library/ProtoGeometry.dll");
 
             var c = LibraryCustomizationServices.GetForAssembly(fn, pathManager: null);
             Assert.NotNull(c);

--- a/test/DynamoCoreTests/MessageLogTests.cs
+++ b/test/DynamoCoreTests/MessageLogTests.cs
@@ -18,7 +18,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestWarningMessageLog()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\messagelog\testwarningmessage.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\messagelog\testwarningmessage.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             ViewModel.HomeSpace.Run();
 

--- a/test/DynamoCoreTests/NodeMigrationTests.cs
+++ b/test/DynamoCoreTests/NodeMigrationTests.cs
@@ -1993,7 +1993,7 @@ namespace Dynamo.Tests
         public void TestSaveDontCorruptForUnresolvedNodes()
         {
             var model = ViewModel.Model;
-            var exPath = Path.Combine(GetTestDirectory(), @"core\migration");
+            var exPath = Path.Combine(TestDirectory, @"core\migration");
             var oldPath = Path.Combine(exPath, @"TestSaveDontCorruptForUnresolvedNodes.dyn");
             OpenModel(oldPath);
 
@@ -2033,7 +2033,7 @@ namespace Dynamo.Tests
         public void TestSaveDontCorruptForDeprecatedNodes()
         {
             var model = ViewModel.Model;
-            var exPath = Path.Combine(GetTestDirectory(), @"core\migration");
+            var exPath = Path.Combine(TestDirectory, @"core\migration");
             var oldPath = Path.Combine(exPath, @"TestSaveDontCorruptForDeprecatedNodes.dyn");
             OpenModel(oldPath);
 
@@ -2068,7 +2068,7 @@ namespace Dynamo.Tests
 
         private string GetDynPath(string sourceDynFile)
         {
-            string sourceDynPath = this.GetTestDirectory();
+            string sourceDynPath = this.TestDirectory;
             sourceDynPath = Path.Combine(sourceDynPath, @"core\migration\");
             return Path.Combine(sourceDynPath, sourceDynFile);
         }

--- a/test/DynamoCoreTests/Nodes/FormulaTests.cs
+++ b/test/DynamoCoreTests/Nodes/FormulaTests.cs
@@ -17,7 +17,7 @@ namespace Dynamo.Tests
         [Test]
         public void FormulaWithIf()
         {
-            string path = Path.Combine(GetTestDirectory(), "core", "formula", "formula-if.dyn");
+            string path = Path.Combine(TestDirectory, "core", "formula", "formula-if.dyn");
             RunModel(path);
 
             var node = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<Formula>();

--- a/test/DynamoCoreTests/Nodes/HigherOrder.cs
+++ b/test/DynamoCoreTests/Nodes/HigherOrder.cs
@@ -13,7 +13,7 @@ namespace Dynamo.Tests
 {
     public class HigherOrder : DSEvaluationViewModelUnitTest
     {
-        string TestFolder { get { return GetTestDirectory(); } }
+        string TestFolder { get { return TestDirectory; } }
 
         [Test]
         public void ComposeOrder()

--- a/test/DynamoCoreTests/Nodes/IfTest.cs
+++ b/test/DynamoCoreTests/Nodes/IfTest.cs
@@ -12,7 +12,7 @@ namespace Dynamo.Tests
     [TestFixture]
     class IfTest : DSEvaluationViewModelUnitTest
     {
-        string testFolder { get { return Path.Combine(GetTestDirectory(), "core", "logic", "conditional"); } }
+        string testFolder { get { return Path.Combine(TestDirectory, "core", "logic", "conditional"); } }
 
         [Test]
         public void TestIFBasic()

--- a/test/DynamoCoreTests/Nodes/ListTests.cs
+++ b/test/DynamoCoreTests/Nodes/ListTests.cs
@@ -12,7 +12,7 @@ namespace Dynamo.Tests
 {
 	class ListTests : DSEvaluationViewModelUnitTest
 	{
-		string listTestFolder { get { return Path.Combine(GetTestDirectory(), "core", "list"); } }
+		string listTestFolder { get { return Path.Combine(TestDirectory, "core", "list"); } }
 
 		#region Test Build Sublist  
 
@@ -576,7 +576,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Sort_NumbersfFromDiffInput.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Sort_NumbersfFromDiffInput.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -606,7 +606,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Sort_SimpleNumbers.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Sort_SimpleNumbers.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -637,7 +637,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Sort_Strings&Numbers.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Sort_Strings&Numbers.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -653,7 +653,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Sort_Strings.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Sort_Strings.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -685,7 +685,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\SortBy_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\SortBy_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -719,7 +719,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Reverse_ListWithOneNumber.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Reverse_ListWithOneNumber.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -736,7 +736,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Reverse_MixedList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Reverse_MixedList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -765,7 +765,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Reverse_NumberRange.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Reverse_NumberRange.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -797,7 +797,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Reverse_UsingStringList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Reverse_UsingStringList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -829,7 +829,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Reverse_WithArrayInput.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Reverse_WithArrayInput.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -857,7 +857,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Reverse_WithSingleInput.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Reverse_WithSingleInput.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -897,7 +897,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Filter_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Filter_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -928,7 +928,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Filter_NegativeTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Filter_NegativeTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -952,7 +952,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Filter_Complex.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Filter_Complex.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -995,7 +995,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\LaceShortest_Simple.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\LaceShortest_Simple.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1044,7 +1044,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\LaceShortest_NegativeInput.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\LaceShortest_NegativeInput.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1055,7 +1055,7 @@ namespace Dynamo.Tests
 		[Test]
 		public void LaceShortest_StringInput()
 		{
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\LaceShortest_StringInput.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\LaceShortest_StringInput.dyn");
 			RunModel(openPath);
 
 			// Elements from first LaceShortest list
@@ -1075,7 +1075,7 @@ namespace Dynamo.Tests
 			// details are given in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2464
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\LaceShortest_WithSingleValueInput.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\LaceShortest_WithSingleValueInput.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1100,7 +1100,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\LaceLongest_Simple.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\LaceLongest_Simple.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1119,7 +1119,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\LaceLongest_Negative.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\LaceLongest_Negative.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1133,7 +1133,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\LaceLongest_ListWith10000Element.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\LaceLongest_ListWith10000Element.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1157,7 +1157,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\FilterOut_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\FilterOut_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// Elements from first FilterOut list
@@ -1183,7 +1183,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\FilterOut_Complex.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\FilterOut_Complex.dyn");
 			RunModel(openPath);
 
 			// Elements from Take from List
@@ -1206,7 +1206,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\FilterOut_NegativeTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\FilterOut_NegativeTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1225,7 +1225,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\NumberRange_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\NumberRange_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1248,7 +1248,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\NumberRange_LargeNumber.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\NumberRange_LargeNumber.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1268,7 +1268,7 @@ namespace Dynamo.Tests
 		[Test]
 		public void NumberRange_LacingShortest()
 		{
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\NumberRange_LacingShortest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\NumberRange_LacingShortest.dyn");
 			RunModel(openPath);
 
             AssertPreviewValue("4e781f03-5b48-4d58-a511-8c732665e961",
@@ -1284,7 +1284,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\NumberRange_LacingLongest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\NumberRange_LacingLongest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1310,7 +1310,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\NumberRange_LacingCrossProduct.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\NumberRange_LacingCrossProduct.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1359,7 +1359,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\ListMaximumMinimum_WithAndWithoutKey.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\ListMaximumMinimum_WithAndWithoutKey.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1390,7 +1390,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\ListMinimum_NumberRange.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\ListMinimum_NumberRange.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1406,7 +1406,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\ListMinimum_Complex.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\ListMinimum_Complex.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1426,7 +1426,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\AddToList_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\AddToList_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1453,7 +1453,7 @@ namespace Dynamo.Tests
         [Test]
         public void AddToList_EmptyList()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\list\AddToList_EmptyList.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\list\AddToList_EmptyList.dyn");
             RunModel(openPath);
 
             AssertPreviewValue("1976caa7-d45e-4a44-9faf-345d98337bbb", new[] { new object[] { string.Empty, 0 } });
@@ -1462,7 +1462,7 @@ namespace Dynamo.Tests
         [Test]
         public void AddToList_Complex()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\list\AddToList_Complex.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\list\AddToList_Complex.dyn");
             RunModel(openPath);
 
             AssertPreviewValue(
@@ -1475,7 +1475,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\AddToList_GeometryToList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\AddToList_GeometryToList.dyn");
 			RunModel(openPath);
 
 			// run the expression
@@ -1495,7 +1495,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\AddToList_Negative.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\AddToList_Negative.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1509,7 +1509,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\AddToList_ContainingNull.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\AddToList_ContainingNull.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1528,7 +1528,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\SplitList_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\SplitList_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1545,7 +1545,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\SplitList_FirstElementAsList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\SplitList_FirstElementAsList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1564,7 +1564,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\SplitList_Complex.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\SplitList_Complex.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1584,7 +1584,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\SplitList_ComplexAnotherExample.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\SplitList_ComplexAnotherExample.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1625,7 +1625,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\TakeFromList_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\TakeFromList_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1654,7 +1654,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\TakeFromList_WithStringList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\TakeFromList_WithStringList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1672,7 +1672,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\TakeFromList_NegativeIntValue.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\TakeFromList_NegativeIntValue.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1688,7 +1688,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\TakeFromList_InputEmptyList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\TakeFromList_InputEmptyList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1702,7 +1702,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\TakeFromList_AmtAsRangeExpn.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\TakeFromList_AmtAsRangeExpn.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1719,7 +1719,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\DropFromList_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\DropFromList_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1746,7 +1746,7 @@ namespace Dynamo.Tests
 
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\DropFromList_InputEmptyList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\DropFromList_InputEmptyList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1763,7 +1763,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\ShiftListIndeces_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\ShiftListIndeces_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1782,7 +1782,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\ShiftListIndeces_Complex.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\ShiftListIndeces_Complex.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1815,7 +1815,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\ShiftListIndeces_InputEmptyList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\ShiftListIndeces_InputEmptyList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1830,7 +1830,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\ShiftListIndeces_InputStringAsAmt.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\ShiftListIndeces_InputStringAsAmt.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1844,7 +1844,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\ShiftListIndeces_MultipleInput.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\ShiftListIndeces_MultipleInput.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1869,7 +1869,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\GetFromList_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\GetFromList_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1884,7 +1884,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\GetFromList_WithStringList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\GetFromList_WithStringList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1899,7 +1899,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\GetFromList_AmtAsRangeExpn.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\GetFromList_AmtAsRangeExpn.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1924,7 +1924,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\GetFromList_InputEmptyList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\GetFromList_InputEmptyList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1938,7 +1938,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\GetFromList_Negative.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\GetFromList_Negative.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1951,7 +1951,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\GetFromList_NegativeIntValue.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\GetFromList_NegativeIntValue.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1969,7 +1969,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\TakeEveryNth_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\TakeEveryNth_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1984,7 +1984,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\TakeEveryNth_Complex.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\TakeEveryNth_Complex.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -1999,7 +1999,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\TakeEveryNth_InputEmptyList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\TakeEveryNth_InputEmptyList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2014,7 +2014,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\TakeEveryNth_NegativeTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\TakeEveryNth_NegativeTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2033,7 +2033,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\DropEveryNth_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\DropEveryNth_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2048,7 +2048,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\DropEveryNth_ComplexTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\DropEveryNth_ComplexTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2079,7 +2079,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\DropEveryNth_InputEmptyList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\DropEveryNth_InputEmptyList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2094,7 +2094,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\DropEveryNth_InputStringForNth.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\DropEveryNth_InputStringForNth.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2110,7 +2110,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\RemoveFromList_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\RemoveFromList_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2135,7 +2135,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\RemoveFromList_StringAsList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\RemoveFromList_StringAsList.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2149,7 +2149,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\RemoveFromList_StringAsIndex.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\RemoveFromList_StringAsIndex.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2162,7 +2162,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\RemoveFromList_Complex.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\RemoveFromList_Complex.dyn");
 			RunModel(openPath);
 
 			Dictionary<int, object> validationData = new Dictionary<int, object>()
@@ -2179,7 +2179,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\RemoveFromList_RangeExpnAsIndex.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\RemoveFromList_RangeExpnAsIndex.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2206,7 +2206,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\SliceList_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\SliceList_SimpleTest.dyn");
 			RunModel(openPath);
 
 			Dictionary<int, object> validationData = new Dictionary<int, object>()
@@ -2222,7 +2222,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\SliceList_Complex.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\SliceList_Complex.dyn");
 			RunModel(openPath);
 			
 			Dictionary<int, object> validationData = new Dictionary<int, object>()
@@ -2240,7 +2240,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\SliceList_MultipleInput.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\SliceList_MultipleInput.dyn");
 			RunModel(openPath);
 
 			AssertPreviewValue("cc3ae092-8644-4a36-ad38-12ffa15cebda",
@@ -2260,7 +2260,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Average_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Average_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2275,7 +2275,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Average_NegativeInputTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Average_NegativeInputTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2293,7 +2293,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\TrueForAny_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\TrueForAny_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2312,7 +2312,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\TrueForAll_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\TrueForAll_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2330,7 +2330,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\JoinList_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\JoinList_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2354,7 +2354,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\JoinList_MoreLists.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\JoinList_MoreLists.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2392,7 +2392,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Combine_SimpleTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Combine_SimpleTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2415,7 +2415,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Combine_ComplexTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Combine_ComplexTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2437,7 +2437,7 @@ namespace Dynamo.Tests
 		{
 			var model = ViewModel.Model;
 
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\Combine_NegativeTest.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\Combine_NegativeTest.dyn");
 			RunModel(openPath);
 
 			// check all the nodes and connectors are loaded
@@ -2453,7 +2453,7 @@ namespace Dynamo.Tests
 		public void TestCreateList()
 		{
 			// Test partially applied Create List node.
-			string openPath = Path.Combine(GetTestDirectory(), @"core\list\createList.dyn");
+			string openPath = Path.Combine(TestDirectory, @"core\list\createList.dyn");
 			RunModel(openPath);
 
 			AssertPreviewValue("0f306478-5a96-4276-baac-0d08e12fe872", new object[] { 1.0, 2.0, 3.0, 4.0 }); 
@@ -2464,7 +2464,7 @@ namespace Dynamo.Tests
 	    [Test]
 	    public void TestListReplace()
 	    {
-	        var openPath = Path.Combine(GetTestDirectory(), @"core\list\listreplace.dyn");
+	        var openPath = Path.Combine(TestDirectory, @"core\list\listreplace.dyn");
             RunModel(openPath);
 
             AssertPreviewValue("13f697db-85b8-4b93-859c-63f2b66c6b72", new object[] { 0.0, "no value", 2.0, "no value", "no value", 5.0 });
@@ -2475,7 +2475,7 @@ namespace Dynamo.Tests
         [Test]
         public void RegressMagn4838_01()
         {
-	        var openPath = Path.Combine(GetTestDirectory(), @"core\list\RegressMagn4838_1.dyn");
+	        var openPath = Path.Combine(TestDirectory, @"core\list\RegressMagn4838_1.dyn");
             RunModel(openPath);
 
             AssertPreviewValue("8dd745bf-220c-49f7-80e0-3f1783bb33a4", new object[] { null });
@@ -2484,7 +2484,7 @@ namespace Dynamo.Tests
         [Test]
         public void RegressMagn4838_02()
         {
-	        var openPath = Path.Combine(GetTestDirectory(), @"core\list\RegressMagn4838_2.dyn");
+	        var openPath = Path.Combine(TestDirectory, @"core\list\RegressMagn4838_2.dyn");
             RunModel(openPath);
         }
         #endregion

--- a/test/DynamoCoreTests/Nodes/LogicTests.cs
+++ b/test/DynamoCoreTests/Nodes/LogicTests.cs
@@ -8,7 +8,7 @@ namespace Dynamo.Tests
     [TestFixture]
     class ComparisonTests : DSEvaluationViewModelUnitTest
     {
-        private string logicTestFolder { get { return Path.Combine(GetTestDirectory(), "core", "logic", "comparison"); } }
+        private string logicTestFolder { get { return Path.Combine(TestDirectory, "core", "logic", "comparison"); } }
 
         [Test]
         public void testLessThan_NumberInput()
@@ -252,7 +252,7 @@ namespace Dynamo.Tests
     [TestFixture]
     class ConditionalTest : DSEvaluationViewModelUnitTest
     {
-        private string logicTestFolder { get { return Path.Combine(GetTestDirectory(), "core", "logic", "conditional"); } }
+        private string logicTestFolder { get { return Path.Combine(TestDirectory, "core", "logic", "conditional"); } }
 
         [Test]
         public void testAnd_NumberInput()

--- a/test/DynamoCoreTests/Nodes/StringTests.cs
+++ b/test/DynamoCoreTests/Nodes/StringTests.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Tests
 {
     class StringTests : DSEvaluationViewModelUnitTest
     {
-        string localDynamoStringTestFolder { get { return Path.Combine(GetTestDirectory(), "core", "string");}}
+        string localDynamoStringTestFolder { get { return Path.Combine(TestDirectory, "core", "string");}}
 
         #region concat string test cases  
 

--- a/test/DynamoCoreTests/PackageManager/PackageDependencyTests.cs
+++ b/test/DynamoCoreTests/PackageManager/PackageDependencyTests.cs
@@ -13,7 +13,7 @@ namespace Dynamo.Tests
         public void CanDiscoverDependenciesForFunctionDefinitionOpenFromFile()
         {
             var vm = ViewModel;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\custom_node_dep_test\");
+            var examplePath = Path.Combine(TestDirectory, @"core\custom_node_dep_test\");
 
             string openPath = Path.Combine(examplePath, "custom_node_dep_test.dyn");
             ViewModel.OpenCommand.Execute(openPath);

--- a/test/DynamoCoreTests/PackageManager/PackageLoaderTests.cs
+++ b/test/DynamoCoreTests/PackageManager/PackageLoaderTests.cs
@@ -9,7 +9,7 @@ namespace Dynamo.Tests
 {
     class PackageLoaderTests : DynamoViewModelUnitTest
     {
-        public string PackagesDirectory { get { return Path.Combine(this.GetTestDirectory(), "pkgs"); } }
+        public string PackagesDirectory { get { return Path.Combine(this.TestDirectory, "pkgs"); } }
 
         [Test]
         public void ScanPackageDirectoryReturnsPackageForValidDirectory()
@@ -103,7 +103,7 @@ namespace Dynamo.Tests
             CustomNodeInfo info;
             Assert.IsTrue(
                 ViewModel.Model.CustomNodeManager.AddUninitializedCustomNode(
-                    Path.Combine(new string[] { GetTestDirectory(), "core", "combine", "combine2.dyf" }),
+                    Path.Combine(new string[] { TestDirectory, "core", "combine", "combine2.dyf" }),
                     true,
                     out info));
 

--- a/test/DynamoCoreTests/ScopedNodeTest.cs
+++ b/test/DynamoCoreTests/ScopedNodeTest.cs
@@ -17,7 +17,7 @@ namespace Dynamo.Tests
         {
             get
             {
-                return Path.Combine(GetTestDirectory(), "core", "scopednode"); 
+                return Path.Combine(TestDirectory, "core", "scopednode"); 
                 
             }
         }

--- a/test/DynamoCoreTests/SearchSideEffects.cs
+++ b/test/DynamoCoreTests/SearchSideEffects.cs
@@ -29,7 +29,7 @@ namespace Dynamo.Tests
         {
             // goto custom node workspace
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\combine", "Sequence2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\combine", "Sequence2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
             Assert.AreEqual(model.CurrentWorkspace.Name, "Sequence2");
@@ -54,7 +54,7 @@ namespace Dynamo.Tests
         {
             // goto custom node workspace
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\combine", "Sequence2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\combine", "Sequence2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
             Assert.AreEqual(model.CurrentWorkspace.Name, "Sequence2");

--- a/test/DynamoCoreTests/UndoRedoRecorderTests.cs
+++ b/test/DynamoCoreTests/UndoRedoRecorderTests.cs
@@ -859,7 +859,7 @@ namespace Dynamo.Tests
         public void TestFunctionNode()
         {
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\custom_node_serialization\");
+            var examplePath = Path.Combine(TestDirectory, @"core\custom_node_serialization\");
             string openPath = Path.Combine(examplePath, "graph function.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
@@ -902,7 +902,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestDummyNodeInternals00()
         {
-            var folder = Path.Combine(GetTestDirectory(), @"core\dummy_node\");
+            var folder = Path.Combine(TestDirectory, @"core\dummy_node\");
             ViewModel.OpenCommand.Execute(Path.Combine(folder, "DummyNodeSample.dyn"));
 
             var workspace = ViewModel.Model.CurrentWorkspace;
@@ -925,7 +925,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestDummyNodeInternals01()
         {
-            var folder = Path.Combine(GetTestDirectory(), @"core\dummy_node\");
+            var folder = Path.Combine(TestDirectory, @"core\dummy_node\");
             ViewModel.OpenCommand.Execute(Path.Combine(folder, "DummyNodeSample.dyn"));
 
             var workspace = ViewModel.Model.CurrentWorkspace;
@@ -951,7 +951,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestDummyNodeSerialization()
         {
-            var folder = Path.Combine(GetTestDirectory(), @"core\dummy_node\");
+            var folder = Path.Combine(TestDirectory, @"core\dummy_node\");
             ViewModel.OpenCommand.Execute(Path.Combine(folder, "dummyNode.dyn"));
 
             var workspace = ViewModel.Model.CurrentWorkspace;

--- a/test/DynamoCoreTests/UnitTestBase.cs
+++ b/test/DynamoCoreTests/UnitTestBase.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
-using Dynamo.Utilities;
 using NUnit.Framework;
 
 namespace Dynamo
@@ -11,6 +10,8 @@ namespace Dynamo
 
         protected string ExecutingDirectory { get; set; }
         protected string TempFolder { get; private set; }
+        public string SampleDirectory { get; private set; }
+        public string TestDirectory { get; private set; }
 
         [SetUp]
         public virtual void Setup()
@@ -42,23 +43,6 @@ namespace Dynamo
                     : Path.ChangeExtension(guid, fileExtension));
         }
 
-        public string GetTestDirectory()
-        {
-            var directory = new DirectoryInfo(ExecutingDirectory);
-            return Path.Combine(directory.Parent.Parent.Parent.FullName, "test");
-        }
-
-        public string GetSampleDirectory()
-        {
-            var directory = new FileInfo(ExecutingDirectory);
-            string assemblyDir = directory.DirectoryName;
-            string sampleLocation = Path.Combine(assemblyDir, @"..\..\doc\distrib\Samples\");
-            string samplePath = Path.GetFullPath(sampleLocation);
-
-            return samplePath;
-
-        }
-
         protected void SetupDirectories()
         {
             ExecutingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
@@ -71,6 +55,25 @@ namespace Dynamo
 
             // Setup Temp PreferenceSetting Location for testing
             PreferenceSettings.DynamoTestPath = Path.Combine(TempFolder, "UserPreferenceTest.xml");
+
+            SampleDirectory = GetSampleDirectory();
+
+            TestDirectory = GetTestDirectory();
+        }
+
+        private string GetSampleDirectory()
+        {
+            var directory = new FileInfo(ExecutingDirectory);
+            string assemblyDir = directory.DirectoryName;
+            string sampleLocation = Path.Combine(assemblyDir, @"..\..\doc\distrib\Samples\");
+            string samplePath = Path.GetFullPath(sampleLocation);
+            return samplePath;
+        }
+
+        private string GetTestDirectory()
+        {
+            var directory = new DirectoryInfo(ExecutingDirectory);
+            return Path.Combine(directory.Parent.Parent.Parent.FullName, "test");
         }
     }
 }

--- a/test/DynamoCoreTests/WatchNodeTests.cs
+++ b/test/DynamoCoreTests/WatchNodeTests.cs
@@ -111,7 +111,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            var openPath = Path.Combine(GetTestDirectory(), @"core\watch\WatchLiterals.dyn");
+            var openPath = Path.Combine(TestDirectory, @"core\watch\WatchLiterals.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             Assert.DoesNotThrow(() => ViewModel.HomeSpace.Run());
@@ -141,7 +141,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            var openPath = Path.Combine(GetTestDirectory(), @"core\watch\Watch1DCollections.dyn");
+            var openPath = Path.Combine(TestDirectory, @"core\watch\Watch1DCollections.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             Assert.DoesNotThrow(() => ViewModel.HomeSpace.Run());
@@ -175,7 +175,7 @@ namespace Dynamo.Tests
         [Test]
         public void WatchFunctionObject()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\watch\watchfunctionobject.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\watch\watchfunctionobject.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             ViewModel.HomeSpace.Run();
 
@@ -191,7 +191,7 @@ namespace Dynamo.Tests
         [Test]
         public void WatchFunctionPointer()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\watch\watchFunctionPointer.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\watch\watchFunctionPointer.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             ViewModel.HomeSpace.Run();
 
@@ -211,7 +211,7 @@ namespace Dynamo.Tests
             // http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5033
             // Watch value for a partially-applied function should say "function" and not "null"
             
-            string openPath = Path.Combine(GetTestDirectory(), @"core\watch\watchfunctionobject_2.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\watch\watchfunctionobject_2.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             ViewModel.HomeSpace.Run();
 

--- a/test/DynamoCoreTests/WorkspaceHeaderTests.cs
+++ b/test/DynamoCoreTests/WorkspaceHeaderTests.cs
@@ -11,7 +11,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanRecognizeCustomNodeWorkspace()
         {
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\combine", "Sequence2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\combine", "Sequence2.dyf");
             var doc = new XmlDocument();
             doc.Load(examplePath);
             WorkspaceInfo workspaceInfo;
@@ -25,7 +25,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanRecognizeHomeWorkspace()
         {
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\combine", "combine-with-three.dyn");
+            var examplePath = Path.Combine(TestDirectory, @"core\combine", "combine-with-three.dyn");
             var doc = new XmlDocument();
             doc.Load(examplePath); WorkspaceInfo workspaceInfo;
             Assert.IsTrue(WorkspaceInfo.FromXmlDocument(doc, examplePath, true, ViewModel.Model.Logger, out workspaceInfo));

--- a/test/DynamoCoreTests/WorkspaceOpeningTests.cs
+++ b/test/DynamoCoreTests/WorkspaceOpeningTests.cs
@@ -56,7 +56,7 @@ namespace Dynamo
 
         private WorkspaceModel OpenWorkspaceFromSampleFile()
         {
-            var examplePath = Path.Combine(GetSampleDirectory(), @"en-US\Basics\Basics_Basic01.dyn");
+            var examplePath = Path.Combine(SampleDirectory, @"en-US\Basics\Basics_Basic01.dyn");
             ViewModel.Model.OpenFileFromPath(examplePath);
             return ViewModel.Model.CurrentWorkspace;
         }

--- a/test/DynamoCoreTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreTests/WorkspaceSaving.cs
@@ -97,7 +97,7 @@ namespace Dynamo.Tests
             // save as
             // file exists
 
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math", "Add.dyn");
+            var examplePath = Path.Combine(TestDirectory, @"core\math", "Add.dyn");
             ViewModel.OpenCommand.Execute(examplePath);
 
             var newPath = GetNewFileNameOnTempPath("dyn");
@@ -115,7 +115,7 @@ namespace Dynamo.Tests
             // file exists
 
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\combine", "Sequence2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\combine", "Sequence2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
             var nodeWorkspace = model.Workspaces.FirstOrDefault(x => x is CustomNodeWorkspaceModel);
@@ -136,7 +136,7 @@ namespace Dynamo.Tests
             // save as
             // file exists
 
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\math", "Add.dyn");
+            var examplePath = Path.Combine(TestDirectory, @"core\math", "Add.dyn");
             ViewModel.OpenCommand.Execute(examplePath);
 
             var res = ViewModel.Model.CurrentWorkspace.SaveAs("", ViewModel.Model.EngineController.LiveRunnerCore);
@@ -540,7 +540,7 @@ namespace Dynamo.Tests
             // custom node instance is in environment
 
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\custom_node_saving", "Constant2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\custom_node_saving", "Constant2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
             var nodeWorkspace =
@@ -571,7 +571,7 @@ namespace Dynamo.Tests
             // can get instance of that node
 
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\custom_node_saving", "Constant2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\custom_node_saving", "Constant2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
             var nodeWorkspace =
@@ -601,7 +601,7 @@ namespace Dynamo.Tests
             // function id is in environment
 
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\custom_node_saving", "Constant2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\custom_node_saving", "Constant2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
             var nodeWorkspace =
@@ -624,7 +624,7 @@ namespace Dynamo.Tests
             // place custom node with new id, run expression and result is correct.
 
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\custom_node_saving", "Constant2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\custom_node_saving", "Constant2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
 
@@ -667,7 +667,7 @@ namespace Dynamo.Tests
             // two nodes are returned in search on custom node name, difer 
 
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\custom_node_saving", "Constant2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\custom_node_saving", "Constant2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
             var nodeWorkspace =
@@ -711,7 +711,7 @@ namespace Dynamo.Tests
 
             // open custom node
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\custom_node_saving", "Constant2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\custom_node_saving", "Constant2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
             var nodeWorkspace =
@@ -759,7 +759,7 @@ namespace Dynamo.Tests
             // two nodes are returned in search on custom node name, difer 
 
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\custom_node_saving", "Constant2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\custom_node_saving", "Constant2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
             var oldId = model.CurrentWorkspace.FirstNodeFromWorkspace<Function>().Definition.FunctionId;
@@ -811,7 +811,7 @@ namespace Dynamo.Tests
             // two nodes are returned in search on custom node name, difer 
 
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\custom_node_saving", "Constant2.dyf");
+            var examplePath = Path.Combine(TestDirectory, @"core\custom_node_saving", "Constant2.dyf");
             ViewModel.OpenCommand.Execute(examplePath);
 
             var oldId = model.CurrentWorkspace.FirstNodeFromWorkspace<Function>().Definition.FunctionId;

--- a/test/DynamoCoreUITests/DynamoConverterTest.cs
+++ b/test/DynamoCoreUITests/DynamoConverterTest.cs
@@ -126,7 +126,7 @@ namespace DynamoCoreUITests
         public void ConvertBetweenUnitsTestForForceReExecute()
         {
             var model = ViewModel.Model;
-            string openPath = Path.Combine(GetTestDirectory(), @"core\ConvertBetweenUnitsTest.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\ConvertBetweenUnitsTest.dyn");
             RunModel(openPath);
 
             var node1 = model.CurrentWorkspace.NodeFromWorkspace("1371db60-371d-406b-a613-2f71ee43ccee");

--- a/test/Libraries/CoreNodesTests/FileTests.cs
+++ b/test/Libraries/CoreNodesTests/FileTests.cs
@@ -247,7 +247,7 @@ namespace Dynamo.Tests
         #region Images
         private IEnumerable<string> GetTestImageFiles()
         {
-            string imagePath = Path.Combine(GetTestDirectory(), @"core\files\images\testImage");
+            string imagePath = Path.Combine(TestDirectory, @"core\files\images\testImage");
             return new[] { "png", "jpg", "bmp", "tif" }.Select(
                 ext => Path.ChangeExtension(imagePath, ext));
         }
@@ -326,7 +326,7 @@ namespace Dynamo.Tests
         public void Image_Write()
         {
             var tmp = GetNewFileNameOnTempPath("png");
-            using (var bmp = new Bitmap(Path.Combine(GetTestDirectory(), @"core\files\images\testImage.png")))
+            using (var bmp = new Bitmap(Path.Combine(TestDirectory, @"core\files\images\testImage.png")))
             {
                 Image.WriteToFile(tmp, bmp);
                 using (var newBmp = new Bitmap(tmp))
@@ -376,7 +376,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\files\FileWriter.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\files\FileWriter.dyn");
             RunModel(openPath);
 
             // check all the nodes and connectors are loaded
@@ -394,7 +394,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\files\ImageFileWriter.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\files\ImageFileWriter.dyn");
             RunModel(openPath);
 
             // check all the nodes and connectors are loaded
@@ -416,7 +416,7 @@ namespace Dynamo.Tests
         {
             var model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\files\MigrationHintGetClosestPoint.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\files\MigrationHintGetClosestPoint.dyn");
             RunModel(openPath);
 
             // check all the nodes and connectors are loaded

--- a/test/Libraries/DataBridgeTests/DataBridgeTests.cs
+++ b/test/Libraries/DataBridgeTests/DataBridgeTests.cs
@@ -17,7 +17,7 @@ namespace DataBridgeTests
         [Category("Failure")]
         public void CanUseWatchInCustomNode()
         {
-            var examplesPath = Path.Combine(GetTestDirectory(), @"core\watch");
+            var examplesPath = Path.Combine(TestDirectory, @"core\watch");
             var model = ViewModel.Model;
 
             RunModel(Path.Combine(examplesPath, "watchdatabridge.dyn"));

--- a/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
+++ b/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
@@ -72,7 +72,7 @@ namespace Dynamo.Tests
         public void CanGetLargeWorkbookWithinThresholdTime()
         {
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\HammersmithExcelFile_Open.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\HammersmithExcelFile_Open.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             Assert.AreEqual(5, ViewModel.CurrentSpace.Nodes.Count);
@@ -80,7 +80,7 @@ namespace Dynamo.Tests
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
                         
             // remap the filename as Excel requires an absolute path
-            filename.Value = filename.Value.Replace(@"..\..\..\test", GetTestDirectory());
+            filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
 
             var timer = new Stopwatch();
             timer.Start();
@@ -95,13 +95,13 @@ namespace Dynamo.Tests
         public void CanGetWorksheets()
         {
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\WorksheetsFromFile.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\WorksheetsFromFile.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
             // remap the filename as Excel requires an absolute path
-            filename.Value = filename.Value.Replace(@"..\..\..\test", GetTestDirectory());
+            filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
 
             var watch = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.GetWorksheetsFromExcelWorkbook");
 
@@ -117,7 +117,7 @@ namespace Dynamo.Tests
         public void CanGetWorksheetByNameWithValidInput()
         {
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\WorksheetByName_ValidInput.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\WorksheetByName_ValidInput.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             Assert.AreEqual(5, ViewModel.CurrentSpace.Nodes.Count);
@@ -125,7 +125,7 @@ namespace Dynamo.Tests
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
             // remap the filename as Excel requires an absolute path
-            filename.Value = filename.Value.Replace(@"..\..\..\test", GetTestDirectory());
+            filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
 
             var watch = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.GetExcelWorksheetByName");
 
@@ -137,13 +137,13 @@ namespace Dynamo.Tests
         [Test]
         public void ThrowExceptionOnGetWorksheetByNameWithInvalidInput()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\WorksheetByName_InvalidInput.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\WorksheetByName_InvalidInput.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
             // remap the filename as Excel requires an absolute path
-            filename.Value = filename.Value.Replace(@"..\..\..\test", GetTestDirectory());
+            filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
 
             var getWorksheet = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.GetExcelWorksheetByName");
             var readFile = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.ReadExcelFile");
@@ -158,13 +158,13 @@ namespace Dynamo.Tests
         public void CanReadWorksheetWithSingleColumnOfNumbers()
         {
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\DataFromFile_ascending.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\DataFromFile_ascending.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
             // remap the filename as Excel requires an absolute path
-            filename.Value = filename.Value.Replace(@"..\..\..\test", GetTestDirectory());
+            filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
 
             var watch = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.GetDataFromExcelWorksheet");
 
@@ -192,13 +192,13 @@ namespace Dynamo.Tests
         public void CanReadMultiDimensionalWorksheet()
         {
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\DataFromFile_2Dimensional.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\DataFromFile_2Dimensional.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
             // remap the filename as Excel requires an absolute path
-            filename.Value = filename.Value.Replace(@"..\..\..\test", GetTestDirectory());
+            filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
 
             var watch = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.GetDataFromExcelWorksheet");
 
@@ -227,13 +227,13 @@ namespace Dynamo.Tests
         [Test]
         public void CanReadWorksheetWithEmptyCellInUsedRange()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\DataFromFile_missingCell.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\DataFromFile_missingCell.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
             // remap the filename as Excel requires an absolute path
-            filename.Value = filename.Value.Replace(@"..\..\..\test", GetTestDirectory());
+            filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
 
             var watch = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.GetDataFromExcelWorksheet");
 
@@ -266,13 +266,13 @@ namespace Dynamo.Tests
         public void CanReadWorksheetWithMixedNumbersAndStrings()
         {
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\DataFromFile_mixedNumbersAndStrings.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\DataFromFile_mixedNumbersAndStrings.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
             // remap the filename as Excel requires an absolute path
-            filename.Value = filename.Value.Replace(@"..\..\..\test", GetTestDirectory());
+            filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
 
             var watch = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.GetDataFromExcelWorksheet");
 
@@ -310,13 +310,13 @@ namespace Dynamo.Tests
         public void CanReadAndWriteExcel()
         {
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\ReadAndWriteExcel.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\ReadAndWriteExcel.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
             // remap the filename as Excel requires an absolute path
-            filename.Value = filename.Value.Replace(@"..\..\..\test", GetTestDirectory());
+            filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
 
             var filePath = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".xlsx";
             var stringNode = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<Dynamo.Nodes.StringInput>();
@@ -391,7 +391,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanWrite1DDataOfMixedTypesToExcelWorksheet()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\NewWorkbook_AddMixed1DData.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\NewWorkbook_AddMixed1DData.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             Assert.AreEqual(13, ViewModel.CurrentSpace.Nodes.Count);
             var watch = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.GetDataFromExcelWorksheet");
@@ -428,7 +428,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanCreateNewWorksheetInNewWorkbook()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\NewWorkbook_AddWorksheet.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\NewWorkbook_AddWorksheet.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             Assert.AreEqual(5, ViewModel.CurrentSpace.Nodes.Count);
             var getWorksheet = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.GetExcelWorksheetByName");
@@ -439,7 +439,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanAddSingleItemToExcelWorksheet()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\NewWorkbook_AddSingleItemData.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\NewWorkbook_AddSingleItemData.dyn");
 
             ViewModel.OpenCommand.Execute(openPath);
             Assert.AreEqual(8, ViewModel.CurrentSpace.Nodes.Count);
@@ -460,7 +460,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanAdd1DListToExcelWorksheet()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\NewWorkbook_Add1DListData.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\NewWorkbook_Add1DListData.dyn");
 
             ViewModel.OpenCommand.Execute(openPath);
             Assert.AreEqual(8, ViewModel.CurrentSpace.Nodes.Count);
@@ -488,7 +488,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanAdd2DListToExcelWorksheet()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\NewWorkbook_Add2DListData.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\NewWorkbook_Add2DListData.dyn");
             ViewModel.OpenCommand.Execute(openPath);
             Assert.AreEqual(11, ViewModel.CurrentSpace.Nodes.Count);
             var watch = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.GetDataFromExcelWorksheet");
@@ -518,7 +518,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanWriteToExcelAndUpdateData()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\WriteNodeAndUpdateData.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\WriteNodeAndUpdateData.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             var filePath = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".xlsx";
@@ -569,7 +569,7 @@ namespace Dynamo.Tests
         [Test]
         public void CanSaveAsWorksheet()
         {
-            string openPath = Path.Combine(GetTestDirectory(), @"core\excel\NewWorkbook_SaveAs.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\excel\NewWorkbook_SaveAs.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 
             var filePath = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".xlsx";
@@ -598,7 +598,7 @@ namespace Dynamo.Tests
         [Test]
         public void Defect_MAGN_883()
         {
-            string testDir = GetTestDirectory();
+            string testDir = TestDirectory;
             string openPath = Path.Combine(testDir, @"core\excel\Defect_MAGN_883.dyn");
             ViewModel.OpenCommand.Execute(openPath);
 

--- a/test/Libraries/DynamoPythonTests/PythonEditTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEditTests.cs
@@ -21,7 +21,7 @@ namespace Dynamo.Tests
         {
             // open file
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\python", "python.dyn");
+            var examplePath = Path.Combine(TestDirectory, @"core\python", "python.dyn");
             ViewModel.OpenCommand.Execute(examplePath);
 
             // get the python node
@@ -42,7 +42,7 @@ namespace Dynamo.Tests
         {
             // open file
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\python", "python.dyn");
+            var examplePath = Path.Combine(TestDirectory, @"core\python", "python.dyn");
             ViewModel.OpenCommand.Execute(examplePath);
 
             // get the python node
@@ -77,7 +77,7 @@ namespace Dynamo.Tests
         {
             // open file
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\python", "varinpython.dyn");
+            var examplePath = Path.Combine(TestDirectory, @"core\python", "varinpython.dyn");
             ViewModel.OpenCommand.Execute(examplePath);
 
             // get the python node
@@ -96,7 +96,7 @@ namespace Dynamo.Tests
         {
             // open file
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"core\python", "varinpython.dyn");
+            var examplePath = Path.Combine(TestDirectory, @"core\python", "varinpython.dyn");
             ViewModel.OpenCommand.Execute(examplePath);
 
             // get the python node

--- a/test/Libraries/WorlflowTests/ComplexTests.cs
+++ b/test/Libraries/WorlflowTests/ComplexTests.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Tests
         {
             // This will test user workflow which contains many nodes, final output is Solid using
             // sweep.
-            string openPath = Path.Combine(GetTestDirectory(), @"core\WorkflowTestFiles\RandomModel_V3.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\WorkflowTestFiles\RandomModel_V3.dyn");
             
             RunModel(openPath);
 
@@ -41,7 +41,7 @@ namespace Dynamo.Tests
              // This will test user workflow which contains many nodes.
              // Crash with "Index was outside the bounds of the array"
  
-            string openPath = Path.Combine(GetTestDirectory(), @"core\WorkflowTestFiles\20140418_buildingSetback_standalone.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\WorkflowTestFiles\20140418_buildingSetback_standalone.dyn");
 
             
 

--- a/test/Libraries/WorlflowTests/DynamoSamples.cs
+++ b/test/Libraries/WorlflowTests/DynamoSamples.cs
@@ -513,11 +513,13 @@ namespace Dynamo.Tests
 
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
-            string resultPath = GetSampleDirectory() + "Data\\helix.csv";
+            string resultPath = SampleDirectory + "Data\\helix.csv";
             // Although old path is a hard coded but that is not going to change 
             // because it is saved in DYN which we have added in Samples folder.
             filename.Value = filename.Value.Replace
                 ("C:\\ProgramData\\Dynamo\\0.8\\samples\\Data\\helix.csv", resultPath);
+
+            RunCurrentModel();
 
             const string lineNodeID = "0cde47c6-106f-4a0a-9566-872fd23a0a20";
             AssertPreviewCount(lineNodeID, 201);
@@ -543,7 +545,7 @@ namespace Dynamo.Tests
             filename.Value = filename.Value.Replace
                 ("C:\\ProgramData\\Dynamo\\0.8\\samples\\Data\\icosohedron_points.csv", resultPath);
 
-            //RunCurrentModel();
+            RunCurrentModel();
 
             const string lineNodeID = "48175079-300b-4b1d-9953-e23d570dce12";
             AssertPreviewCount(lineNodeID, 65);
@@ -565,7 +567,7 @@ namespace Dynamo.Tests
 
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
-            string resultPath = GetSampleDirectory() + "Data\\helix.xlsx";
+            string resultPath = SampleDirectory + "Data\\helix.xlsx";
             // Although old path is a hard coded but that is not going to change 
             // because it is saved in DYN which we have added in Samples folder.
             filename.Value = filename.Value.Replace

--- a/test/Libraries/WorlflowTests/GeometryDefectTests.cs
+++ b/test/Libraries/WorlflowTests/GeometryDefectTests.cs
@@ -20,7 +20,7 @@ namespace Dynamo.Tests
             
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
         @"core\WorkflowTestFiles\\GeometryDefects\MAGN_3996_InputAsPolyCurvetoJoinCurves.dyn");
 
             RunModel(openPath);
@@ -50,7 +50,7 @@ namespace Dynamo.Tests
 
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
         @"core\WorkflowTestFiles\\GeometryDefects\MAGN_4578_CCSForTransformedCuboid.dyn");
 
             RunModel(openPath);
@@ -81,7 +81,7 @@ namespace Dynamo.Tests
 
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
         @"core\WorkflowTestFiles\\GeometryDefects\MAGN_4924_CurveExtractionFromSurface.dyn");
 
             RunModel(openPath);
@@ -114,7 +114,7 @@ namespace Dynamo.Tests
 
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
                 @"core\WorkflowTestFiles\\GeometryDefects\MAGN_5029_CopyPasteWarning.dyn");
 
             RunModel(openPath);
@@ -167,7 +167,7 @@ namespace Dynamo.Tests
 
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
                 @"core\WorkflowTestFiles\\GeometryDefects\MAGN_5041_NurbsCurveExtend.dyn");
 
             RunModel(openPath);
@@ -204,7 +204,7 @@ namespace Dynamo.Tests
             // This will test user workflow which contains many nodes.
             // Crash with "Index was outside the bounds of the array"
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\WorkflowTestFiles\20140418_buildingSetback_standalone.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\WorkflowTestFiles\20140418_buildingSetback_standalone.dyn");
 
             var FARId = "c03065ec-fe54-40de-8c27-8089c7fe1b73";
             Assert.DoesNotThrow(() => RunModel(openPath));
@@ -218,7 +218,7 @@ namespace Dynamo.Tests
             // http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5176
             // Unhandled Exception in Dynamo Engine on second run of recursive custom node
 
-            string openPath = Path.Combine(GetTestDirectory(), @"core\WorkflowTestFiles\ChordMarching_customNode02.dyn");
+            string openPath = Path.Combine(TestDirectory, @"core\WorkflowTestFiles\ChordMarching_customNode02.dyn");
             DynamoModel model = ViewModel.Model;
             Assert.DoesNotThrow(() => RunModel(openPath));
             var watchVal = model.CurrentWorkspace.NodeFromWorkspace("d70522b3-b5e0-4ce4-a765-9daf1bd05b44");
@@ -234,7 +234,7 @@ namespace Dynamo.Tests
 
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
     @"core\WorkflowTestFiles\GeometryDefects\MAGN_5155_CrashCurveDivideByLengthFromParameter.dyn");
 
             RunModel(openPath);
@@ -266,7 +266,7 @@ namespace Dynamo.Tests
 
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
         @"core\WorkflowTestFiles\GeometryDefects\MAGN_5177_LofByGuideCurvesForSurfaceAndSolid.dyn");
 
             RunModel(openPath);
@@ -301,7 +301,7 @@ namespace Dynamo.Tests
 
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
             @"core\WorkflowTestFiles\GeometryDefects\MAGN_5323_ListUniqueNotWorkingWithNull.dyn");
 
             RunModel(openPath);
@@ -328,7 +328,7 @@ namespace Dynamo.Tests
 
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), 
+            string openPath = Path.Combine(TestDirectory, 
             @"core\WorkflowTestFiles\GeometryDefects\MAGN_5365_WrongFunctionPassingToWatchCrashingDynamo.dyn");
 
             Assert.DoesNotThrow(() => ViewModel.HomeSpace.Run());
@@ -349,7 +349,7 @@ namespace Dynamo.Tests
 
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
                 @"core\WorkflowTestFiles\GeometryDefects\MAGN_5397_ListScanWithPolygon.dyn");
 
             RunModel(openPath);
@@ -373,7 +373,7 @@ namespace Dynamo.Tests
 
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(), 
+            string openPath = Path.Combine(TestDirectory, 
             @"core\WorkflowTestFiles\GeometryDefects\MAGN_5407_GroupByKeyWithListOfPoints.dyn");
 
             RunModel(openPath);
@@ -411,7 +411,7 @@ namespace Dynamo.Tests
 
             DynamoModel model = ViewModel.Model;
 
-            string openPath = Path.Combine(GetTestDirectory(),
+            string openPath = Path.Combine(TestDirectory,
             @"core\WorkflowTestFiles\GeometryDefects\MAGN_5408_ListUniqueOnGeometryObjects.dyn");
 
             RunModel(openPath);

--- a/test/System/IntegrationTests/ExecutionEventsObserver.cs
+++ b/test/System/IntegrationTests/ExecutionEventsObserver.cs
@@ -69,7 +69,7 @@ namespace IntegrationTests
 
             //Run the graph
             var model = ViewModel.Model;
-            var examplePath = Path.Combine(GetTestDirectory(), @"System\IntegrationTests\dyns", "ExecutionEvents.dyn");
+            var examplePath = Path.Combine(TestDirectory, @"System\IntegrationTests\dyns", "ExecutionEvents.dyn");
             ViewModel.OpenCommand.Execute(examplePath);
             RunCurrentModel();
 


### PR DESCRIPTION
This PR fixes two broken excel tests which were inexplicably not set to Run and were therefore returning null mirror data. 

In addition to fixing those two tests, this PR changes two methods on the `UnitTestBase` class for consistency with the other properties offered. The large number of file changes are from swapping out calls to the replaced methods with properties.

PTAL:
@pboyer 

Requires Merge:
- [ ] RC0.8.0_master