### PR TITLE
Use culture invariant representation for preview value

### DIFF
--- a/src/Engine/ProtoCore/Reflection/MirrorData.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorData.cs
@@ -3,6 +3,8 @@ using Autodesk.DesignScript.Interfaces;
 using ProtoCore.Utils;
 using ProtoCore.DSASM;
 using System.Linq;
+using System;
+using System.Globalization;
 
 namespace ProtoCore
 {
@@ -205,24 +207,25 @@ namespace ProtoCore
             {
                 get
                 {
-                    if (object.ReferenceEquals(Data, null))
+                    if (object.ReferenceEquals(Data, null) || this.IsNull)
                     {
                         return "null";
                     }
+                    else if (Data is bool)
+                    {
+                        return Data.ToString().ToLower();
+                    }
+                    else if (Data is IFormattable)
+                    {
+                        // Always use invariant culture format for formattable 
+                        // object. For example in Germany system '.' in the
+                        // string representation of a number won't be changed
+                        // to ','
+                        return (Data as IFormattable).ToString(null, CultureInfo.InvariantCulture);
+                    }
                     else
                     {
-                        if (this.IsNull)
-                        {
-                            return "null";
-                        }
-                        else if (Data is bool)
-                        {
-                            return Data.ToString().ToLower();
-                        }
-                        else
-                        {
-                            return Data.ToString();
-                        }
+                        return Data.ToString();
                     }
                 }
             }

--- a/src/Engine/ProtoCore/Reflection/MirrorData.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorData.cs
@@ -217,10 +217,11 @@ namespace ProtoCore
                     }
                     else if (Data is IFormattable)
                     {
-                        // Always use invariant culture format for formattable 
-                        // object. For example in Germany system '.' in the
-                        // string representation of a number won't be changed
-                        // to ','
+                        // Object.ToString() by default will use the current 
+                        // culture to do formatting. For example, Double.ToString()
+                        // https://msdn.microsoft.com/en-us/library/3hfd35ad(v=vs.110).aspx
+                        // We should always use invariant culture format for formattable 
+                        // object.
                         return (Data as IFormattable).ToString(null, CultureInfo.InvariantCulture);
                     }
                     else


### PR DESCRIPTION
This is to fix [defect magn-6714] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6714) that on German System the decimals are displayed as comma for when mouse moved to preview. 

By default if an object is a formattable object, `Object.ToString()` will use culture dependent format to give the string representation of this object. We should format it in culture invariant way.

@ikeough please review the change. Thanks.