### PR TITLE
Move test case ModuloDividendLargerThanDivisor to DSEvaluationViewModelTest

### DIFF
--- a/test/DynamoCoreTests/CoreDynTests.cs
+++ b/test/DynamoCoreTests/CoreDynTests.cs
@@ -635,28 +635,8 @@ namespace Dynamo.Tests
 
             RunModel(Path.Combine(exPath, @"TestNumber_RangeExpr04.dyn"));
 
+
             AssertPreviewValue("e9ad17aa-e30f-4fcb-9d43-71ec2ab027f4", new[] { 5, 4, 3, 2, 1 });
         }
-
-        [Test]
-        public void ModuloDividendLargerThanDivisor()
-        {
-            var model = ViewModel.Model;
-            var examplePath = Path.Combine(TestDirectory, @"core\math");
-
-            string openPath = Path.Combine(examplePath, "ModuloDividendLargerThanDivisor.dyn");
-            RunModel(openPath);
-            double[] Dlist = new double[4];
-            Dlist[0] = 0.129000;
-            Dlist[1] = 0.026000;
-            Dlist[2] = 1.899000;
-            Dlist[3] = 1.830000;
-
-            AssertPreviewValue("9433d723-3708-4773-9b9c-c6def0f17b18", Dlist);
-            AssertPreviewValue("55f03be2-8720-4648-b989-996b261e1502", new [] { false, false, false, false});
-            AssertPreviewValue("0b9eca5b-835b-493e-af4b-84a3366d75d3", Dlist);
-            AssertPreviewValue("7e1f9810-2f4f-4911-975b-d392afc3a674", Dlist);
-        }
-
     }
 }

--- a/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationViewModelTest.cs
@@ -1138,6 +1138,26 @@ namespace Dynamo.Tests
             RunModel(dynFilePath);
             AssertPreviewValue("e95a634b-aab9-4b6e-bb33-2f9669381ad6", 5);
         }
+
+        [Test]
+        public void ModuloDividendLargerThanDivisor()
+        {
+            var model = ViewModel.Model;
+            var examplePath = Path.Combine(TestDirectory, @"core\math");
+
+            string openPath = Path.Combine(examplePath, "ModuloDividendLargerThanDivisor.dyn");
+            RunModel(openPath);
+            double[] Dlist = new double[4];
+            Dlist[0] = 0.129000;
+            Dlist[1] = 0.026000;
+            Dlist[2] = 1.899000;
+            Dlist[3] = 1.830000;
+
+            AssertPreviewValue("9433d723-3708-4773-9b9c-c6def0f17b18", Dlist);
+            AssertPreviewValue("55f03be2-8720-4648-b989-996b261e1502", new[] { false, false, false, false });
+            AssertPreviewValue("0b9eca5b-835b-493e-af4b-84a3366d75d3", Dlist);
+            AssertPreviewValue("7e1f9810-2f4f-4911-975b-d392afc3a674", Dlist);
+        }
     }
 
     [Category("DSCustomNode")]


### PR DESCRIPTION
This test case requires `DSIronPython.dll` but DynCoreTests doesn't. It is to fix broken test case which was committed in PR #3974 