### PR TITLE
Improve performance of usage of XmlDocument.XPathEvaluate

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -114,6 +114,7 @@ limitations under the License.
     <Compile Include="Core\PulseMaker.cs" />
     <Compile Include="Core\NodeGraph.cs" />
     <Compile Include="Core\PathManager.cs" />
+    <Compile Include="Library\MemberDocumentNode.cs" />
     <Compile Include="Models\RunSettings.cs" />
     <Compile Include="Core\Threading\AsyncTaskExtensions.cs" />
     <Compile Include="Interfaces\IPathResolver.cs" />

--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Xml.Linq;
+using System.Xml;
 using Dynamo.Interfaces;
 using DynamoUtilities;
 
@@ -11,8 +11,8 @@ namespace Dynamo.DSEngine
     {
         private static Dictionary<string, bool> _triedPaths = new Dictionary<string, bool>();
 
-        private static Dictionary<string, XDocument> _cached =
-            new Dictionary<string, XDocument>(StringComparer.OrdinalIgnoreCase);
+        private static Dictionary<string, XmlReader> _cached =
+            new Dictionary<string, XmlReader>(StringComparer.OrdinalIgnoreCase);
 
         public static void DestroyCachedData()
         {
@@ -23,7 +23,7 @@ namespace Dynamo.DSEngine
                 _cached.Clear();
         }
 
-        public static XDocument GetForAssembly(string assemblyPath, IPathManager pathManager)
+        public static XmlReader GetForAssembly(string assemblyPath, IPathManager pathManager)
         {
             if (_triedPaths.ContainsKey(assemblyPath))
             {
@@ -33,7 +33,7 @@ namespace Dynamo.DSEngine
             var documentationPath = "";
             if (ResolveForAssembly(assemblyPath, pathManager, ref documentationPath))
             {
-                var c = XDocument.Load(documentationPath);
+                var c = XmlReader.Create(documentationPath);
                 _triedPaths.Add(assemblyPath, true);
                 _cached.Add(assemblyPath, c);
                 return c;

--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -172,7 +172,7 @@ namespace Dynamo.DSEngine
 
         public string Summary
         {
-            get { return summary ?? (summary = this.GetSummary(pathManager)); }
+            get { return summary ?? (summary = this.GetSummary()); }
         }
 
         /// <summary>

--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -92,7 +92,7 @@ namespace Dynamo.DSEngine
             Parameters = funcDescParams.Parameters.Select(
                 x =>
                 {
-                    x.UpdateFunctionDescriptor(this, pathManager);
+                    x.UpdateFunctionDescriptor(this);
                     return x;
                 }).ToList();
 

--- a/src/DynamoCore/Library/MemberDocumentNode.cs
+++ b/src/DynamoCore/Library/MemberDocumentNode.cs
@@ -73,7 +73,7 @@ namespace Dynamo.DSEngine
 
         internal static string MakeFullyQualifiedName(string assemblyName, string memberName)
         {
-            return string.Format("{0}.{1}", assemblyName, memberName);
+            return string.Format("{0},{1}", assemblyName, memberName);
         }
     }
 }

--- a/src/DynamoCore/Library/MemberDocumentNode.cs
+++ b/src/DynamoCore/Library/MemberDocumentNode.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Dynamo.DSEngine
+{
+    class MemberDocumentNode
+    {
+        private readonly string fullyQualifiedName;
+        private string summary;
+        private string searchTags;
+        private readonly Dictionary<string, string> parameters;
+
+        public string FullyQualifiedName { get { return fullyQualifiedName; } }
+
+        public string Summary
+        {
+            get
+            {
+                if (String.IsNullOrEmpty(summary))
+                    return String.Empty;
+                return summary;
+            }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+                summary = value;
+            }
+        }
+
+        public string SearchTags
+        {
+            get
+            {
+                if (String.IsNullOrEmpty(searchTags))
+                    return String.Empty;
+                return searchTags;
+            }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+                searchTags = value;
+            }
+        }
+
+        public IDictionary<string, string> Parameters { get { return parameters; } }
+
+        /// <summary>
+        /// Constructs an instance of MemberDocumentNode object from its 
+        /// given assembly and member name. 
+        /// </summary>
+        /// <param name="assemblyName">The assembly inside which this member 
+        /// resides. If this parameter is null or empty, ArgumentNullException
+        /// is thrown.</param>
+        /// <param name="memberName">The fully qualified name that can be used
+        /// to uniquely identify the member within the same assembly. For an 
+        /// example:
+        /// 
+        ///     "M:Autodesk.DesignScript.Geometry.Point.ByCoordinates(System.Double,System.Double)"
+        /// 
+        /// </param>
+        /// 
+        public MemberDocumentNode(string assemblyName, string memberName)
+        {
+            if (String.IsNullOrWhiteSpace(assemblyName))
+                throw new ArgumentNullException("Assembly Name");
+
+            fullyQualifiedName = MakeFullyQualifiedName(assemblyName, memberName);
+            parameters = new Dictionary<string, string>();
+        }
+
+        internal void AddParameter(string name, string description)
+        {
+            parameters[name] = description;
+        }
+
+        internal static string MakeFullyQualifiedName(string assemblyName, string memberName)
+        {
+            return string.Format("{0}.{1}", assemblyName, memberName);
+        }
+    }
+}

--- a/src/DynamoCore/Library/MemberDocumentNode.cs
+++ b/src/DynamoCore/Library/MemberDocumentNode.cs
@@ -6,8 +6,8 @@ namespace Dynamo.DSEngine
     class MemberDocumentNode
     {
         private readonly string fullyQualifiedName;
-        private string summary;
-        private string searchTags;
+        private string summary = String.Empty;
+        private string searchTags = String.Empty;
         private readonly Dictionary<string, string> parameters;
 
         public string FullyQualifiedName { get { return fullyQualifiedName; } }
@@ -16,8 +16,6 @@ namespace Dynamo.DSEngine
         {
             get
             {
-                if (String.IsNullOrEmpty(summary))
-                    return String.Empty;
                 return summary;
             }
             set
@@ -32,8 +30,6 @@ namespace Dynamo.DSEngine
         {
             get
             {
-                if (String.IsNullOrEmpty(searchTags))
-                    return String.Empty;
                 return searchTags;
             }
             set

--- a/src/DynamoCore/Library/TypedParameter.cs
+++ b/src/DynamoCore/Library/TypedParameter.cs
@@ -10,7 +10,6 @@ namespace Dynamo.Library
     /// </summary>
     public class TypedParameter
     {
-        private IPathManager pathManager;
         private string summary = null; // Indicating that it is not initialized.
 
         public TypedParameter(string parameter, ProtoCore.Type type, AssociativeNode defaultValue = null)
@@ -33,13 +32,8 @@ namespace Dynamo.Library
             get
             {
                 // If 'summary' data member is 'null', it means its value has 
-                // to be repopulated. If an IPathManager is supplied, then 
-                // retrieve the description through it, otherwise set 'summary'
-                // to empty string, so it wil not keep retrieving after failing 
-                // once.
-                // 
-                return summary ?? (summary = ((pathManager != null)
-                    ? this.GetDescription() : string.Empty));
+                // to be repopulated. 
+                return summary ?? this.GetDescription();
             }
         }
 
@@ -58,14 +52,13 @@ namespace Dynamo.Library
             get { return Type.ToShortString(); }
         }
 
-        public void UpdateFunctionDescriptor(FunctionDescriptor funcDesc, IPathManager pathManager)
+        public void UpdateFunctionDescriptor(FunctionDescriptor funcDesc)
         {
             Function = funcDesc;
 
             // Setting 'summary' to 'null' so its value is retrieved later 
             // when 'Summary' property is invoked. See 'Summary' for details.
             summary = null;
-            this.pathManager = pathManager;
         }
 
         public override string ToString()

--- a/src/DynamoCore/Library/TypedParameter.cs
+++ b/src/DynamoCore/Library/TypedParameter.cs
@@ -39,7 +39,7 @@ namespace Dynamo.Library
                 // once.
                 // 
                 return summary ?? (summary = ((pathManager != null)
-                    ? this.GetDescription(pathManager) : string.Empty));
+                    ? this.GetDescription() : string.Empty));
             }
         }
 

--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Xml.Linq;
-using System.Xml.XPath;
+using System.Xml;
 using Dynamo.Interfaces;
 using Dynamo.Library;
 
@@ -15,63 +14,29 @@ namespace Dynamo.DSEngine
     /// </summary>
     public static class XmlDocumentationExtensions
     {
+        private static Dictionary<string, MemberDocumentNode> documentNodes =
+                   new Dictionary<string, MemberDocumentNode>();
+
         #region Public methods
 
-        public static string GetSummary(this FunctionDescriptor member, IPathManager pathManager)
+        /// <param name="xml">Don't set it, it's just for tests.</param>
+        public static string GetDescription(this TypedParameter parameter, XmlReader xml = null)
         {
-            XDocument xml = null;
-
-            if (member.Assembly != null)
-                xml = DocumentationServices.GetForAssembly(member.Assembly, pathManager);
-
-            return member.GetSummary(xml);
+            return GetMemberElement(parameter.Function, xml,
+                DocumentElementType.Description, parameter.Name);
         }
 
-        public static string GetDescription(this TypedParameter member, IPathManager pathManager)
+        /// <param name="xml">Don't set it, it's just for tests.</param>
+        public static string GetSummary(this FunctionDescriptor member, XmlReader xml = null)
         {
-            XDocument xml = null;
 
-            if (member.Function != null && member.Function.Assembly != null)
-                xml = DocumentationServices.GetForAssembly(member.Function.Assembly, pathManager);
-
-            return member.GetDescription(xml);
+            return GetMemberElement(member, xml, DocumentElementType.Summary);
         }
 
-        public static IEnumerable<string> GetSearchTags(this FunctionDescriptor member)
+        /// <param name="xml">Don't set it, it's just for tests.</param>
+        public static IEnumerable<string> GetSearchTags(this FunctionDescriptor member, XmlReader xml = null)
         {
-            XDocument xml = null;
-
-            if (member.Assembly != null)
-                xml = DocumentationServices.GetForAssembly(member.Assembly, member.PathManager);
-
-            return member.GetSearchTags(xml);
-        }
-
-        #endregion
-
-        #region Overloads specifying XDocument
-
-        public static string GetDescription(this TypedParameter parameter, XDocument xml)
-        {
-            if (xml == null) return String.Empty;
-
-            return GetMemberElement(parameter.Function, 
-                String.Format("param[@name='{0}']", parameter.Name), xml).CleanUpDocString();
-        }
-
-        public static string GetSummary(this FunctionDescriptor member, XDocument xml)
-        {
-            if (xml == null) return String.Empty;
-
-            return GetMemberElement(member, "summary", xml).CleanUpDocString();
-        }
-
-        public static IEnumerable<string> GetSearchTags(this FunctionDescriptor member, XDocument xml)
-        {
-            if (xml == null) return new List<string>();
-
-            return GetMemberElement(member, "search", xml)
-                .CleanUpDocString()
+            return GetMemberElement(member, xml, DocumentElementType.SearchTags)
                 .Split(',')
                 .Select(x => x.Trim())
                 .Where(x => x != String.Empty);
@@ -100,35 +65,68 @@ namespace Dynamo.DSEngine
             return sb.ToString();
         }
 
-        private static string GetMemberElement(FunctionDescriptor function,
-            string suffix, XDocument xml)
+        private static string GetMemberElement(
+            FunctionDescriptor function,
+            XmlReader xml,
+            DocumentElementType property,
+            string paramName = "")
         {
-            // Construct the entire function descriptor name, including CLR style names
-            string clrMemberName = GetMemberElementName(function);
+            var assemblyName = function.Assembly;
 
-            // match clr member name
-            var match = xml.XPathEvaluate(
-                String.Format("string(/doc/members/member[@name='{0}']/{1})", clrMemberName, suffix));
+            // Case for operators.
+            if (string.IsNullOrEmpty(assemblyName))
+                return String.Empty;
 
-            if (match is String && !string.IsNullOrEmpty((string)match))
+            string assemblyNameWithoutType;
+            // E.g. ProtoGeometry.dll => ProtoGeometry
+            if (assemblyName.LastIndexOf(".") != -1)
+                assemblyNameWithoutType = assemblyName.Substring(0, assemblyName.LastIndexOf("."));
+            else
+                assemblyNameWithoutType = assemblyName;
+
+            var fullyQualifiedName = MemberDocumentNode.MakeFullyQualifiedName
+                (assemblyNameWithoutType, GetMemberElementName(function));
+
+            if (!documentNodes.ContainsKey(fullyQualifiedName))
             {
-                return match as string;
+                if (xml == null)
+                    xml = DocumentationServices.GetForAssembly(function.Assembly, function.PathManager);
+                LoadDataFromXml(xml, assemblyNameWithoutType);
             }
 
-            // fallback, namespace qualified method name
-            var methodName = function.QualifiedName;
-
-            // match with fallback
-            match = xml.XPathEvaluate(
-                String.Format(
-                    "string(/doc/members/member[contains(@name,'{0}')]/{1})", methodName, suffix));
-
-            if (match is String && !string.IsNullOrEmpty((string)match))
+            MemberDocumentNode documentNode = null;
+            if (documentNodes.ContainsKey(fullyQualifiedName))
+                documentNode = documentNodes[fullyQualifiedName];
+            else
             {
-                return match as string;
-            }
+                var overloadedName = documentNodes.Keys.
+                        Where(key => key.Contains(function.ClassName + "." + function.FunctionName)).FirstOrDefault();
 
-            return String.Empty;
+                if (overloadedName == null)
+                    return String.Empty;
+                if (documentNodes.ContainsKey(overloadedName))
+                    documentNode = documentNodes[overloadedName];
+            }
+            
+            if (documentNode == null)
+                return String.Empty;
+            if (property.Equals(DocumentElementType.Description) && !documentNode.Parameters.ContainsKey(paramName))
+                return String.Empty;
+
+            switch (property)
+            {
+                case DocumentElementType.Summary:
+                    return documentNode.Summary;
+
+                case DocumentElementType.Description:
+                    return documentNode.Parameters[paramName];
+
+                case DocumentElementType.SearchTags:
+                    return documentNode.SearchTags;
+
+                default:
+                    throw new ArgumentException("property");
+            }
         }
 
         private static string PrimitiveMap(string s)
@@ -173,7 +171,7 @@ namespace Dynamo.DSEngine
                     // parameters are listed according to their type, not their name
                     string paramTypesList = String.Join(
                         ",",
-                        member.Parameters.Select(x => x.Type.ToShortString()).Select(PrimitiveMap).ToArray()
+                        member.Parameters.Select(x => x.Type.ToString()).Select(PrimitiveMap).ToArray()
                         );
                     
                     if (!String.IsNullOrEmpty(paramTypesList)) memberName += "(" + paramTypesList + ")";
@@ -197,6 +195,91 @@ namespace Dynamo.DSEngine
 
             // elements are of the form "M:Namespace.Class.Method"
             return String.Format("{0}:{1}", prefixCode, memberName);
+        }
+
+        private enum XmlTagType
+        {
+            None,
+            Member,
+            Summary,
+            Parameter,
+            SearchTags
+        }
+
+        private enum DocumentElementType
+        {
+            Summary,
+            Description,
+            SearchTags
+        }
+
+        private static void LoadDataFromXml(XmlReader reader, string assemblyName)
+        {
+            if (reader == null)
+                return;
+
+            MemberDocumentNode currentDocNode = null;
+            XmlTagType currentTag = XmlTagType.None;
+            string currentParamName = String.Empty;
+
+            while (reader.Read())
+            {
+                switch (reader.NodeType)
+                {
+                    case XmlNodeType.Element:
+                        switch (reader.Name)
+                        {
+                            case "member":
+                                // Find attribute "name".
+                                if (reader.MoveToAttribute("name"))
+                                {
+                                    currentDocNode = new MemberDocumentNode(assemblyName, reader.Value);
+                                    documentNodes.Add(currentDocNode.FullyQualifiedName, currentDocNode);
+                                }
+                                currentTag = XmlTagType.Member;
+                                break;
+
+                            case "summary":
+                                currentTag = XmlTagType.Summary;
+                                break;
+
+                            case "param":
+                                if (reader.MoveToAttribute("name"))
+                                {
+                                    currentParamName = reader.Value;
+                                }
+                                currentTag = XmlTagType.Parameter;
+                                break;
+
+                            case "search":
+                                currentTag = XmlTagType.SearchTags;
+                                break;
+
+                            default:
+                                currentTag = XmlTagType.None;
+                                break;
+                        }
+                        break;
+                    case XmlNodeType.Text:
+                        if (currentDocNode == null)
+                            continue;
+
+                        switch (currentTag)
+                        {
+                            case XmlTagType.Summary:
+                                currentDocNode.Summary = reader.Value.CleanUpDocString();
+                                break;
+                            case XmlTagType.Parameter:
+                                currentDocNode.Parameters.Add(currentParamName, reader.Value.CleanUpDocString());
+                                break;
+                            case XmlTagType.SearchTags:
+                                currentDocNode.SearchTags = reader.Value.CleanUpDocString();
+                                break;
+                        }
+
+                        break;
+                }
+            }
         }
 
         #endregion

--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -77,21 +77,14 @@ namespace Dynamo.DSEngine
             if (string.IsNullOrEmpty(assemblyName))
                 return String.Empty;
 
-            string assemblyNameWithoutType;
-            // E.g. ProtoGeometry.dll => ProtoGeometry
-            if (assemblyName.LastIndexOf(".") != -1)
-                assemblyNameWithoutType = assemblyName.Substring(0, assemblyName.LastIndexOf("."));
-            else
-                assemblyNameWithoutType = assemblyName;
-
             var fullyQualifiedName = MemberDocumentNode.MakeFullyQualifiedName
-                (assemblyNameWithoutType, GetMemberElementName(function));
+                (assemblyName, GetMemberElementName(function));
 
             if (!documentNodes.ContainsKey(fullyQualifiedName))
             {
                 if (xml == null)
                     xml = DocumentationServices.GetForAssembly(function.Assembly, function.PathManager);
-                LoadDataFromXml(xml, assemblyNameWithoutType);
+                LoadDataFromXml(xml, assemblyName);
             }
 
             MemberDocumentNode documentNode = null;

--- a/test/DynamoCoreTests/XmlDocumentationTests.cs
+++ b/test/DynamoCoreTests/XmlDocumentationTests.cs
@@ -2,7 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Xml.Linq;
+using System.Xml;
+using System.IO;
 
 using Dynamo.DSEngine;
 using Dynamo.Library;
@@ -17,7 +18,7 @@ namespace Dynamo.Tests
     {
         #region Helpers
 
-        private static XDocument SampleDocument = XDocument.Parse(
+        private static XmlReader SampleDocument = XmlReader.Create(new StringReader(
 @"
 <doc>          
     <members>
@@ -36,7 +37,7 @@ namespace Dynamo.Tests
         </member>
     </members>
 </doc>
-");
+"));
 
         private static FunctionDescriptor GetTranslateMethod()
         {

--- a/test/DynamoCoreTests/XmlDocumentationTests.cs
+++ b/test/DynamoCoreTests/XmlDocumentationTests.cs
@@ -58,7 +58,7 @@ namespace Dynamo.Tests
                 FunctionType = FunctionType.InstanceMethod
             });
 
-            parms.ForEach(x => x.UpdateFunctionDescriptor(funcDesc, null));
+            parms.ForEach(x => x.UpdateFunctionDescriptor(funcDesc));
 
             return funcDesc;
         }


### PR DESCRIPTION
This PR is copy of [that one](https://github.com/DynamoDS/Dynamo/pull/4012). But this is made with one commit.

Reviewers
@Benglin , please take a look.

Link to YouTrack:
[MAGN-6683](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6683) Improve performance of usage of XmlDocument.XPathEvaluate
