### PR TITLE
MAGN-5390 DUI: Use IEnumerable whenever possible

### DIFF
--- a/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
@@ -97,7 +97,7 @@ namespace Dynamo.Search.SearchElements
             }
         }
 
-        protected override List<Tuple<string, string>> GenerateInputParameters()
+        protected override IEnumerable<Tuple<string, string>> GenerateInputParameters()
         {
             TryLoadDocumentation();
 
@@ -107,7 +107,7 @@ namespace Dynamo.Search.SearchElements
             return inputParameters;
         }
 
-        protected override List<string> GenerateOutputParameters()
+        protected override IEnumerable<string> GenerateOutputParameters()
         {
             TryLoadDocumentation();
 

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -200,7 +200,7 @@ namespace Dynamo.Search.SearchElements
         }
 
         protected List<string> outputParameters;
-        public List<string> OutputParameters
+        public IEnumerable<string> OutputParameters
         {
             get
             {
@@ -258,13 +258,13 @@ namespace Dynamo.Search.SearchElements
             if (handler != null) handler(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        protected virtual List<string> GenerateOutputParameters()
+        protected virtual IEnumerable<string> GenerateOutputParameters()
         {
             outputParameters.Add("none");
             return outputParameters;
         }
 
-        protected virtual List<Tuple<string, string>> GenerateInputParameters()
+        protected virtual IEnumerable<Tuple<string, string>> GenerateInputParameters()
         {
             inputParameters.Add(Tuple.Create("", "none"));
             return inputParameters;

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -117,7 +117,7 @@ namespace Dynamo.Wpf.ViewModels
             get { return Model.InputParameters; }
         }
 
-        public List<string> OutputParameters
+        public IEnumerable<string> OutputParameters
         {
             get { return Model.OutputParameters; }
         }


### PR DESCRIPTION
The following properties/methods used to return  List<xxx> :

 NodeSearchElement.OutputParameters 
 NodeSearchElement.GenerateOutputParameters 
 NodeSearchElement.InputParameters 
 NodeSearchElement.GenerateInputParameters

Now they return IEnumerable<xxx> .

Reviewers
@Benglin , please take a look.

Link to YouTrack:
[MAGN-5390](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5390) DUI: Use IEnumerable whenever possible