### PR TITLE
Fix regressions: shut down DynamoModel in test case

### DIFF
--- a/test/DynamoCoreTests/ConverterTests.cs
+++ b/test/DynamoCoreTests/ConverterTests.cs
@@ -436,9 +436,6 @@ namespace Dynamo.Tests
             textBlock.Height = 10;
 
             # region dynamoViewModel and searchModel
-            var model = DynamoModel.Start();
-            var vizManager = new VisualizationManager(model);
-            var watchHandler = new DefaultWatchHandler(vizManager, model.PreferenceSettings);
             DynamoViewModel dynamoViewModel = DynamoViewModel.Start();
             NodeSearchModel searchModel = new NodeSearchModel();
             # endregion
@@ -469,6 +466,9 @@ namespace Dynamo.Tests
             thickness = new Thickness(0, 0, -6.6733333333333338, 0);
             result = converter.Convert(array, null, null, null);
             Assert.AreEqual(thickness, result);
+
+            var shutdownParams = new DynamoViewModel.ShutdownParams(shutdownHost: false, allowCancellation: false);
+            dynamoViewModel.PerformShutdownSequence(shutdownParams);
         }
 
         [Test]

--- a/test/DynamoCoreTests/IconsTests.cs
+++ b/test/DynamoCoreTests/IconsTests.cs
@@ -62,6 +62,7 @@ namespace Dynamo.Tests
             }
 
             Assert.IsTrue(missingIcons.Count == 0, String.Join(Environment.NewLine, missingIcons));
+            model.ShutDown(false);
         }
     }
 }


### PR DESCRIPTION
The regression test case `Dynamo.Tests.MessageLogTests.TestWarningMessageLog` is because `DynamoModel` is not shutdown in other test cases. 

Fundamentally, there are some static classes in the system, for example, `DynamoServices.LogWarningMessageEvents`, and `DynamoModel` is a subscriber of some event handlers in these static classes. If `DynamoModel` is not shut down, there are two problems:
  1. Memory leak: static class instances still have reference to `DynamoModel`
  2. Unexpected results: events are handled by zombie `DynamoModel` from other test cases that have already done. 

@Benglin please review the change. 