### PR TITLE
Correct erroneous enabling of "Publish This Custom Node" in context menu of custom node

### DIFF
--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -48,15 +48,9 @@ namespace Dynamo.Wpf
                 IsCheckable = false
             };
             nodeView.MainContextMenu.Items.Add(publishCustomNodeItem);
-            publishCustomNodeItem.Click += (sender, args) =>
-            {
-                GoToWorkspace(nodeView.ViewModel);
 
-                if (nodeView.ViewModel.DynamoViewModel.PublishCurrentWorkspaceCommand.CanExecute(null))
-                {
-                    nodeView.ViewModel.DynamoViewModel.PublishCurrentWorkspaceCommand.Execute(null);
-                }
-            };
+            publishCustomNodeItem.Command = nodeView.ViewModel.DynamoViewModel.PublishSelectedNodesCommand;
+            publishCustomNodeItem.CommandParameter = functionNodeModel;
 
             nodeView.UpdateLayout();
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -1,5 +1,7 @@
-﻿using Dynamo.UI.Commands;
+﻿using Dynamo.Nodes;
 using Dynamo.Wpf.ViewModels;
+using Microsoft.Practices.Prism.Commands;
+using DelegateCommand = Dynamo.UI.Commands.DelegateCommand;
 
 namespace Dynamo.ViewModels
 {
@@ -53,6 +55,7 @@ namespace Dynamo.ViewModels
             ShowInstalledPackagesCommand = new DelegateCommand(ShowInstalledPackages, CanShowInstalledPackages);
             PublishCurrentWorkspaceCommand = new DelegateCommand(PackageManagerClientViewModel.PublishCurrentWorkspace, PackageManagerClientViewModel.CanPublishCurrentWorkspace);
             PublishSelectedNodesCommand = new DelegateCommand(PackageManagerClientViewModel.PublishSelectedNodes, PackageManagerClientViewModel.CanPublishSelectedNodes);
+            PublishCustomNodeCommand = new DelegateCommand<Function>(PackageManagerClientViewModel.PublishCustomNode, PackageManagerClientViewModel.CanPublishCustomNode);
             ShowHideConnectorsCommand = new DelegateCommand(ShowConnectors, CanShowConnectors);
             SelectNeighborsCommand = new DelegateCommand(SelectNeighbors, CanSelectNeighbors);
             ClearLogCommand = new DelegateCommand(ClearLog, CanClearLog);
@@ -122,6 +125,7 @@ namespace Dynamo.ViewModels
         public DelegateCommand PublishNewPackageCommand { get; set; }
         public DelegateCommand PublishCurrentWorkspaceCommand { get; set; }
         public DelegateCommand PublishSelectedNodesCommand { get; set; }
+        public DelegateCommand<Function> PublishCustomNodeCommand { get; set; }
         public DelegateCommand PanCommand { get; set; }
         public DelegateCommand ZoomInCommand { get; set; }
         public DelegateCommand ZoomOutCommand { get; set; }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -128,6 +128,22 @@ namespace Dynamo.ViewModels
             return HasAuthProvider;
         }
 
+        public void PublishCustomNode(Dynamo.Nodes.Function m)
+        {
+            CustomNodeInfo currentFunInfo;
+            if (DynamoViewModel.Model.CustomNodeManager.TryGetNodeInfo(
+                m.Definition.FunctionId,
+                out currentFunInfo))
+            {
+                ShowNodePublishInfo(new[] { Tuple.Create(currentFunInfo, m.Definition) });
+            }
+        }
+
+        public bool CanPublishCustomNode(Dynamo.Nodes.Function m)
+        {
+            return HasAuthProvider && m != null;
+        }
+
         public void PublishSelectedNodes(object m)
         {
             var nodeList = DynamoSelection.Instance.Selection


### PR DESCRIPTION
### Issue

The "Publish This Custom Node..." `MenuItem` was erroneously enabled in standalone.  It didn't actually work, but instead solely moved you to the Custom Node Workspace.  This item should ONLY be enabled when an `AuthProvider` is available (e.g. in Revit or in a authentication enabled version of standalone).

### Fix

Use a proper `Command` and specify the `CommandParameter` as the Function when creating this `MenuItem` in the `FunctionNodeViewCustomization`.

### Reviewer

- [x] @ramramps 

### Merging

- [ ] 0.8.0