### PR TITLE
 Add icons support for Custom Nodes

### DIFF
--- a/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
@@ -36,6 +36,8 @@ namespace Dynamo.Search.SearchElements
             inputParameters = new List<Tuple<string, string>>();
             outputParameters = new List<string>();
             SyncWithCustomNodeInfo(info);
+
+            iconName = FullName;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -187,7 +187,7 @@ namespace Dynamo.Wpf.ViewModels
             throw new InvalidOperationException("Unhandled resourceType");
         }
 
-        protected ImageSource GetIcon(string fullNameOfIcon)
+        protected virtual ImageSource GetIcon(string fullNameOfIcon)
         {
             if (string.IsNullOrEmpty(Model.Assembly))
                 return null;
@@ -251,6 +251,14 @@ namespace Dynamo.Wpf.ViewModels
                 Configurations.SmallIconPostfix : Configurations.LargeIconPostfix;
 
             return GetIcon(Configurations.DefaultCustomNodeIcon + postfix);
+        }
+
+        protected override ImageSource GetIcon(string fullNameOfIcon)
+        {
+            var iconRequest = new IconRequestEventArgs(Model.Path, fullNameOfIcon);
+            OnRequestBitmapSource(iconRequest);
+
+            return iconRequest.Icon;
         }
     }
 }


### PR DESCRIPTION
## Overview
Now custom nodes use default custom node icon.
![image](https://cloud.githubusercontent.com/assets/8158404/6963691/ce3450c0-d94a-11e4-87d8-045f305ecb8c.png)

With this PR custom nodes can support icons.
![image](https://cloud.githubusercontent.com/assets/8158404/6963738/33c4d374-d94b-11e4-8238-0922b27d6618.png)

I'm not sure whether this is the best solution.
Since custom nodes don't have assembly, I coded this so that Dynamo searches for `<custom node name>.customization.dll` 

### Advantage
- We don't need to change a lot of code.

### Disadvantage
- For each custom node we should have its' own customization dll. Maybe, it's better to have assembly tag inside of custom node. And we can use one customization dll for several custom nodes. But it will cause bigger code change.

e.g.
```xml
<Workspace Version="0.8" X="0" Y="0" Name="CustomNode" Assembly="SomeAssembly.customization.dll">
  <NamespaceResolutionMap />
  <Elements>
    .  .  .
  <Notes />
</Workspace>
```

### Reviewers
@Benglin , please take a look.

Link to YouTrack:
[MAGN-6311](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6311) Add icons support for Custom Nodes