### PR TITLE
Fixed dialog lingering issue in the event that settings migration fails

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -459,20 +459,23 @@ namespace Dynamo.Models
             if (!isTestMode && this.PreferenceSettings.IsFirstRun)
             {
                 DynamoMigratorBase migrator = null;
+
+                OnRequestMigrationStatusDialog(new SettingsMigrationEventArgs(
+                    SettingsMigrationEventArgs.EventStatusType.Begin));
                 try
                 {
-                    OnRequestMigrationStatusDialog(new SettingsMigrationEventArgs(
-                        SettingsMigrationEventArgs.EventStatusType.Begin));
-
                     migrator = DynamoMigratorBase.MigrateBetweenDynamoVersions(pathManager, config.PathResolver);
-
-                    OnRequestMigrationStatusDialog(new SettingsMigrationEventArgs(
-                        SettingsMigrationEventArgs.EventStatusType.End));
                 }
                 catch (Exception e)
                 {
                     Logger.Log(e.Message);
                 }
+                finally
+                {
+                    OnRequestMigrationStatusDialog(new SettingsMigrationEventArgs(
+                        SettingsMigrationEventArgs.EventStatusType.End));
+                }
+
                 if (migrator != null)
                 {
                     var isFirstRun = this.PreferenceSettings.IsFirstRun;


### PR DESCRIPTION
This fixes defect: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6893

In the event that settings migration fails (an exception occurs) the migration prompt dialog close event was not being raised as it was being skipped and went straight to the `catch` block. This has been fixed by moving the dialog close event into the `finally` block.

@Benglin PTAL