### PR TITLE
Fixed: Notes are not in selection after pasting

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1316,16 +1316,11 @@ namespace Dynamo.Models
         /// <param name="parameters">The object to add to the selection.</param>
         public void AddToSelection(object parameters)
         {
-            var node = parameters as NodeModel;
-
-            //don't add if the object is null
-            if (node == null)
-                return;
-
-            if (!node.IsSelected)
+            var selectable = parameters as ISelectable;
+            if ((selectable != null) && !selectable.IsSelected)
             {
-                if (!DynamoSelection.Instance.Selection.Contains(node))
-                    DynamoSelection.Instance.Selection.Add(node);
+                if (!DynamoSelection.Instance.Selection.Contains(selectable))
+                    DynamoSelection.Instance.Selection.Add(selectable);
             }
         }
 


### PR DESCRIPTION
Background
-----
This fixes the following user reported issues:

- [Notes not in selection after copy/paste](https://github.com/DynamoDS/Dynamo/issues/332)
- [Copy-paste Notes](https://github.com/DynamoDS/Dynamo/issues/4133)

- An internally track defect [MAGN-263](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-263)

Analysis
-----
Both `NodeModel` and `NoteModel` objects are added to selection by calls to `AddToSelection` in `DynamoModel.Paste` method. Unfortunately, `NoteModel` objects are *rejected* inside `AddToSelection` method by the following cast:

```csharp
public void AddToSelection(object parameters)
{
    // Just like NodeModel, a NoteModel is derived from ISelectable interface,
    // but the following cast results in null for NoteModel since it is not in 
    // anyway derived from NodeModel. We should cast it to ISelectable instead.
    // 
    var selectable = parameters as NodeModel;
    if (selectable == null)
        return;
}
```

This pull request fixes that by doing a cast to `ISelectable` instead of `NodeModel`.

Hi @nguyen-binh-minh, do have a look at this one. Thanks!