### PR TITLE
MAGN-6772 Periodic definition with Web Request node crashes app at exit after switching execution modes

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -64,6 +64,13 @@ namespace Dynamo.Wpf.ViewModels.Core
             hwm.EvaluationStarted += hwm_EvaluationStarted;
             hwm.EvaluationCompleted += hwm_EvaluationCompleted;
             hwm.SetNodeDeltaState +=hwm_SetNodeDeltaState;
+
+            dynamoViewModel.Model.ShutdownStarted += Model_ShutdownStarted;
+        }
+
+        void Model_ShutdownStarted(DynamoModel model)
+        {
+            StopPeriodicTimer(null);
         }
 
         /// <summary>
@@ -195,6 +202,8 @@ namespace Dynamo.Wpf.ViewModels.Core
             hwm.EvaluationStarted -= hwm_EvaluationStarted;
             hwm.EvaluationCompleted -= hwm_EvaluationCompleted;
             hwm.SetNodeDeltaState -= hwm_SetNodeDeltaState;
+
+            DynamoViewModel.Model.ShutdownStarted -= Model_ShutdownStarted;
         }
     }
 


### PR DESCRIPTION
This PR addresses the issue in [MAGN-6772](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6772), where exceptions would be thrown during shutdown with Periodic running enabled. It prevents exceptions related to the periodic timer attempting to queue executions while Dynamo is shutting down, by adding a call to `StopPeriodicTimer` in a handler for the `DynamoModel.ShutdownStarted` event. 

PTAL:
@ramramps 