### PR TITLE
Bug fix in element resolver to handle incorrect function calls

### DIFF
--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -70,7 +70,7 @@ namespace ProtoCore.Namespace
                 {
                     // If namespace resolution map does not contain entry for partial name, 
                     // back up on compiler to resolve the namespace from partial name
-                    var matchingClasses = CoreUtils.GetResolvedClassName(classTable, identifier);
+                    var matchingClasses = CoreUtils.GetResolvedClassName(classTable, CoreUtils.CreateNodeFromString(partialName));
 
                     if (matchingClasses.Length == 1)
                     {


### PR DESCRIPTION
This submission fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6906

The example here is typing `Autodesk.Point()`, which is an invalid function call ends up with the namespace `Autodesk` being mapped to the fully qualified name `Autodesk.DesignScript.Geometry.Point` in the element resolver, which is incorrect. 

In this case, the user has intended `Point` to be a function and `Autodesk` to be a class name. Therefore `Autodesk` as a class name should be matched against existing classes in the class table. If done properly the element resolver will not be able to match `Autodesk` as a valid class and therefore not add a mapping for it, which should be the right behaviour in this case.

@junmendoza PTAL