### PR TITLE
MAGN-6755 Simplify the way class button on library is determined

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -208,6 +208,11 @@ namespace Dynamo.Wpf.ViewModels
             }
         }
 
+        public bool IsClassButton
+        {
+            get { return SubCategories.Count == 0; ; }
+        }
+
         ///<summary>
         /// Small icon for class and method buttons.
         ///</summary>
@@ -509,7 +514,7 @@ namespace Dynamo.Wpf.ViewModels
         {
             get
             {
-                if (classDetails == null && SubCategories.Count == 0)
+                if (classDetails == null && IsClassButton)
                 {
                     classDetails = new ClassInformationViewModel();
                     classDetails.IsRootCategoryDetails = true;

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -210,7 +210,7 @@ namespace Dynamo.Wpf.ViewModels
 
         public bool IsClassButton
         {
-            get { return SubCategories.Count == 0; ; }
+            get { return SubCategories.Count == 0; }
         }
 
         ///<summary>

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -278,7 +278,7 @@ namespace Dynamo.ViewModels
         {
             foreach (var item in tree)
             {
-                var classes = item.SubCategories.Where(cat => cat.SubCategories.Count == 0).ToList();
+                var classes = item.SubCategories.Where(cat => cat.IsClassButton).ToList();
                 foreach (var item2 in classes)
                     item.SubCategories.Remove(item2);
 
@@ -474,7 +474,7 @@ namespace Dynamo.ViewModels
                     // New category should be added to existing ClassesNodeCategoryViewModel.
                     // Make notice: ClassesNodeCategoryViewModel is always first item in 
                     // all subcategories.
-                    if (nameStack.Count == 0 && target.SubCategories.Count > 0 &&
+                    if (nameStack.Count == 0 && !target.IsClassButton &&
                         target.SubCategories[0] is ClassesNodeCategoryViewModel)
                     {
                         target.SubCategories[0].SubCategories.Add(newTarget);
@@ -491,7 +491,7 @@ namespace Dynamo.ViewModels
                         if (targetClass.SubCategories.Remove(target))
                             targetClass.Parent.SubCategories.Add(target);
                         // Delete empty classes container.
-                        if (targetClass.SubCategories.Count == 0)
+                        if (targetClass.IsClassButton)
                             targetClass.Parent.SubCategories.RemoveAt(0);
 
                         targetClass.Dispose();
@@ -764,7 +764,7 @@ namespace Dynamo.ViewModels
                 newTarget = target.SubCategories.FirstOrDefault(c => c.Name == currentCategory);
                 if (newTarget == null)
                 {
-                    if (!isCheckedForClassesCategory && target.SubCategories.Count > 0 &&
+                    if (!isCheckedForClassesCategory && !target.IsClassButton &&
                         target.SubCategories[0] is ClassesNodeCategoryViewModel)
                     {
                         isCheckedForClassesCategory = true;

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -147,7 +147,7 @@ namespace Dynamo.UI.Views
                 if (wrapPanel.MakeOrClearSelection(selectedClass))
                 {
                     // If class button was clicked, then handle, otherwise leave it.
-                    e.Handled = selectedClass.SubCategories.Count == 0;
+                    e.Handled = selectedClass.IsClassButton;
                     selectedElement.BringIntoView();
                 }
             }
@@ -190,12 +190,12 @@ namespace Dynamo.UI.Views
                 var searchFurtherInNextLevel = true;
 
                 // If class button was clicked.
-                if (selectedClass.SubCategories.Count == 0)
+                if (selectedClass.IsClassButton)
                 {
                     var categoryClasses = expandedCategory.Items[0] as ClassesNodeCategoryViewModel;
                     if (categoryClasses != null) // There are classes under this category...
                     {
-                        if (expandedCategory.SubCategories.Count == 0)
+                        if (expandedCategory.IsClassButton)
                         {
                             // If the category does not contain any sub category, 
                             // then we won't look for the selected class within it.


### PR DESCRIPTION
Instead of using `SubCategories.Count == 0`, we introduce new property `IsClassButton`.
I couldn't turn SubCategories to private. Because of `GroupByRecursive` in SearchViewModel.cs, row 256. It assumes name, subs, es, where subs is subcategories and es is entries. I think I can't change this black magic...

Reviewers
@Benglin , please take a look.

Link to YouTrack:
[MAGN-6755](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6755) Simplify the way class button on library is determined