### PR TITLE
Close migration dialog on loading usage reporting form on first run

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -470,11 +470,6 @@ namespace Dynamo.Models
                 {
                     Logger.Log(e.Message);
                 }
-                finally
-                {
-                    OnRequestMigrationStatusDialog(new SettingsMigrationEventArgs(
-                        SettingsMigrationEventArgs.EventStatusType.End));
-                }
 
                 if (migrator != null)
                 {

--- a/src/DynamoCoreWpf/Services/UsageReportingManager.cs
+++ b/src/DynamoCoreWpf/Services/UsageReportingManager.cs
@@ -214,7 +214,15 @@ namespace Dynamo.Services
             {
                 Owner = ownerWindow
             };
+            usageReportingPrompt.Loaded += UsageReportingPromptLoaded;
             usageReportingPrompt.ShowDialog();
+            usageReportingPrompt.Loaded -= UsageReportingPromptLoaded;
+        }
+
+        void UsageReportingPromptLoaded(object sender, RoutedEventArgs e)
+        {
+                DynamoModel.OnRequestMigrationStatusDialog(new SettingsMigrationEventArgs(
+                            SettingsMigrationEventArgs.EventStatusType.End));           
         }
     }
 }

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -106,12 +106,19 @@ namespace DynamoSandbox
                     DynamoModel = model
                 });
 
-            DynamoModel.RequestMigrationStatusDialog -= MigrationStatusDialogRequested;
-
             var view = new DynamoView(viewModel);
+            view.Loaded += ViewLoaded;
 
             var app = new Application();
             app.Run(view);
+
+            DynamoModel.RequestMigrationStatusDialog -= MigrationStatusDialogRequested;
+        }
+
+        static void ViewLoaded(object sender, RoutedEventArgs e)
+        {
+            DynamoModel.OnRequestMigrationStatusDialog(new SettingsMigrationEventArgs(
+                        SettingsMigrationEventArgs.EventStatusType.End));
         }
 
         private static void MigrationStatusDialogRequested(SettingsMigrationEventArgs args)
@@ -123,6 +130,9 @@ namespace DynamoSandbox
             }
             else if (args.EventStatus == SettingsMigrationEventArgs.EventStatusType.End)
             {
+                if (migrationWindow == null) 
+                    return;
+
                 migrationWindow.Close();
                 migrationWindow = null;
             }

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -107,7 +107,7 @@ namespace DynamoSandbox
                 });
 
             var view = new DynamoView(viewModel);
-            view.Loaded += ViewLoaded;
+            view.Loaded += (sender, args) => CloseMigrationWindow();
 
             var app = new Application();
             app.Run(view);
@@ -115,10 +115,13 @@ namespace DynamoSandbox
             DynamoModel.RequestMigrationStatusDialog -= MigrationStatusDialogRequested;
         }
 
-        static void ViewLoaded(object sender, RoutedEventArgs e)
+        private static void CloseMigrationWindow()
         {
-            DynamoModel.OnRequestMigrationStatusDialog(new SettingsMigrationEventArgs(
-                        SettingsMigrationEventArgs.EventStatusType.End));
+            if (migrationWindow == null)
+                return;
+
+            migrationWindow.Close();
+            migrationWindow = null;
         }
 
         private static void MigrationStatusDialogRequested(SettingsMigrationEventArgs args)
@@ -130,11 +133,7 @@ namespace DynamoSandbox
             }
             else if (args.EventStatus == SettingsMigrationEventArgs.EventStatusType.End)
             {
-                if (migrationWindow == null) 
-                    return;
-
-                migrationWindow.Close();
-                migrationWindow = null;
+                CloseMigrationWindow();
             }
         }
 


### PR DESCRIPTION
Currently the settings migration dialog's lifespan is from start of settings migration to end of migration on first run. Once migration is complete, the dialog closes and again for a brief period of time there is no other window open to indicate whether Dynamo is loading. It is therefore confusing to the user who may think something wrong happened when the migration dialog disappears. 

This fix is to keep the dialog alive until the user agreement form loads to fill the gap in between. The user agreement form `Loaded` event triggers the closing of the migration dialog. In the unforeseen event of the user agreement form not being present, `DynamoView` is responsible for closing the migration dialog if it is present.

Fixes: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6911

@Benglin please review
@elayabharath - you requested for this :)