### PR TITLE
DUI: Re-implement logic of getting know ElementType of each node

### DIFF
--- a/src/DynamoCore/Core/CustomNodeDefinition.cs
+++ b/src/DynamoCore/Core/CustomNodeDefinition.cs
@@ -230,7 +230,7 @@ namespace Dynamo
     /// </summary>
     public class CustomNodeInfo
     {
-        public CustomNodeInfo(Guid functionId, string name, string category, string description, string path, bool isPackage = false)
+        public CustomNodeInfo(Guid functionId, string name, string category, string description, string path, bool isPackageMember = false)
         {
             if (functionId == Guid.Empty)
                 throw new ArgumentException(@"FunctionId invalid.", "functionId");
@@ -240,7 +240,7 @@ namespace Dynamo
             Category = category;
             Description = description;
             Path = path;
-            IsPackage = isPackage;
+            IsPackageMember = isPackageMember;
         }
 
         public Guid FunctionId { get; set; }
@@ -248,6 +248,6 @@ namespace Dynamo
         public string Category { get; set; }
         public string Description { get; set; }
         public string Path { get; set; }
-        public bool IsPackage { get; set; }
+        public bool IsPackageMember { get; set; }
     }
 }

--- a/src/DynamoCore/Core/CustomNodeDefinition.cs
+++ b/src/DynamoCore/Core/CustomNodeDefinition.cs
@@ -230,7 +230,7 @@ namespace Dynamo
     /// </summary>
     public class CustomNodeInfo
     {
-        public CustomNodeInfo(Guid functionId, string name, string category, string description, string path)
+        public CustomNodeInfo(Guid functionId, string name, string category, string description, string path, bool isPackage = false)
         {
             if (functionId == Guid.Empty)
                 throw new ArgumentException(@"FunctionId invalid.", "functionId");
@@ -240,6 +240,7 @@ namespace Dynamo
             Category = category;
             Description = description;
             Path = path;
+            IsPackage = isPackage;
         }
 
         public Guid FunctionId { get; set; }
@@ -247,5 +248,6 @@ namespace Dynamo
         public string Category { get; set; }
         public string Description { get; set; }
         public string Path { get; set; }
+        public bool IsPackage { get; set; }
     }
 }

--- a/src/DynamoCore/Core/CustomNodeDefinition.cs
+++ b/src/DynamoCore/Core/CustomNodeDefinition.cs
@@ -230,7 +230,7 @@ namespace Dynamo
     /// </summary>
     public class CustomNodeInfo
     {
-        public CustomNodeInfo(Guid functionId, string name, string category, string description, string path, bool isPackageMember = false)
+        public CustomNodeInfo(Guid functionId, string name, string category, string description, string path)
         {
             if (functionId == Guid.Empty)
                 throw new ArgumentException(@"FunctionId invalid.", "functionId");
@@ -240,7 +240,6 @@ namespace Dynamo
             Category = category;
             Description = description;
             Path = path;
-            IsPackageMember = isPackageMember;
         }
 
         public Guid FunctionId { get; set; }

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -238,9 +238,9 @@ namespace Dynamo.Core
         ///     it. Otherwise, it will be set to null.
         /// </param>
         /// <returns>True on success, false if the file could not be read properly.</returns>
-        public bool AddUninitializedCustomNode(string file, bool isTestMode, out CustomNodeInfo info, bool isPackage = false)
+        public bool AddUninitializedCustomNode(string file, bool isTestMode, out CustomNodeInfo info)
         {
-            if (TryGetInfoFromPath(file, isTestMode, isPackage, out info))
+            if (TryGetInfoFromPath(file, isTestMode, out info))
             {
                 SetNodeInfo(info);
                 return true;
@@ -312,8 +312,11 @@ namespace Dynamo.Core
             foreach (var file in Directory.EnumerateFiles(dir, "*.dyf"))
             {
                 CustomNodeInfo info;
-                if (TryGetInfoFromPath(file, isTestMode, isPackage, out info))
+                if (TryGetInfoFromPath(file, isTestMode, out info))
+                {
+                    info.IsPackage = isPackage;
                     yield return info;
+                }
             }
         }
 
@@ -424,7 +427,7 @@ namespace Dynamo.Core
         /// </param>
         /// <param name="info"></param>
         /// <returns>The custom node info object - null if we failed</returns>
-        public bool TryGetInfoFromPath(string path, bool isTestMode, bool isPackage, out CustomNodeInfo info)
+        public bool TryGetInfoFromPath(string path, bool isTestMode, out CustomNodeInfo info)
         {
             try
             {
@@ -443,8 +446,7 @@ namespace Dynamo.Core
                     header.Name,
                     header.Category,
                     header.Description, 
-                    path,
-                    isPackage);
+                    path);
                 return true;
             }
             catch (Exception e)

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -238,9 +238,9 @@ namespace Dynamo.Core
         ///     it. Otherwise, it will be set to null.
         /// </param>
         /// <returns>True on success, false if the file could not be read properly.</returns>
-        public bool AddUninitializedCustomNode(string file, bool isTestMode, out CustomNodeInfo info)
+        public bool AddUninitializedCustomNode(string file, bool isTestMode, out CustomNodeInfo info, bool isPackage = false)
         {
-            if (TryGetInfoFromPath(file, isTestMode, out info))
+            if (TryGetInfoFromPath(file, isTestMode, isPackage, out info))
             {
                 SetNodeInfo(info);
                 return true;
@@ -288,10 +288,10 @@ namespace Dynamo.Core
         ///     Flag specifying whether or not this should operate in "test mode".
         /// </param>
         /// <returns></returns>
-        public IEnumerable<CustomNodeInfo> AddUninitializedCustomNodesInPath(string path, bool isTestMode)
+        public IEnumerable<CustomNodeInfo> AddUninitializedCustomNodesInPath(string path, bool isTestMode, bool isPackage = false)
         {
             var result = new List<CustomNodeInfo>();
-            foreach (var info in ScanNodeHeadersInDirectory(path, isTestMode))
+            foreach (var info in ScanNodeHeadersInDirectory(path, isTestMode, isPackage))
             {
                 SetNodeInfo(info);
                 result.Add(info);
@@ -304,7 +304,7 @@ namespace Dynamo.Core
         ///     Does not instantiate the nodes.
         /// </summary>
         /// <returns>False if SearchPath is not a valid directory, otherwise true</returns>
-        private IEnumerable<CustomNodeInfo> ScanNodeHeadersInDirectory(string dir, bool isTestMode)
+        private IEnumerable<CustomNodeInfo> ScanNodeHeadersInDirectory(string dir, bool isTestMode, bool isPackage)
         {
             if (!Directory.Exists(dir))
                 yield break;
@@ -312,7 +312,7 @@ namespace Dynamo.Core
             foreach (var file in Directory.EnumerateFiles(dir, "*.dyf"))
             {
                 CustomNodeInfo info;
-                if (TryGetInfoFromPath(file, isTestMode, out info))
+                if (TryGetInfoFromPath(file, isTestMode, isPackage, out info))
                     yield return info;
             }
         }
@@ -424,7 +424,7 @@ namespace Dynamo.Core
         /// </param>
         /// <param name="info"></param>
         /// <returns>The custom node info object - null if we failed</returns>
-        public bool TryGetInfoFromPath(string path, bool isTestMode, out CustomNodeInfo info)
+        public bool TryGetInfoFromPath(string path, bool isTestMode, bool isPackage, out CustomNodeInfo info)
         {
             try
             {
@@ -443,7 +443,8 @@ namespace Dynamo.Core
                     header.Name,
                     header.Category,
                     header.Description, 
-                    path);
+                    path,
+                    isPackage);
                 return true;
             }
             catch (Exception e)

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -288,10 +288,10 @@ namespace Dynamo.Core
         ///     Flag specifying whether or not this should operate in "test mode".
         /// </param>
         /// <returns></returns>
-        public IEnumerable<CustomNodeInfo> AddUninitializedCustomNodesInPath(string path, bool isTestMode, bool isPackage = false)
+        public IEnumerable<CustomNodeInfo> AddUninitializedCustomNodesInPath(string path, bool isTestMode, bool isPackageMember = false)
         {
             var result = new List<CustomNodeInfo>();
-            foreach (var info in ScanNodeHeadersInDirectory(path, isTestMode, isPackage))
+            foreach (var info in ScanNodeHeadersInDirectory(path, isTestMode, isPackageMember))
             {
                 SetNodeInfo(info);
                 result.Add(info);
@@ -304,7 +304,7 @@ namespace Dynamo.Core
         ///     Does not instantiate the nodes.
         /// </summary>
         /// <returns>False if SearchPath is not a valid directory, otherwise true</returns>
-        private IEnumerable<CustomNodeInfo> ScanNodeHeadersInDirectory(string dir, bool isTestMode, bool isPackage)
+        private IEnumerable<CustomNodeInfo> ScanNodeHeadersInDirectory(string dir, bool isTestMode, bool isPackageMember)
         {
             if (!Directory.Exists(dir))
                 yield break;
@@ -314,7 +314,7 @@ namespace Dynamo.Core
                 CustomNodeInfo info;
                 if (TryGetInfoFromPath(file, isTestMode, out info))
                 {
-                    info.IsPackage = isPackage;
+                    info.IsPackageMember = isPackageMember;
                     yield return info;
                 }
             }

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -315,9 +315,7 @@ namespace Dynamo.Core
             {
                 CustomNodeInfo info;
                 if (TryGetInfoFromPath(file, isTestMode, out info))
-                {
                     yield return info;
-                }
             }
         }
 

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -291,8 +291,10 @@ namespace Dynamo.Core
         public IEnumerable<CustomNodeInfo> AddUninitializedCustomNodesInPath(string path, bool isTestMode, bool isPackageMember = false)
         {
             var result = new List<CustomNodeInfo>();
-            foreach (var info in ScanNodeHeadersInDirectory(path, isTestMode, isPackageMember))
+            foreach (var info in ScanNodeHeadersInDirectory(path, isTestMode))
             {
+                info.IsPackageMember = isPackageMember;
+
                 SetNodeInfo(info);
                 result.Add(info);
             }
@@ -304,7 +306,7 @@ namespace Dynamo.Core
         ///     Does not instantiate the nodes.
         /// </summary>
         /// <returns>False if SearchPath is not a valid directory, otherwise true</returns>
-        private IEnumerable<CustomNodeInfo> ScanNodeHeadersInDirectory(string dir, bool isTestMode, bool isPackageMember)
+        private IEnumerable<CustomNodeInfo> ScanNodeHeadersInDirectory(string dir, bool isTestMode)
         {
             if (!Directory.Exists(dir))
                 yield break;
@@ -314,7 +316,6 @@ namespace Dynamo.Core
                 CustomNodeInfo info;
                 if (TryGetInfoFromPath(file, isTestMode, out info))
                 {
-                    info.IsPackageMember = isPackageMember;
                     yield return info;
                 }
             }

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -287,6 +287,9 @@ namespace Dynamo.Core
         /// <param name="isTestMode">
         ///     Flag specifying whether or not this should operate in "test mode".
         /// </param>
+        /// <param name="isPackageMember">
+        ///     Indicates whether custom node comes from package or not.
+        /// </param>
         /// <returns></returns>
         public IEnumerable<CustomNodeInfo> AddUninitializedCustomNodesInPath(string path, bool isTestMode, bool isPackageMember = false)
         {

--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -52,7 +52,6 @@ namespace Dynamo.DSEngine
             Parameters = new List<TypedParameter>();
             ReturnKeys = new List<string>();
             ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar);
-            IsBuiltIn = false;
         }
 
         public string Assembly { get; set; }

--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -52,6 +52,7 @@ namespace Dynamo.DSEngine
             Parameters = new List<TypedParameter>();
             ReturnKeys = new List<string>();
             ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar);
+            IsBuiltIn = false;
         }
 
         public string Assembly { get; set; }
@@ -67,6 +68,7 @@ namespace Dynamo.DSEngine
         public IEnumerable<string> ReturnKeys { get; set; }
         public IPathManager PathManager { get; set; }
         public bool IsVarArg { get; set; }
+        public bool IsBuiltIn { get; set; }
     }
 
     /// <summary>
@@ -121,6 +123,7 @@ namespace Dynamo.DSEngine
             IsVisibleInLibrary = funcDescParams.IsVisibleInLibrary;
             ObsoleteMessage = funcDescParams.ObsoleteMsg;
             CanUpdatePeriodically = funcDescParams.CanUpdatePeriodically;
+            IsBuiltIn = funcDescParams.IsBuiltIn;
         }
 
         public bool IsOverloaded { get; set; }
@@ -161,6 +164,8 @@ namespace Dynamo.DSEngine
         ///     Does the function accept a variable number of arguments?
         /// </summary>
         public bool IsVarArg { get; private set; }
+
+        public bool IsBuiltIn { get; private set; }
 
         public string ObsoleteMessage { get; protected set; }
         public bool IsObsolete { get { return !string.IsNullOrEmpty(ObsoleteMessage); } }

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -605,7 +605,8 @@ namespace Dynamo.DSEngine
                                                                 PathManager = pathManager,
                                                                 ReturnType = method.returntype,
                                                                 FunctionType = FunctionType.GenericFunction,
-                                                                IsVisibleInLibrary = visibleInLibrary
+                                                                IsVisibleInLibrary = visibleInLibrary,
+                                                                IsBuiltIn = true
                                                             });
 
             AddBuiltinFunctions(functions);
@@ -644,14 +645,16 @@ namespace Dynamo.DSEngine
                     FunctionName = op,
                     Parameters = args,
                     PathManager = pathManager,
-                    FunctionType = FunctionType.GenericFunction
+                    FunctionType = FunctionType.GenericFunction,
+                    IsBuiltIn = true
                 }))
                 .Concat(new FunctionDescriptor(new FunctionDescriptorParams
                 {
                     FunctionName = Op.GetUnaryOpFunction(UnaryOperator.Not),
                     Parameters = GetUnaryFuncArgs(),
                     PathManager = pathManager,
-                    FunctionType = FunctionType.GenericFunction
+                    FunctionType = FunctionType.GenericFunction,
+                    IsBuiltIn = true
                 }).AsSingleton());
 
             AddBuiltinFunctions(functions);
@@ -819,7 +822,8 @@ namespace Dynamo.DSEngine
                 PathManager = pathManager,
                 IsVarArg = proc.isVarArg,
                 ObsoleteMsg = obsoleteMessage,
-                CanUpdatePeriodically = canUpdatePeriodically
+                CanUpdatePeriodically = canUpdatePeriodically,
+                IsBuiltIn = true
             });
 
             AddImportedFunctions(library, new[] { function });

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -823,7 +823,7 @@ namespace Dynamo.DSEngine
                 IsVarArg = proc.isVarArg,
                 ObsoleteMsg = obsoleteMessage,
                 CanUpdatePeriodically = canUpdatePeriodically,
-                IsBuiltIn = true
+                IsBuiltIn = pathManager.PreloadedLibraries.Contains(library)
             });
 
             AddImportedFunctions(library, new[] { function });

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -504,7 +504,7 @@ namespace Dynamo.Models
             PackageLoader.MessageLogged += LogMessage;
             PackageLoader.RequestLoadNodeLibrary += LoadNodeLibrary;
             PackageLoader.RequestLoadCustomNodeDirectory +=
-                (dir) => this.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode);
+                (dir) => this.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode, true);
 
             DisposeLogic.IsShuttingDown = false;
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -795,6 +795,7 @@ namespace Dynamo.Models
                 {
                     NodeFactory.AddTypeFactoryAndLoader(type.Type);
                     NodeFactory.AddAlsoKnownAs(type.Type, type.AlsoKnownAs);
+                    type.IsPackageMember = true;
                     AddNodeTypeToSearch(type);
                 }
                 catch (Exception e)

--- a/src/DynamoCore/Models/TypeLoadData.cs
+++ b/src/DynamoCore/Models/TypeLoadData.cs
@@ -128,6 +128,9 @@ namespace Dynamo.Models
         /// </summary>
         public readonly string Description;
 
+        /// <summary>
+        ///     Indicates if the type is loaded from a package.
+        /// </summary>
         public bool IsPackageMember;
     }
 }

--- a/src/DynamoCore/Models/TypeLoadData.cs
+++ b/src/DynamoCore/Models/TypeLoadData.cs
@@ -127,5 +127,7 @@ namespace Dynamo.Models
         ///     The description of this type.
         /// </summary>
         public readonly string Description;
+
+        public bool IsPackageMember;
     }
 }

--- a/src/DynamoCore/Search/SearchElementGroup.cs
+++ b/src/DynamoCore/Search/SearchElementGroup.cs
@@ -4,4 +4,13 @@
     {
         None, Create, Action, Query
     }
+
+    public enum ElementTypeEnum
+    {
+        RegularNode,
+        RegularCategory,
+        CustomNode,
+        CustomDll,
+        Package
+    }
 }

--- a/src/DynamoCore/Search/SearchElementGroup.cs
+++ b/src/DynamoCore/Search/SearchElementGroup.cs
@@ -5,6 +5,7 @@
         None, Create, Action, Query
     }
 
+    [System.Flags]
     public enum ElementTypes
     {
         None = 0x00000000,

--- a/src/DynamoCore/Search/SearchElementGroup.cs
+++ b/src/DynamoCore/Search/SearchElementGroup.cs
@@ -5,12 +5,12 @@
         None, Create, Action, Query
     }
 
-    public enum ElementTypeEnum
+    public enum ElementTypes
     {
-        RegularNode,
-        RegularCategory,
-        CustomNode,
-        CustomDll,
-        Package
+        None = 0x00000000,
+        ZeroTouch = 0x00000001, // All the DLLs (can be built-in, third-party, and packaged)
+        CustomNode = 0x00000002, // All the DYFs (both loose DYF files and packaged)
+        BuiltIn = 0x00010000, // Things that Dynamo ships with (operator, geometries...)
+        Packaged = 0x00020000, // Packaged element (either zero-touch DLLs or DYFs)
     }
 }

--- a/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
@@ -49,7 +49,9 @@ namespace Dynamo.Search.SearchElements
             FullCategoryName = info.Category;
             Description = info.Description;
             Path = info.Path;
-            ElementType = (info.IsPackageMember) ? ElementTypes.Packaged : ElementTypes.CustomNode;
+            ElementType = ElementTypes.CustomNode;
+            if (info.IsPackageMember)
+                ElementType |= ElementTypes.Packaged; // Add one more flag.
         }
 
         protected override NodeModel ConstructNewNodeModel()

--- a/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
@@ -49,10 +49,7 @@ namespace Dynamo.Search.SearchElements
             FullCategoryName = info.Category;
             Description = info.Description;
             Path = info.Path;
-            if (info.IsPackageMember)
-                ElementType = ElementTypeEnum.Package;
-            else
-                ElementType = ElementTypeEnum.CustomNode;
+            ElementType = (info.IsPackageMember) ? ElementTypes.Packaged : ElementTypes.CustomNode;
         }
 
         protected override NodeModel ConstructNewNodeModel()

--- a/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
@@ -49,7 +49,7 @@ namespace Dynamo.Search.SearchElements
             FullCategoryName = info.Category;
             Description = info.Description;
             Path = info.Path;
-            if (info.IsPackage)
+            if (info.IsPackageMember)
                 ElementType = ElementTypeEnum.Package;
             else
                 ElementType = ElementTypeEnum.CustomNode;

--- a/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
@@ -49,6 +49,10 @@ namespace Dynamo.Search.SearchElements
             FullCategoryName = info.Category;
             Description = info.Description;
             Path = info.Path;
+            if (info.IsPackage)
+                ElementType = ElementTypeEnum.Package;
+            else
+                ElementType = ElementTypeEnum.CustomNode;
         }
 
         protected override NodeModel ConstructNewNodeModel()

--- a/src/DynamoCore/Search/SearchElements/NodeModelSearchElementBase.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeModelSearchElementBase.cs
@@ -20,6 +20,7 @@ namespace Dynamo.Search.SearchElements
             inputParameters = new List<System.Tuple<string, string>>();
             outputParameters = new List<string>();
             iconName = typeLoadData.Type.FullName;
+            ElementType = ElementTypeEnum.RegularNode;
         }
     }
 }

--- a/src/DynamoCore/Search/SearchElements/NodeModelSearchElementBase.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeModelSearchElementBase.cs
@@ -20,7 +20,9 @@ namespace Dynamo.Search.SearchElements
             inputParameters = new List<System.Tuple<string, string>>();
             outputParameters = new List<string>();
             iconName = typeLoadData.Type.FullName;
-            ElementType = ElementTypes.None;
+            ElementType = ElementTypes.ZeroTouch;
+            if(typeLoadData.IsPackageMember)
+                ElementType |= ElementTypes.Packaged;
         }
     }
 }

--- a/src/DynamoCore/Search/SearchElements/NodeModelSearchElementBase.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeModelSearchElementBase.cs
@@ -20,7 +20,7 @@ namespace Dynamo.Search.SearchElements
             inputParameters = new List<System.Tuple<string, string>>();
             outputParameters = new List<string>();
             iconName = typeLoadData.Type.FullName;
-            ElementType = ElementTypeEnum.RegularNode;
+            ElementType = ElementTypes.None;
         }
     }
 }

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -211,7 +211,11 @@ namespace Dynamo.Search.SearchElements
             }
         }
 
-        public ElementTypeEnum ElementType;
+        public ElementTypeEnum ElementType
+        {
+            get;
+            protected set;
+        }
 
         /// <summary>
         ///     Event fired when this search element produces a new NodeModel. This typically

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -211,7 +211,7 @@ namespace Dynamo.Search.SearchElements
             }
         }
 
-        public ElementTypeEnum ElementType
+        public ElementTypes ElementType
         {
             get;
             protected set;

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -211,6 +211,8 @@ namespace Dynamo.Search.SearchElements
             }
         }
 
+        public ElementTypeEnum ElementType;
+
         /// <summary>
         ///     Event fired when this search element produces a new NodeModel. This typically
         ///     happens when it is selected in the library by the user.

--- a/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/NodeSearchElement.cs
@@ -211,6 +211,10 @@ namespace Dynamo.Search.SearchElements
             }
         }
 
+        /// <summary>
+        ///     Indicates whether it is custom node or zero-touch element.
+        ///     And whether this element comes from package or not.
+        /// </summary>
         public ElementTypes ElementType
         {
             get;

--- a/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
@@ -31,14 +31,14 @@ namespace Dynamo.Search.SearchElements
             Description = functionDescriptor.Description;
             Assembly = functionDescriptor.Assembly;
             if (functionDescriptor.IsBuiltIn)
-                ElementType = ElementTypeEnum.RegularNode;
+                ElementType = ElementTypes.None;
             else
             {
                 // Assembly, that is located in package directory, considered as part of package.
                 if (Assembly.StartsWith(functionDescriptor.PathManager.PackagesDirectory))
-                    ElementType = ElementTypeEnum.Package;
+                    ElementType = ElementTypes.Packaged;
                 else
-                    ElementType = ElementTypeEnum.CustomDll;
+                    ElementType = ElementTypes.ZeroTouch;
             }
 
             inputParameters = new List<Tuple<string, string>>(functionDescriptor.InputParameters);

--- a/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
@@ -33,7 +33,13 @@ namespace Dynamo.Search.SearchElements
             if (functionDescriptor.IsBuiltIn)
                 ElementType = ElementTypeEnum.RegularNode;
             else
-                ElementType = ElementTypeEnum.CustomDll;
+            {
+                // Assembly, that is located in package directory, considered as part of package.
+                if (Assembly.StartsWith(functionDescriptor.PathManager.PackagesDirectory))
+                    ElementType = ElementTypeEnum.Package;
+                else
+                    ElementType = ElementTypeEnum.CustomDll;
+            }
 
             inputParameters = new List<Tuple<string, string>>(functionDescriptor.InputParameters);
             outputParameters = new List<string>() { functionDescriptor.ReturnType };

--- a/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
@@ -30,16 +30,14 @@ namespace Dynamo.Search.SearchElements
             FullCategoryName = functionDescriptor.Category;
             Description = functionDescriptor.Description;
             Assembly = functionDescriptor.Assembly;
+
+            ElementType = ElementTypes.ZeroTouch;
+
             if (functionDescriptor.IsBuiltIn)
-                ElementType = ElementTypes.None;
-            else
-            {
-                // Assembly, that is located in package directory, considered as part of package.
-                if (Assembly.StartsWith(functionDescriptor.PathManager.PackagesDirectory))
-                    ElementType = ElementTypes.Packaged;
-                else
-                    ElementType = ElementTypes.ZeroTouch;
-            }
+                ElementType |= ElementTypes.BuiltIn;
+            // Assembly, that is located in package directory, considered as part of package.
+            if (Assembly.StartsWith(functionDescriptor.PathManager.PackagesDirectory))
+                ElementType |= ElementTypes.Packaged;
 
             inputParameters = new List<Tuple<string, string>>(functionDescriptor.InputParameters);
             outputParameters = new List<string>() { functionDescriptor.ReturnType };

--- a/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
@@ -17,7 +17,7 @@ namespace Dynamo.Search.SearchElements
         /// The name that is used during node creation
         /// </summary>
         public override string CreationName { get { return functionDescriptor != null ? functionDescriptor.MangledName : this.Name; } }
-        
+
         public ZeroTouchSearchElement(FunctionDescriptor functionDescriptor)
         {
             this.functionDescriptor = functionDescriptor;
@@ -30,6 +30,10 @@ namespace Dynamo.Search.SearchElements
             FullCategoryName = functionDescriptor.Category;
             Description = functionDescriptor.Description;
             Assembly = functionDescriptor.Assembly;
+            if (functionDescriptor.IsBuiltIn)
+                ElementType = ElementTypeEnum.RegularNode;
+            else
+                ElementType = ElementTypeEnum.CustomDll;
 
             inputParameters = new List<Tuple<string, string>>(functionDescriptor.InputParameters);
             outputParameters = new List<string>() { functionDescriptor.ReturnType };

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -168,6 +168,7 @@ namespace Dynamo.Wpf.ViewModels
             {
                 if (value == elementType) return;
                 elementType = value;
+                RaisePropertyChanged("ElementType");
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -169,6 +169,10 @@ namespace Dynamo.Wpf.ViewModels
                     subCategories.All(subCat => subCat.ElementType.HasFlag(ElementTypes.ZeroTouch)))
                     return ElementTypes.ZeroTouch;
 
+                if (entries.All(entry => entry.ElementType.HasFlag(ElementTypes.CustomNode)) &&
+                    subCategories.All(subCat => subCat.ElementType.HasFlag(ElementTypes.CustomNode)))
+                    return ElementTypes.CustomNode;
+
                 return ElementTypes.None;
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -157,15 +157,19 @@ namespace Dynamo.Wpf.ViewModels
         {
             get
             {
-                if (entries.All(entry => entry.ElementType == ElementTypes.Packaged) &&
-                    subCategories.All(subCategory => subCategory.ElementType == ElementTypes.Packaged))
+                if (entries.Any(entry => entry.ElementType.HasFlag(ElementTypes.BuiltIn)) ||
+                    subCategories.Any(subCat => subCat.ElementType.HasFlag(ElementTypes.BuiltIn)))
+                    return ElementTypes.BuiltIn;
+
+                if (entries.All(entry => entry.ElementType.HasFlag(ElementTypes.Packaged)) &&
+                    subCategories.All(subCat => subCat.ElementType.HasFlag(ElementTypes.Packaged)))
                     return ElementTypes.Packaged;
-                else
-                    if (entries.All(entry => entry.ElementType == ElementTypes.ZeroTouch) &&
-                        subCategories.All(subCategory => subCategory.ElementType == ElementTypes.ZeroTouch))
-                        return ElementTypes.ZeroTouch;
-                    else
-                        return ElementTypes.None;
+
+                if (entries.All(entry => entry.ElementType.HasFlag(ElementTypes.ZeroTouch)) &&
+                    subCategories.All(subCat => subCat.ElementType.HasFlag(ElementTypes.ZeroTouch)))
+                    return ElementTypes.ZeroTouch;
+
+                return ElementTypes.None;
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -153,27 +153,48 @@ namespace Dynamo.Wpf.ViewModels
             }
         }
 
+
+        private ElementTypes elementType;
         public ElementTypes ElementType
         {
             get
             {
-                if (entries.Any(entry => entry.ElementType.HasFlag(ElementTypes.BuiltIn)) ||
-                    subCategories.Any(subCat => subCat.ElementType.HasFlag(ElementTypes.BuiltIn)))
-                    return ElementTypes.BuiltIn;
+                if (elementType == ElementTypes.None)
+                    DetermineElementType();
+                return elementType;
+            }
 
-                if (entries.All(entry => entry.ElementType.HasFlag(ElementTypes.Packaged)) &&
-                    subCategories.All(subCat => subCat.ElementType.HasFlag(ElementTypes.Packaged)))
-                    return ElementTypes.Packaged;
+            private set
+            {
+                if (value == elementType) return;
+                elementType = value;
+            }
+        }
 
-                if (entries.All(entry => entry.ElementType.HasFlag(ElementTypes.ZeroTouch)) &&
-                    subCategories.All(subCat => subCat.ElementType.HasFlag(ElementTypes.ZeroTouch)))
-                    return ElementTypes.ZeroTouch;
+        private void DetermineElementType()
+        {
+            if (Items.Count == 0)
+            {
+                ElementType = ElementTypes.None;
+                return;
+            }
 
-                if (entries.All(entry => entry.ElementType.HasFlag(ElementTypes.CustomNode)) &&
-                    subCategories.All(subCat => subCat.ElementType.HasFlag(ElementTypes.CustomNode)))
-                    return ElementTypes.CustomNode;
-
-                return ElementTypes.None;
+            // If at list one item is builtin, the whole category considers as builtin.
+            if (Items.Any(item => item.ElementType.HasFlag(ElementTypes.BuiltIn)))
+                ElementType = ElementTypes.BuiltIn;
+            else
+            {
+                // If all items come from package, the whole category considers as package.
+                if (Items.All(item => item.ElementType.HasFlag(ElementTypes.Packaged)))
+                    ElementType = ElementTypes.Packaged;
+                else
+                {
+                    if (Items.All(item => item.ElementType.HasFlag(ElementTypes.ZeroTouch)))
+                        ElementType = ElementTypes.ZeroTouch;
+                    else
+                        if (Items.All(item => item.ElementType.HasFlag(ElementTypes.CustomNode)))
+                            ElementType = ElementTypes.CustomNode;
+                }
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -89,7 +89,7 @@ namespace Dynamo.Wpf.ViewModels
         bool IsSelected { get; }
         string Description { get; }
         ICommand ClickedCommand { get; }
-        ElementTypeEnum ElementType { get; }
+        ElementTypes ElementType { get; }
     }
 
     public class NodeCategoryViewModel : NotificationObject, ISearchEntryViewModel
@@ -153,19 +153,19 @@ namespace Dynamo.Wpf.ViewModels
             }
         }
 
-        public ElementTypeEnum ElementType
+        public ElementTypes ElementType
         {
             get
             {
-                if (entries.All(entry => entry.ElementType == ElementTypeEnum.Package) &&
-                    subCategories.All(subCategory => subCategory.ElementType == ElementTypeEnum.Package))
-                    return ElementTypeEnum.Package;
+                if (entries.All(entry => entry.ElementType == ElementTypes.Packaged) &&
+                    subCategories.All(subCategory => subCategory.ElementType == ElementTypes.Packaged))
+                    return ElementTypes.Packaged;
                 else
-                    if (entries.All(entry => entry.ElementType == ElementTypeEnum.CustomDll) &&
-                        subCategories.All(subCategory => subCategory.ElementType == ElementTypeEnum.CustomDll))
-                        return ElementTypeEnum.CustomDll;
+                    if (entries.All(entry => entry.ElementType == ElementTypes.ZeroTouch) &&
+                        subCategories.All(subCategory => subCategory.ElementType == ElementTypes.ZeroTouch))
+                        return ElementTypes.ZeroTouch;
                     else
-                        return ElementTypeEnum.RegularCategory;
+                        return ElementTypes.None;
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -153,11 +153,20 @@ namespace Dynamo.Wpf.ViewModels
             }
         }
 
-        private ElementTypeEnum elementType;
         public ElementTypeEnum ElementType
         {
-            get { return elementType; }
-            private set { elementType = value; }
+            get
+            {
+                if (entries.All(entry => entry.ElementType == ElementTypeEnum.Package) &&
+                    subCategories.All(subCategory => subCategory.ElementType == ElementTypeEnum.Package))
+                    return ElementTypeEnum.Package;
+                else
+                    if (entries.All(entry => entry.ElementType == ElementTypeEnum.CustomDll) &&
+                        subCategories.All(subCategory => subCategory.ElementType == ElementTypeEnum.CustomDll))
+                        return ElementTypeEnum.CustomDll;
+                    else
+                        return ElementTypeEnum.RegularCategory;
+            }
         }
 
         public ObservableCollection<ISearchEntryViewModel> Items
@@ -264,13 +273,6 @@ namespace Dynamo.Wpf.ViewModels
 
             Visibility = true;
             IsExpanded = false;
-
-            if (entries.All(entry => entry.ElementType == ElementTypeEnum.Package) &&
-                subCategories.All(subCategory => subCategory.ElementType == ElementTypeEnum.Package))
-                ElementType = ElementTypeEnum.Package;
-            if (entries.All(entry => entry.ElementType == ElementTypeEnum.CustomDll) &&
-                subCategories.All(subCategory => subCategory.ElementType == ElementTypeEnum.CustomDll))
-                ElementType = ElementTypeEnum.CustomDll;
         }
 
         private void ItemsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -185,15 +185,15 @@ namespace Dynamo.Wpf.ViewModels
                 ElementType = ElementTypes.BuiltIn;
             else
             {
-                // If all items come from package, the whole category considers as package.
-                if (Items.All(item => item.ElementType.HasFlag(ElementTypes.Packaged)))
+                // If some items come from package, the whole category considers as package.
+                if (Items.Any(item => item.ElementType.HasFlag(ElementTypes.Packaged)))
                     ElementType = ElementTypes.Packaged;
                 else
                 {
-                    if (Items.All(item => item.ElementType.HasFlag(ElementTypes.ZeroTouch)))
+                    if (Items.Any(item => item.ElementType.HasFlag(ElementTypes.ZeroTouch)))
                         ElementType = ElementTypes.ZeroTouch;
                     else
-                        if (Items.All(item => item.ElementType.HasFlag(ElementTypes.CustomNode)))
+                        if (Items.Any(item => item.ElementType.HasFlag(ElementTypes.CustomNode)))
                             ElementType = ElementTypes.CustomNode;
                 }
             }

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -89,6 +89,7 @@ namespace Dynamo.Wpf.ViewModels
         bool IsSelected { get; }
         string Description { get; }
         ICommand ClickedCommand { get; }
+        ElementTypeEnum ElementType { get; }
     }
 
     public class NodeCategoryViewModel : NotificationObject, ISearchEntryViewModel
@@ -150,6 +151,13 @@ namespace Dynamo.Wpf.ViewModels
                 if (!string.IsNullOrEmpty(assembly)) return;
                 assembly = value;
             }
+        }
+
+        private ElementTypeEnum elementType;
+        public ElementTypeEnum ElementType
+        {
+            get { return elementType; }
+            private set { elementType = value; }
         }
 
         public ObservableCollection<ISearchEntryViewModel> Items
@@ -256,6 +264,13 @@ namespace Dynamo.Wpf.ViewModels
 
             Visibility = true;
             IsExpanded = false;
+
+            if (entries.All(entry => entry.ElementType == ElementTypeEnum.Package) &&
+                subCategories.All(subCategory => subCategory.ElementType == ElementTypeEnum.Package))
+                ElementType = ElementTypeEnum.Package;
+            if (entries.All(entry => entry.ElementType == ElementTypeEnum.CustomDll) &&
+                subCategories.All(subCategory => subCategory.ElementType == ElementTypeEnum.CustomDll))
+                ElementType = ElementTypeEnum.CustomDll;
         }
 
         private void ItemsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -11,6 +11,7 @@ using Microsoft.Practices.Prism.ViewModel;
 using System;
 using Dynamo.Models;
 using Dynamo.ViewModels;
+using Dynamo.Search;
 
 namespace Dynamo.Wpf.ViewModels
 {
@@ -26,6 +27,11 @@ namespace Dynamo.Wpf.ViewModels
             {
                 RequestBitmapSource(e);
             }
+        }
+
+        public ElementTypeEnum ElementType
+        {
+            get { return Model.ElementType; }
         }
 
         public NodeSearchElementViewModel(NodeSearchElement element, SearchViewModel svm)

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -29,7 +29,7 @@ namespace Dynamo.Wpf.ViewModels
             }
         }
 
-        public ElementTypeEnum ElementType
+        public ElementTypes ElementType
         {
             get { return Model.ElementType; }
         }


### PR DESCRIPTION
This is the first PR, that is connected to task "Show category type on hover mouse".

# Purpose
On hover over the library item, the type of add-on is display to its right. PKG / DLL
![image](https://cloud.githubusercontent.com/assets/8158404/7022713/33dc2bb0-dd37-11e4-9de0-e401aa4ae001.png)

If Package contains custom nodes, these custom nodes consider as package members. The same with dlls. (if package contains dll, this dll considers as package member)

# Solution
I want to add new property `ElementType`, which can be RegularNode, RegularCategory, CustomNode, CustomDll, Package.

## Overview
If user imports custom dll, it should be consider as custom dll.
If user opens custom node, it should be consider as custom node.
If user loads package(with custom dlls and custom nodes), they should be consider as package members.

BUT for Dynamo there is no difference, if custom node/dll is part of package or not.
That's why I added new properties `IsPackageMember` and `IsBuiltIn` for Custom node and Usual node respectively.

Since Dynamo uses the same functions to load custom nodes/dlls during importing Packages and simple importing/opening, the only posibily, to determine is it member of Package or not, is, when we call Package Manager, say to loading method THIS IS Package Member.

## Reviewers
@Benglin , please take a look.

Link to YouTrack:
[MAGN-5740](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5740) DUI: Re-implement logic of getting know ElementType of each node