### PR TITLE
Change string resources for branding

### DIFF
--- a/src/DynamoCoreWpf/Controls/GraphUpdateNotificationControl.xaml
+++ b/src/DynamoCoreWpf/Controls/GraphUpdateNotificationControl.xaml
@@ -38,7 +38,7 @@
             <Image Source="/DynamoCoreWpf;component/UI/Images/Update/update_static.png" 
                        Width="40" Height="30" Margin="-3,-3,0,0"/>
             <Button.ToolTip>
-                <Label Content="{x:Static p:Resources.DynamoUpdateAvailabeToolTip}"/>
+                <Label Content="{x:Static p:Resources.DynamoUpdateAvailableToolTip}"/>
             </Button.ToolTip>
         </Button>
     </Grid>

--- a/src/DynamoCoreWpf/Interfaces/IBrandingResourceProvider.cs
+++ b/src/DynamoCoreWpf/Interfaces/IBrandingResourceProvider.cs
@@ -39,5 +39,7 @@ namespace Dynamo.Wpf.Interfaces
         string GetString(ResourceNames.ConsentForm resourceName);
 
         Window CreateAboutBox(DynamoViewModel model);
+
+        string ProductName { get; }
     }
 }

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -70,16 +70,16 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo Website.
+        ///   Looks up a localized string similar to {0} Website.
         /// </summary>
-        public static string AboutWIndowDynamoWebsiteButton {
+        public static string AboutWindowDynamoWebsiteButton {
             get {
-                return ResourceManager.GetString("AboutWIndowDynamoWebsiteButton", resourceCulture);
+                return ResourceManager.GetString("AboutWindowDynamoWebsiteButton", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to About Dynamo.
+        ///   Looks up a localized string similar to About {0}.
         /// </summary>
         public static string AboutWindowTitle {
             get {
@@ -169,7 +169,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You can&apos;t submit a package in this version of Dynamo.  You&apos;ll need a host application, like Revit, to submit a package..
+        ///   Looks up a localized string similar to You can&apos;t submit a package in this version of {0}.  You&apos;ll need a host application, like Revit, to submit a package..
         /// </summary>
         public static string CannotSubmitPackage {
             get {
@@ -439,7 +439,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Uh oh... something went wrong and dynamo has crashed, sorry about that.
+        ///   Looks up a localized string similar to Uh oh... something went wrong and {0} has crashed, sorry about that.
         ///
         ///You will get a chance to save your work..
         /// </summary>
@@ -477,7 +477,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo has crashed.
+        ///   Looks up a localized string similar to {0} has crashed.
         /// </summary>
         public static string CrashPromptDialogTitle {
             get {
@@ -578,9 +578,9 @@ namespace Dynamo.Wpf.Properties {
         /// <summary>
         ///   Looks up a localized string similar to A Dynamo update is available. Click to install..
         /// </summary>
-        public static string DynamoUpdateAvailabeToolTip {
+        public static string DynamoUpdateAvailableToolTip {
             get {
-                return ResourceManager.GetString("DynamoUpdateAvailabeToolTip", resourceCulture);
+                return ResourceManager.GetString("DynamoUpdateAvailableToolTip", resourceCulture);
             }
         }
         
@@ -1233,7 +1233,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Detailed reporting sends behaviour data that we use for improving Dynamo.&amp;#x0a;It includes the graph being created as well as errors and warnings.
+        ///   Looks up a localized string similar to Detailed reporting sends behaviour data that we use for improving {0}.&amp;#x0a;It includes the graph being created as well as errors and warnings.
         /// </summary>
         public static string DynamoViewSettingMenuEnableDataReportingTooltip {
             get {
@@ -1764,7 +1764,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo Custom Node ({0})|{0}.
+        ///   Looks up a localized string similar to {0} Custom Node ({1})|{1}.
         /// </summary>
         public static string FileDialogDynamoCustomNode {
             get {
@@ -1773,7 +1773,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo Definitions ({0})|{0}.
+        ///   Looks up a localized string similar to {0} Definitions ({1})|{1}.
         /// </summary>
         public static string FileDialogDynamoDefinitions {
             get {
@@ -1782,7 +1782,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo Workspace ({0})|{0}.
+        ///   Looks up a localized string similar to {0} Workspace ({1})|{1}.
         /// </summary>
         public static string FileDialogDynamoWorkspace {
             get {
@@ -2151,7 +2151,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Arugment lacing is disabled for this node..
+        ///   Looks up a localized string similar to Argument lacing is disabled for this node..
         /// </summary>
         public static string LacingDisabledToolTip {
             get {
@@ -2241,9 +2241,9 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo has already installed {0}.
+        ///   Looks up a localized string similar to {0} has already installed {1}.
         ///
-        ///Dynamo will attempt to uninstall this package before installing..
+        ///{0} will attempt to uninstall this package before installing..
         /// </summary>
         public static string MessageAlreadyInstallDynamo {
             get {
@@ -2395,7 +2395,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo failed to uninstall the package.  You may need to delete the package&apos;s root directory manually..
+        ///   Looks up a localized string similar to {0} failed to uninstall the package.  You may need to delete the package&apos;s root directory manually..
         /// </summary>
         public static string MessageFailedToUninstall {
             get {
@@ -2404,7 +2404,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo failed to uninstall the package: {0}.  The package may need to be reinstalled manually..
+        ///   Looks up a localized string similar to {0} failed to uninstall the package: {1}.  The package may need to be reinstalled manually..
         /// </summary>
         public static string MessageFailToUninstallPackage {
             get {
@@ -2431,7 +2431,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} elapsed for loading Dynamo main window..
+        ///   Looks up a localized string similar to {0} elapsed for loading {1} main window..
         /// </summary>
         public static string MessageLoadingTime {
             get {
@@ -2440,7 +2440,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo and its host application must restart before uninstall takes effect..
+        ///   Looks up a localized string similar to {0} and its host application must restart before uninstall takes effect..
         /// </summary>
         public static string MessageNeedToRestart {
             get {
@@ -2476,9 +2476,9 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The following packages use a newer version of Dynamo than you are currently using:
+        ///   Looks up a localized string similar to The following packages use a newer version of {0} than you are currently using:
         ///
-        ///{0}
+        ///{1}
         ///
         ///Do you want to continue?.
         /// </summary>
@@ -2507,7 +2507,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The node is part of the dynamo package called &quot;{0}&quot; - do you want to submit a new version of this package?
+        ///   Looks up a localized string similar to The node is part of the {0} package called &quot;{1}&quot; - do you want to submit a new version of this package?
         ///
         ///If not, this node will be moved to the new package you are creating.&quot;.
         /// </summary>
@@ -2540,7 +2540,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo needs to uninstall {0} to continue, but cannot as one of its types appears to be in use.  Try restarting Dynamo..
+        ///   Looks up a localized string similar to {0} needs to uninstall {1} to continue, but cannot as one of its types appears to be in use.  Try restarting {0}..
         /// </summary>
         public static string MessageUninstallToContinue {
             get {
@@ -2549,11 +2549,11 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo needs to uninstall {0} to continue but it contains binaries already loaded into Dynamo.  It&apos;s now marked for removal, but you&apos;ll need to first restart Dynamo..
+        ///   Looks up a localized string similar to {0} needs to uninstall {1} to continue but it contains binaries already loaded into Dynamo.  It&apos;s now marked for removal, but you&apos;ll need to first restart {0}..
         /// </summary>
-        public static string MessageUnintallToContinue2 {
+        public static string MessageUninstallToContinue2 {
             get {
-                return ResourceManager.GetString("MessageUnintallToContinue2", resourceCulture);
+                return ResourceManager.GetString("MessageUninstallToContinue2", resourceCulture);
             }
         }
         
@@ -2729,7 +2729,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open Dynamo Definition....
+        ///   Looks up a localized string similar to Open {0} Definition....
         /// </summary>
         public static string OpenDynamoDefinitionDialogTitle {
             get {
@@ -2819,7 +2819,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while Dynamo is not running and try again..
+        ///   Looks up a localized string similar to Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while {0} is not running and try again..
         /// </summary>
         public static string PackageDuplicateAssemblyWarning {
             get {
@@ -3161,7 +3161,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package Uses Newer Version of Dynamo!.
+        ///   Looks up a localized string similar to Package Uses Newer Version of {0}!.
         /// </summary>
         public static string PackageUseNewerDynamoMessageBoxTitle {
             get {
@@ -3359,7 +3359,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Publish a Dynamo Package.
+        ///   Looks up a localized string similar to Publish a {0} Package.
         /// </summary>
         public static string PublishPackageViewTitle {
             get {
@@ -3721,7 +3721,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to I give my consent for Autodesk to collect information on how I use Dynamo..
+        ///   Looks up a localized string similar to I give my consent for Autodesk to collect information on how I use {0}..
         /// </summary>
         public static string UsageReportPromptDialogConsent {
             get {
@@ -3730,7 +3730,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The features and commands you use in Dynamo.
+        ///   Looks up a localized string similar to The features and commands you use in {0}.
         /// </summary>
         public static string UsageReportPromptDialogFeatureUsage {
             get {
@@ -3739,13 +3739,13 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to We would like to collect some information about how Dynamo is used.
+        ///   Looks up a localized string similar to We would like to collect some information about how {0} is used.
         ///
         ///Autodesk will use the information for product improvement purposes, by improving the usability and stability of the product.  For example, we would like to detect if you have difficulty with a specific function call in the language.
         ///
         ///The information will be de-identified and it will not be used for advertising. We will not contact you unless you specifically request it (and provide an email address).
         ///
-        ///The information being collected  [rest of string was truncated]&quot;;.
+        ///The information being collected is:.
         /// </summary>
         public static string UsageReportPromptDialogMessagePart1 {
             get {
@@ -3777,7 +3777,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Agreement to collect usability data on your use of Dynamo.
+        ///   Looks up a localized string similar to Agreement to collect usability data on your use of {0}.
         /// </summary>
         public static string UsageReportPromptDialogTitle {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -121,12 +121,12 @@
     <value>Could not get version.</value>
     <comment>To indicate not abe to get Dynamo version</comment>
   </data>
-  <data name="AboutWIndowDynamoWebsiteButton" xml:space="preserve">
-    <value>Dynamo Website</value>
+  <data name="AboutWindowDynamoWebsiteButton" xml:space="preserve">
+    <value>{0} Website</value>
     <comment>Click button to go to Dynamo website</comment>
   </data>
   <data name="AboutWindowTitle" xml:space="preserve">
-    <value>About Dynamo</value>
+    <value>About {0}</value>
     <comment>About window title</comment>
   </data>
   <data name="AboutWindowUpToDate" xml:space="preserve">
@@ -438,7 +438,7 @@
     <comment>Setting menu | Enable data reporting during usage</comment>
   </data>
   <data name="DynamoViewSettingMenuEnableDataReportingTooltip" xml:space="preserve">
-    <value>Detailed reporting sends behaviour data that we use for improving Dynamo.&amp;#x0a;It includes the graph being created as well as errors and warnings</value>
+    <value>Detailed reporting sends behaviour data that we use for improving {0}.&amp;#x0a;It includes the graph being created as well as errors and warnings</value>
     <comment>Setting menu | Tooltip for enable data reporting during usage menu item</comment>
   </data>
   <data name="DynamoViewSettingMenuEnableSummaryReporting" xml:space="preserve">
@@ -814,9 +814,9 @@
     <value>Import Library</value>
   </data>
   <data name="MessageAlreadyInstallDynamo" xml:space="preserve">
-    <value>Dynamo has already installed {0}.
+    <value>{0} has already installed {1}.
 
-Dynamo will attempt to uninstall this package before installing.</value>
+{0} will attempt to uninstall this package before installing.</value>
   </data>
   <data name="MessageConfirmToInstallPackage" xml:space="preserve">
     <value>Are you sure you want to install {0} {1} ?</value>
@@ -856,10 +856,10 @@ You can always redownload the package.</value>
     <comment>Message box content</comment>
   </data>
   <data name="MessageFailedToUninstall" xml:space="preserve">
-    <value>Dynamo failed to uninstall the package.  You may need to delete the package's root directory manually.</value>
+    <value>{0} failed to uninstall the package.  You may need to delete the package's root directory manually.</value>
   </data>
   <data name="MessageFailToUninstallPackage" xml:space="preserve">
-    <value>Dynamo failed to uninstall the package: {0}.  The package may need to be reinstalled manually.</value>
+    <value>{0} failed to uninstall the package: {1}.  The package may need to be reinstalled manually.</value>
     <comment>Message box content</comment>
   </data>
   <data name="MessageFileNotFound" xml:space="preserve">
@@ -871,15 +871,15 @@ You can always redownload the package.</value>
     <comment>Message box content</comment>
   </data>
   <data name="MessageNeedToRestart" xml:space="preserve">
-    <value>Dynamo and its host application must restart before uninstall takes effect.</value>
+    <value>{0} and its host application must restart before uninstall takes effect.</value>
   </data>
   <data name="MessagePackageContainPythonScript" xml:space="preserve">
     <value>The package or one of its dependencies contains Python scripts or binaries. Do you want to continue?</value>
   </data>
   <data name="MessagePackageNewerDynamo" xml:space="preserve">
-    <value>The following packages use a newer version of Dynamo than you are currently using:
+    <value>The following packages use a newer version of {0} than you are currently using:
 
-{0}
+{1}
 
 Do you want to continue?</value>
   </data>
@@ -892,7 +892,7 @@ Do you want to continue?</value>
     <comment>Message box content</comment>
   </data>
   <data name="MessageSubmitSameNamePackage" xml:space="preserve">
-    <value>The node is part of the dynamo package called "{0}" - do you want to submit a new version of this package?
+    <value>The node is part of the {0} package called "{1}" - do you want to submit a new version of this package?
 
 If not, this node will be moved to the new package you are creating."</value>
     <comment>Message box content</comment>
@@ -908,16 +908,16 @@ You can always undeprecate the package.</value>
 You can always re-deprecate the package.</value>
   </data>
   <data name="MessageUninstallToContinue" xml:space="preserve">
-    <value>Dynamo needs to uninstall {0} to continue, but cannot as one of its types appears to be in use.  Try restarting Dynamo.</value>
+    <value>{0} needs to uninstall {1} to continue, but cannot as one of its types appears to be in use.  Try restarting {0}.</value>
   </data>
-  <data name="MessageUnintallToContinue2" xml:space="preserve">
-    <value>Dynamo needs to uninstall {0} to continue but it contains binaries already loaded into Dynamo.  It's now marked for removal, but you'll need to first restart Dynamo.</value>
+  <data name="MessageUninstallToContinue2" xml:space="preserve">
+    <value>{0} needs to uninstall {1} to continue but it contains binaries already loaded into Dynamo.  It's now marked for removal, but you'll need to first restart {0}.</value>
   </data>
   <data name="OKButton" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OpenDynamoDefinitionDialogTitle" xml:space="preserve">
-    <value>Open Dynamo Definition...</value>
+    <value>Open {0} Definition...</value>
   </data>
   <data name="PackageDownloadConfirmMessageBoxTitle" xml:space="preserve">
     <value>Package Download Confirmation</value>
@@ -931,7 +931,7 @@ You can always re-deprecate the package.</value>
     <value>Package Download</value>
   </data>
   <data name="PackageUseNewerDynamoMessageBoxTitle" xml:space="preserve">
-    <value>Package Uses Newer Version of Dynamo!</value>
+    <value>Package Uses Newer Version of {0}!</value>
   </data>
   <data name="PackageWarningMessageBoxTitle" xml:space="preserve">
     <value>Package Warning</value>
@@ -968,7 +968,7 @@ You can always re-deprecate the package.</value>
     <comment>Copy crash details</comment>
   </data>
   <data name="CrashPromptDialogCrashMessage" xml:space="preserve">
-    <value>Uh oh... something went wrong and dynamo has crashed, sorry about that.
+    <value>Uh oh... something went wrong and {0} has crashed, sorry about that.
 
 You will get a chance to save your work.</value>
   </data>
@@ -985,12 +985,12 @@ You will get a chance to save your work.</value>
     <comment>Submit a bug on github</comment>
   </data>
   <data name="CrashPromptDialogTitle" xml:space="preserve">
-    <value>Dynamo has crashed</value>
+    <value>{0} has crashed</value>
   </data>
   <data name="DownloadWarningMessageBoxTitle" xml:space="preserve">
     <value>Download Warning</value>
   </data>
-  <data name="DynamoUpdateAvailabeToolTip" xml:space="preserve">
+  <data name="DynamoUpdateAvailableToolTip" xml:space="preserve">
     <value>A Dynamo update is available. Click to install.</value>
   </data>
   <data name="EditNodeWindowTitle" xml:space="preserve">
@@ -1015,13 +1015,13 @@ You will get a chance to save your work.</value>
     <value>Generic Task Dialog</value>
   </data>
   <data name="UsageReportPromptDialogConsent" xml:space="preserve">
-    <value>I give my consent for Autodesk to collect information on how I use Dynamo.</value>
+    <value>I give my consent for Autodesk to collect information on how I use {0}.</value>
   </data>
   <data name="UsageReportPromptDialogFeatureUsage" xml:space="preserve">
-    <value>The features and commands you use in Dynamo</value>
+    <value>The features and commands you use in {0}</value>
   </data>
   <data name="UsageReportPromptDialogMessagePart1" xml:space="preserve">
-    <value>We would like to collect some information about how Dynamo is used.
+    <value>We would like to collect some information about how {0} is used.
 
 Autodesk will use the information for product improvement purposes, by improving the usability and stability of the product.  For example, we would like to detect if you have difficulty with a specific function call in the language.
 
@@ -1041,7 +1041,7 @@ Many thanks!</value>
 </value>
   </data>
   <data name="UsageReportPromptDialogTitle" xml:space="preserve">
-    <value>Agreement to collect usability data on your use of Dynamo</value>
+    <value>Agreement to collect usability data on your use of {0}</value>
   </data>
   <data name="DynamoViewContextMenuClearLog" xml:space="preserve">
     <value>Clear</value>
@@ -1132,7 +1132,7 @@ Many thanks!</value>
     <value>For two lists {a,b,c}{1,2,3} returns {a1,a2,a3}{b1,b2,b3}{c1,c2,c3}.</value>
   </data>
   <data name="LacingDisabledToolTip" xml:space="preserve">
-    <value>Arugment lacing is disabled for this node.</value>
+    <value>Argument lacing is disabled for this node.</value>
   </data>
   <data name="LacingFirstToolTip" xml:space="preserve">
     <value>For two lists {a,b,c}{1,2,3} returns {a1}.</value>
@@ -1356,7 +1356,7 @@ Many thanks!</value>
     <comment>Github repository</comment>
   </data>
   <data name="PublishPackageViewTitle" xml:space="preserve">
-    <value>Publish a Dynamo Package</value>
+    <value>Publish a {0} Package</value>
   </data>
   <data name="ShowClassicNodeLibrary" xml:space="preserve">
     <value>Show Classic Node Library</value>
@@ -1381,7 +1381,7 @@ Many thanks!</value>
     <comment>ErrorString</comment>
   </data>
   <data name="CannotSubmitPackage" xml:space="preserve">
-    <value>You can't submit a package in this version of Dynamo.  You'll need a host application, like Revit, to submit a package.</value>
+    <value>You can't submit a package in this version of {0}.  You'll need a host application, like Revit, to submit a package.</value>
     <comment>ErrorString</comment>
   </data>
   <data name="DescriptionNeedMoreCharacters" xml:space="preserve">
@@ -1462,13 +1462,13 @@ Do you want to install the latest Dynamo update?</value>
     <value>DesignScript Files ({0})|{0}</value>
   </data>
   <data name="FileDialogDynamoCustomNode" xml:space="preserve">
-    <value>Dynamo Custom Node ({0})|{0}</value>
+    <value>{0} Custom Node ({1})|{1}</value>
   </data>
   <data name="FileDialogDynamoDefinitions" xml:space="preserve">
-    <value>Dynamo Definitions ({0})|{0}</value>
+    <value>{0} Definitions ({1})|{1}</value>
   </data>
   <data name="FileDialogDynamoWorkspace" xml:space="preserve">
-    <value>Dynamo Workspace ({0})|{0}</value>
+    <value>{0} Workspace ({1})|{1}</value>
   </data>
   <data name="FileDialogLibraryFiles" xml:space="preserve">
     <value>Library Files ({0})|{0}</value>
@@ -1504,7 +1504,7 @@ Do you want to install the latest Dynamo update?</value>
     <value>Failed to save the Workspace as image.</value>
   </data>
   <data name="MessageLoadingTime" xml:space="preserve">
-    <value>{0} elapsed for loading Dynamo main window.</value>
+    <value>{0} elapsed for loading {1} main window.</value>
   </data>
   <data name="MessageNodeWithNullFunction" xml:space="preserve">
     <value>There is a null function definition for this node.</value>
@@ -1561,7 +1561,7 @@ Do you want to install the latest Dynamo update?</value>
     <value>Run started...</value>
   </data>
   <data name="PackageDuplicateAssemblyWarning" xml:space="preserve">
-    <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while Dynamo is not running and try again.</value>
+    <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while {0} is not running and try again.</value>
   </data>
   <data name="PackageDuplicateAssemblyWarningTitle" xml:space="preserve">
     <value>Cannot update assembly</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -121,12 +121,12 @@
     <value>Could not get version.</value>
     <comment>To indicate not abe to get Dynamo version</comment>
   </data>
-  <data name="AboutWIndowDynamoWebsiteButton" xml:space="preserve">
-    <value>Dynamo Website</value>
+  <data name="AboutWindowDynamoWebsiteButton" xml:space="preserve">
+    <value>{0} Website</value>
     <comment>Click button to go to Dynamo website</comment>
   </data>
   <data name="AboutWindowTitle" xml:space="preserve">
-    <value>About Dynamo</value>
+    <value>About {0}</value>
     <comment>About window title</comment>
   </data>
   <data name="AboutWindowUpToDate" xml:space="preserve">
@@ -438,7 +438,7 @@
     <comment>Setting menu | Enable data reporting during usage</comment>
   </data>
   <data name="DynamoViewSettingMenuEnableDataReportingTooltip" xml:space="preserve">
-    <value>Detailed reporting sends behaviour data that we use for improving Dynamo.&amp;#x0a;It includes the graph being created as well as errors and warnings</value>
+    <value>Detailed reporting sends behaviour data that we use for improving {0}.&amp;#x0a;It includes the graph being created as well as errors and warnings</value>
     <comment>Setting menu | Tooltip for enable data reporting during usage menu item</comment>
   </data>
   <data name="DynamoViewSettingMenuEnableSummaryReporting" xml:space="preserve">
@@ -814,9 +814,9 @@
     <value>Import Library</value>
   </data>
   <data name="MessageAlreadyInstallDynamo" xml:space="preserve">
-    <value>Dynamo has already installed {0}.
+    <value>{0} has already installed {1}.
 
-Dynamo will attempt to uninstall this package before installing.</value>
+{0} will attempt to uninstall this package before installing.</value>
   </data>
   <data name="MessageConfirmToInstallPackage" xml:space="preserve">
     <value>Are you sure you want to install {0} {1} ?</value>
@@ -856,10 +856,10 @@ You can always redownload the package.</value>
     <comment>Message box content</comment>
   </data>
   <data name="MessageFailedToUninstall" xml:space="preserve">
-    <value>Dynamo failed to uninstall the package.  You may need to delete the package's root directory manually.</value>
+    <value>{0} failed to uninstall the package.  You may need to delete the package's root directory manually.</value>
   </data>
   <data name="MessageFailToUninstallPackage" xml:space="preserve">
-    <value>Dynamo failed to uninstall the package: {0}.  The package may need to be reinstalled manually.</value>
+    <value>{0} failed to uninstall the package: {1}.  The package may need to be reinstalled manually.</value>
     <comment>Message box content</comment>
   </data>
   <data name="MessageFileNotFound" xml:space="preserve">
@@ -871,15 +871,15 @@ You can always redownload the package.</value>
     <comment>Message box content</comment>
   </data>
   <data name="MessageNeedToRestart" xml:space="preserve">
-    <value>Dynamo and its host application must restart before uninstall takes effect.</value>
+    <value>{0} and its host application must restart before uninstall takes effect.</value>
   </data>
   <data name="MessagePackageContainPythonScript" xml:space="preserve">
     <value>The package or one of its dependencies contains Python scripts or binaries. Do you want to continue?</value>
   </data>
   <data name="MessagePackageNewerDynamo" xml:space="preserve">
-    <value>The following packages use a newer version of Dynamo than you are currently using:
+    <value>The following packages use a newer version of {0} than you are currently using:
 
-{0}
+{1}
 
 Do you want to continue?</value>
   </data>
@@ -892,7 +892,7 @@ Do you want to continue?</value>
     <comment>Message box content</comment>
   </data>
   <data name="MessageSubmitSameNamePackage" xml:space="preserve">
-    <value>The node is part of the dynamo package called "{0}" - do you want to submit a new version of this package?
+    <value>The node is part of the {0} package called "{1}" - do you want to submit a new version of this package?
 
 If not, this node will be moved to the new package you are creating."</value>
     <comment>Message box content</comment>
@@ -908,16 +908,16 @@ You can always undeprecate the package.</value>
 You can always re-deprecate the package.</value>
   </data>
   <data name="MessageUninstallToContinue" xml:space="preserve">
-    <value>Dynamo needs to uninstall {0} to continue, but cannot as one of its types appears to be in use.  Try restarting Dynamo.</value>
+    <value>{0} needs to uninstall {1} to continue, but cannot as one of its types appears to be in use.  Try restarting {0}.</value>
   </data>
-  <data name="MessageUnintallToContinue2" xml:space="preserve">
-    <value>Dynamo needs to uninstall {0} to continue but it contains binaries already loaded into Dynamo.  It's now marked for removal, but you'll need to first restart Dynamo.</value>
+  <data name="MessageUninstallToContinue2" xml:space="preserve">
+    <value>{0} needs to uninstall {1} to continue but it contains binaries already loaded into Dynamo.  It's now marked for removal, but you'll need to first restart {0}.</value>
   </data>
   <data name="OKButton" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OpenDynamoDefinitionDialogTitle" xml:space="preserve">
-    <value>Open Dynamo Definition...</value>
+    <value>Open {0} Definition...</value>
   </data>
   <data name="PackageDownloadConfirmMessageBoxTitle" xml:space="preserve">
     <value>Package Download Confirmation</value>
@@ -931,7 +931,7 @@ You can always re-deprecate the package.</value>
     <value>Package Download</value>
   </data>
   <data name="PackageUseNewerDynamoMessageBoxTitle" xml:space="preserve">
-    <value>Package Uses Newer Version of Dynamo!</value>
+    <value>Package Uses Newer Version of {0}!</value>
   </data>
   <data name="PackageWarningMessageBoxTitle" xml:space="preserve">
     <value>Package Warning</value>
@@ -968,7 +968,7 @@ You can always re-deprecate the package.</value>
     <comment>Copy crash details</comment>
   </data>
   <data name="CrashPromptDialogCrashMessage" xml:space="preserve">
-    <value>Uh oh... something went wrong and dynamo has crashed, sorry about that.
+    <value>Uh oh... something went wrong and {0} has crashed, sorry about that.
 
 You will get a chance to save your work.</value>
   </data>
@@ -985,12 +985,12 @@ You will get a chance to save your work.</value>
     <comment>Submit a bug on github</comment>
   </data>
   <data name="CrashPromptDialogTitle" xml:space="preserve">
-    <value>Dynamo has crashed</value>
+    <value>{0} has crashed</value>
   </data>
   <data name="DownloadWarningMessageBoxTitle" xml:space="preserve">
     <value>Download Warning</value>
   </data>
-  <data name="DynamoUpdateAvailabeToolTip" xml:space="preserve">
+  <data name="DynamoUpdateAvailableToolTip" xml:space="preserve">
     <value>A Dynamo update is available. Click to install.</value>
   </data>
   <data name="EditNodeWindowTitle" xml:space="preserve">
@@ -1015,13 +1015,13 @@ You will get a chance to save your work.</value>
     <value>Generic Task Dialog</value>
   </data>
   <data name="UsageReportPromptDialogConsent" xml:space="preserve">
-    <value>I give my consent for Autodesk to collect information on how I use Dynamo.</value>
+    <value>I give my consent for Autodesk to collect information on how I use {0}.</value>
   </data>
   <data name="UsageReportPromptDialogFeatureUsage" xml:space="preserve">
-    <value>The features and commands you use in Dynamo</value>
+    <value>The features and commands you use in {0}</value>
   </data>
   <data name="UsageReportPromptDialogMessagePart1" xml:space="preserve">
-    <value>We would like to collect some information about how Dynamo is used.
+    <value>We would like to collect some information about how {0} is used.
 
 Autodesk will use the information for product improvement purposes, by improving the usability and stability of the product.  For example, we would like to detect if you have difficulty with a specific function call in the language.
 
@@ -1041,7 +1041,7 @@ Many thanks!</value>
 </value>
   </data>
   <data name="UsageReportPromptDialogTitle" xml:space="preserve">
-    <value>Agreement to collect usability data on your use of Dynamo</value>
+    <value>Agreement to collect usability data on your use of {0}</value>
   </data>
   <data name="DynamoViewContextMenuClearLog" xml:space="preserve">
     <value>Clear</value>
@@ -1132,7 +1132,7 @@ Many thanks!</value>
     <value>For two lists {a,b,c}{1,2,3} returns {a1,a2,a3}{b1,b2,b3}{c1,c2,c3}.</value>
   </data>
   <data name="LacingDisabledToolTip" xml:space="preserve">
-    <value>Arugment lacing is disabled for this node.</value>
+    <value>Argument lacing is disabled for this node.</value>
   </data>
   <data name="LacingFirstToolTip" xml:space="preserve">
     <value>For two lists {a,b,c}{1,2,3} returns {a1}.</value>
@@ -1356,7 +1356,7 @@ Many thanks!</value>
     <comment>Github repository</comment>
   </data>
   <data name="PublishPackageViewTitle" xml:space="preserve">
-    <value>Publish a Dynamo Package</value>
+    <value>Publish a {0} Package</value>
   </data>
   <data name="ShowClassicNodeLibrary" xml:space="preserve">
     <value>Show Classic Node Library</value>
@@ -1381,7 +1381,7 @@ Many thanks!</value>
     <comment>ErrorString</comment>
   </data>
   <data name="CannotSubmitPackage" xml:space="preserve">
-    <value>You can't submit a package in this version of Dynamo.  You'll need a host application, like Revit, to submit a package.</value>
+    <value>You can't submit a package in this version of {0}.  You'll need a host application, like Revit, to submit a package.</value>
     <comment>ErrorString</comment>
   </data>
   <data name="DescriptionNeedMoreCharacters" xml:space="preserve">
@@ -1462,13 +1462,13 @@ Do you want to install the latest Dynamo update?</value>
     <value>DesignScript Files ({0})|{0}</value>
   </data>
   <data name="FileDialogDynamoCustomNode" xml:space="preserve">
-    <value>Dynamo Custom Node ({0})|{0}</value>
+    <value>{0} Custom Node ({1})|{1}</value>
   </data>
   <data name="FileDialogDynamoDefinitions" xml:space="preserve">
-    <value>Dynamo Definitions ({0})|{0}</value>
+    <value>{0} Definitions ({1})|{1}</value>
   </data>
   <data name="FileDialogDynamoWorkspace" xml:space="preserve">
-    <value>Dynamo Workspace ({0})|{0}</value>
+    <value>{0} Workspace ({1})|{1}</value>
   </data>
   <data name="FileDialogLibraryFiles" xml:space="preserve">
     <value>Library Files ({0})|{0}</value>
@@ -1504,7 +1504,7 @@ Do you want to install the latest Dynamo update?</value>
     <value>Failed to save the Workspace as image.</value>
   </data>
   <data name="MessageLoadingTime" xml:space="preserve">
-    <value>{0} elapsed for loading Dynamo main window.</value>
+    <value>{0} elapsed for loading {1} main window.</value>
   </data>
   <data name="MessageNodeWithNullFunction" xml:space="preserve">
     <value>There is a null function definition for this node.</value>
@@ -1561,7 +1561,7 @@ Do you want to install the latest Dynamo update?</value>
     <value>Run started...</value>
   </data>
   <data name="PackageDuplicateAssemblyWarning" xml:space="preserve">
-    <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while Dynamo is not running and try again.</value>
+    <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while {0} is not running and try again.</value>
   </data>
   <data name="PackageDuplicateAssemblyWarningTitle" xml:space="preserve">
     <value>Cannot update assembly</value>

--- a/src/DynamoCoreWpf/UI/DefaultBrandingResourceProvider.cs
+++ b/src/DynamoCoreWpf/UI/DefaultBrandingResourceProvider.cs
@@ -47,7 +47,7 @@ namespace Dynamo.Wpf.UI
             switch (resourceName)
             {
                 case ResourceNames.MainWindow.Title:
-                    resource = "Dynamo";
+                    resource = ProductName;
                     break;
             }
             return EnsureStringLoaded(resource, resourceName.ToString());
@@ -59,10 +59,10 @@ namespace Dynamo.Wpf.UI
             switch (resourceName)
             {
                 case ResourceNames.ConsentForm.Title:
-                    resource = Properties.Resources.UsageReportPromptDialogTitle;
+                    resource = string.Format(Properties.Resources.UsageReportPromptDialogTitle,ProductName);
                     break;
                 case ResourceNames.ConsentForm.AgreementOne:
-                    resource = Properties.Resources.UsageReportPromptDialogMessagePart1;
+                    resource = string.Format(Properties.Resources.UsageReportPromptDialogMessagePart1,ProductName);
                     break;
                 case ResourceNames.ConsentForm.AgreementTwo:
                     resource = Properties.Resources.UsageReportPromptDialogMessagePart2;
@@ -71,10 +71,10 @@ namespace Dynamo.Wpf.UI
                     resource = Properties.Resources.UsageReportPromptDialogNodeUsage;
                     break;
                 case ResourceNames.ConsentForm.FeatureUsage:
-                    resource = Properties.Resources.UsageReportPromptDialogFeatureUsage;
+                    resource = string.Format(Properties.Resources.UsageReportPromptDialogFeatureUsage,ProductName);
                     break;
                 case ResourceNames.ConsentForm.Consent:
-                    resource = Properties.Resources.UsageReportPromptDialogConsent;
+                    resource = string.Format(Properties.Resources.UsageReportPromptDialogConsent,ProductName);
                     break;
 
             }
@@ -86,6 +86,7 @@ namespace Dynamo.Wpf.UI
             return new AboutWindow(model);
         }
 
+        public string ProductName { get { return "Dynamo"; } }
         #endregion
 
         #region private members

--- a/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml
@@ -3,7 +3,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:ui="clr-namespace:Dynamo.UI"
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
-        Title="{x:Static p:Resources.CrashPromptDialogTitle}"
         Width="660"
         SizeToContent="Height"
         ResizeMode="NoResize"
@@ -40,8 +39,7 @@
                            FontSize="13"
                            Foreground="#aaaaaa"
                            HorizontalAlignment="Stretch"
-                           TextWrapping="Wrap"
-                           Text="{x:Static p:Resources.CrashPromptDialogCrashMessage}"/>
+                           TextWrapping="Wrap"/>
             </StackPanel>
 
             <StackPanel Grid.Row="1"

--- a/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml.cs
@@ -20,22 +20,34 @@ namespace Dynamo.Nodes.Prompts
     {
         private string details; // Store here for clipboard copy
         private string folderPath;
+        private string productName;
 
-        public CrashPrompt(string details)
+        public CrashPrompt(string details, DynamoViewModel dynamoViewModel)
         {
             InitializeComponent();
             this.CrashDetailsContent.Text = details;
+
+            productName = dynamoViewModel.BrandingResourceProvider.ProductName;
+            Title = string.Format(Wpf.Properties.Resources.CrashPromptDialogTitle,productName);
+            txtOverridingText.Text = string.Format(Wpf.Properties.Resources.CrashPromptDialogCrashMessage, productName);
         }
         
-        public CrashPrompt()
+        public CrashPrompt(DynamoViewModel dynamoViewModel)
         {
             InitializeComponent();
             this.CrashDetailsContent.Text = "Unknown error";
+            productName = dynamoViewModel.BrandingResourceProvider.ProductName;
+            Title = string.Format(Wpf.Properties.Resources.CrashPromptDialogTitle, productName);
+            txtOverridingText.Text = string.Format(Wpf.Properties.Resources.CrashPromptDialogCrashMessage, productName);
         }
 
-        public CrashPrompt(CrashPromptArgs args)
+        public CrashPrompt(CrashPromptArgs args, DynamoViewModel dynamoViewModel)
         {
             InitializeComponent();
+
+            productName = dynamoViewModel.BrandingResourceProvider.ProductName;
+            Title = string.Format(Wpf.Properties.Resources.CrashPromptDialogTitle, productName);
+            txtOverridingText.Text = string.Format(Wpf.Properties.Resources.CrashPromptDialogCrashMessage, productName);
 
             InstrumentationLogger.LogAnonymousEvent("CrashPrompt", "Stability");
             StabilityTracking.GetInstance().NotifyCrash();

--- a/src/DynamoCoreWpf/UI/Prompts/UsageReportingAgreementPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/UsageReportingAgreementPrompt.xaml
@@ -16,7 +16,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="100"></RowDefinition>
             <RowDefinition Height="*"></RowDefinition>
-            <RowDefinition Height="30"></RowDefinition>
+            <RowDefinition Height="auto"></RowDefinition>
             <RowDefinition Height="60"></RowDefinition>
         </Grid.RowDefinitions>
         <!-- The top banner image -->
@@ -77,6 +77,7 @@
                   FontSize="13.333"
                   Background="White">
             <TextBlock FontWeight="SemiBold"
+                       Foreground="#4790cd"
                        Name="ConsentTextBlock" />
         </CheckBox>
         <!-- Accept or Cancel -->

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -939,12 +939,12 @@ namespace Dynamo.ViewModels
             if (workspace == HomeSpace)
             {
                 ext = ".dyn";
-                fltr = string.Format(Resources.FileDialogDynamoWorkspace,"*.dyn");
+                fltr = string.Format(Resources.FileDialogDynamoWorkspace,BrandingResourceProvider.ProductName,"*.dyn");
             }
             else
             {
                 ext = ".dyf";
-                fltr = string.Format(Resources.FileDialogDynamoCustomNode,"*.dyf");
+                fltr = string.Format(Resources.FileDialogDynamoCustomNode,BrandingResourceProvider.ProductName,"*.dyf");
             }
             fltr += "|" + string.Format(Resources.FileDialogAllFiles, "*.*");
 
@@ -998,9 +998,10 @@ namespace Dynamo.ViewModels
 
             FileDialog _fileDialog = new OpenFileDialog()
             {
-                Filter = string.Format(Resources.FileDialogDynamoDefinitions, "*.dyn;*.dyf") + "|" +
+                Filter = string.Format(Resources.FileDialogDynamoDefinitions,
+                         BrandingResourceProvider.ProductName, "*.dyn;*.dyf") + "|" +
                          string.Format(Resources.FileDialogAllFiles, "*.*"),
-                Title = Resources.OpenDynamoDefinitionDialogTitle
+                Title = string.Format(Resources.OpenDynamoDefinitionDialogTitle,BrandingResourceProvider.ProductName)
             };
 
             // if you've got the current space path, use it as the inital dir

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -203,7 +203,8 @@ namespace Dynamo.ViewModels
 
                 if (DynamoViewModel.Model.PackageLoader.GetOwnerPackage(f.Item1) != null)
                 {
-                    var m = MessageBox.Show(String.Format(Resources.MessageSubmitSameNamePackage, pkg.Name),
+                    var m = MessageBox.Show(String.Format(Resources.MessageSubmitSameNamePackage, 
+                            DynamoViewModel.BrandingResourceProvider.ProductName,pkg.Name),
                             Resources.PackageWarningMessageBoxTitle, 
                             MessageBoxButton.YesNo, MessageBoxImage.Question);
 
@@ -269,7 +270,9 @@ namespace Dynamo.ViewModels
                                 }
                                 catch
                                 {
-                                    MessageBox.Show(String.Format(Resources.MessageFailToUninstallPackage, packageDownloadHandle.Name),
+                                    MessageBox.Show(String.Format(Resources.MessageFailToUninstallPackage, 
+                                        DynamoViewModel.BrandingResourceProvider.ProductName,
+                                        packageDownloadHandle.Name),
                                         Resources.UninstallFailureMessageBoxTitle, 
                                         MessageBoxButton.OK, MessageBoxImage.Error);
                                 }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -489,8 +489,11 @@ namespace Dynamo.PackageManager
                     }
 
                     // If the user
-                    if (MessageBox.Show(String.Format(Resources.MessagePackageNewerDynamo, sb.ToString()),
-                        Resources.PackageUseNewerDynamoMessageBoxTitle,
+                    if (MessageBox.Show(String.Format(Resources.MessagePackageNewerDynamo,
+                        PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName, 
+                        sb.ToString()),
+                        string.Format(Resources.PackageUseNewerDynamoMessageBoxTitle,
+                        PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName),
                         MessageBoxButton.OKCancel,
                         MessageBoxImage.Warning) == MessageBoxResult.Cancel)
                     {
@@ -529,7 +532,9 @@ namespace Dynamo.PackageManager
 
                 if (uninstallRequiringUserModifications.Any())
                 {
-                    MessageBox.Show(String.Format(Resources.MessageUninstallToContinue, JoinPackageNames(uninstallRequiringUserModifications)),
+                    MessageBox.Show(String.Format(Resources.MessageUninstallToContinue,
+                        PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName,
+                        JoinPackageNames(uninstallRequiringUserModifications)),
                         Resources.CannotDownloadPackageMessageBoxTitle, 
                         MessageBoxButton.OK, MessageBoxImage.Error);
                     return;
@@ -543,7 +548,9 @@ namespace Dynamo.PackageManager
                             x.MarkForUninstall(
                                 this.PackageManagerClientViewModel.DynamoViewModel.Model.PreferenceSettings));
 
-                    MessageBox.Show(String.Format(Resources.MessageUnintallToContinue2, JoinPackageNames(uninstallsRequiringRestart)), 
+                    MessageBox.Show(String.Format(Resources.MessageUninstallToContinue2,
+                        PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName, 
+                        JoinPackageNames(uninstallsRequiringRestart)), 
                         Resources.CannotDownloadPackageMessageBoxTitle,
                         MessageBoxButton.OK, MessageBoxImage.Error);
                     return;
@@ -552,7 +559,9 @@ namespace Dynamo.PackageManager
                 if (immediateUninstalls.Any())
                 {
                     // if the package is not in use, tell the user we will be uninstall it and give them the opportunity to cancel
-                    if (MessageBox.Show(String.Format(Resources.MessageAlreadyInstallDynamo, JoinPackageNames(immediateUninstalls)),
+                    if (MessageBox.Show(String.Format(Resources.MessageAlreadyInstallDynamo, 
+                        PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName,
+                        JoinPackageNames(immediateUninstalls)),
                         Resources.DownloadWarningMessageBoxTitle, 
                         MessageBoxButton.OKCancel, MessageBoxImage.Warning) == MessageBoxResult.Cancel)
                         return;

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -125,7 +125,8 @@ namespace Dynamo.ViewModels
             if (Model.LoadedAssemblies.Any())
             {
                 var resAssem =
-                    MessageBox.Show(Resources.MessageNeedToRestart,
+                    MessageBox.Show(string.Format(Resources.MessageNeedToRestart,
+                        dynamoViewModel.BrandingResourceProvider.ProductName),
                         Resources.UninstallingPackageMessageBoxTitle,
                         MessageBoxButton.OKCancel,
                         MessageBoxImage.Exclamation);
@@ -145,7 +146,8 @@ namespace Dynamo.ViewModels
             }
             catch (Exception)
             {
-                MessageBox.Show(Resources.MessageFailedToUninstall,
+                MessageBox.Show(string.Format(Resources.MessageFailedToUninstall,
+                    dynamoViewModel.BrandingResourceProvider.ProductName),
                     Resources.UninstallFailureMessageBoxTitle,
                     MessageBoxButton.OK, MessageBoxImage.Error);
             }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -32,7 +32,10 @@ namespace Dynamo.PackageManager
         #region Properties/Fields
 
         private readonly DynamoViewModel dynamoViewModel;
-
+        public DynamoViewModel DynamoViewModel
+        {
+            get { return dynamoViewModel; }
+        }
         /// <summary>
         /// A event called when publishing was a success
         /// </summary>
@@ -891,7 +894,8 @@ namespace Dynamo.PackageManager
                     // as the existing assembly cannot be modified while Dynamo is active.
                     if (this.Assemblies.Any(x => assemName == x.Assembly.GetName().Name))
                     {
-                        MessageBox.Show(Resources.PackageDuplicateAssemblyWarning, 
+                        MessageBox.Show(string.Format(Resources.PackageDuplicateAssemblyWarning, 
+                                        dynamoViewModel.BrandingResourceProvider.ProductName),
                                         Resources.PackageDuplicateAssemblyWarningTitle, 
                                         MessageBoxButtons.OK, 
                                         MessageBoxIcon.Stop);
@@ -977,7 +981,7 @@ namespace Dynamo.PackageManager
             // be active when there is no authenticator
             if (dynamoViewModel == null || !dynamoViewModel.Model.PackageManagerClient.HasAuthProvider)
             {
-                ErrorString = Resources.CannotSubmitPackage;
+                ErrorString = string.Format(Resources.CannotSubmitPackage,dynamoViewModel.BrandingResourceProvider.ProductName);
                 return false;
             }
 

--- a/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
+++ b/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
@@ -67,7 +67,7 @@
                     </TextBlock>
                 </StackPanel>
             </Grid>
-            <Button Grid.Row="2" Content="{x:Static p:Resources.AboutWIndowDynamoWebsiteButton}" Click="OnClickLink" Style="{StaticResource STextButton}"/>
+            <Button Name="DynamoWebsiteButton" Grid.Row="2" Click="OnClickLink" Style="{StaticResource STextButton}"/>
             <Image Grid.Column="0"
                    Grid.Row="0"
                    Source="/DynamoCoreWpf;component/UI/Images/AboutWindow/logo_about.png" Height="128" Width="128"/>

--- a/src/DynamoCoreWpf/Views/About/AboutWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Views/About/AboutWindow.xaml.cs
@@ -24,7 +24,8 @@ namespace Dynamo.UI.Views
             PreviewKeyDown += new KeyEventHandler(HandleEsc);
             DataContext = dynamoViewModel;
 
-            Title = Dynamo.Wpf.Properties.Resources.AboutWindowTitle;
+            Title = string.Format(Dynamo.Wpf.Properties.Resources.AboutWindowTitle,dynamoViewModel.BrandingResourceProvider.ProductName);
+            DynamoWebsiteButton.Content = string.Format(Dynamo.Wpf.Properties.Resources.AboutWindowDynamoWebsiteButton, dynamoViewModel.BrandingResourceProvider.ProductName);
         }
 
         public bool InstallNewUpdate { get; private set; }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -72,6 +72,10 @@ namespace Dynamo.Controls
 
             InitializeComponent();
 
+            ToggleIsUsageReportingApprovedCommand.ToolTip = string.Format(
+                Wpf.Properties.Resources.DynamoViewSettingMenuEnableDataReportingTooltip,
+                dynamoViewModel.BrandingResourceProvider.ProductName);
+
             Loaded += DynamoView_Loaded;
             Unloaded += DynamoView_Unloaded;
 
@@ -330,7 +334,7 @@ namespace Dynamo.Controls
 
             _timer.Stop();
             dynamoViewModel.Model.Logger.Log(String.Format(Wpf.Properties.Resources.MessageLoadingTime,
-                                                                     _timer.Elapsed));
+                                                                     _timer.Elapsed, dynamoViewModel.BrandingResourceProvider.ProductName));
             InitializeLogin();
             InitializeShortcutBar();
             InitializeStartPage();
@@ -522,7 +526,7 @@ namespace Dynamo.Controls
 
         void Controller_RequestsCrashPrompt(object sender, CrashPromptArgs args)
         {
-            var prompt = new CrashPrompt(args);
+            var prompt = new CrashPrompt(args,dynamoViewModel);
             prompt.ShowDialog();
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml
@@ -13,7 +13,6 @@
         Height="590" Width="700" 
         ResizeMode="CanResizeWithGrip" 
         Name="PublishInfoControl" 
-        Title="{x:Static p:Resources.PublishPackageViewTitle}" 
         Visibility="Visible">
     
     <Window.Resources>

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
@@ -6,6 +6,8 @@ using Dynamo.PackageManager.UI;
 using Dynamo.Search.SearchElements;
 using Dynamo.Utilities;
 
+using Dynamo.Wpf;
+
 namespace Dynamo.PackageManager
 {
     /// <summary>
@@ -19,6 +21,9 @@ namespace Dynamo.PackageManager
             packageViewModel.PublishSuccess += PackageViewModelOnPublishSuccess;
 
             InitializeComponent();
+
+            Title = string.Format(Wpf.Properties.Resources.PublishPackageViewTitle,
+                packageViewModel.DynamoViewModel.BrandingResourceProvider.ProductName);
         }
 
         private void PackageViewModelOnPublishSuccess(PublishPackageViewModel sender)


### PR DESCRIPTION
Hi @aparajit-pratap, please review and merge.

The changes are as follow:

1) ProductName property is added into the IBrandingResourceProvider and supplied with "Dynamo" in the DefaultBrandingResourceProvider.

2) Replace all of the resource strings in the DynamoCoreWpf project that contain "Dynamo" to the product name that is provided by the DefaultBrandingResourceProvider, except for:
          **InstallMessageCaption, DynamoUpdateAvailableToolTip, and UpdateMessage**

3) Changes in UsageReportingAgreementPrompt.xaml, in particular, the row 2's size from "30" to "auto" and the color of the AgreementConsent text to "#4790cd" (as discussed with @elayabharath). This change is reflected in the image below.

![consent form](https://cloud.githubusercontent.com/assets/6823427/7040983/88f86cfa-de07-11e4-90ff-b2e80e90545d.png)

