### PR TITLE
Remove static Instance of UpdateManager

### DIFF
--- a/src/DynamoCore/Core/DynamoLogger.cs
+++ b/src/DynamoCore/Core/DynamoLogger.cs
@@ -110,15 +110,8 @@ namespace Dynamo
                 WarningLevel = WarningLevel.Mild;
                 Warning = "";
 
-                UpdateManager.UpdateManager.Instance.Log += UpdateManager_Log;
-                
                 StartLogging(logDirectory);
             }
-        }
-
-        private void UpdateManager_Log(LogEventArgs args)
-        {
-            Log(args.Message, args.Level);
         }
 
         public void Log(string message, LogLevel level)
@@ -302,8 +295,6 @@ namespace Dynamo
 
             if (ConsoleWriter != null)
                 ConsoleWriter = null;
-
-            UpdateManager.UpdateManager.Instance.Log -= UpdateManager_Log;
         }
 
         public void Dispose()

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -609,7 +609,7 @@ namespace Dynamo.Models
         {
             LibraryServices.Dispose();
             LibraryServices.LibraryManagementCore.__TempCoreHostForRefactoring.Cleanup();
-            UpdateManager.Log -= updateManager_Log;
+            UpdateManager.Log -= UpdateManager_Log;
 
             Logger.Dispose();
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -526,7 +526,7 @@ namespace Dynamo.Models
             AddHomeWorkspace();
 
             UpdateManager = config.UpdateManager ?? new DefaultUpdateManager(null);
-            UpdateManager.Log += updateManager_Log;
+            UpdateManager.Log += UpdateManager_Log;
             if (!IsTestMode)
                 DefaultUpdateManager.CheckForProductUpdate(UpdateManager);
             
@@ -545,7 +545,7 @@ namespace Dynamo.Models
 
         }
 
-        void updateManager_Log(LogEventArgs args)
+        void UpdateManager_Log(LogEventArgs args)
         {
             Logger.Log(args.Message, args.Level);
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -32,6 +32,7 @@ using ProtoCore.Exceptions;
 using FunctionGroup = Dynamo.DSEngine.FunctionGroup;
 using Symbol = Dynamo.Nodes.Symbol;
 using Utils = Dynamo.Nodes.Utilities;
+using DefaultUpdateManager = Dynamo.UpdateManager.UpdateManager;
 
 namespace Dynamo.Models
 {
@@ -49,7 +50,6 @@ namespace Dynamo.Models
         private readonly string geometryFactoryPath;
         private readonly PathManager pathManager;
         private WorkspaceModel currentWorkspace;
-
         #endregion
 
         #region events
@@ -156,8 +156,13 @@ namespace Dynamo.Models
         /// </summary>
         public string Version
         {
-            get { return UpdateManager.UpdateManager.Instance.ProductVersion.ToString(); }
+            get { return UpdateManager.ProductVersion.ToString(); }
         }
+
+        /// <summary>
+        /// UpdateManager to handle automatic upgrade to higher version.
+        /// </summary>
+        public IUpdateManager UpdateManager { get; private set; }
 
         /// <summary>
         ///     The path manager that configures path information required for 
@@ -220,7 +225,7 @@ namespace Dynamo.Models
             get
             {
                 return Process.GetCurrentProcess().ProcessName + "-"
-                    + UpdateManager.UpdateManager.Instance.ProductVersion;
+                    + DefaultUpdateManager.GetProductVersion();
             }
         }
 
@@ -520,9 +525,11 @@ namespace Dynamo.Models
 
             AddHomeWorkspace();
 
+            UpdateManager = config.UpdateManager ?? new DefaultUpdateManager(null);
+            UpdateManager.Log += updateManager_Log;
             if (!IsTestMode)
-                UpdateManager.UpdateManager.CheckForProductUpdate();
-
+                DefaultUpdateManager.CheckForProductUpdate(UpdateManager);
+            
             Logger.Log(
                 string.Format("Dynamo -- Build {0}", Assembly.GetExecutingAssembly().GetName().Version));
 
@@ -536,6 +543,11 @@ namespace Dynamo.Models
 
             InitializeNodeLibrary(preferences);
 
+        }
+
+        void updateManager_Log(LogEventArgs args)
+        {
+            Logger.Log(args.Message, args.Level);
         }
 
         /// <summary>
@@ -597,6 +609,8 @@ namespace Dynamo.Models
         {
             LibraryServices.Dispose();
             LibraryServices.LibraryManagementCore.__TempCoreHostForRefactoring.Cleanup();
+            UpdateManager.Log -= updateManager_Log;
+
             Logger.Dispose();
 
             EngineController.Dispose();

--- a/src/DynamoCore/UpdateManager/UpdateManager.cs
+++ b/src/DynamoCore/UpdateManager/UpdateManager.cs
@@ -318,21 +318,32 @@ namespace Dynamo.UpdateManager
         /// <returns></returns>
         public static UpdateManagerConfiguration GetSettings(IUpdateManager updateManager = null)
         {
-            string location = Assembly.GetExecutingAssembly().Location;
-            string filePath = Path.Combine(
-                Path.GetDirectoryName(location),
-                DEFAULT_CONFIG_FILE_S);
+            string filePath;
+            var exists = TryGetConfigFilePath(out filePath);
 #if DEBUG
             //This code is just to create the default config file to
             //save the default settings, which later on can be modified
             //to re-direct it to other download target for testing.
-            if (!File.Exists(filePath))
+            if (!exists)
             {
                 var config = new UpdateManagerConfiguration();
                 config.Save(filePath, updateManager);
             }
 #endif
-            return File.Exists(filePath) ? Load(filePath, updateManager) : new UpdateManagerConfiguration();
+            return exists ? Load(filePath, updateManager) : new UpdateManagerConfiguration();
+        }
+
+        /// <summary>
+        /// Gets the update manager config file path.
+        /// </summary>
+        /// <param name="filePath">Full path for the config file</param>
+        /// <returns>True if file exists.</returns>
+        public static bool TryGetConfigFilePath(out string filePath)
+        {
+            string location = Assembly.GetExecutingAssembly().Location;
+            // ReSharper disable once AssignNullToNotNullAttribute, location is always available
+            filePath = Path.Combine(Path.GetDirectoryName(location), DEFAULT_CONFIG_FILE_S);
+            return File.Exists(filePath);
         }
     }
 

--- a/src/DynamoCore/UpdateManager/UpdateManager.cs
+++ b/src/DynamoCore/UpdateManager/UpdateManager.cs
@@ -40,6 +40,7 @@ namespace Dynamo.UpdateManager
         BinaryVersion ProductVersion { get; }
         BinaryVersion AvailableVersion { get; }
         IAppVersionInfo UpdateInfo { get; set; }
+        bool IsUpdateAvailable { get; }
         event UpdateDownloadedEventHandler UpdateDownloaded;
         event ShutdownRequestedEventHandler ShutdownRequested;
         void CheckForProductUpdate(IAsynchronousRequest request);
@@ -75,6 +76,11 @@ namespace Dynamo.UpdateManager
         /// Defines whether to force update, default vlaue is false.
         /// </summary>
         bool ForceUpdate { get; set; }
+
+        /// <summary>
+        /// Gets the base name of the installer to be used for upgrade.
+        /// </summary>
+        string InstallerNameBase { get; set; }
     }
 
     /// <summary>
@@ -136,7 +142,7 @@ namespace Dynamo.UpdateManager
         /// <summary>
         /// UpdateManager instance that created this request.
         /// </summary>
-        private IUpdateManager manager = null;
+        private readonly IUpdateManager manager = null;
 
         /// <summary>
         /// The constructor.
@@ -203,6 +209,7 @@ namespace Dynamo.UpdateManager
         private const string PRODUCTION_SOURCE_PATH_S = "http://dyn-builds-data.s3.amazonaws.com/";
         private const string PRODUCTION_SIG_SOURCE_PATH_S = "http://dyn-builds-data-sig.s3.amazonaws.com/";
         private const string DEFAULT_CONFIG_FILE_S = "UpdateManagerConfig.xml";
+        private const string INSTALL_NAME_BASE = "DynamoInstall";
 
         /// <summary>
         /// Defines download location for new installer
@@ -225,6 +232,11 @@ namespace Dynamo.UpdateManager
         public bool ForceUpdate { get; set; }
 
         /// <summary>
+        /// Gets the base name of the installer to be used for upgrade.
+        /// </summary>
+        public string InstallerNameBase { get; set; }
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         public UpdateManagerConfiguration()
@@ -233,6 +245,7 @@ namespace Dynamo.UpdateManager
             SignatureSourcePath = PRODUCTION_SIG_SOURCE_PATH_S;
             CheckNewerDailyBuild = false;
             ForceUpdate = false;
+            InstallerNameBase = INSTALL_NAME_BASE;
         }
 
         /// <summary>
@@ -331,17 +344,14 @@ namespace Dynamo.UpdateManager
         #region Private Class Data Members
 
         private bool versionCheckInProgress;
-        private BinaryVersion productVersion;
+        private static BinaryVersion productVersion;
         private IAppVersionInfo updateInfo;
-        private const string INSTALL_NAME_BASE = "DynamoInstall";
         private const string OLD_DAILY_INSTALL_NAME_BASE = "DynamoDailyInstall";
         private const string INSTALLUPDATE_EXE = "InstallUpdate.exe";
         private string updateFileLocation;
         private int currentDownloadProgress = -1;
         private IAppVersionInfo downloadedUpdateInfo;
-        private static IUpdateManager instance;
-        private static readonly object lockingObject = new object();
-        private UpdateManagerConfiguration configuration = null;
+        private IUpdateManagerConfiguration configuration = null;
         private int hostApplicationProcessId = -1;
 
         #endregion
@@ -366,15 +376,18 @@ namespace Dynamo.UpdateManager
         {
             get
             {
-                if (null == productVersion)
-                {
-                    string executingAssemblyPathName = System.Reflection.Assembly.GetExecutingAssembly().Location;
-                    FileVersionInfo myFileVersionInfo = FileVersionInfo.GetVersionInfo(executingAssemblyPathName);
-                    productVersion = BinaryVersion.FromString(myFileVersionInfo.FileVersion);
-                }
-
-                return productVersion;
+                return GetProductVersion();
             }
+        }
+
+        public static BinaryVersion GetProductVersion()
+        {
+            if (null != productVersion) return productVersion;
+
+            var executingAssemblyName = Assembly.GetExecutingAssembly().GetName();
+            productVersion = BinaryVersion.FromString(executingAssemblyName.Version.ToString());
+
+            return productVersion;
         }
 
         /// <summary>
@@ -434,6 +447,18 @@ namespace Dynamo.UpdateManager
             }
         }
 
+        public bool IsUpdateAvailable
+        {
+            get
+            {
+                //Update is not available unitl it's downloaded
+                if(DownloadedUpdateInfo==null)
+                    return false;
+
+                return ForceUpdate || AvailableVersion > ProductVersion;
+            }
+        }
+
         /// <summary>
         /// This flag is available via the debug menu to
         /// allow the update manager to check for newer daily 
@@ -472,17 +497,6 @@ namespace Dynamo.UpdateManager
             }
         }
 
-        public static IUpdateManager Instance
-        {
-            get
-            {
-                lock (lockingObject)
-                {
-                    return instance ?? (instance = new UpdateManager());
-                }
-            }
-        }
-
         /// <summary>
         /// Returns the configuration settings.
         /// </summary>
@@ -496,8 +510,9 @@ namespace Dynamo.UpdateManager
 
         #endregion
 
-        private UpdateManager()
+        public UpdateManager(IUpdateManagerConfiguration configuration)
         {
+            this.configuration = configuration;
             PropertyChanged += UpdateManager_PropertyChanged;
         }
 
@@ -581,14 +596,14 @@ namespace Dynamo.UpdateManager
             var latestBuildTime = new DateTime();
 
             bool useStable = false;
-            if (IsStableBuild(INSTALL_NAME_BASE, latestBuildFilePath))
+            if (IsStableBuild(Configuration.InstallerNameBase, latestBuildFilePath))
             {
                 useStable = true;
-                latestBuildVersion = GetBinaryVersionFromFilePath(INSTALL_NAME_BASE, latestBuildFilePath);
+                latestBuildVersion = GetBinaryVersionFromFilePath(Configuration.InstallerNameBase, latestBuildFilePath);
             }
-            else if (IsDailyBuild(INSTALL_NAME_BASE, latestBuildFilePath) || IsDailyBuild(OLD_DAILY_INSTALL_NAME_BASE, latestBuildFilePath))
+            else if (IsDailyBuild(Configuration.InstallerNameBase, latestBuildFilePath) || IsDailyBuild(OLD_DAILY_INSTALL_NAME_BASE, latestBuildFilePath))
             {
-                latestBuildTime = GetBuildTimeFromFilePath(INSTALL_NAME_BASE, latestBuildFilePath);
+                latestBuildTime = GetBuildTimeFromFilePath(Configuration.InstallerNameBase, latestBuildFilePath);
                 latestBuildVersion = GetCurrentBinaryVersion();
             }
             else
@@ -777,7 +792,7 @@ namespace Dynamo.UpdateManager
 
             var builds = bucketresult.Descendants(ns + "LastModified").
                 OrderByDescending(x => DateTime.Parse(x.Value)).
-                Where(x => x.Parent.Value.Contains(INSTALL_NAME_BASE) || x.Parent.Value.Contains(OLD_DAILY_INSTALL_NAME_BASE)).
+                Where(x => x.Parent.Value.Contains(Configuration.InstallerNameBase) || x.Parent.Value.Contains(OLD_DAILY_INSTALL_NAME_BASE)).
                 Select(x => x.Parent);
 
 
@@ -791,8 +806,8 @@ namespace Dynamo.UpdateManager
 
             string latestBuild = string.Empty;
             latestBuild = checkDailyBuilds ?
-                fileNames.FirstOrDefault(x => IsDailyBuild(INSTALL_NAME_BASE, x) || IsDailyBuild(OLD_DAILY_INSTALL_NAME_BASE, x)) :
-                fileNames.FirstOrDefault(x => IsStableBuild(INSTALL_NAME_BASE, x));
+                fileNames.FirstOrDefault(x => IsDailyBuild(Configuration.InstallerNameBase, x) || IsDailyBuild(OLD_DAILY_INSTALL_NAME_BASE, x)) :
+                fileNames.FirstOrDefault(x => IsStableBuild(Configuration.InstallerNameBase, x));
 
             return latestBuild;
         }
@@ -1018,17 +1033,20 @@ namespace Dynamo.UpdateManager
         #endregion
 
         /// <summary>
-        /// Checks for the product update. Requests for update version info
-        /// from configured download source path.
+        /// Checks for the product update by requesting for update version info 
+        /// from configured download source path. This method will skip the 
+        /// update check if a newer version of the product is already installed.
         /// </summary>
-        internal static void CheckForProductUpdate()
+        /// <param name="manager">Update manager instance using which product
+        /// update check nees to be done.</param>
+        internal static void CheckForProductUpdate(IUpdateManager manager)
         {
             //If we already have higher version installed, don't look for product update.
-            if(new DynamoLookUp().LatestProduct > Instance.ProductVersion)
+            if(new DynamoLookUp().LatestProduct > manager.ProductVersion)
                 return;
 
-            var downloadUri = new Uri(Instance.Configuration.DownloadSourcePath);
-            Instance.CheckForProductUpdate(new UpdateRequest(downloadUri, Instance));
+            var downloadUri = new Uri(manager.Configuration.DownloadSourcePath);
+            manager.CheckForProductUpdate(new UpdateRequest(downloadUri, manager));
         }
     }
 

--- a/src/DynamoCoreWpf/Controls/GraphUpdateNotificationControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/GraphUpdateNotificationControl.xaml.cs
@@ -18,7 +18,8 @@ namespace DynamoCore.UI.Controls
 
         private void OnInstallButtonClicked(object sender, RoutedEventArgs e)
         {
-            if (!(DataContext is UpdateManager)) return;
+            var um = DataContext as IUpdateManager;
+            if (um == null) return;
 
             var result = MessageBox.Show(Dynamo.Wpf.Properties.Resources.UpdateMessage, 
                 Dynamo.Wpf.Properties.Resources.InstallMessageCaption, 
@@ -26,7 +27,7 @@ namespace DynamoCore.UI.Controls
 
             if (result == MessageBoxResult.OK)
             {
-                UpdateManager.Instance.QuitAndInstallUpdate();
+                um.QuitAndInstallUpdate();
             }
         }
     }

--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml
@@ -132,7 +132,6 @@
                 
                 <controls:GraphUpdateNotificationControl x:Name="UpdateControl" HorizontalAlignment="Right" 
                                                          Margin="0,0,50,0"
-                                                         DataContext="{Binding Source={x:Static updateManager:UpdateManager.Instance}}"
                                                          Visibility="{Binding Path=DataContext.IsUpdateAvailable, RelativeSource={RelativeSource AncestorType={x:Type Window}}, 
                                                          Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"/>
             </Grid>

--- a/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/ShortcutToolbar.xaml.cs
@@ -1,6 +1,9 @@
 ﻿using Dynamo.UI.Commands;
 using System.Collections.ObjectModel;
 using System.Windows.Controls;
+
+using Dynamo.UpdateManager;
+
 using Microsoft.Practices.Prism.ViewModel;
 
 namespace Dynamo.UI.Controls
@@ -21,12 +24,13 @@ namespace Dynamo.UI.Controls
             get { return shortcutBarRightSideItems; }
         }
 
-        public ShortcutToolbar()
+        public ShortcutToolbar(IUpdateManager updateManager)
         {
             shortcutBarItems = new ObservableCollection<ShortcutBarItem>();
             shortcutBarRightSideItems = new ObservableCollection<ShortcutBarItem>();    
 
             InitializeComponent();
+            this.UpdateControl.DataContext = updateManager;
         }
     }
 

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -14,6 +14,7 @@ using Dynamo.Models;
 using Dynamo.PackageManager;
 using Dynamo.UI;
 using Dynamo.UI.Controls;
+using Dynamo.UpdateManager;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Properties;
 using Dynamo.Wpf.ViewModels;
@@ -1762,9 +1763,14 @@ namespace Dynamo.Controls
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if ((bool)value != true) return Resources.AboutWindowUpToDate;
+            var um = value as IUpdateManager;
+            if (um == null)
+                return Resources.AboutWindowCannotGetVersion;
 
-            var latest = UpdateManager.UpdateManager.Instance.AvailableVersion;
+            if (!um.ForceUpdate && um.AvailableVersion <= um.ProductVersion) 
+                return Resources.AboutWindowUpToDate;
+            
+            var latest = um.AvailableVersion;
 
             return latest != null ? latest.ToString() : Resources.AboutWindowCannotGetVersion;
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -370,12 +370,8 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                var um = UpdateManager.UpdateManager.Instance;
-                if (um.ForceUpdate)
-                {
-                    return true;
-                }
-                return um.AvailableVersion > um.ProductVersion;
+                var um = model.UpdateManager;
+                return um.IsUpdateAvailable;
             }
         }
 
@@ -575,14 +571,14 @@ namespace Dynamo.ViewModels
 
         private void SubscribeUpdateManagerHandlers()
         {
-            UpdateManager.UpdateManager.Instance.UpdateDownloaded += Instance_UpdateDownloaded;
-            UpdateManager.UpdateManager.Instance.ShutdownRequested += updateManager_ShutdownRequested;
+            model.UpdateManager.UpdateDownloaded += Instance_UpdateDownloaded;
+            model.UpdateManager.ShutdownRequested += updateManager_ShutdownRequested;
         }
 
         private void UnsubscribeUpdateManagerEvents()
         {
-            UpdateManager.UpdateManager.Instance.UpdateDownloaded -= Instance_UpdateDownloaded;
-            UpdateManager.UpdateManager.Instance.ShutdownRequested -= updateManager_ShutdownRequested;
+            model.UpdateManager.UpdateDownloaded -= Instance_UpdateDownloaded;
+            model.UpdateManager.ShutdownRequested -= updateManager_ShutdownRequested;
         }
 
         private void SubscribeModelUiEvents()
@@ -1974,7 +1970,7 @@ namespace Dynamo.ViewModels
             model.ShutDown(shutdownParams.ShutdownHost);
             if (shutdownParams.ShutdownHost)
             {
-                UpdateManager.UpdateManager.Instance.HostApplicationBeginQuit();
+                model.UpdateManager.HostApplicationBeginQuit();
             }
 
             UsageReportingManager.DestroyInstance();

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -572,13 +572,13 @@ namespace Dynamo.ViewModels
         private void SubscribeUpdateManagerHandlers()
         {
             model.UpdateManager.UpdateDownloaded += Instance_UpdateDownloaded;
-            model.UpdateManager.ShutdownRequested += updateManager_ShutdownRequested;
+            model.UpdateManager.ShutdownRequested += UpdateManager_ShutdownRequested;
         }
 
         private void UnsubscribeUpdateManagerEvents()
         {
             model.UpdateManager.UpdateDownloaded -= Instance_UpdateDownloaded;
-            model.UpdateManager.ShutdownRequested -= updateManager_ShutdownRequested;
+            model.UpdateManager.ShutdownRequested -= UpdateManager_ShutdownRequested;
         }
 
         private void SubscribeModelUiEvents()
@@ -746,7 +746,7 @@ namespace Dynamo.ViewModels
             RaisePropertyChanged("IsUpdateAvailable");
         }
 
-        void updateManager_ShutdownRequested(IUpdateManager updateManager)
+        void UpdateManager_ShutdownRequested(IUpdateManager updateManager)
         {
             PerformShutdownSequence(new ShutdownParams(
                 shutdownHost: true, allowCancellation: true));

--- a/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
+++ b/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
@@ -62,7 +62,7 @@
                                PreviewMouseDown="OnPreviewMouseDown"
                                HorizontalAlignment="Center">
                         <Run Foreground="{Binding IsUpdateAvailable, Converter={StaticResource IsUpdateAvailableBrushConverter}}" 
-                             Text="{Binding IsUpdateAvailable, Converter={StaticResource IsUpdateAvailableToTextConverter}, 
+                             Text="{Binding Model.UpdateManager, Converter={StaticResource IsUpdateAvailableToTextConverter}, 
                              ConverterParameter=DataContext, Mode=OneWay}"/>
                     </TextBlock>
                 </StackPanel>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -788,13 +788,13 @@
                         <MenuItem Focusable="False"
                                   Name="CheckDailyBuilds"
                                   Header="{x:Static p:Resources.DynamoViewDebugMenuCheckDailyBuild}"
-                                  DataContext="{Binding Source={x:Static um:UpdateManager.Instance}}"
+                                  DataContext="{Binding Path=Model.UpdateManager}"
                                   IsCheckable="True"
                                   IsChecked="{Binding Path=CheckNewerDailyBuilds, Mode=TwoWay}"></MenuItem>
                         <MenuItem Focusable="False"
                                   Name="ForceUpdate"
                                   Header="{x:Static p:Resources.DynamoViewDebugMenuForceUpdate}"
-                                  DataContext="{Binding Source={x:Static um:UpdateManager.Instance}}"
+                                  DataContext="{Binding Path=Model.UpdateManager}"
                                   IsCheckable="True"
                                   IsChecked="{Binding Path=ForceUpdate, Mode=TwoWay}" />
                         <MenuItem Focusable="False"

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -187,7 +187,7 @@ namespace Dynamo.Controls
 
         void InitializeShortcutBar()
         {
-            ShortcutToolbar shortcutBar = new ShortcutToolbar();
+            ShortcutToolbar shortcutBar = new ShortcutToolbar(this.dynamoViewModel.Model.UpdateManager);
             shortcutBar.Name = "ShortcutToolbar";
 
             ShortcutBarItem newScriptButton = new ShortcutBarItem();

--- a/test/DynamoCoreUITests/UpdateManagerUITests.cs
+++ b/test/DynamoCoreUITests/UpdateManagerUITests.cs
@@ -1,50 +1,25 @@
-﻿using System;
-using System.IO;
-using System.Reflection;
-using System.Threading;
-using System.Windows;
-using System.Windows.Controls;
-
-using SystemTestServices;
-
-using Dynamo.Controls;
-using Dynamo.Models;
+﻿using System.Windows;
 using Dynamo.UI.Controls;
 using Dynamo.UpdateManager;
-using Dynamo.Utilities;
-using Dynamo.ViewModels;
-
-using DynamoCore.UI.Controls;
-
-using NUnit.Framework;
 using Moq;
+using NUnit.Framework;
+using SystemTestServices;
+
 
 namespace DynamoCoreUITests
 {
     [TestFixture]
-    public class 
-        UpdateManagerUITests : SystemTestBase
+    public class UpdateManagerUITests : SystemTestBase
     {
         private const string DOWNLOAD_SOURCE_PATH_S = "http://downloadsourcepath/";
         private const string SIGNATURE_SOURCE_PATH_S = "http://SignatureSourcePath/";
 
-        private static Mock<IUpdateManager> MockUpdateManager(string availableVersion, string productVersion)
+        private void MockUpdateManager(bool isUpToDate)
         {
-            var um_mock = new Mock<IUpdateManager>();
-            um_mock.Setup(um => um.AvailableVersion).Returns(BinaryVersion.FromString(availableVersion));
-            um_mock.Setup(um => um.ProductVersion).Returns(BinaryVersion.FromString(productVersion));
+            var umMock = new Mock<IUpdateManager>();
+            umMock.Setup(um => um.IsUpdateAvailable).Returns(!isUpToDate);
 
-            var config = new UpdateManagerConfiguration()
-            {
-                DownloadSourcePath = DOWNLOAD_SOURCE_PATH_S,
-                SignatureSourcePath = SIGNATURE_SOURCE_PATH_S
-            };
-            um_mock.Setup(um => um.Configuration).Returns(config);
-
-            var fieldInfo = typeof(UpdateManager).GetField("instance", BindingFlags.Static | BindingFlags.NonPublic);
-            Assert.NotNull(fieldInfo);
-            fieldInfo.SetValue(UpdateManager.Instance, um_mock.Object);
-            return um_mock;
+            UpdateManager = umMock.Object;
         }
 
         [SetUp]
@@ -57,15 +32,14 @@ namespace DynamoCoreUITests
         [Category("UnitTests")]
         public void UpdateButtonNotCollapsedIfNotUpToDate()
         {
-            const string availableVersion = "9.9.9.9";
-            const string productVersion = "1.1.1.1";
-            MockUpdateManager(availableVersion, productVersion);
+            MockUpdateManager(isUpToDate: false);
 
             base.Setup();
 
             var stb = (ShortcutToolbar)View.shortcutBarGrid.Children[0];
-            var sbgrid = (Grid)stb.FindName("ShortcutToolbarGrid");
-            var updateControl = (GraphUpdateNotificationControl)sbgrid.FindName("UpdateControl");
+            Assert.IsNotNull(stb);
+            var updateControl = stb.UpdateControl;
+            Assert.IsNotNull(updateControl);
             Assert.AreEqual(Visibility.Visible, updateControl.Visibility);
         }
 
@@ -73,31 +47,14 @@ namespace DynamoCoreUITests
         [Category("UnitTests")]
         public void UpdateButtonCollapsedIfUpToDate()
         {
-            const string availableVersion = "1.1.1.1";
-            const string productVersion = "9.9.9.9";
-            MockUpdateManager(availableVersion, productVersion);
+            MockUpdateManager(isUpToDate:true);
 
             base.Setup();
 
-            var stb = (ShortcutToolbar)View.shortcutBarGrid.Children[0];
-            var sbgrid = (Grid)stb.FindName("ShortcutToolbarGrid");
-            var updateControl = (GraphUpdateNotificationControl)sbgrid.FindName("UpdateControl");
-            Assert.AreEqual(Visibility.Collapsed, updateControl.Visibility);
-        }
-
-        [Test]
-        [Category("UnitTests")]
-        public void UpdateButtonCollapsedIfNotConnected()
-        {
-            const string availableVersion = "";
-            const string productVersion = "9.9.9.9";
-            MockUpdateManager(availableVersion, productVersion);
-
-            base.Setup();
-
-            var stb = (ShortcutToolbar)View.shortcutBarGrid.Children[0];
-            var sbgrid = (Grid)stb.FindName("ShortcutToolbarGrid");
-            var updateControl = (GraphUpdateNotificationControl)sbgrid.FindName("UpdateControl");
+            var stb = View.shortcutBarGrid.Children[0] as ShortcutToolbar;
+            Assert.IsNotNull(stb);
+            var updateControl = stb.UpdateControl;
+            Assert.IsNotNull(updateControl);
             Assert.AreEqual(Visibility.Collapsed, updateControl.Visibility);
         }
     }

--- a/test/Libraries/SystemTestServices/SystemTestBase.cs
+++ b/test/Libraries/SystemTestServices/SystemTestBase.cs
@@ -11,6 +11,7 @@ using Dynamo.Controls;
 using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.Tests;
+using Dynamo.UpdateManager;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.ViewModels.Core;
 
@@ -43,6 +44,8 @@ namespace SystemTestServices
         protected DynamoView View { get; set; }
 
         protected DynamoModel Model { get; set; }
+
+        protected IUpdateManager UpdateManager { get; set; }
 
         protected string ExecutingDirectory
         {
@@ -158,7 +161,8 @@ namespace SystemTestServices
                 {
                     StartInTestMode = true,
                     PathResolver = pathResolver,
-                    GeometryFactoryPath = preloader.GeometryFactoryPath
+                    GeometryFactoryPath = preloader.GeometryFactoryPath,
+                    UpdateManager = this.UpdateManager
                 });
 
             ViewModel = DynamoViewModel.Start(


### PR DESCRIPTION
- Merge PR: #4188 from master
- UpdateManager class is no more a singleton class, hence static property "Instance" is removed.
- DynamoModel holds IUpdateManager instance, which is initialized via StartConfiguration parameter. If StartConfiguration doesn't have a valid instance of IUpdateManager, then it creates an instance of UpdateManager with default configuration parameter.
- Clients can set IUpdateManager while initializing DynamoModel, thru StartConfiguration parameter.
- A static method GetProductVersion() is introduced to return product version so that this can be called even when DynamoModel is not initialized.
- A new property IsUpdateAvailable is defined to return true only if update info is downloaded, and we have a valid update or force update is set true.
- The green cloud on UI is bound to this property, so the cloud should be visible only after data has been downloaded.
- Tests have been updated to make use of UpdateManager and some new tests are added to test IsUpdateAvailable property.

**PTAL**
- [ ] @aparajit-pratap 