### PR TITLE
Fix the issue with context menu and multiple groups

### DIFF
--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -139,7 +139,7 @@ namespace Dynamo.Models
             }
         }
 
-        private double fontSize = 10;
+        private double fontSize = 14;
         public Double FontSize
         {
             get { return fontSize; }

--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -184,6 +184,9 @@ namespace Dynamo.Models
                     if(!loadFromXML)
                         UpdateBoundaryFromSelection();
                     break;
+                case "Text":
+                    UpdateBoundaryFromSelection();
+                    break;
             }
         }
 

--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -163,7 +163,7 @@ namespace Dynamo.Models
             var nodeModels = nodes as NodeModel[] ?? nodes.ToArray();           
             var noteModels = notes as NoteModel[] ?? notes.ToArray();
 
-            this.SelectedModels = nodeModels.Concat(noteModels.Cast<ModelBase>()).ToList();
+            this.SelectedModels = nodeModels.Concat(noteModels.Cast<ModelBase>()).ToList();            
             loadFromXML = loadFromGraph;
             if (!loadFromGraph)
                 UpdateBoundaryFromSelection();
@@ -337,7 +337,7 @@ namespace Dynamo.Models
         {            
             XmlElementHelper helper = new XmlElementHelper(element);
             this.GUID = helper.ReadGuid("guid", this.GUID);
-            this.annotationText = helper.ReadString("annotationText", String.Empty);
+            this.annotationText = helper.ReadString("annotationText", Resources.GroupDefaultText);
             this.left = helper.ReadDouble("left", doubleValue);
             this.top = helper.ReadDouble("top", doubleValue);
             this.width = helper.ReadDouble("width", doubleValue);

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
+using Dynamo.Properties;
 using Dynamo.Utilities;
 using Newtonsoft.Json;
 using System.Runtime.Serialization;
@@ -1478,7 +1479,7 @@ namespace Dynamo.Models
                 double x, double y, bool defaultPosition)
             {
                 if (string.IsNullOrEmpty(annotationText))
-                    annotationText = string.Empty;
+                    annotationText = Resources.GroupDefaultText;
 
                 AnnotationId = nodeId;
                 AnnotationText = annotationText;

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -668,19 +668,25 @@ namespace Dynamo.Models
         {
             var selectedNodes = this.Nodes == null ? null:this.Nodes.Where(s => s.IsSelected);
             var selectedNotes = this.Notes == null ? null: this.Notes.Where(s => s.IsSelected);
-
-            var annotationModel = new AnnotationModel(selectedNodes, selectedNotes)
+            //No Groups should be selected when creating a new group. This is to avoid creating multiple groups
+            //on the selected nodes.
+            var selectedAnnotation = this.Annotations == null ? null : this.Annotations.Where(s => s.IsSelected);
+            if (selectedAnnotation != null && !selectedAnnotation.Any())
             {
-                GUID = id,
-                AnnotationText = text
-            };
+                var annotationModel = new AnnotationModel(selectedNodes, selectedNotes)
+                {
+                    GUID = id,
+                    AnnotationText = text
+                };
 
-            var args = new ModelEventArgs(annotationModel, true);
-            OnRequestNodeCentered(this, args);
+                var args = new ModelEventArgs(annotationModel, true);
+                OnRequestNodeCentered(this, args);
 
-            Annotations.Add(annotationModel);
-            HasUnsavedChanges = true;
-            return annotationModel;
+                Annotations.Add(annotationModel);
+                HasUnsavedChanges = true;
+                return annotationModel;
+            }
+            return null;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2160,9 +2160,7 @@ namespace Dynamo.Controls
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var text = value == null ? String.Empty:value.ToString();
-            if (text == "" || text == String.Empty)
-                return Resources.GroupDefaultText;
+            var text = value == null ? String.Empty:value.ToString();             
             return text;
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -2,6 +2,8 @@
 using Dynamo.Models;
 using System;
 using Dynamo.UI.Commands;
+using Dynamo.Utilities;
+using Dynamo.Views;
 using Color = System.Windows.Media.Color;
 
 namespace Dynamo.ViewModels
@@ -129,7 +131,10 @@ namespace Dynamo.ViewModels
         {            
             annotationModel = model;           
             this.WorkspaceViewModel = workspaceViewModel;                                     
-            model.PropertyChanged += model_PropertyChanged;          
+            model.PropertyChanged += model_PropertyChanged;
+            // Group is created already.So just populate it.
+            var selectNothing = new DynamoModel.SelectModelCommand(Guid.Empty, System.Windows.Input.ModifierKeys.None.AsDynamoType());
+            WorkspaceViewModel.DynamoViewModel.ExecuteCommand(selectNothing);
         }
 
         private bool CanChangeFontSize(object obj)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -893,7 +893,7 @@ namespace Dynamo.ViewModels
 
         internal bool CanAddAnnotation(object parameter)
         {
-            return DynamoSelection.Instance.Selection.OfType<NodeModel>().Any();
+            return DynamoSelection.Instance.Selection.OfType<ModelBase>().Any();
         }
 
         private void WorkspaceAdded(WorkspaceModel item)

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -141,9 +141,7 @@
                               IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=18}"></MenuItem>
                     <MenuItem Header ="20" Name="FontSize5" Command="{Binding ChangeFontSize}" CommandParameter="20"
                               IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=20}"></MenuItem>              
-                </MenuItem>
-                <MenuItem  Header="{x:Static p:Resources.GroupContextMenuBackground}"
-                               Name="ChooseColor"/>
+                </MenuItem>               
                 <ListBox Style="{StaticResource ColorSelectorListBox}"
                          ItemContainerStyle="{StaticResource ColorSelectorListBoxItem}"
                           SelectionChanged="OnNodeColorSelectionChanged">

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -40,13 +40,13 @@
 
         <Grid.ContextMenu>
             <ContextMenu Name="MainContextMenu"
-                         x:FieldModifier="public">
-                <MenuItem Name="createGroup_cm"
-                          Header="{x:Static p:Resources.ContextCreateGroupFromSelection}"
-                          Command="{Binding Path=CreateGroupCommand}" />
+                         x:FieldModifier="public">               
                 <MenuItem Name="deleteElem_cm"
                           Header="{x:Static p:Resources.ContextMenuDelete}"
                           Command="{Binding Path=DeleteCommand}" />
+                <MenuItem Name="createGroup_cm"
+                          Header="{x:Static p:Resources.ContextCreateGroupFromSelection}"
+                          Command="{Binding Path=CreateGroupCommand}" />
                 <MenuItem Header="{x:Static p:Resources.ContextMenuLacing}"
                           Visibility="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToVisibilityConverter},Mode=OneWay}">
                     <MenuItem IsCheckable="True"

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml
@@ -15,12 +15,12 @@
     
     <Grid Name="BaseGrid">
         <Grid.ContextMenu>
-            <ContextMenu>
+            <ContextMenu>               
+                <MenuItem Name="deleteItem" Header="{x:Static p:Resources.NoteViewContextMenuDelete}" Click="OnDeleteItemClick"  />               
+                <MenuItem Name="editItem" Header="{x:Static p:Resources.NoteViewContextMenuEdit}" Click="OnEditItemClick" />
                 <MenuItem Name="createGroup_cm"
                           Header="{x:Static p:Resources.ContextCreateGroupFromSelection}"
                           Command="{Binding Path=CreateGroupCommand}" />
-                <MenuItem Name="deleteItem" Header="{x:Static p:Resources.NoteViewContextMenuDelete}" Click="OnDeleteItemClick"  />
-                <MenuItem Name="editItem" Header="{x:Static p:Resources.NoteViewContextMenuEdit}" Click="OnEditItemClick" />
             </ContextMenu>
         </Grid.ContextMenu>
         <Canvas Background="{x:Null}">


### PR DESCRIPTION
This is the fix for two issues

MAGN-6924 Create Group should not be first on the context menu
MAGN-6925 Pressing Ctrl-G twice darkens the default pink color for a group
MAGN-6926 Default group title text should be the same size as node titles and get only larger with font increase.
MAGN-6927 Notes don't respect group equal group margin rule.
MAGN-6928 changing note size doesn't update group until group is tweaked
MAGN-6929 Group title should be able to be deleted
MAGN-6930 Ctrl-G doesn't work on notes

**Fix - MAGN-6924** 
 1. Updated the context menu on Nodes / Notes.

**Fix - MAGN-6925** 
   Checked the condition on workspacemodel when creating a group. Ideally there should not be any groups selected when creating a new group. This avoids creating many groups at the same location (or say same nodes / notes). 

**Fix - MAGN-6926** 
1. Changed the default font size to 14.

**Fix - MAGN-6927,**Fix - MAGN-6928** **  
 Updated the boundary selection on Text Changed event (Notes);

**Fix - MAGN-6929**
  Removed the empty string check on the converter.This will allow empty annotation text.

**Fix - MAGN-6930**
 Included Notes on Ctrl G

- [x] @pboyer   - Few more minor fix'es.