### PR TITLE
MAGN-6084 Accidentally added wrong shared info file. Removing

### DIFF
--- a/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
+++ b/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
@@ -49,9 +49,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\AssemblySharedInfoGenerator\AssemblySharedInfo.cs">
-      <Link>AssemblySharedInfo.cs</Link>
-    </Compile>
     <Compile Include="Controls\ExportWithUnitsControl.xaml.cs">
       <DependentUpon>ExportWithUnitsControl.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
I added a wrong assembly shared info file to the project, and am removing it.

