### PR TITLE
Fixed the bugs - Graph Annotation

### DIFF
--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -20,6 +20,35 @@ namespace Dynamo.Models
         private string modelGuids { get; set; }   
         private const double doubleValue = 0.0;
         public bool loadFromXML { get; set; }
+
+        private double width;
+        public new double Width
+        {
+            get
+            {
+                return width;
+            }
+            set
+            {
+                width = value;
+                RaisePropertyChanged("Width");
+            }
+        }
+
+        private double height;
+        public new double Height
+        {
+            get
+            {
+                return height;
+            }
+            set
+            {
+                height = value;
+                RaisePropertyChanged("Height");
+            }
+        }
+
         private string text;
         public string Text
         {
@@ -30,51 +59,7 @@ namespace Dynamo.Models
                 RaisePropertyChanged("Text");
             }
         }
-
-        private double width;
-        public double Width
-        {
-            get { return width; }
-            set
-            {
-                width = value;
-                RaisePropertyChanged("Width");
-            }
-        }
-
-        private double height;
-        public double Height
-        {
-            get { return height; }
-            set
-            {
-                height = value;
-                RaisePropertyChanged("Height");
-            }
-        }
-
-        private double top;
-        public double Top
-        {
-            get { return top; }
-            set
-            {
-                top = value;
-                RaisePropertyChanged("Top");
-            }
-        }
-
-        private double left;
-        public double Left
-        {
-            get { return left; }
-            set
-            {
-                left = value;
-                RaisePropertyChanged("Left");
-            }
-        }
-
+       
         private string annotationText;
         public String AnnotationText
         {
@@ -124,7 +109,7 @@ namespace Dynamo.Models
         /// </summary>      
         public override Rect2D Rect
         {
-            get { return new Rect2D(this.Left, this.Top, this.Width, this.Height); }
+            get { return new Rect2D(this.X, this.Y, this.Width, this.Height); }
         }
 
         private Double textBlockHeight;
@@ -134,7 +119,7 @@ namespace Dynamo.Models
             set
             {
                 textBlockHeight = value;                
-                Top = InitialTop - textBlockHeight;
+                Y = InitialTop - textBlockHeight;
                 Height = InitialHeight + textBlockHeight;
             }
         }
@@ -240,8 +225,8 @@ namespace Dynamo.Models
                     Height = yDistance + maxHeight + 10
                 };
              
-                this.Left = region.X;              
-                this.Top = region.Y;
+                this.X = region.X;              
+                this.Y = region.Y;
                 this.Width = region.Width;
                 this.Height = region.Height;
 
@@ -252,13 +237,13 @@ namespace Dynamo.Models
                     if (!region.Contains(nodes.Rect))
                     {
                         overlap = nodes;
-                        if (overlap.Rect.Top < this.Top ||
+                        if (overlap.Rect.Top < this.X ||
                                     overlap.Rect.Bottom > region.Bottom) //Overlap in height - increase the region height
                         {
                             this.Height += overlap.Rect.Bottom - region.Bottom + 10;
                             region.Height = this.Height;
                         }
-                        if (overlap.Rect.Left < this.Left ||
+                        if (overlap.Rect.Left < this.Y ||
                                 overlap.Rect.Right > region.Right) //Overlap in width - increase the region width
                         {
                             this.Width += overlap.Rect.Right - region.Right + 10;
@@ -311,8 +296,8 @@ namespace Dynamo.Models
             XmlElementHelper helper = new XmlElementHelper(element);
             helper.SetAttribute("guid", this.GUID);
             helper.SetAttribute("annotationText", this.AnnotationText);
-            helper.SetAttribute("left", this.Left);
-            helper.SetAttribute("top", this.Top);
+            helper.SetAttribute("left", this.X);
+            helper.SetAttribute("top", this.Y);
             helper.SetAttribute("width", this.Width);
             helper.SetAttribute("height", this.Height);
             helper.SetAttribute("fontSize", this.FontSize);
@@ -339,8 +324,8 @@ namespace Dynamo.Models
             XmlElementHelper helper = new XmlElementHelper(element);
             this.GUID = helper.ReadGuid("guid", this.GUID);
             this.annotationText = helper.ReadString("annotationText", Resources.GroupDefaultText);
-            this.left = helper.ReadDouble("left", doubleValue);
-            this.top = helper.ReadDouble("top", doubleValue);
+            this.X = helper.ReadDouble("left", doubleValue);
+            this.Y = helper.ReadDouble("top", doubleValue);
             this.width = helper.ReadDouble("width", doubleValue);
             this.height = helper.ReadDouble("height", doubleValue);
             this.background = helper.ReadString("backgrouund", "");

--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -186,7 +186,7 @@ namespace Dynamo.Models
                     break;
                 case "Text":
                     UpdateBoundaryFromSelection();
-                    break;
+                    break;               
             }
         }
 
@@ -318,6 +318,7 @@ namespace Dynamo.Models
             helper.SetAttribute("fontSize", this.FontSize);
             helper.SetAttribute("InitialTop", this.InitialTop);
             helper.SetAttribute("InitialHeight", this.InitialHeight);
+            helper.SetAttribute("TextblockHeight", this.TextBlockHeight);
             helper.SetAttribute("backgrouund", (this.Background == null ? "" : this.Background.ToString()));        
             //Serialize Selected models
             XmlDocument xmlDoc = element.OwnerDocument;            
@@ -344,6 +345,7 @@ namespace Dynamo.Models
             this.height = helper.ReadDouble("height", doubleValue);
             this.background = helper.ReadString("backgrouund", "");
             this.fontSize = helper.ReadDouble("fontSize", fontSize);
+            this.textBlockHeight = helper.ReadDouble("TextblockHeight", doubleValue);
             this.InitialTop = helper.ReadDouble("InitialTop", doubleValue);
             this.InitialHeight = helper.ReadDouble("InitialHeight", doubleValue);
             //Deserialize Selected models
@@ -367,13 +369,14 @@ namespace Dynamo.Models
 
         #endregion
 
-        public virtual void Dispose()
+        public override void Dispose()
         {
             if (this.SelectedModels.Any())
             {
                 foreach (var model in this.SelectedModels)
                 {
                     model.PropertyChanged -= model_PropertyChanged;
+                    model.Disposed -= model_Disposed;
                 }
             }
         }

--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -268,27 +268,7 @@ namespace Dynamo.Models
           
             return Tuple.Create(xgroup.Last().Width, ygroup.Last().Height);
         }
-        
-        /// <summary>
-        /// Deserializes the model guids from XML
-        /// and creates group on those model guids.
-        /// </summary>
-        private void DeserializeGroup()
-        {
-            var listOfModels = new List<ModelBase>();
-            foreach (var objGuid in modelGuids.Split(','))
-            {
-                Guid result;
-                if (Guid.TryParse(objGuid, out result))
-                    if (SelectedModels != null)
-                    {
-                        var model = SelectedModels.FirstOrDefault(x => x.GUID == result);
-                        listOfModels.Add(model);
-                    }
-            }
-            selectedModels = listOfModels;           
-        }
-
+              
         #region Serialization/Deserialization Methods
 
         protected override void SerializeCore(XmlElement element, SaveContext context)

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1314,7 +1314,13 @@ namespace Dynamo.Models
             var newAnnotations = new List<AnnotationModel>();
             foreach (var annotation in annotations)
             {
-                var annotationModel = new AnnotationModel(newNodeModels, newNoteModels) {GUID = Guid.NewGuid()};
+                var annotationModel = new AnnotationModel(newNodeModels, newNoteModels)
+                {
+                    GUID = Guid.NewGuid(),
+                    AnnotationText = annotation.AnnotationText,
+                    Background = annotation.Background
+                    
+                };
                 newAnnotations.Add(annotationModel);              
             }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1298,17 +1298,17 @@ namespace Dynamo.Models
                 // re-connect to the original.
                 let startNode =
                     modelLookup.TryGetValue(c.Start.Owner.GUID, out start)
-                        ? start
+                        ? start as NodeModel
                         : CurrentWorkspace.Nodes.FirstOrDefault(x => x.GUID == c.Start.Owner.GUID)
                 let endNode =
                     modelLookup.TryGetValue(c.End.Owner.GUID, out end)
-                        ? end
+                        ? end as NodeModel
                         : CurrentWorkspace.Nodes.FirstOrDefault(x => x.GUID == c.End.Owner.GUID)
-
+             
                 // Don't make a connector if either end is null.
                 where startNode != null && endNode != null
                 select
-                    ConnectorModel.Make(startNode as NodeModel, endNode as NodeModel, c.Start.Index, c.End.Index);
+                    ConnectorModel.Make(startNode, endNode, c.Start.Index, c.End.Index);
 
             createdModels.AddRange(newConnectors);
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -678,10 +678,7 @@ namespace Dynamo.Models
                     GUID = id,
                     AnnotationText = text
                 };
-
-                var args = new ModelEventArgs(annotationModel, true);
-                OnRequestNodeCentered(this, args);
-
+             
                 Annotations.Add(annotationModel);
                 HasUnsavedChanges = true;
                 return annotationModel;

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -1881,7 +1881,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Font.
+        ///   Looks up a localized string similar to Font Size.
         /// </summary>
         public static string GroupContextMenuFont {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1626,7 +1626,7 @@ Do you want to install the latest Dynamo update?</value>
     <value>Select Background</value>
   </data>
   <data name="GroupContextMenuFont" xml:space="preserve">
-    <value>Font</value>
+    <value>Font Size</value>
   </data>
   <data name="GroupContextMenuUngroup" xml:space="preserve">
     <value>Ungroup</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1575,7 +1575,7 @@ Do you want to install the latest Dynamo update?</value>
     <value>Select Background</value>
   </data>
   <data name="GroupContextMenuFont" xml:space="preserve">
-    <value>Font</value>
+    <value>Font Size</value>
   </data>
   <data name="GroupContextMenuUngroup" xml:space="preserve">
     <value>Ungroup</value>

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -40,17 +40,17 @@ namespace Dynamo.ViewModels
 
         public Double Top
         {
-            get { return annotationModel.Top; }
+            get { return annotationModel.Y; }
             set
             {
-                annotationModel.Top = value;                
+                annotationModel.Y = value;                
             }
         }
        
         public Double Left
         {
-            get { return annotationModel.Left; }
-            set { annotationModel.Left = value; }
+            get { return annotationModel.X; }
+            set { annotationModel.X = value; }
         }
 
         public double ZIndex
@@ -154,10 +154,10 @@ namespace Dynamo.ViewModels
         {
             switch (e.PropertyName)
             {
-                case "Left":
+                case "X":
                     RaisePropertyChanged("Left");
                     break;
-                case "Top":
+                case "Y":
                     RaisePropertyChanged("Top");
                     break;
                 case "Width":

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -92,8 +92,7 @@ namespace Dynamo.ViewModels
 
         public void UpdateSizeFromView(double w, double h)
         {
-            this._model.Width = w;
-            this._model.Height = h;
+            this._model.SetSize(w,h);     
         }
 
         private bool CanSelect(object parameter)

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -129,18 +129,17 @@
                            Click="OnDeleteAnnotation"/>
                 <MenuItem  Header="{x:Static p:Resources.GroupContextMenuFont}"
                                Name="ChangeSize">                   
-                    <MenuItem Header ="10" Name="FontSize0" Command="{Binding ChangeFontSize}" CommandParameter="10"
-                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=10}"></MenuItem>
-                    <MenuItem Header ="12" Name="FontSize1" Command="{Binding ChangeFontSize}" CommandParameter="12"
-                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=12}"></MenuItem>
-                    <MenuItem Header ="14" Name="FontSize2" Command="{Binding ChangeFontSize}" CommandParameter="14"
+                    <MenuItem Header ="14" Name="FontSize0" Command="{Binding ChangeFontSize}" CommandParameter="14"
                               IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=14}"></MenuItem>
-                    <MenuItem Header ="16" Name="FontSize3" Command="{Binding ChangeFontSize}" CommandParameter="16"
-                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=16}"></MenuItem>
-                    <MenuItem Header ="18" Name="FontSize4" Command="{Binding ChangeFontSize}" CommandParameter="18"
+                    <MenuItem Header ="18" Name="FontSize1" Command="{Binding ChangeFontSize}" CommandParameter="18"
                               IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=18}"></MenuItem>
-                    <MenuItem Header ="20" Name="FontSize5" Command="{Binding ChangeFontSize}" CommandParameter="20"
-                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=20}"></MenuItem>              
+                    <MenuItem Header ="20" Name="FontSize2" Command="{Binding ChangeFontSize}" CommandParameter="20"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=20}"></MenuItem>
+                    <MenuItem Header ="30" Name="FontSize3" Command="{Binding ChangeFontSize}" CommandParameter="30"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=30}"></MenuItem>
+                    <MenuItem Header ="48" Name="FontSize4" Command="{Binding ChangeFontSize}" CommandParameter="48"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=48}"></MenuItem>
+                    
                 </MenuItem>               
                 <ListBox Style="{StaticResource ColorSelectorListBox}"
                          ItemContainerStyle="{StaticResource ColorSelectorListBoxItem}"
@@ -202,8 +201,8 @@
                     MaxWidth="{Binding Width}"  
                     MinHeight="20"   
                     FontFamily="Trebuchet" 
-                    FontSize="{Binding FontSize}"
-                    Style="{StaticResource SZoomFadeText}"
+                    FontSize="{Binding FontSize}"                   
+                    LineStackingStrategy="BlockLineHeight"
                     TextWrapping="Wrap">                  
             </TextBlock>
             <TextBox 

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -74,8 +74,7 @@ namespace Dynamo.Nodes
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="MouseButtonEventArgs"/> instance containing the event data.</param>
         private void AnnotationView_OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
-        { 
-            DynamoSelection.Instance.ClearSelection();
+        {         
             if (GroupTextBlock.IsVisible)
             {
                 var annotationGuid = this.ViewModel.AnnotationModel.GUID;

--- a/test/DynamoCoreUITests/CoreUITests.cs
+++ b/test/DynamoCoreUITests/CoreUITests.cs
@@ -665,8 +665,8 @@ namespace DynamoCoreUITests
             Assert.AreEqual(1, Model.CurrentWorkspace.Annotations.Count);
 
             //verify whether group is not empty
-            Assert.AreNotEqual(0, annotation.Top);
-            Assert.AreNotEqual(0, annotation.Left);
+            Assert.AreNotEqual(0, annotation.Y);
+            Assert.AreNotEqual(0, annotation.X);
             Assert.AreNotEqual(0, annotation.Width);
             Assert.AreNotEqual(0, annotation.Height);
 


### PR DESCRIPTION
This PR fixes the following issues
MAGN-6983 Can't select multiple groups
MAGN-6982 Fit to screen does not work as expected for groups
MAGN-6980 copied groups have no title and color is not copied
MAGN-6979 Change group context menu "Font" label to "Font Size"
MAGN-6926 Default group title text should be the same size as node titles and get only larger with font increase.

**Fix MAGN-6983 , MAGN-6980**
 Changed the paste function to include Nodes and Notes to a lookup (today only nodes are stored).
And checked a condition against that lookup to get those models that belong to a group, when a paste is attempted on a group. This is mainly to have multiple groups copy paste.

**Fix MAGN-6982**
Now, the annotation model uses the X and Y from Modelbase. (Removed the Left and Top from model).  This fixed the issue with Fit To Screen.

- [x] @pboyer 