### PR TITLE
Code Cleanup: remove exception handling related code from the language

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -4840,10 +4840,6 @@ namespace ProtoAssociative
                 //Validity.Assert(codeBlock.children[codeBlock.children.Count - 1].blockType == ProtoCore.DSASM.CodeBlockType.kLanguage);
                 codeBlock.children[codeBlock.children.Count - 1].Attributes = PopulateAttributes(langblock.Attributes);
 
-#if ENABLE_EXCEPTION_HANDLING
-                core.ExceptionHandlingManager.Register(blockId, globalProcIndex, globalClassIndex);
-#endif
-
                 int startpc = pc;
 
                 EmitInstrConsole(ProtoCore.DSASM.kw.bounce + " " + blockId + ", " + entry.ToString());
@@ -5961,10 +5957,6 @@ namespace ProtoAssociative
                         // The first node in the top level block is a function
                         core.DSExecutable.isSingleAssocBlock = false;
                     }
-
-#if ENABLE_EXCEPTION_HANDLING
-                    core.ExceptionHandlingManager.Register(codeBlock.codeBlockId, globalProcIndex, globalClassIndex);
-#endif
                 }
                 else
                 {
@@ -8824,108 +8816,6 @@ namespace ProtoAssociative
             }
         }
 
-        protected void EmitExceptionHandlingNode(AssociativeNode node, ProtoCore.AssociativeGraph.GraphNode graphNode = null, ProtoCore.CompilerDefinitions.Associative.SubCompilePass subPass = ProtoCore.CompilerDefinitions.Associative.SubCompilePass.kNone)
-        {
-#if ENABLE_EXCEPTION_HANDLING
-            if (!IsParsingGlobal() && !IsParsingGlobalFunctionBody() && !IsParsingMemberFunctionBody())
-            {
-                return;
-            }
-            
-            tryLevel++;
-
-            ExceptionHandlingNode exceptionNode = node as ExceptionHandlingNode;
-            if (exceptionNode == null)
-                return;
-
-            ExceptionHandler exceptionHandler = new ExceptionHandler();
-            exceptionHandler.TryLevel = tryLevel;
-
-            ExceptionRegistration registration = core.ExceptionHandlingManager.Register(codeBlock.codeBlockId, globalProcIndex, globalClassIndex);
-            registration.Add(exceptionHandler);
-
-            exceptionHandler.StartPc = pc;
-            TryBlockNode tryNode = exceptionNode.tryBlock;
-            Validity.Assert(tryNode != null);
-            foreach (var subnode in tryNode.body)
-            {
-                ProtoCore.Type inferedType = new ProtoCore.Type();
-                inferedType.UID = (int) ProtoCore.PrimitiveType.kTypeVar;
-                inferedType.IsIndexable = false;
-                DfsTraverse(subnode, ref inferedType, false, graphNode, subPass);
-            }
-            exceptionHandler.EndPc = pc;
-
-            // Jmp to code after catch block
-            BackpatchTable backpatchTable = new BackpatchTable();
-            backpatchTable.Append(pc);
-            EmitJmp(ProtoCore.DSASM.Constants.kInvalidIndex);
-
-            foreach (var catchBlock in exceptionNode.catchBlocks)
-            {
-                CatchHandler catchHandler = new CatchHandler();
-                exceptionHandler.AddCatchHandler(catchHandler);
-
-                CatchFilterNode filterNode = catchBlock.catchFilter;
-                Validity.Assert(filterNode != null);
-                catchHandler.FilterTypeUID = core.TypeSystem.GetType(filterNode.type.Name);
-                if (catchHandler.FilterTypeUID == (int)PrimitiveType.kInvalidType)
-                {
-                    string message = String.Format(ProtoCore.Properties.Resources.kExceptionTypeUndefined, filterNode.type.Name);
-                    buildStatus.LogWarning(ProtoCore.BuildData.WarningID.kTypeUndefined, message, core.CurrentDSFileName, filterNode.line, filterNode.col);
-                    catchHandler.FilterTypeUID = (int)PrimitiveType.kTypeVar;
-                }
-
-                ProtoCore.Type inferedType = new ProtoCore.Type();
-                inferedType.UID = (int) ProtoCore.PrimitiveType.kTypeVar;
-                inferedType.IsIndexable = false;
-                DfsTraverse(filterNode.var, ref inferedType, false, graphNode, subPass);
-                
-                catchHandler.Entry = pc;
-                foreach (var subnode in catchBlock.body)
-                {
-                    inferedType.UID = (int) ProtoCore.PrimitiveType.kTypeVar;
-                    inferedType.IsIndexable = false;
-                    DfsTraverse(subnode, ref inferedType, false, graphNode, subPass);
-                }
-
-                // Jmp to code after catch block
-                backpatchTable.Append(pc);
-                EmitJmp(ProtoCore.DSASM.Constants.kInvalidIndex);
-            }
-
-            Backpatch(backpatchTable.backpatchList, pc);
-
-            tryLevel--;
-#endif
-        }
-
-        protected void EmitThrowNode(AssociativeNode node, ProtoCore.AssociativeGraph.GraphNode graphNode = null, ProtoCore.CompilerDefinitions.Associative.SubCompilePass subPass = ProtoCore.CompilerDefinitions.Associative.SubCompilePass.kNone)
-        {
-#if ENABLE_EXCEPTION_HANDLING
-            if (!IsParsingGlobal() && !IsParsingGlobalFunctionBody() && !IsParsingMemberFunctionBody())
-                return;
-
-            ThrowNode throwNode = node as ThrowNode;
-            if (throwNode == null)
-            {
-                return;
-            }
-
-            ProtoCore.Type inferedType = new ProtoCore.Type();
-            inferedType.UID = (int)ProtoCore.PrimitiveType.kTypeVar;
-            inferedType.IsIndexable = false;
-            DfsTraverse(throwNode.expression, ref inferedType, false, graphNode);
-
-            EmitInstrConsole(ProtoCore.DSASM.kw.pop, ProtoCore.DSASM.kw.regLX);
-            StackValue opLx = StackValue.BuildRegister(Registers.LX);
-            EmitPop(opLx, Constants.kGlobalScope);
-
-            EmitInstrConsole(ProtoCore.DSASM.kw.throwexception);
-            EmitThrow();
-#endif
-        }
-
         // what we are going to do here is go through the identifier list node,
         // and for each identifier node we convert it to a getter. Say:
         // 
@@ -9448,14 +9338,6 @@ namespace ProtoAssociative
             else if (node is DynamicNode)
             {
                 EmitDynamicNode(subPass);
-            }
-            else if (node is ExceptionHandlingNode)
-            {
-                EmitExceptionHandlingNode(node, graphNode, subPass);
-            }
-            else if (node is ThrowNode)
-            {
-                EmitThrowNode(node, graphNode, subPass);
             }
             else if (node is GroupExpressionNode)
             {

--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -2038,20 +2038,6 @@ namespace ProtoCore
             AppendInstruction(instr);
         }
 
-        protected void EmitThrow()
-        {
-            SetEntry();
-
-            Instruction instr = new Instruction();
-            instr.opCode = ProtoCore.DSASM.OpCode.THROW;
-            instr.op1 = StackValue.BuildBlockIndex(codeBlock.codeBlockId);
-            instr.op2 = StackValue.BuildClassIndex(globalClassIndex);
-            instr.op3 = StackValue.BuildFunctionIndex(globalProcIndex);
-
-            ++pc;
-            AppendInstruction(instr);
-        }
-
         protected abstract void EmitRetb(int line = ProtoCore.DSASM.Constants.kInvalidIndex, int col = ProtoCore.DSASM.Constants.kInvalidIndex,
              int endline = ProtoCore.DSASM.Constants.kInvalidIndex, int endcol = ProtoCore.DSASM.Constants.kInvalidIndex);
 			

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -2912,34 +2912,10 @@ namespace ProtoCore.DSASM
                 Exec(istream.instrList[pc]);
             }
 
-            // the exception won't handled at this level, so need to unwind
-#if ENABLE_EXCEPTION_HANDLING
-            if (!core.ExceptionHandlingManager.IsStackUnwinding)
-            {
-                // Comment Jun:
-                // X-lang dependency should be done for all languages 
-                // as they can potentially trigger parent block updates 
-
-                // Comment Jun: XLang dep is only done in RestoreFromBounce 
-                // Propagate only on lang block bounce (non fep)
-                //if (!fepRun)
-                //{
-                //    XLangUpdateDependencyGraph(exeblock);
-                //}
-
-
-
-                if (!fepRun || fepRun && debugRun)
-                {
-                    logVMMessage("End JIL Execution - " + engine);
-                }
-            }
-#else
             if (!fepRun || fepRun && debugRun)
             {
                 logVMMessage("End JIL Execution - " + engine);
             }
-#endif
         }
 
         protected SymbolNode GetSymbolNode(int blockId, int classIndex, int symbolIndex)

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -5822,10 +5822,6 @@ namespace ProtoCore.DSASM
                 runtimeCore.RuntimeMemory.PushConstructBlockId(blockId);
             }
 
-#if ENABLE_EXCEPTION_HANDLING
-                core.stackActiveExceptionRegistration.Push(core.ExceptionHandlingManager.CurrentActiveRegistration);
-#endif
-
             int ci = Constants.kInvalidIndex;
             int fi = Constants.kInvalidIndex;
             if (rmem.Stack.Count >= StackFrame.kStackFrameSize)
@@ -5838,10 +5834,6 @@ namespace ProtoCore.DSASM
                     fi = (int)sfi.opdata;
                 }
             }
-
-#if ENABLE_EXCEPTION_HANDLING
-            core.ExceptionHandlingManager.SwitchContextTo(blockId, fi, ci, pc);
-#endif
 
             StackValue svThisPtr;
             if (rmem.CurrentStackFrame == null)
@@ -6085,11 +6077,6 @@ namespace ProtoCore.DSASM
             runtimeVerify(instr.op3.IsInteger);
             int depth = (int)instr.op3.opdata;
 
-#if ENABLE_EXCEPTION_HANDLING
-            core.stackActiveExceptionRegistration.Push(core.ExceptionHandlingManager.CurrentActiveRegistration);
-            core.ExceptionHandlingManager.SwitchContextTo(blockId, functionIndex, classIndex, pc);
-#endif
-
             ++runtimeCore.FunctionCallDepth;
 
             bool explicitCall = false;
@@ -6132,49 +6119,7 @@ namespace ProtoCore.DSASM
 
             if (!explicitCall)
             {
-#if ENABLE_EXCEPTION_HANDLING
-                core.ExceptionHandlingManager.CurrentActiveRegistration = core.stackActiveExceptionRegistration.Pop();
-
-                if (core.ExceptionHandlingManager.IsStackUnwinding)
-                {
-                    int newpc = Constants.kInvalidIndex;
-                    if (core.ExceptionHandlingManager.CanHandleIt(ref newpc))
-                    {
-                        LX = RX;
-                        pc = newpc;
-                        core.ExceptionHandlingManager.SetHandled();
-                    }
-                    else
-                    {
-                        // Clean up stack
-                        isGlobScope = true;
-                        runtimeVerify(rmem.ValidateStackFrame());
-                        pc = (int)rmem.GetAtRelative(StackFrame.kFrameIndexReturnAddress).opdata;
-
-                        ReturnSiteGC(blockId, classIndex, functionIndex);
-
-                        rmem.FramePointer = (int)rmem.GetAtRelative(StackFrame.kFrameIndexFramePointer).opdata;
-                        int localCount, paramCount;
-                        GetLocalAndParamCount(blockId, classIndex, functionIndex, out localCount, out paramCount);
-                        rmem.PopFrame(StackFrame.kStackFrameSize + localCount + paramCount);
-
-                        if (fepRunStack.Count > 0)
-                        {
-                            terminate = fepRunStack.Pop();
-                        }
-                        else if (fepRun)
-                        {
-                            terminate = true;
-                        }
-                    }
-                }
-                else
-                {
-                    ++pc; setPC(pc);
-                }
-#else
                 ++pc;
-#endif
             }
         }
 
@@ -6295,38 +6240,6 @@ namespace ProtoCore.DSASM
                     RestoreRegistersFromStackFrame();
 
                     bounceType = (CallingConvention.BounceType)TX.opdata;
-
-#if ENABLE_EXCEPTION_HANDLING
-                    core.ExceptionHandlingManager.CurrentActiveRegistration = core.stackActiveExceptionRegistration.Pop();
-                    if (core.ExceptionHandlingManager.IsStackUnwinding)
-                    {
-                    #region __MERGE_WITH_STACKUNWIND
-                        // The excecution of last langage block is interrupted
-                        // abnormally because of stack unwinding, so we need to 
-                        // run GC to reclaim those allocated memory.
-                        GCCodeBlock(runtimeCore.RunningBlock);
-
-                        int newpc = Constants.kInvalidIndex;
-                        if (core.ExceptionHandlingManager.CanHandleIt(ref newpc))
-                        {
-                            LX = RX;
-                            pc = newpc;
-                            core.ExceptionHandlingManager.SetHandled();
-                        }
-                        // else cannot handle in this scope, so in the next
-                        // loop of Execute(), current executive will be ;
-                        // ended and returns to the last scope, continues
-                        // stack unwinding
-
-                        int origRunningBlock = executingBlock;
-                        runtimeCore.RunningBlock = origRunningBlock;
-                    #endregion
-                    }
-                    else
-                    {
-                        DecRefCounter(RX);
-                    }
-#endif
                 }
             }
 
@@ -7211,125 +7124,6 @@ namespace ProtoCore.DSASM
             SetupNextExecutableGraph(fi, ci);
         }
 
-        private void THROW_Handler()
-        {
-#if ENABLE_EXCEPTION_HANDLING
-            runtimeVerify(instruction.op1.IsBlockIndex);
-            int blockId = (int)instruction.op1.opdata;
-
-            runtimeVerify(instruction.op2.IsClassIndex);
-            int classScope = (int)instruction.op2.opdata;
-
-            runtimeVerify(instruction.op3.IsFunctionIndex);
-            int functionScope = (int)instruction.op3.opdata;
-
-            StackValue exceptionValue = LX;
-            ProtoCore.Exceptions.ExceptionContext context = new Exceptions.ExceptionContext();
-            context.pc = pc;
-            context.codeBlockId = blockId;
-            context.functionScope = functionScope;
-            context.classScope = classScope;
-            switch (exceptionValue.optype)
-            {
-                case AddressType.Int:
-                    context.typeUID = (int)ProtoCore.PrimitiveType.kTypeInt;
-                    break;
-                case AddressType.Double:
-                    context.typeUID = (int)ProtoCore.PrimitiveType.kTypeDouble;
-                    break;
-                case AddressType.Boolean:
-                    context.typeUID = (int)ProtoCore.PrimitiveType.kTypeBool;
-                    break;
-                case AddressType.Pointer:
-                    context.typeUID = (int)exceptionValue.metaData.type;
-                    break;
-                default:
-                    context.typeUID = (int)ProtoCore.PrimitiveType.kTypeVar;
-                    break;
-            }
-            // Walk through exception chain, a.k.a. 1st hand exception
-            // handling
-            core.ExceptionHandlingManager.HandleFirstHandException(context);
-
-            // The exception can be handled in current scope, so simply jmp to 
-            // the corresponding catch block
-            int newpc = Constants.kInvalidIndex;
-            if (core.ExceptionHandlingManager.CanHandleIt(ref newpc))
-            {
-                pc = newpc;
-                core.ExceptionHandlingManager.SetHandled();
-            }
-            else
-            {
-                RX = LX;
-            }
-
-            if (core.ExceptionHandlingManager.IsStackUnwinding)
-            {
-                while (core.stackActiveExceptionRegistration.Count > 1)
-                {
-                    StackValue svType = rmem.GetAtRelative(StackFrame.kFrameIndexStackFrameType);
-                    StackFrameType type = (StackFrameType)svType.opdata;
-                    if (StackFrameType.kTypeLanguage == type)
-                    {
-                        RestoreFromBounce();
-                        rmem.FramePointer = (int)rmem.GetAtRelative(StackFrame.kFrameIndexFramePointer).opdata;
-                        rmem.PopFrame(StackFrame.kStackFrameSize);
-
-
-                        // Restoring the registers require the current frame pointer of the stack frame 
-                        RestoreRegistersFromStackFrame();
-
-                        bounceType = (ProtoCore.DSASM.CallingConvention.BounceType)TX.opdata;
-
-                        core.ExceptionHandlingManager.CurrentActiveRegistration = core.stackActiveExceptionRegistration.Pop();
-
-            #region __MERGE_WITH_STACKUNWIND
-
-                        // The excecution of last langage block is interrupted
-                        // abnormally because of stack unwinding, so we need to 
-                        // run GC to reclaim those allocated memory.
-                        GCCodeBlock(runtimeCore.RunningBlock);
-
-                        newpc = Constants.kInvalidIndex;
-                        if (core.ExceptionHandlingManager.CanHandleIt(ref newpc))
-                        {
-                            LX = RX;
-                            pc = newpc;
-                            core.ExceptionHandlingManager.SetHandled();
-                            break;
-                        }
-                        // else cannot handle in this scope, so in the next
-                        // loop of Execute(), current executive will be ;
-                        // ended and returns to the last scope, continues
-                        // stack unwinding
-
-                        int origRunningBlock = executingBlock;
-                        runtimeCore.RunningBlock = origRunningBlock;
-#endregion
-                    }
-                    else
-                    {
-                        RestoreFromCall();
-
-                        int ci = (int)rmem.GetAtRelative(StackFrame.kFrameIndexClass).opdata;
-                        int fi = (int)rmem.GetAtRelative(StackFrame.kFrameIndexFunction).opdata;
-
-                        int localCount = 0;
-                        int paramCount = 0;
-                        GetLocalAndParamCount(executingBlock, ci, fi, out localCount, out paramCount);
-
-                        rmem.FramePointer = (int)rmem.GetAtRelative(StackFrame.kFrameIndexFramePointer).opdata;
-                        rmem.PopFrame(StackFrame.kStackFrameSize + localCount + paramCount);
-                    }
-                }
-            }
-            return;
-#else
-            throw new NotImplementedException();
-#endif
-        }
-
         private void SETEXPUID_Handler()
         {
             if (runtimeCore.Options.IDEDebugMode && runtimeCore.Options.RunMode != InterpreterMode.kExpressionInterpreter)
@@ -7711,12 +7505,6 @@ namespace ProtoCore.DSASM
                 case OpCode.DEPX:
                     {
                         DEPX_Handler();
-                        return;
-                    }
-
-                case OpCode.THROW:
-                    {
-                        THROW_Handler();
                         return;
                     }
 

--- a/src/Engine/ProtoCore/DSASM/InstructionSet.cs
+++ b/src/Engine/ProtoCore/DSASM/InstructionSet.cs
@@ -116,7 +116,6 @@ namespace ProtoCore.DSASM
         PUSHB,
         POPB,
 
-        THROW,
         // TODO Jun: This is temporary until the lib system is implemented. 
         PUSH_ARRAYKEY,
         SETEXPUID

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -2368,130 +2368,6 @@ namespace ProtoCore.AST.AssociativeAST
         }
     }
 
-    public class ThrowNode : AssociativeNode
-    {
-        public AssociativeNode expression { get; set; }
-
-        public override bool Equals(object other)
-        {
-            var otherNode = other as ThrowNode;
-            if (null == otherNode)
-                return false;
-               
-            return expression.Equals(otherNode.expression);
-        }
-
-        public override int GetHashCode()
-        {
-            var expressionHashCode =
-                (expression == null ? base.GetHashCode() : expression.GetHashCode());
-
-            return expressionHashCode;
-        }
-    }
-
-    public class TryBlockNode : AssociativeNode
-    {
-        public List<AssociativeNode> body { get; set; }
-
-        public override bool Equals(object other)
-        {
-            var otherNode = other as TryBlockNode;
-            if (null == otherNode)
-                return false;
-
-            return body.SequenceEqual(otherNode.body);
-        }
-
-        public override int GetHashCode()
-        {
-            var bodyHashCode =
-                (body == null ? base.GetHashCode() : body.GetHashCode());
-
-            return bodyHashCode;
-        }
-    }
-
-    public class CatchFilterNode : AssociativeNode
-    {
-        public IdentifierNode var { get; set; }
-        public Type type { get; set; }
-
-        public override bool Equals(object other)
-        {
-            var otherNode = other as CatchFilterNode;
-            if (null == otherNode)
-                return false;
-
-            return var.Equals(otherNode.var) &&
-                   type.Equals(otherNode.type);
-        }
-
-        public override int GetHashCode()
-        {
-            var varHashCode =
-                (var == null ? base.GetHashCode() : var.GetHashCode());
-            var typeHashCode = type.GetHashCode();
-
-            return varHashCode ^ typeHashCode;
-        }
-    }
-
-    public class CatchBlockNode : AssociativeNode
-    {
-        public CatchFilterNode catchFilter { get; set; }
-        public List<AssociativeNode> body { get; set; }
-
-        public override bool Equals(object other)
-        {
-            var otherNode = other as CatchBlockNode;
-            if (null == otherNode)
-                return false;
-
-            return catchFilter.Equals(otherNode.catchFilter) && body.SequenceEqual(otherNode.body);
-        }
-
-        public override int GetHashCode()
-        {
-            var catchFilterHashCode =
-                (catchFilter == null ? base.GetHashCode() : catchFilter.GetHashCode());
-            var bodyHashCode =
-                (body == null ? base.GetHashCode() : body.GetHashCode());
-
-            return catchFilterHashCode ^ bodyHashCode;
-        }
-    }
-
-    public class ExceptionHandlingNode : AssociativeNode
-    {
-        public TryBlockNode tryBlock { get; set; }
-        public List<CatchBlockNode> catchBlocks { get; set; }
-
-        public ExceptionHandlingNode()
-        {
-            catchBlocks = new List<CatchBlockNode>();
-        }
-
-        public override bool Equals(object other)
-        {
-            var otherNode = other as ExceptionHandlingNode;
-            if (null == otherNode)
-                return false;
-
-            return tryBlock.Equals(otherNode.tryBlock) && catchBlocks.SequenceEqual(otherNode.catchBlocks);
-        }
-
-        public override int GetHashCode()
-        {
-            var tryBlockHashCode =
-                (tryBlock == null ? base.GetHashCode() : tryBlock.GetHashCode());
-            var catchBlocksHashCode =
-                (catchBlocks == null ? base.GetHashCode() : catchBlocks.GetHashCode());
-
-            return tryBlockHashCode ^ catchBlocksHashCode;
-        }
-    }
-
     public class AstFactory
     {
         public static NullNode BuildNullNode()
@@ -3089,32 +2965,6 @@ namespace ProtoCore.AST.AssociativeAST
             return result;
         }
 
-        public static ImperativeAST.CatchBlockNode ToImperativeNode(this CatchBlockNode aNode)
-        {
-            if (aNode == null) return null;
-
-            var result = new ImperativeAST.CatchBlockNode
-            {
-                body = aNode.body.Select(ToImperativeAST).ToList(),
-                catchFilter = aNode.catchFilter.ToImperativeNode()
-            };
-            CopyProps(aNode, result);
-            return result;
-        }
-
-        public static ImperativeAST.CatchFilterNode ToImperativeNode(this CatchFilterNode aNode)
-        {
-            if (aNode == null) return null;
-
-            var result = new ImperativeAST.CatchFilterNode
-            {
-                type = aNode.type,
-                var = aNode.var.ToImperativeNode()
-            };
-            CopyProps(aNode, result);
-            return result;
-        }
-
         public static ImperativeAST.CharNode ToImperativeNode(this CharNode aNode)
         {
             if (aNode == null) return null;
@@ -3176,19 +3026,6 @@ namespace ProtoCore.AST.AssociativeAST
             if (aNode == null) return null;
 
             var result = new ImperativeAST.DoubleNode(aNode.Value);
-            CopyProps(aNode, result);
-            return result;
-        }
-
-        public static ImperativeAST.ExceptionHandlingNode ToImperativeNode(this ExceptionHandlingNode aNode)
-        {
-            if (aNode == null) return null;
-
-            var result = new ImperativeAST.ExceptionHandlingNode
-            {
-                catchBlocks = aNode.catchBlocks.Select(ToImperativeNode).ToList(),
-                tryBlock = aNode.tryBlock.ToImperativeNode()
-            };
             CopyProps(aNode, result);
             return result;
         }
@@ -3383,30 +3220,6 @@ namespace ProtoCore.AST.AssociativeAST
             var result = new ImperativeAST.StringNode
             {
                 value = aNode.value
-            };
-            CopyProps(aNode, result);
-            return result;
-        }
-
-        public static ImperativeAST.ThrowNode ToImperativeNode(this ThrowNode aNode)
-        {
-            if (aNode == null) return null;
-
-            var result = new ImperativeAST.ThrowNode
-            {
-                expression = aNode.ToImperativeAST()
-            };
-            CopyProps(aNode, result);
-            return result;
-        }
-
-        public static ImperativeAST.TryBlockNode ToImperativeNode(this TryBlockNode aNode)
-        {
-            if (aNode == null) return null;
-
-            var result = new ImperativeAST.TryBlockNode
-            {
-                body = aNode.body.Select(ToImperativeAST).ToList()
             };
             CopyProps(aNode, result);
             return result;

--- a/src/Engine/ProtoCore/Parser/ImperativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/ImperativeAST.cs
@@ -1362,37 +1362,4 @@ namespace ProtoCore.AST.ImperativeAST
     public class DefaultArgNode : ImperativeNode
     {// not supposed to be used in parser 
     }
-
-    public class ThrowNode : ImperativeNode
-    {
-        public ImperativeNode expression { get; set; }
-    }
-
-    public class TryBlockNode : ImperativeNode
-    {
-        public List<ImperativeNode> body { get; set; }
-    }
-
-    public class CatchFilterNode : ImperativeNode
-    {
-        public IdentifierNode var { get; set; }
-        public ProtoCore.Type type { get; set; }
-    }
-
-    public class CatchBlockNode : ImperativeNode
-    {
-        public CatchFilterNode catchFilter { get; set; }
-        public List<ImperativeNode> body { get; set; }
-    }
-
-    public class ExceptionHandlingNode : ImperativeNode
-    {
-        public TryBlockNode tryBlock { get; set; }
-        public List<CatchBlockNode> catchBlocks { get; set; }
-
-        public ExceptionHandlingNode()
-        {
-            catchBlocks = new List<CatchBlockNode>();
-        }
-    }
 }

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -60,9 +60,9 @@ public class Parser {
 	public const int _literal_false = 43;
 	public const int _literal_null = 44;
 	public const int _replicationguide_postfix = 45;
-	public const int maxT = 72;
-	public const int _inlinecomment = 73;
-	public const int _blockcomment = 74;
+	public const int maxT = 69;
+	public const int _inlinecomment = 70;
+	public const int _blockcomment = 71;
 
 	const bool T = true;
 	const bool x = false;
@@ -736,11 +736,11 @@ public Node root { get; set; }
 			t = la;
 			la = scanner.Scan();
 			if (la.kind <= maxT) { ++errDist; break; }
-				if (la.kind == 73) {
+				if (la.kind == 70) {
 				CommentNode cNode = new CommentNode(la.col, la.line, la.val, CommentNode.CommentType.Inline); 
 				commentNode.Body.Add(cNode); 
 				}
-				if (la.kind == 74) {
+				if (la.kind == 71) {
 				CommentNode cNode = new CommentNode(la.col, la.line, la.val, CommentNode.CommentType.Block); 
 				commentNode.Body.Add(cNode); 
 				}
@@ -856,7 +856,7 @@ public Node root { get; set; }
 					Associative_functiondecl(out node, attrs);
 				} else if (la.kind == 24) {
 					Associative_classdecl(out node, attrs);
-				} else SynErr(73);
+				} else SynErr(70);
 			}
 			if (null != node)
 			{
@@ -883,7 +883,7 @@ public Node root { get; set; }
 	}
 
 	void Import_Statement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		while (!(la.kind == 0 || la.kind == 35)) {SynErr(74); Get();}
+		while (!(la.kind == 0 || la.kind == 35)) {SynErr(71); Get();}
 		string moduleName = "", typeName = "", alias = "";
 		
 		Expect(35);
@@ -898,7 +898,7 @@ public Node root { get; set; }
 			Expect(37);
 			Expect(4);
 			moduleName = t.val; 
-		} else SynErr(75);
+		} else SynErr(72);
 		Expect(11);
 		if (la.kind == 36) {
 			Get();
@@ -941,23 +941,17 @@ public Node root { get; set; }
 	}
 
 	void Associative_Statement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		while (!(StartOf(2))) {SynErr(76); Get();}
+		while (!(StartOf(2))) {SynErr(73); Get();}
 		if (!IsFullClosure()) SynErr(Resources.CloseBracketExpected); 
 		node = null; 
 		if (IsNonAssignmentStatement()) {
 			Associative_NonAssignmentStatement(out node);
 		} else if (IsFunctionCallStatement()) {
 			Associative_FunctionCallStatement(out node);
-		} else if (la.kind == 1 || la.kind == 10 || la.kind == 47) {
+		} else if (la.kind == 1 || la.kind == 10 || la.kind == 46) {
 			Associative_FunctionalStatement(out node);
 		} else if (la.kind == 8) {
 			Associative_LanguageBlock(out node);
-		} else if (la.kind == 57) {
-			#if ENABLE_EXCEPTION_HANDLING 
-			Associative_ExceptionBlock(out node);
-		} else if (la.kind == 46) {
-			#endif 
-			Associative_ThrowStatement(out node);
 		} else if (la.kind == 38) {
 			Get();
 			if (la.val != ";")
@@ -984,7 +978,7 @@ public Node root { get; set; }
 				
 				Get();
 			}
-		} else SynErr(77);
+		} else SynErr(74);
 	}
 
 	void Associative_AttributeDeclaration(out List<ProtoCore.AST.AssociativeAST.AssociativeNode> nodes) {
@@ -993,7 +987,7 @@ public Node root { get; set; }
 		ProtoCore.AST.AssociativeAST.AssociativeNode node; 
 		Associative_Attribute(out node);
 		if (node != null) nodes.Add(node); 
-		while (WeakSeparator(49,5,6) ) {
+		while (WeakSeparator(48,5,6) ) {
 			node = null; 
 			Associative_Attribute(out node);
 			if (node != null) nodes.Add(node); 
@@ -1043,12 +1037,12 @@ public Node root { get; set; }
 		
 		if (la.kind == 21) {
 			Get();
-		} else if (la.kind == 50) {
+		} else if (la.kind == 49) {
 			Get();
 			Associative_FunctionalMethodBodySingleLine(out functionBody);
-		} else if (la.kind == 47) {
+		} else if (la.kind == 46) {
 			Associative_FunctionalMethodBodyMultiLine(out functionBody);
-		} else SynErr(78);
+		} else SynErr(75);
 		f.FunctionBody = functionBody as ProtoCore.AST.AssociativeAST.CodeBlockNode; 
 		node = f;   
 		
@@ -1077,14 +1071,14 @@ public Node root { get; set; }
 				classnode.superClass.Add(t.val); 
 			}
 		}
-		Expect(47);
+		Expect(46);
 		while (StartOf(7)) {
 			List<ProtoCore.AST.AssociativeAST.AssociativeNode> attributes = new List<ProtoCore.AST.AssociativeAST.AssociativeNode>(); 
 			if (la.kind == 8) {
 				Associative_AttributeDeclaration(out attributes);
 			}
 			ProtoCore.CompilerDefinitions.AccessSpecifier access = ProtoCore.CompilerDefinitions.AccessSpecifier.kPublic; 
-			if (la.kind == 52 || la.kind == 53 || la.kind == 54) {
+			if (la.kind == 51 || la.kind == 52 || la.kind == 53) {
 				Associative_AccessSpecifier(out access);
 			}
 			if (la.kind == 25) {
@@ -1117,16 +1111,16 @@ public Node root { get; set; }
 					NodeUtils.SetNodeEndLocation(varnode, t); 
 				} else if (la.kind == 21) {
 					Get();
-				} else SynErr(79);
-			} else SynErr(80);
+				} else SynErr(76);
+			} else SynErr(77);
 		}
-		Expect(48);
+		Expect(47);
 		isInClass = false; classnode.endLine = t.line; classnode.endCol = t.col; 
 		node = classnode; 
 	}
 
 	void Associative_NonAssignmentStatement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		while (!(StartOf(9))) {SynErr(81); Get();}
+		while (!(StartOf(9))) {SynErr(78); Get();}
 		node = null; 
 		ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
 		 
@@ -1156,7 +1150,7 @@ public Node root { get; set; }
 	}
 
 	void Associative_FunctionCallStatement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		while (!(StartOf(9))) {SynErr(82); Get();}
+		while (!(StartOf(9))) {SynErr(79); Get();}
 		node = null; 
 		ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
 		 
@@ -1195,7 +1189,7 @@ public Node root { get; set; }
 	}
 
 	void Associative_FunctionalStatement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		while (!(StartOf(10))) {SynErr(83); Get();}
+		while (!(StartOf(10))) {SynErr(80); Get();}
 		node = null; 
 		ProtoCore.AST.AssociativeAST.AssociativeNode leftNode = null; 
 		ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode(); 
@@ -1216,7 +1210,7 @@ public Node root { get; set; }
 			   node = expressionNode;
 			}
 			
-		} else if (la.kind == 50) {
+		} else if (la.kind == 49) {
 			if(!(leftNode is ProtoCore.AST.AssociativeAST.PostFixNode)) {
 			
 			Get();
@@ -1260,7 +1254,7 @@ public Node root { get; set; }
 			} else if (IsModifierStack()) {
 				withinModifierCheckScope = false; 
 				
-				Expect(47);
+				Expect(46);
 				ProtoCore.AST.AssociativeAST.ModifierStackNode mstack = new ProtoCore.AST.AssociativeAST.ModifierStackNode();
 				NodeUtils.SetNodeStartLocation(mstack, t);
 				
@@ -1270,7 +1264,7 @@ public Node root { get; set; }
 				
 				ProtoCore.AST.AssociativeAST.IdentifierNode identifier = null;
 				
-				if (la.kind == 55) {
+				if (la.kind == 54) {
 					Get();
 					Expect(1);
 					identifier = mstack.CreateIdentifierNode(t, leftNode);
@@ -1287,7 +1281,7 @@ public Node root { get; set; }
 				if (la.val != ";")
 				   SynErr(Resources.SemiColonExpected); 
 				
-				while (!(la.kind == 0 || la.kind == 21)) {SynErr(84); Get();}
+				while (!(la.kind == 0 || la.kind == 21)) {SynErr(81); Get();}
 				Expect(21);
 				NodeUtils.SetNodeEndLocation(elementNode, t); 
 				while (StartOf(11)) {
@@ -1309,7 +1303,7 @@ public Node root { get; set; }
 					
 					identifier = null;
 					
-					if (la.kind == 55) {
+					if (la.kind == 54) {
 						Get();
 						Expect(1);
 						identifier = mstack.CreateIdentifierNode(t, leftNode); 
@@ -1340,7 +1334,7 @@ public Node root { get; set; }
 					if (la.val != ";")
 					   SynErr(Resources.SemiColonExpected); 
 					
-					while (!(la.kind == 0 || la.kind == 21)) {SynErr(85); Get();}
+					while (!(la.kind == 0 || la.kind == 21)) {SynErr(82); Get();}
 					Expect(21);
 					NodeUtils.SetNodeEndLocation(elementNode, t); 
 				}
@@ -1364,7 +1358,7 @@ public Node root { get; set; }
 				
 				node = mstack; 
 				
-				Expect(48);
+				Expect(47);
 				NodeUtils.SetNodeEndLocation(expressionNode, t);
 				NodeUtils.SetNodeEndLocation(mstack, t);
 				
@@ -1383,7 +1377,7 @@ public Node root { get; set; }
 				
 				Expect(21);
 				NodeUtils.SetNodeEndLocation(expressionNode, t); node = expressionNode; 
-			} else SynErr(86);
+			} else SynErr(83);
 			if (isLeftMostNode) 
 			{
 			   leftVar = null;
@@ -1405,7 +1399,7 @@ public Node root { get; set; }
 			} 
 		} else if (StartOf(13)) {
 			SynErr(Resources.SemiColonExpected); 
-		} else SynErr(87);
+		} else SynErr(84);
 	}
 
 	void Associative_LanguageBlock(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -1426,11 +1420,11 @@ public Node root { get; set; }
 		   errors.SemErr(t.line, t.col, String.Format(Resources.InvalidLanguageBlockIdentifier, t.val));
 		}
 		
-		while (WeakSeparator(49,5,6) ) {
+		while (WeakSeparator(48,5,6) ) {
 			if (IsLanguageBlockProperty()) {
 				Expect(1);
 				string key = t.val; 
-				Expect(50);
+				Expect(49);
 				Expect(4);
 				if ("fingerprint" == key)
 				{
@@ -1449,17 +1443,17 @@ public Node root { get; set; }
 				ProtoCore.AST.AssociativeAST.AssociativeNode attr = null; 
 				Associative_Attribute(out attr);
 				if (attr != null) langblock.Attributes.Add(attr); 
-			} else SynErr(88);
+			} else SynErr(85);
 		}
 		Expect(9);
-		Expect(47);
+		Expect(46);
 		Node codeBlockNode = null; 
 		if (langblock.codeblock.language == ProtoCore.Language.kAssociative ||
 langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			Hydrogen(out codeBlockNode);
 		} else if (langblock.codeblock.language == ProtoCore.Language.kImperative ) {
 			Imperative(out codeBlockNode);
-		} else SynErr(89);
+		} else SynErr(86);
 		if (langblock.codeblock.language == ProtoCore.Language.kInvalid ) {
 			int openCurlyBraceCount = 0, closeCurlyBraceCount = 0; 
 			ProtoCore.AST.AssociativeAST.CodeBlockNode codeBlockInvalid = new ProtoCore.AST.AssociativeAST.CodeBlockNode(); 
@@ -1468,63 +1462,32 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 				if (la.kind == 8) {
 					Associative_LanguageBlock(out validBlockInInvalid);
 					codeBlockInvalid.Body.Add(validBlockInInvalid); 
-				} else if (la.kind == 47) {
+				} else if (la.kind == 46) {
 					Get();
 					openCurlyBraceCount++; 
-				} else if (la.kind == 48) {
+				} else if (la.kind == 47) {
 					Get();
 					closeCurlyBraceCount++; 
 				} else if (la.kind == 0) {
 					Get();
-					Expect(48);
+					Expect(47);
 					break; 
 				} else if (StartOf(13)) {
 					Get(); 
-				} else SynErr(90);
+				} else SynErr(87);
 			}
 			codeBlockNode = codeBlockInvalid; 
-		} else if (la.kind == 48) {
+		} else if (la.kind == 47) {
 			Get();
-		} else SynErr(91);
+		} else SynErr(88);
 		langblock.CodeBlockNode = codeBlockNode; 
 		node = langblock; 
-	}
-
-	void Associative_ExceptionBlock(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		ProtoCore.AST.AssociativeAST.ExceptionHandlingNode exceptionNode = new ProtoCore.AST.AssociativeAST.ExceptionHandlingNode(); 
-		ProtoCore.AST.AssociativeAST.TryBlockNode tryBlockNode; 
-		Associative_TryBlock(out tryBlockNode);
-		exceptionNode.tryBlock = tryBlockNode; 
-		ProtoCore.AST.AssociativeAST.CatchBlockNode catchBlockNode; 
-		Associative_CatchBlock(out catchBlockNode);
-		exceptionNode.catchBlocks.Add(catchBlockNode); 
-		while (la.kind == 58) {
-			Associative_CatchBlock(out catchBlockNode);
-			exceptionNode.catchBlocks.Add(catchBlockNode); 
-		}
-		node = exceptionNode; 
-	}
-
-	void Associative_ThrowStatement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		ProtoCore.AST.AssociativeAST.ThrowNode throwNode = new ProtoCore.AST.AssociativeAST.ThrowNode(); 
-		Expect(46);
-		ProtoCore.AST.AssociativeAST.AssociativeNode expression; 
-		Associative_Expression(out expression);
-		throwNode.expression = expression; 
-		if (la.val != ";")
-		   SynErr(Resources.SemiColonExpected);  
-		
-		if (la.val != ";")
-		   SynErr(Resources.SemiColonExpected); 
-		
-		Expect(21);
-		node = throwNode; 
 	}
 
 	void Associative_Expression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		node = null; 
 		Associative_LogicalExpression(out node);
-		while (la.kind == 56) {
+		while (la.kind == 55) {
 			Associative_TernaryOp(ref node);
 		}
 	}
@@ -1545,15 +1508,15 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Associative_AccessSpecifier(out ProtoCore.CompilerDefinitions.AccessSpecifier access) {
 		access = ProtoCore.CompilerDefinitions.AccessSpecifier.kPublic; 
-		if (la.kind == 52) {
+		if (la.kind == 51) {
 			Get();
-		} else if (la.kind == 53) {
+		} else if (la.kind == 52) {
 			Get();
 			access = ProtoCore.CompilerDefinitions.AccessSpecifier.kPrivate; 
-		} else if (la.kind == 54) {
+		} else if (la.kind == 53) {
 			Get();
 			access = ProtoCore.CompilerDefinitions.AccessSpecifier.kProtected; 
-		} else SynErr(92);
+		} else SynErr(89);
 	}
 
 	void Associative_constructordecl(out ProtoCore.AST.AssociativeAST.AssociativeNode constrNode, ProtoCore.CompilerDefinitions.AccessSpecifier access, List<ProtoCore.AST.AssociativeAST.AssociativeNode> attrs = null) {
@@ -1575,7 +1538,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		constr.Attributes = attrs;
 		ProtoCore.AST.AssociativeAST.AssociativeNode functionBody = null; 
 		
-		if (la.kind == 51) {
+		if (la.kind == 50) {
 			Get();
 			ProtoCore.AST.AssociativeAST.AssociativeNode bnode; 
 			Associative_BaseConstructorCall(out bnode);
@@ -1605,7 +1568,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		NodeUtils.SetNodeLocation(tNode, t);
 		varDeclNode.NameNode = tNode;
 		
-		if (la.kind == 51) {
+		if (la.kind == 50) {
 			Get();
 			Expect(1);
 			ProtoCore.Type argtype = new ProtoCore.Type(); argtype.Name = t.val; argtype.rank = 0; 
@@ -1613,7 +1576,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 				Get();
 				Expect(9);
 				argtype.rank = 1; 
-				if (la.kind == 8 || la.kind == 22 || la.kind == 50) {
+				if (la.kind == 8 || la.kind == 22 || la.kind == 49) {
 					if (la.kind == 22) {
 						Get();
 						Expect(8);
@@ -1647,7 +1610,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			varDeclNode.ArgumentType = argtype;
 			
 		}
-		if (la.kind == 50) {
+		if (la.kind == 49) {
 			Get();
 			ProtoCore.AST.AssociativeAST.AssociativeNode rhsNode; 
 			Associative_Expression(out rhsNode);
@@ -1756,10 +1719,10 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		List<ProtoCore.AST.AssociativeAST.AssociativeNode> body = new List<ProtoCore.AST.AssociativeAST.AssociativeNode>(); 
 		NodeUtils.SetNodeStartLocation(functionBody, la);
 		
-		Expect(47);
+		Expect(46);
 		Associative_StatementList(out body);
 		functionBody.Body =body;  
-		Expect(48);
+		Expect(47);
 		NodeUtils.SetNodeEndLocation(functionBody, t); 
 		funcBody = functionBody; 
 	}
@@ -1781,7 +1744,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		NodeUtils.SetNodeLocation(var, t);
 		
 		#if ENABLE_INC_DEC_FIX 
-		if (la.kind == 68 || la.kind == 69) {
+		if (la.kind == 65 || la.kind == 66) {
 			Associative_PostFixOp(out op);
 			ProtoCore.AST.AssociativeAST.PostFixNode pfNode = new ProtoCore.AST.AssociativeAST.PostFixNode();
 			pfNode.Operator = op;
@@ -1801,7 +1764,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			ProtoCore.AST.AssociativeAST.AssociativeNode t; 
 			Associative_Expression(out t);
 			nodes.Add(t); 
-			while (WeakSeparator(49,4,16) ) {
+			while (WeakSeparator(48,4,16) ) {
 				Associative_Expression(out t);
 				nodes.Add(t); 
 			}
@@ -1831,7 +1794,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		// TODO Jun: Luke made changes to array representation, handle this
 		//returnType.IsArray = false;
 		
-		if (la.kind == 51) {
+		if (la.kind == 50) {
 			Associative_TypeRestriction(out returnType);
 		}
 		Associative_ArgumentSignatureDefinition(out argumentSignature);
@@ -1868,7 +1831,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 	}
 
 	void Associative_TypeRestriction(out ProtoCore.Type type) {
-		Expect(51);
+		Expect(50);
 		Associative_ClassReference(out type);
 		type.rank = 0; 
 		if (la.kind == 8) {
@@ -1901,22 +1864,22 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			if (NotDefaultArg()) { 
 			Associative_ArgDecl(out arg);
 			argumentSignature.AddArgument(arg as ProtoCore.AST.AssociativeAST.VarDeclNode); 
-			while (la.kind == 49) {
+			while (la.kind == 48) {
 				if (NotDefaultArg()) { 
-				ExpectWeak(49, 17);
+				ExpectWeak(48, 17);
 				Associative_ArgDecl(out arg);
 				argumentSignature.AddArgument(arg as ProtoCore.AST.AssociativeAST.VarDeclNode); 
 				} else break; 
 			}
 			} 
 		}
-		if (la.kind == 1 || la.kind == 49) {
-			if (la.kind == 49) {
+		if (la.kind == 1 || la.kind == 48) {
+			if (la.kind == 48) {
 				Get();
 			}
 			Associative_DefaultArgDecl(out arg);
 			argumentSignature.AddArgument(arg as ProtoCore.AST.AssociativeAST.VarDeclNode); 
-			while (la.kind == 49) {
+			while (la.kind == 48) {
 				Get();
 				Associative_DefaultArgDecl(out arg);
 				argumentSignature.AddArgument(arg as ProtoCore.AST.AssociativeAST.VarDeclNode); 
@@ -1950,7 +1913,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		NodeUtils.CopyNodeLocation(varDeclNode, tNode);
 		
 		ProtoCore.Type argtype = new ProtoCore.Type(); argtype.Name = "var"; argtype.rank = 0; argtype.UID = 0; 
-		if (la.kind == 51) {
+		if (la.kind == 50) {
 			Get();
 			Expect(1);
 			argtype.Name = t.val; 
@@ -1981,7 +1944,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 	void Associative_DefaultArgDecl(out ProtoCore.AST.AssociativeAST.AssociativeNode node, ProtoCore.CompilerDefinitions.AccessSpecifier access = ProtoCore.CompilerDefinitions.AccessSpecifier.kPublic) {
 		Associative_ArgDecl(out node);
 		ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = node as ProtoCore.AST.AssociativeAST.VarDeclNode; 
-		Expect(50);
+		Expect(49);
 		ProtoCore.AST.AssociativeAST.AssociativeNode rhsNode; 
 		Associative_Expression(out rhsNode);
 		ProtoCore.AST.AssociativeAST.BinaryExpressionNode bNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
@@ -1996,38 +1959,38 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Associative_BinaryOps(out Operator op) {
 		op = Operator.none; 
-		if (la.kind == 13 || la.kind == 59) {
+		if (la.kind == 13 || la.kind == 56) {
 			Associative_AddOp(out op);
-		} else if (la.kind == 60 || la.kind == 61 || la.kind == 62) {
+		} else if (la.kind == 57 || la.kind == 58 || la.kind == 59) {
 			Associative_MulOp(out op);
 		} else if (StartOf(18)) {
 			Associative_ComparisonOp(out op);
-		} else if (la.kind == 65 || la.kind == 66) {
+		} else if (la.kind == 62 || la.kind == 63) {
 			Associative_LogicalOp(out op);
-		} else SynErr(93);
+		} else SynErr(90);
 	}
 
 	void Associative_AddOp(out Operator op) {
 		op = Operator.add; 
-		if (la.kind == 59) {
+		if (la.kind == 56) {
 			Get();
 		} else if (la.kind == 13) {
 			Get();
 			op = Operator.sub; 
-		} else SynErr(94);
+		} else SynErr(91);
 	}
 
 	void Associative_MulOp(out Operator op) {
 		op = Operator.mul; 
-		if (la.kind == 60) {
+		if (la.kind == 57) {
 			Get();
-		} else if (la.kind == 61) {
+		} else if (la.kind == 58) {
 			Get();
 			op = Operator.div; 
-		} else if (la.kind == 62) {
+		} else if (la.kind == 59) {
 			Get();
 			op = Operator.mod; 
-		} else SynErr(95);
+		} else SynErr(92);
 	}
 
 	void Associative_ComparisonOp(out Operator op) {
@@ -2063,18 +2026,18 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			op = Operator.nq; 
 			break;
 		}
-		default: SynErr(96); break;
+		default: SynErr(93); break;
 		}
 	}
 
 	void Associative_LogicalOp(out Operator op) {
 		op = Operator.and; 
-		if (la.kind == 65) {
+		if (la.kind == 62) {
 			Get();
-		} else if (la.kind == 66) {
+		} else if (la.kind == 63) {
 			Get();
 			op = Operator.or; 
-		} else SynErr(97);
+		} else SynErr(94);
 	}
 
 	void Associative_ClassReference(out ProtoCore.Type type) {
@@ -2117,7 +2080,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			typedVar.Name = typedVar.Value = t.val;
 			NodeUtils.SetNodeLocation(typedVar, t);
 			
-			Expect(51);
+			Expect(50);
 			Expect(41);
 			typedVar.IsLocal = true;
 			
@@ -2167,7 +2130,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			identNode.Name = identNode.Value = t.val;
 			NodeUtils.SetNodeLocation(identNode, t);
 			
-			Expect(51);
+			Expect(50);
 			Expect(41);
 			identNode.IsLocal = true;
 			
@@ -2182,7 +2145,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			typedVar.Name = typedVar.Value = t.val;
 			NodeUtils.SetNodeLocation(typedVar, t);
 			
-			Expect(51);
+			Expect(50);
 			string strIdent = string.Empty;
 			int type = ProtoCore.DSASM.Constants.kInvalidIndex;
 			
@@ -2192,7 +2155,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			} else if (la.kind == 1) {
 				Get();
 				strIdent = t.val; 
-			} else SynErr(98);
+			} else SynErr(95);
 			type = core.TypeSystem.GetType(strIdent);
 			typedVar.TypeAlias = strIdent;
 			if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
@@ -2229,9 +2192,9 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 				typedVar.datatype = datatype; 
 			}
 			node = typedVar; 
-		} else if (la.kind == 1 || la.kind == 10 || la.kind == 47) {
+		} else if (la.kind == 1 || la.kind == 10 || la.kind == 46) {
 			Associative_IdentifierList(out node);
-		} else SynErr(99);
+		} else SynErr(96);
 	}
 
 	void Associative_IdentifierList(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -2342,7 +2305,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Associative_LogicalExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		Associative_ComparisonExpression(out node);
-		while (la.kind == 65 || la.kind == 66) {
+		while (la.kind == 62 || la.kind == 63) {
 			Operator op;
 			Associative_LogicalOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
@@ -2366,11 +2329,11 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Associative_TernaryOp(ref ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		ProtoCore.AST.AssociativeAST.InlineConditionalNode inlineConNode = new ProtoCore.AST.AssociativeAST.InlineConditionalNode(); 
-		Expect(56);
+		Expect(55);
 		inlineConNode.ConditionExpression = node; node = null; 
 		Associative_Expression(out node);
 		inlineConNode.TrueExpression = node; 
-		Expect(51);
+		Expect(50);
 		node = null; 
 		Associative_Expression(out node);
 		inlineConNode.FalseExpression = node;
@@ -2385,7 +2348,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			Associative_NegExpression(out node);
 		} else if (StartOf(20)) {
 			Associative_BitUnaryExpression(out node);
-		} else SynErr(100);
+		} else SynErr(97);
 	}
 
 	void Associative_NegExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -2441,15 +2404,15 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			Get();
 			op = UnaryOperator.Not;    
 			#if ENABLE_BIT_OP          
-		} else if (la.kind == 67) {
+		} else if (la.kind == 64) {
 			Get();
 			op = UnaryOperator.Negate; 
 			#endif                     
 			#if ENABLE_INC_DEC_FIX 
-		} else if (la.kind == 68 || la.kind == 69) {
+		} else if (la.kind == 65 || la.kind == 66) {
 			Associative_PostFixOp(out op);
 			#endif 
-		} else SynErr(101);
+		} else SynErr(98);
 		#if ENABLE_INC_DEC_FIX
 		#else
 		if (la.val == "++" || la.val == "--") Get(); 
@@ -2480,20 +2443,20 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			Associative_Char(out node);
 		} else if (la.kind == 4) {
 			Associative_String(out node);
-		} else if (la.kind == 1 || la.kind == 10 || la.kind == 47) {
+		} else if (la.kind == 1 || la.kind == 10 || la.kind == 46) {
 			Associative_IdentifierList(out node);
 		} else if (StartOf(21)) {
 			Associative_UnaryExpression(out node);
-		} else SynErr(102);
+		} else SynErr(99);
 	}
 
 	void Associative_negop(out UnaryOperator op) {
 		op = UnaryOperator.None; 
-		if (la.kind == 1 || la.kind == 10 || la.kind == 47) {
+		if (la.kind == 1 || la.kind == 10 || la.kind == 46) {
 		} else if (la.kind == 13) {
 			Get();
 			op = UnaryOperator.Neg; 
-		} else SynErr(103);
+		} else SynErr(100);
 	}
 
 	void Associative_ComparisonExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -2529,7 +2492,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			bool hasRangeAmountOperator = false;
 			
 			Get();
-			if (la.kind == 70) {
+			if (la.kind == 67) {
 				Associative_rangeAmountOperator(out hasRangeAmountOperator);
 			}
 			rnode.HasRangeAmountOperator = hasRangeAmountOperator; 
@@ -2553,7 +2516,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Associative_ArithmeticExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		Associative_Term(out node);
-		while (la.kind == 13 || la.kind == 59) {
+		while (la.kind == 13 || la.kind == 56) {
 			Operator op; 
 			Associative_AddOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
@@ -2578,14 +2541,14 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Associative_rangeAmountOperator(out bool hasRangeAmountOperator) {
 		hasRangeAmountOperator = false; 
-		Expect(70);
+		Expect(67);
 		hasRangeAmountOperator = true; 
 	}
 
 	void Associative_rangeStepOperator(out RangeStepOperator op) {
 		op = RangeStepOperator.stepsize; 
-		if (la.kind == 67 || la.kind == 70) {
-			if (la.kind == 70) {
+		if (la.kind == 64 || la.kind == 67) {
+			if (la.kind == 67) {
 				Get();
 				op = RangeStepOperator.num; 
 			} else {
@@ -2595,74 +2558,28 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		}
 	}
 
-	void Associative_TryBlock(out ProtoCore.AST.AssociativeAST.TryBlockNode tryBlockNode) {
-		tryBlockNode = new ProtoCore.AST.AssociativeAST.TryBlockNode(); 
-		Expect(57);
-		Expect(47);
-		List<ProtoCore.AST.AssociativeAST.AssociativeNode> tryBlockBody = null; 
-		Associative_StatementList(out tryBlockBody);
-		tryBlockNode.body = tryBlockBody; 
-		Expect(48);
-	}
-
-	void Associative_CatchFilter(out ProtoCore.AST.AssociativeAST.CatchFilterNode catchFilterNode) {
-		catchFilterNode = new ProtoCore.AST.AssociativeAST.CatchFilterNode(); 
-		Expect(1);
-		if (IsKeyWord(t.val, true))
-		{
-		   errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
-		}
-		
-		catchFilterNode.var =  ProtoCore.Utils.CoreUtils.BuildAssocIdentifier(core, t.val);
-		
-		Expect(51);
-		Expect(1);
-		ProtoCore.Type exceptionType = new ProtoCore.Type()
-		{
-		   Name = t.val, 
-		   rank = 0, 
-		};
-		catchFilterNode.type = exceptionType;
-		
-	}
-
-	void Associative_CatchBlock(out ProtoCore.AST.AssociativeAST.CatchBlockNode catchBlockNode) {
-		Expect(58);
-		catchBlockNode = new ProtoCore.AST.AssociativeAST.CatchBlockNode(); 
-		Expect(10);
-		ProtoCore.AST.AssociativeAST.CatchFilterNode catchFilterNode = null; 
-		Associative_CatchFilter(out catchFilterNode);
-		catchBlockNode.catchFilter = catchFilterNode; 
-		Expect(11);
-		Expect(47);
-		List<ProtoCore.AST.AssociativeAST.AssociativeNode> catchBlockBody = null; 
-		Associative_StatementList(out catchBlockBody);
-		catchBlockNode.body = catchBlockBody; 
-		Expect(48);
-	}
-
 	void Associative_BitOp(out Operator op) {
 		op = Operator.bitwiseand; 
-		if (la.kind == 63) {
+		if (la.kind == 60) {
 			Get();
-		} else if (la.kind == 64) {
+		} else if (la.kind == 61) {
 			Get();
 			op = Operator.bitwisexor; 
 		} else if (la.kind == 14) {
 			Get();
 			op = Operator.bitwiseor; 
-		} else SynErr(104);
+		} else SynErr(101);
 	}
 
 	void Associative_PostFixOp(out UnaryOperator op) {
 		op = UnaryOperator.None; 
-		if (la.kind == 68) {
+		if (la.kind == 65) {
 			Get();
 			op = UnaryOperator.Increment; 
-		} else if (la.kind == 69) {
+		} else if (la.kind == 66) {
 			Get();
 			op = UnaryOperator.Decrement; 
-		} else SynErr(105);
+		} else SynErr(102);
 	}
 
 	void Associative_Term(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -2671,7 +2588,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		#else             
 		Associative_Factor(out node);
 		#endif            
-		while (la.kind == 60 || la.kind == 61 || la.kind == 62) {
+		while (la.kind == 57 || la.kind == 58 || la.kind == 59) {
 			Operator op; 
 			Associative_MulOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
@@ -2699,7 +2616,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Associative_interimfactor(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		Associative_Factor(out node);
-		while (la.kind == 14 || la.kind == 63 || la.kind == 64) {
+		while (la.kind == 14 || la.kind == 60 || la.kind == 61) {
 			Operator op; 
 			Associative_BitOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
@@ -2778,7 +2695,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			   node.line = line; node.col = col;
 			}
 			
-		} else SynErr(106);
+		} else SynErr(103);
 	}
 
 	void Associative_Char(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -2810,19 +2727,19 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 	}
 
 	void Associative_ArrayExprList(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		Expect(47);
+		Expect(46);
 		ProtoCore.AST.AssociativeAST.ExprListNode exprlist = new ProtoCore.AST.AssociativeAST.ExprListNode(); 
 		NodeUtils.SetNodeStartLocation(exprlist, t); 
 		if (StartOf(4)) {
 			Associative_Expression(out node);
 			exprlist.list.Add(node); 
-			while (la.kind == 49) {
+			while (la.kind == 48) {
 				Get();
 				Associative_Expression(out node);
 				exprlist.list.Add(node); 
 			}
 		}
-		Expect(48);
+		Expect(47);
 		NodeUtils.SetNodeEndLocation(exprlist, t); 
 		node = exprlist; 
 	}
@@ -2859,11 +2776,11 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			Associative_Ident(out node);
 			nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode; 
 			
-		} else if (la.kind == 47) {
+		} else if (la.kind == 46) {
 			Associative_ArrayExprList(out node);
 			nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode;
 			
-		} else SynErr(107);
+		} else SynErr(104);
 		if (la.kind == 8) {
 			ProtoCore.AST.AssociativeAST.ArrayNode array = new ProtoCore.AST.AssociativeAST.ArrayNode(); 
 			
@@ -3002,7 +2919,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 				repGuideNode.IsLongest = isLongest;
 				NodeUtils.SetNodeLocation(numNode, t); 
 				
-			} else SynErr(108);
+			} else SynErr(105);
 			Expect(16);
 			guides.Add(repGuideNode); 
 			while (la.kind == 15) {
@@ -3029,7 +2946,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 					repGuideNode.IsLongest = isLongest;
 					NodeUtils.SetNodeLocation(numNode, t); 
 					
-				} else SynErr(109);
+				} else SynErr(106);
 				Expect(16);
 				guides.Add(repGuideNode); 
 				
@@ -3106,12 +3023,6 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			Imperative_forloop(out node);
 		} else if (la.kind == 8) {
 			Imperative_languageblock(out node);
-		} else if (la.kind == 46) {
-			Imperative_ThrowStatement(out node);
-			#if ENABLE_EXCEPTION_HANDLING 
-		} else if (la.kind == 57) {
-			Imperative_ExceptionBlock(out node);
-			#endif 
 		} else if (la.kind == 38) {
 			Get();
 			if (la.kind != _endline)
@@ -3139,7 +3050,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			  SynErr(Resources.SemiColonExpected);
 			
 			Get();
-		} else SynErr(110);
+		} else SynErr(107);
 	}
 
 	void Imperative_AttributeDeclaration(out List<ProtoCore.AST.ImperativeAST.ImperativeNode> nodes) {
@@ -3148,7 +3059,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		ProtoCore.AST.ImperativeAST.ImperativeNode node; 
 		Imperative_Attribute(out node);
 		if (node != null) nodes.Add(node); 
-		while (WeakSeparator(49,5,6) ) {
+		while (WeakSeparator(48,5,6) ) {
 			node = null; 
 			Imperative_Attribute(out node);
 			if (node != null) nodes.Add(node); 
@@ -3168,7 +3079,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		    errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
 		}
 		
-		if (la.kind == 51) {
+		if (la.kind == 50) {
 			Get();
 			Imperative_ReturnType(out rtype);
 		}
@@ -3181,14 +3092,14 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		NodeUtils.SetNodeStartLocation(funcDecl.FunctionBody, la);
 		List<ProtoCore.AST.ImperativeAST.ImperativeNode> body = new List<ProtoCore.AST.ImperativeAST.ImperativeNode>();
 		
-		if (la.kind == 50) {
+		if (la.kind == 49) {
 			Get();
 			Imperative_functionalMethodBodySingleStatement(out body);
-		} else if (la.kind == 47) {
+		} else if (la.kind == 46) {
 			Get();
 			Imperative_stmtlist(out body);
-			Expect(48);
-		} else SynErr(111);
+			Expect(47);
+		} else SynErr(108);
 		funcDecl.localVars = localVarCount;
 		NodeUtils.SetNodeEndLocation(funcDecl.FunctionBody, t);
 		funcDecl.FunctionBody.Body = body;
@@ -3217,11 +3128,11 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		   errors.SemErr(t.line, t.col, String.Format(Resources.InvalidLanguageBlockIdentifier, t.val));
 		}
 		
-		while (WeakSeparator(49,5,6) ) {
+		while (WeakSeparator(48,5,6) ) {
 			if (IsLanguageBlockProperty()) {
 				Expect(1);
 				string key = t.val; 
-				Expect(50);
+				Expect(49);
 				Expect(4);
 				if ("fingerprint" == key)
 				{
@@ -3240,17 +3151,17 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode attr = null; 
 				Imperative_Attribute(out attr);
 				if (attr != null) langblock.Attributes.Add(attr); 
-			} else SynErr(112);
+			} else SynErr(109);
 		}
 		Expect(9);
-		Expect(47);
+		Expect(46);
 		Node codeBlockNode = null; 
 		if (langblock.codeblock.language == ProtoCore.Language.kAssociative ||
 langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			Hydrogen(out codeBlockNode);
 		} else if (langblock.codeblock.language == ProtoCore.Language.kImperative ) {
 			Imperative(out codeBlockNode);
-		} else SynErr(113);
+		} else SynErr(110);
 		if (langblock.codeblock.language == ProtoCore.Language.kInvalid ) {
 			int openCurlyBraceCount = 0, closeCurlyBraceCount = 0; 
 			ProtoCore.AST.ImperativeAST.CodeBlockNode codeBlockInvalid = new ProtoCore.AST.ImperativeAST.CodeBlockNode(); 
@@ -3259,24 +3170,24 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 				if (la.kind == 8) {
 					Imperative_languageblock(out validBlockInInvalid);
 					codeBlockInvalid.Body.Add(validBlockInInvalid); 
-				} else if (la.kind == 47) {
+				} else if (la.kind == 46) {
 					Get();
 					openCurlyBraceCount++; 
-				} else if (la.kind == 48) {
+				} else if (la.kind == 47) {
 					Get();
 					closeCurlyBraceCount++; 
 				} else if (la.kind == 0) {
 					Get();
-					Expect(48);
+					Expect(47);
 					break; 
 				} else if (StartOf(13)) {
 					Get(); 
-				} else SynErr(114);
+				} else SynErr(111);
 			}
 			codeBlockNode = codeBlockInvalid; 
-		} else if (la.kind == 48) {
+		} else if (la.kind == 47) {
 			Get();
-		} else SynErr(115);
+		} else SynErr(112);
 		langblock.CodeBlockNode = codeBlockNode; 
 		node = langblock; 
 	}
@@ -3291,7 +3202,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode argNode; 
 			Imperative_expr(out argNode);
 			f.FormalArguments.Add(argNode); 
-			while (la.kind == 49) {
+			while (la.kind == 48) {
 				Get();
 				Imperative_expr(out argNode);
 				f.FormalArguments.Add(argNode); 
@@ -3318,16 +3229,16 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		NodeUtils.SetNodeEndLocation(ifStmtNode.IfExprNode, t);
 		NodeUtils.SetNodeStartLocation(ifStmtNode.IfBodyPosition, la);
 		
-		if (la.kind == 47) {
+		if (la.kind == 46) {
 			Get();
 			Imperative_stmtlist(out body);
 			ifStmtNode.IfBody = body; 
-			Expect(48);
+			Expect(47);
 		} else if (StartOf(22)) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt; 
 			Imperative_stmt(out singleStmt);
 			ifStmtNode.IfBody.Add(singleStmt); 
-		} else SynErr(116);
+		} else SynErr(113);
 		NodeUtils.SetNodeEndLocation(ifStmtNode.IfBodyPosition, t); 
 		while (la.kind == 31) {
 			ProtoCore.AST.ImperativeAST.ElseIfBlock elseifBlock = new ProtoCore.AST.ImperativeAST.ElseIfBlock(); 
@@ -3342,32 +3253,32 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			NodeUtils.SetNodeEndLocation(elseifBlock.Expr, t);
 			NodeUtils.SetNodeStartLocation(elseifBlock.ElseIfBodyPosition, la);
 			
-			if (la.kind == 47) {
+			if (la.kind == 46) {
 				Get();
 				Imperative_stmtlist(out body);
 				elseifBlock.Body = body; 
-				Expect(48);
+				Expect(47);
 			} else if (StartOf(22)) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				elseifBlock.Body.Add(singleStmt); 
-			} else SynErr(117);
+			} else SynErr(114);
 			NodeUtils.SetNodeEndLocation(elseifBlock.ElseIfBodyPosition, t); 
 			ifStmtNode.ElseIfList.Add(elseifBlock); 
 		}
 		if (la.kind == 32) {
 			Get();
 			NodeUtils.SetNodeStartLocation(ifStmtNode.ElseBodyPosition, la); 
-			if (la.kind == 47) {
+			if (la.kind == 46) {
 				Get();
 				Imperative_stmtlist(out body);
 				ifStmtNode.ElseBody = body; 
-				Expect(48);
+				Expect(47);
 			} else if (StartOf(22)) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				ifStmtNode.ElseBody.Add(singleStmt); 
-			} else SynErr(118);
+			} else SynErr(115);
 			NodeUtils.SetNodeEndLocation(ifStmtNode.ElseBodyPosition, t); 
 		}
 		node = ifStmtNode; 
@@ -3385,10 +3296,10 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		NodeUtils.SetNodeStartLocation(whileStmtNode.Expr, whileStmtNode);
 		NodeUtils.SetNodeEndLocation(whileStmtNode.Expr, t);
 		
-		Expect(47);
+		Expect(46);
 		Imperative_stmtlist(out body);
 		whileStmtNode.Body = body; 
-		Expect(48);
+		Expect(47);
 		NodeUtils.SetNodeEndLocation(whileStmtNode, t);  
 		node = whileStmtNode;                            
 	}
@@ -3405,22 +3316,22 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		int idLine = la.line; int idCol = la.col; 
 		Imperative_Ident(out node);
 		loopNode.loopVar = node; loopNode.loopVar.line = idLine; loopNode.loopVar.col = idCol; 
-		Expect(71);
+		Expect(68);
 		loopNode.KwInLine = t.line; loopNode.KwInCol = t.col; int exprLine = la.line; int exprCol = la.col; 
 		Imperative_expr(out node);
 		loopNode.expression = node; if (loopNode.expression != null) {  loopNode.expression.line = exprLine; loopNode.expression.col = exprCol; } 
 		Expect(11);
-		if (la.kind == 47) {
+		if (la.kind == 46) {
 			Get();
 			Imperative_stmtlist(out body);
 			loopNode.body = body; 
-			Expect(48);
+			Expect(47);
 			NodeUtils.SetNodeEndLocation(loopNode, t); 
 		} else if (StartOf(22)) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 			Imperative_stmt(out singleStmt);
 			loopNode.body.Add(singleStmt); 
-		} else SynErr(119);
+		} else SynErr(116);
 		dummyIfNode.IfExprNode
 		= new ProtoCore.AST.ImperativeAST.BooleanNode(true);
 		dummyIfNode.IfBody.Add(loopNode);
@@ -3430,34 +3341,6 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		dummyIfNode.endCol = loopNode.endCol;
 		forloop = dummyIfNode;
 		
-	}
-
-	void Imperative_ThrowStatement(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
-		ProtoCore.AST.ImperativeAST.ThrowNode throwNode = new ProtoCore.AST.ImperativeAST.ThrowNode(); 
-		Expect(46);
-		ProtoCore.AST.ImperativeAST.ImperativeNode expression; 
-		Imperative_expr(out expression);
-		throwNode.expression = expression; 
-		if (la.kind != _endline)
-		  SynErr(Resources.SemiColonExpected);
-		
-		Expect(21);
-		node = throwNode; 
-	}
-
-	void Imperative_ExceptionBlock(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
-		ProtoCore.AST.ImperativeAST.ExceptionHandlingNode exceptionNode = new ProtoCore.AST.ImperativeAST.ExceptionHandlingNode(); 
-		ProtoCore.AST.ImperativeAST.TryBlockNode tryBlockNode; 
-		Imperative_TryBlock(out tryBlockNode);
-		exceptionNode.tryBlock = tryBlockNode; 
-		ProtoCore.AST.ImperativeAST.CatchBlockNode catchBlockNode; 
-		Imperative_CatchBlock(out catchBlockNode);
-		exceptionNode.catchBlocks.Add(catchBlockNode); 
-		while (la.kind == 58) {
-			Imperative_CatchBlock(out catchBlockNode);
-			exceptionNode.catchBlocks.Add(catchBlockNode); 
-		}
-		node = exceptionNode; 
 	}
 
 	void Imperative_assignstmt(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3477,7 +3360,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			node = bNode; 
 			
 		} else if (!(lhsNode is ProtoCore.AST.ImperativeAST.PostFixNode)) {
-			Expect(50);
+			Expect(49);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode = null; 
 			if (HasMoreAssignmentStatements()) {
 				Imperative_assignstmt(out rhsNode);
@@ -3489,7 +3372,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 				Expect(21);
 			} else if (la.kind == 8) {
 				Imperative_languageblock(out rhsNode);
-			} else SynErr(120);
+			} else SynErr(117);
 			bNode.LeftNode = lhsNode;
 			bNode.RightNode = rhsNode;
 			bNode.Optr = Operator.assign;
@@ -3498,13 +3381,13 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			
 		} else if (StartOf(13)) {
 			SynErr("';' is expected"); 
-		} else SynErr(121);
+		} else SynErr(118);
 	}
 
 	void Imperative_expr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null; 
 		Imperative_binexpr(out node);
-		while (la.kind == 56) {
+		while (la.kind == 55) {
 			Imperative_TernaryOp(ref node);
 		}
 	}
@@ -3530,7 +3413,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			typedVar.Name = typedVar.Value = t.val;
 			NodeUtils.SetNodeLocation(typedVar, t);
 			
-			Expect(51);
+			Expect(50);
 			Expect(41);
 			typedVar.IsLocal = true;
 			
@@ -3580,7 +3463,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			identNode.Name = identNode.Value = t.val;
 			NodeUtils.SetNodeLocation(identNode, t);
 			
-			Expect(51);
+			Expect(50);
 			Expect(41);
 			identNode.IsLocal = true;
 			
@@ -3595,7 +3478,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			typedVar.Name = typedVar.Value = t.val;
 			NodeUtils.SetNodeLocation(typedVar, t);
 			
-			Expect(51);
+			Expect(50);
 			Expect(1);
 			int type = core.TypeSystem.GetType(t.val); 
 			if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
@@ -3632,9 +3515,9 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 				typedVar.datatype = datatype; 
 			}
 			node = typedVar; 
-		} else if (la.kind == 1 || la.kind == 10 || la.kind == 47) {
+		} else if (la.kind == 1 || la.kind == 10 || la.kind == 46) {
 			Imperative_IdentifierList(out node);
-		} else SynErr(122);
+		} else SynErr(119);
 	}
 
 	void Imperative_IdentifierList(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3682,7 +3565,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		NodeUtils.SetNodeLocation(var, t);
 		
 		#if ENABLE_INC_DEC_FIX 
-		if (la.kind == 68 || la.kind == 69) {
+		if (la.kind == 65 || la.kind == 66) {
 			Imperative_PostFixOp(out op);
 			ProtoCore.AST.ImperativeAST.PostFixNode pfNode = new ProtoCore.AST.ImperativeAST.PostFixNode();
 			pfNode.Operator = op;
@@ -3697,7 +3580,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 	void Imperative_binexpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null;
 		Imperative_logicalexpr(out node);
-		while (la.kind == 65 || la.kind == 66) {
+		while (la.kind == 62 || la.kind == 63) {
 			Operator op; 
 			Imperative_logicalop(out op);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode = null; 
@@ -3714,11 +3597,11 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Imperative_TernaryOp(ref ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		ProtoCore.AST.ImperativeAST.InlineConditionalNode inlineConNode = new ProtoCore.AST.ImperativeAST.InlineConditionalNode(); 
-		Expect(56);
+		Expect(55);
 		inlineConNode.ConditionExpression = node; node = null; 
 		Imperative_expr(out node);
 		inlineConNode.TrueExpression = node; 
-		Expect(51);
+		Expect(50);
 		node = null; 
 		Imperative_expr(out node);
 		inlineConNode.FalseExpression = node; 
@@ -3752,11 +3635,11 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			Imperative_Ident(out node);
 			nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
 			
-		} else if (la.kind == 47) {
+		} else if (la.kind == 46) {
 			Imperative_ExprList(out node);
 			nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
 			
-		} else SynErr(123);
+		} else SynErr(120);
 		if (la.kind == 8) {
 			ProtoCore.AST.ImperativeAST.ArrayNode array = new ProtoCore.AST.ImperativeAST.ArrayNode();
 			
@@ -3833,7 +3716,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			Imperative_negexpr(out node);
 		} else if (StartOf(20)) {
 			Imperative_bitunaryexpr(out node);
-		} else SynErr(124);
+		} else SynErr(121);
 	}
 
 	void Imperative_negexpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3871,15 +3754,15 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			Get();
 			op = UnaryOperator.Not; 
 			#if ENABLE_BIT_OP       
-		} else if (la.kind == 67) {
+		} else if (la.kind == 64) {
 			Get();
 			op = UnaryOperator.Negate; 
 			#endif                     
 			#if ENABLE_INC_DEC_FIX 
-		} else if (la.kind == 68 || la.kind == 69) {
+		} else if (la.kind == 65 || la.kind == 66) {
 			Imperative_PostFixOp(out op);
 			#endif 
-		} else SynErr(125);
+		} else SynErr(122);
 		#if ENABLE_INC_DEC_FIX 
 		#else
 		   if (la.val == "++" || la.val == "--") Get(); 
@@ -3910,11 +3793,11 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			node = new ProtoCore.AST.ImperativeAST.NullNode(); 
 			NodeUtils.SetNodeLocation(node, t); 
 			
-		} else if (la.kind == 1 || la.kind == 10 || la.kind == 47) {
+		} else if (la.kind == 1 || la.kind == 10 || la.kind == 46) {
 			Imperative_IdentifierList(out node);
 		} else if (StartOf(23)) {
 			Imperative_unaryexpr(out node);
-		} else SynErr(126);
+		} else SynErr(123);
 	}
 
 	void Imperative_negop(out UnaryOperator op) {
@@ -3942,13 +3825,13 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Imperative_logicalop(out Operator op) {
 		op = Operator.none; 
-		if (la.kind == 65) {
+		if (la.kind == 62) {
 			Get();
 			op = Operator.and; 
-		} else if (la.kind == 66) {
+		} else if (la.kind == 63) {
 			Get();
 			op = Operator.or; 
-		} else SynErr(127);
+		} else SynErr(124);
 	}
 
 	void Imperative_RangeExpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3960,7 +3843,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			bool hasAmountOperator = false;
 			
 			Get();
-			if (la.kind == 70) {
+			if (la.kind == 67) {
 				Imperative_rangeAmountOperator(out hasAmountOperator);
 			}
 			rnode.HasRangeAmountOperator = hasAmountOperator; 
@@ -4015,14 +3898,14 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			op = Operator.nq; 
 			break;
 		}
-		default: SynErr(128); break;
+		default: SynErr(125); break;
 		}
 	}
 
 	void Imperative_rel(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null;
 		Imperative_term(out node);
-		while (la.kind == 13 || la.kind == 59) {
+		while (la.kind == 13 || la.kind == 56) {
 			Operator op; 
 			Imperative_addop(out op);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode; 
@@ -4039,14 +3922,14 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Imperative_rangeAmountOperator(out bool hasAmountOperator) {
 		hasAmountOperator = false; 
-		Expect(70);
+		Expect(67);
 		hasAmountOperator = true; 
 	}
 
 	void Imperative_rangeStepOperator(out RangeStepOperator op) {
 		op = RangeStepOperator.stepsize; 
-		if (la.kind == 67 || la.kind == 70) {
-			if (la.kind == 70) {
+		if (la.kind == 64 || la.kind == 67) {
+			if (la.kind == 67) {
 				Get();
 				op = RangeStepOperator.num; 
 			} else {
@@ -4063,7 +3946,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		#else             
 		Imperative_factor(out node);
 		#endif            
-		while (la.kind == 60 || la.kind == 61 || la.kind == 62) {
+		while (la.kind == 57 || la.kind == 58 || la.kind == 59) {
 			Operator op; 
 			Imperative_mulop(out op);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode; 
@@ -4084,19 +3967,19 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Imperative_addop(out Operator op) {
 		op = Operator.none; 
-		if (la.kind == 59) {
+		if (la.kind == 56) {
 			Get();
 			op = Operator.add; 
 		} else if (la.kind == 13) {
 			Get();
 			op = Operator.sub; 
-		} else SynErr(129);
+		} else SynErr(126);
 	}
 
 	void Imperative_interimfactor(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null;
 		Imperative_factor(out node);
-		while (la.kind == 14 || la.kind == 63 || la.kind == 64) {
+		while (la.kind == 14 || la.kind == 60 || la.kind == 61) {
 			Operator op; 
 			Imperative_bitop(out op);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode; 
@@ -4113,30 +3996,30 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Imperative_mulop(out Operator op) {
 		op = Operator.none; 
-		if (la.kind == 60) {
+		if (la.kind == 57) {
 			Get();
 			op = Operator.mul; 
-		} else if (la.kind == 61) {
+		} else if (la.kind == 58) {
 			Get();
 			op = Operator.div; 
-		} else if (la.kind == 62) {
+		} else if (la.kind == 59) {
 			Get();
 			op = Operator.mod; 
-		} else SynErr(130);
+		} else SynErr(127);
 	}
 
 	void Imperative_bitop(out Operator op) {
 		op = Operator.none; 
-		if (la.kind == 63) {
+		if (la.kind == 60) {
 			Get();
 			op = Operator.bitwiseand; 
 		} else if (la.kind == 14) {
 			Get();
 			op = Operator.bitwiseor; 
-		} else if (la.kind == 64) {
+		} else if (la.kind == 61) {
 			Get();
 			op = Operator.bitwisexor; 
-		} else SynErr(131);
+		} else SynErr(128);
 	}
 
 	void Imperative_Char(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -4217,7 +4100,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			else{
 			   NodeUtils.SetNodeLocation(node, t); }
 			
-		} else SynErr(132);
+		} else SynErr(129);
 	}
 
 	void Imperative_functioncall(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -4230,7 +4113,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode argNode; 
 			Imperative_expr(out argNode);
 			arglist.Add(argNode); 
-			while (la.kind == 49) {
+			while (la.kind == 48) {
 				Get();
 				Imperative_expr(out argNode);
 				arglist.Add(argNode); 
@@ -4248,30 +4131,30 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 
 	void Imperative_PostFixOp(out UnaryOperator op) {
 		op = UnaryOperator.None; 
-		if (la.kind == 68) {
+		if (la.kind == 65) {
 			Get();
 			op = UnaryOperator.Increment; 
-		} else if (la.kind == 69) {
+		} else if (la.kind == 66) {
 			Get();
 			op = UnaryOperator.Decrement; 
-		} else SynErr(133);
+		} else SynErr(130);
 	}
 
 	void Imperative_ExprList(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
-		Expect(47);
+		Expect(46);
 		ProtoCore.AST.ImperativeAST.ExprListNode exprlist = new ProtoCore.AST.ImperativeAST.ExprListNode();
 		NodeUtils.SetNodeStartLocation(exprlist, t);
 		
 		if (StartOf(4)) {
 			Imperative_expr(out node);
 			exprlist.list.Add(node); 
-			while (la.kind == 49) {
+			while (la.kind == 48) {
 				Get();
 				Imperative_expr(out node);
 				exprlist.list.Add(node); 
 			}
 		}
-		Expect(48);
+		Expect(47);
 		NodeUtils.SetNodeEndLocation(exprlist, t);
 		node = exprlist;
 		
@@ -4299,7 +4182,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		NodeUtils.CopyNodeLocation(varDeclNode, tNode);
 		
 		ProtoCore.Type argtype = new ProtoCore.Type(); argtype.Name = "var"; argtype.rank = 0; argtype.UID = 0; 
-		if (la.kind == 51) {
+		if (la.kind == 50) {
 			Get();
 			Expect(1);
 			argtype.Name = t.val; 
@@ -4334,7 +4217,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 	void Imperative_DefaultArgDecl(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		Imperative_ArgDecl(out node);
 		ProtoCore.AST.ImperativeAST.VarDeclNode varDeclNode = node as ProtoCore.AST.ImperativeAST.VarDeclNode; 
-		Expect(50);
+		Expect(49);
 		ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode; 
 		Imperative_expr(out rhsNode);
 		ProtoCore.AST.ImperativeAST.BinaryExpressionNode bNode = new ProtoCore.AST.ImperativeAST.BinaryExpressionNode();
@@ -4385,7 +4268,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			if (NotDefaultArg()) { 
 			Imperative_ArgDecl(out argdecl);
 			args.AddArgument(argdecl as ProtoCore.AST.ImperativeAST.VarDeclNode); 
-			while (la.kind == 49) {
+			while (la.kind == 48) {
 				if (NotDefaultArg()) { 
 				Get();
 				Imperative_ArgDecl(out argdecl);
@@ -4394,13 +4277,13 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 			}
 			} 
 		}
-		if (la.kind == 1 || la.kind == 29 || la.kind == 49) {
-			if (la.kind == 49) {
+		if (la.kind == 1 || la.kind == 29 || la.kind == 48) {
+			if (la.kind == 48) {
 				Get();
 			}
 			Imperative_DefaultArgDecl(out argdecl);
 			args.AddArgument(argdecl as ProtoCore.AST.ImperativeAST.VarDeclNode); 
-			while (la.kind == 49) {
+			while (la.kind == 48) {
 				Get();
 				Imperative_DefaultArgDecl(out argdecl);
 				args.AddArgument(argdecl as ProtoCore.AST.ImperativeAST.VarDeclNode); 
@@ -4428,52 +4311,6 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		Expect(21);
 	}
 
-	void Imperative_TryBlock(out ProtoCore.AST.ImperativeAST.TryBlockNode tryBlockNode) {
-		tryBlockNode = new ProtoCore.AST.ImperativeAST.TryBlockNode(); 
-		Expect(57);
-		Expect(47);
-		List<ProtoCore.AST.ImperativeAST.ImperativeNode> tryBlockBody = null; 
-		Imperative_stmtlist(out tryBlockBody);
-		tryBlockNode.body = tryBlockBody; 
-		Expect(48);
-	}
-
-	void Imperative_CatchFilter(out ProtoCore.AST.ImperativeAST.CatchFilterNode catchFilterNode) {
-		catchFilterNode = new ProtoCore.AST.ImperativeAST.CatchFilterNode(); 
-		Expect(1);
-		if (IsKeyWord(t.val, true))
-		{
-		   errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
-		}
-		
-		catchFilterNode.var =  BuildImperativeIdentifier(t.val);
-		
-		Expect(51);
-		Expect(1);
-		ProtoCore.Type exceptionType = new ProtoCore.Type()
-		{
-		   Name = t.val, 
-		   rank = 0, 
-		};
-		catchFilterNode.type = exceptionType;
-		
-	}
-
-	void Imperative_CatchBlock(out ProtoCore.AST.ImperativeAST.CatchBlockNode catchBlockNode) {
-		Expect(58);
-		catchBlockNode = new ProtoCore.AST.ImperativeAST.CatchBlockNode(); 
-		Expect(10);
-		ProtoCore.AST.ImperativeAST.CatchFilterNode catchFilterNode = null; 
-		Imperative_CatchFilter(out catchFilterNode);
-		catchBlockNode.catchFilter = catchFilterNode; 
-		Expect(11);
-		Expect(47);
-		List<ProtoCore.AST.ImperativeAST.ImperativeNode> catchBlockBody = null; 
-		Imperative_stmtlist(out catchBlockBody);
-		catchBlockNode.body = catchBlockBody; 
-		Expect(48);
-	}
-
 
 
 	public void Parse() {
@@ -4486,30 +4323,30 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 	}
 	
 	static readonly bool[,] set = {
-		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,T,T, x,x,T,T, T,x,T,T, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,T,T, x,x,T,T, T,x,T,T, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, x,x,T,T, T,x,T,T, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,T,T,T, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{T,T,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,T,x,T, T,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,x,T, x,x,x,x, x,x,x,x, x,x,x,T, T,T,T,x, x,T,T,T, T,T,x,x, x,x},
-		{x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,T, T,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,T,T,x, x,T,T,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, T,x,T,T, x,x,T,T, T,T,T,x, x,x,T,T, x,x,T,T, T,x,T,T, T,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, x,x,T,T, T,x,T,T, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,T,x, x,x,T,x, x,T,T,x, x,x,T,T, x,x,T,T, T,x,T,T, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,T,T, x,x,T,T, T,x,T,T, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,T,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,T,x, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,T,x, x,T,T,x, x,x,T,T, x,x,T,T, T,x,T,T, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x},
-		{x,x,x,x, x,x,x,x, x,x,x,x, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x}
+		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,T,T,T, T,T,x,x, x,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,T,T,T, T,T,x,x, x,x,T,x, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
+		{x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
+		{x,T,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,T,T,T, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,T, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
+		{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
+		{T,T,T,T, T,T,x,x, x,x,T,x, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{T,T,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
+		{x,T,T,T, T,T,x,x, x,x,T,x, T,T,x,T, T,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, T,T,T,T, x,x,T,T, T,T,T,x, x,x,x},
+		{x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,T, T,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,T, x,x,T,T, x,x,x,x, x,x,x},
+		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, T,x,T,T, x,x,T,T, T,T,T,x, x,x,T,T, x,x,T,T, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,T,x, x,x,T,x, x,T,T,x, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
+		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
+		{x,T,x,x, x,x,x,x, x,x,T,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
+		{x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,T,x,x, x,x,x,x, x,x,T,x, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,T,x, x,T,T,x, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,x,x,x, x,x,x,x, x,x,x,x, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x}
 
 	};
 } // end Parser
@@ -4571,94 +4408,91 @@ public class Errors {
 			case 43: s = "literal_false expected"; break;
 			case 44: s = "literal_null expected"; break;
 			case 45: s = "replicationguide_postfix expected"; break;
-			case 46: s = "\"throw\" expected"; break;
-			case 47: s = "\"{\" expected"; break;
-			case 48: s = "\"}\" expected"; break;
-			case 49: s = "\",\" expected"; break;
-			case 50: s = "\"=\" expected"; break;
-			case 51: s = "\":\" expected"; break;
-			case 52: s = "\"public\" expected"; break;
-			case 53: s = "\"private\" expected"; break;
-			case 54: s = "\"protected\" expected"; break;
-			case 55: s = "\"=>\" expected"; break;
-			case 56: s = "\"?\" expected"; break;
-			case 57: s = "\"try\" expected"; break;
-			case 58: s = "\"catch\" expected"; break;
-			case 59: s = "\"+\" expected"; break;
-			case 60: s = "\"*\" expected"; break;
-			case 61: s = "\"/\" expected"; break;
-			case 62: s = "\"%\" expected"; break;
-			case 63: s = "\"&\" expected"; break;
-			case 64: s = "\"^\" expected"; break;
-			case 65: s = "\"&&\" expected"; break;
-			case 66: s = "\"||\" expected"; break;
-			case 67: s = "\"~\" expected"; break;
-			case 68: s = "\"++\" expected"; break;
-			case 69: s = "\"--\" expected"; break;
-			case 70: s = "\"#\" expected"; break;
-			case 71: s = "\"in\" expected"; break;
-			case 72: s = "??? expected"; break;
-			case 73: s = "invalid Hydrogen"; break;
-			case 74: s = "this symbol not expected in Import_Statement"; break;
-			case 75: s = "invalid Import_Statement"; break;
-			case 76: s = "this symbol not expected in Associative_Statement"; break;
-			case 77: s = "invalid Associative_Statement"; break;
-			case 78: s = "invalid Associative_functiondecl"; break;
-			case 79: s = "invalid Associative_classdecl"; break;
-			case 80: s = "invalid Associative_classdecl"; break;
-			case 81: s = "this symbol not expected in Associative_NonAssignmentStatement"; break;
-			case 82: s = "this symbol not expected in Associative_FunctionCallStatement"; break;
-			case 83: s = "this symbol not expected in Associative_FunctionalStatement"; break;
-			case 84: s = "this symbol not expected in Associative_FunctionalStatement"; break;
-			case 85: s = "this symbol not expected in Associative_FunctionalStatement"; break;
-			case 86: s = "invalid Associative_FunctionalStatement"; break;
-			case 87: s = "invalid Associative_FunctionalStatement"; break;
+			case 46: s = "\"{\" expected"; break;
+			case 47: s = "\"}\" expected"; break;
+			case 48: s = "\",\" expected"; break;
+			case 49: s = "\"=\" expected"; break;
+			case 50: s = "\":\" expected"; break;
+			case 51: s = "\"public\" expected"; break;
+			case 52: s = "\"private\" expected"; break;
+			case 53: s = "\"protected\" expected"; break;
+			case 54: s = "\"=>\" expected"; break;
+			case 55: s = "\"?\" expected"; break;
+			case 56: s = "\"+\" expected"; break;
+			case 57: s = "\"*\" expected"; break;
+			case 58: s = "\"/\" expected"; break;
+			case 59: s = "\"%\" expected"; break;
+			case 60: s = "\"&\" expected"; break;
+			case 61: s = "\"^\" expected"; break;
+			case 62: s = "\"&&\" expected"; break;
+			case 63: s = "\"||\" expected"; break;
+			case 64: s = "\"~\" expected"; break;
+			case 65: s = "\"++\" expected"; break;
+			case 66: s = "\"--\" expected"; break;
+			case 67: s = "\"#\" expected"; break;
+			case 68: s = "\"in\" expected"; break;
+			case 69: s = "??? expected"; break;
+			case 70: s = "invalid Hydrogen"; break;
+			case 71: s = "this symbol not expected in Import_Statement"; break;
+			case 72: s = "invalid Import_Statement"; break;
+			case 73: s = "this symbol not expected in Associative_Statement"; break;
+			case 74: s = "invalid Associative_Statement"; break;
+			case 75: s = "invalid Associative_functiondecl"; break;
+			case 76: s = "invalid Associative_classdecl"; break;
+			case 77: s = "invalid Associative_classdecl"; break;
+			case 78: s = "this symbol not expected in Associative_NonAssignmentStatement"; break;
+			case 79: s = "this symbol not expected in Associative_FunctionCallStatement"; break;
+			case 80: s = "this symbol not expected in Associative_FunctionalStatement"; break;
+			case 81: s = "this symbol not expected in Associative_FunctionalStatement"; break;
+			case 82: s = "this symbol not expected in Associative_FunctionalStatement"; break;
+			case 83: s = "invalid Associative_FunctionalStatement"; break;
+			case 84: s = "invalid Associative_FunctionalStatement"; break;
+			case 85: s = "invalid Associative_LanguageBlock"; break;
+			case 86: s = "invalid Associative_LanguageBlock"; break;
+			case 87: s = "invalid Associative_LanguageBlock"; break;
 			case 88: s = "invalid Associative_LanguageBlock"; break;
-			case 89: s = "invalid Associative_LanguageBlock"; break;
-			case 90: s = "invalid Associative_LanguageBlock"; break;
-			case 91: s = "invalid Associative_LanguageBlock"; break;
-			case 92: s = "invalid Associative_AccessSpecifier"; break;
-			case 93: s = "invalid Associative_BinaryOps"; break;
-			case 94: s = "invalid Associative_AddOp"; break;
-			case 95: s = "invalid Associative_MulOp"; break;
-			case 96: s = "invalid Associative_ComparisonOp"; break;
-			case 97: s = "invalid Associative_LogicalOp"; break;
-			case 98: s = "invalid Associative_DecoratedIdentifier"; break;
-			case 99: s = "invalid Associative_DecoratedIdentifier"; break;
-			case 100: s = "invalid Associative_UnaryExpression"; break;
-			case 101: s = "invalid Associative_unaryop"; break;
-			case 102: s = "invalid Associative_Factor"; break;
-			case 103: s = "invalid Associative_negop"; break;
-			case 104: s = "invalid Associative_BitOp"; break;
-			case 105: s = "invalid Associative_PostFixOp"; break;
-			case 106: s = "invalid Associative_Number"; break;
-			case 107: s = "invalid Associative_NameReference"; break;
-			case 108: s = "invalid Associative_NameReference"; break;
-			case 109: s = "invalid Associative_NameReference"; break;
-			case 110: s = "invalid Imperative_stmt"; break;
-			case 111: s = "invalid Imperative_functiondecl"; break;
+			case 89: s = "invalid Associative_AccessSpecifier"; break;
+			case 90: s = "invalid Associative_BinaryOps"; break;
+			case 91: s = "invalid Associative_AddOp"; break;
+			case 92: s = "invalid Associative_MulOp"; break;
+			case 93: s = "invalid Associative_ComparisonOp"; break;
+			case 94: s = "invalid Associative_LogicalOp"; break;
+			case 95: s = "invalid Associative_DecoratedIdentifier"; break;
+			case 96: s = "invalid Associative_DecoratedIdentifier"; break;
+			case 97: s = "invalid Associative_UnaryExpression"; break;
+			case 98: s = "invalid Associative_unaryop"; break;
+			case 99: s = "invalid Associative_Factor"; break;
+			case 100: s = "invalid Associative_negop"; break;
+			case 101: s = "invalid Associative_BitOp"; break;
+			case 102: s = "invalid Associative_PostFixOp"; break;
+			case 103: s = "invalid Associative_Number"; break;
+			case 104: s = "invalid Associative_NameReference"; break;
+			case 105: s = "invalid Associative_NameReference"; break;
+			case 106: s = "invalid Associative_NameReference"; break;
+			case 107: s = "invalid Imperative_stmt"; break;
+			case 108: s = "invalid Imperative_functiondecl"; break;
+			case 109: s = "invalid Imperative_languageblock"; break;
+			case 110: s = "invalid Imperative_languageblock"; break;
+			case 111: s = "invalid Imperative_languageblock"; break;
 			case 112: s = "invalid Imperative_languageblock"; break;
-			case 113: s = "invalid Imperative_languageblock"; break;
-			case 114: s = "invalid Imperative_languageblock"; break;
-			case 115: s = "invalid Imperative_languageblock"; break;
-			case 116: s = "invalid Imperative_ifstmt"; break;
-			case 117: s = "invalid Imperative_ifstmt"; break;
-			case 118: s = "invalid Imperative_ifstmt"; break;
-			case 119: s = "invalid Imperative_forloop"; break;
-			case 120: s = "invalid Imperative_assignstmt"; break;
-			case 121: s = "invalid Imperative_assignstmt"; break;
-			case 122: s = "invalid Imperative_decoratedIdentifier"; break;
-			case 123: s = "invalid Imperative_NameReference"; break;
-			case 124: s = "invalid Imperative_unaryexpr"; break;
-			case 125: s = "invalid Imperative_unaryop"; break;
-			case 126: s = "invalid Imperative_factor"; break;
-			case 127: s = "invalid Imperative_logicalop"; break;
-			case 128: s = "invalid Imperative_relop"; break;
-			case 129: s = "invalid Imperative_addop"; break;
-			case 130: s = "invalid Imperative_mulop"; break;
-			case 131: s = "invalid Imperative_bitop"; break;
-			case 132: s = "invalid Imperative_num"; break;
-			case 133: s = "invalid Imperative_PostFixOp"; break;
+			case 113: s = "invalid Imperative_ifstmt"; break;
+			case 114: s = "invalid Imperative_ifstmt"; break;
+			case 115: s = "invalid Imperative_ifstmt"; break;
+			case 116: s = "invalid Imperative_forloop"; break;
+			case 117: s = "invalid Imperative_assignstmt"; break;
+			case 118: s = "invalid Imperative_assignstmt"; break;
+			case 119: s = "invalid Imperative_decoratedIdentifier"; break;
+			case 120: s = "invalid Imperative_NameReference"; break;
+			case 121: s = "invalid Imperative_unaryexpr"; break;
+			case 122: s = "invalid Imperative_unaryop"; break;
+			case 123: s = "invalid Imperative_factor"; break;
+			case 124: s = "invalid Imperative_logicalop"; break;
+			case 125: s = "invalid Imperative_relop"; break;
+			case 126: s = "invalid Imperative_addop"; break;
+			case 127: s = "invalid Imperative_mulop"; break;
+			case 128: s = "invalid Imperative_bitop"; break;
+			case 129: s = "invalid Imperative_num"; break;
+			case 130: s = "invalid Imperative_PostFixOp"; break;
 
 			default: s = "error " + n; break;
 		}

--- a/src/Engine/ProtoCore/Parser/Scanner.cs
+++ b/src/Engine/ProtoCore/Parser/Scanner.cs
@@ -203,8 +203,8 @@ public class UTF8Buffer: Buffer {
 public class Scanner {
 	const char EOL = '\n';
 	const int eofSym = 0; /* pdt */
-	const int maxT = 72;
-	const int noSym = 72;
+	const int maxT = 69;
+	const int noSym = 69;
 
 
 	public Buffer buffer; // scanner buffer
@@ -716,13 +716,10 @@ public class Scanner {
 			case "false": t.kind = 43; break;
 			case "null": t.kind = 44; break;
 			case "L": t.kind = 45; break;
-			case "throw": t.kind = 46; break;
-			case "public": t.kind = 52; break;
-			case "private": t.kind = 53; break;
-			case "protected": t.kind = 54; break;
-			case "try": t.kind = 57; break;
-			case "catch": t.kind = 58; break;
-			case "in": t.kind = 71; break;
+			case "public": t.kind = 51; break;
+			case "private": t.kind = 52; break;
+			case "protected": t.kind = 53; break;
+			case "in": t.kind = 68; break;
 			default: break;
 		}
 	}
@@ -812,15 +809,15 @@ public class Scanner {
 			case 22:
 				{t.kind = 22; break;}
 			case 23:
-				recEnd = pos; recKind = 73;
+				recEnd = pos; recKind = 70;
 				if (ch <= 9 || ch >= 11 && ch <= 65535) {AddCh(); goto case 23;}
-				else {t.kind = 73; break;}
+				else {t.kind = 70; break;}
 			case 24:
 				if (ch <= ')' || ch >= '+' && ch <= 65535) {AddCh(); goto case 24;}
 				else if (ch == '*') {AddCh(); goto case 33;}
 				else {goto case 0;}
 			case 25:
-				{t.kind = 74; break;}
+				{t.kind = 71; break;}
 			case 26:
 				recEnd = pos; recKind = 2;
 				if (ch >= '0' && ch <= '9') {AddCh(); goto case 26;}
@@ -868,35 +865,35 @@ public class Scanner {
 				if (ch == 39) {AddCh(); goto case 11;}
 				else {t.kind = 5; break;}
 			case 36:
-				{t.kind = 47; break;}
+				{t.kind = 46; break;}
 			case 37:
-				{t.kind = 48; break;}
+				{t.kind = 47; break;}
 			case 38:
-				{t.kind = 49; break;}
+				{t.kind = 48; break;}
 			case 39:
-				{t.kind = 51; break;}
+				{t.kind = 50; break;}
 			case 40:
-				{t.kind = 55; break;}
+				{t.kind = 54; break;}
 			case 41:
-				{t.kind = 56; break;}
+				{t.kind = 55; break;}
 			case 42:
-				{t.kind = 60; break;}
+				{t.kind = 57; break;}
 			case 43:
-				{t.kind = 62; break;}
+				{t.kind = 59; break;}
 			case 44:
-				{t.kind = 64; break;}
+				{t.kind = 61; break;}
 			case 45:
-				{t.kind = 65; break;}
+				{t.kind = 62; break;}
 			case 46:
-				{t.kind = 66; break;}
+				{t.kind = 63; break;}
 			case 47:
-				{t.kind = 67; break;}
+				{t.kind = 64; break;}
 			case 48:
-				{t.kind = 68; break;}
+				{t.kind = 65; break;}
 			case 49:
-				{t.kind = 69; break;}
+				{t.kind = 66; break;}
 			case 50:
-				{t.kind = 70; break;}
+				{t.kind = 67; break;}
 			case 51:
 				recEnd = pos; recKind = 13;
 				if (ch == '-') {AddCh(); goto case 49;}
@@ -906,23 +903,23 @@ public class Scanner {
 				if (ch == '|') {AddCh(); goto case 46;}
 				else {t.kind = 14; break;}
 			case 53:
-				recEnd = pos; recKind = 50;
+				recEnd = pos; recKind = 49;
 				if (ch == '=') {AddCh(); goto case 19;}
 				else if (ch == '>') {AddCh(); goto case 40;}
-				else {t.kind = 50; break;}
+				else {t.kind = 49; break;}
 			case 54:
-				recEnd = pos; recKind = 61;
+				recEnd = pos; recKind = 58;
 				if (ch == '/') {AddCh(); goto case 23;}
 				else if (ch == '*') {AddCh(); goto case 24;}
-				else {t.kind = 61; break;}
+				else {t.kind = 58; break;}
 			case 55:
-				recEnd = pos; recKind = 59;
+				recEnd = pos; recKind = 56;
 				if (ch == '+') {AddCh(); goto case 48;}
-				else {t.kind = 59; break;}
+				else {t.kind = 56; break;}
 			case 56:
-				recEnd = pos; recKind = 63;
+				recEnd = pos; recKind = 60;
 				if (ch == '&') {AddCh(); goto case 45;}
-				else {t.kind = 63; break;}
+				else {t.kind = 60; break;}
 
 		}
 		t.val = new String(tval, 0, tlen);

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -173,12 +173,6 @@ Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
     |      
         Associative_LanguageBlock<out node>
     |
-        (. #if ENABLE_EXCEPTION_HANDLING .)
-        Associative_ExceptionBlock<out node>
-    | 
-        (. #endif .)
-        Associative_ThrowStatement<out node>
-    |
         (
             kw_break 
                 (. 
@@ -215,26 +209,6 @@ Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
             )      
         )
 )
-.
-
-Associative_ThrowStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
-=
-                                (. ProtoCore.AST.AssociativeAST.ThrowNode throwNode = new ProtoCore.AST.AssociativeAST.ThrowNode(); .)
-    "throw"
-                                (. ProtoCore.AST.AssociativeAST.AssociativeNode expression; .)
-    Associative_Expression<out expression>
-                                (. throwNode.expression = expression; .)
-                                (. 
-                                    if (la.val != ";")
-                                        SynErr(Resources.SemiColonExpected);  
-                                .)
-        
-                                (. 
-                                    if (la.val != ";")
-                                        SynErr(Resources.SemiColonExpected); 
-                                .)
-    endline
-                                (. node = throwNode; .)
 .
 
 Associative_StatementList<.out List<ProtoCore.AST.AssociativeAST.AssociativeNode> nodelist.> 
@@ -1674,96 +1648,6 @@ Associative_RangeExpr<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 
                                         (. node = rnode; .)
     ]
-.
-//------------------------------------------------------------------------
-/*
-Associative_ForLoop<out ProtoCore.AST.AssociativeAST.AssociativeNode forLoop>
-=                                   (. 
-                                        ProtoCore.AST.AssociativeAST.AssociativeNode node;
-                                        ProtoCore.AST.AssociativeAST.ForLoopNode loop = new ProtoCore.AST.AssociativeAST.ForLoopNode(); 
-                                        List<ProtoCore.AST.AssociativeAST.AssociativeNode> forBody = null; 
-                                    .)
-    "for"                           (. NodeUtils.SetNodeStartLocation(loop, t); .)
-    '('
-        Associative_IdentifierList<out node>        (. loop.loopVar = node; .)
-    "in"
-        Associative_Expression<out node>            (. loop.expression = node; .)
-    ')'
-    '{'
-        Associative_StatementList<out forBody>  (. loop.body = forBody; .)
-    '}'                 
-                                    (.
-                                        NodeUtils.SetNodeEndLocation(loop, t);
-                                        forLoop = loop;
-                                    .)
-.
-*/
-
-Associative_TryBlock<out ProtoCore.AST.AssociativeAST.TryBlockNode tryBlockNode>
-=    
-                                    (. tryBlockNode = new ProtoCore.AST.AssociativeAST.TryBlockNode(); .)
-    "try"
-    '{'
-                                    (. List<ProtoCore.AST.AssociativeAST.AssociativeNode> tryBlockBody = null; .)
-        Associative_StatementList<out tryBlockBody>
-                                    (. tryBlockNode.body = tryBlockBody; .)
-    '}'
-.
-
-Associative_CatchFilter<out ProtoCore.AST.AssociativeAST.CatchFilterNode catchFilterNode>
-=
-                                    (. catchFilterNode = new ProtoCore.AST.AssociativeAST.CatchFilterNode(); .)
-
-    ident                       
-                                    (. 
-                                        if (IsKeyWord(t.val, true))
-                                        {
-                                            errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
-                                        }
-
-                                        catchFilterNode.var =  ProtoCore.Utils.CoreUtils.BuildAssocIdentifier(core, t.val);
-                                    .)  
-    ':'
-    ident                           (. 
-                                        ProtoCore.Type exceptionType = new ProtoCore.Type()
-                                        {
-                                            Name = t.val, 
-                                            rank = 0, 
-                                        };
-                                        catchFilterNode.type = exceptionType;
-                                    .)
-.
-
-Associative_CatchBlock<out ProtoCore.AST.AssociativeAST.CatchBlockNode catchBlockNode>
-=    
-    "catch"                         (. catchBlockNode = new ProtoCore.AST.AssociativeAST.CatchBlockNode(); .)
-    "("
-                                    (. ProtoCore.AST.AssociativeAST.CatchFilterNode catchFilterNode = null; .)
-        Associative_CatchFilter<out catchFilterNode>
-                                    (. catchBlockNode.catchFilter = catchFilterNode; .)  
-    ")"
-    '{'
-                                    (. List<ProtoCore.AST.AssociativeAST.AssociativeNode> catchBlockBody = null; .)
-        Associative_StatementList<out catchBlockBody>
-                                    (. catchBlockNode.body = catchBlockBody; .)
-    '}'
-.
-
-Associative_ExceptionBlock<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
-=
-                                    (. ProtoCore.AST.AssociativeAST.ExceptionHandlingNode exceptionNode = new ProtoCore.AST.AssociativeAST.ExceptionHandlingNode(); .)
-                                    (. ProtoCore.AST.AssociativeAST.TryBlockNode tryBlockNode; .)
-    Associative_TryBlock<out tryBlockNode>
-                                    (. exceptionNode.tryBlock = tryBlockNode; .)
-                                    (. ProtoCore.AST.AssociativeAST.CatchBlockNode catchBlockNode; .)
-    Associative_CatchBlock<out catchBlockNode>
-                                    (. exceptionNode.catchBlocks.Add(catchBlockNode); .)
-    {
-        Associative_CatchBlock<out catchBlockNode>
-                                    (. exceptionNode.catchBlocks.Add(catchBlockNode); .)
-    }
-    
-                                    (. node = exceptionNode; .)
 .
 
 //------------------------------------------------------------------------

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -137,12 +137,6 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
         |
         Imperative_languageblock<out node>      
         |
-        Imperative_ThrowStatement<out node>
-        (. #if ENABLE_EXCEPTION_HANDLING .)
-        |
-        Imperative_ExceptionBlock<out node>
-        (. #endif .)
-        |
         (
             kw_break 
             (.
@@ -182,21 +176,6 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
             endline 
         )
     )   
-.
-
-Imperative_ThrowStatement<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
-=
-                                (. ProtoCore.AST.ImperativeAST.ThrowNode throwNode = new ProtoCore.AST.ImperativeAST.ThrowNode(); .)
-    "throw"
-                                (. ProtoCore.AST.ImperativeAST.ImperativeNode expression; .)
-    Imperative_expr<out expression>
-                                (. throwNode.expression = expression; .)
-                                (.
-                                    if (la.kind != _endline)
-                                       SynErr(Resources.SemiColonExpected);
-                                .)
-    endline
-                                (. node = throwNode; .)
 .
 
 Imperative_stmtlist<.out List<ProtoCore.AST.ImperativeAST.ImperativeNode> nodelist.> 
@@ -1323,73 +1302,6 @@ Imperative_num<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                 NodeUtils.SetNodeLocation(node, t); }
         .)
     )
-.
-
-Imperative_TryBlock<out ProtoCore.AST.ImperativeAST.TryBlockNode tryBlockNode>
-=    
-                                    (. tryBlockNode = new ProtoCore.AST.ImperativeAST.TryBlockNode(); .)
-    "try"
-    '{'
-                                    (. List<ProtoCore.AST.ImperativeAST.ImperativeNode> tryBlockBody = null; .)
-        Imperative_stmtlist<out tryBlockBody>
-                                    (. tryBlockNode.body = tryBlockBody; .)
-    '}'
-.
-
-Imperative_CatchFilter<out ProtoCore.AST.ImperativeAST.CatchFilterNode catchFilterNode>
-=
-                                    (. catchFilterNode = new ProtoCore.AST.ImperativeAST.CatchFilterNode(); .)
-
-    ident                       
-                                    (. 
-                                        if (IsKeyWord(t.val, true))
-                                        {
-                                            errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
-                                        }
-
-                                        catchFilterNode.var =  BuildImperativeIdentifier(t.val);
-                                    .)  
-    ':'
-    ident                           (. 
-                                        ProtoCore.Type exceptionType = new ProtoCore.Type()
-                                        {
-                                            Name = t.val, 
-                                            rank = 0, 
-                                        };
-                                        catchFilterNode.type = exceptionType;
-                                    .)
-.
-
-Imperative_CatchBlock<out ProtoCore.AST.ImperativeAST.CatchBlockNode catchBlockNode>
-=    
-    "catch"                         (. catchBlockNode = new ProtoCore.AST.ImperativeAST.CatchBlockNode(); .)
-    "("
-                                    (. ProtoCore.AST.ImperativeAST.CatchFilterNode catchFilterNode = null; .)
-        Imperative_CatchFilter<out catchFilterNode>
-                                    (. catchBlockNode.catchFilter = catchFilterNode; .)  
-    ")"
-    '{'
-                                    (. List<ProtoCore.AST.ImperativeAST.ImperativeNode> catchBlockBody = null; .)
-        Imperative_stmtlist<out catchBlockBody>
-                                    (. catchBlockNode.body = catchBlockBody; .)
-    '}'
-.
-
-Imperative_ExceptionBlock<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
-=
-                                    (. ProtoCore.AST.ImperativeAST.ExceptionHandlingNode exceptionNode = new ProtoCore.AST.ImperativeAST.ExceptionHandlingNode(); .)
-                                    (. ProtoCore.AST.ImperativeAST.TryBlockNode tryBlockNode; .)
-    Imperative_TryBlock<out tryBlockNode>
-                                    (. exceptionNode.tryBlock = tryBlockNode; .)
-                                    (. ProtoCore.AST.ImperativeAST.CatchBlockNode catchBlockNode; .)
-    Imperative_CatchBlock<out catchBlockNode>
-                                    (. exceptionNode.catchBlocks.Add(catchBlockNode); .)
-    {
-        Imperative_CatchBlock<out catchBlockNode>
-                                    (. exceptionNode.catchBlocks.Add(catchBlockNode); .)
-    }
-    
-                                    (. node = exceptionNode; .)
 .
 
 Imperative_mulop<out Operator op>       

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -1259,10 +1259,6 @@ namespace ProtoImperative
                 //Validity.Assert(codeBlock.children[codeBlock.children.Count - 1].blockType == ProtoCore.DSASM.CodeBlockType.kLanguage);
                 codeBlock.children[codeBlock.children.Count - 1].Attributes = PopulateAttributes(langblock.Attributes);
 
-#if ENABLE_EXCEPTION_HANDLING
-                core.ExceptionHandlingManager.Register(blockId, globalProcIndex, globalClassIndex);
-#endif
-
                 EmitInstrConsole("bounce " + blockId + ", " + entry.ToString());
                 EmitBounceIntrinsic(blockId, entry);
 
@@ -1359,9 +1355,6 @@ namespace ProtoImperative
                     // The first node in the top level block is a function
                     core.DSExecutable.isSingleAssocBlock = false;
                 }
-#if ENABLE_EXCEPTION_HANDLING
-                core.ExceptionHandlingManager.Register(codeBlock.codeBlockId, globalProcIndex, globalClassIndex);
-#endif
             }
             else if (parseGlobalFunctionBody)
             {
@@ -2922,127 +2915,6 @@ namespace ProtoImperative
             }
         }
 
-        protected void EmitExceptionHandlingNode(ProtoCore.AST.Node node, ProtoCore.AssociativeGraph.GraphNode graphNode = null, ProtoCore.CompilerDefinitions.Associative.SubCompilePass subPass = ProtoCore.CompilerDefinitions.Associative.SubCompilePass.kNone)
-        {
-#if ENABLE_EXCEPTION_HANDLING
-            if (!IsParsingGlobal() && !IsParsingGlobalFunctionBody())
-            {
-                return;
-            }
-
-            ExceptionHandlingNode exceptionNode = node as ExceptionHandlingNode;
-            if (exceptionNode == null)
-                return;
-
-            tryLevel++;
-            ExceptionHandler exceptionHandler = new ExceptionHandler();
-            exceptionHandler.TryLevel = tryLevel;
-
-            ExceptionRegistration registration = core.ExceptionHandlingManager.Register(codeBlock.codeBlockId, globalProcIndex, globalClassIndex);
-            registration.Add(exceptionHandler);
-
-            exceptionHandler.StartPc = pc;
-            TryBlockNode tryNode = exceptionNode.tryBlock;
-            Validity.Assert(tryNode != null);
-            foreach (var subnode in tryNode.body)
-            {
-                ProtoCore.Type inferedType = new ProtoCore.Type();
-                inferedType.UID = (int)ProtoCore.PrimitiveType.kTypeVar;
-                inferedType.IsIndexable = false;
-                DfsTraverse(subnode, ref inferedType, false, graphNode, subPass);
-            }
-            exceptionHandler.EndPc = pc;
-
-            // Jmp to code after catch block
-            BackpatchTable backpatchTable = new BackpatchTable();
-            backpatchTable.Append(pc);
-            EmitJmp(ProtoCore.DSASM.Constants.kInvalidIndex);
-
-            foreach (var catchBlock in exceptionNode.catchBlocks)
-            {
-                CatchHandler catchHandler = new CatchHandler();
-                exceptionHandler.AddCatchHandler(catchHandler);
-
-                CatchFilterNode filterNode = catchBlock.catchFilter;
-                Validity.Assert(filterNode != null);
-                catchHandler.FilterTypeUID = core.TypeSystem.GetType(filterNode.type.Name);
-                if (catchHandler.FilterTypeUID == (int)PrimitiveType.kInvalidType)
-                {
-                    string message = String.Format(ProtoCore.Properties.Resources.kExceptionTypeUndefined, filterNode.type.Name);
-                    buildStatus.LogWarning(ProtoCore.BuildData.WarningID.kTypeUndefined, message, null, filterNode.line, filterNode.col);
-                    catchHandler.FilterTypeUID = (int)PrimitiveType.kTypeVar;
-                }
-
-                // For filter expression catch(e:int), generate an assignment
-                //    e = LX;
-                catchHandler.Entry = pc;
-
-                EmitInstrConsole(ProtoCore.DSASM.kw.push, ProtoCore.DSASM.kw.regLX);
-                StackValue opLx = StackValue.BuildRegister(Registers.LX);
-                EmitPush(opLx);
-
-                ProtoCore.DSASM.SymbolNode excpVarSymbol = null;
-                bool stub;
-                bool isAllocated = VerifyAllocation(filterNode.var.Value, globalClassIndex, globalProcIndex, out excpVarSymbol, out stub);
-                int runtimeIndex = (!isAllocated) ? codeBlock.symbolTable.runtimeIndex : excpVarSymbol.runtimeTableIndex;
-                if (!isAllocated)
-                {
-                    excpVarSymbol = Allocate(filterNode.var.Value, globalProcIndex, new ProtoCore.Type());
-                }
-                EmitPushVarData(runtimeIndex, 0, (int)PrimitiveType.kTypeVar, 0);
-                EmitInstrConsole(ProtoCore.DSASM.kw.pop, filterNode.var.Value);
-                EmitPopForSymbol(excpVarSymbol, filterNode.var.line, filterNode.var.col, filterNode.var.endLine, filterNode.var.endCol);
-
-                ProtoCore.Type inferedType = new ProtoCore.Type();
-                inferedType.UID = (int)ProtoCore.PrimitiveType.kTypeVar;
-                inferedType.IsIndexable = false;
-                
-                foreach (var subnode in catchBlock.body)
-                {
-                    inferedType.UID = (int)ProtoCore.PrimitiveType.kTypeVar;
-                    inferedType.IsIndexable = false;
-                    DfsTraverse(subnode, ref inferedType, false, graphNode, subPass);
-                }
-
-                // Jmp to code after catch block
-                backpatchTable.Append(pc);
-                EmitJmp(ProtoCore.DSASM.Constants.kInvalidIndex);
-            }
-
-            Backpatch(backpatchTable.backpatchList, pc);
-
-            tryLevel--;
-#endif
-        }
-
-        protected void EmitThrowNode(ProtoCore.AST.Node node, ProtoCore.AssociativeGraph.GraphNode graphNode = null, ProtoCore.CompilerDefinitions.Associative.SubCompilePass subPass = ProtoCore.CompilerDefinitions.Associative.SubCompilePass.kNone)
-        {
-#if ENABLE_EXCEPTION_HANDLING
-            if (!IsParsingGlobal() && !IsParsingGlobalFunctionBody())
-            {
-                return;
-            }
-
-            ThrowNode throwNode = node as ThrowNode;
-            if (throwNode == null)
-            {
-                return;
-            }
-
-            ProtoCore.Type inferedType = new ProtoCore.Type();
-            inferedType.UID = (int)ProtoCore.PrimitiveType.kTypeVar;
-            inferedType.IsIndexable = false;
-            DfsTraverse(throwNode.expression, ref inferedType, false, graphNode, subPass);
-
-            EmitInstrConsole(ProtoCore.DSASM.kw.pop, ProtoCore.DSASM.kw.regLX);
-            StackValue opLx = StackValue.BuildRegister(Registers.LX);
-            EmitPop(opLx, Constants.kGlobalScope);
-
-            EmitInstrConsole(ProtoCore.DSASM.kw.throwexception);
-            EmitThrow();
-#endif
-        }
-
         // what we are going to do here is go through the identifier list node,
         // and for each identifier node we convert it to a getter. Say:
         // 
@@ -3523,14 +3395,6 @@ namespace ProtoImperative
             else if (node is DefaultArgNode)
             {
                 EmitDefaultArgNode();
-            }
-            else if (node is ExceptionHandlingNode)
-            {
-                EmitExceptionHandlingNode(node);
-            }
-            else if (node is ThrowNode)
-            {
-                EmitThrowNode(node);
             }
             else if (node is GroupExpressionNode)
             {


### PR DESCRIPTION
Exception handling in the language was just half baked feature: it was never enabled nor ever worked properly in some cases like stack unwinding for replicated function call. This PR completely removes it from the core language. 

As all code path are disabled by a compilation flag `ENABLE_EXCEPTION_HANDLING`. this PR shouldn't have any impact on Dynamo. 

@lukechurch / @junmendoza PTAL. 