### PR TITLE
MAGN-6937 Curves draw black when all components are 255 with ColoredGeometry.

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -966,11 +966,6 @@ namespace Dynamo.Controls
                             1);
                     }
 
-                    if (startColor == Color.White)
-                    {
-                        startColor = Color.Black;
-                    }
-
                     // Line segments are represented as a 
                     // start point and an end point. Except
                     // where we are starting the curve or ending it,


### PR DESCRIPTION
This PR fixes [MAGN-6937](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6937) by removing a legacy check which forced lines to render as black even if their package's color components were black.

PTAL:
@pboyer 

![image](https://cloud.githubusercontent.com/assets/1139788/7121628/b2e43b54-e1ca-11e4-95ee-2f3d8d384675.png)
