### PR TITLE
Fix crash when loading .dyn file with custom node in run auto mode

### DIFF
--- a/src/DynamoCore/DSEngine/EngineController.cs
+++ b/src/DynamoCore/DSEngine/EngineController.cs
@@ -38,8 +38,6 @@ namespace Dynamo.DSEngine
         private readonly SyncDataManager syncDataManager;
         private readonly Queue<GraphSyncData> graphSyncDataQueue = new Queue<GraphSyncData>();
         private readonly Queue<List<Guid>> previewGraphQueue = new Queue<List<Guid>>();
-        private readonly DynamoModel dynamoModel;
-        private readonly ProtoCore.Core libraryCore;
         private int shortVarCounter;
         public bool VerboseLogging;
         private readonly Object macroMutex = new Object();

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -680,7 +680,7 @@ namespace Dynamo.Models
                     }
                 };
             };
-            CustomNodeManager.DefinitionUpdated += RegisterCustomNodeDefinitionWithEngine;
+            CustomNodeManager.DefinitionUpdated += UpdateCustomNodeDefinition;
         }
 
         private void InitializeIncludedNodes()
@@ -880,6 +880,17 @@ namespace Dynamo.Models
         #region engine management
 
         /// <summary>
+        ///     Register custom node defintion and execute all custom node 
+        ///     instances.
+        /// </summary>
+        /// <param name="?"></param>
+        private void UpdateCustomNodeDefinition(CustomNodeDefinition definition)
+        {
+            RegisterCustomNodeDefinitionWithEngine(definition);
+            MarkAllDependenciesAsModified(definition);
+        }
+
+        /// <summary>
         ///     Registers (or re-registers) a Custom Node definition with the DesignScript VM,
         ///     so that instances of the custom node can be evaluated.
         /// </summary>
@@ -890,8 +901,6 @@ namespace Dynamo.Models
                 Workspaces.OfType<HomeWorkspaceModel>().SelectMany(ws => ws.Nodes),
                 definition,
                 DebugSettings.VerboseLogging);
-
-            MarkAllDependenciesAsModified(definition);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes defect [MAGN 7073 Any dy file with any custom node crashes in run auto mode](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7073).

This is because of inconsistent state `EngineController` of `HomeWorkspaceModel` and `DynamoModel`. When a .dyn file is loaded, 
  1. A `HomeWorkspaceModel` will be created, and its `EngineController` will be set to `DynamoModel`'s `EngineController`.
  2. `DynamoModel.RestEngine()` is called, `EngineController` is disposed and a new `EngineController` will be created. At this moment, the `EngineController` in `HomeWorkspaceModel` is invalid.
  3. `DynamoModel` will register all custom node definitions, which consequently will mark all custom node instances as dirty and trigger run for `HomeWorkspaceModel`. As `EngineController` in `HomeWorkspaceModel` is invalid, Dynamo crashes.
  4. `DynamoModel` sets `HomeWorkspaceModel`'s `EngineController` to the correct one. But it is too late.

Ideally `HomeWorkspaceModel` should use `DynamoModel`'s `EngineController` instead of keeping its own copy, but @Benglin  points out that `HomeWorkspaceModel` shouldn't keep a reference to `DynamoModel`. 

But it is not necessary to mark all custom node instances as dirty in resetting `EngineController`. The reason is, `EngineController` will be reset if a new .dyn file is loaded, in which case .dyn file will be executed eventually, or a new library is loaded, in which case it shouldn't have any change on the existing custom node instances, so here `RegisterCustomNodeDefinitionWithEngine()` only does registration work and a new function `UpdateCustomNodeDefinition()` is created for registration and updating instances, the latter is used by `CustomNodeWorkspaceModel`.

@Benglin, @ikeough  please help to review the change. 
