### PR TITLE
merge markGraphnodesDirty and markGraphNodeDirty

### DIFF
--- a/src/Engine/ProtoCore/AssociativeGraph.cs
+++ b/src/Engine/ProtoCore/AssociativeGraph.cs
@@ -490,33 +490,6 @@ namespace ProtoCore.AssociativeEngine
 
        
 
-        /// <summary>
-        /// Marks a graphnode dirty and returns the graphnode
-        /// </summary>
-        /// <param name="runtimeCore"></param>
-        /// <param name="astID"></param>
-        /// <returns></returns>
-        public static AssociativeGraph.GraphNode MarkGraphNodeDirty(RuntimeCore runtimeCore, int astID)
-        {
-            Executable exe = runtimeCore.DSExecutable;
-            List<AssociativeGraph.GraphNode> nodesInScope = 
-                exe.instrStreamList[0].dependencyGraph.GetGraphNodesAtScope(Constants.kInvalidIndex, Constants.kGlobalScope);
-            foreach (var gnode in nodesInScope)
-            {
-                if (gnode.isActive && gnode.OriginalAstID == astID)
-                {
-                    gnode.isDirty = true;
-                    gnode.isActive = true;
-
-                    if (gnode.updateBlock.updateRegisterStartPC != Constants.kInvalidIndex)
-                    {
-                        gnode.updateBlock.startpc = gnode.updateBlock.updateRegisterStartPC;
-                    }
-                    return gnode;
-                }
-            }
-            return null;
-        }
 
         /// <summary>
         ///  Finds all graphnodes associated with each AST and marks them dirty. Returns the first dirty node
@@ -524,7 +497,7 @@ namespace ProtoCore.AssociativeEngine
         /// <param name="core"></param>
         /// <param name="nodeList"></param>
         /// <returns></returns>
-        public static AssociativeGraph.GraphNode MarkGraphNodesDirty(Core core, IEnumerable<AST.AssociativeAST.AssociativeNode> nodeList)
+        public static AssociativeGraph.GraphNode MarkGraphNodesDirty(RuntimeCore core, IEnumerable<AST.AssociativeAST.AssociativeNode> nodeList)
         {
             if (nodeList == null)
             {
@@ -540,16 +513,21 @@ namespace ProtoCore.AssociativeEngine
                     continue;
                 }
 
-                foreach (var gnode in core.DSExecutable.instrStreamList[0].dependencyGraph.GraphList)
+                foreach (var gnode in core.DSExecutable.instrStreamList[0].dependencyGraph.GetGraphNodesAtScope(Constants.kInvalidIndex, Constants.kGlobalScope))
                 {
                     if (gnode.isActive && gnode.OriginalAstID == bNode.OriginalAstID)
                     {
+                        
+                        gnode.isDirty = true;
+                        gnode.isActive = true;
+                        if (gnode.updateBlock.updateRegisterStartPC != Constants.kInvalidIndex)
+                        {
+                            gnode.updateBlock.startpc = gnode.updateBlock.updateRegisterStartPC;
+                        }
                         if (firstDirtyNode == null)
                         {
                             firstDirtyNode = gnode;
                         }
-                        gnode.isDirty = true;
-                        gnode.isActive = true;
                     }
                 }
             }

--- a/src/Engine/ProtoCore/AssociativeGraph.cs
+++ b/src/Engine/ProtoCore/AssociativeGraph.cs
@@ -497,7 +497,8 @@ namespace ProtoCore.AssociativeEngine
         /// <param name="core"></param>
         /// <param name="nodeList"></param>
         /// <returns></returns>
-        public static AssociativeGraph.GraphNode MarkGraphNodesDirty(RuntimeCore core, IEnumerable<AST.AssociativeAST.AssociativeNode> nodeList)
+        public static AssociativeGraph.GraphNode MarkGraphNodesDirtyAtGlobalScope
+(RuntimeCore core, IEnumerable<AST.AssociativeAST.AssociativeNode> nodeList)
         {
             if (nodeList == null)
             {

--- a/src/Engine/ProtoCore/RuntimeCore.cs
+++ b/src/Engine/ProtoCore/RuntimeCore.cs
@@ -331,7 +331,8 @@ namespace ProtoCore
         public int SetValue(List<AssociativeNode> modifiedNodes, StackValue sv)
         {
             ExecutionInstance.CurrentDSASMExec.SetAssociativeUpdateRegister(sv);
-            AssociativeGraph.GraphNode gnode =  ProtoCore.AssociativeEngine.Utils.MarkGraphNodesDirty(this, modifiedNodes);
+            AssociativeGraph.GraphNode gnode = ProtoCore.AssociativeEngine.Utils.MarkGraphNodesDirtyAtGlobalScope
+(this, modifiedNodes);
             Validity.Assert(gnode != null);
             return gnode.updateBlock.startpc;
         }

--- a/src/Engine/ProtoCore/RuntimeCore.cs
+++ b/src/Engine/ProtoCore/RuntimeCore.cs
@@ -328,10 +328,10 @@ namespace ProtoCore
         /// <param name="astID"></param>
         /// <param name="sv"></param>
         /// <returns></returns>
-        public int SetValue(int astID, StackValue sv)
+        public int SetValue(List<AssociativeNode> modifiedNodes, StackValue sv)
         {
             ExecutionInstance.CurrentDSASMExec.SetAssociativeUpdateRegister(sv);
-            AssociativeGraph.GraphNode gnode =  ProtoCore.AssociativeEngine.Utils.MarkGraphNodeDirty(this, astID);
+            AssociativeGraph.GraphNode gnode =  ProtoCore.AssociativeEngine.Utils.MarkGraphNodesDirty(this, modifiedNodes);
             Validity.Assert(gnode != null);
             return gnode.updateBlock.startpc;
         }

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -172,7 +172,8 @@ namespace ProtoScript.Runners
             if (changeSet.ForceExecuteASTList.Count > 0)
             {
                 // Mark all graphnodes dirty which are associated with the force exec ASTs
-                ProtoCore.AssociativeGraph.GraphNode firstDirtyNode = ProtoCore.AssociativeEngine.Utils.MarkGraphNodesDirty(runtimeCore, changeSet.ForceExecuteASTList);
+                ProtoCore.AssociativeGraph.GraphNode firstDirtyNode = ProtoCore.AssociativeEngine.Utils.MarkGraphNodesDirtyAtGlobalScope
+(runtimeCore, changeSet.ForceExecuteASTList);
                 Validity.Assert(firstDirtyNode != null);
 
                 // If the only ASTs to execute are force exec, then set the entrypoint here.

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -172,7 +172,7 @@ namespace ProtoScript.Runners
             if (changeSet.ForceExecuteASTList.Count > 0)
             {
                 // Mark all graphnodes dirty which are associated with the force exec ASTs
-                ProtoCore.AssociativeGraph.GraphNode firstDirtyNode = ProtoCore.AssociativeEngine.Utils.MarkGraphNodesDirty(core, changeSet.ForceExecuteASTList);
+                ProtoCore.AssociativeGraph.GraphNode firstDirtyNode = ProtoCore.AssociativeEngine.Utils.MarkGraphNodesDirty(runtimeCore, changeSet.ForceExecuteASTList);
                 Validity.Assert(firstDirtyNode != null);
 
                 // If the only ASTs to execute are force exec, then set the entrypoint here.
@@ -226,7 +226,7 @@ namespace ProtoScript.Runners
                 AssociativeNode node = modifiedNodes[0];
 
                 StackValue sv = GetStackValueForRuntime(node);
-                int startPC = runtimeCore.SetValue((node as BinaryExpressionNode).OriginalAstID, sv);
+                int startPC = runtimeCore.SetValue(modifiedNodes, sv);
                 Validity.Assert(startPC != Constants.kInvalidIndex);
                 runtimeCore.SetStartPC(startPC);
             }


### PR DESCRIPTION
@junmendoza  
please help to review it thank you very much ~~~

MarkGraphNodeDirty method is deleted.
Only MarGraphNodesDirty is used

The relevant task is here http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6966