### PR TITLE
MAGN-7076 Geometry (Curves) are not at all visible in background preview with default White color.

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
@@ -182,6 +182,20 @@ namespace Dynamo.Core.Threading
                             geom.Dispose();
                         }
                     }
+
+                    // The default color coming from the geometry library for
+                    // curves is 255,255,255,255 (White). Because we want a default
+                    // color of 0,0,0,255 (Black), we adjust the color components here.
+                    var packageCurve = graphicItem as Curve;
+                    if (packageCurve != null)
+                    {
+                        for (var i = 0; i < package.LineStripVertexColors.Count; i += 4)
+                        {
+                            package.LineStripVertexColors[i] = 0;
+                            package.LineStripVertexColors[i + 1] = 0;
+                            package.LineStripVertexColors[i + 2] = 0;
+                        }
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
This PR addresses [MAGN-7076](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7076), by converting curve vertex color components to black during render package update.

As seen in the image below, the default curve color of black is now supported (on the right) as well as the display colors on curve (on the left).

PTAL:
@ramramps 

![image](https://cloud.githubusercontent.com/assets/1139788/7144634/b58511d6-e29b-11e4-81bf-63d721e5bf35.png)
