### PR TITLE
MAGN-6914 Rotate/Pan buttons not working in 3D.

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1306,34 +1306,6 @@ namespace Dynamo.Controls
         }
     }
 
-    public class BackgroundPreviewGestureConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            // When "DynamoViewModel.CanNavigateBackground" is set to "true" 
-            // (i.e. background 3D navigation is turned on), and "IsOrbiting"
-            // is "true", then left mouse dragging will be orbiting the 3D view. 
-            // Otherwise left clicking will do nothing to the view (same is 
-            // applicable to "IsPanning" property).
-            // 
-            if ((parameter as string).Equals("IsPanning"))
-            {
-                bool isPanning = ((bool)value);
-                return new MouseGesture(isPanning ? MouseAction.LeftClick : MouseAction.MiddleClick);
-            }
-            else
-            {
-                bool isOrbiting = ((bool)value);
-                return new MouseGesture(isOrbiting ? MouseAction.LeftClick : MouseAction.None);
-            }
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
     public class LacingToVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -111,7 +111,6 @@
     <controls:InverseBooleanToVisibilityCollapsedConverter x:Key="InverseBoolToVisibilityCollapsedConverter" />
     <controls:NavigationToOpacityConverter x:Key="NavigationToOpacityConverter" />
     <controls:ViewButtonClipRectConverter x:Key="ViewButtonClipRectConverter" />
-    <controls:BackgroundPreviewGestureConverter x:Key="BackgroundPreviewGestureConverter" />
     <controls:ZoomToVisibilityConverter x:Key="ZoomToVisibilityConverter" />
     <controls:ZoomToBooleanConverter x:Key="ZoomToBooleanConverter" />
     <controls:PortNameToWidthConverter x:Key="PortNameToWidthConverter" />

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml
@@ -108,7 +108,18 @@
             IsChangeFieldOfViewEnabled="False" 
             SpinReleaseTime="0" 
             ShowFieldOfView="False">
-
+            <hx:Viewport3DX.InputBindings>
+                <KeyBinding Command="hx:ViewportCommands.ZoomExtents" Gesture="Ctrl+E"/>
+                <MouseBinding Command="hx:ViewportCommands.ZoomExtents" Gesture="Ctrl+LeftDoubleClick"/>
+                <MouseBinding Command="hx:ViewportCommands.Rotate" MouseAction="RightClick"/>
+                <MouseBinding Command="hx:ViewportCommands.Pan" MouseAction="MiddleClick"/>
+                <MouseBinding Command="hx:ViewportCommands.Zoom" Gesture="Ctrl+RightClick"/>
+                <MouseBinding Command="hx:ViewportCommands.ChangeFieldOfView" Gesture="Alt+RightClick"/>
+                <MouseBinding Command="hx:ViewportCommands.ZoomRectangle" Gesture="Ctrl+Shift+RightClick"/>
+                <MouseBinding Command="hx:ViewportCommands.SetTarget" Gesture="Ctrl+RightDoubleClick"/>
+                <MouseBinding Command="hx:ViewportCommands.Reset" Gesture="Ctrl+MiddleDoubleClick"/>
+                <MouseBinding Command="{Binding LeftClickCommand}" Gesture="LeftClick"/>
+            </hx:Viewport3DX.InputBindings>
             <hx:ShadowMap3D x:Name="shadowMap" Resolution="{Binding ShadowMapResolution}" />
             <hx:AmbientLight3D Color="{Binding AmbientLightColor}"/>
             <hx:DirectionalLight3D Name="key" Color="{Binding DirectionalLightColor}" Direction = "{Binding DirectionalLightDirection}"/>


### PR DESCRIPTION
This PR addresses [MAGN-6914](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6914). The Rotate and Pan buttons in the background preview should allow the orbiting or the panning of the view respectively, when the user drags in the viewport with the left mouse button pressed. When converting from the `Helix3DViewer` component to the `Viewport3DX` component, these gestures were not re-implemented.

The original `Helix3DViewer` used gestures set with bindings like so:
```xml
<HelixToolkit:HelixViewport3D.PanGesture2>
                <Binding Path="DataContext.IsPanning"
                         Mode="OneWay"
                         RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}"
                         Converter="{StaticResource BackgroundPreviewGestureConverter}"
                         ConverterParameter="IsPanning" />
            </HelixToolkit:HelixViewport3D.PanGesture2>
```
The new `Viewport3DX` control does not have exposed, bind-able gestures. But, you can create `MouseBinding` objects. To enable conditional panning or rotating, we add a `MouseBinding` whose `Command` property is bound to the `LeftClickCommand` on our data context, like this: 
```xml
<MouseBinding Command="{Binding LeftClickCommand}" Gesture="LeftClick"/>
```

This PR also moves the creation of the `MouseBinding` objects from the code-behind to the xaml, for brevity.

PTAL:
@pboyer 
We then swap the command returned by this property whenever the `IsPanning` or `IsOrbiting` properties are set on the view model.