### PR TITLE
Improvements to Graph Annotation

### DIFF
--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -277,7 +277,26 @@ namespace Dynamo.Models
               
         #region Serialization/Deserialization Methods
 
-        protected override void SerializeCore(XmlElement element, SaveContext context)
+        protected override bool UpdateValueCore(UpdateValueParams updateValueParams)
+        {
+            string name = updateValueParams.PropertyName;
+            string value = updateValueParams.PropertyValue;
+
+            switch (name)
+            {
+                case "FSize":
+                    FontSize = Convert.ToDouble(value);
+                    break;
+                case "Background":
+                    Background = value;
+                    break;                    
+            }
+
+            return base.UpdateValueCore(updateValueParams);
+        }
+
+        protected override
+             void SerializeCore(XmlElement element, SaveContext context)
         {            
             XmlElementHelper helper = new XmlElementHelper(element);
             helper.SetAttribute("guid", this.GUID);
@@ -335,6 +354,9 @@ namespace Dynamo.Models
                 }
                 selectedModels = listOfModels;        
             }
+
+            RaisePropertyChanged("Background");
+            RaisePropertyChanged("FontSize");
           
         }
 

--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -240,13 +240,19 @@ namespace Dynamo.Models
                         if (overlap.Rect.Top < this.X ||
                                     overlap.Rect.Bottom > region.Bottom) //Overlap in height - increase the region height
                         {
-                            this.Height += overlap.Rect.Bottom - region.Bottom + 10;
+                            if (overlap.Rect.Bottom - region.Bottom > 0)
+                            {
+                                this.Height += overlap.Rect.Bottom - region.Bottom + 10;
+                            }
                             region.Height = this.Height;
                         }
                         if (overlap.Rect.Left < this.Y ||
                                 overlap.Rect.Right > region.Right) //Overlap in width - increase the region width
                         {
-                            this.Width += overlap.Rect.Right - region.Right + 10;
+                            if (overlap.Rect.Right - region.Right > 0)
+                            {
+                                this.Width += overlap.Rect.Right - region.Right + 10;
+                            }
                             region.Width = this.Width;
                         }
                     }

--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -314,7 +314,7 @@ namespace Dynamo.Models
             this.Y = helper.ReadDouble("top", doubleValue);
             this.width = helper.ReadDouble("width", doubleValue);
             this.height = helper.ReadDouble("height", doubleValue);
-            this.background = helper.ReadString("backgrouund", "");
+            this.Background = helper.ReadString("backgrouund", "");
             this.fontSize = helper.ReadDouble("fontSize", fontSize);
             this.textBlockHeight = helper.ReadDouble("TextblockHeight", doubleValue);
             this.InitialTop = helper.ReadDouble("InitialTop", doubleValue);

--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -3,6 +3,7 @@ using System;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.Remoting.Messaging;
+using System.Text;
 using System.Xml;
 using Dynamo.Properties;
 using Dynamo.Utilities;
@@ -19,6 +20,7 @@ namespace Dynamo.Models
         public double InitialHeight { get; set; } //required to calculate the HEIGHT of a group 
         private string modelGuids { get; set; }   
         private const double doubleValue = 0.0;
+        public List<ModelBase> DeletedModelBases { get; set; }
         public bool loadFromXML { get; set; }
 
         private double width;
@@ -98,8 +100,7 @@ namespace Dynamo.Models
                         model.Disposed+=model_Disposed;
                     }
                 }
-            }
-            
+            }            
         }
 
         /// <summary>
@@ -147,7 +148,7 @@ namespace Dynamo.Models
         {                                 
             var nodeModels = nodes as NodeModel[] ?? nodes.ToArray();           
             var noteModels = notes as NoteModel[] ?? notes.ToArray();
-
+            DeletedModelBases = new List<ModelBase>(); 
             this.SelectedModels = nodeModels.Concat(noteModels.Cast<ModelBase>()).ToList();            
             loadFromXML = loadFromGraph;
             if (!loadFromGraph)
@@ -185,6 +186,7 @@ namespace Dynamo.Models
             bool remove = modelList.Remove(model);
             if (remove)
             {
+                DeletedModelBases.Add(model);
                 SelectedModels = modelList;
                 UpdateBoundaryFromSelection();
             }
@@ -193,7 +195,7 @@ namespace Dynamo.Models
         /// <summary>
         /// Updates the group boundary based on the nodes / notes selection.
         /// </summary>      
-        private void UpdateBoundaryFromSelection()
+        internal void UpdateBoundaryFromSelection()
         {
             var selectedModelsList = selectedModels.ToList();
           
@@ -372,12 +374,6 @@ namespace Dynamo.Models
                     model.Disposed -= model_Disposed;
                 }
             }
-        }
-
-        internal bool CheckForEmptyModels(List<ModelBase> modelsToDelete)
-        {
-            var checkForModels = this.SelectedModels.Except(modelsToDelete).ToList();
-            return !checkForModels.Any() ;
-        }
+        }     
     }   
 }

--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -392,15 +392,16 @@ namespace Dynamo.Models
         #endregion
 
         public override void Dispose()
-        {
+        {           
             if (this.SelectedModels.Any())
             {
                 foreach (var model in this.SelectedModels)
                 {
                     model.PropertyChanged -= model_PropertyChanged;
-                    model.Disposed -= model_Disposed;
+                    model.Disposed -= model_Disposed;                    
                 }
             }
+            base.Dispose();
         }     
     }   
 }

--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -16,7 +16,7 @@ namespace Dynamo.Models
     public class AnnotationModel : ModelBase
     {
         #region Properties
-        public event Func<Guid,ModelBase> GetModelBaseEvent;      
+        public event Func<Guid, ModelBase> ModelBaseRequested;      
         public double InitialTop { get; set; } //required to calculate the TOP position in a group         
         public double InitialHeight { get; set; } //required to calculate the HEIGHT of a group          
         private const double DoubleValue = 0.0;
@@ -358,12 +358,9 @@ namespace Dynamo.Models
                      {
                          var result = mhelper.ReadGuid("ModelGuid", new Guid());
                          ModelBase model = null;
-                         if(GetModelBaseEvent != null)
-                              model = GetModelBaseEvent(result);
-                         else
-                         {
-                             model = SelectedModels.FirstOrDefault(x => x.GUID == result);
-                         }
+                         model = ModelBaseRequested != null ? ModelBaseRequested(result) : 
+                             SelectedModels.FirstOrDefault(x => x.GUID == result);
+
                         listOfModels.Add(model);
                     }                  
                 }

--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -373,5 +373,11 @@ namespace Dynamo.Models
                 }
             }
         }
+
+        internal bool CheckForEmptyModels(List<ModelBase> modelsToDelete)
+        {
+            var checkForModels = this.SelectedModels.Except(modelsToDelete).ToList();
+            return !checkForModels.Any() ;
+        }
     }   
 }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1017,13 +1017,7 @@ namespace Dynamo.Models
 
             RegisterHomeWorkspace(newWorkspace);
            
-            workspace = newWorkspace;
-            //this sets the event on Annotation. This event return the model from the workspace.
-            //When a model is ungrouped from a group, that model will be deleted from that group.
-            //So, when UNDO execution, cannot get that model from that group, it has to get from the workspace.
-            //The below method will set the event on every annotation model, that will return the specific model
-            //from workspace.
-            workspace.SetModelEventOnAnnotation();
+            workspace = newWorkspace;            
             return true;
         }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1049,15 +1049,13 @@ namespace Dynamo.Models
             var annotations = Workspaces.OfType<HomeWorkspaceModel>().SelectMany(ws => ws.Annotations);
             foreach (var annotation in annotations)
             {
-                if (!annotation.SelectedModels.Except(modelsToDelete).ToList().Any())
+                if (!annotation.SelectedModels.Except(modelsToDelete).Any())
                 {
                     //Annotation Model has to be serialized first - before the nodes.
                     //so, store the Annotation model as first object. This will serialize the 
                     //annotation before the nodes are deleted. So, when Undo is pressed,
                     //annotation model is deserialized correctly.
-                    var models = new LinkedList<ModelBase>(modelsToDelete);
-                    models.AddFirst(annotation);
-                    modelsToDelete = models.ToList();
+                    modelsToDelete.Insert(0, annotation);                   
                 }
             }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1339,8 +1339,8 @@ namespace Dynamo.Models
                 {
                     GUID = Guid.NewGuid(),
                     AnnotationText = annotation.AnnotationText,
-                    Background = annotation.Background
-
+                    Background = annotation.Background,
+                    FontSize = annotation.FontSize
                 };
                 newAnnotations.Add(annotationModel);
             }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1045,6 +1045,14 @@ namespace Dynamo.Models
             if (null == CurrentWorkspace)
                 return;
 
+            //Check for empty group
+            var annotations = Workspaces.OfType<HomeWorkspaceModel>().SelectMany(ws => ws.Annotations);
+            foreach (var annotation in annotations)
+            {
+                if(annotation.CheckForEmptyModels(modelsToDelete))
+                    modelsToDelete.Add(annotation);
+            }
+
             OnDeletionStarted();
 
             CurrentWorkspace.RecordAndDeleteModels(modelsToDelete);

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1075,6 +1075,27 @@ namespace Dynamo.Models
             OnDeletionComplete(this, EventArgs.Empty);
         }
 
+        internal void UngroupModel(List<ModelBase> modelsToUngroup)
+        {
+            var annotations = Workspaces.OfType<HomeWorkspaceModel>().SelectMany(ws => ws.Annotations);
+            foreach (var model in modelsToUngroup)
+            {
+                foreach (var annotation in annotations)
+                {
+                    if (annotation.SelectedModels.Any(x => x.GUID == model.GUID))
+                    {
+                        CurrentWorkspace.RecordGroupModelBeforeUngroup(annotation);
+                        var list = annotation.SelectedModels.ToList();
+                        if (list.Remove(model))
+                        {
+                            annotation.SelectedModels = list;
+                            annotation.UpdateBoundaryFromSelection();
+                        }                        
+                    }
+                }
+            }
+        }
+
         internal void DumpLibraryToXml(object parameter)
         {
             string fileName = String.Format("LibrarySnapshot_{0}.xml", DateTime.Now.ToString("yyyyMMddHmmss"));

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1049,8 +1049,16 @@ namespace Dynamo.Models
             var annotations = Workspaces.OfType<HomeWorkspaceModel>().SelectMany(ws => ws.Annotations);
             foreach (var annotation in annotations)
             {
-                if(annotation.CheckForEmptyModels(modelsToDelete))
-                    modelsToDelete.Add(annotation);
+                if (!annotation.SelectedModels.Except(modelsToDelete).ToList().Any())
+                {
+                    //Annotation Model has to be serialized first - before the nodes.
+                    //so, store the Annotation model as first object. This will serialize the 
+                    //annotation before the nodes are deleted. So, when Undo is pressed,
+                    //annotation model is deserialized correctly.
+                    var models = new LinkedList<ModelBase>(modelsToDelete);
+                    models.AddFirst(annotation);
+                    modelsToDelete = models.ToList();
+                }
             }
 
             OnDeletionStarted();

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1018,7 +1018,12 @@ namespace Dynamo.Models
             RegisterHomeWorkspace(newWorkspace);
            
             workspace = newWorkspace;
-
+            //this sets the event on Annotation. This event return the model from the workspace.
+            //When a model is ungrouped from a group, that model will be deleted from that group.
+            //So, when UNDO execution, cannot get that model from that group, it has to get from the workspace.
+            //The below method will set the event on every annotation model, that will return the specific model
+            //from workspace.
+            workspace.SetModelEventOnAnnotation();
             return true;
         }
 
@@ -1046,7 +1051,7 @@ namespace Dynamo.Models
                 return;
 
             //Check for empty group
-            var annotations = Workspaces.OfType<HomeWorkspaceModel>().SelectMany(ws => ws.Annotations);
+            var annotations = Workspaces.SelectMany(ws => ws.Annotations);
             foreach (var annotation in annotations)
             {
                 if (!annotation.SelectedModels.Except(modelsToDelete).Any())
@@ -1075,7 +1080,7 @@ namespace Dynamo.Models
 
         internal void UngroupModel(List<ModelBase> modelsToUngroup)
         {
-            var annotations = Workspaces.OfType<HomeWorkspaceModel>().SelectMany(ws => ws.Annotations);
+            var annotations = Workspaces.SelectMany(ws => ws.Annotations);
             foreach (var model in modelsToUngroup)
             {
                 foreach (var annotation in annotations)

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -294,7 +294,7 @@ namespace Dynamo.Models
             DeleteModelInternal(modelsToDelete);
         }
 
-        void UngroupModelImpl(UngroupNodeCommand command)
+        void UngroupModelImpl(UngroupModelCommand command)
         {
             var modelsToUngroup = new List<ModelBase>();
             if (command.ModelGuid != Guid.Empty)

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -294,6 +294,17 @@ namespace Dynamo.Models
             DeleteModelInternal(modelsToDelete);
         }
 
+        void UngroupModelImpl(UngroupNodeCommand command)
+        {
+            var modelsToUngroup = new List<ModelBase>();
+            if (command.ModelGuid != Guid.Empty)
+            {
+                modelsToUngroup.Add(CurrentWorkspace.GetModelInternal(command.ModelGuid));
+            }
+
+            UngroupModel(modelsToUngroup);
+        }
+
         void UndoRedoImpl(UndoRedoCommand command)
         {
             switch (command.CmdOperation)

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1532,6 +1532,41 @@ namespace Dynamo.Models
             #endregion
         }
 
+        [DataContract]
+        public class UngroupNodeCommand : ModelSpecificRecordableCommand
+        {
+            #region Public Class Methods
+
+            [JsonConstructor]
+            public UngroupNodeCommand(string modelGuid) : base(modelGuid) { }
+
+            public UngroupNodeCommand(Guid modelGuid) : base(modelGuid) { }
+
+            internal static UngroupNodeCommand DeserializeCore(XmlElement element)
+            {
+                var helper = new XmlElementHelper(element);
+                Guid modelGuid = helper.ReadGuid("ModelGuid");
+                return new UngroupNodeCommand(modelGuid);
+            }
+
+            #endregion
+
+            #region Protected Overridable Methods
+
+            protected override void ExecuteCore(DynamoModel dynamoModel)
+            {
+                dynamoModel.UngroupModelImpl(this);
+            }
+
+            protected override void SerializeCore(XmlElement element)
+            {
+                var helper = new XmlElementHelper(element);
+                helper.SetAttribute("ModelGuid", ModelGuid);
+            }
+
+            #endregion
+        }
+
     }
 
     // public class XxxYyyCommand : RecordableCommand

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1533,20 +1533,20 @@ namespace Dynamo.Models
         }
 
         [DataContract]
-        public class UngroupNodeCommand : ModelSpecificRecordableCommand
+        public class UngroupModelCommand : ModelSpecificRecordableCommand
         {
             #region Public Class Methods
 
             [JsonConstructor]
-            public UngroupNodeCommand(string modelGuid) : base(modelGuid) { }
+            public UngroupModelCommand(string modelGuid) : base(modelGuid) { }
 
-            public UngroupNodeCommand(Guid modelGuid) : base(modelGuid) { }
+            public UngroupModelCommand(Guid modelGuid) : base(modelGuid) { }
 
-            internal static UngroupNodeCommand DeserializeCore(XmlElement element)
+            internal static UngroupModelCommand DeserializeCore(XmlElement element)
             {
                 var helper = new XmlElementHelper(element);
                 Guid modelGuid = helper.ReadGuid("ModelGuid");
-                return new UngroupNodeCommand(modelGuid);
+                return new UngroupModelCommand(modelGuid);
             }
 
             #endregion

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -683,11 +683,22 @@ namespace Dynamo.Models
             return null;
         }
 
+        /// <summary>
+        /// Sets the event on Annotaiton model.
+        /// When a node is removed from a group, this event will be
+        /// used to include that node again in that group (UNDO operation)
+        /// </summary>
+        /// <param name="model">The model.</param>
         internal void SetGetModelsForGrouping(AnnotationModel model)
         {
             model.GetModelBaseEvent += annotationModel_GetModelBaseEvent;
         }
 
+        /// <summary>
+        /// Get the model from Workspace
+        /// </summary>
+        /// <param name="modelGuid">The model unique identifier.</param>
+        /// <returns></returns>
         private ModelBase annotationModel_GetModelBaseEvent(Guid modelGuid)
         {
             ModelBase model = null;

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -674,8 +674,9 @@ namespace Dynamo.Models
                 var annotationModel = new AnnotationModel(selectedNodes, selectedNotes)
                 {
                     GUID = id,
-                    AnnotationText = text
-                };               
+                    AnnotationText = text                   
+                };
+                annotationModel.GetModelBaseEvent += annotationModel_GetModelBaseEvent;
                 Annotations.Add(annotationModel);
                 HasUnsavedChanges = true;
                 return annotationModel;
@@ -689,9 +690,12 @@ namespace Dynamo.Models
         /// used to include that node again in that group (UNDO operation)
         /// </summary>
         /// <param name="model">The model.</param>
-        internal void SetGetModelsForGrouping(AnnotationModel model)
+        internal void SetModelEventOnAnnotation()
         {
-            model.GetModelBaseEvent += annotationModel_GetModelBaseEvent;
+            foreach (var model in this.Annotations)
+            {
+                model.GetModelBaseEvent += annotationModel_GetModelBaseEvent;
+            }
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -724,7 +724,7 @@ namespace Dynamo.Models
             foreach (var group in this.Annotations)
             {
                 var groupModels = group.SelectedModels;
-                nodesInSameGroup = selectedModels.Except(groupModels).ToList().Count <= 0;
+                nodesInSameGroup = !selectedModels.Except(groupModels).Any();
                 if (nodesInSameGroup)
                     break;
             }
@@ -1369,11 +1369,7 @@ namespace Dynamo.Models
                     //this note "was" in a group
                     if (annotation.DeletedModelBases.Any(m => m.GUID == noteModel.GUID))
                     {
-                        var list = annotation.SelectedModels.ToList();
-                        list.Add(noteModel);
-                        annotation.SelectedModels = list;
-                        annotation.loadFromXML = false;
-                        annotation.UpdateBoundaryFromSelection();
+                        annotation.AddToSelectedModels(noteModel);
                     }
                 }
             }
@@ -1394,11 +1390,7 @@ namespace Dynamo.Models
                     //this node "was" in a group
                     if (annotation.DeletedModelBases.Any(m=>m.GUID == nodeModel.GUID))
                     {
-                        var list = annotation.SelectedModels.ToList();
-                        list.Add(nodeModel);
-                        annotation.SelectedModels = list;
-                        annotation.loadFromXML = false;
-                        annotation.UpdateBoundaryFromSelection();
+                        annotation.AddToSelectedModels(nodeModel);
                     }
                 }
             }

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -484,6 +484,8 @@ namespace Dynamo.Models
 
             foreach (var connector in Connectors)
                 RegisterConnector(connector);
+
+            SetModelEventOnAnnotation();
         }
 
         /// <summary>
@@ -677,6 +679,7 @@ namespace Dynamo.Models
                     AnnotationText = text                   
                 };
                 annotationModel.ModelBaseRequested += annotationModel_GetModelBase;
+                annotationModel.Disposed += (_) => annotationModel.ModelBaseRequested -= annotationModel_GetModelBase;
                 Annotations.Add(annotationModel);
                 HasUnsavedChanges = true;
                 return annotationModel;
@@ -685,16 +688,19 @@ namespace Dynamo.Models
         }
 
         /// <summary>
-        /// Sets the event on Annotation model.
-        /// When a node is removed from a group, this event will be
-        /// used to include that node again in that group (UNDO operation)
+        //this sets the event on Annotation. This event return the model from the workspace.
+        //When a model is ungrouped from a group, that model will be deleted from that group.
+        //So, when UNDO execution, cannot get that model from that group, it has to get from the workspace.
+        //The below method will set the event on every annotation model, that will return the specific model
+        //from workspace.
         /// </summary>
         /// <param name="model">The model.</param>
-        internal void SetModelEventOnAnnotation()
-        {
+        private void SetModelEventOnAnnotation()
+        {           
             foreach (var model in this.Annotations)
             {
                 model.ModelBaseRequested += annotationModel_GetModelBase;
+                model.Disposed += (_) => model.ModelBaseRequested -= annotationModel_GetModelBase;
             }
         }
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1327,6 +1327,20 @@ namespace Dynamo.Models
             {
                 var noteModel = NodeGraph.LoadNoteFromXml(modelData);
                 Notes.Add(noteModel);
+
+                //check whether this note belongs to a group
+                foreach (var annotation in Annotations)
+                {
+                    //this note "was" in a group
+                    if (annotation.DeletedModelBases.Any(m => m.GUID == noteModel.GUID))
+                    {
+                        var list = annotation.SelectedModels.ToList();
+                        list.Add(noteModel);
+                        annotation.SelectedModels = list;
+                        annotation.loadFromXML = false;
+                        annotation.UpdateBoundaryFromSelection();
+                    }
+                }
             }
             else if (typeName.StartsWith("Dynamo.Models.AnnotationModel"))
             {
@@ -1338,6 +1352,20 @@ namespace Dynamo.Models
                 NodeModel nodeModel = NodeFactory.CreateNodeFromXml(modelData, SaveContext.Undo);
                 Nodes.Add(nodeModel);
                 RegisterNode(nodeModel);
+                
+                //check whether this node belongs to a group
+                foreach (var annotation in Annotations)
+                {
+                    //this node "was" in a group
+                    if (annotation.DeletedModelBases.Any(m=>m.GUID == nodeModel.GUID))
+                    {
+                        var list = annotation.SelectedModels.ToList();
+                        list.Add(nodeModel);
+                        annotation.SelectedModels = list;
+                        annotation.loadFromXML = false;
+                        annotation.UpdateBoundaryFromSelection();
+                    }
+                }
             }
         }
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -676,7 +676,7 @@ namespace Dynamo.Models
                     GUID = id,
                     AnnotationText = text                   
                 };
-                annotationModel.GetModelBaseEvent += annotationModel_GetModelBaseEvent;
+                annotationModel.ModelBaseRequested += annotationModel_GetModelBase;
                 Annotations.Add(annotationModel);
                 HasUnsavedChanges = true;
                 return annotationModel;
@@ -685,7 +685,7 @@ namespace Dynamo.Models
         }
 
         /// <summary>
-        /// Sets the event on Annotaiton model.
+        /// Sets the event on Annotation model.
         /// When a node is removed from a group, this event will be
         /// used to include that node again in that group (UNDO operation)
         /// </summary>
@@ -694,7 +694,7 @@ namespace Dynamo.Models
         {
             foreach (var model in this.Annotations)
             {
-                model.GetModelBaseEvent += annotationModel_GetModelBaseEvent;
+                model.ModelBaseRequested += annotationModel_GetModelBase;
             }
         }
 
@@ -703,7 +703,7 @@ namespace Dynamo.Models
         /// </summary>
         /// <param name="modelGuid">The model unique identifier.</param>
         /// <returns></returns>
-        private ModelBase annotationModel_GetModelBaseEvent(Guid modelGuid)
+        private ModelBase annotationModel_GetModelBase(Guid modelGuid)
         {
             ModelBase model = null;
             model = this.Nodes.FirstOrDefault(x => x.GUID == modelGuid);

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -123,7 +123,7 @@ namespace Dynamo.ViewModels
                 case "ModelEventCommand":
                 case "UpdateModelValueCommand":
                 case "ConvertNodesToCodeCommand":
-                case "UngroupNodeCommand":
+                case "UngroupModelCommand":
                     UndoCommand.RaiseCanExecuteChanged();
                     RedoCommand.RaiseCanExecuteChanged();
                     break;
@@ -177,7 +177,7 @@ namespace Dynamo.ViewModels
                 case "CreateCustomNodeCommand":
                 case "SwitchTabCommand":
                 case "MutateTestCommand":
-                case "UngroupNodeCommand":
+                case "UngroupModelCommand":
                     // for this commands there is no need
                     // to do anything before execution
                     break;

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -123,6 +123,7 @@ namespace Dynamo.ViewModels
                 case "ModelEventCommand":
                 case "UpdateModelValueCommand":
                 case "ConvertNodesToCodeCommand":
+                case "UngroupNodeCommand":
                     UndoCommand.RaiseCanExecuteChanged();
                     RedoCommand.RaiseCanExecuteChanged();
                     break;
@@ -176,6 +177,7 @@ namespace Dynamo.ViewModels
                 case "CreateCustomNodeCommand":
                 case "SwitchTabCommand":
                 case "MutateTestCommand":
+                case "UngroupNodeCommand":
                     // for this commands there is no need
                     // to do anything before execution
                     break;

--- a/src/DynamoCoreWpf/Commands/NodeCommands.cs
+++ b/src/DynamoCoreWpf/Commands/NodeCommands.cs
@@ -20,6 +20,7 @@ namespace Dynamo.ViewModels
         private DelegateCommand _setModelSizeCommand;
         private DelegateCommand _gotoWorkspaceCommand;
         private DelegateCommand _createGroupCommand;
+        private DelegateCommand _ungroupCommand;
 
         public DelegateCommand RenameCommand
         {
@@ -168,6 +169,18 @@ namespace Dynamo.ViewModels
                         new DelegateCommand(CreateGroup, CanCreateGroup);
 
                 return _createGroupCommand;
+            }
+        }
+       
+        public DelegateCommand UngroupCommand
+        {
+            get
+            {
+                if (_ungroupCommand == null)
+                    _ungroupCommand =
+                        new DelegateCommand(UngroupNode, CanUngroupNode);
+
+                return _ungroupCommand;
             }
         }
     }

--- a/src/DynamoCoreWpf/Commands/NoteCommands.cs
+++ b/src/DynamoCoreWpf/Commands/NoteCommands.cs
@@ -27,5 +27,18 @@ namespace Dynamo.ViewModels
                 return _createGroupCommand;
             }
         }
+
+        private DelegateCommand _ungroupCommand;
+        public DelegateCommand UngroupCommand
+        {
+            get
+            {
+                if (_ungroupCommand == null)
+                    _ungroupCommand =
+                        new DelegateCommand(UngroupNote, CanUngroupNote);
+
+                return _ungroupCommand;
+            }
+        }
     }
 }

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -403,6 +403,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Ungroup.
+        /// </summary>
+        public static string ContextUnGroupFromSelection {
+            get {
+                return ResourceManager.GetString("ContextUnGroupFromSelection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Continue.
         /// </summary>
         public static string ContinueButton {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -153,6 +153,10 @@
     <value>Create Group</value>
     <comment>Context menu item</comment>
   </data>
+  <data name="ContextUnGroupFromSelection" xml:space="preserve">
+    <value>Ungroup</value>
+    <comment>Context menu item</comment>
+  </data>
   <data name="ContextMenuNodesFromGeometry" xml:space="preserve">
     <value>Nodes From _Selected Geometry</value>
     <comment>Context menu item</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -153,6 +153,10 @@
     <value>Create Group</value>
     <comment>Context menu item</comment>
   </data>
+  <data name="ContextUnGroupFromSelection" xml:space="preserve">
+    <value>Ungroup</value>
+    <comment>Context menu item</comment>
+  </data>
   <data name="ContextMenuNodesFromGeometry" xml:space="preserve">
     <value>Nodes From _Selected Geometry</value>
     <comment>Context menu item</comment>

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Media;
+﻿using System.Globalization;
+using System.Windows.Media;
 using Dynamo.Models;
 using System;
 using Dynamo.UI.Commands;
@@ -146,7 +147,12 @@ namespace Dynamo.ViewModels
         {
             if (parameter != null)
             {
-                FontSize = Convert.ToDouble(parameter);
+                this.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
+                    new DynamoModel.UpdateModelValueCommand(
+                    System.Guid.Empty, this.AnnotationModel.GUID, "FSize", parameter.ToString()));
+
+                this.WorkspaceViewModel.DynamoViewModel.UndoCommand.RaiseCanExecuteChanged();
+                this.WorkspaceViewModel.DynamoViewModel.RedoCommand.RaiseCanExecuteChanged();                              
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System.Globalization;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Windows.Media;
 using Dynamo.Models;
 using System;
@@ -122,6 +124,11 @@ namespace Dynamo.ViewModels
                 annotationModel.FontSize = value;                
             }
         }
+
+        public IEnumerable<ModelBase> SelectedModels
+        {
+            get { return annotationModel.SelectedModels; }
+        }
        
         public AnnotationViewModel(WorkspaceViewModel workspaceViewModel, AnnotationModel model)
         {             
@@ -178,6 +185,9 @@ namespace Dynamo.ViewModels
                     break;
                 case "FontSize":
                     RaisePropertyChanged("FontSize");
+                    break;
+                case "SelectedModels":
+                    this.AnnotationModel.UpdateBoundaryFromSelection();
                     break;
             }
         }      

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -13,8 +13,7 @@ namespace Dynamo.ViewModels
     {
         private AnnotationModel annotationModel;
         public readonly WorkspaceViewModel WorkspaceViewModel;        
-        private double zIndex = 2;
-        
+      
         public AnnotationModel AnnotationModel
         {
             get { return annotationModel; }
@@ -56,12 +55,8 @@ namespace Dynamo.ViewModels
 
         public double ZIndex
         {
-            get { return zIndex; }
-            set
-            {
-                zIndex = value;
-                RaisePropertyChanged("ZIndex");
-            }
+            get { return 1; }
+            
         }
 
         public String AnnotationText
@@ -129,8 +124,7 @@ namespace Dynamo.ViewModels
         }
        
         public AnnotationViewModel(WorkspaceViewModel workspaceViewModel, AnnotationModel model)
-        {
-            ZIndex = 0; //Dont want the group to be in the foreground
+        {             
             annotationModel = model;           
             this.WorkspaceViewModel = workspaceViewModel;                                     
             model.PropertyChanged += model_PropertyChanged;

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -129,7 +129,8 @@ namespace Dynamo.ViewModels
         }
        
         public AnnotationViewModel(WorkspaceViewModel workspaceViewModel, AnnotationModel model)
-        {            
+        {
+            ZIndex = 0; //Dont want the group to be in the foreground
             annotationModel = model;           
             this.WorkspaceViewModel = workspaceViewModel;                                     
             model.PropertyChanged += model_PropertyChanged;

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -151,7 +151,7 @@ namespace Dynamo.ViewModels
             {
                 this.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
                     new DynamoModel.UpdateModelValueCommand(
-                    System.Guid.Empty, this.AnnotationModel.GUID, "FSize", parameter.ToString()));
+                    System.Guid.Empty, this.AnnotationModel.GUID, "FontSize", parameter.ToString()));
 
                 this.WorkspaceViewModel.DynamoViewModel.UndoCommand.RaiseCanExecuteChanged();
                 this.WorkspaceViewModel.DynamoViewModel.RedoCommand.RaiseCanExecuteChanged();                              

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -56,9 +56,10 @@ namespace Dynamo.ViewModels
             get { return 0; }
         }
 
+        //Changed the connectors ZIndex to 2. Groups have ZIndex of 1.
         public double ZIndex
         {
-            get { return 1; }
+            get { return 2; }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -896,6 +896,26 @@ namespace Dynamo.ViewModels
             return DynamoSelection.Instance.Selection.OfType<ModelBase>().Any();
         }
 
+        internal void UngroupAnnotation(object parameters)
+        {
+            if (null != parameters)
+            {
+                var message = "Internal error, argument must be null";
+                throw new ArgumentException(message, "parameters");
+            }
+            //Check for multiple groups - Delete the group and not the nodes.
+            foreach (var group in DynamoSelection.Instance.Selection.OfType<AnnotationModel>().ToList())
+            {
+                var command = new DynamoModel.DeleteModelCommand(group.GUID);
+                this.ExecuteCommand(command);
+            }            
+        }
+
+        internal bool CanUngroupAnnotation(object parameter)
+        {
+            return DynamoSelection.Instance.Selection.OfType<AnnotationModel>().Any();
+        }
+
         private void WorkspaceAdded(WorkspaceModel item)
         {
             if (item is HomeWorkspaceModel)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -928,7 +928,7 @@ namespace Dynamo.ViewModels
             {
                 if (!(modelb is AnnotationModel))
                 {
-                    var command = new DynamoModel.UngroupNodeCommand(modelb.GUID);
+                    var command = new DynamoModel.UngroupModelCommand(modelb.GUID);
                     this.ExecuteCommand(command);
                 }
             }  

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -916,6 +916,29 @@ namespace Dynamo.ViewModels
             return DynamoSelection.Instance.Selection.OfType<AnnotationModel>().Any();
         }
 
+        internal void UngroupModel(object parameters)
+        {
+            if (null != parameters)
+            {
+                var message = "Internal error, argument must be null";
+                throw new ArgumentException(message, "parameters");
+            }
+            //Check for multiple groups - Delete the group and not the nodes.
+            foreach (var modelb in DynamoSelection.Instance.Selection.OfType<ModelBase>().ToList())
+            {
+                if (!(modelb is AnnotationModel))
+                {
+                    var command = new DynamoModel.UngroupNodeCommand(modelb.GUID);
+                    this.ExecuteCommand(command);
+                }
+            }  
+        }
+
+        internal bool CanUngroupModel(object parameter)
+        {
+            return DynamoSelection.Instance.Selection.OfType<ModelBase>().Any();
+        }
+
         private void WorkspaceAdded(WorkspaceModel item)
         {
             if (item is HomeWorkspaceModel)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -23,6 +23,7 @@ namespace Dynamo.ViewModels
             AddNoteCommand = new DelegateCommand(AddNote, CanAddNote);
             AddAnnotationCommand = new DelegateCommand(AddAnnotation,CanAddAnnotation);
             UngroupAnnotationCommand = new DelegateCommand(UngroupAnnotation,CanUngroupAnnotation);
+            UngroupModelCommand = new DelegateCommand(UngroupModel,CanUngroupModel);
             AddToSelectionCommand = new DelegateCommand(model.AddToSelection, CanAddToSelection);
             ShowNewFunctionDialogCommand = new DelegateCommand(ShowNewFunctionDialogAndMakeFunction, CanShowNewFunctionDialogCommand);
             SaveRecordedCommand = new DelegateCommand(SaveRecordedCommands, CanSaveRecordedCommands);
@@ -83,6 +84,7 @@ namespace Dynamo.ViewModels
         public DelegateCommand AddNoteCommand { get; set; }
         public DelegateCommand AddAnnotationCommand { get; set; }
         public DelegateCommand UngroupAnnotationCommand { get; set; }
+        public DelegateCommand UngroupModelCommand { get; set; }
         public DelegateCommand UndoCommand { get; set; }
         public DelegateCommand RedoCommand { get; set; }
         public DelegateCommand CopyCommand { get; set; }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -22,6 +22,7 @@ namespace Dynamo.ViewModels
             PostUiActivationCommand = new DelegateCommand(model.PostUIActivation);
             AddNoteCommand = new DelegateCommand(AddNote, CanAddNote);
             AddAnnotationCommand = new DelegateCommand(AddAnnotation,CanAddAnnotation);
+            UngroupAnnotationCommand = new DelegateCommand(UngroupAnnotation,CanUngroupAnnotation);
             AddToSelectionCommand = new DelegateCommand(model.AddToSelection, CanAddToSelection);
             ShowNewFunctionDialogCommand = new DelegateCommand(ShowNewFunctionDialogAndMakeFunction, CanShowNewFunctionDialogCommand);
             SaveRecordedCommand = new DelegateCommand(SaveRecordedCommands, CanSaveRecordedCommands);
@@ -81,6 +82,7 @@ namespace Dynamo.ViewModels
         public DelegateCommand PostUiActivationCommand { get; set; }
         public DelegateCommand AddNoteCommand { get; set; }
         public DelegateCommand AddAnnotationCommand { get; set; }
+        public DelegateCommand UngroupAnnotationCommand { get; set; }
         public DelegateCommand UndoCommand { get; set; }
         public DelegateCommand RedoCommand { get; set; }
         public DelegateCommand CopyCommand { get; set; }

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -11,7 +11,7 @@ using Dynamo.Models;
 using Dynamo.Nodes;
 
 using System.Windows;
-
+using Dynamo.Selection;
 using DynCmd = Dynamo.ViewModels.DynamoViewModel;
 
 namespace Dynamo.ViewModels
@@ -892,7 +892,7 @@ namespace Dynamo.ViewModels
 
         private bool CanCreateGroup(object parameters)
         {
-            return true;
+            return DynamoSelection.Instance.Selection.OfType<ModelBase>().Any();
         }
 
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -902,7 +902,10 @@ namespace Dynamo.ViewModels
 
         private bool CanUngroupNode(object parameters)
         {
-            return DynamoSelection.Instance.Selection.OfType<NodeModel>().Any();
+            var groups = WorkspaceViewModel.Model.Annotations;
+            return (from model in groups 
+                    let nodeModel = DynamoSelection.Instance.Selection.OfType<NodeModel>().FirstOrDefault() 
+                    where model.SelectedModels.Any(x => x.GUID == nodeModel.GUID) select model).Any();
         }
 
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -895,6 +895,16 @@ namespace Dynamo.ViewModels
             return DynamoSelection.Instance.Selection.OfType<ModelBase>().Any();
         }
 
+        private void UngroupNode(object parameters)
+        {
+            WorkspaceViewModel.DynamoViewModel.UngroupModelCommand.Execute(null);
+        }
+
+        private bool CanUngroupNode(object parameters)
+        {
+            return DynamoSelection.Instance.Selection.OfType<NodeModel>().Any();
+        }
+
 
         #region Private Helper Methods
         private Point GetTopLeft()

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -143,7 +143,11 @@ namespace Dynamo.ViewModels
 
         private bool CanUngroupNote(object parameters)
         {
-            return DynamoSelection.Instance.Selection.OfType<NoteModel>().Any();
+            var groups = WorkspaceViewModel.Model.Annotations;
+            return (from model in groups
+                    let noteModel = DynamoSelection.Instance.Selection.OfType<NoteModel>().FirstOrDefault()
+                    where model.SelectedModels.Any(x => x.GUID == noteModel.GUID)
+                    select model).Any();
         }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -135,5 +135,15 @@ namespace Dynamo.ViewModels
         {
             return DynamoSelection.Instance.Selection.OfType<ModelBase>().Any();
         }
+
+        private void UngroupNote(object parameters)
+        {
+            WorkspaceViewModel.DynamoViewModel.UngroupModelCommand.Execute(null);
+        }
+
+        private bool CanUngroupNote(object parameters)
+        {
+            return DynamoSelection.Instance.Selection.OfType<NoteModel>().Any();
+        }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Dynamo.Models;
 using Dynamo.Selection;
 
@@ -132,7 +133,7 @@ namespace Dynamo.ViewModels
 
         private bool CanCreateGroup(object parameters)
         {
-            return true;
+            return DynamoSelection.Instance.Selection.OfType<ModelBase>().Any();
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -127,7 +127,7 @@
     </UserControl.Triggers>
     <Grid Name="AnnotationGrid" Height="Auto">    
         <Grid.RowDefinitions>
-            <RowDefinition Height="*"></RowDefinition>            
+            <RowDefinition Height="Auto"></RowDefinition>            
         </Grid.RowDefinitions>
         <Grid.ContextMenu>
             <ContextMenu>
@@ -210,6 +210,7 @@
                     FontFamily="Trebuchet" 
                     FontSize="{Binding FontSize}"                   
                     LineStackingStrategy="BlockLineHeight"
+                    IsVisibleChanged="GroupTextBlock_OnIsVisibleChanged"   
                     TextWrapping="Wrap">                  
             </TextBlock>
             <TextBox 

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -11,7 +11,7 @@
              MouseLeftButtonDown="AnnotationView_OnMouseLeftButtonDown"                                                  
              MouseRightButtonDown="AnnotationView_OnMouseRightButtonDown"              
              Canvas.Left="{Binding Left, Mode=TwoWay}" 
-             Canvas.Top="{Binding Top, Mode=TwoWay}">
+             Canvas.Top="{Binding Top, Mode=TwoWay}">   
     <UserControl.Resources>
         <Style x:Key="ColorSelectorListBox"
            TargetType="ListBox">
@@ -101,22 +101,29 @@
         </Style>    
     </UserControl.Resources>
     <UserControl.Triggers>
-        <EventTrigger  SourceName="Group" RoutedEvent="UserControl.MouseLeftButtonDown">
+        <EventTrigger  SourceName="Group" RoutedEvent="UserControl.MouseDoubleClick">
             <BeginStoryboard>
                 <Storyboard>
                     <ObjectAnimationUsingKeyFrames Duration="0"  
                                                                Storyboard.TargetName="GroupTextBlock"
                                                                Storyboard.TargetProperty="(TextBlock.Visibility)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                        <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Collapsed}" />
                     </ObjectAnimationUsingKeyFrames>
                     <ObjectAnimationUsingKeyFrames Duration="0"  
                                                                Storyboard.TargetName="GroupTextBox"
                                                                Storyboard.TargetProperty="(TextBox.Visibility)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Collapsed}" />
+                        <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                     </ObjectAnimationUsingKeyFrames>
+                    <BooleanAnimationUsingKeyFrames
+                                    Storyboard.TargetName="GroupTextBox"
+                                    Storyboard.TargetProperty="(TextBox.Focusable)">
+                        <DiscreteBooleanKeyFrame
+                                            KeyTime="0"
+                                            Value="True" />
+                    </BooleanAnimationUsingKeyFrames>
                 </Storyboard>
             </BeginStoryboard>
-        </EventTrigger>
+        </EventTrigger>      
     </UserControl.Triggers>
     <Grid Name="AnnotationGrid" Height="Auto">    
         <Grid.RowDefinitions>
@@ -221,7 +228,7 @@
             </TextBox>
             
             <Grid.Triggers>                
-                <EventTrigger  SourceName="GroupTextBlock" RoutedEvent="TextBlock.MouseLeftButtonDown">
+                <EventTrigger  SourceName="GroupTextBlock" RoutedEvent="UserControl.MouseDoubleClick">
                     <BeginStoryboard>
                         <Storyboard>
                             <ObjectAnimationUsingKeyFrames Duration="0"  
@@ -270,4 +277,5 @@
             </Grid.Triggers>
         </Grid>              
     </Grid>
+    
 </UserControl>

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -227,30 +227,7 @@
                     Style="{StaticResource SZoomFadeTextBox}">                  
             </TextBox>
             
-            <Grid.Triggers>                
-                <EventTrigger  SourceName="GroupTextBlock" RoutedEvent="UserControl.MouseDoubleClick">
-                    <BeginStoryboard>
-                        <Storyboard>
-                            <ObjectAnimationUsingKeyFrames Duration="0"  
-                                                               Storyboard.TargetName="GroupTextBlock"
-                                                               Storyboard.TargetProperty="(TextBlock.Visibility)">
-                                <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Collapsed}" />
-                            </ObjectAnimationUsingKeyFrames>
-                            <ObjectAnimationUsingKeyFrames Duration="0"  
-                                                               Storyboard.TargetName="GroupTextBox"
-                                                               Storyboard.TargetProperty="(TextBox.Visibility)">
-                                <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
-                            </ObjectAnimationUsingKeyFrames>
-                            <BooleanAnimationUsingKeyFrames
-                                    Storyboard.TargetName="GroupTextBox"
-                                    Storyboard.TargetProperty="(TextBox.Focusable)">
-                                <DiscreteBooleanKeyFrame
-                                            KeyTime="0"
-                                            Value="True" />
-                            </BooleanAnimationUsingKeyFrames>                            
-                        </Storyboard>                      
-                    </BeginStoryboard>
-                </EventTrigger>
+            <Grid.Triggers>                           
                 <EventTrigger  SourceName="GroupTextBox" RoutedEvent="TextBox.LostKeyboardFocus">
                     <BeginStoryboard>
                         <Storyboard>

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -39,6 +39,7 @@ namespace Dynamo.Nodes
             ViewModel = this.DataContext as AnnotationViewModel;
             if (ViewModel != null)
             {
+                //Set the event when Annotation view is loaded.
                 ViewModel.WorkspaceViewModel.Model.SetGetModelsForGrouping(ViewModel.AnnotationModel);
                 //Set the height of Textblock based on the content.
                 if (!ViewModel.AnnotationModel.loadFromXML)

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -79,7 +79,7 @@ namespace Dynamo.Nodes
             {
                 var annotationGuid = this.ViewModel.AnnotationModel.GUID;
                 ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
-                    new DynCmd.SelectModelCommand(annotationGuid, Keyboard.Modifiers.AsDynamoType()));
+                    new DynCmd.SelectModelCommand(annotationGuid, Dynamo.Utilities.ModifierKeys.Shift));
 
                 foreach (var models in this.ViewModel.AnnotationModel.SelectedModels)
                 {

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -29,8 +29,7 @@ namespace Dynamo.Nodes
             Resources.MergedDictionaries.Add(SharedDictionaryManager.PortsDictionary);
 
             InitializeComponent();
-            Loaded += AnnotationView_Loaded;           
-            this.GroupTextBlock.MouseLeftButtonDown += UIElement_OnMouseLeftButtonDown;   
+            Loaded += AnnotationView_Loaded;                      
             this.GroupTextBlock.SizeChanged +=GroupTextBlock_SizeChanged;          
         }
      
@@ -112,12 +111,7 @@ namespace Dynamo.Nodes
             ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
                new DynCmd.SelectModelCommand(annotationGuid, Keyboard.Modifiers.AsDynamoType()));
         }
-
-        private void UIElement_OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
-        {                      
-            e.Handled = true;
-        }
-
+       
         /// <summary>
         /// Handles the OnTextChanged event of the GroupTextBox control.
         /// Calculates the height of a Group based on the height of textblock

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Shapes;
@@ -36,10 +37,14 @@ namespace Dynamo.Nodes
         private void AnnotationView_Loaded(object sender, RoutedEventArgs e)
         {
             ViewModel = this.DataContext as AnnotationViewModel;
-            //Set the height of Textblock based on the content.
-            if (ViewModel != null && !ViewModel.AnnotationModel.loadFromXML)
+            if (ViewModel != null)
             {
-                ViewModel.AnnotationModel.TextBlockHeight = this.GroupTextBlock.ActualHeight;
+                ViewModel.WorkspaceViewModel.Model.SetGetModelsForGrouping(ViewModel.AnnotationModel);
+                //Set the height of Textblock based on the content.
+                if (!ViewModel.AnnotationModel.loadFromXML)
+                {
+                    ViewModel.AnnotationModel.TextBlockHeight = this.GroupTextBlock.ActualHeight;
+                }
             }
         }
 
@@ -122,6 +127,14 @@ namespace Dynamo.Nodes
         {             
             if (ViewModel != null)
             {
+                ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
+                    new DynCmd.UpdateModelValueCommand(
+                        System.Guid.Empty, this.ViewModel.AnnotationModel.GUID, "TextBlockText",
+                        GroupTextBox.Text));
+
+                ViewModel.WorkspaceViewModel.DynamoViewModel.UndoCommand.RaiseCanExecuteChanged();
+                ViewModel.WorkspaceViewModel.DynamoViewModel.RedoCommand.RaiseCanExecuteChanged();  
+
                 ViewModel.AnnotationModel.TextBlockHeight = GroupTextBox.ActualHeight;
                 ViewModel.WorkspaceViewModel.HasUnsavedChanges = true;
             }           
@@ -170,6 +183,11 @@ namespace Dynamo.Nodes
         private void GroupTextBox_OnGotFocus(object sender, RoutedEventArgs e)
         {
             this.GroupTextBox.CaretIndex = Int32.MaxValue;
+        }
+
+        private void GroupTextBlock_OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -49,14 +49,30 @@ namespace Dynamo.Nodes
             if (e.AddedItems == null || (e.AddedItems.Count <= 0))
                 return;
 
+            //store the old one
+            if (e.RemovedItems != null || e.RemovedItems.Count > 0)
+            {
+                var orectangle = e.AddedItems[0] as Rectangle;
+                if (orectangle != null)
+                {
+                    var brush = orectangle.Fill as SolidColorBrush;
+                    if (brush != null)
+                    {
+                        ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
+                         new DynCmd.UpdateModelValueCommand(
+                         System.Guid.Empty, ViewModel.AnnotationModel.GUID, "Background", brush.Color.ToString()));
+                    }
+                        
+                }               
+            }
+
             var rectangle = e.AddedItems[0] as Rectangle;
             if (rectangle != null)
             {
                 var brush = rectangle.Fill as SolidColorBrush;
                 if (brush != null)
                     ViewModel.Background = brush.Color;
-            }
-            ViewModel.WorkspaceViewModel.HasUnsavedChanges = true;
+            }                                
         }
 
         private void OnDeleteAnnotation(object sender, RoutedEventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -38,9 +38,7 @@ namespace Dynamo.Nodes
         {
             ViewModel = this.DataContext as AnnotationViewModel;
             if (ViewModel != null)
-            {
-                //Set the event when Annotation view is loaded.
-                ViewModel.WorkspaceViewModel.Model.SetGetModelsForGrouping(ViewModel.AnnotationModel);
+            {               
                 //Set the height of Textblock based on the content.
                 if (!ViewModel.AnnotationModel.loadFromXML)
                 {

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -124,6 +124,9 @@
         <KeyBinding Key="G"
                     Modifiers="Control"
                     Command="{Binding Path=DataContext.AddAnnotationCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+        <KeyBinding Key="U"
+                    Modifiers="Control"
+                    Command="{Binding Path=DataContext.UngroupAnnotationCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
         <KeyBinding Key="Left"
                     Modifiers="Ctrl+Alt"
                     CommandParameter="Left"
@@ -343,6 +346,11 @@
                                   Command="{Binding AddAnnotationCommand}"
                                   Name="noteMenuAnnotation"
                                   InputGestureText="Ctrl + G" />
+                        <MenuItem Focusable="False"
+                                  Header="{x:Static p:Resources.GroupContextMenuUngroup}"
+                                  Command="{Binding UngroupAnnotationCommand}"
+                                  Name="ungroupGroup"
+                                  InputGestureText="Ctrl + U" />
                         <MenuItem Focusable="False"                                
                                   Header="{x:Static p:Resources.DynamoViewEditMenuCreateNodeFromSelection}"
                                   Command="{Binding Path=CurrentSpaceViewModel.NodeFromSelectionCommand}"

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -47,6 +47,9 @@
                 <MenuItem Name="createGroup_cm"
                           Header="{x:Static p:Resources.ContextCreateGroupFromSelection}"
                           Command="{Binding Path=CreateGroupCommand}" />
+                <MenuItem Name="unGroup_cm"
+                          Header="{x:Static p:Resources.ContextUnGroupFromSelection}"
+                          Command="{Binding Path=UngroupCommand}" />
                 <MenuItem Header="{x:Static p:Resources.ContextMenuLacing}"
                           Visibility="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToVisibilityConverter},Mode=OneWay}">
                     <MenuItem IsCheckable="True"

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -342,6 +342,9 @@ namespace Dynamo.Controls
 
         private void topControl_MouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
+            Guid nodeGuid = ViewModel.NodeModel.GUID;
+            ViewModel.DynamoViewModel.ExecuteCommand(
+                new DynCmd.SelectModelCommand(nodeGuid, Keyboard.Modifiers.AsDynamoType()));
             //Debug.WriteLine("Node right selected.");
             e.Handled = true;
         }

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml
@@ -21,6 +21,9 @@
                 <MenuItem Name="createGroup_cm"
                           Header="{x:Static p:Resources.ContextCreateGroupFromSelection}"
                           Command="{Binding Path=CreateGroupCommand}" />
+                <MenuItem Name="unGroup_cm"
+                          Header="{x:Static p:Resources.ContextUnGroupFromSelection}"
+                          Command="{Binding Path=UngroupCommand}" />
             </ContextMenu>
         </Grid.ContextMenu>
         <Canvas Background="{x:Null}">

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -148,6 +148,7 @@ namespace Dynamo.Views
             if (ViewModel == null) return;
             ViewModel.NodeFromSelectionCommand.RaiseCanExecuteChanged();
             ViewModel.DynamoViewModel.AddAnnotationCommand.RaiseCanExecuteChanged();
+            ViewModel.DynamoViewModel.UngroupAnnotationCommand.RaiseCanExecuteChanged();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes bugs / issues with Graph Annotation. Also added new features and made some improvements to the existing one.

**Fixed the below bugs**
 MAGN-7068 Moving groups is sometimes slow
MAGN-6923 Group should be deleted if all nodes in group are deleted
MAGN-6932 Connectors are not rendered in the "foreground" when they are in groups
MAGN-6932 Connectors are not rendered in the "foreground" when they are in groups
MAGN-6925 Pressing Ctrl-G twice darkens the default pink color for a group
MAGN-6999 Group can be created decoupled from its selection nodes
MAGN-7001 Group can be dragged away from its selection nodes
MAGN-7061 Create group is available on node context menu, but does nothing when node is not selected
MAGN-7065 Ctrl-Z does not revert a group's color re-assignment
MAGN-7063 Can't undo group title change
MAGN-6980 copied groups have no title and color is not copied

**New Features added**
MAGN-7085 Remove a single node from a group
MAGN-7066 As a user, I want to UNgroup groups with ctrl-U
MAGN-7067 Change group title editing to require double click

- [x] @pboyer 
