### PR TITLE
Check for Login state before publishing to package manager

### DIFF
--- a/src/DynamoCore/PackageManager/PackageManagerClient.cs
+++ b/src/DynamoCore/PackageManager/PackageManagerClient.cs
@@ -213,10 +213,9 @@ namespace Dynamo.PackageManager
             this.authProvider.Logout();
         }
 
-        internal void Login()
+        internal bool Login()
         {
-            if (!HasAuthProvider) return;
-            this.authProvider.Login();
+            return HasAuthProvider && this.authProvider.Login();
         }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -90,6 +90,12 @@ namespace Dynamo.ViewModels
 
         public void PublishCurrentWorkspace(object m)
         {
+            if (LoginState == LoginState.LoggedOut)
+            {
+                if (!Model.Login())
+                    return;
+            }
+
             var ws = (CustomNodeWorkspaceModel)DynamoViewModel.CurrentSpace;
 
             CustomNodeDefinition currentFunDef;
@@ -120,6 +126,12 @@ namespace Dynamo.ViewModels
 
         public void PublishNewPackage(object m)
         {
+            if (LoginState == LoginState.LoggedOut)
+            {
+                if (!Model.Login())
+                    return;
+            }
+
             ShowNodePublishInfo();
         }
 
@@ -130,6 +142,12 @@ namespace Dynamo.ViewModels
 
         public void PublishCustomNode(Dynamo.Nodes.Function m)
         {
+            if (LoginState == LoginState.LoggedOut)
+            {
+                if (!Model.Login())
+                    return;
+            }
+
             CustomNodeInfo currentFunInfo;
             if (DynamoViewModel.Model.CustomNodeManager.TryGetNodeInfo(
                 m.Definition.FunctionId,
@@ -146,6 +164,12 @@ namespace Dynamo.ViewModels
 
         public void PublishSelectedNodes(object m)
         {
+            if (LoginState == LoginState.LoggedOut)
+            {
+                if (!Model.Login())
+                    return;
+            }
+
             var nodeList = DynamoSelection.Instance.Selection
                                 .Where(x => x is Function)
                                 .Cast<Function>()


### PR DESCRIPTION
This submission checks for login state before publishing. In case the user is already logged in, he can readily publish otherwise the Login dialog is prompted for him to sign in and publish anything to package manager.

@Benglin PTAL