### PR TITLE
fix PathManager always return en-US samples

### DIFF
--- a/src/DynamoCore/Core/PathManager.cs
+++ b/src/DynamoCore/Core/PathManager.cs
@@ -328,7 +328,7 @@ namespace Dynamo.Core
             var di = new DirectoryInfo(sampleDirectory);
             if (!Directory.Exists(sampleDirectory) ||
                 !di.GetDirectories().Any() ||
-                !di.GetFiles().Any())
+                !di.GetFiles("*.dyn", SearchOption.AllDirectories).Any())
             {
                 var neturalCommonSamples = Path.Combine(dataRootDirectory, "samples", "en-US");
                 if (Directory.Exists(neturalCommonSamples))


### PR DESCRIPTION
Since GetFiles() method only look at the current folder but not its sub-directories, it always returns *false* since there is no sample file in the top level folder (e.g. no file in %appdata%/..../samples/de-DE). Hence the conditional is always true and so sample path is always en-US even for localized version.

@Benglin PTAL