### PR TITLE
Fixed a typo in UpdateGraphAsyncTask

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -18,7 +18,7 @@ namespace Dynamo.Core.Threading
 
         private GraphSyncData graphSyncData;
         private EngineController engineController;
-        private bool verboseLogging;
+        private readonly bool verboseLogging;
 
         internal override TaskPriority Priority
         {
@@ -31,9 +31,9 @@ namespace Dynamo.Core.Threading
 
         #region Public Class Operational Methods
 
-        internal UpdateGraphAsyncTask(IScheduler scheduler, bool verboseLogging1) : base(scheduler)
+        internal UpdateGraphAsyncTask(IScheduler scheduler, bool verboseLogging) : base(scheduler)
         {
-            verboseLogging = verboseLogging;
+            this.verboseLogging = verboseLogging;
         }
 
         /// <summary>


### PR DESCRIPTION
Originally parameter `verboseLogging1` was never used in the constructor of `UpdateGraphAsyncTask`, this pull request updated that.