### PR TITLE
DUI: Down arrow button on latest visible member should scroll down for next 5 members

### DIFF
--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -229,6 +229,8 @@ namespace Dynamo.UI.Views
             if (HighlightedItem != null)
             {
                 HighlightedItem.IsSelected = true;
+                // If HighlightedItem is not visible for user, bring it and 5 next items into view.
+                HighlightedItem.BringIntoView(new Rect(0, 0, 0, HighlightedItem.ActualHeight * 5));
                 ShowTooltip(HighlightedItem);
             }
         }


### PR DESCRIPTION
During key navigation there is one bug in search view.
If you press down key, highlighted item moves down, which is ok.
But, if highlighted item is at the bottom of search view and user presses down,  highlighted item goes out of user.
Tooltip updates according selected item, which might be confusing for user.
E.g.
![image](https://cloud.githubusercontent.com/assets/8158404/7249658/98a4d98c-e824-11e4-86dc-e2f383ac7a10.png)


This PR fixes it by bringing into view 5 next items, if item is at the bottom.

Reviewers
@Benglin , please take a look.

Link to YouTrack:
[MAGN-5725](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5725) DUI: Down arrow button on latest visible member should scroll down for next 5 members