### PR TITLE
Add visitor class to Associative ASTs

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -4774,11 +4774,6 @@ namespace ProtoAssociative
             }
         }
 
-        private void EmitForLoopNode(AssociativeNode node)
-        {
-            throw new NotImplementedException();
-        }
-
         private void EmitLanguageBlockNode(AssociativeNode node, ref ProtoCore.Type inferedType, ProtoCore.AssociativeGraph.GraphNode graphNode, ProtoCore.CompilerDefinitions.Associative.SubCompilePass subPass = ProtoCore.CompilerDefinitions.Associative.SubCompilePass.kNone)
         {
             if (IsParsingGlobal() || IsParsingGlobalFunctionBody() || IsParsingMemberFunctionBody() )
@@ -8342,30 +8337,23 @@ namespace ProtoAssociative
                 {
                     leftNodeGlobalRef = GetUpdatedNodeRef(bnode.LeftNode);
 
-                    // right node is statement which wont return any value, so push null to stack
-                    if ((bnode.RightNode is IfStatementNode) || (bnode.RightNode is ForLoopNode))
+                    // check whether the variable name is a function name
+                    bool isAccessibleFp;
+                    int realType;
+                    ProtoCore.DSASM.ProcedureNode procNode = null;
+                    if (globalClassIndex != ProtoCore.DSASM.Constants.kGlobalScope)
                     {
-                        EmitPushNull();
+                        procNode = core.ClassTable.ClassNodes[globalClassIndex].GetMemberFunction(t.Name, null, globalClassIndex, out isAccessibleFp, out realType);
                     }
+                    if (procNode == null)
                     {
-                        // check whether the variable name is a function name
-                        bool isAccessibleFp;
-                        int realType;
-                        ProtoCore.DSASM.ProcedureNode procNode = null;
-                        if (globalClassIndex != ProtoCore.DSASM.Constants.kGlobalScope)
+                        procNode = CoreUtils.GetFirstVisibleProcedure(t.Name, null, codeBlock);
+                    }
+                    if (procNode != null)
+                    {
+                        if (ProtoCore.DSASM.Constants.kInvalidIndex != procNode.procId && emitDebugInfo)
                         {
-                            procNode = core.ClassTable.ClassNodes[globalClassIndex].GetMemberFunction(t.Name, null, globalClassIndex, out isAccessibleFp, out realType);
-                        }
-                        if (procNode == null)
-                        {
-                            procNode = CoreUtils.GetFirstVisibleProcedure(t.Name, null, codeBlock);
-                        }
-                        if (procNode != null)
-                        {
-                            if (ProtoCore.DSASM.Constants.kInvalidIndex != procNode.procId && emitDebugInfo)
-                            {
-                                buildStatus.LogSemanticError(String.Format(Resources.FunctionAsVariableError, t.Name), core.CurrentDSFileName, t.line, t.col);
-                            }
+                            buildStatus.LogSemanticError(String.Format(Resources.FunctionAsVariableError, t.Name), core.CurrentDSFileName, t.line, t.col);
                         }
                     }
 
@@ -9261,10 +9249,6 @@ namespace ProtoAssociative
             else if (node is RangeExprNode)
             {
                 EmitRangeExprNode(node, ref inferedType, graphNode, subPass);
-            }
-            else if (node is ForLoopNode)
-            {
-                EmitForLoopNode(node);
             }
             else if (node is LanguageBlockNode)
             {

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -9236,16 +9236,6 @@ namespace ProtoAssociative
             {
                 EmitNullNode(node, ref inferedType, isBooleanOp, subPass);
             }
-#if ENABLE_INC_DEC_FIX
-            else if (node is PostFixNode)
-            {
-                EmitPostFixNode(node, ref inferedType);
-            }
-#endif
-            else if (node is ReturnNode)
-            {
-                EmitReturnNode(node);
-            }
             else if (node is RangeExprNode)
             {
                 EmitRangeExprNode(node, ref inferedType, graphNode, subPass);

--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -2472,11 +2472,6 @@ namespace ProtoCore
             }
         }
 
-        protected void EmitReturnNode(Node node)
-        {
-            throw new NotImplementedException();
-        }
-
         protected int EmitReplicationGuides(List<ProtoCore.AST.AssociativeAST.AssociativeNode> replicationGuidesList, bool emitNumber = false)
         {
             int replicationGuides = 0;

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -795,51 +795,6 @@ namespace ProtoCore.AST.AssociativeAST
         }
     }
 
-    public class ReturnNode : AssociativeNode
-    {
-        public AssociativeNode ReturnExpr
-        {
-            get;
-            set;
-        }
-
-        public override bool Equals(object other)
-        {
-            var otherNode = other as ReturnNode;
-            if (null == otherNode)
-                return false;
-
-            return null != ReturnExpr && ReturnExpr.Equals(otherNode.ReturnExpr);
-        }
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
-
-        public override string ToString()
-        {
-            var buf = new StringBuilder();
-
-            buf.Append(Keyword.Return);
-            buf.Append(" = ");
-            buf.Append(null == ReturnExpr ? Keyword.Null : ReturnExpr.ToString());
-            buf.Append(Constants.termline);
-
-            return buf.ToString();
-        }
-
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitReturnNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
-        {
-            return visitor.VisitReturnNode(this);
-        }
-    }
-
     public class FunctionCallNode : ArrayNameNode
     {
         public int DynamicTableIndex { get; set; }
@@ -3349,18 +3304,6 @@ namespace ProtoCore.AST.AssociativeAST
                 StepNode = aNode.StepNode.ToImperativeAST(),
                 ToNode = aNode.ToNode.ToImperativeAST(),
                 stepoperator = aNode.stepoperator
-            };
-            CopyProps(aNode, result);
-            return result;
-        }
-
-        public static ImperativeAST.ReturnNode ToImperativeNode(this ReturnNode aNode)
-        {
-            if (aNode == null) return null;
-
-            var result = new ImperativeAST.ReturnNode
-            {
-                ReturnExpr = aNode.ReturnExpr.ToImperativeAST()
             };
             CopyProps(aNode, result);
             return result;

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -9,6 +9,7 @@ using ProtoCore.DSASM;
 using ProtoCore.DSDefinitions;
 using ProtoCore.Lang;
 using ProtoCore.Utils;
+using ProtoCore.SyntaxAnalysis;
 
 namespace ProtoCore.AST.AssociativeAST
 {
@@ -28,6 +29,9 @@ namespace ProtoCore.AST.AssociativeAST
             IsModifier = rhs.IsModifier;
             IsProcedureOwned = rhs.IsProcedureOwned;
         }
+
+        public abstract void Accept(AssociativeAstVisitor visitor);
+        public abstract TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor);
     }
 
     public class CommentNode : AssociativeNode
@@ -41,6 +45,16 @@ namespace ProtoCore.AST.AssociativeAST
             this.line = line;
             Value = value;
             Type = type;
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitCommentNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitCommentNode(this);
         }
     }
 
@@ -117,6 +131,16 @@ namespace ProtoCore.AST.AssociativeAST
 
             return buf.ToString();
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitLanguageBlockNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitLanguageBlockNode(this);
+        }
     }
 
     public class ReplicationGuideNode : AssociativeNode
@@ -173,8 +197,17 @@ namespace ProtoCore.AST.AssociativeAST
             }
             return buf.ToString();
         }
-    }
 
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitReplicationGuideNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitReplicationGuideNode(this);
+        }
+    }
 
     public class ArrayNameNode : AssociativeNode
     {
@@ -254,6 +287,16 @@ namespace ProtoCore.AST.AssociativeAST
 
             return buf.ToString();
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitArrayNameNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitArrayNameNode(this);
+        }
     }
 
     public class GroupExpressionNode : ArrayNameNode
@@ -294,6 +337,16 @@ namespace ProtoCore.AST.AssociativeAST
             if (Expression == null)
                 return Keyword.Null;
             return "(" + Expression + ")" + base.ToString();
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitGroupExpressionNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitGroupExpressionNode(this);
         }
     }
 
@@ -357,6 +410,16 @@ namespace ProtoCore.AST.AssociativeAST
         {
             return Value.Replace("%", string.Empty) + base.ToString();
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitIdentifierNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitIdentifierNode(this);
+        }
     }
 
     public class TypedIdentifierNode : IdentifierNode
@@ -373,6 +436,16 @@ namespace ProtoCore.AST.AssociativeAST
         public override string ToString()
         {
             return base.ToString() + " : " + datatype;
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitTypedIdentifierNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitTypedIdentifierNode(this);
         }
     }
 
@@ -437,6 +510,16 @@ namespace ProtoCore.AST.AssociativeAST
         {
             return LeftNode + "." + RightNode;
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitIdentifierListNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitIdentifierListNode(this);
+        }
     }
 
     public class IntNode : AssociativeNode
@@ -471,6 +554,16 @@ namespace ProtoCore.AST.AssociativeAST
         public override string ToString()
         {
             return Value.ToString();
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitIntNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitIntNode(this);
         }
     }
 
@@ -509,6 +602,16 @@ namespace ProtoCore.AST.AssociativeAST
         public override string ToString()
         {
             return Value.ToString();
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitDoubleNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitDoubleNode(this);
         }
     }
 
@@ -552,6 +655,16 @@ namespace ProtoCore.AST.AssociativeAST
             return (Value ? "true" : "false");
 
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitBooleanNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitBooleanNode(this);
+        }
     }
 
     public class CharNode : AssociativeNode
@@ -588,6 +701,16 @@ namespace ProtoCore.AST.AssociativeAST
         public override string ToString()
         {
             return "'" + value + "'";
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitCharNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitCharNode(this);
         }
     }
 
@@ -627,6 +750,16 @@ namespace ProtoCore.AST.AssociativeAST
         {
             return "\"" + value + "\"";
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitStringNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitStringNode(this);
+        }
     }
 
     public class NullNode : AssociativeNode
@@ -649,6 +782,16 @@ namespace ProtoCore.AST.AssociativeAST
         public override string ToString()
         {
             return Keyword.Null;
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitNullNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitNullNode(this);
         }
     }
 
@@ -684,6 +827,16 @@ namespace ProtoCore.AST.AssociativeAST
             buf.Append(Constants.termline);
 
             return buf.ToString();
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitReturnNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitReturnNode(this);
         }
     }
 
@@ -806,6 +959,16 @@ namespace ProtoCore.AST.AssociativeAST
 
             return buf.ToString();
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitFunctionCallNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitFunctionCallNode(this);
+        }
     }
 
     public class FunctionDotCallNode : AssociativeNode
@@ -880,6 +1043,16 @@ namespace ProtoCore.AST.AssociativeAST
             buf.Append(".");
             buf.Append(FunctionCall);
             return buf.ToString();
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitFunctionDotCallNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitFunctionDotCallNode(this);
         }
     }
 
@@ -966,6 +1139,16 @@ namespace ProtoCore.AST.AssociativeAST
             return memregionHashCode ^ argumentTypeHashCode ^ 
                 nameNodeHashCode ^ isStaticHashCode ^ attributesHashCode;
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitVarDeclNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitVarDeclNode(this);
+        }
     }
 
     public class ArgumentSignatureNode : AssociativeNode
@@ -1016,6 +1199,16 @@ namespace ProtoCore.AST.AssociativeAST
 
             return argumentsHashCode;
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitArgumentSignatureNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitArgumentSignatureNode(this);
+        }
     }
 
     public class CodeBlockNode : AssociativeNode
@@ -1063,6 +1256,16 @@ namespace ProtoCore.AST.AssociativeAST
                 buf.Append(Body[i].ToString());
             }
             return buf.ToString();
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitCodeBlockNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitCodeBlockNode(this);
         }
     }
 
@@ -1178,6 +1381,16 @@ namespace ProtoCore.AST.AssociativeAST
 
             return classNameHashCode ^ superClassHashCode ^ 
                 varlistHashCode ^ attributesHashCode ^ funclistHashCode;
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitClassDeclNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitClassDeclNode(this);
         }
     }
 
@@ -1341,6 +1554,16 @@ namespace ProtoCore.AST.AssociativeAST
             return localVarsHashCode ^ signatureHashCode ^
                 returnTypeHashCode ^ functionBodyHashCode ^ attributesHashCode;
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitConstructorDefinitionNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitConstructorDefinitionNode(this);
+        }
     }
 
     public class FunctionDefinitionNode : AssociativeNode
@@ -1463,6 +1686,16 @@ namespace ProtoCore.AST.AssociativeAST
 
             return buf.ToString();
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitFunctionDefinitionNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitFunctionDefinitionNode(this);
+        }
     }
 
     public class IfStatementNode : AssociativeNode
@@ -1498,6 +1731,16 @@ namespace ProtoCore.AST.AssociativeAST
                 (ElseBody == null ? base.GetHashCode() : ElseBody.GetHashCode());
 
             return ifExprNodeHashCode ^ ifBodyHashCode ^ elseBodyHashCode;
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitIfStatementNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitIfStatementNode(this);
         }
     }
 
@@ -1560,6 +1803,16 @@ namespace ProtoCore.AST.AssociativeAST
             buf.Append(")");
 
             return buf.ToString();
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitInlineConditionalNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitInlineConditionalNode(this);
         }
     }
 
@@ -1696,6 +1949,16 @@ namespace ProtoCore.AST.AssociativeAST
 
             return buf.ToString();
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitBinaryExpressionNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitBinaryExpressionNode(this);
+        }
     }
 
     public class UnaryExpressionNode : AssociativeNode
@@ -1724,8 +1987,17 @@ namespace ProtoCore.AST.AssociativeAST
 
             return operatorHashCode ^ expressionHashCode;
         }
-    }
 
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitUnaryExpressionNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitUnaryExpressionNode(this);
+        }
+    }
 
     public class ModifierStackNode : AssociativeNode
     {
@@ -1857,6 +2129,16 @@ namespace ProtoCore.AST.AssociativeAST
 
             return buf.ToString();
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitModifierStackNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitModifierStackNode(this);
+        }
     }
 
     public class RangeExprNode : ArrayNameNode
@@ -1949,6 +2231,8 @@ namespace ProtoCore.AST.AssociativeAST
 
             return buf.ToString();
         }
+
+
     }
 
     public class ExprListNode : ArrayNameNode
@@ -2067,6 +2351,16 @@ namespace ProtoCore.AST.AssociativeAST
 
             return buf.ToString();
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitArrayNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitArrayNode(this);
+        }
     }
 
     public class ImportNode : AssociativeNode
@@ -2137,10 +2431,29 @@ namespace ProtoCore.AST.AssociativeAST
         {
             return Keyword.Import + "(\"" + ModuleName + "\")" + Constants.termline;
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitImportNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitImportNode(this);
+        }
     }
 
     public class DefaultArgNode : AssociativeNode
     {// not supposed to be used in parser 
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitDefaultArgNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitDefaultArgNode(this);
+        }
     }
 
     public class DynamicNode : AssociativeNode
@@ -2151,6 +2464,16 @@ namespace ProtoCore.AST.AssociativeAST
 
         public DynamicNode(DynamicNode rhs) : base(rhs)
         {
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitDynamicNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitDynamicNode(this);
         }
     }
 
@@ -2177,6 +2500,16 @@ namespace ProtoCore.AST.AssociativeAST
 
             return blockHashCode;
         }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitDynamicBlockNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitDynamicBlockNode(this);
+        }
     }
 
     public class ThisPointerNode : AssociativeNode
@@ -2202,6 +2535,16 @@ namespace ProtoCore.AST.AssociativeAST
         public override int GetHashCode()
         {
             return 10037;
+        }
+
+        public override void Accept(AssociativeAstVisitor visitor)
+        {
+            visitor.VisitThisPointerNode(this);
+        }
+
+        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        {
+            return visitor.VisitThisPointerNode(this);
         }
     }
 

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -2000,36 +2000,6 @@ namespace ProtoCore.AST.AssociativeAST
         }
     }
 
-    public class ForLoopNode : AssociativeNode
-    {
-        public AssociativeNode loopVar { get; set; }
-        public AssociativeNode expression { get; set; }
-        public List<AssociativeNode> body { get; set; }
-
-        public override bool Equals(object other)
-        {
-            var otherNode = other as ForLoopNode;
-            if (null == otherNode)
-                return false;
-
-            return loopVar.Equals(otherNode.loopVar) &&
-                   expression.Equals(otherNode.expression) &&
-                   body.SequenceEqual(otherNode.body);
-        }
-
-        public override int GetHashCode()
-        {
-            var loopVarHashCode =
-                (loopVar == null ? base.GetHashCode() : loopVar.GetHashCode());
-            var expressionHashCode =
-                (expression == null ? base.GetHashCode() : expression.GetHashCode());
-            var bodyHashCode =
-                (body == null ? base.GetHashCode() : body.GetHashCode());
-
-            return loopVarHashCode ^ expressionHashCode ^ bodyHashCode;
-        }
-    }
-
     public class ArrayNode : AssociativeNode
     {
         public ArrayNode()
@@ -2905,20 +2875,6 @@ namespace ProtoCore.AST.AssociativeAST
             {
                 ArrayDimensions = aNode.ArrayDimensions.ToImperativeNode(),
                 list = aNode.list.Select(ToImperativeAST).ToList()
-            };
-            CopyProps(aNode, result);
-            return result;
-        }
-
-        public static ImperativeAST.ForLoopNode ToImperativeNode(this ForLoopNode aNode)
-        {
-            if (aNode == null) return null;
-
-            var result = new ImperativeAST.ForLoopNode
-            {
-                body = aNode.body.Select(ToImperativeAST).ToList(),
-                expression = aNode.expression.ToImperativeAST(),
-                loopVar = aNode.loopVar.ToImperativeAST()
             };
             CopyProps(aNode, result);
             return result;

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -119,78 +119,6 @@ namespace ProtoCore.AST.AssociativeAST
         }
     }
 
-    /// <summary>
-    /// This node will be used by the optimiser
-    /// </summary>
-    public class MergeNode : AssociativeNode
-    {
-        public List<AssociativeNode> MergedNodes
-        {
-            get;
-            private set;
-        }
-
-        public MergeNode()
-        {
-            MergedNodes = new List<AssociativeNode>();
-        }
-
-        public override bool Equals(object other)
-        {
-            var otherNode = other as MergeNode;
-            return null != otherNode && MergedNodes.SequenceEqual(otherNode.MergedNodes);
-        }
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
-    }
-
-    /// <summary>
-    /// This class is only used in GraphCompiler
-    /// </summary>
-    public class ArrayIndexerNode : AssociativeNode 
-    {
-        public ArrayNode ArrayDimensions;
-        public AssociativeNode Array;
-
-        public override bool Equals(object other)
-        {
-            var otherNode = other as ArrayIndexerNode;
-            if (null == otherNode)
-                return false;
-
-            return EqualityComparer<ArrayNode>.Default.Equals(ArrayDimensions, otherNode.ArrayDimensions) &&
-                   EqualityComparer<AssociativeNode>.Default.Equals(Array, otherNode.Array);
-        }
-
-        public override int GetHashCode()
-        {
-            var ArrayDimensionsHashCode =
-                (ArrayDimensions == null ? base.GetHashCode() : ArrayDimensions.GetHashCode());
-            var ArrayHashCode =
-                (Array == null ? base.GetHashCode() : Array.GetHashCode());
-
-            return ArrayDimensionsHashCode ^ ArrayHashCode;
-        }
-
-        public override string ToString()
-        {
-            var buf = new StringBuilder();
-
-            buf.Append(Array);
-            buf.Append("[");
-            buf.Append(ArrayDimensions.Expr);
-            buf.Append("]");
-
-            if (ArrayDimensions.Type != null)
-                buf.Append(ArrayDimensions.Type);
-
-            return buf.ToString();
-        }
-    }
-
     public class ReplicationGuideNode : AssociativeNode
     {
         public bool IsLongest { get; set; }
@@ -2241,67 +2169,6 @@ namespace ProtoCore.AST.AssociativeAST
         }
     }
 
-    public class PostFixNode : AssociativeNode
-    {
-        public AssociativeNode Identifier { get; set; }
-        public UnaryOperator Operator { get; set; }
-
-        public override bool Equals(object other)
-        {
-            var otherNode = other as PostFixNode;
-            if (null == otherNode)
-                return false;
-
-            return Operator.Equals(otherNode.Operator) &&
-                   Identifier.Equals(otherNode.Identifier);
-        }
-
-        public override int GetHashCode()
-        {
-            var operatorHashCode = Operator.GetHashCode();
-            var identifierHashCode =
-                (Identifier == null ? base.GetHashCode() : Identifier.GetHashCode());
-
-            return operatorHashCode ^ identifierHashCode;
-        }
-    }
-
-    public class BreakNode : AssociativeNode
-    {
-        public override string ToString()
-        {
-            return Keyword.Break;
-        }
-
-        public override bool Equals(object other)
-        {
-            return other is BreakNode;
-        }
-
-        public override int GetHashCode()
-        {
-            return 10007;
-        }
-    }
-
-    public class ContinueNode : AssociativeNode
-    {
-        public override string ToString()
-        {
-            return Keyword.Continue;
-        }
-
-        public override bool Equals(object other)
-        {
-            return other is ContinueNode;
-        }
-
-        public override int GetHashCode()
-        {
-            return 10009;
-        }
-    }
-
     public class DefaultArgNode : AssociativeNode
     {// not supposed to be used in parser 
     }
@@ -3168,19 +3035,6 @@ namespace ProtoCore.AST.AssociativeAST
             if (aNode == null) return null;
 
             var result = new ImperativeAST.NullNode();
-            CopyProps(aNode, result);
-            return result;
-        }
-
-        public static ImperativeAST.PostFixNode ToImperativeNode(this PostFixNode aNode)
-        {
-            if (aNode == null) return null;
-
-            var result = new ImperativeAST.PostFixNode
-            {
-                Identifier = aNode.Identifier.ToImperativeAST(),
-                Operator = aNode.Operator
-            };
             CopyProps(aNode, result);
             return result;
         }

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -952,20 +952,6 @@ public Node root { get; set; }
 			Associative_FunctionalStatement(out node);
 		} else if (la.kind == 8) {
 			Associative_LanguageBlock(out node);
-		} else if (la.kind == 38) {
-			Get();
-			if (la.val != ";")
-			   SynErr(Resources.SemiColonExpected);  
-			
-			Expect(21);
-			node = new ProtoCore.AST.AssociativeAST.BreakNode(); 
-		} else if (la.kind == 39) {
-			Get();
-			if (la.val != ";")
-			   SynErr(Resources.SemiColonExpected); 
-			
-			Expect(21);
-			node = new ProtoCore.AST.AssociativeAST.ContinueNode(); 
 		} else if (StartOf(3)) {
 			if (core.ParsingMode == ParseMode.AllowNonAssignment) {
 				if (StartOf(4)) {
@@ -1211,8 +1197,6 @@ public Node root { get; set; }
 			}
 			
 		} else if (la.kind == 49) {
-			if(!(leftNode is ProtoCore.AST.AssociativeAST.PostFixNode)) {
-			
 			Get();
 			ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
 			bool isLeftMostNode = false; 
@@ -1396,7 +1380,6 @@ public Node root { get; set; }
 			   isLeftVarIdentList = false;                                  
 			}  
 			
-			} 
 		} else if (StartOf(13)) {
 			SynErr(Resources.SemiColonExpected); 
 		} else SynErr(84);
@@ -4323,9 +4306,9 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 	}
 	
 	static readonly bool[,] set = {
-		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
-		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
-		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
 		{x,T,T,T, T,T,x,x, x,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
 		{x,T,T,T, T,T,x,x, x,x,T,x, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
 		{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
@@ -4337,10 +4320,10 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		{x,T,T,T, T,T,x,x, x,x,T,x, T,T,x,T, T,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, T,T,T,T, x,x,T,T, T,T,T,x, x,x,x},
 		{x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,T, T,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,T, x,x,T,T, x,x,x,x, x,x,x},
 		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, T,x,T,T, x,x,T,T, T,T,T,x, x,x,T,T, x,x,T,T, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
-		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
 		{x,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,T,x, x,x,T,x, x,T,T,x, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
 		{x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
-		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,T,T, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
+		{T,T,T,T, T,T,x,x, T,x,T,x, T,T,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,T,T, T,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},
 		{x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
 		{x,T,x,x, x,x,x,x, x,x,T,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
 		{x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,T,T,x, x,x,x},

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -174,24 +174,6 @@ Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
         Associative_LanguageBlock<out node>
     |
         (
-            kw_break 
-                (. 
-                    if (la.val != ";")
-                        SynErr(Resources.SemiColonExpected);  
-                .)
-            endline
-        )      (. node = new ProtoCore.AST.AssociativeAST.BreakNode(); .)
-    |   
-        (
-            kw_continue 
-                (. 
-                    if (la.val != ";")
-                        SynErr(Resources.SemiColonExpected); 
-                .)
-            endline
-        )   (. node = new ProtoCore.AST.AssociativeAST.ContinueNode(); .)
-    |
-        (
             (
                 IF(core.ParsingMode == ParseMode.AllowNonAssignment)  
                     [
@@ -1240,9 +1222,6 @@ Associative_FunctionalStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode
                                 .)
         |
         (
-                                (. 
-                                    if(!(leftNode is ProtoCore.AST.AssociativeAST.PostFixNode)) {
-                                .)
             '='                 
                                 (. 
                                     ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
@@ -1458,7 +1437,6 @@ Associative_FunctionalStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode
                                         isLeftVarIdentList = false;                                  
                                     }  
                                 .)
-            (. } .)
         )
         |
         (

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -96,6 +96,7 @@
     </Compile>
     <Compile Include="AssociativeGraph.cs" />
     <Compile Include="ASTCompilerUtils.cs" />
+    <Compile Include="SyntaxAnalysis\AstVisitor.cs" />
     <Compile Include="AttributeEntry.cs" />
     <Compile Include="BuildStatus.cs" />
     <Compile Include="CodeBlock.cs" />

--- a/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
@@ -90,11 +90,6 @@ namespace ProtoCore.SyntaxAnalysis
             DefaultVisit(node);
         }
 
-        public virtual void VisitReturnNode(ReturnNode node)
-        {
-            DefaultVisit(node);
-        }
-
         public virtual void VisitFunctionCallNode(FunctionCallNode node)
         {
             DefaultVisit(node);
@@ -283,11 +278,6 @@ namespace ProtoCore.SyntaxAnalysis
         }
 
         public virtual TResult VisitNullNode(NullNode node)
-        {
-            return DefaultVisit(node);
-        }
-
-        public virtual TResult VisitReturnNode(ReturnNode node)
         {
             return DefaultVisit(node);
         }

--- a/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
@@ -1,0 +1,400 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ProtoCore.AST.AssociativeAST;
+using ProtoCore.AST;
+
+namespace ProtoCore.SyntaxAnalysis
+{
+    public class AssociativeAstVisitor
+    {
+        public virtual void DefaultVisit(AssociativeNode node)
+        {
+        }
+
+        public virtual void Visit(Node node)
+        {
+            AssociativeNode assocNode = node as AssociativeNode;
+            if (assocNode != null)
+                assocNode.Accept(this);
+        }
+
+        public virtual void VisitCommentNode(CommentNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitLanguageBlockNode(LanguageBlockNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitReplicationGuideNode(ReplicationGuideNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitArrayNameNode(ArrayNameNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitGroupExpressionNode(GroupExpressionNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitIdentifierNode(IdentifierNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitTypedIdentifierNode(TypedIdentifierNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitIdentifierListNode(IdentifierListNode node)
+        {
+            DefaultVisit(node); 
+        }
+
+        public virtual void VisitIntNode(IntNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitDoubleNode(DoubleNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitBooleanNode(BooleanNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitCharNode(CharNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitStringNode(StringNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitNullNode(NullNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitReturnNode(ReturnNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitFunctionCallNode(FunctionCallNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitFunctionDotCallNode(FunctionDotCallNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitVarDeclNode(VarDeclNode node)
+        {
+            DefaultVisit(node);
+        }
+        
+        public virtual void VisitArgumentSignatureNode(ArgumentSignatureNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitCodeBlockNode(CodeBlockNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitClassDeclNode(ClassDeclNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitConstructorDefinitionNode(ConstructorDefinitionNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitFunctionDefinitionNode(FunctionDefinitionNode node)
+        {
+            DefaultVisit(node); ;
+        }
+
+        public virtual void VisitIfStatementNode(IfStatementNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitInlineConditionalNode(InlineConditionalNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitBinaryExpressionNode(BinaryExpressionNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitUnaryExpressionNode(UnaryExpressionNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitRangeExprNode(RangeExprNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitExprListNode(ExprListNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitArrayNode(ArrayNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitImportNode(ImportNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitDynamicNode(DynamicNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitDynamicBlockNode(DynamicBlockNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitThisPointerNode(ThisPointerNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitDefaultArgNode(DefaultArgNode node)
+        {
+            DefaultVisit(node);
+        }
+
+        public virtual void VisitModifierStackNode(ModifierStackNode node)
+        {
+            DefaultVisit(node);
+        }
+    }
+
+    public class AssociativeAstVisitor<TResult>
+    {
+        public virtual TResult DefaultVisit(AssociativeNode node)
+        {
+            return default(TResult);
+        }
+
+        public virtual TResult Visit(Node node)
+        {
+            AssociativeNode assocNode = node as AssociativeNode;
+            if (assocNode != null)
+                return assocNode.Accept(this);
+
+            return default(TResult);
+        }
+
+        public virtual TResult VisitCommentNode(CommentNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitLanguageBlockNode(LanguageBlockNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitReplicationGuideNode(ReplicationGuideNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitArrayNameNode(ArrayNameNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitGroupExpressionNode(GroupExpressionNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitIdentifierNode(IdentifierNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitTypedIdentifierNode(TypedIdentifierNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitIdentifierListNode(IdentifierListNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitIntNode(IntNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitDoubleNode(DoubleNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitBooleanNode(BooleanNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitCharNode(CharNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitStringNode(StringNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitNullNode(NullNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitReturnNode(ReturnNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitFunctionCallNode(FunctionCallNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitFunctionDotCallNode(FunctionDotCallNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitVarDeclNode(VarDeclNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitArgumentSignatureNode(ArgumentSignatureNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitCodeBlockNode(CodeBlockNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitClassDeclNode(ClassDeclNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitConstructorDefinitionNode(ConstructorDefinitionNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitFunctionDefinitionNode(FunctionDefinitionNode node)
+        {
+            return DefaultVisit(node); ;
+        }
+
+        public virtual TResult VisitIfStatementNode(IfStatementNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitInlineConditionalNode(InlineConditionalNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitBinaryExpressionNode(BinaryExpressionNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitUnaryExpressionNode(UnaryExpressionNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitRangeExprNode(RangeExprNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitExprListNode(ExprListNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitArrayNode(ArrayNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitImportNode(ImportNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitDynamicNode(DynamicNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitDynamicBlockNode(DynamicBlockNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitThisPointerNode(ThisPointerNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitDefaultArgNode(DefaultArgNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        public virtual TResult VisitModifierStackNode(ModifierStackNode node)
+        {
+            return DefaultVisit(node);
+        }
+    }
+}

--- a/test/Engine/ProtoTest/ProtoTest.csproj
+++ b/test/Engine/ProtoTest/ProtoTest.csproj
@@ -200,6 +200,7 @@
     <Compile Include="TD\TraceUtilsTests.cs" />
     <Compile Include="FFITests\TestCSharpAttribute.cs" />
     <Compile Include="UtilsTests\AstFactoryTest.cs" />
+    <Compile Include="UtilsTests\AstVisitorTest.cs" />
     <Compile Include="UtilsTests\ClassUtilsTest.cs" />
     <Compile Include="UtilsTests\CoreDump.cs" />
     <Compile Include="UtilsTests\CoreUtilsTest.cs" />

--- a/test/Engine/ProtoTest/UtilsTests/AstVisitorTest.cs
+++ b/test/Engine/ProtoTest/UtilsTests/AstVisitorTest.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using ProtoCore.AST.AssociativeAST;
+using ProtoCore.SyntaxAnalysis;
+using ProtoTestFx.TD;
+
+namespace ProtoTest.UtilsTests
+{
+    class AstRewriter : AssociativeAstVisitor<AssociativeNode>
+    {
+        private string variableName;
+        private IntNode newValueNode;
+
+        public BinaryExpressionNode ReplaceWithConstant(BinaryExpressionNode node, string variable, int value)
+        {
+            variableName = variable;
+            newValueNode = AstFactory.BuildIntNode(value);
+            return node.Accept(this) as BinaryExpressionNode;
+        }
+
+        public override AssociativeNode VisitIdentifierNode(IdentifierNode node)
+        {
+            if (node.Value.Equals(variableName))
+                return newValueNode;
+            else
+                return node;
+        }
+
+        public override AssociativeNode VisitBinaryExpressionNode(BinaryExpressionNode node)
+        {
+            if (node.Optr != ProtoCore.DSASM.Operator.assign)
+                return node;
+
+            var leftNode = node.LeftNode;
+            var rightNode = node.RightNode;
+
+            var newLeftNode = leftNode.Accept(this); 
+            var newRightNode = rightNode.Accept(this); 
+
+            if (newLeftNode == leftNode && newRightNode == rightNode)
+            {
+                return node;
+            }
+            else
+            {
+                return new BinaryExpressionNode(newLeftNode, newRightNode, ProtoCore.DSASM.Operator.assign);
+            }
+        }
+    }
+
+    [TestFixture]
+    class AstVisitorTest
+    {
+        [Test]
+        public void TestAstVisitorForReplacement()
+        {
+            AstRewriter rewriter = new AstRewriter();
+
+            var lhs = AstFactory.BuildIdentifier("x");
+            var rhs = AstFactory.BuildIdentifier("y");
+            var expression1 = AstFactory.BuildAssignment(lhs, rhs);
+
+            var newExpression = rewriter.ReplaceWithConstant(expression1, "y", 21);
+            var newLhs = newExpression.LeftNode as IdentifierNode;
+            var newRhs = newExpression.RightNode as IntNode;
+            Assert.IsTrue(newLhs != null && newLhs.Value == "x" && newRhs != null && newRhs.Value == 21);
+        }
+        
+    }
+}


### PR DESCRIPTION
This PR removes some dead Associaitve AST nodes: `BreakNode`, `ContinueNode`, `ForLoopNode` and `PostFixNode`, and removes them from parser as well.

During the implementation of node to code, it is quite frequently to go through ASTs to do some replacment, for example, to replace an identifier "a" to "b", so two visitor classes are added to Associative AST to support AST traversal and modification.  Unit test `AstVisitorTest.TestAstVisitorForReplacement` shows how to use these classes. 

In the long term, we may support more code analysis functionalists like query or re-factoring. It is too cumbersome to do DFS traversal again and again,

@junmendoza , @lukechurch  please take a look.