### PR TITLE
Fix build error - remove ReturnNode from imperative language

### DIFF
--- a/src/Engine/ProtoCore/Parser/ImperativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/ImperativeAST.cs
@@ -562,20 +562,6 @@ namespace ProtoCore.AST.ImperativeAST
         }
     }
 
-    public class ReturnNode : ImperativeNode
-    {
-        public ImperativeNode ReturnExpr { get; set; }
-
-        public override bool Equals(object other)
-        {
-            var otherNode = other as ReturnNode;
-            if (null == otherNode)
-                return false;
-
-            return null != ReturnExpr && ReturnExpr.Equals(otherNode.ReturnExpr);
-        }
-    }
-
     public class ArgumentSignatureNode : ImperativeNode
     {
         public ArgumentSignatureNode()

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -3324,10 +3324,6 @@ namespace ProtoImperative
                 EmitPostFixNode(node, ref inferedType);
             }
 #endif
-            else if (node is ReturnNode)
-            {
-                EmitReturnNode(node);
-            }
             else if (node is LanguageBlockNode)
             {
                 EmitLanguageBlockNode(node, ref inferedType, graphNode);

--- a/test/Engine/ProtoTest/ProtoAST/ProtoASTExecutionTests.cs
+++ b/test/Engine/ProtoTest/ProtoAST/ProtoASTExecutionTests.cs
@@ -1389,8 +1389,9 @@ namespace ProtoTest.ProtoAST
                 new ProtoCore.AST.AssociativeAST.IdentifierNode("b"),
                 new ProtoCore.AST.AssociativeAST.IntNode(10),
                 ProtoCore.DSASM.Operator.add);
-            ProtoCore.AST.AssociativeAST.ReturnNode returnNode = new ProtoCore.AST.AssociativeAST.ReturnNode();
-            returnNode.ReturnExpr = returnExpr;
+
+            var returnIdent = new ProtoCore.AST.AssociativeAST.IdentifierNode("return");
+            ProtoCore.AST.AssociativeAST.BinaryExpressionNode returnNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode(returnIdent, returnExpr);
             cbn.Body.Add(assignment1);
             cbn.Body.Add(returnNode);
             ///


### PR DESCRIPTION
This is caused by my PR #4297 which removes `EmitReturnNode()` function. 