### PR TITLE
Remove usage of Segoe UI in package manager search

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -182,73 +182,79 @@
                                 </TextBlock>
 
                                 <StackPanel Orientation="Horizontal" Margin="1" Width="450">
-
+   
                                     <Button Name="DownloadButton" Style="{StaticResource FlatButton}" Command="{Binding DownloadLatestCommand }" Foreground="#666">
-                                        <Grid Width="40" Height="64">
-                                            <TextBlock IsHitTestVisible="True" Background="Transparent" FontSize="30" Padding="12">⬇</TextBlock>
-                                            <Ellipse
-                                                        Fill="Transparent"
-                                                        Height="36"
-                                                        Width="36"
-                                                        StrokeThickness="3"
-                                                        Stroke="#666" />
-                                        </Grid>
-                                    </Button>
+                                            <Grid Width="40" Height="64">
+                                                <TextBlock IsHitTestVisible="True" Background="Transparent" FontSize="30" Padding="12">⬇</TextBlock>
+                                                <Ellipse
+                                                            Fill="Transparent"
+                                                            Height="36"
+                                                            Width="36"
+                                                            StrokeThickness="3"
+                                                            Stroke="#666" />
+                                            </Grid>
+                                        </Button>
 
-                                    <Button Style="{StaticResource FlatButton}" Command="{Binding ToggleIsExpandedCommand }" Background="#333">
+                                    <StackPanel Orientation="Vertical">
+                                        <StackPanel Orientation="Horizontal">
+                                            <Button Style="{StaticResource FlatButton}" Command="{Binding ToggleIsExpandedCommand }" Background="#333">
 
-                                        <StackPanel Width="350" Height="75" IsHitTestVisible="True" >
-                                            <TextBlock FontSize="14"  Name="name" Text="{Binding Path=Model.Name}" Margin="5,0,0,0" HorizontalAlignment="Left" Foreground="WhiteSmoke" />
+                                                <StackPanel Width="350" IsHitTestVisible="True" >
+                                                    <TextBlock FontSize="14"  Name="name" Text="{Binding Path=Model.Name}" Margin="5,0,0,0" HorizontalAlignment="Left" Foreground="WhiteSmoke" />
 
-                                            <StackPanel Orientation="Horizontal" Margin="0,6,0,2">
+                                                    <StackPanel Orientation="Horizontal" Margin="0,6,0,2">
 
-                                                <StackPanel Orientation="Horizontal" Margin="5" Width="100">
-                                                    <TextBlock FontSize="10" FontFamily="Segoe UI Symbol" Text="&#xE13D;   " Foreground="Gray" />
-                                                    <TextBlock FontSize="10" MaxWidth="100" Text="{Binding Path= Model.Maintainers}" TextTrimming="WordEllipsis" Foreground="Gray"  />
+                                                        <StackPanel Orientation="Horizontal" Margin="5" Width="100">
+                                                            <TextBlock FontSize="10" FontWeight="Bold" Text="✎   " Foreground="Gray" />
+                                                            <TextBlock FontSize="10" MaxWidth="100" Text="{Binding Path= Model.Maintainers}" TextTrimming="WordEllipsis" Foreground="Gray"  />
+                                                        </StackPanel>
+
+                                                        <StackPanel Orientation="Horizontal" Margin="5" Width="60">
+                                                            <TextBlock FontSize="10" FontWeight="Bold" Text="⚑   " Foreground="Gray" />
+                                                            <TextBlock FontSize="10" Text="{Binding Path= Model.LatestVersion}" Foreground="Gray"  />
+                                                        </StackPanel>
+
+                                                        <StackPanel Orientation="Horizontal" Margin="5" Width="50">
+                                                            <TextBlock FontSize="10" FontWeight="Bold" Text="▼   " Foreground="Gray" />
+                                                            <TextBlock FontSize="10" Text="{Binding Path= Model.Downloads}" Foreground="Gray"  />
+                                                        </StackPanel>
+
+                                                        <StackPanel Orientation="Horizontal" Margin="5" Width="80">
+                                                            <TextBlock FontSize="10" FontWeight="Bold" Text="◷   " Foreground="Gray" />
+                                                            <TextBlock FontSize="10" Text="{Binding Path= Model.LatestVersionCreated, Converter={StaticResource PrettyDateConverter}}" Foreground="Gray"  />
+                                                        </StackPanel>
+
+                                                    </StackPanel>
+
+
                                                 </StackPanel>
+                                            </Button>
 
-                                                <StackPanel Orientation="Horizontal" Margin="5" Width="60">
-                                                    <TextBlock FontSize="10" FontWeight="Bold" Text="⚑   " Foreground="Gray" />
-                                                    <TextBlock FontSize="10" Text="{Binding Path= Model.LatestVersion}" Foreground="Gray"  />
+                                            <StackPanel Width="40"  Orientation="Vertical" Margin="3,0,0,0">
+                                                <StackPanel Orientation="Horizontal">
+                                                    <Button Name="UpvoteButton" 
+                                                        FontSize="15" 
+                                                        ToolTip="{x:Static p:Resources.PackageSearchViewUpvoteButtonTooltip}"  
+                                                        Content="⬆"
+                                                        Margin="0,0,8,0"
+                                                        Foreground="Gray" 
+                                                        Command="{Binding Path=UpvoteCommand}" 
+                                                        Style="{StaticResource FlatButton}" />
+                                                    <Button Name="DownvoteButton" 
+                                                        FontSize="15" 
+                                                        ToolTip="{x:Static p:Resources.PackageSearchViewDownvoteButtonTooltip}" 
+                                                        Foreground="Gray" 
+                                                        Content="⬇"  
+                                                        Command="{Binding Path=DownvoteCommand}" 
+                                                        Style="{StaticResource FlatButton}" />
                                                 </StackPanel>
-
-                                                <StackPanel Orientation="Horizontal" Margin="5" Width="50">
-                                                    <TextBlock FontSize="10" FontFamily="Segoe UI Symbol" Text="&#xE118;   " Foreground="Gray" />
-                                                    <TextBlock FontSize="10" Text="{Binding Path= Model.Downloads}" Foreground="Gray"  />
-                                                </StackPanel>
-
-                                                <StackPanel Orientation="Horizontal" Margin="5" Width="80">
-                                                    <TextBlock FontSize="10" FontFamily="Segoe UI Symbol" Text="&#xE121;   " Foreground="Gray" />
-                                                    <TextBlock FontSize="10" Text="{Binding Path= Model.LatestVersionCreated, Converter={StaticResource PrettyDateConverter}}" Foreground="Gray"  />
-                                                </StackPanel>
-
+                                                <TextBlock FontSize="10" TextAlignment="Center" Margin="0,0,5,0" Text="{Binding Path=Model.Votes}" Foreground="Gray"  />
                                             </StackPanel>
-
-                                            <TextBlock FontSize="11" Margin="3" Foreground="#AAA" Text="{Binding Path=Model.Description}" TextWrapping="Wrap" TextTrimming="WordEllipsis" MaxHeight="20"/>
-
                                         </StackPanel>
-                                    </Button>
 
-                                    <StackPanel Width="40"  Orientation="Vertical" Margin="6,0,0,0">
-                                        <StackPanel Orientation="Horizontal" Margin="0,25,0,0">
-                                            <Button Name="UpvoteButton" 
-                                                FontSize="11" 
-                                                ToolTip="{x:Static p:Resources.PackageSearchViewUpvoteButtonTooltip}"  
-                                                FontFamily="Segoe UI Symbol"
-                                                Content="&#xE19F;"
-                                                Foreground="Gray" 
-                                                Command="{Binding Path=UpvoteCommand}" 
-                                                Style="{StaticResource FlatButton}" />
-                                            <Button Name="DownvoteButton" 
-                                                FontSize="11" 
-                                                ToolTip="{x:Static p:Resources.PackageSearchViewDownvoteButtonTooltip}" 
-                                                Foreground="Gray" 
-                                                FontFamily="Segoe UI Symbol"
-                                                Content="&#xE19E;" 
-                                                Command="{Binding Path=DownvoteCommand}" 
-                                                Style="{StaticResource FlatButton}" />
-                                        </StackPanel>
-                                        <TextBlock FontSize="10" Width="40" TextAlignment="Center" Margin="0,0,0,0" Text="{Binding Path=Model.Votes}" Foreground="Gray"  />
+                                        <Button Style="{StaticResource FlatButton}" Command="{Binding ToggleIsExpandedCommand }" Background="#333">
+                                            <TextBlock FontSize="11" Margin="3" Width="390" Foreground="#AAA" Text="{Binding Path=Model.Description}" TextWrapping="Wrap" TextTrimming="WordEllipsis" MaxHeight="20"/>
+                                        </Button>
                                     </StackPanel>
                                 </StackPanel>
 


### PR DESCRIPTION
### Issue 

Segoe UI Symbol is unavailable on some Windows 7 machines, so we apparently cannot use it.

### Fix

I replaced all usages with simple UTF-8 icons.  I did some other minor rearrangements to expand the description as well.  

### Screenshot

![image](https://cloud.githubusercontent.com/assets/916345/7283216/264b613c-e903-11e4-925d-945b5558e6ba.png)

### Reviewer

- [ ] @ramramps 
