### PR TITLE
Remove unnecessary temporary assignments in range expression

### DIFF
--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -2817,24 +2817,6 @@ namespace ProtoImperative
                 }
             }
 
-            // Replace with build-in RangeExpression() function. - Yu Ke
-            var tmpFrom = nodeBuilder.BuildTempVariable();
-            var assignFrom = nodeBuilder.BuildBinaryExpression(tmpFrom, range.FromNode);
-            EmitBinaryExpressionNode(assignFrom, ref inferedType);
-
-            var tmpTo = nodeBuilder.BuildTempVariable();
-            var assignTo = nodeBuilder.BuildBinaryExpression(tmpTo, range.ToNode);
-            EmitBinaryExpressionNode(assignTo, ref inferedType);
-
-            var tmpStep = nodeBuilder.BuildTempVariable();
-            var assignStep = nodeBuilder.BuildBinaryExpression(tmpStep, range.StepNode == null ? new NullNode() : range.StepNode);
-            EmitBinaryExpressionNode(assignStep, ref inferedType);
-
-            BooleanNode hasStep = new BooleanNode(range.StepNode != null);
-            var tmpStepSkip = nodeBuilder.BuildTempVariable();
-            var assignStepSkip = nodeBuilder.BuildBinaryExpression(tmpStepSkip, hasStep);
-            EmitBinaryExpressionNode(assignStepSkip, ref inferedType);
-
             IntNode op = null;
             switch (range.stepoperator)
             {
@@ -2852,8 +2834,17 @@ namespace ProtoImperative
                     break;
             }
 
-            var rangeExprFunc = nodeBuilder.BuildFunctionCall(Constants.kFunctionRangeExpression,
-                new List<ImperativeNode> { tmpFrom, tmpTo, tmpStep, op, tmpStepSkip, new BooleanNode(range.HasRangeAmountOperator) });
+            var rangeExprFunc = nodeBuilder.BuildFunctionCall(
+                Constants.kFunctionRangeExpression,
+                new List<ImperativeNode> 
+                { 
+                    range.FromNode, 
+                    range.ToNode, 
+                    range.StepNode ?? new NullNode(),
+                    op, 
+                    new BooleanNode(range.StepNode != null),
+                    new BooleanNode(range.HasRangeAmountOperator) 
+                });
 
             NodeUtils.CopyNodeLocation(rangeExprFunc, range);
             EmitFunctionCallNode(rangeExprFunc, ref inferedType, false, graphNode);

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestScope.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestScope.cs
@@ -1042,7 +1042,7 @@ a = 10;
 // expected: sum = 21
 // result: sum = 11";
             ExecutionMirror mirror = thisTest.RunScriptSource(src);
-            Assert.IsTrue((Int64)mirror.GetValue("sum").Payload == 11);
+            Assert.IsTrue((Int64)mirror.GetValue("sum").Payload == 21);
 
         }
 

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestScope.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestScope.cs
@@ -1030,19 +1030,19 @@ y = 1;
             string src = @"
 a = 5;
 b = 2 * a;
-sum;
+count;
 [Imperative] {
-	sum = 0;
+	count = 0;
 	arr = 0..b;
 	for (i  in arr) {
-		sum = sum + 1;
+		count = count + 1;
 	}
 }
 a = 10;
-// expected: sum = 21
-// result: sum = 11";
+// expected: count = 21
+// result: count = 11";
             ExecutionMirror mirror = thisTest.RunScriptSource(src);
-            Assert.IsTrue((Int64)mirror.GetValue("sum").Payload == 21);
+            Assert.IsTrue((Int64)mirror.GetValue("count").Payload == 21);
 
         }
 


### PR DESCRIPTION
For a range expression in imperative language block, for example, `0..10..1`, the codegen will create unnecessary temporary assignments:
```
t1 = 0;
t2 = 10;
t3 = 1;
%generate_range(t1, t2, t3, ...);
```
These temporary assignments could be safely removed:
```
%generate_range(0, 10, 1, ...);
```

@junmendoza  PTAL.

