### PR TITLE
Disable a memory hungry test case

### DIFF
--- a/test/DynamoCoreTests/Nodes/ListTests.cs
+++ b/test/DynamoCoreTests/Nodes/ListTests.cs
@@ -1134,7 +1134,9 @@ namespace Dynamo.Tests
 
 		}
 
-		[Test]
+        // NOTE: This test itself increases the memory consumption by 2.1 GB.
+        // Temporary disabling it so that the build server can continue...
+        [Test, Category("Failure")]
         public void LaceLongest_ListWith10000Element()
 		{
 			var model = ViewModel.Model;


### PR DESCRIPTION
This pull request temporary marked `LaceLongest_ListWith10000Element` as failure so it won't be included in continuous integration test run. This test case itself is causing the memory consumption to increase by 2.1 GB. Merging this in so that the build can continue.

@riteshchandawar, please log a defect to track this performance issue. Thanks!