### PR TITLE
Preventing migration settings dialog from appearing if there is no previ...

### DIFF
--- a/src/DynamoCore/Core/DynamoMigrator.cs
+++ b/src/DynamoCore/Core/DynamoMigrator.cs
@@ -182,6 +182,9 @@ namespace Dynamo.Core
             if (versions.Count() < 2)
                 return null; // No need for migration
 
+            DynamoModel.OnRequestMigrationStatusDialog(new SettingsMigrationEventArgs(
+                    SettingsMigrationEventArgs.EventStatusType.Begin));
+
             var previousVersion = versions[1];
             var currentVersion = versions[0];
             Debug.Assert(currentVersion.MajorPart == pathManager.MajorFileVersion

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -465,8 +465,6 @@ namespace Dynamo.Models
             {
                 DynamoMigratorBase migrator = null;
 
-                OnRequestMigrationStatusDialog(new SettingsMigrationEventArgs(
-                    SettingsMigrationEventArgs.EventStatusType.Begin));
                 try
                 {
                     migrator = DynamoMigratorBase.MigrateBetweenDynamoVersions(pathManager, config.PathResolver);

--- a/src/DynamoCore/Models/DynamoModelEvents.cs
+++ b/src/DynamoCore/Models/DynamoModelEvents.cs
@@ -44,7 +44,7 @@ namespace Dynamo.Models
         }
 
         public static event SettingsMigrationHandler RequestMigrationStatusDialog;
-        public static void OnRequestMigrationStatusDialog(SettingsMigrationEventArgs args)
+        internal static void OnRequestMigrationStatusDialog(SettingsMigrationEventArgs args)
         {
             if (RequestMigrationStatusDialog != null)
                 RequestMigrationStatusDialog(args);

--- a/src/DynamoCore/Models/DynamoModelEvents.cs
+++ b/src/DynamoCore/Models/DynamoModelEvents.cs
@@ -43,9 +43,7 @@ namespace Dynamo.Models
                 action();
         }
 
-        // public delegate void SettingsMigrationHandler(object sender, SettingsMigrationEventArgs args);
         public static event SettingsMigrationHandler RequestMigrationStatusDialog;
-
         public static void OnRequestMigrationStatusDialog(SettingsMigrationEventArgs args)
         {
             if (RequestMigrationStatusDialog != null)


### PR DESCRIPTION
...ously installed version to migrate from

Basically invoking the migration dialog only if there is a migration required, not otherwise. Earlier it was implemented in such a way that if there were no files to migrate the dialog would close immediately
but later it was changed to stay on until the user agreement dialog came up. That's why it could be misleading if it comes up when there's nothing to migrate and therefore this fix.

This fixes issue: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7216

Also needed to go in for DS release.

@Benglin PTAL