### PR TITLE
Implemented support for additional terms of use document

### DIFF
--- a/src/DynamoCoreWpf/Interfaces/IBrandingResourceProvider.cs
+++ b/src/DynamoCoreWpf/Interfaces/IBrandingResourceProvider.cs
@@ -34,12 +34,20 @@ namespace Dynamo.Wpf.Interfaces
     {
         ImageSource GetImageSource(ResourceNames.ConsentForm resourceName);
         ImageSource GetImageSource(ResourceNames.StartPage resourceName);
-
         string GetString(ResourceNames.MainWindow resourceName);
         string GetString(ResourceNames.ConsentForm resourceName);
-
         Window CreateAboutBox(DynamoViewModel model);
-
         string ProductName { get; }
+
+        /// <summary>
+        /// This property returns the full file path to the additional terms of 
+        /// use document, if any. The terms of use will be shown in addition to 
+        /// the existing Dynamo TermsOfUse.rtf before the user is allowed to 
+        /// publish any package. If specified, this property should represent an
+        /// existing file, otherwise an exception will be thrown. If there is no
+        /// additional terms of use document to show, this property should return
+        /// an empty string.
+        /// </summary>
+        string AdditionalPackagePublisherTermsOfUse { get; }
     }
 }

--- a/src/DynamoCoreWpf/UI/DefaultBrandingResourceProvider.cs
+++ b/src/DynamoCoreWpf/UI/DefaultBrandingResourceProvider.cs
@@ -87,6 +87,12 @@ namespace Dynamo.Wpf.UI
         }
 
         public string ProductName { get { return "Dynamo"; } }
+
+        public string AdditionalPackagePublisherTermsOfUse
+        {
+            get { return String.Empty; } // No additional terms of use.
+        }
+
         #endregion
 
         #region private members

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -5,13 +5,13 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Forms.VisualStyles;
 using System.Windows.Input;
 using Dynamo.Core;
 using Dynamo.Models;
 using Dynamo.Nodes;
 using Dynamo.PackageManager;
 using Dynamo.Selection;
+using Dynamo.Wpf.Interfaces;
 using Greg.AuthProviders;
 
 using Dynamo.Wpf.Properties;
@@ -22,24 +22,37 @@ using System.IO;
 
 namespace Dynamo.ViewModels
 {
+    public class TermsOfUseHelperParams
+    {
+        internal IBrandingResourceProvider ResourceProvider { get; set; }
+        internal PackageManagerClient PackageManagerClient { get; set; }
+        internal Action AcceptanceCallback { get; set; }
+    }
+
     /// <summary>
     /// A helper class to check asynchronously whether the Terms of Use has 
     /// been accepted, and if so, continue to execute the provided Action.
     /// </summary>
     public class TermsOfUseHelper
     {
+        private readonly IBrandingResourceProvider resourceProvider;
         private readonly Action callbackAction;
         private readonly PackageManagerClient packageManagerClient;
 
-        public TermsOfUseHelper(PackageManagerClient client, Action callback)
+        public TermsOfUseHelper(TermsOfUseHelperParams touParams)
         {
-            if (client == null)
-                throw new ArgumentNullException("client");
-            if (callback == null)
-                throw new ArgumentNullException("callback");
+            if (touParams == null)
+                throw new ArgumentNullException("touParams");
+            if (touParams.PackageManagerClient == null)
+                throw new ArgumentNullException("PackageManagerClient");
+            if (touParams.AcceptanceCallback == null)
+                throw new ArgumentNullException("AcceptanceCallback");
+            if (touParams.ResourceProvider == null)
+                throw new ArgumentNullException("ResourceProvider");
 
-            packageManagerClient = client;
-            callbackAction = callback;
+            resourceProvider = touParams.ResourceProvider;
+            packageManagerClient = touParams.PackageManagerClient;
+            callbackAction = touParams.AcceptanceCallback;
         }
 
         public void Execute()
@@ -70,7 +83,7 @@ namespace Dynamo.ViewModels
                 }, TaskScheduler.FromCurrentSynchronizationContext());
         }
 
-        internal static bool ShowTermsOfUseDialog()
+        internal static bool ShowTermsOfUseDialog(bool forPublishing, string additionalTerms)
         {
             var executingAssemblyPathName = Assembly.GetExecutingAssembly().Location;
             var rootModuleDirectory = Path.GetDirectoryName(executingAssemblyPathName);
@@ -78,12 +91,31 @@ namespace Dynamo.ViewModels
 
             var termsOfUseView = new TermsOfUseView(touFilePath);
             termsOfUseView.ShowDialog();
-            return termsOfUseView.AcceptedTermsOfUse;
+            if (!termsOfUseView.AcceptedTermsOfUse)
+                return false; // User rejected the terms, go no further.
+
+            if (string.IsNullOrEmpty(additionalTerms)) // No additional terms.
+                return termsOfUseView.AcceptedTermsOfUse;
+
+            // If user has accepted the terms, and if there is an additional 
+            // terms specified, then that should be shown, too. Note that if 
+            // the file path is provided, it has to represent a valid file path.
+            // 
+            if (!File.Exists(additionalTerms))
+                throw new FileNotFoundException(additionalTerms);
+
+            var additionalTermsView = new TermsOfUseView(additionalTerms);
+            additionalTermsView.ShowDialog();
+            return additionalTermsView.AcceptedTermsOfUse;
         }
 
         private void ShowTermsOfUseForPublishing()
         {
-            if (!ShowTermsOfUseDialog())
+            var additionalTerms = string.Empty;
+            if (resourceProvider != null)
+                additionalTerms = resourceProvider.AdditionalPackagePublisherTermsOfUse;
+
+            if (!ShowTermsOfUseDialog(true, additionalTerms))
                 return; // Terms of use not accepted.
 
             // If user accepts the terms of use, then update the record on 
@@ -186,10 +218,17 @@ namespace Dynamo.ViewModels
                     ws.CustomNodeId,
                     out currentFunInfo))
                 {
-                    var termsOfUseCheck = new TermsOfUseHelper(Model, () => 
+                    var touParams = new TermsOfUseHelperParams
                     {
-                        ShowNodePublishInfo(new[] { Tuple.Create(currentFunInfo, currentFunDef) });
-                    });
+                        PackageManagerClient = Model,
+                        ResourceProvider = DynamoViewModel.BrandingResourceProvider,
+                        AcceptanceCallback = () => ShowNodePublishInfo(new[]
+                        {
+                            Tuple.Create(currentFunInfo, currentFunDef)
+                        })
+                    };
+
+                    var termsOfUseCheck = new TermsOfUseHelper(touParams);
                     termsOfUseCheck.Execute();
                     return;
                 }
@@ -207,7 +246,13 @@ namespace Dynamo.ViewModels
 
         public void PublishNewPackage(object m)
         {
-            var termsOfUseCheck = new TermsOfUseHelper(Model, ShowNodePublishInfo );
+            var termsOfUseCheck = new TermsOfUseHelper(new TermsOfUseHelperParams
+            {
+                PackageManagerClient = Model,
+                ResourceProvider = DynamoViewModel.BrandingResourceProvider,
+                AcceptanceCallback = ShowNodePublishInfo
+            });
+
             termsOfUseCheck.Execute();
         }
 
@@ -223,10 +268,16 @@ namespace Dynamo.ViewModels
                 m.Definition.FunctionId,
                 out currentFunInfo))
             {
-                var termsOfUseCheck = new TermsOfUseHelper(Model, () =>
+                var termsOfUseCheck = new TermsOfUseHelper(new TermsOfUseHelperParams
                 {
-                    ShowNodePublishInfo(new[] { Tuple.Create(currentFunInfo, m.Definition) });
+                    PackageManagerClient = Model,
+                    ResourceProvider = DynamoViewModel.BrandingResourceProvider,
+                    AcceptanceCallback = () => ShowNodePublishInfo(new[]
+                    {
+                        Tuple.Create(currentFunInfo, m.Definition)
+                    })
                 });
+
                 termsOfUseCheck.Execute();
             }
         }
@@ -272,7 +323,13 @@ namespace Dynamo.ViewModels
                     MessageBoxButton.OK, MessageBoxImage.Question);
             }
 
-            var termsOfUseCheck = new TermsOfUseHelper(Model, () => ShowNodePublishInfo(defs));
+            var termsOfUseCheck = new TermsOfUseHelper(new TermsOfUseHelperParams
+            {
+                PackageManagerClient = Model,
+                ResourceProvider = DynamoViewModel.BrandingResourceProvider,
+                AcceptanceCallback = () => ShowNodePublishInfo(defs)
+            });
+
             termsOfUseCheck.Execute();
         }
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -410,7 +410,7 @@ namespace Dynamo.Controls
             if (prefSettings.PackageDownloadTouAccepted)
                 return true; // User accepts the terms of use.
 
-            var acceptedTermsOfUse = TermsOfUseHelper.ShowTermsOfUseDialog();
+            var acceptedTermsOfUse = TermsOfUseHelper.ShowTermsOfUseDialog(false, null);
             prefSettings.PackageDownloadTouAccepted = acceptedTermsOfUse;
 
             // User may or may not accept the terms.


### PR DESCRIPTION
Background
-----
As of the latest build, Dynamo displays a *Terms of Use* dialog before user could publish any package. This pull request adds the ability for a client application to specify an additional *Terms of Use* dialog, if it is desirable. The following new property on `IBrandingResourceProvider` interface enables this new functionality:

```csharp
/// <summary>
/// This property returns the full file path to the additional terms of 
/// use document, if any. The terms of use will be shown in addition to 
/// the existing Dynamo TermsOfUse.rtf before the user is allowed to 
/// publish any package. If specified, this property should represent an
/// existing file, otherwise an exception will be thrown. If there is no
/// additional terms of use document to show, this property should return
/// an empty string.
/// </summary>
string AdditionalPackagePublisherTermsOfUse { get; }
```

If the client application returns a valid `*.rtf` file path when this property is retrieved, it will be displayed right after user accepts the default Dynamo *Terms of Use* dialog. If user rejects the first *Terms of Use* dialog, then this additional terms will not be shown. Default implementation of Dynamo returns an empty string for this, so Dynamo (on Autodesk Revit) only brings up a single *Terms of Use* dialog before user publishes.

Hi @nguyen-binh-minh, could you please review these changes? Thanks!