### PR TITLE
Prevent VM from loading Cell2, Vertex2 types in Tessellation

### DIFF
--- a/src/Libraries/Tesellation/Adapters/Cell2.cs
+++ b/src/Libraries/Tesellation/Adapters/Cell2.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Autodesk.DesignScript.Geometry;
+using Autodesk.DesignScript.Runtime;
 using MIConvexHull;
 
 using StarMathLib;
@@ -9,6 +10,7 @@ namespace Tessellation.Adapters
     /// <summary>
     /// A cell for a 2d tesselation
     /// </summary>
+    [SupressImportIntoVM]
     public class Cell2 : TriangulationCell<Vertex2, Cell2>
     {
         Point GetCircumcenter()

--- a/src/Libraries/Tesellation/Adapters/Vertex2.cs
+++ b/src/Libraries/Tesellation/Adapters/Vertex2.cs
@@ -1,9 +1,11 @@
 using Autodesk.DesignScript.Geometry;
 using Autodesk.DesignScript.Interfaces;
+using Autodesk.DesignScript.Runtime;
 using MIConvexHull;
 
 namespace Tessellation.Adapters
 {
+    [SupressImportIntoVM]
     public class Vertex2 : IVertex, IGraphicItem
     {
         public static Vertex2 FromUV(UV uv)


### PR DESCRIPTION
### Info

This is a regression that causes various types from MIConvexHull to be erroneously loaded into the VM due to the introduction of the `SurfaceData` class.

### Fix

Just add the required attribute to prevent loading.  These types aren't used anywhere in user-facing code, so this will not affect anyone's graphs.  

FYI @ikeough 