### PR TITLE
Fixed issues with login/register screens not displaying right

### DIFF
--- a/src/DynamoCoreWpf/Windows/BrowserWindow.xaml
+++ b/src/DynamoCoreWpf/Windows/BrowserWindow.xaml
@@ -2,14 +2,20 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
-        Title="SignInWindow" Height="365" Width="360">
-    <Grid>
+        Title="SignInWindow"
+        Height="365"
+        Width="360">
+    <Grid Background="#222">
 
-        <Grid Name="LoadingGrid" Background="#222">
-            <TextBlock Padding="40" FontSize="20" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="#AAA" Text="{x:Static p:Resources.BrowserWindowLoading}"></TextBlock>
-        </Grid>
-        
-        <WebBrowser Name="Browser" Visibility="Collapsed"></WebBrowser>
-                 
+        <TextBlock Name="LoadingTextBlock"
+                   FontSize="20"
+                   VerticalAlignment="Center"
+                   HorizontalAlignment="Center"
+                   Foreground="#AAA"
+                   Text="{x:Static p:Resources.BrowserWindowLoading}" />
+
+        <WebBrowser Name="Browser"
+                    Visibility="Collapsed" />
+
     </Grid>
 </Window>

--- a/src/DynamoCoreWpf/Windows/BrowserWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Windows/BrowserWindow.xaml.cs
@@ -1,26 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace Dynamo.Wpf
 {
-    public partial class BrowserWindow : Window
+    public partial class BrowserWindow
     {
         private readonly Uri _location;
 
         public BrowserWindow(Uri location)
         {
-            this._location = location;
-            this.Loaded += Window_Loaded;
+            _location = location;
+            Loaded += Window_Loaded;
 
             InitializeComponent();
         }
@@ -28,12 +18,22 @@ namespace Dynamo.Wpf
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
             // hide loading grid when navigation ready
-            this.Browser.Navigated += (s, a) =>
+            Browser.Navigated += (s, a) =>
             {
-                this.LoadingGrid.Visibility = Visibility.Collapsed;
-                this.Browser.Visibility = Visibility.Visible;
+                LoadingTextBlock.Visibility = Visibility.Collapsed;
+                Browser.Visibility = Visibility.Visible;
+
+                var localPath = ((a.Uri == null) ? string.Empty : a.Uri.LocalPath);
+                if (localPath.ToLowerInvariant().Equals("/register"))
+                {
+                    // This is navigating to new user registration page,
+                    // which requires the window to be of a larger size.
+                    Width = 460;
+                    Height = 722;
+                }
             };
-            this.Browser.Navigate( _location.AbsoluteUri );
+
+            Browser.Navigate(_location.AbsoluteUri);
         }
     }
 }


### PR DESCRIPTION
Background
-----
This pull request resizes the login window to fit the new *Create an Account* window. The problem is being tracked internally as the following defect:

[MAGN-7192](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7192) Sign In dialog having wrong alignment of Text and edit boxes.

There is another defect that outlines some rendering issues with *Login* dialog, but that defect can only be fixed with a registry key that is outlined in *Changes* section below.

[MAGN-7191](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7191) Sign In dialog missing text for creating new account.

![autodesk-sign-in-page](https://cloud.githubusercontent.com/assets/5086849/7314279/74810e18-ea95-11e4-9738-d3484f8fd24b.png)

![create-autodesk-account-page](https://cloud.githubusercontent.com/assets/5086849/7314281/7b6f53a6-ea95-11e4-9b14-b022c2c24ec5.png)

Changes
-----
1. After user clicks on *Need an Autodesk ID?* link, he/she is redirected to *Create an Account* page. When this happens, the window is resized to `460 x 722` to accommodate the new content.

2. To fix [MAGN-7191](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7191), this is the registry key we need:

```
HKEY_LOCAL_MACHINE (or HKEY_CURRENT_USER)
   SOFTWARE
      Microsoft
         Internet Explorer
            Main
               FeatureControl
                  FEATURE_BROWSER_EMULATION
                     MyAppName.exe = (DWORD) 0x00001f40
```

Hi @aparajit-pratap, @nguyen-binh-minh, please have a look at these changes, thanks!