### PR TITLE
Fix Sign-in UI to display current login-state/username

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -161,31 +161,19 @@ namespace Dynamo.ViewModels
         public readonly DynamoViewModel DynamoViewModel;
         public PackageManagerClient Model { get; private set; }
 
-        private LoginState loginState;
         public LoginState LoginState
         {
             get
             {
-                return loginState;
-            }
-            private set
-            {
-                loginState = value;
-                RaisePropertyChanged("LoginState");
+                return Model.LoginState;
             }
         }
 
-        private string username;
         public string Username
         {
             get
             {
-                return username;
-            }
-            private set
-            {
-                username = value;
-                RaisePropertyChanged("Username");
+                return Model.Username;
             }
         }
 
@@ -208,8 +196,8 @@ namespace Dynamo.ViewModels
 
             model.LoginStateChanged += (loginState) =>
             {
-                Username = Model.Username;
-                LoginState = loginState;
+                RaisePropertyChanged("LoginState");
+                RaisePropertyChanged("Username");
             };
 
         }


### PR DESCRIPTION
This fixes issue: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7194

This fixes the following usage scenarios:
A.
1. After Launching DS
2. Sing in in with a username - the username should display
3. Logout - text must update to "Sign In"
4. Sing-In again with a different user name - it should correctly update the username

B.
1. Sign in from Revit
2. Launch DS -> the UI must show the currently logged in user in A360

C.
1. Launch DS - Sign in 
2. Exit Dynamo without logging out
3. Launch DS again - The UI should show the last logged in user

@Benglin PTAL