### PR TITLE
Graph annotation - Fixed the issue around moving groups slow

### DIFF
--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -128,6 +128,7 @@ namespace Dynamo.Models
                 // a model and textbox. Otherwise there will be some overlap
                 Y = InitialTop - ExtendSize - textBlockHeight;
                 Height = InitialHeight + textBlockHeight - MinTextHeight;
+                UpdateBoundaryFromSelection();
             }
         }
 
@@ -163,15 +164,9 @@ namespace Dynamo.Models
         private void model_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
-            {
-                case "X":
-                    UpdateBoundaryFromSelection();
-                    break;
-                case "Y":
-                    UpdateBoundaryFromSelection();
-                    break;
+            {                
                 case "Position":                  
-                        UpdateBoundaryFromSelection();
+                     UpdateBoundaryFromSelection();
                     break;
                 case "Text":
                     UpdateBoundaryFromSelection();
@@ -388,7 +383,7 @@ namespace Dynamo.Models
         internal void AddToSelectedModels(ModelBase model, bool checkOverlap = false)
         {           
             var list = this.SelectedModels.ToList();
-            if (!list.Select(x => x.GUID != model.GUID).FirstOrDefault()) return;
+            if (list.Where(x => x.GUID == model.GUID).Any()) return;
             if (!CheckModelIsInsideGroup(model, checkOverlap)) return;           
             list.Add(model);
             this.SelectedModels = list;

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -101,19 +101,15 @@ namespace Dynamo.Nodes
                 var annotationGuid = this.ViewModel.AnnotationModel.GUID;
                 ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
                     new DynCmd.SelectModelCommand(annotationGuid, Keyboard.Modifiers.AsDynamoType()));
-                
+
+                //Select all the models inside the group - This avoids some performance bottleneck 
+                //with many nodes selected at the same time - which makes moving the group very slow
+                DynamoSelection.Instance.Selection.AddRange(ViewModel.AnnotationModel.SelectedModels);
+
                 foreach (var models in this.ViewModel.AnnotationModel.SelectedModels)
                 {
-                    //when a node is added to group, that node will be in selected mode. 
-                    //so remove that node from selection. Select that node with other nodes
-                    //in that group. Otherwise, this node will be unselected while the other 
-                    //nodes will be in selected.
-                    if (models.IsSelected)
-                    {
-                        DynamoSelection.Instance.Selection.Remove(models);
-                    }
-                    ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
-                        new DynCmd.SelectModelCommand(models.GUID, Dynamo.Utilities.ModifierKeys.Shift));
+                    //Make sure that models have the selection border inside a group when selected
+                    models.IsSelected = true;                    
                 }
             }
         }
@@ -150,7 +146,7 @@ namespace Dynamo.Nodes
         /// <param name="e">The <see cref="SizeChangedEventArgs"/> instance containing the event data.</param>
         private void GroupTextBlock_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            if (ViewModel != null && !ViewModel.AnnotationModel.loadFromXML)
+            if (ViewModel != null && !ViewModel.AnnotationModel.loadFromXML && e.HeightChanged)
             {
                 ViewModel.AnnotationModel.TextBlockHeight = GroupTextBlock.ActualHeight;                
             }  

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -146,7 +146,7 @@ namespace Dynamo.Nodes
         /// <param name="e">The <see cref="SizeChangedEventArgs"/> instance containing the event data.</param>
         private void GroupTextBlock_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            if (ViewModel != null && !ViewModel.AnnotationModel.loadFromXML && e.HeightChanged)
+            if (ViewModel != null && e.HeightChanged)
             {
                 ViewModel.AnnotationModel.TextBlockHeight = GroupTextBlock.ActualHeight;                
             }  


### PR DESCRIPTION
This  PR fixes the below issue
MAGN-7068 Moving groups is sometimes slow

**Fix**
    Adding all the models in a group to selection is very slow and this creates a bottleneck when moving the group. For this, add all the modes in a  group using AddRange and then just update the selection border around those models. This makes only the group to update its position (eventually all those models will update is position and not vice versa).  Also, did some calculation update when a textblock height is changed. 

- [x] @pboyer 