### PR TITLE
Make block id be one of operands of push instruction

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -8510,12 +8510,12 @@ namespace ProtoAssociative
                             if (symbolnode.isStatic)
                             {
                                 var op = StackValue.BuildStaticMemVarIndex(symbol);
-                                EmitPopm(op, node.line, node.col, node.endLine, node.endCol);
+                                EmitPopm(op, runtimeIndex, node.line, node.col, node.endLine, node.endCol);
                             }
                             else
                             {
                                 var op = StackValue.BuildMemVarIndex(symbol);
-                                EmitPopm(op, node.line, node.col, node.endLine, node.endCol);
+                                EmitPopm(op, runtimeIndex, node.line, node.col, node.endLine, node.endCol);
                             }
                         }
 

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -854,14 +854,18 @@ namespace ProtoAssociative
             // Jun TODO: Implementeation of indexing into a function call:
             //  x = f()[0][1]
             int dimensions = 0;
-            EmitPushVarData(blockId, dimensions);
+            EmitPushVarData(dimensions);
+
+            // Emit depth
+            EmitInstrConsole(kw.push, depth + "[depth]");
+            EmitPush(StackValue.BuildInt(depth));
 
             // The function call
             EmitInstrConsole(ProtoCore.DSASM.kw.callr, procNode.name);
 
             if (isGetter)
             {
-                EmitCall(procNode.procId, type, depth,
+                EmitCall(procNode.procId, blockId, type, 
                          Constants.kInvalidIndex, Constants.kInvalidIndex,
                          Constants.kInvalidIndex, Constants.kInvalidIndex, 
                          procNode.pc);
@@ -874,15 +878,15 @@ namespace ProtoAssociative
                 ProtoCore.CodeModel.CodePoint startInclusive = core.DebuggerProperties.highlightRange.StartInclusive;
                 ProtoCore.CodeModel.CodePoint endExclusive = core.DebuggerProperties.highlightRange.EndExclusive;
 
-                EmitCall(procNode.procId, type, depth, startInclusive.LineNo, startInclusive.CharNo, endExclusive.LineNo, endExclusive.CharNo, procNode.pc);
+                EmitCall(procNode.procId, blockId, type, startInclusive.LineNo, startInclusive.CharNo, endExclusive.LineNo, endExclusive.CharNo, procNode.pc);
             }
             else if (parentExpression != null)
             {
-                EmitCall(procNode.procId, type, depth, parentExpression.line, parentExpression.col, parentExpression.endLine, parentExpression.endCol, procNode.pc);
+                EmitCall(procNode.procId, blockId, type, parentExpression.line, parentExpression.col, parentExpression.endLine, parentExpression.endCol, procNode.pc);
             }
             else
             {
-                EmitCall(procNode.procId, type, depth, funcCall.line, funcCall.col, funcCall.endLine, funcCall.endCol, procNode.pc);
+                EmitCall(procNode.procId, blockId, type, funcCall.line, funcCall.col, funcCall.endLine, funcCall.endCol, procNode.pc);
             }
 
             // The function return value
@@ -1940,7 +1944,11 @@ namespace ProtoAssociative
                     // Jun TODO: Implementeation of indexing into a function call:
                     //  x = f()[0][1]
                     int dimensions = 0;
-                    EmitPushVarData(blockId, dimensions);
+                    EmitPushVarData(dimensions);
+
+                    // Emit depth
+                    EmitInstrConsole(kw.push, depth + "[depth]");
+                    EmitPush(StackValue.BuildInt(depth));
 
                     // The function call
                     EmitInstrConsole(kw.callr, procNode.name);
@@ -1949,8 +1957,8 @@ namespace ProtoAssociative
                     if (procNode.isAssocOperator || procNode.name.Equals(Constants.kInlineConditionalMethodName))
                     {
                         EmitCall(procNode.procId, 
+                                 blockId,
                                  type, 
-                                 depth, 
                                  Constants.kInvalidIndex, 
                                  Constants.kInvalidIndex, 
                                  Constants.kInvalidIndex, 
@@ -1967,8 +1975,8 @@ namespace ProtoAssociative
                         var endExclusive = codeRange.EndExclusive;
 
                         EmitCall(procNode.procId, 
+                                 blockId,
                                  type, 
-                                 depth, 
                                  startInclusive.LineNo, 
                                  startInclusive.CharNo, 
                                  endExclusive.LineNo, 
@@ -1979,8 +1987,8 @@ namespace ProtoAssociative
                     else if (bnode != null && !procNode.name.StartsWith(Constants.kSetterPrefix))
                     {
                         EmitCall(procNode.procId, 
+                                 blockId,
                                  type, 
-                                 depth, 
                                  bnode.line, 
                                  bnode.col, 
                                  bnode.endLine, 
@@ -1990,8 +1998,8 @@ namespace ProtoAssociative
                     else
                     {
                         EmitCall(procNode.procId, 
+                                 blockId,
                                  type, 
-                                 depth, 
                                  funcCall.line, 
                                  funcCall.col, 
                                  funcCall.endLine, 
@@ -2044,11 +2052,15 @@ namespace ProtoAssociative
                         }
                     }
 
+                    // Emit depth
+                    EmitInstrConsole(kw.push, depth + "[depth]");
+                    EmitPush(StackValue.BuildInt(depth));
+
                     // The function call
                     EmitInstrConsole(kw.callr, funcCall.Function.Name + "[dynamic]");
                     EmitDynamicCall(dynFunc.Index, 
                                     globalClassIndex, 
-                                    depth, 
+                                    blockId,
                                     funcCall.line, 
                                     funcCall.col, 
                                     funcCall.endLine, 
@@ -4287,11 +4299,11 @@ namespace ProtoAssociative
                             core.FunctionPointerTable.functionPointerDictionary.TryAdd(fptr, fptrNode);
                             core.FunctionPointerTable.functionPointerDictionary.TryGetBySecond(fptrNode, out fptr);
 
-                            EmitPushVarData(runtimeIndex, 0);
+                            EmitPushVarData(0);
 
                             EmitInstrConsole(ProtoCore.DSASM.kw.push, t.Name);
                             StackValue opFunctionPointer = StackValue.BuildFunctionPointer(fptr);
-                            EmitPush(opFunctionPointer, t.line, t.col);
+                            EmitPush(opFunctionPointer, runtimeIndex, t.line, t.col);
                         }
                         return;
                     }
@@ -4348,7 +4360,7 @@ namespace ProtoAssociative
 
                         // Push the identifier local block  
                         dimensions = 0;
-                        EmitPushVarData(runtimeIndex, dimensions);
+                        EmitPushVarData(dimensions);
                         ProtoCore.Type varType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, 0);
 
                         // TODO Jun: Refactor Allocate() to just return the symbol node itself
@@ -4367,7 +4379,7 @@ namespace ProtoAssociative
                         }
 
                         EmitInstrConsole(ProtoCore.DSASM.kw.pop, t.Value);
-                        EmitPopForSymbol(unboundVariable);
+                        EmitPopForSymbol(unboundVariable, runtimeIndex);
 
 
                         nullAssignGraphNode.PushSymbolReference(symbolnode);
@@ -4549,7 +4561,7 @@ namespace ProtoAssociative
                     }
                 }
 
-                EmitPushVarData(runtimeIndex, dimensions);
+                EmitPushVarData(dimensions);
 
                 if (ProtoCore.DSASM.InterpreterMode.kExpressionInterpreter == core.Options.RunMode)
                 {
@@ -4559,7 +4571,7 @@ namespace ProtoAssociative
                 else
                 {
                     EmitInstrConsole(ProtoCore.DSASM.kw.push, t.Value);
-                    EmitPushForSymbol(symbolnode, t);
+                    EmitPushForSymbol(symbolnode, runtimeIndex, t);
 
                     if (core.Options.TempReplicationGuideEmptyFlag && emitReplicationGuide)
                     {
@@ -8463,20 +8475,20 @@ namespace ProtoAssociative
                                 symbolnode.SetStaticType(castType);
                             }
                             castType = symbolnode.staticType;
-                            EmitPushVarData(runtimeIndex, dimensions, castType.UID, castType.rank);
+                            EmitPushVarData(dimensions, castType.UID, castType.rank);
 
                             symbol = symbolnode.symbolTableIndex;
                             if (t.Name == ProtoCore.DSASM.Constants.kTempArg)
                             {
                                 EmitInstrConsole(ProtoCore.DSASM.kw.pop, t.Name);
-                                EmitPopForSymbol(symbolnode);
+                                EmitPopForSymbol(symbolnode, runtimeIndex);
                             }
                             else
                             {
                                 if (core.Options.RunMode != ProtoCore.DSASM.InterpreterMode.kExpressionInterpreter)
                                 {
                                     EmitInstrConsole(ProtoCore.DSASM.kw.pop, t.Name);
-                                    EmitPopForSymbol(symbolnode, node.line, node.col, node.endLine, node.endCol);
+                                    EmitPopForSymbol(symbolnode, runtimeIndex, node.line, node.col, node.endLine, node.endCol);
                                 }
                                 else
                                 {
@@ -8492,7 +8504,7 @@ namespace ProtoAssociative
                                 symbolnode.SetStaticType(castType);
                             }
                             castType = symbolnode.staticType;
-                            EmitPushVarData(runtimeIndex, dimensions, castType.UID, castType.rank);
+                            EmitPushVarData(dimensions, castType.UID, castType.rank);
 
                             EmitInstrConsole(ProtoCore.DSASM.kw.popm, t.Name);
 
@@ -8570,17 +8582,17 @@ namespace ProtoAssociative
                             EmitPush(regLX);
                         }
 
-                        EmitPushVarData(runtimeIndex, dimensions, castType.UID, castType.rank);
+                        EmitPushVarData(dimensions, castType.UID, castType.rank);
 
                         if (core.Options.RunMode != ProtoCore.DSASM.InterpreterMode.kExpressionInterpreter)
                         {
                             EmitInstrConsole(ProtoCore.DSASM.kw.pop, symbolnode.name);
-                            EmitPopForSymbol(symbolnode, node.line, node.col, node.endLine, node.endCol);
+                            EmitPopForSymbol(symbolnode, runtimeIndex, node.line, node.col, node.endLine, node.endCol);
                         }
                         else
                         {
                             EmitInstrConsole(ProtoCore.DSASM.kw.popw, symbolnode.name);
-                            EmitPopForSymbolW(symbolnode, node.line, node.col, node.endLine, node.endCol);                            
+                            EmitPopForSymbolW(symbolnode, runtimeIndex, node.line, node.col, node.endLine, node.endCol);                            
                         }
 
                         AutoGenerateUpdateReference(bnode.LeftNode, graphNode);
@@ -8670,9 +8682,9 @@ namespace ProtoAssociative
                             nullAssignGraphNode1.updateBlock.startpc = pc;
 
                             EmitPushNull();
-                            EmitPushVarData(cyclicSymbol1.runtimeTableIndex, 0);
+                            EmitPushVarData(0);
                             EmitInstrConsole(ProtoCore.DSASM.kw.pop, cyclicSymbol1.name);
-                            EmitPopForSymbol(cyclicSymbol1, node.line, node.col, node.endLine, node.endCol);
+                            EmitPopForSymbol(cyclicSymbol1, cyclicSymbol1.runtimeTableIndex, node.line, node.col, node.endLine, node.endCol);
 
                             nullAssignGraphNode1.PushSymbolReference(cyclicSymbol1);
                             nullAssignGraphNode1.procIndex = globalProcIndex;
@@ -8689,9 +8701,9 @@ namespace ProtoAssociative
                             nullAssignGraphNode2.updateBlock.startpc = pc;
 
                             EmitPushNull();
-                            EmitPushVarData(cyclicSymbol2.runtimeTableIndex, 0);
+                            EmitPushVarData(0);
                             EmitInstrConsole(ProtoCore.DSASM.kw.pop, cyclicSymbol2.name);
-                            EmitPopForSymbol(cyclicSymbol2, node.line, node.col, node.endLine, node.endCol);
+                            EmitPopForSymbol(cyclicSymbol2, cyclicSymbol2.runtimeTableIndex, node.line, node.col, node.endLine, node.endCol);
 
                             nullAssignGraphNode2.PushSymbolReference(cyclicSymbol2);
                             nullAssignGraphNode2.procIndex = globalProcIndex;

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -4565,7 +4565,7 @@ namespace ProtoAssociative
                 if (ProtoCore.DSASM.InterpreterMode.kExpressionInterpreter == core.Options.RunMode)
                 {
                     EmitInstrConsole(ProtoCore.DSASM.kw.pushw, t.Value);
-                    EmitPushForSymbolW(symbolnode, t.line, t.col);
+                    EmitPushForSymbolW(symbolnode, runtimeIndex, t.line, t.col);
                 }
                 else
                 {
@@ -8492,7 +8492,7 @@ namespace ProtoAssociative
                                 else
                                 {
                                     EmitInstrConsole(ProtoCore.DSASM.kw.popw, t.Name);
-                                    EmitPopForSymbolW(symbolnode, node.line, node.col, node.endLine, node.endCol);
+                                    EmitPopForSymbolW(symbolnode, runtimeIndex, node.line, node.col, node.endLine, node.endCol);
                                 }
                             }
                         }

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -2060,7 +2060,6 @@ namespace ProtoAssociative
                     EmitInstrConsole(kw.callr, funcCall.Function.Name + "[dynamic]");
                     EmitDynamicCall(dynFunc.Index, 
                                     globalClassIndex, 
-                                    blockId,
                                     funcCall.line, 
                                     funcCall.col, 
                                     funcCall.endLine, 

--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -1561,7 +1561,6 @@ namespace ProtoCore
         }
 
         protected void EmitDynamicCall(int functionIndex, int type, 
-            int blockId,
             int line = ProtoCore.DSASM.Constants.kInvalidIndex, int col = ProtoCore.DSASM.Constants.kInvalidIndex, 
             int endline = ProtoCore.DSASM.Constants.kInvalidIndex, int endcol = ProtoCore.DSASM.Constants.kInvalidIndex, 
             int entrypoint = ProtoCore.DSASM.Constants.kInvalidIndex)

--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -1990,7 +1990,7 @@ namespace ProtoCore
             // Pop to the rx register
             StackValue op = StackValue.BuildRegister(Registers.RX);
             EmitInstrConsole(ProtoCore.DSASM.kw.pop, ProtoCore.DSASM.kw.regRX);
-            EmitPop(op, Constants.kGlobalScope, line, col, endline, endcol);
+            EmitPop(op, Constants.kGlobalScope, Constants.kInvalidIndex, line, col, endline, endcol);
 
             // Emit the ret instruction only if this is a function we are returning from
             if (core.IsFunctionCodeBlock(codeBlock))

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -971,7 +971,8 @@ namespace ProtoCore.DSASM
             return sv;
         }
 
-        private StackValue CallrForMemberFunction(int classIndex,
+        private StackValue CallrForMemberFunction(int blockIndex,
+                                                  int classIndex,
                                                   int procIndex,
                                                   bool hasDebugInfo,
                                                   ref bool isExplicitCall)
@@ -981,9 +982,6 @@ namespace ProtoCore.DSASM
 
             var arrayDim = rmem.Pop();
             Validity.Assert(arrayDim.IsArrayDimension);
-
-            var blockIndex = rmem.Pop();
-            Validity.Assert(blockIndex.IsBlockIndex);
 
             ClassNode classNode = exe.classTable.ClassNodes[classIndex];
             ProcedureNode procNode = classNode.vtable.procList[procIndex];
@@ -5691,7 +5689,7 @@ namespace ProtoCore.DSASM
             //
             if (isMemberFunctionPointer)
             {
-                RX = CallrForMemberFunction(classIndex, functionIndex, instr.debug != null, ref explicitCall);
+                RX = CallrForMemberFunction(blockIndex, classIndex, functionIndex, instr.debug != null, ref explicitCall);
             }
             else if (!runtimeCore.Options.IsDeltaExecution)
             {

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -6149,8 +6149,11 @@ namespace ProtoCore.DSASM
             // This is unused in Callr() but needed for stack alignment
             rmem.Push(StackValue.BuildStaticType((int)PrimitiveType.kTypeVar));
 
+            // Depth
+            rmem.Push(StackValue.BuildInt(runtimeCore.ContinuationStruct.InitialDepth));
+
             bool explicitCall = true;
-            Callr(fi, ci, runtimeCore.ContinuationStruct.InitialDepth, ref explicitCall);
+            Callr(procNode.runtimeIndex, fi, ci, ref explicitCall);
         }
 
         private void JMP_Handler(Instruction instruction)

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -3731,8 +3731,9 @@ namespace ProtoCore.DSASM
                 if (isLeftClass || (isFunctionPointerCall && depth > 0)) //constructor or static function or function pointer call
                 {
                     rmem.Pop(); //remove the array dimension for "isLeftClass" or final pointer for "isFunctionPointerCall"
-                    instr.op3.opdata = 0; //depth = 0
+                    depth = 0;
                 }
+
                 //push back the function arguments
                 for (int i = argSvList.Count - 1; i >= 0; i--)
                 {
@@ -3746,11 +3747,13 @@ namespace ProtoCore.DSASM
 
                 // Push the function declaration block  
                 StackValue opblock = StackValue.BuildBlockIndex(procNode.runtimeIndex);
-                rmem.Push(opblock);
+                instr.op3 = opblock;
 
                 int dimensions = 0;
                 StackValue opdim = StackValue.BuildArrayDimension(dimensions);
                 rmem.Push(opdim);
+
+                rmem.Push(StackValue.BuildInt(depth));
 
                 //Modify the operand data
                 instr.op1.opdata = procNode.procId;
@@ -3763,6 +3766,7 @@ namespace ProtoCore.DSASM
             if (!(isFunctionPointerCall && depth == 0))
             {
                 rmem.Pop(); //remove the array dimension for "isLeftClass" or final pointer
+                rmem.Push(StackValue.BuildInt(0));
             }
             return false;
         }

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -594,14 +594,17 @@ namespace ProtoCore.DSASM
             }
         }
 
-        public StackValue Callr(int functionIndex, 
+        public StackValue Callr(int blockDeclId,
+                                int functionIndex, 
                                 int classIndex, 
-                                int depth, 
                                 ref bool explicitCall, 
                                 bool isDynamicCall = false, 
                                 bool hasDebugInfo = false)
         {
             // This is curently unused but required for stack alignment
+            var svDepth = rmem.Pop();
+            int depth = (int)svDepth.opdata;
+
             if (!isDynamicCall)
             {
                 StackValue svType = rmem.Pop();
@@ -614,11 +617,6 @@ namespace ProtoCore.DSASM
             // f()[0][1] -> 2 dimensions
             StackValue svDim = rmem.Pop();
             runtimeVerify(svDim.IsArrayDimension);
-
-            // Jun Comment: The block where the function was declared in
-            StackValue svBlockDeclaration = rmem.Pop();
-            runtimeVerify(svBlockDeclaration.IsBlockIndex);
-            int blockDeclId = (int)svBlockDeclaration.opdata;
 
             bool isCallingMemberFunction = Constants.kInvalidIndex != classIndex;
             if (isCallingMemberFunction)
@@ -749,7 +747,7 @@ namespace ProtoCore.DSASM
 
             int returnAddr = pc + 1;
 
-            int blockDecl = (int)svBlockDeclaration.opdata;
+            int blockDecl = blockDeclId;
 
             if (null != Properties.executingGraphNode)
             {
@@ -870,8 +868,8 @@ namespace ProtoCore.DSASM
                     }
                 }
 
-                SX = svBlockDeclaration;
-                stackFrame.SX = svBlockDeclaration;
+                SX = StackValue.BuildBlockIndex(blockDeclId);
+                stackFrame.SX = SX;
 
                 //Dispatch without recursion tracking 
                 explicitCall = false;
@@ -978,6 +976,9 @@ namespace ProtoCore.DSASM
                                                   bool hasDebugInfo,
                                                   ref bool isExplicitCall)
         {
+            var svDepth = rmem.Pop();
+            Validity.Assert(svDepth.IsInteger);
+
             var arrayDim = rmem.Pop();
             Validity.Assert(arrayDim.IsArrayDimension);
 
@@ -3469,7 +3470,7 @@ namespace ProtoCore.DSASM
             int fptr = Constants.kInvalidIndex;
             int functionDynamicIndex = (int)instr.op1.opdata;
             int classIndex = (int)instr.op2.opdata;
-            int depth = (int)instr.op3.opdata;
+            int depth = (int)rmem.Pop().opdata;
             bool isDotMemFuncBody = functionDynamicIndex == Constants.kInvalidIndex;
             bool isFunctionPointerCall = false;
             if (isDotMemFuncBody)
@@ -3982,9 +3983,7 @@ namespace ProtoCore.DSASM
                 runtimeVerify(svDim.IsArrayDimension);
                 dimensions = (int)svDim.opdata;
 
-                StackValue svBlock = rmem.Pop();
-                runtimeVerify(svBlock.IsBlockIndex);
-                blockId = (int)svBlock.opdata;
+                blockId = (int)instruction.op3.opdata;
 
                 objectIndexing = true;
             }
@@ -4048,7 +4047,7 @@ namespace ProtoCore.DSASM
                 runtimeVerify(svDim.IsArrayDimension);
                 dimensions = (int)svDim.opdata;
 
-                StackValue svBlock = rmem.Pop();
+                StackValue svBlock = instruction.op3; 
                 runtimeVerify(svBlock.IsBlockIndex);
                 blockId = (int)svBlock.opdata;
             }
@@ -4434,18 +4433,9 @@ namespace ProtoCore.DSASM
                 runtimeVerify(svDim.IsArrayDimension);
                 dimensions = (int)svDim.opdata;
 
-                StackValue svBlock = rmem.Pop();
-                runtimeVerify(svBlock.IsBlockIndex);
-                blockId = (int)svBlock.opdata;
+                blockId = (int)instruction.op3.opdata;
 
                 objectIndexing = true;
-                // TODO(Jun/Jiong): Find a more reliable way to update the current block Id
-                //  eg: [Imperative] { a = 10; if (a > 10) c = a; else c = 10; m = a; } 
-                //  when the execution cursor is at "m = a;", the user should not be allowed to inspect the value of c 
-                //  because it is in the inner scope, 3, of the current block, 1. 
-                //  for now, since the pop instruction in "m = a" has not been executed, the currentBlockId has not been updated 
-                //  from 3 to 1, the user will be able to inspect the value of c 
-                //runtimeCore.DebugProps.CurrentBlockId = blockId;
             }
 
             bool isSSANode = Properties.executingGraphNode != null && Properties.executingGraphNode.IsSSANode();
@@ -4540,18 +4530,9 @@ namespace ProtoCore.DSASM
                 runtimeVerify(svDim.IsArrayDimension);
                 dimensions = (int)svDim.opdata;
 
-                StackValue svBlock = rmem.Pop();
+                StackValue svBlock = instruction.op3;
                 runtimeVerify(svBlock.IsBlockIndex);
                 blockId = (int)svBlock.opdata;
-
-
-                // TODO(Jun/Jiong): Find a more reliable way to update the current block Id
-                //  eg: [Imperative] { a = 10; if (a > 10) c = a; else c = 10; m = a; } 
-                //  when the execution cursor is at "m = a;", the user should not be allowed to inspect the value of c 
-                //  because it is in the inner scope, 3, of the current block, 1. 
-                //  for now, since the pop instruction in "m = a" has not been executed, the currentBlockId has not been updated 
-                //  from 3 to 1, the user will be able to inspect the value of c 
-                //runtimeCore.DebugProps.CurrentBlockId = blockId;
             }
 
             StackValue svData;
@@ -4613,6 +4594,10 @@ namespace ProtoCore.DSASM
             StackValue op1 = instruction.op1;
             runtimeVerify(op1.IsMemberVariableIndex || op1.IsStaticVariableIndex);
 
+            StackValue svBlock = instruction.op2;
+            runtimeVerify(svBlock.IsBlockIndex);
+            blockId = (int)svBlock.opdata;
+
             StackValue svType = rmem.Pop();
             runtimeVerify(svType.IsStaticType);
             int staticType = svType.metaData.type;
@@ -4621,10 +4606,6 @@ namespace ProtoCore.DSASM
             StackValue svDim = rmem.Pop();
             runtimeVerify(svDim.IsArrayDimension);
             int dimensions = (int)svDim.opdata;
-
-            StackValue svBlock = rmem.Pop();
-            runtimeVerify(svBlock.IsBlockIndex);
-            blockId = (int)svBlock.opdata;
 
             List<StackValue> dimList = new List<StackValue>();
             for (int i = 0; i < dimensions; ++i)
@@ -5688,8 +5669,8 @@ namespace ProtoCore.DSASM
             runtimeVerify(instr.op2.IsClassIndex);
             int classIndex = (int)instr.op2.opdata;
 
-            runtimeVerify(instr.op3.IsInteger);
-            int depth = (int)instr.op3.opdata;
+            runtimeVerify(instr.op3.IsBlockIndex);
+            int blockIndex = (int)instr.op3.opdata;
 
             ++runtimeCore.FunctionCallDepth;
 
@@ -5710,7 +5691,7 @@ namespace ProtoCore.DSASM
             }
             else if (!runtimeCore.Options.IsDeltaExecution)
             {
-                RX = Callr(functionIndex, classIndex, depth, ref explicitCall, isDynamicCall, instr.debug != null);
+                RX = Callr(blockIndex, functionIndex, classIndex, ref explicitCall, isDynamicCall, instr.debug != null);
             }
             else
             {
@@ -5720,7 +5701,7 @@ namespace ProtoCore.DSASM
                 //      The only affected downstream operations are the ones connected to the graph associated with this call
                 try
                 {
-                    RX = Callr(functionIndex, classIndex, depth, ref explicitCall, isDynamicCall, instr.debug != null);
+                    RX = Callr(blockIndex, functionIndex, classIndex, ref explicitCall, isDynamicCall, instr.debug != null);
                 }
                 catch (ReplicationCaseNotCurrentlySupported e)
                 {

--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -500,9 +500,9 @@ namespace ProtoCore.DSASM
                 // TODO Jun/Jiong: Use build pointer utilities 
                 exe.rmem.Push(StackValue.BuildArrayDimension(0));
                 exe.rmem.Push(StackValue.BuildPointer(svPtr.opdata, svPtr.metaData));
-                exe.rmem.Push(StackValue.BuildBlockIndex(pn.runtimeIndex));
                 exe.rmem.Push(StackValue.BuildArrayDimension(0));
                 exe.rmem.Push(StackValue.BuildStaticType((int)PrimitiveType.kTypeVar));
+                exe.rmem.Push(StackValue.BuildInt(1));
                 
                 ++exe.RuntimeCore.FunctionCallDepth;
 
@@ -510,7 +510,7 @@ namespace ProtoCore.DSASM
                 // fix for IDE-963 - pratapa
                 bool explicitCall = exe.IsExplicitCall;
                 bool tempFlag = explicitCall;
-                exe.Callr(pn.procId, classIndex, 1, ref explicitCall);
+                exe.Callr(pn.runtimeIndex, pn.procId, classIndex, ref explicitCall);
 
                 exe.IsExplicitCall = tempFlag;
 

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -739,8 +739,11 @@ namespace ProtoImperative
                     // Jun TODO: Implementeation of indexing into a function call:
                     //  x = f()[0][1]
                     int dimensions = 0;
-                    EmitPushVarData(blockId, dimensions);
+                    EmitPushVarData(dimensions);
 
+                    // Emit depth
+                    EmitInstrConsole(kw.push, depth + "[depth]");
+                    EmitPush(StackValue.BuildInt(depth));
 
                     // The function call
                     EmitInstrConsole(ProtoCore.DSASM.kw.callr, procNode.name);
@@ -748,24 +751,20 @@ namespace ProtoImperative
                     DebugProperties.BreakpointOptions oldOptions = core.DebuggerProperties.breakOptions;
                     if(procNode.name.StartsWith(Constants.kSetterPrefix))
                     {
-                        EmitCall(procNode.procId, type, depth, parentNode.line, parentNode.col, parentNode.endLine, parentNode.endCol);
+                        EmitCall(procNode.procId, blockId, type, parentNode.line, parentNode.col, parentNode.endLine, parentNode.endCol);
                     }
-                    /*else if(procNode.isExternal)
-                    {
-                        EmitCall(procNode.procId, type, depth);
-                    }*/
                     else if (bnode != null)
                     {
-                        EmitCall(procNode.procId, type, depth, bnode.line, bnode.col, bnode.endLine, bnode.endCol);
+                        EmitCall(procNode.procId, blockId, type, bnode.line, bnode.col, bnode.endLine, bnode.endCol);
                     }
                     else if (!procNode.name.Equals(Constants.kFunctionRangeExpression) ||
                         oldOptions.HasFlag(DebugProperties.BreakpointOptions.EmitCallrForTempBreakpoint))
                     {
-                        EmitCall(procNode.procId, type, depth, node.line, node.col, node.endLine, node.endCol);
+                        EmitCall(procNode.procId, blockId, type, node.line, node.col, node.endLine, node.endCol);
                     }
                     else
                     {
-                        EmitCall(procNode.procId, type, depth);
+                        EmitCall(procNode.procId, blockId, type);
                     }
                     EmitInstrConsole(ProtoCore.DSASM.kw.push, ProtoCore.DSASM.kw.regRX);
                     StackValue opReturn = StackValue.BuildRegister(Registers.RX);
@@ -821,9 +820,14 @@ namespace ProtoImperative
                             dynFunc = core.DynamicFunctionTable.AddNewFunction(procName, arglist.Count, lefttype);
                         }
                     }
+
+                    // Emit depth
+                    EmitInstrConsole(kw.push, depth + "[depth]");
+                    EmitPush(StackValue.BuildInt(depth));
+
                     // The function call
                     EmitInstrConsole(ProtoCore.DSASM.kw.callr, funcCall.Function.Name + "[dynamic]");
-                    EmitDynamicCall(dynFunc.Index, globalClassIndex, depth, funcCall.line, funcCall.col, funcCall.endLine, funcCall.endCol);
+                    EmitDynamicCall(dynFunc.Index, globalClassIndex, blockId, funcCall.line, funcCall.col, funcCall.endLine, funcCall.endCol);
 
                     // The function return value
                     EmitInstrConsole(ProtoCore.DSASM.kw.push, ProtoCore.DSASM.kw.regRX);
@@ -1053,11 +1057,11 @@ namespace ProtoImperative
                         core.FunctionPointerTable.functionPointerDictionary.TryAdd(fptr, fptrNode);
                         core.FunctionPointerTable.functionPointerDictionary.TryGetBySecond(fptrNode, out fptr);
 
-                        EmitPushVarData(runtimeIndex, 0);
+                        EmitPushVarData(0);
 
                         EmitInstrConsole(ProtoCore.DSASM.kw.push, t.Name);
                         StackValue opFunctionPointer = StackValue.BuildFunctionPointer(fptr);
-                        EmitPush(opFunctionPointer, t.line, t.col);
+                        EmitPush(opFunctionPointer, runtimeIndex, t.line, t.col);
                         return;
                     }
                 }
@@ -1088,13 +1092,13 @@ namespace ProtoImperative
 
                 EmitPushNull();
 
-                EmitPushVarData(runtimeIndex, dimensions);
+                EmitPushVarData(dimensions);
 
                 ProtoCore.Type varType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, 0);
                 symbolnode = Allocate(t.Value, globalProcIndex, varType);
 
                 EmitInstrConsole(ProtoCore.DSASM.kw.pop, t.Value);
-                EmitPopForSymbol(symbolnode);
+                EmitPopForSymbol(symbolnode, runtimeIndex);
             }
             else
             {
@@ -1135,10 +1139,10 @@ namespace ProtoImperative
                 }
             }
 
-            EmitPushVarData(runtimeIndex, dimensions);
+            EmitPushVarData(dimensions);
 
             EmitInstrConsole(ProtoCore.DSASM.kw.push, t.Value);
-            EmitPushForSymbol(symbolnode, t);
+            EmitPushForSymbol(symbolnode, runtimeIndex, t);
 
             if (core.TypeSystem.IsHigherRank(type.UID, inferedType.UID))
             {
@@ -1965,7 +1969,7 @@ namespace ProtoImperative
                             EmitPop(opRes, Constants.kGlobalScope);
 
                             EmitInstrConsole(ProtoCore.DSASM.kw.pop, tVar.Value);
-                            EmitPopForSymbol(symnode);
+                            EmitPopForSymbol(symnode, symnode.runtimeTableIndex);
                         }
                     }
                     else
@@ -1982,7 +1986,7 @@ namespace ProtoImperative
                     DfsTraverse(bNode.RightNode, ref inferedType);
 
                     EmitInstrConsole(ProtoCore.DSASM.kw.pop, tVar.Value);
-                    EmitPopForSymbol(symnode);
+                    EmitPopForSymbol(symnode, symnode.runtimeTableIndex);
                 }
             }
             else
@@ -2326,11 +2330,11 @@ namespace ProtoImperative
                                 symbolnode.SetStaticType(castType);
                             }
                             castType = symbolnode.staticType;
-                            EmitPushVarData(runtimeIndex, dimensions, castType.UID, castType.rank);
+                            EmitPushVarData(dimensions, castType.UID, castType.rank);
 
                             EmitInstrConsole(ProtoCore.DSASM.kw.pop, s);
                             StackValue operand = StackValue.BuildVarIndex(symbol);
-                            EmitPop(operand, symbolnode.classScope, node.line, node.col, node.endLine, node.endCol);
+                            EmitPop(operand, symbolnode.classScope, runtimeIndex, node.line, node.col, node.endLine, node.endCol);
                         }
                         else
                         {
@@ -2339,7 +2343,7 @@ namespace ProtoImperative
                                 symbolnode.SetStaticType(castType);
                             }
                             castType = symbolnode.staticType;
-                            EmitPushVarData(runtimeIndex, dimensions, castType.UID, castType.rank);
+                            EmitPushVarData(dimensions, castType.UID, castType.rank);
 
                             EmitInstrConsole(ProtoCore.DSASM.kw.popm, t.Name);
 
@@ -2347,7 +2351,7 @@ namespace ProtoImperative
                                                  ? StackValue.BuildStaticMemVarIndex(symbol)
                                                  : StackValue.BuildMemVarIndex(symbol);
 
-                            EmitPopm(operand, node.line, node.col, node.endLine, node.endCol);
+                            EmitPopm(operand, runtimeIndex, node.line, node.col, node.endLine, node.endCol);
                         }
                     }
                     else
@@ -2373,15 +2377,15 @@ namespace ProtoImperative
                             symbolnode.SetStaticType(castType);
                         }
                         castType = symbolnode.staticType;
-                        EmitPushVarData(runtimeIndex, dimensions, castType.UID, castType.rank);
+                        EmitPushVarData(dimensions, castType.UID, castType.rank);
                         EmitInstrConsole(ProtoCore.DSASM.kw.pop, t.Value);
                         if (parentNode != null)
                         {
-                            EmitPopForSymbol(symbolnode, parentNode.line, parentNode.col, parentNode.endLine, parentNode.endCol);
+                            EmitPopForSymbol(symbolnode, runtimeIndex, parentNode.line, parentNode.col, parentNode.endLine, parentNode.endCol);
                         }
                         else
                         {
-                            EmitPopForSymbol(symbolnode, node.line, node.col, node.endLine, node.endCol);
+                            EmitPopForSymbol(symbolnode, runtimeIndex, node.line, node.col, node.endLine, node.endCol);
                         }
                         
 
@@ -2609,7 +2613,7 @@ namespace ProtoImperative
                 // Push the identifier local block information 
                 // Push the array dimensions
                 int dimensions = 0;
-                EmitPushVarData(codeBlock.symbolTable.RuntimeIndex, dimensions);
+                EmitPushVarData(dimensions);
 
                 if (ProtoCore.DSASM.Constants.kInvalidIndex != globalClassIndex && !IsInLanguageBlockDefinedInFunction())
                 {
@@ -2629,7 +2633,7 @@ namespace ProtoImperative
                 }
                 StackValue opDest = StackValue.BuildVarIndex(symbolIndex);
                 EmitInstrConsole(ProtoCore.DSASM.kw.pop, keyIdent);
-                EmitPop(opDest, (symbol == null) ? globalClassIndex : symbol.classScope);
+                EmitPop(opDest, (symbol == null) ? globalClassIndex : symbol.classScope, symbol.runtimeTableIndex);
 
                 // key == null ?
                 BinaryExpressionNode condition = new BinaryExpressionNode();

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -827,7 +827,7 @@ namespace ProtoImperative
 
                     // The function call
                     EmitInstrConsole(ProtoCore.DSASM.kw.callr, funcCall.Function.Name + "[dynamic]");
-                    EmitDynamicCall(dynFunc.Index, globalClassIndex, blockId, funcCall.line, funcCall.col, funcCall.endLine, funcCall.endCol);
+                    EmitDynamicCall(dynFunc.Index, globalClassIndex, funcCall.line, funcCall.col, funcCall.endLine, funcCall.endCol);
 
                     // The function return value
                     EmitInstrConsole(ProtoCore.DSASM.kw.push, ProtoCore.DSASM.kw.regRX);


### PR DESCRIPTION
To push a value to stack, we need 4 instructions to achieve this goal: 
```
push block id
push dimention
push type
push variable
``` 
Similarly, 4 instructions needed for pop operation. 

The extra 3 `push` instructions actually could be removed. In this PR we try to remove the first one by saving block id to instruction's operands. That is, for `push` for a symbol `x`:
  * Instruction's `op1` is index of symbol `x`
  * Instruction's `op2` is class index
  * Instruction's `op3` is block index

To follow this convention, this PR updates `callr` instructions as well. Previously its `op3` is calling depth, but now we push depth to the stack and save block id in `op3`.

@junmendoza  please take a look. 