### PR TITLE
MAGN-6978 Group titles need a little bit more room where they start

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -200,7 +200,7 @@
             </Rectangle.Fill>
         </Rectangle>
         <Grid x:Name="TextBlockGrid" Grid.Row="0" Height="auto" MaxWidth="{Binding Width}" 
-              Margin="0,0,0,0"
+              Margin="5,0,0,0"
               VerticalAlignment="Top">            
             <TextBlock x:Name="GroupTextBlock"                                     
                     Text ="{Binding AnnotationText, Converter={StaticResource AnnotationTextConverter}}"    


### PR DESCRIPTION
**Issue**:
MAGN-6978 Group titles need a little bit more room where they start

After talking with Lilli, updated the Margin property of Textblock / textbox.

- [x] @pboyer 