### PR TITLE
Fixed sign-in dialog sizing issues

### DIFF
--- a/src/DynamoCoreWpf/Windows/BrowserWindow.xaml.cs
+++ b/src/DynamoCoreWpf/Windows/BrowserWindow.xaml.cs
@@ -23,17 +23,39 @@ namespace Dynamo.Wpf
                 LoadingTextBlock.Visibility = Visibility.Collapsed;
                 Browser.Visibility = Visibility.Visible;
 
+                var windowSize = new Size();
                 var localPath = ((a.Uri == null) ? string.Empty : a.Uri.LocalPath);
-                if (localPath.ToLowerInvariant().Equals("/register"))
+                if (GetWindowSizeForContent(localPath, ref windowSize))
                 {
-                    // This is navigating to new user registration page,
-                    // which requires the window to be of a larger size.
-                    Width = 460;
-                    Height = 722;
+                    Width = windowSize.Width;
+                    Height = windowSize.Height;
                 }
             };
 
             Browser.Navigate(_location.AbsoluteUri);
+        }
+
+        private bool GetWindowSizeForContent(string localPath, ref Size size)
+        {
+            switch (localPath.ToLowerInvariant()) // All lower case!
+            {
+                case "/logon":
+                    size.Width = 360;
+                    size.Height = 365;
+                    return true;
+
+                case "/register":
+                    size.Width = 460;
+                    size.Height = 722;
+                    return true;
+
+                case "/account/forgotcredentials":
+                    size.Width = 640;
+                    size.Height = 260;
+                    return true;
+            }
+
+            return false; // No window size change required.
         }
     }
 }


### PR DESCRIPTION
This pull request fixes the following internal defect:

- [MAGN-7192](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7192) Sign In dialog having wrong alignment of Text and edit boxes.

Now the three dialogs are sized properly, even when navigated backward (e.g. from *Forgot password* back to *Log in* page).

![sign-in-dialog-sizes-fixed](https://cloud.githubusercontent.com/assets/5086849/7362783/4fcd6bc0-eda1-11e4-8321-c3152aada044.png)

Hi @aparajit-pratap, please have a look, thanks.