### PR TITLE
Removed logging of exceptions thrown from auto-complete failing

### DIFF
--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.xaml.cs
@@ -230,9 +230,6 @@ namespace Dynamo.UI.Controls
             }
             catch (System.Exception ex)
             {
-                this.dynamoViewModel.Model.Logger.Log(Wpf.Properties.Resources.MessageFailedToAutocomple);
-                this.dynamoViewModel.Model.Logger.Log(ex.Message);
-                this.dynamoViewModel.Model.Logger.Log(ex.StackTrace);
             }
         }
 
@@ -301,9 +298,6 @@ namespace Dynamo.UI.Controls
             }
             catch (System.Exception ex)
             {
-                this.dynamoViewModel.Model.Logger.Log(Wpf.Properties.Resources.MessageFailedToAutocomple);
-                this.dynamoViewModel.Model.Logger.Log(ex.Message);
-                this.dynamoViewModel.Model.Logger.Log(ex.StackTrace);
             }
         }
 


### PR DESCRIPTION
This fixes defect: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5730

It prevents logging exceptions thrown on autocompletion failure such as in cases of trying to autocomplete on typing `.` meant to be decimal after a digit or typing `.` on an string that is not a class name.

@Benglin PTAL