### PR TITLE
Add AST node location for stringASTs

### DIFF
--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -2703,9 +2703,8 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		node = new ProtoCore.AST.AssociativeAST.StringNode() 
 		{ 
 		   value = GetEscapedString(t.val.Length <= 2 ? "" : t.val.Substring(1, t.val.Length - 2)),
-		   line = t.line,
-		   col = t.col
-		}; 
+		};
+        NodeUtils.SetNodeLocation(node, t);
 		
 	}
 

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1904,9 +1904,8 @@ Associative_String<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
                 node = new ProtoCore.AST.AssociativeAST.StringNode() 
                 { 
                     value = GetEscapedString(t.val.Length <= 2 ? "" : t.val.Substring(1, t.val.Length - 2)),
-                    line = t.line,
-                    col = t.col
                 }; 
+                NodeUtils.SetNodeLocation(node, t);
             .)
 .
 

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -581,6 +581,16 @@ b = c[w][x][y][z];";
             Assert.AreEqual(1, codeBlockNode.OutPortData.Count);
         }
 
+        [Test]
+        public void Defect_MAGN_6723()
+        {
+            var codeBlockNode = CreateCodeBlockNode();
+            string code = @"x + ""anyString"";";
+
+            UpdateCodeBlockNodeContent(codeBlockNode, code);
+            Assert.AreEqual(1, codeBlockNode.InPortData.Count);
+        }
+
         #region CodeBlockUtils Specific Tests
 
         [Test]


### PR DESCRIPTION
@aparajit-pratap 

Calls the SetNodeLocation for an ast StringNode

Fixes issues where the codeblock has no input port:
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6723