### PR TITLE
Add List.FirstIndexOf() and List.AllIndiceOf()

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -470,7 +470,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, ProtoCore.Type>("ObjectB", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, Constants.kArbitraryRank)),
                     },
                     ID = BuiltInMethods.MethodID.kEquals,
-                    MethodAttributes = new MethodAttributes(){Description = Resources.DeterminesObjectsAreEqual}
+                    MethodAttributes = new MethodAttributes(true){Description = Resources.DeterminesObjectsAreEqual}
                    
                 },
 

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -782,6 +782,35 @@ namespace DSCore
                     .ToList();
         }
 
+        /// <summary>
+        ///     Return the first index of item in the given list. 
+        ///     Return -1 if not found.
+        /// </summary>
+        /// <param name="list">List to search in</param>
+        /// <param name="item">Item to look for</param>
+        /// <returns></returns>
+        public static int FirstIndexOf(IList list, object item)
+        {
+            if (list == null)
+                return -1;
+
+            int index = list.IndexOf(item);
+            return index;
+        }
+
+        /// <summary>
+        ///     Return all indice of item in the given list.
+        ///     Return empty list if not found.
+        /// </summary>
+        /// <param name="list"></param>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public static IList AllIndicesOf(IList list, object item)
+        {
+            var indices = Enumerable.Range(0, list.Count).Where(i => list[i].Equals(item)).ToList();
+            return indices;
+        }
+
         #region Combinatorics Helpers
         private static IEnumerable<T> Singleton<T>(T t)
         {

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -807,6 +807,9 @@ namespace DSCore
         /// <returns></returns>
         public static IList AllIndicesOf(IList list, object item)
         {
+            if (list == null)
+                return new List<int> { }; 
+
             var indices = Enumerable.Range(0, list.Count).Where(i => list[i].Equals(item)).ToList();
             return indices;
         }

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -783,12 +783,15 @@ namespace DSCore
         }
 
         /// <summary>
-        ///     Return the first index of item in the given list. 
-        ///     Return -1 if not found.
+        ///     Given an item, returns the zero-based index of its first occurrence 
+        ///     in the list. If the item cannot be found in the list, -1 is returned.
         /// </summary>
-        /// <param name="list">List to search in</param>
-        /// <param name="item">Item to look for</param>
-        /// <returns></returns>
+        /// <param name="list">
+        ///     List to search in. If this argument is null, -1 is returned.
+        /// </param>
+        /// <param name="item">Item to look for.</param>
+        /// <returns>Zero-based index of the item in the list, or -1 if it is not found.
+        /// </returns>
         public static int FirstIndexOf(IList list, object item)
         {
             if (list == null)
@@ -799,12 +802,15 @@ namespace DSCore
         }
 
         /// <summary>
-        ///     Return all indice of item in the given list.
-        ///     Return empty list if not found.
+        ///     Given an item, returns the zero-based indices of all its occurrences
+        ///     in the list. If the item cannot be found, an empty list is returned.
         /// </summary>
-        /// <param name="list"></param>
-        /// <param name="item"></param>
-        /// <returns></returns>
+        /// <param name="list">
+        ///     List to search in. If this argument is null, an empty list is returned.
+        /// </param>
+        /// <param name="item">Item to look for.</param>
+        /// <returns>A list of zero-based indices of all occurrences of the item if 
+        /// found, or an empty list if the item does not exist in the list.</returns>
         public static IList AllIndicesOf(IList list, object item)
         {
             if (list == null)

--- a/test/DynamoCoreTests/Nodes/ListTests.cs
+++ b/test/DynamoCoreTests/Nodes/ListTests.cs
@@ -2505,5 +2505,23 @@ namespace Dynamo.Tests
             AssertPreviewValue("fe77da6f-71db-4712-bffb-27d5acc86e0b", new object[] { });
         }
         #endregion
+
+        [Test]
+        public void FirstIndexOf()
+        {
+            var model = ViewModel.Model;
+            string openPath = Path.Combine(TestDirectory, @"core\list\FirstIndexOf.dyn");
+            RunModel(openPath);
+            AssertPreviewValue("04a0347f-b931-40ff-81c9-7c0e5c61d051", 0); 
+        }
+
+        [Test]
+        public void AllIndicesOf()
+        {
+            var model = ViewModel.Model;
+            string openPath = Path.Combine(TestDirectory, @"core\list\AllIndicesOf.dyn");
+            RunModel(openPath);
+            AssertPreviewValue("404af9cd-3668-4aa8-aea1-314a228bd6e1", new object[] { 0, 2 });
+        }
     }
 }

--- a/test/Libraries/CoreNodesTests/ListTests.cs
+++ b/test/Libraries/CoreNodesTests/ListTests.cs
@@ -723,5 +723,32 @@ namespace DSCoreNodesTests
 
 
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void FirstIndexOf()
+        {
+            List<int> input = Enumerable.Range(0, 10).ToList();
+
+            int index = List.FirstIndexOf(input, 3);
+            Assert.AreEqual(index, 3);
+
+            index = List.FirstIndexOf(input, 21);
+            Assert.AreEqual(index, -1);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void AllIndicesOf()
+        {
+            List<int> input = new List<int> { 1, 2, 3, 1, 2, 3 };
+
+            var indices = List.AllIndicesOf(input, 3).Cast<int>();
+            Assert.IsTrue(indices.SequenceEqual(new [] {2, 5}));
+
+            indices = List.AllIndicesOf(input, 21).Cast<int>();
+            Assert.IsEmpty(indices);
+        }
+ 
     }
 }

--- a/test/core/list/AllIndicesOf.dyn
+++ b/test/core/list/AllIndicesOf.dyn
@@ -1,0 +1,14 @@
+<Workspace Version="0.8.1.1181" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="100" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="a3111ceb-e391-4e9a-993d-43611df84599" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="390" y="390" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{&quot;foo&quot;, &quot;bar&quot;, &quot;foo&quot;};" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="4aa2b2f2-c157-4a4a-9be2-92bfcc217402" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="376" y="557" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="&quot;foo&quot;;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="404af9cd-3668-4aa8-aea1-314a228bd6e1" type="Dynamo.Nodes.DSFunction" nickname="List.AllIndicesOf" x="778.6159" y="492.68978125" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.AllIndicesOf@var[]..[],var" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="a3111ceb-e391-4e9a-993d-43611df84599" start_index="0" end="404af9cd-3668-4aa8-aea1-314a228bd6e1" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="4aa2b2f2-c157-4a4a-9be2-92bfcc217402" start_index="0" end="404af9cd-3668-4aa8-aea1-314a228bd6e1" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>

--- a/test/core/list/FirstIndexOf.dyn
+++ b/test/core/list/FirstIndexOf.dyn
@@ -1,0 +1,14 @@
+<Workspace Version="0.8.1.1181" X="-146.1159" Y="-116.68978125" zoom="1.33823125" Name="Home" RunType="Automatic" RunPeriod="100" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="04a0347f-b931-40ff-81c9-7c0e5c61d051" type="Dynamo.Nodes.DSFunction" nickname="List.FirstIndexOf" x="608.5" y="352" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.FirstIndexOf@var[]..[],var" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="4d9b9114-da01-4931-bd74-92034a1d8100" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="307" y="322" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{&quot;foo&quot;, &quot;bar&quot;};" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="cdb27c20-fa8e-412a-a039-957f613e3502" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="329" y="420" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="&quot;foo&quot;;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="4d9b9114-da01-4931-bd74-92034a1d8100" start_index="0" end="04a0347f-b931-40ff-81c9-7c0e5c61d051" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="cdb27c20-fa8e-412a-a039-957f613e3502" start_index="0" end="04a0347f-b931-40ff-81c9-7c0e5c61d051" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
For fixing defect [MAGN-6190](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6190). 

`IndexOf()` is builtin method. As list related operation now is done in external node `List`, this PR added two methods `FirstIndexOf()` and `AllIndicesOf()` to `List` node instead of renaming `IndexOf()` to the other name. 

@Benglin for review. 