### PR TITLE
move rtf files back to the correct directory

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -341,8 +341,8 @@ limitations under the License.
       <SampleFiles Include="$(SolutionDir)..\doc\distrib\Samples\**\*.*" />
     </ItemGroup>
     <Copy SourceFiles="$(SolutionDir)..\README.md" DestinationFiles="$(OutputPath)README.txt" />
-    <Copy SourceFiles="$(SolutionDir)..\doc\distrib\License.rtf" DestinationFolder="$(OutputPath)\$(UICulture)" />
-    <Copy SourceFiles="$(SolutionDir)..\doc\distrib\TermsOfUse.rtf" DestinationFolder="$(OutputPath)\$(UICulture)" />
+    <Copy SourceFiles="$(SolutionDir)..\doc\distrib\License.rtf" DestinationFolder="$(OutputPath)" />
+    <Copy SourceFiles="$(SolutionDir)..\doc\distrib\TermsOfUse.rtf" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="@(ExternProtoGeometry)" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="@(ExternProtoGeometryXml)" DestinationFolder="$(OutputPath)\$(UICulture)" />
     <Copy SourceFiles="@(ExternProtoGeometryUICulture)" DestinationFolder="$(OutputPath)\$(UICulture)" />


### PR DESCRIPTION
Fix for the defect: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7267
@Randy-Ma, please review and merge. This PR causes the rtf files to be copied to the correct directory. 

Please refer to this commit https://github.com/DynamoDS/Dynamo/commit/c8f45c589136ff4c61f53eb59b1a9ccfec9f0e1b