### PR TITLE
Remove two test cases from Failure category

### DIFF
--- a/test/Engine/ProtoTest/TD/Associative/InlineCondition.cs
+++ b/test/Engine/ProtoTest/TD/Associative/InlineCondition.cs
@@ -931,7 +931,6 @@ d;
 
 
         [Test]
-        [Category("Failure")]
         public void T019_conditionequalto_1467469()
         {
             // Tracked by http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1692

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestClass.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestClass.cs
@@ -5959,7 +5959,6 @@ r = a.x;
 
         [Test]
         [Category("SmokeTest")]
-        [Category("Failure")]
         public void T99_1467469
             ()
         {


### PR DESCRIPTION
CI reports test cases `T019_conditionequalto_1467469` and `T99_1467469` both are green now. Verified locally that they pass. 