### PR TITLE
Fixed List.Transpose for jagged arrays

### DIFF
--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -676,8 +676,10 @@ namespace DSCore
 
             foreach (IList sublist in ilists)
             {
-                for (int i = 0; i < sublist.Count; i++)
-                    transposedList[i].Add(sublist[i]);
+                for (int i = 0; i < transposedList.Count; i++)
+                {
+                    transposedList[i].Add(i < sublist.Count ? sublist[i] : null);
+                }
             }
 
             return transposedList;

--- a/test/DynamoCoreTests/Nodes/ListTests.cs
+++ b/test/DynamoCoreTests/Nodes/ListTests.cs
@@ -520,8 +520,8 @@ namespace Dynamo.Tests
 			// {                            {
 			//     { "AB", "CD" }               { "AB", 21, 31 }
 			//     { 21, 22, 23, 24 }           { "CD", 22, 32 }
-			//     { 31, 32, 33 }               { 23, 33 }
-			// }                                { 24 }
+			//     { 31, 32, 33 }               { null, 23, 33 }
+			// }                                { null, 24, null }
 			//                              }
 
 			DynamoModel model = ViewModel.Model;
@@ -535,16 +535,16 @@ namespace Dynamo.Tests
 			Assert.AreEqual(4, elements.Count);
 			Assert.AreEqual(3, elements[0].GetElements().Count);
 			Assert.AreEqual(3, elements[1].GetElements().Count);
-			Assert.AreEqual(2, elements[2].GetElements().Count);
-			Assert.AreEqual(1, elements[3].GetElements().Count);
+			Assert.AreEqual(3, elements[2].GetElements().Count);
+			Assert.AreEqual(3, elements[3].GetElements().Count);
 
 			AssertPreviewValue(guid,
 				new object[][]
 				{
 					new object[] { "AB", 21, 31 },
 					new object[] { "CD", 22, 32 },
-					new object[] { 23, 33 },
-					new object[] { 24 }
+					new object[] { null, 23, 33 },
+					new object[] { null, 24, null }
 				});
 		}
 
@@ -559,7 +559,7 @@ namespace Dynamo.Tests
 				new object[] { new object[] {1,3 }, new object[] {2, 4}, });
 
 			AssertPreviewValue("919d4d0d-f4e3-4a3c-87c8-dd4466a8ca87",
-				new object[] { new object[] {1,4,6}, new object[] {2, 5,7}, new object[] {3, 8}, new object[] {9}});
+				new object[] { new object[] {1,4,6}, new object[] {2, 5,7}, new object[] {3, null, 8}, new object[] {null, null, 9}});
 
 			AssertPreviewValue("bcf696d1-43e7-4633-8eb9-d5cb64dde939",
 				new object[] { new object[] { new object[] { 1 }, 3 }, new object[] { 2, 4 } });

--- a/test/Libraries/CoreNodesTests/ListTests.cs
+++ b/test/Libraries/CoreNodesTests/ListTests.cs
@@ -501,19 +501,33 @@ namespace DSCoreNodesTests
                 List.DiagonalLeft(Enumerable.Range(0, 20).ToList(), 5));
         }
 
-        //[Test]
-        //public static void TransposeListOfLists()
-        //{
-        //    Assert.AreEqual(
-        //        new List<IList> { new ArrayList { 0, 3, 6 }, new ArrayList { 1, 4, 7 }, new ArrayList { 2, 5, 8 } },
-        //        List.Transpose(
-        //            new List<IList<object>>
-        //            {
-        //                new List<object> { 0, 1, 2 },
-        //                new List<object> { 3, 4, 5 },
-        //                new List<object> { 6, 7, 8 }
-        //            }));
-        //}
+        [Test]
+        public static void TransposeListOfLists()
+        {
+            Assert.AreEqual(
+                new List<IList> { new ArrayList { 0, 3, 6 }, new ArrayList { 1, 4, 7 }, new ArrayList { 2, 5, 8 } },
+                List.Transpose(
+                    new List<IList<object>>
+                    {
+                        new List<object> { 0, 1, 2 },
+                        new List<object> { 3, 4, 5 },
+                        new List<object> { 6, 7, 8 }
+                    }));
+        }
+
+        [Test]
+        public static void TransposeJaggedListOfLists()
+        {
+            Assert.AreEqual(
+                new List<IList> { new ArrayList { 0, 3, 6 }, new ArrayList { 1, 4, 7 }, new ArrayList { 2, 5, 8 }, new ArrayList { null, 6, null} },
+                List.Transpose(
+                    new List<IList<object>>
+                    {
+                        new List<object> { 0, 1, 2 },
+                        new List<object> { 3, 4, 5, 6 },
+                        new List<object> { 6, 7, 8 }
+                    }));
+        }
 
         [Test]
         [Category("UnitTests")]


### PR DESCRIPTION
Given a list like:
```
{{1, 2, 3}, {1, 2, 3, 4}}
```
Its transpose using `List.Transpose` node would compute to:
```
{{1, 1}, {2, 2}, {3, 3}, {4}}
```

I'm not sure if this is acceptable especially if you're writing this out to a table such as in Excel; the expected output would be:
```
{{1, 1}, {2, 2}, {3, 3}, {null, 4}}
```

This submission fixes this.

@ke-yu PTAL