### PR TITLE
Added null-checks before dereferencing

### DIFF
--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1940,6 +1940,10 @@ namespace ProtoScript.Runners
         /// <returns></returns>
         public IDictionary<Guid, List<ProtoCore.Runtime.WarningEntry>> GetRuntimeWarnings()
         {
+            var ret = new Dictionary<Guid, List<ProtoCore.Runtime.WarningEntry>>();
+            if (runtimeCore == null)
+                return ret;
+
             // Group all warnings by their expression ids, and only keep the last
             // warning for each expression, and then group by GUID.  
             var warnings = runtimeCore.RuntimeStatus
@@ -1948,7 +1952,6 @@ namespace ProtoScript.Runners
                                      .OrderBy(w => w.GraphNodeGuid)
                                      .GroupBy(w => w.GraphNodeGuid);
 
-            var ret = new Dictionary<Guid, List<ProtoCore.Runtime.WarningEntry>>();
             foreach (var w in warnings)
             {
                 Guid guid = w.FirstOrDefault().GraphNodeGuid;
@@ -1964,6 +1967,10 @@ namespace ProtoScript.Runners
         /// <returns></returns>
         public IDictionary<Guid, List<ProtoCore.BuildData.WarningEntry>> GetBuildWarnings()
         {
+            var ret = new Dictionary<Guid, List<ProtoCore.BuildData.WarningEntry>>();
+            if (runnerCore == null)
+                return ret;
+
             // Group all warnings by their expression ids, and only keep the last
             // warning for each expression, and then group by GUID.  
             var warnings = runnerCore.BuildStatus
@@ -1972,7 +1979,6 @@ namespace ProtoScript.Runners
                                      .OrderBy(w => w.GraphNodeGuid)
                                      .GroupBy(w => w.GraphNodeGuid);
 
-            var ret = new Dictionary<Guid, List<ProtoCore.BuildData.WarningEntry>>();
             foreach (var w in warnings)
             {
                 Guid guid = w.FirstOrDefault().GraphNodeGuid;


### PR DESCRIPTION
Background
-----
This pull request fixes an internally tracked defect:

- [MAGN-7148](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7148) Opening Manual execute dyn after running Auto execute dyn twice gives crash

There are two public APIs that do not check for `null` values before they are being dereferenced:

```csharp
LiveRunner.GetRuntimeWarnings();
LiveRunner.GetBuildWarnings();
```

This can cause issue as illustrated with the defect when `LiveRunner` is disposed before these methods are invoked (typically from an `AsyncTask` derived class which gets executed in an indeterministic way).

Call-stack during crash:

```
at ProtoScript.Runners.LiveRunner.GetBuildWarnings()
at Dynamo.DSEngine.LiveRunnerServices.GetBuildWarnings()
at Dynamo.DSEngine.EngineController.GetBuildWarnings()
at Dynamo.Core.Threading.UpdateGraphAsyncTask.HandleTaskCompletionCore()
at Dynamo.Core.Threading.AsyncTask.HandleTaskCompletion()
at Dynamo.Core.Threading.DynamoScheduler.ProcessTaskInternal(AsyncTask asyncTask)
at Dynamo.Core.Threading.DynamoScheduler.ProcessNextTask(Boolean waitIfTaskQueueIsEmpty)
at Dynamo.Core.Threading.DynamoSchedulerThread.ThreadProc() in 
at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, Cont
at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallb
at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallb
at System.Threading.ThreadHelper.ThreadStart()
```

Notes for Reviewer
-----
Hi @junmendoza, since this is related to `LiveRunner`, I'm sending it your way for approval.

:ghost: :jack_o_lantern: Thanks! 
