### PR TITLE
Reset return code of "1" from "robocopy" for downstream scripts

### DIFF
--- a/tools/install/ExtractResources.bat
+++ b/tools/install/ExtractResources.bat
@@ -52,3 +52,6 @@ robocopy "%binroot%\Revit_2016\en-US"         "%wwlroot%\Revit_2016\en-US"      
 robocopy "%binroot%\Revit_2016\nodes"         "%wwlroot%\Revit_2016\nodes"          *.dll
 robocopy "%binroot%\Revit_2016\nodes\en-US"   "%wwlroot%\Revit_2016\nodes\en-US"    *.resources.dll *.xml
 )
+
+rem Reset error codes of "1" returned from "robocopy" for downstream scripts.
+if %ERRORLEVEL% equ 1 ( set errorlevel=0 ) else if %ERRORLEVEL% equ 3 ( set errorlevel=0 )


### PR DESCRIPTION
This is to reset `errorlevel` returned from `robocopy` when it indicates a success operation. This `errorlevel = 1` causes downstream scripts to think that there has been an error in `ExtractResources.bat` (those scripts generally expect `errorlevel = 0` when there is no error).

Hi @nguyen-binh-minh, could you help taking a look at this? Thanks!