### PR TITLE
Type minor clean up

### DIFF
--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -93,13 +93,11 @@ namespace ProtoCore
         kTypeArray,
         kTypeDouble,
         kTypeInt,
-        kTypeDynamic,
         kTypeBool,
         kTypeChar,
         kTypeString,
         kTypeVar,
         kTypeVoid,
-        kTypeHostEntityID,
         kTypePointer,
         kTypeFunctionPointer,
         kTypeReturn,
@@ -138,7 +136,6 @@ namespace ProtoCore
                 primitiveTypeNames[PrimitiveType.kTypeNull] = DSDefinitions.Keyword.Null;
                 primitiveTypeNames[PrimitiveType.kTypeVoid] = DSDefinitions.Keyword.Void;
                 primitiveTypeNames[PrimitiveType.kTypeArray] = DSDefinitions.Keyword.Array;
-                primitiveTypeNames[PrimitiveType.kTypeHostEntityID] = "hostentityid";
                 primitiveTypeNames[PrimitiveType.kTypePointer] = DSDefinitions.Keyword.PointerReserved;
                 primitiveTypeNames[PrimitiveType.kTypeFunctionPointer] = DSDefinitions.Keyword.FunctionPointer;
                 primitiveTypeNames[PrimitiveType.kTypeReturn] = "return_reserved";
@@ -241,10 +238,6 @@ namespace ProtoCore
             cnode = new ClassNode { name = DSDefinitions.Keyword.Void, rank = 0, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeVoid;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeVoid);
-
-            cnode = new ClassNode { name = "hostentityid", rank = 0, typeSystem = this };
-            cnode.classId = (int)PrimitiveType.kTypeHostEntityID;
-            classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeHostEntityID);
 
             cnode = new ClassNode { name = DSDefinitions.Keyword.PointerReserved, rank = 0, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
@@ -494,13 +487,6 @@ namespace ProtoCore
                         return StackValue.Null;
                     }
                     return sv;
-
-                case (int)PrimitiveType.kTypeHostEntityID:
-                    {
-                        StackValue newSV = sv.ShallowClone();
-                        newSV.metaData = new MetaData { type = (int)PrimitiveType.kTypeHostEntityID };
-                        return newSV;
-                    }
 
                 case (int)PrimitiveType.kTypeInt:
                     {

--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -193,43 +193,26 @@ namespace ProtoCore
 
             ClassNode cnode;
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Array, size = 0, rank = 5, symbols = null, vtable = null, typeSystem = this };
-            /*cnode.coerceTypes.Add((int)PrimitiveType.kTypeDouble, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
-            cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
-            cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
-            cnode.coerceTypes.Add((int)PrimitiveType.kTypeChar, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
-            cnode.coerceTypes.Add((int)PrimitiveType.kTypeString, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
-            */
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Array, size = 0, rank = 5, symbols = null, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeArray;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeArray);
 
-            //
-            //
             cnode = new ClassNode { name = DSDefinitions.Keyword.Double, size = 0, rank = 4, symbols = null, vtable = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceDoubleToIntScore);
             cnode.classId = (int)PrimitiveType.kTypeDouble;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeDouble);
 
-            //
-            //
             cnode = new ClassNode { name = DSDefinitions.Keyword.Int, size = 0, rank = 3, symbols = null, vtable = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeDouble, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceIntToDoubleScore);
             cnode.classId = (int)PrimitiveType.kTypeInt;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeInt);
 
-            //
-            //
             cnode = new ClassNode { name = DSDefinitions.Keyword.Bool, size = 0, rank = 2, symbols = null, vtable = null, typeSystem = this };
-            // if convert operator to method call, without the following statement
-            // a = true + 1 will fail, because _add expects two integers 
-            //cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypeBool;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeBool);
 
-            //
-            //
             cnode = new ClassNode { name = DSDefinitions.Keyword.Char, size = 0, rank = 1, symbols = null, vtable = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeString, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
@@ -237,26 +220,15 @@ namespace ProtoCore
             cnode.classId = (int)PrimitiveType.kTypeChar;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeChar);
 
-            //
-            //
             cnode = new ClassNode { name = DSDefinitions.Keyword.String, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypeString;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeString);
 
-            //
-            //
             cnode = new ClassNode { name = DSDefinitions.Keyword.Var, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
-            /*cnode.coerceTypes.Add((int)PrimitiveType.kTypeDouble, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
-            cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
-            cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
-            cnode.coerceTypes.Add((int)PrimitiveType.kTypeChar, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
-            cnode.coerceTypes.Add((int)PrimitiveType.kTypeString, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);*/
             cnode.classId = (int)PrimitiveType.kTypeVar;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeVar);
 
-            //
-            //
             cnode = new ClassNode { name = DSDefinitions.Keyword.Null, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeDouble, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
@@ -266,34 +238,24 @@ namespace ProtoCore
             cnode.classId = (int)PrimitiveType.kTypeNull;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeNull);
 
-            //
-            //
             cnode = new ClassNode { name = DSDefinitions.Keyword.Void, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeVoid;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeVoid);
 
-            //
-            //
             cnode = new ClassNode { name = "hostentityid", size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeHostEntityID;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeHostEntityID);
-            //
-            //
+
             cnode = new ClassNode { name = DSDefinitions.Keyword.PointerReserved, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
-            // if convert operator to method call, without the following statement, 
-            // a = b.c + d.e will fail, b.c and d.e are resolved as pointer and _add method requires two integer
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypePointer;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypePointer);
-            //
-            //
+
             cnode = new ClassNode { name = DSDefinitions.Keyword.FunctionPointer, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypeFunctionPointer;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeFunctionPointer);
 
-            //
-            //
             cnode = new ClassNode { name = "return_reserved", size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeReturn;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeReturn);

--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -197,39 +197,39 @@ namespace ProtoCore
             cnode.classId = (int)PrimitiveType.kTypeArray;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeArray);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Double, size = 0, rank = 4, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Double, size = 0, rank = 4, symbols = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceDoubleToIntScore);
             cnode.classId = (int)PrimitiveType.kTypeDouble;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeDouble);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Int, size = 0, rank = 3, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Int, size = 0, rank = 3, symbols = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeDouble, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceIntToDoubleScore);
             cnode.classId = (int)PrimitiveType.kTypeInt;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeInt);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Bool, size = 0, rank = 2, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Bool, size = 0, rank = 2, symbols = null, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeBool;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeBool);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Char, size = 0, rank = 1, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Char, size = 0, rank = 1, symbols = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeString, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
 
             cnode.classId = (int)PrimitiveType.kTypeChar;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeChar);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.String, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.String, size = 0, rank = 0, symbols = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypeString;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeString);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Var, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Var, size = 0, rank = 0, symbols = null, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeVar;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeVar);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Null, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Null, size = 0, rank = 0, symbols = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeDouble, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
@@ -238,25 +238,25 @@ namespace ProtoCore
             cnode.classId = (int)PrimitiveType.kTypeNull;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeNull);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Void, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Void, size = 0, rank = 0, symbols = null, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeVoid;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeVoid);
 
-            cnode = new ClassNode { name = "hostentityid", size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = "hostentityid", size = 0, rank = 0, symbols = null, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeHostEntityID;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeHostEntityID);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.PointerReserved, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.PointerReserved, size = 0, rank = 0, symbols = null, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypePointer;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypePointer);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.FunctionPointer, size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.FunctionPointer, size = 0, rank = 0, symbols = null,typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypeFunctionPointer;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeFunctionPointer);
 
-            cnode = new ClassNode { name = "return_reserved", size = 0, rank = 0, symbols = null, vtable = null, typeSystem = this };
+            cnode = new ClassNode { name = "return_reserved", size = 0, rank = 0, symbols = null, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeReturn;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeReturn);
         }

--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -193,43 +193,43 @@ namespace ProtoCore
 
             ClassNode cnode;
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Array, size = 0, rank = 5, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Array, rank = 5, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeArray;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeArray);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Double, size = 0, rank = 4, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Double, rank = 4, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceDoubleToIntScore);
             cnode.classId = (int)PrimitiveType.kTypeDouble;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeDouble);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Int, size = 0, rank = 3, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Int, rank = 3, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeDouble, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceIntToDoubleScore);
             cnode.classId = (int)PrimitiveType.kTypeInt;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeInt);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Bool, size = 0, rank = 2, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Bool, rank = 2, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeBool;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeBool);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Char, size = 0, rank = 1, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Char, rank = 1, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeString, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
 
             cnode.classId = (int)PrimitiveType.kTypeChar;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeChar);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.String, size = 0, rank = 0, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.String, rank = 0, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypeString;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeString);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Var, size = 0, rank = 0, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Var, rank = 0, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeVar;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeVar);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Null, size = 0, rank = 0, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Null, rank = 0, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeDouble, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
@@ -238,25 +238,25 @@ namespace ProtoCore
             cnode.classId = (int)PrimitiveType.kTypeNull;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeNull);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.Void, size = 0, rank = 0, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.Void, rank = 0, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeVoid;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeVoid);
 
-            cnode = new ClassNode { name = "hostentityid", size = 0, rank = 0, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = "hostentityid", rank = 0, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeHostEntityID;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeHostEntityID);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.PointerReserved, size = 0, rank = 0, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.PointerReserved, rank = 0, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypePointer;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypePointer);
 
-            cnode = new ClassNode { name = DSDefinitions.Keyword.FunctionPointer, size = 0, rank = 0, symbols = null,typeSystem = this };
+            cnode = new ClassNode { name = DSDefinitions.Keyword.FunctionPointer, rank = 0,typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypeFunctionPointer;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeFunctionPointer);
 
-            cnode = new ClassNode { name = "return_reserved", size = 0, rank = 0, symbols = null, typeSystem = this };
+            cnode = new ClassNode { name = "return_reserved", rank = 0, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeReturn;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeReturn);
         }

--- a/src/Engine/ProtoCore/Utils/ClassUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ClassUtils.cs
@@ -92,7 +92,9 @@ namespace ProtoCore.Utils
 
             int myself = classNode.typeSystem.classTable.IndexOf(classNode.name);
             bool isInMemberFunctionContext = (classScope == myself) && (functionScope != ProtoCore.DSASM.Constants.kInvalidIndex);
-            bool isInStaticFunction = isInMemberFunctionContext && (classNode.vtable.procList[functionScope].isStatic);
+            bool isInStaticFunction = isInMemberFunctionContext && 
+                classNode.vtable.procList.Count > functionScope &&
+                classNode.vtable.procList[functionScope].isStatic;
 
             // Try for member function variables
             var blocks = GetAncestorBlockIdsOfBlock(blockId, codeblockList);


### PR DESCRIPTION
Remove two unused primitive type `PrimitiveType.kTypeHostEntityID` and `PrimitiveType.kTypeHostEntityID`. 

Not setting vtable and symbol table to null so that it is not necessary to do null check at runtime. 

@junmendoza this is cleanup work, please take a look.