### PR TITLE
DUI: remove small grey square

### DIFF
--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -83,7 +83,6 @@
                                Name="memberName"
                                HorizontalAlignment="Left"
                                Text="{Binding Name}"
-                               VerticalAlignment="Top"
                                Margin="5,10,0,0"
                                Foreground="{StaticResource CommonSidebarTextColor}"
                                FontSize="13" />


### PR DESCRIPTION
## Overview
Type "poi". You'll notice, that near ByCartesianCoordinates is tiny grey square.
This can be easily find by Snoop tool.
![image](https://cloud.githubusercontent.com/assets/8158404/7473882/ce93e7ea-f346-11e4-92a6-f673baa25682.png)

![image](https://cloud.githubusercontent.com/assets/8158404/7473889/d713978a-f346-11e4-8c91-2dfb83b27999.png)

## Solution
This grey rectangle is created by margin converter. But this converter doesn't take in account, that text was made with `VerticalAlignment="Top"`. The easiest solution is just remove VerticalAlignment. It doesn't have influence on UI.

## Reviewers

@Benglin , please take a look.
Link to YouTrack:
[MAGN-7238](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7238) DUI: remove small grey square if there is no highlighted search phrase in member label