### PR TITLE
"Greg.Responses.PackageVersion" is shown for packages from the future, rather than the actual version

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -482,15 +482,11 @@ namespace Dynamo.PackageManager
                 // allowing them to cancel the package download
                 if (futureDeps.Any())
                 {
-                    var sb = new StringBuilder();
-                    foreach (var elem in futureDeps)
-                    {
-                        sb.AppendLine(elem.Item1.name + " " + elem.Item2.version);
-                    }
+                    var versionList = FormatPackageVersionList(futureDeps);
 
                     if (MessageBox.Show(String.Format(Resources.MessagePackageNewerDynamo,
-                        PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName, 
-                        sb.ToString()),
+                        PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName,
+                        versionList),
                         string.Format(Resources.PackageUseNewerDynamoMessageBoxTitle,
                         PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName),
                         MessageBoxButton.OKCancel,
@@ -571,6 +567,14 @@ namespace Dynamo.PackageManager
                         .ForEach(x => this.PackageManagerClientViewModel.DownloadAndInstall(x));
 
             }
+        }
+
+        /// <summary>
+        ///     Returns a newline delimited string representing the package name and version of the argument
+        /// </summary>
+        public static string FormatPackageVersionList(IEnumerable<Tuple<PackageHeader, PackageVersion>> packages)
+        {
+            return String.Join("\r\n", packages.Select(x => x.Item1.name + " " + x.Item2.version));
         }
 
         private void DownloadsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -488,7 +488,6 @@ namespace Dynamo.PackageManager
                         sb.AppendLine(elem.Item1.name + " " + elem.Item2.version);
                     }
 
-                    // If the user
                     if (MessageBox.Show(String.Format(Resources.MessagePackageNewerDynamo,
                         PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName, 
                         sb.ToString()),
@@ -527,8 +526,6 @@ namespace Dynamo.PackageManager
 
                     immediateUninstalls.Add(localPkg);
                 }
-
-                string msg;
 
                 if (uninstallRequiringUserModifications.Any())
                 {

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -485,7 +485,7 @@ namespace Dynamo.PackageManager
                     var sb = new StringBuilder();
                     foreach (var elem in futureDeps)
                     {
-                        sb.AppendLine(elem.Item1.name + " " + elem.Item2);
+                        sb.AppendLine(elem.Item1.name + " " + elem.Item2.version);
                     }
 
                     // If the user

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -37,6 +37,10 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Greg, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\extern\greg\Greg.dll</HintPath>
+    </Reference>
     <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2014.2.1.1, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\extern\Helix3D\NET40\Helix3D_SharpDX\HelixToolkit.Wpf.SharpDX.dll</HintPath>
@@ -88,6 +92,7 @@
     <Compile Include="NodePreviewTests.cs" />
     <Compile Include="NodeViewCustomizationTests.cs" />
     <Compile Include="PackageManagerUITests.cs" />
+    <Compile Include="PackageManager\PackageManagerSearchViewModelTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RecordedTests.cs" />
     <Compile Include="RunSettingsTests.cs" />

--- a/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PackageManager/PackageManagerSearchViewModelTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Greg.Responses;
+using NUnit.Framework;
+
+namespace Dynamo.PackageManager.Wpf.Tests
+{
+    class PackageManagerSearchViewModelTests
+    {
+        [Test]
+        public void FormatPackageVersionList_CorrectlyFormatsASingleElement()
+        {
+            IEnumerable<Tuple<PackageHeader, PackageVersion>> l = new[]
+            {
+                new Tuple<PackageHeader, PackageVersion>(
+                    new PackageHeader()
+                    {
+                        name = "Foo"
+                    },
+                    new PackageVersion()
+                    {
+                        version = "0.1.0"
+                    })
+            };
+
+            var e =
+@"Foo 0.1.0";
+
+            Assert.AreEqual(e, PackageManagerSearchViewModel.FormatPackageVersionList(l));
+        }
+
+        [Test]
+        public void FormatPackageVersionList_CorrectlyFormatsMultipleElements()
+        {
+            IEnumerable<Tuple<PackageHeader, PackageVersion>> l = new []
+            {
+                new Tuple<PackageHeader, PackageVersion>(
+                    new PackageHeader()
+                    {
+                        name = "Foo"
+                    },
+                    new PackageVersion()
+                    {
+                        version = "0.1.0"
+                    }),
+                new Tuple<PackageHeader, PackageVersion>(
+                    new PackageHeader()
+                    {
+                        name = "Bar"
+                    },
+                    new PackageVersion()
+                    {
+                        version = "1.2.3"
+                    })
+            };
+
+            var e =
+@"Foo 0.1.0
+Bar 1.2.3";
+
+            Assert.AreEqual(e, PackageManagerSearchViewModel.FormatPackageVersionList(l));
+        }
+
+    }
+}


### PR DESCRIPTION
### Purpose

This PR fixes a minor UI defect when a user attempts to download a package from the future.  Specifically, the text "Greg.PackageVersion" would appear rather than the expected version, e.g. "0.1.0".

It's fixed.  

![capture](https://cloud.githubusercontent.com/assets/916345/7482917/b6c2d6d8-f348-11e4-99da-066e86297bf2.PNG)

Note the text is purposely obscured to avoid any legal foibles.

@jnealb It does not make sense to manually test this and, sadly, would require a lot of changes to mock the entirety of this.  There are unit tests to validate the *specific fix* introduced here.  

### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

#### YouTrack Task

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7126

#### Reviewers

@ramramps 

#### FYIs

@jnealb 