### PR TITLE
Leave one home workspace.

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1079,9 +1079,14 @@ namespace Dynamo.Models
                         var currentHomeSpaces = Workspaces.OfType<HomeWorkspaceModel>().ToList();
                         if (currentHomeSpaces.Any())
                         {
-                            foreach (var s in currentHomeSpaces)
+                            // If the workspace we're opening is a home workspace,
+                            // then remove all the other home workspaces. Otherwise,
+                            // Remove all but the first home workspace.
+                            var end = ws is HomeWorkspaceModel ? 0 : 1;
+
+                            for (var i = currentHomeSpaces.Count - 1; i >= end; i--)
                             {
-                                RemoveWorkspace(s);
+                                RemoveWorkspace(currentHomeSpaces[i]);
                             }
                         }
 

--- a/test/Libraries/NodeServicesTest/WorkspaceEventTests.cs
+++ b/test/Libraries/NodeServicesTest/WorkspaceEventTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Reflection;
 
 using SystemTestServices;
@@ -37,8 +38,11 @@ namespace DynamoServicesTests
             // Open a definition
             OpenDynamoDefinition(@".\math\Add.dyn");
 
+            var ws = Model.Workspaces.FirstOrDefault();
+            Assert.NotNull(ws);
+
             // Register for the removed event.
-            WorkspaceEvents.WorkspaceRemoved += (args) => Assert.AreEqual(args.Name, "Add");
+            WorkspaceEvents.WorkspaceRemoved += (args) => Assert.AreEqual(args.Id, ws.Guid);
 
             // Open a new definition which should trigger both the 
             // workspace removed and the workspace added events.


### PR DESCRIPTION
This PR updates the logic for `HomeWorkspaceModel` removal. We [recently moved the logic](https://github.com/DynamoDS/Dynamo/commit/e2a6cddeb98a21f1063e34b2d483b49a41502174) which removes workspaces from the `DynamoModel`'s collection from the view model to the model, where it belongs. But, we were overly aggressive in our removal, removing all `HomeWorkspaceModel`s when a new workspace of any type was added. This meant that the addition of a `CustomNodeWorkspaceModel` would remove all the `HomeWorkspaceModel`s and many tests expected, correctly, for there to be at least one `HomeWorkspaceModel` at all times. 

This logic will be removed when we fully support multiple `HomeWorkspaceModel`s.

I'm merging this to fix the core tests, but @pboyer please take a look as we discussed this during an earlier PR.