### PR TITLE
Test packages building

### DIFF
--- a/src/Libraries/Samples/SampleLibraryTests/SampleLibraryTests.csproj
+++ b/src/Libraries/Samples/SampleLibraryTests/SampleLibraryTests.csproj
@@ -1,9 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <ImportGroup Label="PropertySheets">
-    <Import Project="$(SolutionDir)Config/CS.props" />
-  </ImportGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -93,12 +90,12 @@
   </Target>
   <Target Name="AfterBuild">
     <ItemGroup>
-      <Dlls Include="$(OutputPath)*.dll"/>
-      <Pdbs Include="$(OutputPath)*.pdb"/>
-      <Dyns Include="$(OutputPath)*.dyn"/>
+      <Dlls Include="$(OutDir)*.dll"/>
+      <Pdbs Include="$(OutDir)*.pdb"/>
+      <Dyns Include="$(OutDir)*.dyn"/>
     </ItemGroup>
-    <Copy SourceFiles="@(Dlls)" DestinationFolder="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\bin\"/>
-    <Copy SourceFiles="@(Pdbs)" DestinationFolder="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\bin\"/>
-    <Copy SourceFiles="@(Dyns)" DestinationFolder="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\extra\"/>
+    <Copy SourceFiles="@(Dlls)" DestinationFolder="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\bin\"/>
+    <Copy SourceFiles="@(Pdbs)" DestinationFolder="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\bin\"/>
+    <Copy SourceFiles="@(Dyns)" DestinationFolder="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\extra\"/>
   </Target>
 </Project>

--- a/src/Libraries/Samples/SampleLibraryUI/SampleLibraryUI.csproj
+++ b/src/Libraries/Samples/SampleLibraryUI/SampleLibraryUI.csproj
@@ -116,9 +116,9 @@
       <Xmls Include="$(OutDir)*.xml"/>
       <Res Include="$(OutDir)en-US\*.*"/>
     </ItemGroup>
-    <Copy SourceFiles="@(Dlls)" DestinationFolder="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\bin\"/>
-    <Copy SourceFiles="@(Pdbs)" DestinationFolder="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\bin\"/>
-    <Copy SourceFiles="@(Xmls)" DestinationFolder="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\bin\"/>
-    <Copy SourceFiles="@(Res)" DestinationFolder="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\bin\en-US\"/>
+    <Copy SourceFiles="@(Dlls)" DestinationFolder="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\bin\"/>
+    <Copy SourceFiles="@(Pdbs)" DestinationFolder="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\bin\"/>
+    <Copy SourceFiles="@(Xmls)" DestinationFolder="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\bin\"/>
+    <Copy SourceFiles="@(Res)" DestinationFolder="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\bin\en-US\"/>
   </Target>
 </Project>

--- a/src/Libraries/Samples/SampleLibraryZeroTouch/SampleLibraryZeroTouch.csproj
+++ b/src/Libraries/Samples/SampleLibraryZeroTouch/SampleLibraryZeroTouch.csproj
@@ -79,10 +79,10 @@
       <Pdbs Include="$(OutDir)*.pdb"/>
       <Xmls Include="$(OutDir)*.xml"/>
     </ItemGroup>
-    <Copy SourceFiles="@(Dlls)" DestinationFolder="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\bin\"/>
-    <Copy SourceFiles="@(Pdbs)" DestinationFolder="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\bin\"/>
-    <Copy SourceFiles="@(Xmls)" DestinationFolder="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\bin\"/>
-    <Copy SourceFiles="$(ProjectDir)..\pkg.json" DestinationFiles="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\pkg.json"/>
-    <MakeDir Directories="$(APPDATA)\Dynamo\0.8\packages\Dynamo Samples\dyf"/>
+    <Copy SourceFiles="@(Dlls)" DestinationFolder="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\bin\"/>
+    <Copy SourceFiles="@(Pdbs)" DestinationFolder="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\bin\"/>
+    <Copy SourceFiles="@(Xmls)" DestinationFolder="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\bin\"/>
+    <Copy SourceFiles="$(ProjectDir)..\pkg.json" DestinationFiles="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\pkg.json"/>
+    <MakeDir Directories="$(SolutionDir)..\bin\$(Platform)\$(Configuration)\0.8\packages\Dynamo Samples\dyf"/>
   </Target>
 </Project>

--- a/test/DynamoCoreTests/CallsiteTests.cs
+++ b/test/DynamoCoreTests/CallsiteTests.cs
@@ -46,6 +46,17 @@ namespace Dynamo.Tests
             base.GetLibrariesToPreload(libraries);
         }
 
+        /// <summary>
+        /// These tests depend on nodes in the Dynamo Samples package, which are copied
+        /// at build time into a packages folder in the build directory. We
+        /// override the UserDataRootFolder on the IPathResolver to have the tests look in 
+        /// the packages folder built into the build directory.
+        /// </summary>
+        protected override string GetUserUserDataRootFolder()
+        {
+            return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        }
+
         /* Multi-dimension tests
          * This graph contains:
          * One list: {"Tywin","Cersei","Hodor"}

--- a/test/DynamoCoreTests/DynamoModelTestBase.cs
+++ b/test/DynamoCoreTests/DynamoModelTestBase.cs
@@ -66,7 +66,14 @@ namespace Dynamo
                 // created, otherwise DynamoModel gets created without preloading 
                 // any library.
                 // 
-                pathResolver = new TestPathResolver();
+
+                var pathResolverParams = new TestPathResolverParams()
+                {
+                    UserDataRootFolder = GetUserUserDataRootFolder(),
+                    CommonDataRootFolder = GetCommonDataRootFolder()
+                };
+
+                pathResolver = new TestPathResolver(pathResolverParams);
                 foreach (var preloadedLibrary in preloadedLibraries.Distinct())
                 {
                     pathResolver.AddPreloadLibraryPath(preloadedLibrary);
@@ -89,6 +96,20 @@ namespace Dynamo
             // is designed to contain no test cases, so it does not need any 
             // preloaded library, all of which should only be specified in the
             // derived class.
+        }
+
+        protected virtual string GetUserUserDataRootFolder()
+        {
+            // Override in derived classed to provide a custom
+            // UserAppDataRootFolder
+            return string.Empty;
+        }
+
+        protected virtual string GetCommonDataRootFolder()
+        {
+            // Override in derived classed to provide a custom
+            // CommonAppDataRootFolder
+            return string.Empty;
         }
 
         protected T Open<T>(params string[] relativePathParts) where T : WorkspaceModel

--- a/test/DynamoCoreTests/DynamoModelTestBase.cs
+++ b/test/DynamoCoreTests/DynamoModelTestBase.cs
@@ -101,14 +101,16 @@ namespace Dynamo
         protected virtual string GetUserUserDataRootFolder()
         {
             // Override in derived classed to provide a custom
-            // UserAppDataRootFolder
+            // UserAppDataRootFolder. Returning an empty string
+            // here will cause the PathManager to use its default.
             return string.Empty;
         }
 
         protected virtual string GetCommonDataRootFolder()
         {
             // Override in derived classed to provide a custom
-            // CommonAppDataRootFolder
+            // CommonAppDataRootFolder. Returning an empty string
+            // here will cause the PathManager to use its default.
             return string.Empty;
         }
 

--- a/test/Libraries/TestServices/TestPathResolver.cs
+++ b/test/Libraries/TestServices/TestPathResolver.cs
@@ -6,17 +6,41 @@ using Dynamo.Interfaces;
 
 namespace TestServices
 {
+    public class TestPathResolverParams
+    {
+        public string CommonDataRootFolder { get; set; }
+        public string UserDataRootFolder { get; set; }
+
+        public TestPathResolverParams()
+        {
+            CommonDataRootFolder = string.Empty;
+            UserDataRootFolder = string.Empty;
+        }
+    }
+
     public class TestPathResolver : IPathResolver
     {
         private readonly HashSet<string> additionalResolutionPaths;
         private readonly HashSet<string> additionalNodeDirectories;
         private readonly HashSet<string> preloadedLibraryPaths;
+        private readonly string userDataRootFolder = string.Empty;
+        private readonly string commonDataRootFolder = string.Empty;
 
         public TestPathResolver()
         {
             additionalResolutionPaths = new HashSet<string>();
             additionalNodeDirectories = new HashSet<string>();
             preloadedLibraryPaths = new HashSet<string>();
+        }
+
+        public TestPathResolver(TestPathResolverParams resolverParams)
+        {
+            additionalResolutionPaths = new HashSet<string>();
+            additionalNodeDirectories = new HashSet<string>();
+            preloadedLibraryPaths = new HashSet<string>();
+
+            userDataRootFolder = resolverParams.UserDataRootFolder;
+            commonDataRootFolder = resolverParams.CommonDataRootFolder;
         }
 
         public void AddNodeDirectory(string nodeDirectory)
@@ -53,12 +77,12 @@ namespace TestServices
 
         public string UserDataRootFolder
         {
-            get { return string.Empty; }
+            get { return userDataRootFolder; }
         }
 
         public string CommonDataRootFolder
         {
-            get { return string.Empty; }
+            get { return commonDataRootFolder; }
         }
     }
 }


### PR DESCRIPTION
### Purpose

- Adjusts the copy tasks on the Dynamo Samples libraries to copy assets into a package in the build folder. This allows us to maintain cross-platform copy functionality (AppData is locked on Linux). 
- The `CallsiteTests` are updated to load packages from this "testing" packages directory.
- Augments `DynamoModelTestBase` with two methods that allow custom setting of app data folders without having to override any of the test setup methods.

### Declarations

- [x] The code base is in a better state after this PR
  - `DynamoModelTestBase` now allows configuration of the data folders on the `IPathResolver` without needing to override the `StartDynamo` method.
  - The code is now safe for cross platform environments where `$(AppData)` can not be used.
  - The packages to be used for testing are isolated.
- [x] The level of testing this PR includes is appropriate.
  - This addition re-enables tests disabled by missing packages on the build machine.
### Reviewers

@pboyer 
