### PR TITLE
MAGN-7321 After rename a group when click on another group or node first group jumps to the position of latter.

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -115,6 +115,7 @@ namespace Dynamo.Nodes
 
             //When Textbox is visible,clear the selection. That way, models will not be added to
             //dragged nodes one more time. Ref: MAGN-7321
+            if (GroupTextBlock.IsVisible && e.ClickCount >= 2)
             {
                 DynamoSelection.Instance.ClearSelection();
             }

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -112,6 +112,12 @@ namespace Dynamo.Nodes
                     models.IsSelected = true;                    
                 }
             }
+
+            //When Textbox is visible,clear the selection. That way, models will not be added to
+            //dragged nodes one more time. Ref: MAGN-7321
+            {
+                DynamoSelection.Instance.ClearSelection();
+            }
         }
      
         private void AnnotationView_OnMouseRightButtonDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
This PR fixes the below issue

MAGN-7321 After rename a group when click on another group or node first group jumps to the position of latter.

Fix:
 Clears the selection on Usercontrol double click.

- [ ] @pboyer 