### PR TITLE
Periodic Fixes 1 : Fix issue where UI cannot change RunPeriod

### DIFF
--- a/src/DynamoCore/Models/RunSettings.cs
+++ b/src/DynamoCore/Models/RunSettings.cs
@@ -18,6 +18,11 @@ namespace Dynamo.Models
     {
         #region private members
 
+        /// <summary>
+        /// The default run period is intended to produce "real-time" rates.
+        /// </summary>
+        public const int DefaultRunPeriod = 1000;
+
         private int runPeriod;
         private RunType runType;
         private bool runEnabled;
@@ -80,7 +85,7 @@ namespace Dynamo.Models
 
         public RunSettings()
         {
-            RunPeriod = 500;
+            RunPeriod = DefaultRunPeriod;
             RunType = RunType.Manual;
             RunEnabled = true;
         }
@@ -109,7 +114,7 @@ namespace Dynamo.Models
         {
             RunEnabled = true;
             RunType = RunType.Automatic;
-            RunPeriod = 100;
+            RunPeriod = DefaultRunPeriod;
         }
 
         #endregion

--- a/src/DynamoCore/Models/RunSettings.cs
+++ b/src/DynamoCore/Models/RunSettings.cs
@@ -16,20 +16,13 @@ namespace Dynamo.Models
     /// </summary>
     public class RunSettings : NotificationObject
     {
-        #region private members
-
-        /// <summary>
-        /// The default run period is intended to produce "real-time" rates.
-        /// </summary>
-        public const int DefaultRunPeriod = 1000;
+        #region Class Data Members and Properties
 
         private int runPeriod;
         private RunType runType;
         private bool runEnabled;
 
-        #endregion
-
-        #region properties
+        public const int DefaultRunPeriod = 1000;
 
         /// <summary>
         /// The length, in milliseconds, of the period
@@ -81,7 +74,7 @@ namespace Dynamo.Models
 
         #endregion
 
-        #region constructors
+        #region Constructors
 
         public RunSettings()
         {
@@ -99,16 +92,7 @@ namespace Dynamo.Models
 
         #endregion
 
-        #region private methods
-
-        private void RaisePropertyChangeWithDebug(string propertyName)
-        {
-            RaisePropertyChanged(propertyName);
-        }
-
-        #endregion
-
-        #region public methods
+        #region Public Operational Methods
 
         public void Reset()
         {
@@ -118,5 +102,15 @@ namespace Dynamo.Models
         }
 
         #endregion
+
+        #region Private Class Methods
+
+        private void RaisePropertyChangeWithDebug(string propertyName)
+        {
+            RaisePropertyChanged(propertyName);
+        }
+
+        #endregion
+
     }
 }

--- a/src/DynamoCore/Models/WorkspaceInfo.cs
+++ b/src/DynamoCore/Models/WorkspaceInfo.cs
@@ -15,7 +15,7 @@ namespace Dynamo.Models
             X = 0; 
             Y = 0;
             RunType = RunType.Automatic;
-            RunPeriod = 100;
+            RunPeriod = RunSettings.DefaultRunPeriod;
             HasRunWithoutCrash = true;
         }
 
@@ -33,7 +33,7 @@ namespace Dynamo.Models
                 string description = "";
                 string version = "";
                 var runType = RunType.Manual;
-                int runPeriod = 100;
+                int runPeriod = RunSettings.DefaultRunPeriod;
                 bool hasRunWithoutCrash = false;
 
                 var topNode = xmlDoc.GetElementsByTagName("Workspace");

--- a/src/DynamoCoreWpf/Controls/RunSettingsControl.xaml
+++ b/src/DynamoCoreWpf/Controls/RunSettingsControl.xaml
@@ -87,7 +87,7 @@
                                 Focusable="False" Margin="0,0,2.5,0"/>
             
             <TextBox Name="RunPeriodTextBox" 
-                    Text="{Binding RunPeriod, Converter={StaticResource RunPeriodConverter}, UpdateSourceTrigger=Explicit}"
+                    Text="{Binding RunPeriod, Converter={StaticResource RunPeriodConverter}, Mode=TwoWay}"
                      VerticalContentAlignment="Center"
                      Visibility="{Binding RunPeriodInputVisibility}"
                      Width="80" FontSize="14px"

--- a/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
@@ -105,7 +105,8 @@ namespace Dynamo.Wpf.ViewModels
             get { return Model.RunPeriod; }
             set
             {
-                Model.RunPeriod = value; 
+                Model.RunPeriod = value;
+                RaisePropertyChanged("RunPeriod");
             }
         }
 
@@ -330,15 +331,27 @@ namespace Dynamo.Wpf.ViewModels
     /// </summary>
     public class RunPeriodConverter : IValueConverter
     {
+        public const string ExpectedSuffix = "ms";
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return string.Format("{0}{1}", value, "ms");
+            return string.Format("{0}{1}", value, ExpectedSuffix);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            var s = value.ToString();
+
+            if (s.EndsWith(ExpectedSuffix))
+            {
+                s = s.Remove(s.Length - ExpectedSuffix.Length);
+            }
+            
             int ms;
-            return !Int32.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out ms) ? 100 : Math.Abs(ms);
+            var parseSuccess =
+                Int32.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out ms);
+
+            return parseSuccess ? Math.Abs(ms) : RunSettings.DefaultRunPeriod;
         }
     }
 }

--- a/test/DynamoCoreWpfTests/RunSettingsTests.cs
+++ b/test/DynamoCoreWpfTests/RunSettingsTests.cs
@@ -83,6 +83,15 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void RunPeriodAcceptsTextWithProperSuffix()
+        {
+            var tb = View.RunSettingsControl.RunPeriodTextBox;
+            View.RunSettingsControl.RunPeriodTextBox.Text = "5000" + RunPeriodConverter.ExpectedSuffix;
+            tb.RaiseEvent(GetKeyboardEnterEventArgs(tb));
+            Assert.AreEqual(GetHomeSpace().RunSettings.RunPeriod, 5000);
+        }
+
+        [Test]
         public void RunPeriodDoesNotAllowNegativeInput()
         {
             var tb = View.RunSettingsControl.RunPeriodTextBox;

--- a/test/DynamoCoreWpfTests/RunSettingsTests.cs
+++ b/test/DynamoCoreWpfTests/RunSettingsTests.cs
@@ -79,7 +79,7 @@ namespace DynamoCoreWpfTests
             var tb = View.RunSettingsControl.RunPeriodTextBox;
             View.RunSettingsControl.RunPeriodTextBox.Text = "dingbat";
             tb.RaiseEvent(GetKeyboardEnterEventArgs(tb));
-            Assert.AreEqual(GetHomeSpace().RunSettings.RunPeriod, 100);
+            Assert.AreEqual(GetHomeSpace().RunSettings.RunPeriod, RunSettings.DefaultRunPeriod);
         }
 
         [Test]
@@ -120,7 +120,7 @@ namespace DynamoCoreWpfTests
             homeSpace.RunSettings.RunPeriod = 10;
             homeSpace.Clear();
             Assert.AreEqual(homeSpace.RunSettings.RunType, RunType.Automatic);
-            Assert.AreEqual(homeSpace.RunSettings.RunPeriod, 100);
+            Assert.AreEqual(homeSpace.RunSettings.RunPeriod, RunSettings.DefaultRunPeriod);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

The default run period was scattered throughout the code.  I moved it to one place and increased it to 1000 ms until this code has stabilized.  I also fixed the issue where the user setting the run period could not change the run period.  This was an issue with `RunPeriodConverter`.

### Declarations

- [x] The code base is in a better state after this PR
  * Add const field `DefaultRunPeriod`, `ExpectedSuffix` for `RunPeriodConverter`
- [x] The level of testing this PR includes is appropriate
  * Added more tests to validate the typical

### Reviewers

@ikeough 