### PR TITLE
Fixed failing "TestTaskQueuePreProcessing00" test case

### DIFF
--- a/test/DynamoCoreTests/DynamoModelTestBase.cs
+++ b/test/DynamoCoreTests/DynamoModelTestBase.cs
@@ -36,11 +36,11 @@ namespace Dynamo
                 preloader = null;
                 DynamoSelection.Instance.ClearSelection();
 
-                if (this.CurrentDynamoModel == null)
-                    return;
-
-                this.CurrentDynamoModel.ShutDown(false);
-                this.CurrentDynamoModel = null;
+                if (this.CurrentDynamoModel != null)
+                {
+                    this.CurrentDynamoModel.ShutDown(false);
+                    this.CurrentDynamoModel = null;
+                }
             }
             catch (Exception ex)
             {

--- a/test/DynamoCoreTests/SchedulerTests.cs
+++ b/test/DynamoCoreTests/SchedulerTests.cs
@@ -22,7 +22,7 @@ using ProtoCore.AST;
 using ProtoCore.DSASM;
 using TestServices;
 
-namespace Dynamo
+namespace Dynamo.Tests
 {
     using TaskState = TaskStateChangedEventArgs.State;
 


### PR DESCRIPTION
### Purpose

This pull request fixes the failing `TestTaskQueuePreProcessing00` test. If this test case is run on its own, it passes. If it is run right after `CanDiscoverDependenciesForFunctionDefinitionOpenFromFile`, then it will fail by not being able to resolve `'DSCoreNodesUI.dll` location. The failure is probably (not confirmed) introduced by [an earlier pull request](https://github.com/DynamoDS/Dynamo/pull/4371) since it is related to the above-mentioned test case.

This pull request fixes the failure by moving test class `SchedulerIntegrationTests` under `Dynamo.Tests` namespace. This causes NUnit to pick up `RunBeforeAllTests` set-up routine in the following file:

    Dynamo\test\DynamoCoreTests\Setup.cs

`RunBeforeAllTests` properly sets up `AssemblyHelper` to include `nodes` folder where `DSCoreNodesUI.dll` is located. This helps resolve the issue where `DSCoreNodesUI.dll` cannot be located.

### Declarations

Check these iff you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

Hi @pboyer, I'm merging this right in to stabilize the build, I'm just wondering how your pull request may have affected this (I have yet to confirm this point, but it looks close enough). Thoughts?

### FYIs

Hi @RodRecker, this is the fix for that failing test case.