### PR TITLE
MAGN-7328 Copy paste into group title stops at carriage return

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -223,7 +223,9 @@
                     FontSize="{Binding FontSize}"                                 
                     IsVisibleChanged="GroupTextBox_OnIsVisibleChanged"
                     GotFocus="GroupTextBox_OnGotFocus"                   
-                    TextChanged="GroupTextBox_OnTextChanged"                            
+                    TextChanged="GroupTextBox_OnTextChanged"   
+                    AcceptsReturn="True"
+                    AcceptsTab="True"
                     Style="{StaticResource SZoomFadeTextBox}">                  
             </TextBox>
             

--- a/test/DynamoCoreTests/AnnotationModelTest.cs
+++ b/test/DynamoCoreTests/AnnotationModelTest.cs
@@ -364,5 +364,35 @@ namespace Dynamo.Tests
             //Group should have the new note added 
             Assert.AreEqual(4, annotation.SelectedModels.Count());
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void CopyPasteTextWithCarriageIntoAGroup()
+        {
+            //Add a Node
+            var model = CurrentDynamoModel;
+            var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
+            model.CurrentWorkspace.AddNode(addNode, false);
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count, 1);
+
+            //Add a Note 
+            Guid id = Guid.NewGuid();
+            var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+
+            //Select the node and notes
+            DynamoSelection.Instance.Selection.Add(addNode);
+            DynamoSelection.Instance.Selection.Add(addNote);
+
+            //create the group around selected nodes and notes
+            Guid groupid = Guid.NewGuid();
+            var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreNotEqual(0, annotation.Width);
+
+            //now change the text
+            annotation.AnnotationText = "This is a test\r\n\r\nfor carriage return";
+            Assert.AreEqual(annotation.AnnotationText, "This is a test\r\n\r\nfor carriage return");
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Text with carriage return was not pasted correctly in a group.

### Declarations

Check these iff you believe they are true

- [ ] The code base is in a better state after this PR
           Textbox in UI should have Accepts tab and Accepts Enter set to true
- [ ] The level of testing this PR includes is appropriate
          Added test [CopyPasteTextWithCarriageIntoAGroup ] to validate this.

### Reviewers
  - [ ] @pboyer 