### PR TITLE
MAGN-7317 Turn off edge rendering in for 0.8.1 release

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
@@ -41,6 +41,7 @@ namespace Dynamo.Core.Threading
         private const byte DefB = 130;
         private const byte DefA = 255;
         private const byte MidTone = 180;
+        private bool renderEdges = false;
 
         #region Class Data Members and Properties
 
@@ -170,25 +171,29 @@ namespace Dynamo.Core.Threading
                 {
                     graphicItem.Tessellate(package, -1.0, factory.MaxTessellationDivisions);
 
-                    var surf = graphicItem as Surface;
-                    if (surf != null)
+                    if (renderEdges)
                     {
-                        foreach (var curve in surf.PerimeterCurves())
+                        var surf = graphicItem as Surface;
+                        if (surf != null)
                         {
-                            curve.Tessellate(package, -1.0, factory.MaxTessellationDivisions);
-                            curve.Dispose();
+                            foreach (var curve in surf.PerimeterCurves())
+                            {
+                                curve.Tessellate(package, -1.0, factory.MaxTessellationDivisions);
+                                curve.Dispose();
+                            }
+                        }
+
+                        var solid = graphicItem as Solid;
+                        if (solid != null)
+                        {
+                            foreach (var geom in solid.Edges.Select(edge => edge.CurveGeometry))
+                            {
+                                geom.Tessellate(package, -1.0, factory.MaxTessellationDivisions);
+                                geom.Dispose();
+                            }
                         }
                     }
-
-                    var solid = graphicItem as Solid;
-                    if (solid != null)
-                    {
-                        foreach (var geom in solid.Edges.Select(edge => edge.CurveGeometry)) {
-                            geom.Tessellate(package, -1.0, factory.MaxTessellationDivisions);
-                            geom.Dispose();
-                        }
-                    }
-
+                    
                     var plane = graphicItem as Plane;
                     if (plane != null)
                     {

--- a/src/Libraries/CoreNodes/GeometryColor.cs
+++ b/src/Libraries/CoreNodes/GeometryColor.cs
@@ -12,6 +12,7 @@ namespace DSCore
     {
         internal Geometry geometry;
         internal Color color;
+        private bool renderEdges = false;
 
         private Display(Geometry geometry, Color color)
         {
@@ -51,23 +52,26 @@ namespace DSCore
 
             geometry.Tessellate(package, tol, maxGridLines);
 
-            var surf = geometry as Surface;
-            if (surf != null)
+            if (renderEdges)
             {
-                foreach (var curve in surf.PerimeterCurves())
+                var surf = geometry as Surface;
+                if (surf != null)
                 {
-                    curve.Tessellate(package, tol, maxGridLines);
-                    curve.Dispose();
+                    foreach (var curve in surf.PerimeterCurves())
+                    {
+                        curve.Tessellate(package, tol, maxGridLines);
+                        curve.Dispose();
+                    }
                 }
-            }
 
-            var solid = geometry as Solid;
-            if (solid != null)
-            {
-                foreach (var geom in solid.Edges.Select(edge => edge.CurveGeometry))
+                var solid = geometry as Solid;
+                if (solid != null)
                 {
-                    geom.Tessellate(package, tol, maxGridLines);
-                    geom.Dispose();
+                    foreach (var geom in solid.Edges.Select(edge => edge.CurveGeometry))
+                    {
+                        geom.Tessellate(package, tol, maxGridLines);
+                        geom.Dispose();
+                    }
                 }
             }
 


### PR DESCRIPTION
### Purpose

The PR addresses [MAGN-7317](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7317). It disables edge rendering in the background preview, and by the Display class by wrapping their the methods for calculating tessellated edges in a conditional block set, for the time being, to false.

### Declarations

- [x] The code base is in a better state after this PR
  - Edge rendering can now be controlled with a variable. Further work will need to be done in the future to tie to this an application-level preference.
- [ ] The level of testing this PR includes is appropriate
  - No testing included as this is disabling functionality.

### Reviewers

@ramramps 

### FYIs

@kronz 