### PR TITLE
Fix for writing node that returns FunctionObject as "ProtoCore.DSASM.StackValue" into Excel Sheet

### DIFF
--- a/src/Libraries/DSOffice/DSOffice.csproj
+++ b/src/Libraries/DSOffice/DSOffice.csproj
@@ -23,7 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-	<DocumentationFile>..\..\..\bin\AnyCPU\Debug\$(UICulture)\DSOffice.xml</DocumentationFile>
+    <DocumentationFile>..\..\..\bin\AnyCPU\Debug\$(UICulture)\DSOffice.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,7 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-	<DocumentationFile>..\..\..\bin\AnyCPU\Release\$(UICulture)\DSOffice.xml</DocumentationFile>
+    <DocumentationFile>..\..\..\bin\AnyCPU\Release\$(UICulture)\DSOffice.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Office.Interop.Excel, Version=14.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
@@ -77,6 +77,12 @@
     <Content Include="DSOffice_DynamoCustomization.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Engine\ProtoCore\ProtoCore.csproj">
+      <Project>{7a9e0314-966f-4584-baa3-7339cbb849d1}</Project>
+      <Name>ProtoCore</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/Libraries/DSOffice/Excel.cs
+++ b/src/Libraries/DSOffice/Excel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -375,9 +376,12 @@ namespace DSOffice
                         {
                             output[i, j] = "";
                         }
-                        else if (((StackValue) item).IsPointer)
+                        else if (item is StackValue)
                         {
-                            return null;
+                            if(((StackValue)item).IsPointer)
+                                return null;
+
+                            output[i, j] = item.ToString();
                         }
                         else
                         {

--- a/src/Libraries/DSOffice/Excel.cs
+++ b/src/Libraries/DSOffice/Excel.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using Microsoft.Office.Interop.Excel;
 
 using Autodesk.DesignScript.Runtime;
+using ProtoCore.DSASM;
 
 namespace DSOffice
 {
@@ -374,6 +375,10 @@ namespace DSOffice
                         {
                             output[i, j] = "";
                         }
+                        else if (((StackValue) item).IsPointer)
+                        {
+                            return null;
+                        }
                         else
                         {
                             output[i, j] = item.ToString();
@@ -457,6 +462,9 @@ namespace DSOffice
             int numRows, numColumns;
 
             object[,] rangeData = ConvertToDimensionalArray(data, out numRows, out numColumns);
+
+            if (rangeData == null)
+                return this;
 
             var c1 = (Range)ws.Cells[startRow + 1, startColumn + 1];
             var c2 = (Range)ws.Cells[startRow + numRows, startColumn + numColumns];

--- a/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
+++ b/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
@@ -17,6 +17,7 @@ namespace Dynamo.Tests
         {
             libraries.Add("DSCoreNodes.dll");
             libraries.Add("DSOffice.dll");
+            libraries.Add("FunctionObject.ds");
             base.GetLibrariesToPreload(libraries);
         }
 
@@ -701,6 +702,28 @@ namespace Dynamo.Tests
 
         }
 
+        [Test]
+        public void TestWriteFunctionObjectToExcel()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\excel\WriteFunctionobject.dyn");
+            ViewModel.OpenCommand.Execute(openPath);
+
+            var filePath = System.IO.Path.Combine(TempFolder, "output.xlsx");
+            var stringNode = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<Dynamo.Nodes.StringInput>();
+            stringNode.Value = filePath;
+
+            var writeNode = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.WriteToFile");
+
+            ViewModel.HomeSpace.Run();
+
+            Assert.IsTrue(File.Exists(filePath));
+
+            Assert.IsTrue(writeNode.CachedValue.IsCollection);
+            var list = writeNode.CachedValue.GetElements();
+
+            // Empty list expected
+            Assert.AreEqual(0, list.Count);
+        }
 
         #endregion
 


### PR DESCRIPTION
### Purpose

This submission fixes the [bug] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7336) with `ProtoCore.DSASM.StackValue` getting printed to Excel files when a function object is getting passed into the `WriteToFile` node. In such cases, the existing worksheet should remain unaffected as though the node never executed.

![image](https://cloud.githubusercontent.com/assets/5710686/7562948/5499aab4-f80b-11e4-9e5b-e062ee5937e9.png)


### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@junmendoza  Reviewer 1  

### FYIs

@monikaprabhu  
