### PR TITLE
Fix build installer error

### DIFF
--- a/src/Config/Install.props
+++ b/src/Config/Install.props
@@ -24,7 +24,7 @@
     <DYNAMO_HARVEST_PATH Condition=" '$(DYNAMO_HARVEST_PATH)' == '' ">$(MSBuildProjectDirectory)\harvest</DYNAMO_HARVEST_PATH>
     <DYNAMO_MIGRATION_NODES_PATH Condition=" '$(DYNAMO_MIGRATION_NODES_PATH)' == '' ">$(DYNAMO_BASE_PATH)\doc\distrib\migration_nodes</DYNAMO_MIGRATION_NODES_PATH>
     <DYNAMO_SAMPLES_PATH Condition=" '$(DYNAMO_SAMPLES_PATH)' == '' ">$(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration)\samples</DYNAMO_SAMPLES_PATH>
-    <DYNAMO_GALLERY_PATH Condition=" '$(DYNAMO_GALLERY_PATH)' == '' ">$(DYNAMO_BASE_PATH)\extern\gallery</DYNAMO_GALLERY_PATH>
+    <DYNAMO_GALLERY_PATH Condition=" '$(DYNAMO_GALLERY_PATH)' == '' ">$(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration)\gallery</DYNAMO_GALLERY_PATH>
     <DYNAMO_REVIT_SIGN_TOOLS Condition=" '$(DYNAMO_REVIT_SIGN_TOOLS)' == '' ">$(MSBuildProjectDirectory)\sign</DYNAMO_REVIT_SIGN_TOOLS>
     <BaseIntermediateOutputPath>$(OutputPath)\int\</BaseIntermediateOutputPath>
     <DebugType>pdbonly</DebugType>

--- a/tools/install/CreateInstallers.bat
+++ b/tools/install/CreateInstallers.bat
@@ -48,7 +48,7 @@ robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\samples %cwd%\temp\s
 
 robocopy %cwd%\Extra\DirectX %cwd%\temp\DirectX
 
-robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\gallery %cwd%\temp\gallery
+robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\gallery %cwd%\temp\gallery /s
 
 "C:\Program Files (x86)\Inno Setup 5\iscc.exe" %cwd%\DynamoInstaller.iss
 rmdir /Q /S %cwd%\temp

--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -108,7 +108,7 @@ Source: temp\definitions\*; DestDir: {commonappdata}\Dynamo\{#Major}.{#Minor}\de
 Source: temp\DirectX\*.*; DestDir: {tmp}\DirectX;
 
 ;Gallery
-Source: temp\gallery\*; DestDir: "{commonappdata}\Dynamo\{#Major}.{#Minor}\gallery\en-US"; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
+Source: temp\gallery\*; DestDir: "{commonappdata}\Dynamo\{#Major}.{#Minor}\gallery"; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 
 [Registry]
 Root: HKCU64; Subkey: "Software\{#ProductName}\{#Major}.{#Minor}"; Flags: uninsdeletekey


### PR DESCRIPTION
Hi @Benglin, sorry for the errors caused. This fixes DynamoRevit - Build #1614. The CreateInstallers.bat gallery files' robocopy need /s option to copy it subdirectories.
Please take a look and merge.