### PR TITLE
Updated DynamoSandbox.exe to avoid invalid ASM paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@ Looking to learn or download Dynamo?  Check out [dynamobim.org](http://dynamobim
 
 ## Build ###
 
-You will need Visual Studio and a git client to build Dynamo.  Find more about how to build Dynamo at our [wiki](https://github.com/DynamoDS/Dynamo/wiki).
+You will need the following to build Dynamo:
+
+- Microsoft Visual Studio 2013
+- [GitHub for Windows](https://windows.github.com/)
+- []Microsoft .NET Framework 3.5 with SP1](http://www.microsoft.com/en-sg/download/details.aspx?id=25150)
+- Microsoft .NET Framework 4.0 and above (included with Visual Studio 2013)
+- Microsoft DirectX (install from %GitHub%\Dynamo\tools\install\Extra\DirectX\DXSETUP.exe)
+
+Find more about how to build Dynamo at our [wiki](https://github.com/DynamoDS/Dynamo/wiki).
 
 
 ## Contribute ##

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You will need the following to build Dynamo:
 
 - Microsoft Visual Studio 2013
 - [GitHub for Windows](https://windows.github.com/)
-- []Microsoft .NET Framework 3.5 with SP1](http://www.microsoft.com/en-sg/download/details.aspx?id=25150)
+- [Microsoft .NET Framework 3.5 with SP1](http://www.microsoft.com/en-sg/download/details.aspx?id=25150)
 - Microsoft .NET Framework 4.0 and above (included with Visual Studio 2013)
 - Microsoft DirectX (install from %GitHub%\Dynamo\tools\install\Extra\DirectX\DXSETUP.exe)
 

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -26,10 +26,9 @@ namespace DynamoSandbox
 
         internal PathResolver(string preloaderLocation)
         {
-            additionalResolutionPaths = new List<string>
-            {
-                preloaderLocation
-            };
+            additionalResolutionPaths = new List<string>();
+            if (Directory.Exists(preloaderLocation))
+                additionalResolutionPaths.Add(preloaderLocation);
 
             additionalNodeDirectories = new List<string>();
             preloadedLibraryPaths = new List<string>

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -88,6 +88,8 @@ namespace DynamoSandbox
             var preloaderLocation = string.Empty;
             PreloadShapeManager(ref geometryFactoryPath, ref preloaderLocation);
 
+            DynamoModel.RequestMigrationStatusDialog += MigrationStatusDialogRequested;
+
             var model = DynamoModel.Start(
                 new DynamoModel.DefaultStartConfiguration()
                 {

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -26,6 +26,11 @@ namespace DynamoSandbox
 
         internal PathResolver(string preloaderLocation)
         {
+            // If a suitable preloader cannot be found on the system, then do 
+            // not add invalid path into additional resolution. The default 
+            // implementation of IPathManager in Dynamo insists on having valid 
+            // paths specified through "IPathResolver" implementation.
+            // 
             additionalResolutionPaths = new List<string>();
             if (Directory.Exists(preloaderLocation))
                 additionalResolutionPaths.Add(preloaderLocation);
@@ -83,20 +88,12 @@ namespace DynamoSandbox
             var preloaderLocation = string.Empty;
             PreloadShapeManager(ref geometryFactoryPath, ref preloaderLocation);
 
-            // TODO(PATHMANAGER): Do we really libg_xxx folder on resolution path?
-            // If not, PathResolver will be completely redundant so please remove it.
-            var pathResolver = new PathResolver(preloaderLocation);
-
-            DynamoModel.RequestMigrationStatusDialog += MigrationStatusDialogRequested;
-
             var model = DynamoModel.Start(
                 new DynamoModel.DefaultStartConfiguration()
                 {
-                    PathResolver = pathResolver,
+                    PathResolver = new PathResolver(preloaderLocation),
                     GeometryFactoryPath = geometryFactoryPath
                 });
-
-            
 
             viewModel = DynamoViewModel.Start(
                 new DynamoViewModel.StartConfiguration()


### PR DESCRIPTION
I tried building Dynamo on my new machine with just `Visual Studio 2013 Ultimate` installed, Dynamo crashes because `PathManager` insists on `IPathResolver` providing valid resolution paths. Since `Autodesk Revit` isn't installed on this new machine, no ASM preloader can be found, resulting in invalid LibG folder such as `libg_0`. I have added code to prevent invalid directory such as this being added to the additional resolution paths.

Also, I realized that `DynamoIcons.csproj` requires `.NET Framework 2.0` to be installed. So I have updated the `ReadMe.md` file to include that as a build requirement.

@nguyen-binh-minh, please have a look at this one, thanks!
