### PR TITLE
Do not start the backup files timer when running test cases

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1209,6 +1209,11 @@ namespace Dynamo.Models
         /// </summary>
         private void StartBackupFilesTimer()
         {
+            // When running test cases, the dispatcher may be null which will cause the timer to
+            // introduce a lot of threads. So the timer will not be started if test cases are running.
+            if (!IsTestMode)
+                return;
+
             if (backupFilesTimer != null)
             {
                 throw new Exception("The timer to backup files has already been started!");


### PR DESCRIPTION
### Purpose

This submission is to fix the issue that there are a number of threads to back up files when running test cases. When running some test cases, the UI dispatcher is null which is causing the timer to always back up files in a new worker thread. This submission fixes the issue by not starting the timer if it is running test cases.

### Reviewers

@Benglin 