### PR TITLE
Fix for input ports not appearing for variables in chained CBN expressions

### DIFF
--- a/src/Engine/ProtoCore/CompilerUtils.cs
+++ b/src/Engine/ProtoCore/CompilerUtils.cs
@@ -304,12 +304,12 @@ namespace ProtoCore.Utils
                 // partial classnames with their fully qualified names in ASTs
                 // before passing them for pre-compilation. If partial class is not found in map, 
                 // update Resolution map in elementResolver with fully resolved name from compiler.
-                ElementRewriter.RewriteElementNames(core.ClassTable, parseParams.ElementResolver, astNodes);
+                var reWrittenNodes = ElementRewriter.RewriteElementNames(core.ClassTable, parseParams.ElementResolver, astNodes);
 
                 // Clone a disposable copy of AST nodes for PreCompile() as Codegen mutates AST's
                 // while performing SSA transforms and we want to keep the original AST's
                 var codeblock = new CodeBlockNode();
-                var nodes = astNodes.OfType<AssociativeNode>().Select(assocNode => NodeUtils.Clone(assocNode)).ToList();
+                var nodes = reWrittenNodes.OfType<AssociativeNode>().Select(NodeUtils.Clone).ToList();
                 codeblock.Body.AddRange(nodes);
 
                 buildStatus = PreCompile(string.Empty, core, codeblock, out blockId);

--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -2,6 +2,7 @@
 using ProtoCore.AST;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM;
+using ProtoCore.SyntaxAnalysis;
 using ProtoCore.Utils;
 using System;
 using System.Collections.Generic;
@@ -11,13 +12,15 @@ using System.Text;
 namespace ProtoCore.Namespace
 {
 
-    public class ElementRewriter
+    public class ElementRewriter : AstReplacer
     {
         private readonly ClassTable classTable;
-        
-        internal ElementRewriter(ClassTable classTable)
+        private readonly ElementResolver elementResolver;
+
+        internal ElementRewriter(ClassTable classTable, ElementResolver resolver)
         {
             this.classTable = classTable;
+            this.elementResolver = resolver;
         }
 
         /// <summary>
@@ -29,236 +32,112 @@ namespace ProtoCore.Namespace
         /// <param name="classTable"></param>
         /// <param name="elementResolver"></param>
         /// <param name="astNodes"> parent AST node </param>
-        public static void RewriteElementNames(ClassTable classTable,
+        public static IEnumerable<Node> RewriteElementNames(ClassTable classTable,
             ElementResolver elementResolver, IEnumerable<Node> astNodes)
         {
-            var elementRewriter = new ElementRewriter(classTable);
-            foreach (var node in astNodes)
-            {
-                var astNode = node as AssociativeNode;
-                if (astNode == null)
-                    continue;
-
-                elementRewriter.LookupResolvedNameAndRewriteAst(elementResolver, ref astNode);
-            }
+            var elementRewriter = new ElementRewriter(classTable, elementResolver);
+            return astNodes.OfType<AssociativeNode>().Select(astNode => astNode.Accept(elementRewriter)).Cast<Node>().ToList();
         }
 
-        internal void LookupResolvedNameAndRewriteAst(ElementResolver elementResolver, 
-            ref AssociativeNode astNode)
+        #region overridden methods
+
+        public override AssociativeNode VisitTypedIdentifierNode(TypedIdentifierNode node)
         {
-            Debug.Assert(elementResolver != null);
+            // If type is primitive type
+            if (node.datatype.UID != (int)PrimitiveType.kInvalidType &&
+                node.datatype.UID < (int)PrimitiveType.kMaxPrimitives)
+                return node;
 
-            // Get partial class identifier/identifier lists
-            var classIdentifiers = GetClassIdentifiers(astNode);
+            var identListNode = CoreUtils.CreateNodeFromString(node.TypeAlias);
 
-            var resolvedNames = new Queue<string>();
-            foreach (var identifier in classIdentifiers)
+            // Rewrite node with resolved name
+            if (identListNode is IdentifierNode)
             {
-                string partialName = string.Empty;
-                var identifierList = identifier as IdentifierListNode;
-                if (identifierList != null)
-                {
-                    partialName = CoreUtils.GetIdentifierExceptMethodName(identifierList);    
-                }
-                else
-                {
-                    partialName = identifier.Name;
-                }
-                
-                var resolvedName = elementResolver.LookupResolvedName(partialName);
-                if (string.IsNullOrEmpty(resolvedName))
-                {
-                    // If namespace resolution map does not contain entry for partial name, 
-                    // back up on compiler to resolve the namespace from partial name
-                    var matchingClasses = CoreUtils.GetResolvedClassName(classTable, CoreUtils.CreateNodeFromString(partialName));
-
-                    if (matchingClasses.Length == 1)
-                    {
-                        resolvedName = matchingClasses[0];
-                        var assemblyName = CoreUtils.GetAssemblyFromClassName(classTable, resolvedName);
-
-                        elementResolver.AddToResolutionMap(partialName, resolvedName, assemblyName);
-                    }
-                    else
-                    {
-                        // Class name could not be resolved - Possible namespace conflict 
-                        // This will be reported subsequently in the pre-compilation stage if there's a conflict
-                        // Enter an empty resolved name to the list and continue
-                        resolvedNames.Enqueue(string.Empty);
-                        continue;
-                    }
-                }
-                resolvedNames.Enqueue(resolvedName);
+                identListNode = RewriteIdentifierListNode(identListNode);
             }
-            
-            if(resolvedNames.Any())
-                RewriteAstWithResolvedName(ref astNode, resolvedNames);
+            else
+                identListNode = identListNode.Accept(this);
+
+            var identListString = identListNode.ToString();
+            var type = new Type
+            {
+                Name = identListString,
+                UID = classTable.IndexOf(identListString),
+                rank = node.datatype.rank
+            };
+
+            var typedNode = new TypedIdentifierNode
+            {
+                Name = node.Name,
+                Value = node.Name,
+                datatype = type
+            };
+
+            NodeUtils.CopyNodeLocation(typedNode, node);
+            return typedNode;
         }
 
-        internal IEnumerable<AssociativeNode> GetClassIdentifiers(AssociativeNode astNode)
+        public override AssociativeNode VisitIdentifierListNode(IdentifierListNode node)
         {
-            var classIdentifiers = new List<AssociativeNode>();
-            var resolvedNames = new Queue<string>();
-            DfsTraverse(ref astNode, classIdentifiers, resolvedNames);
-            return classIdentifiers;
+            var rightNode = node.RightNode;
+            var leftNode = node.LeftNode;
+
+            rightNode = rightNode.Accept(this);
+            leftNode = leftNode.Accept(this);
+
+            node = new IdentifierListNode
+            {
+                LeftNode = leftNode,
+                RightNode = rightNode,
+                Optr = Operator.dot
+            };
+            return RewriteIdentifierListNode(node);
         }
 
-        /// <summary>
-        /// Replace partial identifier with fully resolved identifier list in original AST
-        /// This is the same AST that is also passed to the VM for execution
-        /// </summary>
-        /// <param name="astNode"></param>
-        /// <param name="resolvedNames"> fully qualified class identifier list </param>
-        private void RewriteAstWithResolvedName(ref AssociativeNode astNode, Queue<string> resolvedNames)
+        #endregion
+
+        #region private helper methods
+
+        private AssociativeNode RewriteIdentifierListNode(AssociativeNode identifierList)
         {
-            DfsTraverse(ref astNode, null, resolvedNames);
-        }
+            var identListNode = identifierList as IdentifierListNode;
 
-        #region private utility methods
+            string partialName = identListNode != null ?
+                CoreUtils.GetIdentifierExceptMethodName(identListNode) : identifierList.Name;
 
-        private void DfsTraverse(ref AssociativeNode astNode, ICollection<AssociativeNode> classIdentifiers, 
-            Queue<string> resolvedNames)
-        {
-            if (astNode is BinaryExpressionNode)
-            {
-                var bnode = astNode as BinaryExpressionNode;
-                AssociativeNode leftNode = bnode.LeftNode;
-                AssociativeNode rightNode = bnode.RightNode;
-                DfsTraverse(ref leftNode, classIdentifiers, resolvedNames);
-                DfsTraverse(ref rightNode, classIdentifiers, resolvedNames);
-
-                bnode.LeftNode = leftNode;
-                bnode.RightNode = rightNode;
-            }
-            else if (astNode is FunctionCallNode)
-            {
-                var fCall = astNode as FunctionCallNode;
-                for (int n = 0; n < fCall.FormalArguments.Count; ++n)
-                {
-                    AssociativeNode argNode = fCall.FormalArguments[n];
-                    DfsTraverse(ref argNode, classIdentifiers, resolvedNames);
-                    fCall.FormalArguments[n] = argNode;
-                }
-            }
-            else if (astNode is ExprListNode)
-            {
-                var exprList = astNode as ExprListNode;
-                for (int n = 0; n < exprList.list.Count; ++n)
-                {
-                    AssociativeNode exprNode = exprList.list[n];
-                    DfsTraverse(ref exprNode, classIdentifiers, resolvedNames);
-                    exprList.list[n] = exprNode;
-                }
-            }
-            else if (astNode is InlineConditionalNode)
-            {
-                var inlineNode = astNode as InlineConditionalNode;
-                AssociativeNode condition = inlineNode.ConditionExpression;
-                AssociativeNode trueBody = inlineNode.TrueExpression;
-                AssociativeNode falseBody = inlineNode.FalseExpression;
-
-                DfsTraverse(ref condition, classIdentifiers, resolvedNames);
-                DfsTraverse(ref trueBody, classIdentifiers, resolvedNames);
-                DfsTraverse(ref falseBody, classIdentifiers, resolvedNames);
-
-                inlineNode.ConditionExpression = condition;
-                inlineNode.FalseExpression = falseBody;
-                inlineNode.TrueExpression = trueBody;
-            }
-            else if (astNode is TypedIdentifierNode)
-            {
-                var typedNode = astNode as TypedIdentifierNode;
-
-                // If type is primitive type
-                if (typedNode.datatype.UID != (int)PrimitiveType.kInvalidType &&
-                    typedNode.datatype.UID < (int) PrimitiveType.kMaxPrimitives)
-                    return;
-
-                var identListNode = CoreUtils.CreateNodeFromString(typedNode.TypeAlias);
-
-                // Rewrite node with resolved name
-                if (resolvedNames.Any())
-                {
-                    if (identListNode is IdentifierNode)
-                    {
-                        identListNode = RewriteIdentifierListNode(identListNode, resolvedNames);
-                    }
-                    else
-                        DfsTraverse(ref identListNode, classIdentifiers, resolvedNames);
-
-                    var identListString = identListNode.ToString();
-                    int indx = identListString.LastIndexOf('.');
-                    string name = indx >= 0 ? identListString.Remove(indx) : identListString;
-
-                    var type = new Type
-                    {
-                        Name = name,
-                        UID = classTable.IndexOf(name),
-                        rank = typedNode.datatype.rank
-                    };
-
-                    typedNode = new TypedIdentifierNode
-                    {
-                        Name = astNode.Name,
-                        Value = astNode.Name,
-                        datatype = type
-                    };
-
-                    NodeUtils.CopyNodeLocation(typedNode, astNode);
-                    astNode = typedNode;
-                }
-                else if (identListNode is IdentifierNode)
-                {
-                    classIdentifiers.Add(identListNode);
-                }
-                else
-                {
-                    DfsTraverse(ref identListNode, classIdentifiers, resolvedNames);
-                }
-                
-            }
-            else if (astNode is IdentifierListNode)
-            {
-                var identListNode = astNode as IdentifierListNode;
-                var rightNode = identListNode.RightNode;
-                var leftNode = identListNode.LeftNode;
-
-                if (rightNode is FunctionCallNode)
-                {
-                    DfsTraverse(ref rightNode, classIdentifiers, resolvedNames);
-                }
-                DfsTraverse(ref leftNode, classIdentifiers, resolvedNames);
-
-                if (resolvedNames.Any())
-                {
-                    astNode = RewriteIdentifierListNode(identListNode, resolvedNames);
-                }
-                else
-                {
-                    classIdentifiers.Add(identListNode);
-                }
-            }
-
-        }
-
-        private static AssociativeNode RewriteIdentifierListNode(AssociativeNode identifier, Queue<string> resolvedNames)
-        {
-            var resolvedName = resolvedNames.Dequeue();
-
-            // if resolved name is null or empty, return the identifier list node as is
+            var resolvedName = elementResolver.LookupResolvedName(partialName);
             if (string.IsNullOrEmpty(resolvedName))
-                return identifier;
+            {
+                // If namespace resolution map does not contain entry for partial name, 
+                // back up on compiler to resolve the namespace from partial name
+                var matchingClasses = CoreUtils.GetResolvedClassName(classTable, identifierList);
+
+                if (matchingClasses.Length == 1)
+                {
+                    resolvedName = matchingClasses[0];
+                    var assemblyName = CoreUtils.GetAssemblyFromClassName(classTable, resolvedName);
+
+                    elementResolver.AddToResolutionMap(partialName, resolvedName, assemblyName);
+                }
+            }
+            if (string.IsNullOrEmpty(resolvedName))
+                return identifierList;
 
             var newIdentList = CoreUtils.CreateNodeFromString(resolvedName);
             Validity.Assert(newIdentList is IdentifierListNode);
 
-            var identListNode = identifier as IdentifierListNode;
+            // If the original input node matches with the resolved name, simply return 
+            // the identifier list constructed from the resolved name
+            var symbol = new Symbol(resolvedName);
+            if (symbol.Matches(identifierList.ToString()))
+                return newIdentList;
 
-            AssociativeNode leftNode = identListNode != null ? identListNode.LeftNode : identifier;
-            AssociativeNode rightNode = identListNode != null ? identListNode.RightNode : identifier;
+            // Remove partialName from identListNode and replace with newIdentList
+            AssociativeNode leftNode = identListNode != null ? identListNode.LeftNode : identifierList;
+            AssociativeNode rightNode = identListNode != null ? identListNode.RightNode : identifierList;
 
             var intermediateNodes = new List<AssociativeNode>();
-            while (leftNode is IdentifierListNode)
+            while (leftNode is IdentifierListNode && !symbol.Matches(leftNode.ToString()))
             {
                 intermediateNodes.Insert(0, ((IdentifierListNode)leftNode).RightNode);
                 leftNode = ((IdentifierListNode)leftNode).LeftNode;

--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -221,11 +221,14 @@ namespace ProtoCore.Namespace
             {
                 var identListNode = astNode as IdentifierListNode;
                 var rightNode = identListNode.RightNode;
+                var leftNode = identListNode.LeftNode;
 
                 if (rightNode is FunctionCallNode)
                 {
                     DfsTraverse(ref rightNode, classIdentifiers, resolvedNames);
                 }
+                DfsTraverse(ref leftNode, classIdentifiers, resolvedNames);
+
                 if (resolvedNames.Any())
                 {
                     astNode = RewriteIdentifierListNode(identListNode, resolvedNames);

--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -250,12 +250,25 @@ namespace ProtoCore.Namespace
             Validity.Assert(newIdentList is IdentifierListNode);
 
             var identListNode = identifier as IdentifierListNode;
+
+            AssociativeNode leftNode = identListNode != null ? identListNode.LeftNode : identifier;
             AssociativeNode rightNode = identListNode != null ? identListNode.RightNode : identifier;
+
+            var intermediateNodes = new List<AssociativeNode>();
+            while (leftNode is IdentifierListNode)
+            {
+                intermediateNodes.Insert(0, ((IdentifierListNode)leftNode).RightNode);
+                leftNode = ((IdentifierListNode)leftNode).LeftNode;
+            }
+            intermediateNodes.Insert(0, newIdentList);
+
+            var lNode = CoreUtils.CreateNodeByCombiningIdentifiers(intermediateNodes);
+            Validity.Assert(lNode is IdentifierListNode);
 
             // The last ident list for the functioncall or identifier rhs
             var lastIdentList = new IdentifierListNode
             {
-                LeftNode = newIdentList,
+                LeftNode = lNode,
                 RightNode = rightNode,
                 Optr = Operator.dot
             };

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Linq;
 using ProtoCore.DSASM;
 using System.Collections.Generic;
 using ProtoCore.AST.AssociativeAST;
@@ -788,6 +789,38 @@ namespace ProtoCore.Utils
                 {
                     LeftNode = newIdentList,
                     RightNode = new IdentifierNode(strIdentList[n]),
+                    Optr = Operator.dot
+                };
+                newIdentList = subIdentList;
+            }
+
+            return newIdentList;
+        }
+
+        public static AssociativeNode CreateNodeByCombiningIdentifiers(IList<AssociativeNode> nodeList)
+        {
+            int count = nodeList.Count;
+            if(count == 0)
+                return null;
+
+            if (count == 1)
+            {
+                return nodeList[0];
+            }
+
+            var newIdentList = new IdentifierListNode
+            {
+                LeftNode = nodeList[0],
+                RightNode = nodeList[1],
+                Optr = Operator.dot
+            };
+
+            for (var n = 2; n < count; ++n)
+            {
+                var subIdentList = new IdentifierListNode
+                {
+                    LeftNode = newIdentList,
+                    RightNode = nodeList[n],
                     Optr = Operator.dot
                 };
                 newIdentList = subIdentList;

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -705,18 +705,19 @@ namespace ProtoCore.Utils
         }
 
         /// <summary>
-        /// Traverses the identifierlist argument until class name resolution succeeds or fails.
+        /// Inspects the input identifier list to match all class names with the class used in it
         /// </summary>
         /// <param name="classTable"></param>
-        /// <param name="identifier"></param>
-        /// <returns></returns>
-        public static string[] GetResolvedClassName(ClassTable classTable, AssociativeNode identifier)
+        /// <param name="identifierList">single identifier or identifier list</param>
+        /// <returns>list of fully resolved class names</returns>
+        public static string[] GetResolvedClassName(ClassTable classTable, AssociativeNode identifierList)
         {
-            var identList = identifier as IdentifierListNode;
-            var identifierNode = identifier as IdentifierNode;
-            Validity.Assert(identList != null || identifierNode != null);
+            var identListNode = identifierList as IdentifierListNode;
+            var identifierNode = identifierList as IdentifierNode;
+            Validity.Assert(identListNode != null || identifierNode != null);
 
-            string partialName = identList != null ? GetIdentifierStringUntilFirstParenthesis(identList) : identifier.Name;
+            string partialName = identListNode != null ? 
+                GetIdentifierStringUntilFirstParenthesis(identListNode) : identifierList.Name;
 
             string[] classNames = classTable.GetAllMatchingClasses(partialName);
 
@@ -725,11 +726,11 @@ namespace ProtoCore.Utils
             while (0 == classNames.Length)
             {
                 // Move to the left node
-                AssociativeNode leftNode = identList != null ? identList.LeftNode : identifierNode;
+                AssociativeNode leftNode = identListNode != null ? identListNode.LeftNode : identifierNode;
                 if (leftNode is IdentifierListNode)
                 {
-                    identList = leftNode as IdentifierListNode;
-                    classNames = classTable.GetAllMatchingClasses(GetIdentifierStringUntilFirstParenthesis(identList));
+                    identListNode = leftNode as IdentifierListNode;
+                    classNames = classTable.GetAllMatchingClasses(GetIdentifierStringUntilFirstParenthesis(identListNode));
                 }
                 if (leftNode is IdentifierNode)
                 {

--- a/test/Engine/FFITarget/ElementResolverTarget.cs
+++ b/test/Engine/FFITarget/ElementResolverTarget.cs
@@ -7,5 +7,29 @@ namespace FFITarget
 {
     public class ElementResolverTarget
     {
+        public static ElementResolverTarget Create()
+        {
+            return null;
+        }
+
+        public static ElementResolverTarget Create(ElementResolverTarget target)
+        {
+            return null;
+        }
+
+        public static ElementResolverTarget StaticProperty { get; set; }
+
+        public ElementResolverTarget Property { get; set; }
+
+        public ElementResolverTarget Method()
+        {
+            return null;
+        }
+
+        public ElementResolverTarget Method(ElementResolverTarget target)
+        {
+            return null;
+        }
     }
+
 }

--- a/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
+++ b/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
@@ -127,6 +127,30 @@ namespace ProtoTest.FFITests
         }
 
         [Test]
+        public void LookupResolvedName_ForTypedIdentifierFromCompiler_RewriteAst()
+        {
+
+            const string code = @"import (""FFITarget.dll"");";
+            var mirror = thisTest.RunScriptSource(code);
+
+            var testCore = thisTest.GetTestCore();
+            var astNodes = CoreUtils.BuildASTList(testCore, "d : ElementResolverTarget;");
+
+            var elementResolver = new ElementResolver();
+
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("d : FFITarget.ElementResolverTarget", newNodes.ElementAt(0).ToString());
+
+            // Add verification for contents of element resolver resolution map
+            var assembly = elementResolver.LookupAssemblyName("ElementResolverTarget");
+            var resolvedName = elementResolver.LookupResolvedName("ElementResolverTarget");
+
+            Assert.AreEqual("FFITarget.dll", assembly);
+            Assert.AreEqual("FFITarget.ElementResolverTarget", resolvedName);
+        }
+
+        [Test]
         public void LookupResolvedName_ForComplexExpression_RewriteAst()
         {
             var astNodes = CoreUtils.BuildASTList(core, "p = Point.ByCoordinates(x, y, z).X;");

--- a/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
+++ b/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
@@ -52,6 +52,36 @@ namespace ProtoTest.FFITests
             Assert.AreEqual("FFITarget.ElementResolverTarget", resolvedName);
         }
 
+        [Test]
+        public void LookupResolvedName_ForComplexExpression_RewriteAst()
+        {
+            var astNodes = CoreUtils.BuildASTList(core, "p = Point.ByCoordinates(x, y, z).X;");
+            var astNode = astNodes[0];
+
+            var elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            var elementRewriter = new ElementRewriter(core.ClassTable);
+            elementRewriter.LookupResolvedNameAndRewriteAst(elementResolver, ref astNode);
+
+            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", astNode.ToString());
+        }
+
+        [Test]
+        public void LookupResolvedName_ForTypedIdentifier_RewriteAst()
+        {
+            var astNodes = CoreUtils.BuildASTList(core, "p : Point;");
+            var astNode = astNodes[0];
+
+            var elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            var elementRewriter = new ElementRewriter(core.ClassTable);
+            elementRewriter.LookupResolvedNameAndRewriteAst(elementResolver, ref astNode);
+
+            Assert.AreEqual("p : Autodesk.DS.Geometry.Point", astNode.ToString());
+        }
+
         // Add tests for ElementRewriter.GetClassIdentifiers() api
         [Test]
         public void GetClassIdentifiers_FromAst()

--- a/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
+++ b/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
+using ProtoCore.AST;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.Namespace;
 using ProtoCore.Utils;
@@ -13,38 +15,110 @@ namespace ProtoTest.FFITests
         public void LookupResolvedName_FromElementResolver_RewriteAst()
         {
             var astNodes = CoreUtils.BuildASTList(core, "p = Point.ByCoordinates(0,0,0);");
-            var astNode = astNodes[0];
 
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var elementRewriter = new ElementRewriter(core.ClassTable);
-            elementRewriter.LookupResolvedNameAndRewriteAst(elementResolver, ref astNode);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
-            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(0, 0, 0);\n", astNode.ToString());
+            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(0, 0, 0);\n", newNodes.ElementAt(0).ToString());
         }
 
         [Test]
         public void LookupResolvedName_FromCompiler_RewriteAst()
         {
 
-            string code = @"import (""FFITarget.dll"");";
+            const string code = @"import (""FFITarget.dll"");";
             var mirror = thisTest.RunScriptSource(code);
 
             var testCore = thisTest.GetTestCore();
             var astNodes = CoreUtils.BuildASTList(testCore, "d = ElementResolverTarget.ElementResolverTarget();");
-            var astNode = astNodes[0];
 
             var elementResolver = new ElementResolver();
 
-            var elementRewriter = new ElementRewriter(testCore.ClassTable);
-            elementRewriter.LookupResolvedNameAndRewriteAst(elementResolver, ref astNode);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
 
-            Assert.AreEqual("d = FFITarget.ElementResolverTarget.ElementResolverTarget();\n", astNode.ToString());
+            Assert.AreEqual("d = FFITarget.ElementResolverTarget.ElementResolverTarget();\n", newNodes.ElementAt(0).ToString());
 
             // Add verification for contents of element resolver resolution map
             Assert.AreEqual(1, elementResolver.ResolutionMap.Count);
-            
+
+            var assembly = elementResolver.LookupAssemblyName("ElementResolverTarget");
+            var resolvedName = elementResolver.LookupResolvedName("ElementResolverTarget");
+
+            Assert.AreEqual("FFITarget.dll", assembly);
+            Assert.AreEqual("FFITarget.ElementResolverTarget", resolvedName);
+        }
+
+        [Test]
+        public void LookupResolvedName_ForComplexExpressionFromCompiler_RewriteAst()
+        {
+
+            const string code = @"import (""FFITarget.dll"");";
+            var mirror = thisTest.RunScriptSource(code);
+
+            var testCore = thisTest.GetTestCore();
+            var astNodes = CoreUtils.BuildASTList(testCore, "d = ElementResolverTarget.Create().Property.Method();");
+
+            var elementResolver = new ElementResolver();
+
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("d = FFITarget.ElementResolverTarget.Create().Property.Method();\n", newNodes.ElementAt(0).ToString());
+
+            // Add verification for contents of element resolver resolution map
+            Assert.AreEqual(1, elementResolver.ResolutionMap.Count);
+
+            var assembly = elementResolver.LookupAssemblyName("ElementResolverTarget");
+            var resolvedName = elementResolver.LookupResolvedName("ElementResolverTarget");
+
+            Assert.AreEqual("FFITarget.dll", assembly);
+            Assert.AreEqual("FFITarget.ElementResolverTarget", resolvedName);
+        }
+
+        [Test]
+        public void LookupResolvedName_ForNestedExpressionFromCompiler_RewriteAst()
+        {
+
+            const string code = @"import (""FFITarget.dll"");";
+            var mirror = thisTest.RunScriptSource(code);
+
+            var testCore = thisTest.GetTestCore();
+            var astNodes = CoreUtils.BuildASTList(testCore, "d = ElementResolverTarget.Create().Property.Method(ElementResolverTarget.Create().Property);");
+
+            var elementResolver = new ElementResolver();
+
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("d = FFITarget.ElementResolverTarget.Create().Property.Method(FFITarget.ElementResolverTarget.Create().Property);\n", newNodes.ElementAt(0).ToString());
+
+            // Add verification for contents of element resolver resolution map
+            Assert.AreEqual(1, elementResolver.ResolutionMap.Count);
+
+            var assembly = elementResolver.LookupAssemblyName("ElementResolverTarget");
+            var resolvedName = elementResolver.LookupResolvedName("ElementResolverTarget");
+
+            Assert.AreEqual("FFITarget.dll", assembly);
+            Assert.AreEqual("FFITarget.ElementResolverTarget", resolvedName);
+        }
+
+        [Test]
+        public void LookupResolvedName_ForNestedExpressionFromCompiler_RewriteAst2()
+        {
+
+            const string code = @"import (""FFITarget.dll"");";
+            var mirror = thisTest.RunScriptSource(code);
+
+            var testCore = thisTest.GetTestCore();
+            var astNodes = CoreUtils.BuildASTList(testCore, "d = ElementResolverTarget.StaticProperty.Method(ElementResolverTarget.Create().Property.Method(ElementResolverTarget.Create().Property));");
+
+            var elementResolver = new ElementResolver();
+
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("d = FFITarget.ElementResolverTarget.StaticProperty.Method(FFITarget.ElementResolverTarget.Create().Property.Method(FFITarget.ElementResolverTarget.Create().Property));\n", newNodes.ElementAt(0).ToString());
+
+            // Add verification for contents of element resolver resolution map
             var assembly = elementResolver.LookupAssemblyName("ElementResolverTarget");
             var resolvedName = elementResolver.LookupResolvedName("ElementResolverTarget");
 
@@ -56,60 +130,149 @@ namespace ProtoTest.FFITests
         public void LookupResolvedName_ForComplexExpression_RewriteAst()
         {
             var astNodes = CoreUtils.BuildASTList(core, "p = Point.ByCoordinates(x, y, z).X;");
-            var astNode = astNodes[0];
 
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var elementRewriter = new ElementRewriter(core.ClassTable);
-            elementRewriter.LookupResolvedNameAndRewriteAst(elementResolver, ref astNode);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
-            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", astNode.ToString());
+            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
+        }
+
+        [Test]
+        public void LookupResolvedName_ForPartialComplexExpression_RewriteAst()
+        {
+            var astNodes = CoreUtils.BuildASTList(core, "p = Autodesk.Point.ByCoordinates(x, y, z).X;");
+
+            var elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
+
+            /////////////////////////////
+            astNodes = CoreUtils.BuildASTList(core, "p = Autodesk.DS.Point.ByCoordinates(x, y, z).X;");
+
+            elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Autodesk.DS.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
+
+            /////////////////////////////
+            astNodes = CoreUtils.BuildASTList(core, "p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;");
+
+            elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Autodesk.DS.Geometry.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
         }
 
         [Test]
         public void LookupResolvedName_ForNestedExpression_RewriteAst()
         {
             var astNodes = CoreUtils.BuildASTList(core, "p = Point.ByCoordinates(Point.ByCoordinates(x, y, z).X, y, z).X;");
-            var astNode = astNodes[0];
 
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var elementRewriter = new ElementRewriter(core.ClassTable);
-            elementRewriter.LookupResolvedNameAndRewriteAst(elementResolver, ref astNode);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
-            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", astNode.ToString());
+            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
+        }
+
+        [Test]
+        public void LookupResolvedName_ForPartialNestedExpression_RewriteAst()
+        {
+            var astNodes = CoreUtils.BuildASTList(core, "p = Autodesk.Point.ByCoordinates(Autodesk.Point.ByCoordinates(x, y, z).X, y, z).X;");
+
+            var elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
+
+            /////////////////////////////////////
+            astNodes = CoreUtils.BuildASTList(core, "p = Autodesk.DS.Point.ByCoordinates(Autodesk.Point.ByCoordinates(x, y, z).X, y, z).X;");
+
+            elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+            elementResolver.AddToResolutionMap("Autodesk.DS.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
+
+            //////////////////////////////////////
+            astNodes = CoreUtils.BuildASTList(core, "p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.Point.ByCoordinates(x, y, z).X, y, z).X;");
+
+            elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+            elementResolver.AddToResolutionMap("Autodesk.DS.Geometry.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
         }
 
         [Test]
         public void LookupResolvedName_ForTypedIdentifier_RewriteAst()
         {
-            var astNodes = CoreUtils.BuildASTList(core, "p : Point;");
-            var astNode = astNodes[0];
+            IEnumerable<Node> astNodes = CoreUtils.BuildASTList(core, "p : Point;");
 
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var elementRewriter = new ElementRewriter(core.ClassTable);
-            elementRewriter.LookupResolvedNameAndRewriteAst(elementResolver, ref astNode);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
-            Assert.AreEqual("p : Autodesk.DS.Geometry.Point", astNode.ToString());
+            Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
         }
 
-        // Add tests for ElementRewriter.GetClassIdentifiers() api
         [Test]
-        public void GetClassIdentifiers_FromAst()
+        public void LookupResolvedName_ForPartialTypedIdentifier_RewriteAst()
         {
-            var astNodes = CoreUtils.BuildASTList(core, "d = Point.ByCoordinates(0, 0, pt.X + 5);");
-            var astNode = astNodes[0];
+            var astNodes = CoreUtils.BuildASTList(core, "p : Autodesk.Point;");
 
-            var elementRewriter = new ElementRewriter(null);
-            var identifiers = elementRewriter.GetClassIdentifiers(astNode);
-            var identifierListNodes = identifiers as IdentifierListNode[] ?? identifiers.ToArray();
-            Assert.AreEqual(2, identifierListNodes.Count());
-            Assert.AreEqual("pt.X", identifierListNodes.ElementAt(0).ToString());
-            Assert.AreEqual("Point.ByCoordinates(0, 0, (pt.X) + 5)", identifierListNodes.ElementAt(1).ToString());
+            var elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
+
+            astNodes = CoreUtils.BuildASTList(core, "p : Autodesk.DS.Point;");
+
+            elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Autodesk.DS.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
+
+            astNodes = CoreUtils.BuildASTList(core, "p : Autodesk.DS.Geometry.Point;");
+
+            elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Autodesk.DS.Geometry.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+
+            Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
         }
+
+        [Test]
+        public void SkipResolvingName_ForPrimitiveTypedIdentifier_RetainAst()
+        {
+            var astNodes = CoreUtils.BuildASTList(core, "p : int;");
+
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, new ElementResolver(), astNodes);
+
+            Assert.AreEqual("p : int", newNodes.ElementAt(0).ToString());
+        }
+
     }
 }

--- a/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
+++ b/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
@@ -68,6 +68,21 @@ namespace ProtoTest.FFITests
         }
 
         [Test]
+        public void LookupResolvedName_ForNestedExpression_RewriteAst()
+        {
+            var astNodes = CoreUtils.BuildASTList(core, "p = Point.ByCoordinates(Point.ByCoordinates(x, y, z).X, y, z).X;");
+            var astNode = astNodes[0];
+
+            var elementResolver = new ElementResolver();
+            elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
+
+            var elementRewriter = new ElementRewriter(core.ClassTable);
+            elementRewriter.LookupResolvedNameAndRewriteAst(elementResolver, ref astNode);
+
+            Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", astNode.ToString());
+        }
+
+        [Test]
         public void LookupResolvedName_ForTypedIdentifier_RewriteAst()
         {
             var astNodes = CoreUtils.BuildASTList(core, "p : Point;");


### PR DESCRIPTION
### Purpose

This PR fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6896 - issue with input ports not appearing for variables in chained CBN expressions.

![image](https://cloud.githubusercontent.com/assets/5710686/7604599/846cf95e-f977-11e4-8a8d-9e37c6b373c1.png)

### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@junmendoza Reviewer 1  
The reason for this is that the AST for the expression typed in the CBN was getting corrupt in the `ElementRewriter`. This has now been taken care of.

### FYIs

@monikaprabhu 
