### PR TITLE
Fixed failure in "TestTaskQueuePreProcessing00"

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -25,7 +25,7 @@ namespace Dynamo.Core.Threading
             get { return TaskPriority.AboveNormal; }
         }
 
-        internal IEnumerable<NodeModel> ModifiedNodes { get; private set; }
+        public IEnumerable<NodeModel> ModifiedNodes { get; protected set; }
 
         #endregion
 
@@ -109,9 +109,8 @@ namespace Dynamo.Core.Threading
             if (theOtherTask == null)
                 return base.CanMergeWithCore(otherTask);
 
-
-            // Comparing to another UpdateGraphAsyncTask, verify that they are updating
-            // a similar set of nodes
+            // Comparing to another UpdateGraphAsyncTask, verify 
+            // that they are updating a similar set of nodes.
 
             // Other node is either equal or a superset of this task
             if (ModifiedNodes.All(x => theOtherTask.ModifiedNodes.Contains(x)))

--- a/test/DynamoCoreTests/SchedulerTests.cs
+++ b/test/DynamoCoreTests/SchedulerTests.cs
@@ -1315,7 +1315,7 @@ namespace Dynamo.Tests
         private AsyncTask MakeUpdateGraphAsyncTask()
         {
             var t = new FakeUpdateGraphAsyncTask(MakeAsyncTaskData());
-            t.InitializeTestData();
+            t.InitializeTestData(); // Just to initialize ModifiedNodes
             return t;
         }
 

--- a/test/DynamoCoreTests/SchedulerTests.cs
+++ b/test/DynamoCoreTests/SchedulerTests.cs
@@ -406,6 +406,12 @@ namespace Dynamo.Tests
             this.data = data;
         }
 
+        internal void InitializeTestData()
+        {
+            if (ModifiedNodes == null)
+                ModifiedNodes = new List<NodeModel>();
+        }
+
         protected override void HandleTaskExecutionCore()
         {
             data.WriteExecutionLog(this);
@@ -1016,6 +1022,12 @@ namespace Dynamo.Tests
                 MakeAggregateRenderPackageAsyncTask(Guid.Empty),
             };
 
+            // Due to defaulting to auto-run mode, multiple UpdateGraphAsyncTask
+            // may have been scheduled prior to this. Clear those tasks before test 
+            // starts in a predictable state.
+            // 
+            schedulerThread.GetSchedulerToProcessTasks();
+
             var scheduler = dynamoModel.Scheduler;
             foreach (var stubAsyncTask in tasksToSchedule)
             {
@@ -1026,7 +1038,6 @@ namespace Dynamo.Tests
 
             var expected = new List<string>
             {
-                "FakeUpdateGraphAsyncTask: 6",
                 "FakeUpdateGraphAsyncTask: 10",
                 "FakeQueryMirrorDataAsyncTask: 0",
                 "FakeUpdateRenderPackageAsyncTask: 1",
@@ -1303,7 +1314,9 @@ namespace Dynamo.Tests
 
         private AsyncTask MakeUpdateGraphAsyncTask()
         {
-            return new FakeUpdateGraphAsyncTask(MakeAsyncTaskData());
+            var t = new FakeUpdateGraphAsyncTask(MakeAsyncTaskData());
+            t.InitializeTestData();
+            return t;
         }
 
         private AsyncTask MakeUpdateRenderPackageAsyncTask(Guid nodeGuid)


### PR DESCRIPTION
### Purpose

This pull request is meant to fix the following test case:

    SchedulerIntegrationTests.TestTaskQueuePreProcessing00

The failure was introduced due to a number of different behaviors in both the system and tests:

1. [Add task merging for graph updates](https://github.com/DynamoDS/Dynamo/pull/4276)
2. [Run all recorded test case in auto mode](https://github.com/DynamoDS/Dynamo/pull/4448)

### Declarations

Check these iff you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

Hi @aparajit-pratap, this is related to the failing test case that you were debugging this morning. Please have a look, thanks!

### FYIs

Hi @lukechurch and @ke-yu, just FYI. The new `UpdateGraphAsyncTask` merging behavior definitely has changed the expected behavior of this test (and one of the two tasks was dropped as expected).