### PR TITLE
MAGN-7002 Testing of Grouping/Clipboard/Undo sequence gives crash with stack trace

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1612,7 +1612,7 @@ namespace Dynamo.Models
                     Background = annotation.Background,
                     FontSize = annotation.FontSize
                 };
-                annotationModel.ModelBaseRequested += CurrentWorkspace.annotationModel_GetModelBase;
+              
                 newAnnotations.Add(annotationModel);
             }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1612,6 +1612,7 @@ namespace Dynamo.Models
                     Background = annotation.Background,
                     FontSize = annotation.FontSize
                 };
+                annotationModel.ModelBaseRequested += CurrentWorkspace.annotationModel_GetModelBase;
                 newAnnotations.Add(annotationModel);
             }
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -663,6 +663,8 @@ namespace Dynamo.Models
 
         public void AddAnnotation(AnnotationModel annotationModel)
         {
+            annotationModel.ModelBaseRequested += annotationModel_GetModelBase;
+            annotationModel.Disposed += (_) => annotationModel.ModelBaseRequested -= annotationModel_GetModelBase;
             Annotations.Add(annotationModel);
         }
 
@@ -709,7 +711,7 @@ namespace Dynamo.Models
         /// </summary>
         /// <param name="modelGuid">The model unique identifier.</param>
         /// <returns></returns>
-        public ModelBase annotationModel_GetModelBase(Guid modelGuid)
+        private ModelBase annotationModel_GetModelBase(Guid modelGuid)
         {
             ModelBase model = null;
             model = this.Nodes.FirstOrDefault(x => x.GUID == modelGuid);

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -709,7 +709,7 @@ namespace Dynamo.Models
         /// </summary>
         /// <param name="modelGuid">The model unique identifier.</param>
         /// <returns></returns>
-        private ModelBase annotationModel_GetModelBase(Guid modelGuid)
+        public ModelBase annotationModel_GetModelBase(Guid modelGuid)
         {
             ModelBase model = null;
             model = this.Nodes.FirstOrDefault(x => x.GUID == modelGuid);
@@ -1363,19 +1363,32 @@ namespace Dynamo.Models
 
         public void DeleteModel(XmlElement modelData)
         {
+            //When there is a Redo operation, model is removed from 
+            //the workspace but the model is "not disposed" from memory.
+            //Identified this when redo operation is performed on groups
             ModelBase model = GetModelForElement(modelData);
 
             if (model is NoteModel)
-                Notes.Remove(model as NoteModel);
+            {
+                var note = model as NoteModel;
+                Notes.Remove(note);                
+                note.Dispose();
+            }
             else if (model is AnnotationModel)
-                Annotations.Remove(model as AnnotationModel);
+            {
+                var annotation = model as AnnotationModel;
+                Annotations.Remove(annotation);
+                annotation.Dispose();
+            }
             else if (model is ConnectorModel)
             {
                 var connector = model as ConnectorModel;
                 connector.Delete();
             }
             else if (model is NodeModel)
-                Nodes.Remove(model as NodeModel);
+            {
+                RemoveNode(model as NodeModel);
+            }
             else
             {
                 // If it gets here we obviously need to handle it.

--- a/test/DynamoCoreTests/AnnotationModelTest.cs
+++ b/test/DynamoCoreTests/AnnotationModelTest.cs
@@ -507,5 +507,217 @@ namespace Dynamo.Tests
             annotation.FontSize = 30;
             Assert.AreEqual(annotation.FontSize, 30.0);
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void TestRedoForGroups()
+        {
+            //Add a Node
+            var model = CurrentDynamoModel;
+            var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
+            model.CurrentWorkspace.AddNode(addNode, false);
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count, 1);
+
+            //Add a Note 
+            Guid id = Guid.NewGuid();
+            var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+
+            //Select the node and notes
+            DynamoSelection.Instance.Selection.Add(addNode);
+            DynamoSelection.Instance.Selection.Add(addNote);
+
+            //create the group around selected nodes and notes
+            Guid groupid = Guid.NewGuid();
+            var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreNotEqual(0, annotation.Width);
+
+            var modelToDelete = new List<ModelBase> { addNode };
+
+            //Delete the model
+            model.DeleteModelInternal(modelToDelete);
+
+            //Check for the model count now
+            Assert.AreEqual(1, annotation.SelectedModels.Count());
+
+            //Undo the operation
+            model.CurrentWorkspace.Undo();
+
+            //Check for the model count now
+            Assert.AreEqual(2, annotation.SelectedModels.Count());
+
+            //Redo the operation
+            model.CurrentWorkspace.Redo();
+            
+            //Check for the model count now
+            Assert.AreEqual(1, annotation.SelectedModels.Count());
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void TestCopyPasteGroups()
+        {
+            //Add a Node
+            var model = CurrentDynamoModel;
+            var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
+            model.CurrentWorkspace.AddNode(addNode, false);
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count, 1);
+
+            //Add a Note 
+            Guid id = Guid.NewGuid();
+            var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+
+            //Select the node and notes
+            DynamoSelection.Instance.Selection.Add(addNode);
+            DynamoSelection.Instance.Selection.Add(addNote);
+
+            //create the group around selected nodes and notes
+            Guid groupid = Guid.NewGuid();
+            var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreNotEqual(0, annotation.Width);
+
+            //Add the group  selection
+            DynamoSelection.Instance.Selection.Add(annotation);
+
+            //Copy the group
+            model.Copy();
+
+            //paste the group
+            model.Paste();
+
+            //there should be 2 groups in the workspace
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 2);         
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void UndoRedoCopyPasteGroups()
+        {
+            //Add a Node
+            var model = CurrentDynamoModel;
+            var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
+            model.CurrentWorkspace.AddNode(addNode, false);
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count, 1);
+
+            //Add a Note 
+            Guid id = Guid.NewGuid();
+            var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+
+            //Select the node and notes
+            DynamoSelection.Instance.Selection.Add(addNode);
+            DynamoSelection.Instance.Selection.Add(addNote);
+
+            //create the group around selected nodes and notes
+            Guid groupid = Guid.NewGuid();
+            var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreNotEqual(0, annotation.Width);
+
+            //Add the group  selection
+            DynamoSelection.Instance.Selection.Add(annotation);
+
+            //Copy the group
+            model.Copy();
+
+            //paste the group
+            model.Paste();
+
+            //there should be 2 groups in the workspace
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 2);
+
+            //Undo the paste
+            model.CurrentWorkspace.Undo();
+
+            //there should be 1 groups in the workspace
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+
+            //Redo the Undo
+            model.CurrentWorkspace.Redo();
+
+            //there should be 2 groups in the workspace
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 2);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void RedoAddModelToAGroup()
+        {
+            //Add a Node
+            var model = CurrentDynamoModel;
+            var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
+            model.CurrentWorkspace.AddNode(addNode, false);
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count, 1);
+
+            //Add a Note 
+            Guid id = Guid.NewGuid();
+            var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+
+            //Select the node and notes
+            DynamoSelection.Instance.Selection.Add(addNode);
+            DynamoSelection.Instance.Selection.Add(addNote);
+
+            //create the group around selected nodes and notes
+            Guid groupid = Guid.NewGuid();
+            var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreNotEqual(0, annotation.Width);
+
+            //Create Another node
+            //Add a Node            
+            var secondNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
+            model.CurrentWorkspace.AddNode(secondNode, false);
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count, 2);
+
+            DynamoSelection.Instance.ClearSelection();
+
+            //Select the group and newly created node
+            DynamoSelection.Instance.Selection.Add(annotation);
+            DynamoSelection.Instance.Selection.Add(secondNode);
+
+            var modelsToAdd = new List<ModelBase>();
+            modelsToAdd.Add(secondNode);
+
+            //Add the model to group
+            model.AddToGroup(modelsToAdd);
+
+            //Group should have the new node added 
+            Assert.AreEqual(3, annotation.SelectedModels.Count());
+
+            DynamoSelection.Instance.ClearSelection();
+
+            //Add a new note
+            id = Guid.NewGuid();
+            var secondNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 2);
+
+            //Select the group and newly created note
+            DynamoSelection.Instance.Selection.Add(annotation);
+            DynamoSelection.Instance.Selection.Add(secondNote);
+
+            modelsToAdd.Clear();
+            modelsToAdd.Add(secondNote);
+
+            //Add the model to group
+            model.AddToGroup(modelsToAdd);
+
+            //Group should have the new note added 
+            Assert.AreEqual(4, annotation.SelectedModels.Count());
+
+            //Undo the operation
+            model.CurrentWorkspace.Undo();
+
+            //Notes should not be a part of the group
+            Assert.AreEqual(3, annotation.SelectedModels.Count());
+
+            //Redo the operation - notes should be within that group
+            model.CurrentWorkspace.Redo();
+            Assert.AreEqual(4, annotation.SelectedModels.Count());
+   
+        }
     }
 }


### PR DESCRIPTION
### Purpose
 This PR fixes the crash around Redo operation on Groups

### Declarations
- [x] The code base is in a better state after this PR.
                ModelBaseRequested event was missing when a group is copied and pasted in the workspace. Added that event to the group. This handles the exception when that group is Undo'ed.
                Identified that on every redo operation models are only removed from workspace and not disposed. Added that functionality.

- [x] The level of testing this PR includes is appropriate
                  Added tests related to Redo operations.

### Reviewers
- [ ] @pboyer 