### PR TITLE
MAGN-6391 Groups should have equal margins all the way around

### DIFF
--- a/src/DynamoCore/Models/AnnotationModel.cs
+++ b/src/DynamoCore/Models/AnnotationModel.cs
@@ -246,7 +246,7 @@ namespace Dynamo.Models
                         {
                             if (overlap.Rect.Bottom - region.Bottom > 0)
                             {
-                                this.Height += overlap.Rect.Bottom - region.Bottom + ExtendSize;
+                                this.Height += overlap.Rect.Bottom - region.Bottom + ExtendSize + ExtendYHeight;
                             }
                             region.Height = this.Height;
                         }


### PR DESCRIPTION
### Purpose
 During overlap in height, the height should be extended such that the margin in equal.

### Declarations
- [x] The code base is in a better state after this PR.
                 Updated the height in overlap.
- [ ] The level of testing this PR includes is appropriate
                   

### Reviewers
- [ ] @pboyer 