### PR TITLE
Fix: ColorRange incompatible type cast

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
@@ -55,7 +55,7 @@ namespace Dynamo.Wpf.Nodes
                         var data = colorsMirror.GetData();
                         if (data.IsCollection)
                         {
-                            colors.AddRange(data.GetElements().Select(e => e.Data).Cast<Color>());
+                            colors.AddRange(data.GetElements().Select(e => e.Data).OfType<Color>());
                         }
                         else
                         {

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -321,5 +321,19 @@ namespace DynamoCoreWpfTests
             inPortGrid = nodeView.inPortGrid;
             Assert.AreEqual(2, inPortGrid.ChildrenOfType<TextBlock>().Count());
         }
+
+        [Test]
+        public void InvalidInputShouldNotCrashColorRangeNode()
+        {
+            Open(@"UI\ColorRangeInvalidInputCrash.dyn");
+
+            // Update the code block node from "Color.FromRGBA" to "5.6", making 
+            // it a double value type. After the fix this should not have caused 
+            // any crash in ColorRange node.
+            //
+            var guid = System.Guid.Parse("c1d3a92a-e4d4-47a8-8533-bf19e63e0bf9");
+            Model.ExecuteCommand(new DynamoModel.UpdateModelValueCommand(
+                Model.CurrentWorkspace.Guid, guid, "Code", "5.6"));
+        }
     }
 }

--- a/test/UI/ColorRangeInvalidInputCrash.dyn
+++ b/test/UI/ColorRangeInvalidInputCrash.dyn
@@ -1,0 +1,27 @@
+<Workspace Version="0.8.1.1314" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Color" resolvedName="DSCore.Color" assemblyName="DSCoreNodes.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="36ddb91d-d2ba-4613-a3c9-df6c5b5b4cfe" type="Dynamo.Nodes.DSFunction" nickname="Color.ByARGB" x="485.333333333333" y="401.333333333334" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.Color.ByARGB@int,int,int,int">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+      <PortInfo index="3" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="9537b551-ac1f-4599-9a68-ac3a8c2e3a80" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="249.333333333333" y="530.666666666667" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="255;&#xA;&#xA;indices = 0.5;&#xA;value = 0.5;" ShouldFocus="false" />
+    <DSCoreNodesUI.ColorRange guid="fb0cfaae-cd3f-481e-b796-81eaadf6d3bf" type="DSCoreNodesUI.ColorRange" nickname="Color Range" x="976" y="432" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="c1d3a92a-e4d4-47a8-8533-bf19e63e0bf9" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Change This To Number" x="255" y="301.666666666667" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="green = Color.ByARGB(255, 0, 255, 0);" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="d21b2895-9fa3-4cc1-8ec6-cfad5143a5ba" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="671.333333333333" y="333.666666666667" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{ color1, color2 };" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="36ddb91d-d2ba-4613-a3c9-df6c5b5b4cfe" start_index="0" end="d21b2895-9fa3-4cc1-8ec6-cfad5143a5ba" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="9537b551-ac1f-4599-9a68-ac3a8c2e3a80" start_index="0" end="36ddb91d-d2ba-4613-a3c9-df6c5b5b4cfe" end_index="3" portType="0" />
+    <Dynamo.Models.ConnectorModel start="9537b551-ac1f-4599-9a68-ac3a8c2e3a80" start_index="1" end="fb0cfaae-cd3f-481e-b796-81eaadf6d3bf" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="9537b551-ac1f-4599-9a68-ac3a8c2e3a80" start_index="2" end="fb0cfaae-cd3f-481e-b796-81eaadf6d3bf" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="c1d3a92a-e4d4-47a8-8533-bf19e63e0bf9" start_index="0" end="d21b2895-9fa3-4cc1-8ec6-cfad5143a5ba" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d21b2895-9fa3-4cc1-8ec6-cfad5143a5ba" start_index="0" end="fb0cfaae-cd3f-481e-b796-81eaadf6d3bf" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
### Purpose

This pull request is meant to fix a crash in `ColorRange` node when it receives invalid input of type other than `DSCore.Color`. The defect is being tracked internally as:

- [MAGN-7319](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7319) Color Range node crashes Dynamo when there is type mismatch in arguments

The following code assume every element in the collection is of type `DSCore.Color`:

```csharp
colors.AddRange(data.GetElements().Select(e => e.Data).Cast<Color>());
```

It should instead be done this way to handle possibly unknown object types:

```csharp
colors.AddRange(data.GetElements().Select(e => e.Data).OfType<Color>());
```

A new test case `InvalidInputShouldNotCrashColorRangeNode` is added to verify this fix (the test fails before the fix and pass after it).

### Declarations

Check these iff you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

Hi @junmendoza, as discussed, please take a look, thanks!
