### PR TITLE
Add warning to Excel write node when passed function object

### DIFF
--- a/src/Libraries/DSOffice/DSOffice.csproj
+++ b/src/Libraries/DSOffice/DSOffice.csproj
@@ -84,26 +84,26 @@
       <Project>{7a9e0314-966f-4584-baa3-7339cbb849d1}</Project>
       <Name>ProtoCore</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\NodeServices\DynamoServices.csproj">
+      <Project>{ef879a10-041d-4c68-83e7-3192685f1bae}</Project>
+      <Name>DynamoServices</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>copy /Y "$(ProjectDir)*_DynamoCustomization.xml" "$(OutputPath)"</PreBuildEvent>
   </PropertyGroup>
   <Target Name="AfterBuild" Condition=" '$(OS)' != 'Unix' ">
-
-	<!-- Get System.Drawing.dll -->
-	<GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v2.0">
-      		<Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
-    	</GetReferenceAssemblyPaths>
-	
-	<!-- Get assembly -->
-	<GetAssemblyIdentity AssemblyFiles="$(OutDir)$(TargetName).dll">
-		<Output TaskParameter="Assemblies" ItemName="AssemblyInfo"/>
-	</GetAssemblyIdentity>
-	
-	<!-- Generate customization dll -->
-    	<GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DSOfficeImages.resx" OutputResources="$(ProjectDir)DSOfficeImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    	<AL TargetType="library" EmbedResources="$(ProjectDir)DSOfficeImages.resources" OutputAssembly="$(OutDir)DSOffice.customization.dll" Version="%(AssemblyInfo.Version)" />
-
+    <!-- Get System.Drawing.dll -->
+    <GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v2.0">
+      <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
+    </GetReferenceAssemblyPaths>
+    <!-- Get assembly -->
+    <GetAssemblyIdentity AssemblyFiles="$(OutDir)$(TargetName).dll">
+      <Output TaskParameter="Assemblies" ItemName="AssemblyInfo" />
+    </GetAssemblyIdentity>
+    <!-- Generate customization dll -->
+    <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DSOfficeImages.resx" OutputResources="$(ProjectDir)DSOfficeImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DSOfficeImages.resources" OutputAssembly="$(OutDir)DSOffice.customization.dll" Version="%(AssemblyInfo.Version)" />
   </Target>
 </Project>

--- a/src/Libraries/DSOffice/Excel.cs
+++ b/src/Libraries/DSOffice/Excel.cs
@@ -6,9 +6,10 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Office.Interop.Excel;
-
+using DynamoServices;
 using Autodesk.DesignScript.Runtime;
 using ProtoCore.DSASM;
+using ProtoCore.Properties;
 
 namespace DSOffice
 {
@@ -378,8 +379,13 @@ namespace DSOffice
                         }
                         else if (item is StackValue)
                         {
-                            if(((StackValue)item).IsPointer)
+                            if (((StackValue) item).IsPointer)
+                            {
+                                string message = string.Format(Resources.kMethodResolutionFailureWithTypes, 
+                                    "Excel.WriteToFile", "_SingleFunctionObject");
+                                LogWarningMessageEvents.OnLogWarningMessage(message);
                                 return null;
+                            }
 
                             output[i, j] = item.ToString();
                         }

--- a/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
+++ b/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
@@ -81,7 +81,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(5, ViewModel.CurrentSpace.Nodes.Count);
 
             var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
-                        
+
             // remap the filename as Excel requires an absolute path
             filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
 
@@ -222,7 +222,7 @@ namespace Dynamo.Tests
 
                 for (var j = 0; j < 3; j++)
                 {
-                    Assert.AreEqual((i+1)+j, rowList[j].Data);
+                    Assert.AreEqual((i + 1) + j, rowList[j].Data);
                 }
             }
         }
@@ -638,7 +638,7 @@ namespace Dynamo.Tests
             rowList = list[2].GetElements();
             Assert.AreEqual(1, rowList.Count());
             Assert.AreEqual(3, rowList[0].Data);
-            
+
         }
 
         [Test]
@@ -716,6 +716,12 @@ namespace Dynamo.Tests
 
             ViewModel.HomeSpace.Run();
 
+            ProtoCore.RuntimeCore runtimeCore = ViewModel.Model.EngineController.LiveRunnerRuntimeCore;
+            Assert.AreEqual(1, runtimeCore.RuntimeStatus.WarningCount);
+
+            ProtoCore.Runtime.WarningEntry warningEntry = runtimeCore.RuntimeStatus.Warnings.ElementAt(0);
+            Assert.AreEqual(ProtoCore.Runtime.WarningID.kDefault, warningEntry.ID);
+
             Assert.IsTrue(File.Exists(filePath));
 
             Assert.IsTrue(writeNode.CachedValue.IsCollection);
@@ -745,7 +751,7 @@ namespace Dynamo.Tests
             Assert.IsTrue(File.Exists(filePath));
         }
 
-       
+
         #endregion
 
         #region Defects


### PR DESCRIPTION
### Purpose

This is an enhancement for the [fix] (https://github.com/DynamoDS/Dynamo/pull/4445) for: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7336

If the `Excel.WriteToFile` node is run with a function object as input, while it does not have any effect on the excel file being written, it should also show a warning to the user that the function object input is invalid for this node.

![image](https://cloud.githubusercontent.com/assets/5710686/7626765/ce94042c-fa40-11e4-89f5-0e0e66f920b8.png)


### Declarations

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@junmendoza  Reviewer 1  


### FYIs

@monikaprabhu @mccrone 
