### PR TITLE
Fixed issue with copying "LibG_Locale" folders

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -342,7 +342,7 @@ limitations under the License.
       <ExternProtoGeometry Include="$(SolutionDir)..\extern\ProtoGeometry\*" />
       <ExternProtoGeometryXml Include="$(SolutionDir)..\extern\ProtoGeometry\ProtoGeometry.XML" />
       <ExternProtoGeometryUICulture Include="$(SolutionDir)..\extern\ProtoGeometry\$(UICulture)\*" />
-      <ExternProtoGeometryLibGLocale Include="$(SolutionDir)..\extern\ProtoGeometry\libg_locale\*" />
+      <ExternProtoGeometryLibGLocale Include="$(SolutionDir)..\extern\ProtoGeometry\libg_locale\**\*.*" />
       <ExternLibG219 Include="$(SolutionDir)..\extern\LibG_219\*" />
       <ExternLibG220 Include="$(SolutionDir)..\extern\LibG_220\*" />
       <ExternLibG221 Include="$(SolutionDir)..\extern\LibG_221\*" />
@@ -358,7 +358,7 @@ limitations under the License.
     <Copy SourceFiles="@(ExternProtoGeometry)" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="@(ExternProtoGeometryXml)" DestinationFolder="$(OutputPath)\$(UICulture)" />
     <Copy SourceFiles="@(ExternProtoGeometryUICulture)" DestinationFolder="$(OutputPath)\$(UICulture)" />
-    <Copy SourceFiles="@(ExternProtoGeometryLibGLocale)" DestinationFolder="$(OutputPath)\libg_locale\" />
+    <Copy SourceFiles="@(ExternProtoGeometryLibGLocale)" DestinationFolder="$(OutputPath)\libg_locale\%(RecursiveDir)" />
     <Copy SourceFiles="@(ExternLibG219)" DestinationFolder="$(OutputPath)libg_219\" />
     <Copy SourceFiles="@(ExternLibG220)" DestinationFolder="$(OutputPath)libg_220\" />
     <Copy SourceFiles="@(ExternLibG221)" DestinationFolder="$(OutputPath)libg_221\" />


### PR DESCRIPTION
### Purpose

This pull request fixes an issue where `extern\ProtoGeometry\libg_locale` is no longer copied recursively to the destination folder `$(OutputDir)\libg_locale`.

### Declarations

Check these iff you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

Hi @nguyen-binh-minh, please take a look, thanks!

I have tried wiping out my `%bin%` folder and verified that the `libg_locale` and its sub-folders are successfully copied over.

### FYIs

Hi @pboyer, this is a slight correction of your original [cross-platform build pull request](https://github.com/DynamoDS/Dynamo/pull/4287).