### PR TITLE
MAGN-7390 Category list in Library is getting changed after placing Custom node from that category

### DIFF
--- a/src/DynamoCore/Search/SearchDictionary.cs
+++ b/src/DynamoCore/Search/SearchDictionary.cs
@@ -12,7 +12,7 @@ namespace Dynamo.Search
     /// </summary>
     public class SearchDictionary<V>
     {
-        private readonly Dictionary<V, Dictionary<string, double>> entryDictionary =
+        protected readonly Dictionary<V, Dictionary<string, double>> entryDictionary =
             new Dictionary<V, Dictionary<string, double>>();
 
         /// <summary>
@@ -52,6 +52,14 @@ namespace Dynamo.Search
         protected virtual void OnEntryRemoved(V entry)
         {
             var handler = EntryRemoved;
+            if (handler != null) handler(entry);
+        }
+
+        public event Action<V> EntryUpdated;
+
+        protected virtual void OnEntryUpdated(V entry)
+        {
+            var handler = EntryUpdated;
             if (handler != null) handler(entry);
         }
 

--- a/src/DynamoCore/Search/SearchLibrary.cs
+++ b/src/DynamoCore/Search/SearchLibrary.cs
@@ -32,7 +32,20 @@ namespace Dynamo.Search
         /// <param name="entry"></param>
         public void Update(TEntry entry)
         {
-            Remove(entry);
+            Dictionary<string, double> keys;
+            if (entryDictionary.TryGetValue(entry, out keys)) // Found the entry to update.
+            {
+                keys[entry.Name.ToLower()] = 1.0;
+                keys[entry.Description.ToLower()] = 0.1;
+
+                foreach (var tag in entry.SearchTags.Select(x => x.ToLower()))
+                    keys[tag] = 0.5;
+
+                OnEntryUpdated(entry);
+                return; // Entry updated.
+            }
+
+            // Entry could not be found, add it into the search collection.
             Add(entry);
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -540,17 +540,38 @@ namespace Dynamo.Wpf.ViewModels
             var nextLargerItemIndex = -1;
             foreach (var item in list)
             {
+                // Compare names. E.g. "B" > "A", "Point" > "Geometry"
                 if (string.Compare(item.Name, name, StringComparison.Ordinal) >= 0)
                 {
+                    // For the first time set index to the first found larger item.
                     if (nextLargerItemIndex < 0)
                     {
                         nextLargerItemIndex = list.ToList().IndexOf(item);
+                        // If larger item is node, then subtract the number of categories.
                         if(item is NodeSearchElementViewModel)
                             nextLargerItemIndex -= list.Count(cat => cat is NodeCategoryViewModel);
                     }
+                    // If item(for which we are looking index) is category, Then we are done here.
                     if (!IsEntry) break;
                 }
-                else if (item is NodeSearchElementViewModel && nextLargerItemIndex >= 0)
+                else 
+                    // If index was found among categories and 
+                    // if item(for which we are looking index) is node, 
+                    // we have to add +1.
+                    // E.g.
+                    //           Top
+                    //            |
+                    //     ┌──────┴─────┐
+                    // ZCategory     AMember
+                    //
+                    // We are trying to add BMember.
+                    //
+                    // ZCategory > BMember => nextLargerItemIndex = ZCategory.index (it is 0)
+                    // AMember < BMember => nextLargerItemIndex++ (it is 1 now)
+                    // After last iteration answer will be 1.
+                    // If we insert entry, we are adding number of categories (look in AddToItems).
+                    // Final index will be 2 (nextLargerItemIndex + Subcategories.Count).
+                    if (item is NodeSearchElementViewModel && nextLargerItemIndex >= 0)
                     nextLargerItemIndex++;
             }
             return nextLargerItemIndex;

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -477,7 +477,7 @@ namespace Dynamo.Wpf.ViewModels
                 }
 
                 var list = Items.Where(cat => !(cat is ClassesNodeCategoryViewModel));
-                var nextLargerItemIndex = FindInsertionPointByName(list, entry.Name);
+                var nextLargerItemIndex = FindInsertionPointByName(list, entry.Name, entry is NodeSearchElementViewModel);
 
                 // Nodecategories(i.e. namespaces) should be before members.
                 if (entry is NodeSearchElementViewModel)
@@ -522,7 +522,7 @@ namespace Dynamo.Wpf.ViewModels
         public void InsertSubCategory(NodeCategoryViewModel newSubCategory)
         {
             var list = SubCategories.Where(cat => !(cat is ClassesNodeCategoryViewModel));
-            var nextLargerItemIndex = FindInsertionPointByName(list, newSubCategory.Name);
+            var nextLargerItemIndex = FindInsertionPointByName(list, newSubCategory.Name, false);
 
             if (nextLargerItemIndex >= 0)
             {
@@ -534,16 +534,24 @@ namespace Dynamo.Wpf.ViewModels
                 SubCategories.Add(newSubCategory);
         }
 
-        internal static int FindInsertionPointByName(IEnumerable<ISearchEntryViewModel> list, string name)
+        internal static int FindInsertionPointByName(IEnumerable<ISearchEntryViewModel> list, string name,
+            bool IsEntry)
         {
-            var nextLargerItemIndex = -1; ;
+            var nextLargerItemIndex = -1;
             foreach (var item in list)
             {
                 if (string.Compare(item.Name, name, StringComparison.Ordinal) >= 0)
                 {
-                    nextLargerItemIndex = list.ToList().IndexOf(item);
-                    break;
+                    if (nextLargerItemIndex < 0)
+                    {
+                        nextLargerItemIndex = list.ToList().IndexOf(item);
+                        if(item is NodeSearchElementViewModel)
+                            nextLargerItemIndex -= list.Count(cat => cat is NodeCategoryViewModel);
+                    }
+                    if (!IsEntry) break;
                 }
+                else if (item is NodeSearchElementViewModel && nextLargerItemIndex >= 0)
+                    nextLargerItemIndex++;
             }
             return nextLargerItemIndex;
         }

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -477,7 +477,7 @@ namespace Dynamo.Wpf.ViewModels
                 }
 
                 var list = Items.Where(cat => !(cat is ClassesNodeCategoryViewModel));
-                var nextLargerItemIndex = FindInsertionPointByName(list, entry.Name, entry is NodeSearchElementViewModel);
+                var nextLargerItemIndex = FindInsertionPointByName(list, entry.Name);
 
                 // Nodecategories(i.e. namespaces) should be before members.
                 if (entry is NodeSearchElementViewModel)
@@ -522,7 +522,7 @@ namespace Dynamo.Wpf.ViewModels
         public void InsertSubCategory(NodeCategoryViewModel newSubCategory)
         {
             var list = SubCategories.Where(cat => !(cat is ClassesNodeCategoryViewModel));
-            var nextLargerItemIndex = FindInsertionPointByName(list, newSubCategory.Name, false);
+            var nextLargerItemIndex = FindInsertionPointByName(list, newSubCategory.Name);
 
             if (nextLargerItemIndex >= 0)
             {
@@ -534,45 +534,16 @@ namespace Dynamo.Wpf.ViewModels
                 SubCategories.Add(newSubCategory);
         }
 
-        internal static int FindInsertionPointByName(IEnumerable<ISearchEntryViewModel> list, string name,
-            bool IsEntry)
+        internal static int FindInsertionPointByName(IEnumerable<ISearchEntryViewModel> list, string name)
         {
             var nextLargerItemIndex = -1;
             foreach (var item in list)
             {
-                // Compare names. E.g. "B" > "A", "Point" > "Geometry"
                 if (string.Compare(item.Name, name, StringComparison.Ordinal) >= 0)
                 {
-                    // For the first time set index to the first found larger item.
-                    if (nextLargerItemIndex < 0)
-                    {
-                        nextLargerItemIndex = list.ToList().IndexOf(item);
-                        // If larger item is node, then subtract the number of categories.
-                        if(item is NodeSearchElementViewModel)
-                            nextLargerItemIndex -= list.Count(cat => cat is NodeCategoryViewModel);
-                    }
-                    // If item(for which we are looking index) is category, Then we are done here.
-                    if (!IsEntry) break;
+                    nextLargerItemIndex = list.ToList().IndexOf(item);
+                    break;
                 }
-                else 
-                    // If index was found among categories and 
-                    // if item(for which we are looking index) is node, 
-                    // we have to add +1.
-                    // E.g.
-                    //           Top
-                    //            |
-                    //     ┌──────┴─────┐
-                    // ZCategory     AMember
-                    //
-                    // We are trying to add BMember.
-                    //
-                    // ZCategory > BMember => nextLargerItemIndex = ZCategory.index (it is 0)
-                    // AMember < BMember => nextLargerItemIndex++ (it is 1 now)
-                    // After last iteration answer will be 1.
-                    // If we insert entry, we are adding number of categories (look in AddToItems).
-                    // Final index will be 2 (nextLargerItemIndex + Subcategories.Count).
-                    if (item is NodeSearchElementViewModel && nextLargerItemIndex >= 0)
-                    nextLargerItemIndex++;
             }
             return nextLargerItemIndex;
         }

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -374,6 +374,10 @@ namespace Dynamo.ViewModels
                 if (parent is ClassesNodeCategoryViewModel && parent.SubCategories.Contains(target))
                     return;
 
+                // Do not continue if parent is root library tree category (i.e. Top).
+                if (!treeStack.Any() && parent.Name == String.Empty && parent.Description == String.Empty)
+                    return;
+
                 // Do not continue as soon as our target is not class.
                 if (target.SubCategories.Any())
                     return;

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -312,9 +312,19 @@ namespace Dynamo.ViewModels
             var rootNode = libraryRoot;
             foreach (var categoryName in entry.Categories)
             {
-                rootNode = rootNode.SubCategories.Where(item => item.Name == categoryName).FirstOrDefault();
+                var tempNode = rootNode.SubCategories.FirstOrDefault(item => item.Name == categoryName);
+                // Root node can be null, if there is classes-viewmodel between updated entry and current category.
+                if (tempNode == null)
+                {
+                    // Get classes.
+                    var classes = rootNode.SubCategories.FirstOrDefault();
+                    // Search in classes.
+                    tempNode = classes.SubCategories.FirstOrDefault(item => item.Name == categoryName);
+                }
+
+                rootNode = tempNode;
             }
-            var entryVM = rootNode.Entries.Where(foundEntryVM => foundEntryVM.Name == entry.Name).FirstOrDefault();
+            var entryVM = rootNode.Entries.FirstOrDefault(foundEntryVM => foundEntryVM.Name == entry.Name);
             entryVM.Model = entry;
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -386,10 +386,6 @@ namespace Dynamo.ViewModels
                 if (parent is ClassesNodeCategoryViewModel && parent.SubCategories.Contains(target))
                     return;
 
-                // Do not continue if parent is root library tree category (i.e. Top).
-                if (!treeStack.Any())
-                    return;
-
                 // Do not continue as soon as our target is not class.
                 if (target.SubCategories.Any())
                     return;

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -375,7 +375,7 @@ namespace Dynamo.ViewModels
                     return;
 
                 // Do not continue if parent is root library tree category (i.e. Top).
-                if (!treeStack.Any() && parent.Name == String.Empty && parent.Description == String.Empty)
+                if (!treeStack.Any())
                     return;
 
                 // Do not continue as soon as our target is not class.

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -228,6 +228,7 @@ namespace Dynamo.ViewModels
                 InsertEntry(MakeNodeSearchElementVM(entry), entry.Categories);
                 RaisePropertyChanged("BrowserRootCategories");
             };
+            Model.EntryUpdated += UpdateEntry;
             Model.EntryRemoved += RemoveEntry;
 
             if (dynamoViewModel != null)
@@ -304,6 +305,17 @@ namespace Dynamo.ViewModels
 
                 DefineFullCategoryNames(item.SubCategories, item.FullCategoryName);
             }
+        }
+
+        internal void UpdateEntry(NodeSearchElement entry)
+        {
+            var rootNode = libraryRoot;
+            foreach (var categoryName in entry.Categories)
+            {
+                rootNode = rootNode.SubCategories.Where(item => item.Name == categoryName).FirstOrDefault();
+            }
+            var entryVM = rootNode.Entries.Where(foundEntryVM => foundEntryVM.Name == entry.Name).FirstOrDefault();
+            entryVM.Model = entry;
         }
 
         internal void RemoveEntry(NodeSearchElement entry)

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -610,6 +610,25 @@ namespace Dynamo.Tests
             Assert.IsFalse(viewModel.BrowserRootCategories.Any());
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void UpdateEntry01()
+        {
+            var element = CreateCustomNode("Member", "TopCategory.SubCategory");
+            element.Description = "AAA";
+            viewModel.InsertEntry(CreateCustomNodeViewModel(element), element.Categories);
+
+            element.Description = "BBB";
+            viewModel.UpdateEntry(element);
+
+            var elementVM = viewModel.BrowserRootCategories.First(c => c.Name == "TopCategory").
+                SubCategories.First(c => c is ClassesNodeCategoryViewModel).
+                SubCategories.First(s => s.Name == "SubCategory").
+                Entries.First(e => e.Name == "Member");
+            Assert.IsNotNull(elementVM);
+            Assert.AreEqual("BBB", elementVM.Description);
+        }
+
         #endregion
 
         #region Helpers

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -414,49 +414,6 @@ namespace Dynamo.Tests
             Assert.AreEqual("OneMore", category.Name);
 
         }
-        //                   Top
-        //                    │
-        //       ┌─────────┰─┴───────┰─────────┐
-        //    ZCategory  AMember    BMember    CMember     
-        //       │          
-        //    Classes       
-        //       │          
-        //    SubClass     
-        //       │           
-        //     Member      
-        [Test]
-        [Category("UnitTests")]
-        public void InsertEntry12SeveralMembersInAlphabeticalOrder()
-        {
-            var elementVM = CreateCustomNodeViewModel("BMember", "TopCategory");
-            viewModel.InsertEntry(elementVM, elementVM.Model.Categories);
-
-            elementVM = CreateCustomNodeViewModel("Member", "TopCategory.ZCategory.SubClass");
-            viewModel.InsertEntry(elementVM, elementVM.Model.Categories);
-
-            elementVM = CreateCustomNodeViewModel("CMember", "TopCategory");
-            viewModel.InsertEntry(elementVM, elementVM.Model.Categories);
-
-            elementVM = CreateCustomNodeViewModel("AMember", "TopCategory");
-            viewModel.InsertEntry(elementVM, elementVM.Model.Categories);
-
-            var category = viewModel.BrowserRootCategories.First(c => c.Name == "TopCategory").
-                 Items.ElementAt(0);
-            Assert.AreEqual("ZCategory", category.Name);
-
-            category = viewModel.BrowserRootCategories.First(c => c.Name == "TopCategory").
-                 Items.ElementAt(1);
-            Assert.AreEqual("AMember", category.Name);
-
-            category = viewModel.BrowserRootCategories.First(c => c.Name == "TopCategory").
-                 Items.ElementAt(2);
-            Assert.AreEqual("BMember", category.Name);
-
-            category = viewModel.BrowserRootCategories.First(c => c.Name == "TopCategory").
-                 Items.ElementAt(3);
-            Assert.AreEqual("CMember", category.Name);
-
-        }
 
         [Test]
         [Category("UnitTests")]
@@ -470,14 +427,14 @@ namespace Dynamo.Tests
 
             var listOfMembers = viewModel.BrowserRootCategories.First(c => c.Name == "TopCategory").Items;
 
-            var index = NodeCategoryViewModel.FindInsertionPointByName(listOfMembers, "BMember", true);
+            var index = NodeCategoryViewModel.FindInsertionPointByName(listOfMembers, "BMember");
 
             Assert.AreEqual(1, index);
 
             elementVM = CreateCustomNodeViewModel("BMember", "TopCategory");
             viewModel.InsertEntry(elementVM, elementVM.Model.Categories);
 
-            index = NodeCategoryViewModel.FindInsertionPointByName(listOfMembers, "BMember", true);
+            index = NodeCategoryViewModel.FindInsertionPointByName(listOfMembers, "BMember");
 
             Assert.AreEqual(1, index);
         }

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -414,6 +414,49 @@ namespace Dynamo.Tests
             Assert.AreEqual("OneMore", category.Name);
 
         }
+        //                   Top
+        //                    │
+        //       ┌─────────┰─┴───────┰─────────┐
+        //    ZCategory  AMember    BMember    CMember     
+        //       │          
+        //    Classes       
+        //       │          
+        //    SubClass     
+        //       │           
+        //     Member      
+        [Test]
+        [Category("UnitTests")]
+        public void InsertEntry12SeveralMembersInAlphabeticalOrder()
+        {
+            var elementVM = CreateCustomNodeViewModel("BMember", "TopCategory");
+            viewModel.InsertEntry(elementVM, elementVM.Model.Categories);
+
+            elementVM = CreateCustomNodeViewModel("Member", "TopCategory.ZCategory.SubClass");
+            viewModel.InsertEntry(elementVM, elementVM.Model.Categories);
+
+            elementVM = CreateCustomNodeViewModel("CMember", "TopCategory");
+            viewModel.InsertEntry(elementVM, elementVM.Model.Categories);
+
+            elementVM = CreateCustomNodeViewModel("AMember", "TopCategory");
+            viewModel.InsertEntry(elementVM, elementVM.Model.Categories);
+
+            var category = viewModel.BrowserRootCategories.First(c => c.Name == "TopCategory").
+                 Items.ElementAt(0);
+            Assert.AreEqual("ZCategory", category.Name);
+
+            category = viewModel.BrowserRootCategories.First(c => c.Name == "TopCategory").
+                 Items.ElementAt(1);
+            Assert.AreEqual("AMember", category.Name);
+
+            category = viewModel.BrowserRootCategories.First(c => c.Name == "TopCategory").
+                 Items.ElementAt(2);
+            Assert.AreEqual("BMember", category.Name);
+
+            category = viewModel.BrowserRootCategories.First(c => c.Name == "TopCategory").
+                 Items.ElementAt(3);
+            Assert.AreEqual("CMember", category.Name);
+
+        }
 
         [Test]
         [Category("UnitTests")]
@@ -427,14 +470,14 @@ namespace Dynamo.Tests
 
             var listOfMembers = viewModel.BrowserRootCategories.First(c => c.Name == "TopCategory").Items;
 
-            var index = NodeCategoryViewModel.FindInsertionPointByName(listOfMembers, "BMember");
+            var index = NodeCategoryViewModel.FindInsertionPointByName(listOfMembers, "BMember", true);
 
             Assert.AreEqual(1, index);
 
             elementVM = CreateCustomNodeViewModel("BMember", "TopCategory");
             viewModel.InsertEntry(elementVM, elementVM.Model.Categories);
 
-            index = NodeCategoryViewModel.FindInsertionPointByName(listOfMembers, "BMember");
+            index = NodeCategoryViewModel.FindInsertionPointByName(listOfMembers, "BMember", true);
 
             Assert.AreEqual(1, index);
         }


### PR DESCRIPTION
### Purpose
#### Link to YouTrack
[MAGN-7390](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7390) [Regression:0.8.0] Category list in Library is getting changed after placing Custom node from that category
*Priority: Show-stopper*

##### Reason of bug
For the first time user clicks on custom node, it's created custom workspace. As result of it search model updates itself. That means delete node and add this node again.
Removing node is made so that:
if node is removed, SearchVM tries to load all nodes, that are not part of class, into one class.
This works pretty good, when category from which item is deleted is not root category.

So, as soon as node is deleted SearchVM looks though its' nodes, that are not part of class. SearchVM creates class and adds it at the top.
That's why it appears like that:
![image](https://cloud.githubusercontent.com/assets/8158404/7632532/ab350bf0-fa56-11e4-8031-e9cfe8b0ee47.png)
The solution is to check whether parent item is root tree.

##### Another bug
During trying many other possible variants of placing members, I found one more bug.
Let's say we have next structure:
![image](https://cloud.githubusercontent.com/assets/8158404/7632671/fe547ea0-fa57-11e4-8a84-120ad3a26c0a.png)

We have loop, where for each element in top category, we check if element name is bigger than name of adding item. If name is bigger, insert item before this element.
Since element is member, then found index + number of categories.
![image](https://cloud.githubusercontent.com/assets/8158404/7632760/9538b70a-fa58-11e4-8b9c-dc63baa45382.png)
![image](https://cloud.githubusercontent.com/assets/8158404/7632799/df2239fe-fa58-11e4-82d4-aea3aeb1826a.png)

BUT, as we know, letter B should  be after A. So right place for BMember is after AMember.
![image](https://cloud.githubusercontent.com/assets/8158404/7632849/4b366912-fa59-11e4-81ba-05dca87cd595.png)

I've added fix and test for that case.

### Declarations

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

- [ ] @Benglin 

### FYIs

@riteshchandawar 