### PR TITLE
Show more informative preview information on Display object

### DIFF
--- a/src/Libraries/CoreNodes/Color.cs
+++ b/src/Libraries/CoreNodes/Color.cs
@@ -233,7 +233,7 @@ namespace DSCore
 
         public override string ToString()
         {
-            return string.Format("Color: Red={0}, Green={1}, Blue={2}, Alpha={3}", Red, Green, Blue, Alpha);
+            return string.Format("Color(Red = {0}, Green = {1}, Blue = {2}, Alpha = {3})", Red, Green, Blue, Alpha);
         }
 
         [IsVisibleInDynamoLibrary(false)]

--- a/src/Libraries/CoreNodes/GeometryColor.cs
+++ b/src/Libraries/CoreNodes/GeometryColor.cs
@@ -12,6 +12,7 @@ namespace DSCore
     {
         internal Geometry geometry;
         internal Color color;
+
         private bool renderEdges = false;
 
         private Display(Geometry geometry, Color color)
@@ -112,6 +113,11 @@ namespace DSCore
                 arr[i + 3] = alpha;
             }
             return arr;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("Display" + "(Geometry = {0}, Appearance = {1})", geometry, color);
         }
 
         //private static IEnumerable<double> NudgeVertexAlongVector(IList<double> vertices, IList<double> normals, int i, double amount)


### PR DESCRIPTION
### Purpose

Previously, the `Display` class did not override `ToString`.  As a result, it showed, `"DSCore.Display"` when it could show a more informative piece of information.  

Now, the `Display` class shows, `"Display(Geometry = {0}, Appearance = {1}"`, which is more informative and also consistent with the ProtoGeometry library.  

I've also modified the `Color` class to be more consistent with this pattern - a minor change.

Here's the result:

![displaycolor](https://cloud.githubusercontent.com/assets/916345/7636874/d500c2a4-fa37-11e4-92fe-98452ed929c8.png)

### Declarations

Check these iff you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@ramramps 

### FYIs

@lillismith