### PR TITLE
Fix the condition to avoid starting the backup timer

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1211,7 +1211,7 @@ namespace Dynamo.Models
         {
             // When running test cases, the dispatcher may be null which will cause the timer to
             // introduce a lot of threads. So the timer will not be started if test cases are running.
-            if (!IsTestMode)
+            if (IsTestMode)
                 return;
 
             if (backupFilesTimer != null)


### PR DESCRIPTION
### Purpose

This is a fix to avoid to start the timer when we are running tests. Otherwise, the timer needs to be started.

### Reviewers

@ke-yu 