### PR TITLE
Fix broken watch node testcases

### DIFF
--- a/test/DynamoCoreWpfTests/ExecutionIntervalTests.cs
+++ b/test/DynamoCoreWpfTests/ExecutionIntervalTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.IO;
-
 using NUnit.Framework;
+using Dynamo.Tests;
 
-namespace Dynamo.Tests
+namespace DynamoCoreWpfTests 
 {
     class ExecutionIntervalTests : DynamoViewModelUnitTest
     {

--- a/test/DynamoCoreWpfTests/WatchNodeTests.cs
+++ b/test/DynamoCoreWpfTests/WatchNodeTests.cs
@@ -114,7 +114,6 @@ namespace DynamoCoreWpfTests
         }
         
         [Test]
-        [Category("Failure")]
         public void WatchLiterals()
         {
             var model = ViewModel.Model;
@@ -145,7 +144,6 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        [Category("Failure")]
         public void Watch1DCollections()
         {
             var model = ViewModel.Model;
@@ -182,7 +180,6 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        [Category("Failure")]
         public void WatchFunctionObject()
         {
             string openPath = Path.Combine(TestDirectory, @"core\watch\watchfunctionobject.dyn");
@@ -199,7 +196,6 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        [Category("Failure")]
         public void WatchFunctionPointer()
         {
             string openPath = Path.Combine(TestDirectory, @"core\watch\watchFunctionPointer.dyn");
@@ -217,7 +213,6 @@ namespace DynamoCoreWpfTests
             }
         }
         [Test]
-        [Category("Failure")]
         public void WatchFunctionObject_collection_5033()
         {
             // http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5033

--- a/test/DynamoCoreWpfTests/WatchNodeTests.cs
+++ b/test/DynamoCoreWpfTests/WatchNodeTests.cs
@@ -7,8 +7,9 @@ using ProtoCore.Mirror;
 using Dynamo.Models;
 using System.Collections.Generic;
 using System.Linq;
+using Dynamo.Tests;
 
-namespace Dynamo.Tests
+namespace DynamoCoreWpfTests 
 {
     [Category("DSExecution")]
     class WatchNodeTests : DynamoViewModelUnitTest


### PR DESCRIPTION
## Purpose

To fix broken watch node test cases. These test cases fail because they fail to load `DSCoreNodesUI.dll`. Further, the resolution of this library should be done by an instance of `AssemblyHelper` that created in `DynamoCoreWpfTests.SetUp.RunBeforeAllTests()`. 

`RunBeforeAllTests()` will be called before all tests **in the same namespace**. As `WatchNodeTests` is in `Dynamo.Tests` namespace, the global assembly resolver is never set up for it.

So the fix is to move `WatchNodeTests` to namespace `DynamoCoreWpfTests`.

## FYIs
@Benglin , @pboyer 