### PR TITLE
Preparing build to include localized resources

### DIFF
--- a/extern/Localized/remove-me-soon.txt
+++ b/extern/Localized/remove-me-soon.txt
@@ -1,0 +1,1 @@
+The "Localized" folder is meant to keep all localized assemblies coming from WWL team. For a start, it is empty (we need this folder to make sure build scripts work fine). Once the actual localized binaries are added, this file should be removed.

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -349,6 +349,7 @@ limitations under the License.
       <ExternSimplexNoise Include="$(SolutionDir)..\extern\SimplexNoise\*" />
       <SampleFiles Include="$(SolutionDir)..\doc\distrib\Samples\**\*.*" />
       <GalleryFiles Include="$(SolutionDir)..\extern\gallery\**\*.*" />
+      <LocalizedResources Include="$(SolutionDir)..\extern\Localized\**\*.*" />
     </ItemGroup>
     <Copy SourceFiles="$(SolutionDir)..\README.md" DestinationFiles="$(OutputPath)README.txt" />
     <Copy SourceFiles="$(SolutionDir)..\doc\distrib\License.rtf" DestinationFolder="$(OutputPath)" />
@@ -365,6 +366,7 @@ limitations under the License.
     <Copy SourceFiles="@(ExternSimplexNoise)" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="@(SampleFiles)" DestinationFolder="$(OutputPath)samples\%(RecursiveDir)" />
     <Copy SourceFiles="@(GalleryFiles)" DestinationFolder="$(OutputPath)gallery\%(RecursiveDir)"/>
+    <Copy SourceFiles="@(LocalizedResources)" DestinationFolder="$(OutputPath)%(RecursiveDir)"/>
   </Target>
   <Target Name="AfterBuild" Condition=" '$(OS)' != 'Unix' ">
 

--- a/src/DynamoInstall/DynamoInstall.wixproj
+++ b/src/DynamoInstall/DynamoInstall.wixproj
@@ -47,7 +47,7 @@
   <Import Project="$(WixTargetsPath)" />
   <PropertyGroup>
     <PreBuildEvent>rd /s /q $(DYNAMO_HARVEST_PATH)
-robocopy $(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration) $(DYNAMO_HARVEST_PATH) -XF %2aTest%2a.dll %2a.pdb TestResult.xml -e -XD int -XD samples
+robocopy $(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration) $(DYNAMO_HARVEST_PATH) -XF %2aTest%2a.dll %2a.pdb TestResult.xml -e -XD int -XD samples -XD gallery -XD 0.8
 copy $(DYNAMO_BASE_PATH)\tools\install\Extra\DynamoAddinGenerator.exe $(DYNAMO_HARVEST_PATH)\DynamoAddinGenerator.exe
 copy $(DYNAMO_BASE_PATH)\tools\install\Extra\RevitAddinUtility.dll $(DYNAMO_HARVEST_PATH)\RevitAddinUtility.dll
 

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -15,6 +15,8 @@ using Dynamo.Services;
 using Dynamo.ViewModels;
 using DynamoShapeManager;
 using DynamoUtilities;
+using System.Threading;
+using System.Globalization;
 
 namespace DynamoSandbox
 {
@@ -76,6 +78,76 @@ namespace DynamoSandbox
         { 
             get { return string.Empty; }
         }
+    }
+
+    struct CommandLineArguments
+    {
+        internal static CommandLineArguments FromArguments(string[] args)
+        {
+            // Running Dynamo sandbox with a command file:
+            // DynamoSandbox.exe /c "C:\file path\file.xml"
+            // 
+            var commandFilePath = string.Empty;
+
+            // Running Dynamo under a different locale setting:
+            // DynamoSandbox.exe /l "ja-JP"
+            //
+            var locale = string.Empty;
+
+            // Running Dynamo sandbox with a dyn/dyf file:
+            // DynamoSandbox.exe "C:\file path\file.dyn"
+            //
+            var startUpDynFilePath = string.Empty;
+
+            for (var i = 0; i < args.Length; ++i)
+            {
+                var arg = args[i];
+
+                // Looking for '/c'
+                if (arg.Length != 2 || (arg[0] != '/'))
+                {
+                    try
+                    {
+                        if (!string.IsNullOrEmpty(arg) && File.Exists(arg))
+                        {
+                            var extension = Path.GetExtension(arg).ToLower();
+                            if (extension.Equals(".dyn") || extension.Equals(".dyf"))
+                                startUpDynFilePath = arg;
+                        }
+                    }
+                    catch { }
+
+                    continue;
+                }
+
+                switch (arg[1])
+                {
+                    case 'c':
+                    case 'C':
+                        // If there's at least one more argument...
+                        if (i < args.Length - 1)
+                            commandFilePath = args[++i];
+                        break;
+
+                    case 'l':
+                    case 'L':
+                        if (i < args.Length - 1)
+                            locale = args[++i];
+                        break;
+                }
+            }
+
+            return new CommandLineArguments
+            {
+                Locale = locale,
+                CommandFilePath = commandFilePath,
+                StartUpDynFilePath = startUpDynFilePath
+            };
+        }
+
+        internal string Locale { get; set; }
+        internal string CommandFilePath { get; set; }
+        internal string StartUpDynFilePath { get; set; }
     }
 
     internal class Program
@@ -160,28 +232,16 @@ namespace DynamoSandbox
 
             try
             {
-                // Running Dynamo sandbox with a command file:
-                // DynamoSandbox.exe /c "C:\file path\file.xml"
-                // 
-                var commandFilePath = string.Empty;
+                var cmdLineArgs = CommandLineArguments.FromArguments(args);
 
-                for (var i = 0; i < args.Length; ++i)
+                if (!string.IsNullOrEmpty(cmdLineArgs.Locale))
                 {
-                    var arg = args[i];
-
-                    // Looking for '/c'
-                    if (arg.Length != 2 || (arg[0] != '/'))
-                        continue;
-
-                    if (arg[1] == 'c' || (arg[1] == 'C'))
-                    {
-                        // If there's at least one more argument...
-                        if (i < args.Length - 1)
-                            commandFilePath = args[i + 1];
-                    }
+                    // Change the application locale, if a locale information is supplied.
+                    Thread.CurrentThread.CurrentUICulture = new CultureInfo(cmdLineArgs.Locale);
+                    Thread.CurrentThread.CurrentCulture = new CultureInfo(cmdLineArgs.Locale);
                 }
 
-                MakeStandaloneAndRun(commandFilePath, out viewModel);
+                MakeStandaloneAndRun(cmdLineArgs.CommandFilePath, out viewModel);
             }
             catch (Exception e)
             {

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -94,30 +94,12 @@ namespace DynamoSandbox
             //
             var locale = string.Empty;
 
-            // Running Dynamo sandbox with a dyn/dyf file:
-            // DynamoSandbox.exe "C:\file path\file.dyn"
-            //
-            var startUpDynFilePath = string.Empty;
-
             for (var i = 0; i < args.Length; ++i)
             {
                 var arg = args[i];
-
-                // Looking for '/c'
                 if (arg.Length != 2 || (arg[0] != '/'))
                 {
-                    try
-                    {
-                        if (!string.IsNullOrEmpty(arg) && File.Exists(arg))
-                        {
-                            var extension = Path.GetExtension(arg).ToLower();
-                            if (extension.Equals(".dyn") || extension.Equals(".dyf"))
-                                startUpDynFilePath = arg;
-                        }
-                    }
-                    catch { }
-
-                    continue;
+                    continue; // Not a "/x" type of command switch.
                 }
 
                 switch (arg[1])
@@ -140,14 +122,12 @@ namespace DynamoSandbox
             return new CommandLineArguments
             {
                 Locale = locale,
-                CommandFilePath = commandFilePath,
-                StartUpDynFilePath = startUpDynFilePath
+                CommandFilePath = commandFilePath
             };
         }
 
         internal string Locale { get; set; }
         internal string CommandFilePath { get; set; }
-        internal string StartUpDynFilePath { get; set; }
     }
 
     internal class Program

--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -199,7 +199,7 @@ begin
     begin
 	  MsgBox('Dynamo requires an installation of Revit 2014, Revit 2015 or Revit 2016 in order to proceed!', mbCriticalError, MB_OK);
       result := false;
-    end
+    end;
 
   // if old EXE version of 0.8.0 is installed, uninstall it
   sUnInstPath := 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{6B5FA6CA-9D69-46CF-B517-1F90C64F7C0B}_is1'


### PR DESCRIPTION
### Purpose

This pull request updates `DynamoCore.csproj` to copy all localized resources from `extern/Localized` folder to `%OutputPath% folder during build. These binaries that now reside in %OutputPath% will be consumed by installer build to produce MUI installer.

The `DynamoSandbox.exe` has also been updated to take in a new *locale* related command line argument. For example, to launch Dynamo in Japan locale, do the following:

    DynamoSandbox.exe /L "ja-JP"

### Declarations

Check these iff you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

Hi @nguyen-binh-minh, this is the work that we have talked about before. Could you see if anything in the installer step (both `*.msi` and `*.exe` installers) is missing?

I have tried the `exe` installer and it correctly packages and installs all localized resources. As part of your review, can you help to try out `*.msi` installer on `Benglin:LocalizedBuild` branch (not this branch)? That branch has all the necessary localized resources. Thanks!

### FYIs

@RodRecker, this is the work that will enable us to build MUI installers, but the actual localized resources are incomplete (e.g. `libg_locale` folder has gone missing for a week now and `gallery` is a new folder for localization), therefore the daily builds will have incomplete localized resources contained in them. Once WWL team delivers a new round of localized resources, they will automatically be completing our installers.