### PR TITLE
Fixed the issue around Create Group on blank canvas

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -928,6 +928,12 @@ namespace Dynamo.ViewModels
             if (!groups.Any(x => x.IsSelected))
             {
                 var modelSelected = DynamoSelection.Instance.Selection.OfType<ModelBase>().Where(x => x.IsSelected);
+                //If there are no nodes selected then return false
+                if (!modelSelected.Any())
+                {
+                    return false;
+                }
+
                 foreach (var model in modelSelected)
                 {
                     if (groups.ContainsModel(model.GUID))

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -51,6 +51,15 @@ namespace DynamoCoreWpfTests
 
         [Test]
         [Category("DynamoUI")]
+        public void CanCreateGroupIfNoModelsAreSelectedInTheCanvas()
+        {
+            //Check whether Create Group is enabled in a blank canvas.
+            Assert.AreEqual(false, ViewModel.CanAddAnnotation(null));
+        }
+
+
+        [Test]
+        [Category("DynamoUI")]
         public void CanCreateGroupIfANodeIsAlreadyInAGroup()
         {
             //Create a Node

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -51,7 +51,7 @@ namespace DynamoCoreWpfTests
 
         [Test]
         [Category("DynamoUI")]
-        public void CanCreateGroupIfNoModelsAreSelectedInTheCanvas()
+        public void CannotCreateGroupIfNoModelsAreSelectedInTheCanvas()
         {
             //Check whether Create Group is enabled in a blank canvas.
             Assert.AreEqual(false, ViewModel.CanAddAnnotation(null));


### PR DESCRIPTION
### Purpose
 This PR fixes the issue : Create Group is enabled on blank canvas

### Declarations
- [x] The code base is in a better state after this PR.
           Added a condition to check whether any nodes are selected.
- [x] The level of testing this PR includes is appropriate
                  Added test CanCreateGroupIfNoModelsAreSelectedInTheCanvas to check for create group on blank canvas.

### Reviewers
- [ ] @pboyer 