### PR TITLE
Fix to stop excel from prompting message box before overwriting file

### DIFF
--- a/src/Libraries/DSOffice/Excel.cs
+++ b/src/Libraries/DSOffice/Excel.cs
@@ -93,6 +93,7 @@ namespace DSOffice
             AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
 
             excel.Visible = ShowOnStartup;
+            excel.DisplayAlerts = false;
 
             return excel;
         }


### PR DESCRIPTION
### Purpose
This PR fixes the issue where Excel sometimes prompts the user with a message box asking whether to overwrite an existing file. The display of this message appears to hang Dynamo. A global Excel flag is set at the time of instantiating Excel to prevent these alerts from displaying. This issue is tracked here: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7249

### Declarations

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@junmendoza  Reviewer 1  

This issue cannot be reproduced consistently and so it's difficult to add a test to simulate it. However adding the fix should hopefully ensure that even those few instances when the alert messages are displayed, don't happen anymore.