### PR TITLE
Handle invalid (but possible) value of "ElementTypes" enum

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2209,10 +2209,8 @@ namespace Dynamo.Controls
 
                 case ElementTypes.BuiltIn:
                 case ElementTypes.None:
-                    return "";
-
                 default:
-                    throw new ArgumentException("Unknown element type.");
+                    return string.Empty;
             }
         }
 

--- a/test/DynamoCoreWpfTests/ConverterTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterTests.cs
@@ -494,6 +494,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        [Category("UnitTests")]
         public void ElementTypeToShortConverterTest()
         {
             var converter = new ElementTypeToShortConverter();
@@ -516,6 +517,9 @@ namespace Dynamo.Tests
             Assert.AreEqual(String.Empty, result);
 
             result = converter.Convert(ElementTypes.None, null, null, null);
+            Assert.AreEqual(String.Empty, result);
+
+            result = converter.Convert(ElementTypes.ZeroTouch | ElementTypes.BuiltIn, null, null, null);
             Assert.AreEqual(String.Empty, result);
         }
 


### PR DESCRIPTION
### Purpose

This pull request fixes a crash when expanding `Builtin Functions` category on the library UI. A highly possible value of `ElementTypes.BuiltIn | ElementTypes.ZeroTouch` can find its way into `ElementTypeToShortConverter`, therefore we should not be throwing an exception (simply return `string.Empty` would do).

### Declarations

Check these iff you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

Hi @aosyatnik, please have a look at this later. I'm merging this in because it fails our daily build.