### PR TITLE
Remove TestTextFromDynamoText test case from Failure category

### DIFF
--- a/test/Libraries/WorkflowTests/PackageValidationTest.cs
+++ b/test/Libraries/WorkflowTests/PackageValidationTest.cs
@@ -33,7 +33,6 @@ namespace Dynamo.Tests
         #region Dynamo Text Package Tests
 
         [Test]
-        [Category("Failure")]
         public void TestTextFromDynamoText()
         {
             var testFilePath = Path.Combine(TestDirectory, @"core\userdata\BasicTextTest.dyn");


### PR DESCRIPTION
### Purpose

This package test case has been fixed before, as it passes now, remove it from Failure category. 

### Reviewers

- [ ] @riteshchandawar 
