### PR TITLE
Fix tests.

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -742,8 +742,9 @@ namespace Dynamo.Models
                 {
                     if (info.FunctionId == newInfo.FunctionId)
                     {
+                        bool isCategoryChanged = searchElement.FullCategoryName != newInfo.Category;
                         searchElement.SyncWithCustomNodeInfo(newInfo);
-                        SearchModel.Update(searchElement);
+                        SearchModel.Update(searchElement, isCategoryChanged);
                     }
                 };
                 CustomNodeManager.CustomNodeRemoved += id =>

--- a/src/DynamoCore/Search/SearchLibrary.cs
+++ b/src/DynamoCore/Search/SearchLibrary.cs
@@ -30,16 +30,23 @@ namespace Dynamo.Search
         ///     Updates an entry in search.
         /// </summary>
         /// <param name="entry"></param>
-        public void Update(TEntry entry)
+        public void Update(TEntry entry, bool isCategoryChanged = false)
         {
+            // If entry's category is changed, we need to delete this entry from search.
+            // And add it to new category.
+            if (isCategoryChanged)
+                Remove(entry);
+
             Dictionary<string, double> keys;
             if (entryDictionary.TryGetValue(entry, out keys)) // Found the entry to update.
             {
-                keys[entry.Name.ToLower()] = 1.0;
-                keys[entry.Description.ToLower()] = 0.1;
+                // Remove old tags.
+                keys.Clear();
+                keys.Add(entry.Name.ToLower(), 1);
+                keys.Add(entry.Description.ToLower(), 0.1);
 
                 foreach (var tag in entry.SearchTags.Select(x => x.ToLower()))
-                    keys[tag] = 0.5;
+                    keys.Add(tag, 0.5);
 
                 OnEntryUpdated(entry);
                 return; // Entry updated.


### PR DESCRIPTION
### Purpose

There are 4 fallen tests.
Errors:
* CustomNodeSaveAsAddsNewCustomNodeToSearchAndItCanBeRefactoredWhilePreservingOriginalFromExistingDyf
* CustomNodeSaveAsAddsNewCustomNodeToSearchAndItCanBeRefactoredWhilePreservingOriginalFromExistingDyf2

Failures:
* CanRefactorCustomNodeName
* CanRefactorCustomNodeWhilePreservingDuplicates

First two failed because custom node category is changed. And search view model tries to find custom node model in the old category destination and can't find it. If node category is changed we have to remove this node and add it(as it was before).

Other two failed because old tags are left. We just changed the weights of tags, but didn't update them.

### Declarations

Check these iff you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@Benglin 
