### PR TITLE
MAGN-7426 Group title can bleed outside the group's right side

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -211,7 +211,7 @@
             </Rectangle.Fill>
         </Rectangle>
         <Grid x:Name="TextBlockGrid" Grid.Row="0" Height="auto" MaxWidth="{Binding Width}" 
-              Margin="5,0,0,0"
+              Margin="5,0,5,0"
               VerticalAlignment="Top">            
             <TextBlock x:Name="GroupTextBlock"                                     
                     Text ="{Binding AnnotationText, Converter={StaticResource AnnotationTextConverter}}"    


### PR DESCRIPTION
### Purpose
 This PR fixes the issue with Margin on Textblock

### Declarations
- [x] The code base is in a better state after this PR.
           Updated the Margin.Right property.
- [] The level of testing this PR includes is appropriate
            
### Reviewers
- [ ] @pboyer 