### PR TITLE
Unmarshal DS array to C# dictionary

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
@@ -326,17 +326,15 @@ namespace ProtoFFI
             }
 
             var dict = (IDictionary)Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(keyType, valueType)); 
-            var dsKeys = ArrayUtils.GetKeys(dsObject, dsi.runtime.RuntimeCore);
+            var dsKeyValues = ArrayUtils.GetKeyValuePairs(dsObject, dsi.runtime.RuntimeCore);
 
-            foreach (var dsKey in dsKeys)
+            foreach (var pair in dsKeyValues)
             {
-                var key = primitiveMarshaler.UnMarshal(dsKey, context, dsi, keyType);
+                var key = primitiveMarshaler.UnMarshal(pair.Key, context, dsi, keyType);
                 if (key == null || !keyType.IsAssignableFrom(key.GetType()))
                     continue;
 
-                var dsValue = ArrayUtils.GetValueFromIndex(dsObject, dsKey, dsi.runtime.RuntimeCore);
-                var value = primitiveMarshaler.UnMarshal(dsValue, context, dsi, valueType);
-
+                var value = primitiveMarshaler.UnMarshal(pair.Value, context, dsi, valueType);
                 if (value != null && valueType.IsAssignableFrom(value.GetType()))
                     dict.Add(key, value);
                 else

--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
@@ -327,10 +327,10 @@ namespace ProtoFFI
             System.Type keyType, System.Type valueType)
         {
             if (csDictionary == null)
-                throw new ArgumentNullException("dict");
+                throw new ArgumentNullException("csDictionary");
 
             if (dsDictionary == null)
-                throw new ArgumentNullException("dsDict");
+                throw new ArgumentNullException("dsDictionary");
 
             foreach (var pair in dsDictionary)
             {

--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
@@ -322,17 +322,17 @@ namespace ProtoFFI
 
         private object AddToDictionary(ProtoCore.Runtime.Context context,
             Interpreter dsi,
-            IDictionary dict,
-            IDictionary<StackValue, StackValue> dsDict,
+            IDictionary csDictionary,
+            IDictionary<StackValue, StackValue> dsDictionary,
             System.Type keyType, System.Type valueType)
         {
-            if (dict == null)
+            if (csDictionary == null)
                 throw new ArgumentNullException("dict");
 
-            if (dsDict == null)
+            if (dsDictionary == null)
                 throw new ArgumentNullException("dsDict");
 
-            foreach (var pair in dsDict)
+            foreach (var pair in dsDictionary)
             {
                 var key = primitiveMarshaler.UnMarshal(pair.Key, context, dsi, keyType);
                 if (key == null || !keyType.IsAssignableFrom(key.GetType()))
@@ -340,12 +340,12 @@ namespace ProtoFFI
 
                 var value = primitiveMarshaler.UnMarshal(pair.Value, context, dsi, valueType);
                 if (value != null && valueType.IsAssignableFrom(value.GetType()))
-                    dict.Add(key, value);
+                    csDictionary.Add(key, value);
                 else
-                    dict.Add(key, null);
+                    csDictionary.Add(key, null);
             }
 
-            return dict;
+            return csDictionary;
         }
 
         private object ToIDictionary(StackValue dsObject, ProtoCore.Runtime.Context context, Interpreter dsi, System.Type expectedType)
@@ -359,7 +359,6 @@ namespace ProtoFFI
 
             if (expectedType.IsGenericType)
             {
-                // Create an instance of IDictionary<TKey, TValue>
                 keyType = expectedType.GetGenericArguments().First();
                 valueType = expectedType.GetGenericArguments().Last();
                 instanceType = expectedType.GetGenericTypeDefinition().MakeGenericType(keyType, valueType);

--- a/src/Engine/ProtoCore/Utils/ArrayUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ArrayUtils.cs
@@ -1051,6 +1051,28 @@ namespace ProtoCore.Utils
         }
 
         /// <summary>
+        /// Get a list of key-value pairs for an array.
+        /// </summary>
+        /// <param name="array"></param>
+        /// <param name="runtimeCore"></param>
+        /// <returns></returns>
+        public static IEnumerable<KeyValuePair<StackValue, StackValue>> GetKeyValuePairs(StackValue array, RuntimeCore runtimeCore)
+        {
+            Validity.Assert(array.IsArray);
+            if (!array.IsArray)
+            {
+                return null;
+            }
+
+            HeapElement he = GetHeapElement(array, runtimeCore);
+            var pairs = Enumerable.Range(0, he.VisibleSize)
+                                  .Select(i => new KeyValuePair<StackValue, StackValue>(StackValue.BuildInt(i),
+                                                                                        StackUtils.GetValue(he, i, runtimeCore)))
+                                  .Concat(he.Dict ?? Enumerable.Empty<KeyValuePair<StackValue, StackValue>>());
+            return pairs;
+        }
+
+        /// <summary>
         /// Check if an array contain key
         /// </summary>
         /// <param name="array"></param>

--- a/src/Engine/ProtoCore/Utils/ArrayUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ArrayUtils.cs
@@ -1056,7 +1056,7 @@ namespace ProtoCore.Utils
         /// <param name="array"></param>
         /// <param name="runtimeCore"></param>
         /// <returns></returns>
-        public static IEnumerable<KeyValuePair<StackValue, StackValue>> GetKeyValuePairs(StackValue array, RuntimeCore runtimeCore)
+        public static IDictionary<StackValue, StackValue> ToDictionary(StackValue array, RuntimeCore runtimeCore)
         {
             Validity.Assert(array.IsArray);
             if (!array.IsArray)
@@ -1065,11 +1065,11 @@ namespace ProtoCore.Utils
             }
 
             HeapElement he = GetHeapElement(array, runtimeCore);
-            var pairs = Enumerable.Range(0, he.VisibleSize)
-                                  .Select(i => new KeyValuePair<StackValue, StackValue>(StackValue.BuildInt(i),
-                                                                                        StackUtils.GetValue(he, i, runtimeCore)))
-                                  .Concat(he.Dict ?? Enumerable.Empty<KeyValuePair<StackValue, StackValue>>());
-            return pairs;
+            var dict = Enumerable.Range(0, he.VisibleSize)
+                                 .Select(i => new KeyValuePair<StackValue, StackValue>(StackValue.BuildInt(i), StackUtils.GetValue(he, i, runtimeCore)))
+                                 .Concat(he.Dict ?? Enumerable.Empty<KeyValuePair<StackValue, StackValue>>())
+                                 .ToDictionary(p => p.Key, p =>p.Value);
+            return dict;
         }
 
         /// <summary>

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -423,6 +423,24 @@ namespace FFITarget
             };
         }
 
+        public static Hashtable GetHashTable()
+        {
+            var hashTable = new Hashtable();
+            hashTable.Add("color", "green");
+            hashTable.Add("weight", 42);
+            hashTable.Add(37, "thirty-seven");
+
+            return hashTable;
+        }
+
+        public static object GetValueFromHashTable(Hashtable table, object key)
+        {
+            if (table.Contains(key))
+                return table[key];
+            else
+                return 1024;
+        }
+
         public static object GetValueFromDictionary(Dictionary<object, object> dict, object key)
         {
             if (dict.ContainsKey(key))

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -423,6 +423,14 @@ namespace FFITarget
             };
         }
 
+        public static object GetValueFromDictionary(Dictionary<object, object> dict, object key)
+        {
+            if (dict.ContainsKey(key))
+                return dict[key];
+            else
+                return 1024;
+        }
+
         public static object GetObjectValue( Dictionary<String, object> result, String key)
         {
             if (result.ContainsKey(key))

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -423,6 +423,30 @@ namespace FFITarget
             };
         }
 
+        public static object GetObjectValue( Dictionary<String, object> result, String key)
+        {
+            if (result.ContainsKey(key))
+            {
+                return result[key];
+            }
+            else
+            {
+                return 37;
+            }
+        }
+
+        public static String GetStringValue(Dictionary<String, String> result, String key)
+        {
+            if (result.ContainsKey(key))
+            {
+                return result[key];
+            }
+            else
+            {
+                return "novalue";
+            }
+        }
+
         public static object ReturnObject(object x)
         {
             return x;

--- a/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
@@ -447,6 +447,26 @@ namespace ProtoFFITests
             ExecuteAndVerify(code, data);
         }
 
+        [Test]
+        public void Test_UnMarshalHybridDictionary()
+        {
+            string code =
+                @"
+arr = {21, 42, 63};
+arr[""foo""] = ""xyz"";
+r1 = TestData.GetValueFromDictionary(arr, ""foo"");
+r2 = TestData.GetValueFromDictionary(arr, 1);
+r3 = TestData.GetValueFromDictionary(arr, 3);
+";            
+            ValidationData[] data = { new ValidationData { ValueName = "r1", ExpectedValue = "xyz", BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r2", ExpectedValue = 42, BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r3", ExpectedValue = 1024, BlockIndex = 0 },
+                                    };
+            Type dummy = typeof(FFITarget.TestData);
+            code = string.Format("import(\"{0}\");\r\n{1}", dummy.AssemblyQualifiedName, code);
+            ExecuteAndVerify(code, data);
+ 
+        }
 
         [Test]
         public void Test_DefaultArgument()

--- a/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
@@ -465,7 +465,47 @@ r3 = TestData.GetValueFromDictionary(arr, 3);
             Type dummy = typeof(FFITarget.TestData);
             code = string.Format("import(\"{0}\");\r\n{1}", dummy.AssemblyQualifiedName, code);
             ExecuteAndVerify(code, data);
- 
+        }
+
+        [Test]
+        public void Test_UnMarshalHashTable()
+        {
+            string code =
+                @"
+table = TestData.GetHashTable();
+r1 = TestData.GetValueFromHashTable(table, ""color"");
+r2 = TestData.GetValueFromHashTable(table, ""weight"");
+r3 = TestData.GetValueFromHashTable(table, 37);
+r4 = TestData.GetValueFromHashTable(table, 1024);
+";
+            ValidationData[] data = { new ValidationData { ValueName = "r1", ExpectedValue = "green", BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r2", ExpectedValue = 42, BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r3", ExpectedValue = "thirty-seven", BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r4", ExpectedValue = 1024, BlockIndex = 0 },
+                                    };
+            Type dummy = typeof(FFITarget.TestData);
+            code = string.Format("import(\"{0}\");\r\n{1}", dummy.AssemblyQualifiedName, code);
+            ExecuteAndVerify(code, data);
+        }
+
+        [Test]
+        public void Test_UnMarshalArrayToHashTable()
+        {
+            string code =
+                @"
+arr = {21, 42, 63};
+arr[""foo""] = ""xyz"";
+r1 = TestData.GetValueFromHashTable(arr, 1);
+r2 = TestData.GetValueFromHashTable(arr, ""foo"");
+r3 = TestData.GetValueFromHashTable(arr, 100);
+";
+            ValidationData[] data = { new ValidationData { ValueName = "r1", ExpectedValue = 42, BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r2", ExpectedValue = "xyz", BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r3", ExpectedValue = 1024, BlockIndex = 0 },
+                                    };
+            Type dummy = typeof(FFITarget.TestData);
+            code = string.Format("import(\"{0}\");\r\n{1}", dummy.AssemblyQualifiedName, code);
+            ExecuteAndVerify(code, data);
         }
 
         [Test]

--- a/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
@@ -432,6 +432,23 @@ namespace ProtoFFITests
         }
 
         [Test]
+        public void Test_UnMarshalDictionary()
+        {
+            string code =
+                @" t = TestData.TestData();                   d = t.GetDictionary();                     r1 = TestData.GetStringValue(d, ""color"");                   r2 = TestData.GetStringValue(d, ""weight"");                   r3 = TestData.GetObjectValue(d, ""weight"");                   r4 = TestData.GetObjectValue(d, ""invalidkey"");
+";
+            ValidationData[] data = { new ValidationData { ValueName = "r1", ExpectedValue = "green", BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r2", ExpectedValue = null, BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r3", ExpectedValue = 42, BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r4", ExpectedValue = 37, BlockIndex = 0 },
+                                    };
+            Type dummy = typeof(FFITarget.TestData);
+            code = string.Format("import(\"{0}\");\r\n{1}", dummy.AssemblyQualifiedName, code);
+            ExecuteAndVerify(code, data);
+        }
+
+
+        [Test]
         public void Test_DefaultArgument()
         {
             string code =

--- a/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
@@ -509,6 +509,48 @@ r3 = TestData.GetValueFromHashTable(arr, 100);
         }
 
         [Test]
+        public void Test_UnMarshal1DArrayToDictionary()
+        {
+            string code =
+                @"
+arr = {21, 42, 63};
+r1 = TestData.GetValueFromDictionary(arr, 0);
+r2 = TestData.GetValueFromDictionary(arr, 1);
+r3 = TestData.GetValueFromDictionary(arr, 2);
+r4 = TestData.GetValueFromDictionary(arr, 3);
+";
+            ValidationData[] data = { new ValidationData { ValueName = "r1", ExpectedValue = 21, BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r2", ExpectedValue = 42, BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r3", ExpectedValue = 63, BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r4", ExpectedValue = 1024, BlockIndex = 0 },
+                                    };
+            Type dummy = typeof(FFITarget.TestData);
+            code = string.Format("import(\"{0}\");\r\n{1}", dummy.AssemblyQualifiedName, code);
+            ExecuteAndVerify(code, data);
+        }
+
+        [Test]
+        public void Test_UnMarshal1DArrayToHashtable()
+        {
+            string code =
+                @"
+arr = {21, 42, 63};
+r1 = TestData.GetValueFromHashTable(arr, 0);
+r2 = TestData.GetValueFromHashTable(arr, 1);
+r3 = TestData.GetValueFromHashTable(arr, 2);
+r4 = TestData.GetValueFromHashTable(arr, 3);
+";
+            ValidationData[] data = { new ValidationData { ValueName = "r1", ExpectedValue = 21, BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r2", ExpectedValue = 42, BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r3", ExpectedValue = 63, BlockIndex = 0 },
+                                      new ValidationData { ValueName = "r4", ExpectedValue = 1024, BlockIndex = 0 },
+                                    };
+            Type dummy = typeof(FFITarget.TestData);
+            code = string.Format("import(\"{0}\");\r\n{1}", dummy.AssemblyQualifiedName, code);
+            ExecuteAndVerify(code, data);
+        }
+
+        [Test]
         public void Test_DefaultArgument()
         {
             string code =

--- a/test/Engine/ProtoTest/FFITests/CSFFITest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFITest.cs
@@ -268,15 +268,14 @@ namespace ProtoFFITests
         }
 
         [Test]
-        [Category("Failure")]
         public void TestDictionaryMarshalling_DStoCS_CStoDS()
         {
             // Tracked by: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4035
             String code =
-            @"             [Associative]              {                dummy = Dummy.Dummy();                dictionary =                 {                     dummy.CreateDictionary() => dict;                    dummy.AddData(dict, ""ABCD"", 22);                    dummy.AddData(dict, ""xyz"", 11);                    dummy.AddData(dict, ""teas"", 12);                }                sum = dummy.SumAges(dictionary);             }            ";
+            @"                dummy = Dummy.Dummy();                dictionary =                 {                     dummy.CreateDictionary() => dict;                    dummy.AddData(dict, ""ABCD"", 22) => dict;                    dummy.AddData(dict, ""xyz"", 11) => dict;                    dummy.AddData(dict, ""teas"", 12) => dict;                }                sum = dummy.SumAges(dictionary);            ";
             Type dummy = typeof (FFITarget.Dummy);
             code = string.Format("import(\"{0}\");\r\n{1}", dummy.AssemblyQualifiedName, code);
-            ValidationData[] data = { new ValidationData { ValueName = "sum", ExpectedValue = 45, BlockIndex = 1 } };
+            ValidationData[] data = { new ValidationData { ValueName = "sum", ExpectedValue = 45, BlockIndex = 0 } };
             Assert.IsTrue(ExecuteAndVerify(code, data) == 0); //runs without any error
         }
 


### PR DESCRIPTION
### Purpose

Marshalling C# `Dictionary<TKey, TValue>` or `IDictionary` to DS array has already been supported in DesignScript's clr object marshaller. This PR supports to unmarshal DS dictionary back to C# instance whose type implements `IDictionary<TKey, TValue>` or  `IDictionary`. 

For example, for the following two C# functions:
```
public class Sample 
{
    public static object GetValueFromDictionary(Dictionary<String, String> dict, string key)
    { ... }

    public static object GetValueFromHashtable(Hashtable table, object key)
    { ... }
}
```
Now we can calls these two functions with a DS array:
```
arr = {};
arr["color"] = "blue";
arr["name"] = "Dynamo";

r1 = Sample.GetValueFromDictionary(arr, "color");   // "blue"
r2 = Sample.GetValueFromHashtable(arr, "name"); // "Dynamo"
```

### Reviewers

- [ ] @sharadkjaiswal 

### FYIs

@riteshchandawar , we haven't had a defect yet, could you please log one?