### PR TITLE
Fix regressed language test cases

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -3283,8 +3283,17 @@ namespace ProtoAssociative
                 astlist.AddRange(inlineExpressionASTList);
                 inlineExpressionASTList.Clear();
 
+                DFSEmitSSA_AST(ilnode.TrueExpression, ssaStack, ref inlineExpressionASTList);
+                cexpr = ssaStack.Pop();
+                ilnode.TrueExpression = cexpr is BinaryExpressionNode ? (cexpr as BinaryExpressionNode).LeftNode : cexpr;
+                astlist.AddRange(inlineExpressionASTList);
+                inlineExpressionASTList.Clear();
 
-                // SSA for true and false body are handled by EmitInlineConditionalNode
+                DFSEmitSSA_AST(ilnode.FalseExpression, ssaStack, ref inlineExpressionASTList);
+                cexpr = ssaStack.Pop();
+                ilnode.FalseExpression = cexpr is BinaryExpressionNode ? (cexpr as BinaryExpressionNode).LeftNode : cexpr;
+                astlist.AddRange(inlineExpressionASTList);
+                inlineExpressionASTList.Clear();
 
                 BinaryExpressionNode bnode = new BinaryExpressionNode();
                 bnode.Optr = ProtoCore.DSASM.Operator.assign;

--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -1605,7 +1605,7 @@ namespace ProtoTest.TD.Associative
 @" class A{    static def foo1(x,y)    {        return = x + y;    }    static def foo2()    {        return = {1, 2};    }    static def foo3()    {        return = {3, 4};    }    static def foo ( x )    {        return = x;    }}def foo( x){    return = x;}x = 2;t1 = A.foo ( x > 1 ? A.foo1(A.foo2()<1>,A.foo3()<2>) : 0);";
             string errmsg = "DNL-1467591 replication guides in class instantiation is not giving expected output";
             thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("t1", new [] { 4,  6 });
+            thisTest.Verify("t1", new [] { new object[] {4, 5}, new object[]{5, 6} });
         }
 
         [Test]
@@ -1615,7 +1615,7 @@ namespace ProtoTest.TD.Associative
 @" class A{    static def foo1(x,y)    {        return = x + y;    }    static def foo2()    {        return = {1, 2};    }    static def foo3()    {        return = {3, 4};    }    static def fooo ( x )    {        return = x;    }    static def foo ( x )    {        return = A.fooo ( x > 1 ? A.foo1(A.foo2()<1>,A.foo3()<2>) : 0);    }}x = 2;t1 = A.foo ( x );";
             string errmsg = "DNL-1467591 replication guides in class instantiation is not giving expected output";
             thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("t1", new Object[] { 4, 6});
+            thisTest.Verify("t1", new Object[] { new object[]{4, 5}, new object[] {5, 6}});
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -866,7 +866,6 @@ namespace ProtoTest.TD.Associative
         }
 
         [Test]
-        [Category("Failure")]
         [Category("Replication")]
         public void T039_1467423_replication_guide_on_array_5()
         {
@@ -874,7 +873,7 @@ namespace ProtoTest.TD.Associative
 @"class A{    x: int;    constructor A ( a, b, c)    {        x = a + b + c ;    }}test;[Associative]{    y = 3..4;    test = Count ( A.A(1, { 1, 2}<1>, y<2>).x ) > 1 ? A.A(1, { 1, 2}<1>, y<2>).x : 0;}";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("test", new object[] { 5, 7});
+            thisTest.Verify("test", new object[] { new object[] { 5, 6 }, new object[] { 6, 7 } });
         }
 
         [Test]
@@ -911,7 +910,6 @@ namespace ProtoTest.TD.Associative
         }
 
         [Test]
-        [Category("Failure")]
         [Category("Replication")]
         public void T039_1467423_replication_guide_on_array_9()
         {
@@ -919,11 +917,10 @@ namespace ProtoTest.TD.Associative
 @"class A{    x: int;    constructor A ( a, b, c)    {        x = a + b + c ;    }}test;[Associative]{    y = 3..4;    test = Count ( A.A(1, (1..2..1)<1>, y<2>).x ) > 1 ? A.A(1, (1..2)<1>, y<2>).x : 0;}";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("test", new object[] { 5, 7});
+            thisTest.Verify("test", new object[] { new object[]{5, 6}, new object[] {6, 7}});
         }
 
         [Test]
-        [Category("Failure")]
         [Category("Replication")]
         public void T039_1467423_replication_guide_on_array_10()
         {
@@ -931,7 +928,7 @@ namespace ProtoTest.TD.Associative
 @"class A{    x: int;    constructor A ( a, b, c)    {        x = a + b + c ;    }}test;[Associative]{    y = 3..4;    test = Count ( A.A(1, (1..2..1)<1>, y<2>).x ) > 1 ? A.A(1, (1..2..#2)<1>, y<2>).x : 0;}";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("test", new object[] { 5, 7 } );
+            thisTest.Verify("test", new object[] { new object[] {5, 6}, new object[]{6, 7} } );
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -866,6 +866,7 @@ namespace ProtoTest.TD.Associative
         }
 
         [Test]
+        [Category("Failure")]
         [Category("Replication")]
         public void T039_1467423_replication_guide_on_array_5()
         {
@@ -910,6 +911,7 @@ namespace ProtoTest.TD.Associative
         }
 
         [Test]
+        [Category("Failure")]
         [Category("Replication")]
         public void T039_1467423_replication_guide_on_array_9()
         {
@@ -921,6 +923,7 @@ namespace ProtoTest.TD.Associative
         }
 
         [Test]
+        [Category("Failure")]
         [Category("Replication")]
         public void T039_1467423_replication_guide_on_array_10()
         {


### PR DESCRIPTION
### Purpose

Three replication test cases `T039_1467423_replication_guide_on_array_10`, `T039_1467423_replication_guide_on_array_5`, `T039_1467423_replication_guide_on_array_5` fail because of inline condition expression doesn't SSA its true and false branch.

Previously for inline condition expression, the codegen will create dynamic language block for its true and false expression, but now the codegen won't create language blocks. Need to SSA these two branches.  

### Reviewers

- [ ] @junmendoza 
