### PR TITLE
Fixed various crashes in ColorRange node

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
@@ -58,11 +58,8 @@ namespace Dynamo.Wpf.Nodes
                 if (colorsMirror != null && colorsMirror.GetData() != null)
                 {
                     var data = colorsMirror.GetData();
-                    if (data.IsCollection)
+                    if (data != null)
                     {
-
-                        colors.AddRange(data.GetElements().Select(e => e.Data).Cast<Color>());
-                        
                         if (data.IsCollection)
                         {
                             colors.AddRange(data.GetElements().Select(e => e.Data).OfType<Color>());
@@ -74,12 +71,6 @@ namespace Dynamo.Wpf.Nodes
                                 colors.Add(color);
                         }
                     }
-                    else
-                    {
-                        var color = data.Data as Color;
-                        if (color != null)
-                            colors.Add(color);
-                    }
                 }
 
                 if (valuesMirror != null && valuesMirror.GetData() != null)
@@ -87,15 +78,19 @@ namespace Dynamo.Wpf.Nodes
                     var data = valuesMirror.GetData();
                     if (data.IsCollection)
                     {
-                        values.AddRange(data.
-                            GetElements().
-                            Select(e => e.Data).
-                            Select(d => Convert.ToDouble((object)d, CultureInfo.InvariantCulture)));
+                        var elements = data.GetElements().Select(e => e.Data);
+                        foreach (var element in elements)
+                        {
+                            double parsed;
+                            if (TryConvertToDouble(element, out parsed))
+                                values.Add(parsed);
+                        }
                     }
                     else
                     {
-                        var value = Convert.ToDouble(data.Data, CultureInfo.InvariantCulture);
-                        values.Add(value);
+                        double parsed;
+                        if (TryConvertToDouble(data.Data, out parsed))
+                            values.Add(parsed);
                     }
                 }
 
@@ -128,6 +123,21 @@ namespace Dynamo.Wpf.Nodes
             bitmap.WritePixels(new Int32Rect(0, 0, width, height), pixels, width * 4, 0);
 
             return bitmap;
+        }
+
+        private bool TryConvertToDouble(object value, out double parsed)
+        {
+            parsed = 0.0;
+
+            try
+            {
+                parsed = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
@@ -127,7 +127,7 @@ namespace Dynamo.Wpf.Nodes
 
         private bool TryConvertToDouble(object value, out double parsed)
         {
-            parsed = 0.0;
+            parsed = default(double);
 
             try
             {

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -341,6 +341,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(image.Source);
         }
 
+        [Test]
         public void InvalidInputShouldNotCrashColorRangeNode()
         {
             Open(@"UI\ColorRangeInvalidInputCrash.dyn");
@@ -352,6 +353,19 @@ namespace DynamoCoreWpfTests
             var guid = System.Guid.Parse("c1d3a92a-e4d4-47a8-8533-bf19e63e0bf9");
             Model.ExecuteCommand(new DynamoModel.UpdateModelValueCommand(
                 Model.CurrentWorkspace.Guid, guid, "Code", "5.6"));
+        }
+
+        [Test]
+        public void ArrayExprShouldNotCrashColorRangeNode()
+        {
+            var guid = System.Guid.Parse("c90f5c20-8c63-4708-bd1a-289647bae471");
+
+            OpenAndRun(@"UI\ArrayExprShouldNotCrashColorRangeNode.dyn");
+            var nodes = Model.CurrentWorkspace.Nodes.Where(n => n.GUID == guid);
+            var node = nodes.ElementAt(0) as CodeBlockNodeModel;
+            node.OnNodeModified(); // Mark node as dirty to tigger an immediate run.
+
+            Assert.Pass(); // We should reach here safely without exception.
         }
     }
 }

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -367,5 +367,22 @@ namespace DynamoCoreWpfTests
 
             Assert.Pass(); // We should reach here safely without exception.
         }
+
+        [Test]
+        public void InvalidValueShouldNotCrashColorRangeNode()
+        {
+            var guid0 = System.Guid.Parse("1a245b04-ad9e-4b9c-8301-730afbd4e6fc");
+            var guid1 = System.Guid.Parse("cece298a-22de-4f4a-a323-fdb04af406a4");
+
+            OpenAndRun(@"UI\InvalidValueShouldNotCrashColorRangeNode.dyn");
+            var nodes0 = Model.CurrentWorkspace.Nodes.Where(n => n.GUID == guid0);
+            var nodes1 = Model.CurrentWorkspace.Nodes.Where(n => n.GUID == guid0);
+            var node0 = nodes0.ElementAt(0) as CodeBlockNodeModel;
+            var node1 = nodes0.ElementAt(0) as CodeBlockNodeModel;
+            node0.OnNodeModified(); // Mark node as dirty to tigger an immediate run.
+            node1.OnNodeModified(); // Mark node as dirty to tigger an immediate run.
+
+            Assert.Pass(); // We should reach here safely without exception.
+        }
     }
 }

--- a/test/UI/ArrayExprShouldNotCrashColorRangeNode.dyn
+++ b/test/UI/ArrayExprShouldNotCrashColorRangeNode.dyn
@@ -1,7 +1,7 @@
 <Workspace Version="0.8.1.1314" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="c90f5c20-8c63-4708-bd1a-289647bae471" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="30" y="100" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{ { 1.0 }, 1.0 };&#xA;0.3;&#xA;0.6;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="c90f5c20-8c63-4708-bd1a-289647bae471" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="60.6666666666667" y="129.333333333333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{ { 1.0 }, 1.0 };&#xA;0.3;&#xA;0.6;" ShouldFocus="false" />
     <DSCoreNodesUI.ColorRange guid="6465aa45-ef84-4a34-90b0-49b659b3898c" type="DSCoreNodesUI.ColorRange" nickname="Color Range" x="282.666666666667" y="129.333333333333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
   </Elements>
   <Connectors>

--- a/test/UI/ArrayExprShouldNotCrashColorRangeNode.dyn
+++ b/test/UI/ArrayExprShouldNotCrashColorRangeNode.dyn
@@ -1,0 +1,14 @@
+<Workspace Version="0.8.1.1314" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="c90f5c20-8c63-4708-bd1a-289647bae471" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="30" y="100" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{ { 1.0 }, 1.0 };&#xA;0.3;&#xA;0.6;" ShouldFocus="false" />
+    <DSCoreNodesUI.ColorRange guid="6465aa45-ef84-4a34-90b0-49b659b3898c" type="DSCoreNodesUI.ColorRange" nickname="Color Range" x="282.666666666667" y="129.333333333333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="c90f5c20-8c63-4708-bd1a-289647bae471" start_index="0" end="6465aa45-ef84-4a34-90b0-49b659b3898c" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="c90f5c20-8c63-4708-bd1a-289647bae471" start_index="1" end="6465aa45-ef84-4a34-90b0-49b659b3898c" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="c90f5c20-8c63-4708-bd1a-289647bae471" start_index="2" end="6465aa45-ef84-4a34-90b0-49b659b3898c" end_index="2" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>

--- a/test/UI/InvalidValueShouldNotCrashColorRangeNode.dyn
+++ b/test/UI/InvalidValueShouldNotCrashColorRangeNode.dyn
@@ -3,10 +3,10 @@
     <ClassMap partialName="Color" resolvedName="DSCore.Color" assemblyName="DSCoreNodes.dll" />
   </NamespaceResolutionMap>
   <Elements>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="1a245b04-ad9e-4b9c-8301-730afbd4e6fc" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="11" y="88" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{ Color.ByARGB(255, 0, 255, 128), Color.ByARGB(255, 0, 128, 255) };&#xA;{ &quot;Value that can't be converted to double&quot;, 0.68 };" ShouldFocus="false" />
-    <DSCoreNodesUI.ColorRange guid="90cbbc86-35cf-49e8-b96d-9d3fc0ee95e4" type="DSCoreNodesUI.ColorRange" nickname="Color Range" x="750.666666666667" y="68.6666666666667" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
-    <Dynamo.Nodes.CodeBlockNodeModel guid="cece298a-22de-4f4a-a323-fdb04af406a4" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="14.6666666666666" y="255.333333333333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{ Color.ByARGB(255, 0, 255, 128), Color.ByARGB(255, 0, 128, 255) };&#xA;&quot;Value that can't be converted to double&quot;;" ShouldFocus="false" />
-    <DSCoreNodesUI.ColorRange guid="ba5762a2-9f93-4d74-af17-b2701ed28010" type="DSCoreNodesUI.ColorRange" nickname="Color Range" x="754.333333333334" y="236" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="1a245b04-ad9e-4b9c-8301-730afbd4e6fc" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="11" y="88" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{&#xA;    Color.ByARGB(255, 0, 255, 128),&#xA;    Color.ByARGB(255, 0, 128, 255)&#xA;};&#xA;&#xA;{ &quot;Value that can't be converted to double&quot;, 0.68 };" ShouldFocus="false" />
+    <DSCoreNodesUI.ColorRange guid="90cbbc86-35cf-49e8-b96d-9d3fc0ee95e4" type="DSCoreNodesUI.ColorRange" nickname="Color Range" x="541.333333333334" y="88" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="cece298a-22de-4f4a-a323-fdb04af406a4" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="11" y="254.666666666667" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{&#xA;    Color.ByARGB(255, 0, 255, 128),&#xA;    Color.ByARGB(255, 0, 128, 255)&#xA;};&#xA;&#xA;&quot;Value that can't be converted to double&quot;;" ShouldFocus="false" />
+    <DSCoreNodesUI.ColorRange guid="ba5762a2-9f93-4d74-af17-b2701ed28010" type="DSCoreNodesUI.ColorRange" nickname="Color Range" x="541.333333333334" y="254.666666666667" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
   </Elements>
   <Connectors>
     <Dynamo.Models.ConnectorModel start="1a245b04-ad9e-4b9c-8301-730afbd4e6fc" start_index="0" end="90cbbc86-35cf-49e8-b96d-9d3fc0ee95e4" end_index="0" portType="0" />

--- a/test/UI/InvalidValueShouldNotCrashColorRangeNode.dyn
+++ b/test/UI/InvalidValueShouldNotCrashColorRangeNode.dyn
@@ -1,0 +1,21 @@
+<Workspace Version="0.8.1.1314" X="16.6666666666666" Y="-21.3333333333333" zoom="1" Name="Home" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Color" resolvedName="DSCore.Color" assemblyName="DSCoreNodes.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="1a245b04-ad9e-4b9c-8301-730afbd4e6fc" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="11" y="88" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{ Color.ByARGB(255, 0, 255, 128), Color.ByARGB(255, 0, 128, 255) };&#xA;{ &quot;Value that can't be converted to double&quot;, 0.68 };" ShouldFocus="false" />
+    <DSCoreNodesUI.ColorRange guid="90cbbc86-35cf-49e8-b96d-9d3fc0ee95e4" type="DSCoreNodesUI.ColorRange" nickname="Color Range" x="750.666666666667" y="68.6666666666667" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="cece298a-22de-4f4a-a323-fdb04af406a4" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="14.6666666666666" y="255.333333333333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{ Color.ByARGB(255, 0, 255, 128), Color.ByARGB(255, 0, 128, 255) };&#xA;&quot;Value that can't be converted to double&quot;;" ShouldFocus="false" />
+    <DSCoreNodesUI.ColorRange guid="ba5762a2-9f93-4d74-af17-b2701ed28010" type="DSCoreNodesUI.ColorRange" nickname="Color Range" x="754.333333333334" y="236" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="1a245b04-ad9e-4b9c-8301-730afbd4e6fc" start_index="0" end="90cbbc86-35cf-49e8-b96d-9d3fc0ee95e4" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="1a245b04-ad9e-4b9c-8301-730afbd4e6fc" start_index="1" end="90cbbc86-35cf-49e8-b96d-9d3fc0ee95e4" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="1a245b04-ad9e-4b9c-8301-730afbd4e6fc" start_index="1" end="90cbbc86-35cf-49e8-b96d-9d3fc0ee95e4" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="cece298a-22de-4f4a-a323-fdb04af406a4" start_index="0" end="ba5762a2-9f93-4d74-af17-b2701ed28010" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="cece298a-22de-4f4a-a323-fdb04af406a4" start_index="1" end="ba5762a2-9f93-4d74-af17-b2701ed28010" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="cece298a-22de-4f4a-a323-fdb04af406a4" start_index="1" end="ba5762a2-9f93-4d74-af17-b2701ed28010" end_index="2" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
### Purpose

This pull request fixes various crashing issues in `ColorRange` node when it is fed invalid inputs. This is the extension of [my previous fix](https://github.com/DynamoDS/Dynamo/pull/4477) that has unfortunately regressed due to [another auto-merge commit](https://github.com/DynamoDS/Dynamo/commit/4cb46420fdde34205811a43347a5977e0e602fcc). It is now covering all other scenarios in this internal defect:

- [MAGN-7319](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7319) Color Range node crashes Dynamo when there is type mismatch in arguments

The following crashing scenarios are being tested by the two new test cases:

![color-range-crash-scenario](https://cloud.githubusercontent.com/assets/5086849/7720543/1c0d34d4-ff01-11e4-93e8-a56933c19df6.png)

![color-range-crash-scenarios](https://cloud.githubusercontent.com/assets/5086849/7720546/21889124-ff01-11e4-818a-7634c972d48d.png)

### Declarations

Check these iff you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

Hi @ke-yu, please have a look (since you have previously handled valid/invalid `MirrorData.Data` values).

### FYIs

Hi @ramramps, unfortunately [your previous auto-merge commit](https://github.com/DynamoDS/Dynamo/commit/4cb46420fdde34205811a43347a5977e0e602fcc) re-introduced the defect, so I'm just removing what `git` had added on your behalf :)