### PR TITLE
Reenable the SurfaceData node.

### DIFF
--- a/src/Libraries/Analysis/SurfaceData.cs
+++ b/src/Libraries/Analysis/SurfaceData.cs
@@ -1,30 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Diagnostics;
-using System.Dynamic;
 using System.Linq;
-using System.Net.Configuration;
-using System.Text;
-using System.Threading;
-
 using Autodesk.DesignScript.Geometry;
 using Autodesk.DesignScript.Interfaces;
 using Autodesk.DesignScript.Runtime;
-
 using DSCore;
-
 using MIConvexHull;
-
-using Tessellation;
 using Tessellation.Adapters;
+using Math = System.Math;
 
 namespace Analysis
 {
     /// <summary>
     /// A class for storing structured surface analysis data.
     /// </summary>
-    [IsVisibleInDynamoLibrary(false)]
     public class SurfaceData : ISurfaceData<UV, double>, IGraphicItem
     {
         private Color[,] colorMap ;
@@ -378,7 +368,7 @@ namespace Analysis
     {
         public static bool IsAlmostEqualTo(this UV a, UV b)
         {
-            return System.Math.Abs(a.U - b.U) < 1.0e-6 && System.Math.Abs(a.V - b.V) < 1.0e-6;
+            return Math.Abs(a.U - b.U) < 1.0e-6 && Math.Abs(a.V - b.V) < 1.0e-6;
         }
     }
 }


### PR DESCRIPTION
### Purpose

The SurfaceData node is required for the Solar Analysis for Dynamo package. @kronz and I have discussed splitting this node into two, but there is a separate task for that, and I don't want to block Solar Analysis for Dynamo being available for 0.8.1.

### Declarations

- [x] The code base is in a better state after this PR
  - A minor change, removing an attribute to show  the node in the library.
- [x] The level of testing this PR includes is appropriate
  - No new tests added.

### Reviewers

@ramramps 

### FYIs

@kronz 