### PR TITLE
MAGN-7439 After grouping operation loading Recent, Files can crash application

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -251,7 +251,7 @@
                                 <Condition Value="True">
                                     <Condition.Binding>
                                         <MultiBinding Converter="{StaticResource GroupFontSizeToEditorEnabledConverter }">
-                                            <Binding Path ="DataContext.Zoom" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type views:WorkspaceView}}"></Binding>
+                                            <Binding Path ="DataContext.Zoom" FallbackValue="1.0" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type views:WorkspaceView}}"></Binding>
                                             <Binding ElementName="GroupTextBlock" Path="FontSize"/>
                                             <Binding ElementName="GroupTextBlock" Path="Visibility"/>
                                         </MultiBinding>


### PR DESCRIPTION
### Purpose
 This PR fixes the issue with crash if the same file is opened twice (Only with groups)

### Declarations
- [x] The code base is in a better state after this PR.
          Included a fallbackvalue (like default value) in Multitrigger
- [] The level of testing this PR includes is appropriate
            
### Reviewers
- [ ] @pboyer