### PR TITLE
MAGN-7431 Custom node creation does not carry over existing groups

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1388,9 +1388,7 @@ namespace Dynamo.Models
             }
             else if (model is AnnotationModel)
             {
-                var annotation = model as AnnotationModel;
-                Annotations.Remove(annotation);
-                annotation.Dispose();
+                RemoveGroup(model);
             }
             else if (model is ConnectorModel)
             {
@@ -1407,6 +1405,13 @@ namespace Dynamo.Models
                 throw new InvalidOperationException(string.Format(
                     "Unhandled type: {0}", model.GetType()));
             }
+        }
+
+        public void RemoveGroup(ModelBase model)
+        {
+            var annotation = model as AnnotationModel;
+            Annotations.Remove(annotation);
+            annotation.Dispose();
         }
 
         public void ReloadModel(XmlElement modelData)

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -251,7 +251,7 @@
                                 <Condition Value="True">
                                     <Condition.Binding>
                                         <MultiBinding Converter="{StaticResource GroupFontSizeToEditorEnabledConverter }">
-                                            <Binding Path ="DataContext.Zoom" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type views:WorkspaceView}}"></Binding>
+                                            <Binding Path ="DataContext.Zoom" FallbackValue="1.0" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type views:WorkspaceView}}"></Binding>
                                             <Binding ElementName="GroupTextBlock" Path="FontSize"/>
                                             <Binding ElementName="GroupTextBlock" Path="Visibility"/>
                                         </MultiBinding>

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -815,5 +815,55 @@ namespace Dynamo.Tests
             Assert.AreEqual("x", customInstance.InPorts.First().PortName);
             Assert.AreEqual("bool", customInstance.InPorts.First().ToolTipContent);
         }
+
+        [Test]
+        public void TestGroupsOnCustomNodes()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\collapse\collapse.dyn");
+            OpenModel(openPath);
+
+            var nodesToCollapse = new[]
+            {
+                "1da395b9-2539-4705-a479-1f6e575df01d", 
+                "b8130bf5-dd14-4784-946d-9f4705df604e",
+                "a54c7cfa-450a-4edc-b7a5-b3e15145a9e1"
+            };
+
+            foreach (
+                var node in
+                    nodesToCollapse.Select(CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace))
+            {
+                CurrentDynamoModel.AddToSelection(node);
+            }
+
+            //create the group around selected nodes
+            Guid groupid = Guid.NewGuid();
+            var annotation = CurrentDynamoModel.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
+            Assert.AreEqual(CurrentDynamoModel.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(CurrentDynamoModel.CurrentWorkspace.Annotations.First().SelectedModels.Count(), 3);
+
+            CurrentDynamoModel.AddToSelection(annotation);
+
+            var ws = CurrentDynamoModel.CustomNodeManager.Collapse(
+                DynamoSelection.Instance.Selection.OfType<NodeModel>(),
+                CurrentDynamoModel.CurrentWorkspace,
+                true,
+                new FunctionNamePromptEventArgs
+                {
+                    Category = "Testing",
+                    Description = "",
+                    Name = "__CollapseTest2__",
+                    Success = true
+                });
+
+            CurrentDynamoModel.AddCustomNodeWorkspace(ws);
+
+            SelectTabByGuid(ws.CustomNodeId);
+
+            Assert.AreEqual(6, CurrentDynamoModel.CurrentWorkspace.Nodes.Count);
+
+            //Check whether the group is copied to custom workspace
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Annotations.Count); 
+        }
     }
 }


### PR DESCRIPTION
### Purpose
 This PR fixes the issue with Groups on Custom Nodes. 

### Declarations
- [x] The code base is in a better state after this PR.
          Included the functionality to carry over groups to custom workspace. 
          The groups in Home workspace will be removed, even if there is any note in that group.
- [x] The level of testing this PR includes is appropriate
            Included a test  TestGroupsOnCustomNodes
 
### Reviewers
- [ ] @pboyer