### PR TITLE
Fix new connectors not cleanup after undo n2c

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1158,7 +1158,7 @@ namespace Dynamo.Models
                     }
 
                     var newOutputConnectors = ReConnectOutputConnections(externalOutputConnections, codeBlockNode);
-                    foreach (var connector in newInputConnectors)
+                    foreach (var connector in newOutputConnectors)
                     {
                         undoHelper.RecordCreation(connector);
                     }

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -587,6 +587,53 @@ namespace Dynamo.Tests
             Assert.AreEqual("Point.ByCoordinates(t1, 0)", expr.RightNode.ToString());
         }
 
+        private void TestNodeToCodeUndoBase(string filePath)
+        {
+            // Verify after undo all nodes and connectors should be resotored back
+            // to original state.
+            OpenModel(filePath);
+
+            var wp = CurrentDynamoModel.CurrentWorkspace;
+            var nodeGuids = wp.Nodes.Select(n => n.GUID).ToList();
+            nodeGuids.Sort();
+
+            var connectorGuids = wp.Connectors.Select(c => c.GUID).ToList();
+            connectorGuids.Sort();
+
+            SelectAll(wp.Nodes);
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            var undo = new DynamoModel.UndoRedoCommand(DynamoModel.UndoRedoCommand.Operation.Undo);
+            CurrentDynamoModel.ExecuteCommand(undo);
+
+            var curNodeGuids = wp.Nodes.Select(n => n.GUID).ToList();
+            curNodeGuids.Sort();
+
+            var curConnectorGuids = wp.Connectors.Select(c => c.GUID).ToList();
+            curConnectorGuids.Sort();
+
+            Assert.AreEqual(curNodeGuids.Count, nodeGuids.Count);
+            Assert.IsTrue(nodeGuids.SequenceEqual(curNodeGuids));
+
+            Assert.AreEqual(curConnectorGuids.Count, connectorGuids.Count);
+            Assert.IsTrue(connectorGuids.SequenceEqual(curConnectorGuids));
+        }
+
+        [Test]
+        public void TestNodeToCodeUndo1()
+        {
+            TestNodeToCodeUndoBase(@"core\node2code\undo1.dyn");
+        }
+
+        [Test]
+        public void TestNodeToCodeUndo2()
+        {
+            TestNodeToCodeUndoBase(@"core\node2code\undo2.dyn");
+        }
+
+
+
         [Test]
         [Category("UnitTest")]
         public void TestNodeToCodeUndoRecorder()

--- a/test/core/node2code/undo1.dyn
+++ b/test/core/node2code/undo1.dyn
@@ -1,0 +1,73 @@
+<Workspace Version="0.8.1.1401" X="16047.4764983494" Y="13158.6041061022" zoom="0.650868662862132" Name="Home" RunType="Manual" RunPeriod="100" HasRunWithoutCrash="False">
+  <NamespaceResolutionMap />
+  <Elements>
+    <DSCoreNodesUI.CreateList guid="fc159a46-e230-462d-91e7-ac387a527d64" type="DSCoreNodesUI.CreateList" nickname="List.Create" x="-24180.0283403342" y="-19861.4432371731" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="4" />
+    <DSCoreNodesUI.BoolSelector guid="6e4f5b2b-2389-451b-9545-9dea13431b8b" type="DSCoreNodesUI.BoolSelector" nickname="Boolean" x="-23930.9783744459" y="-19851.6236889259" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Boolean>True</System.Boolean>
+    </DSCoreNodesUI.BoolSelector>
+    <Dynamo.Nodes.DSFunction guid="2c8d0d14-0440-438c-b81c-dcdeefc1b77e" type="Dynamo.Nodes.DSFunction" nickname="Curve.PointAtParameter" x="-23180.3194152019" y="-19793.7458270855" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.PointAtParameter@double">
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="8ba3309a-6ded-4059-a074-fa0c2b291919" type="Dynamo.Nodes.DSFunction" nickname="NurbsCurve.ByControlPoints" x="-23754.5915986248" y="-19921.0404200555" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByControlPoints@Autodesk.DesignScript.Geometry.Point[],int,bool">
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="835b1ec2-52ca-4b63-9a1f-2a0dde80b497" type="Dynamo.Nodes.DSFunction" nickname="PolyCurve.ByPoints" x="-23758.4578201975" y="-19648.9736913069" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.PolyCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],bool">
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="d200379e-5c8c-4f8b-968d-2f0887223d68" type="Dynamo.Nodes.DSFunction" nickname="NurbsCurve.ByPoints" x="-23753.2993692271" y="-19749.5634852303" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="7820af5f-481d-4af7-9b35-9e608a64b96d" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-23325.7070393249" y="-19700.2562560531" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0..1..#20;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="eaae1aa1-4188-4897-8ae4-a743ac654a51" type="Dynamo.Nodes.DSFunction" nickname="Curve.Length" x="-23167.7427863276" y="-19987.0611419685" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.Length" />
+    <Dynamo.Nodes.DSFunction guid="7979f6ce-63b6-4cfb-9872-9d05812a111c" type="Dynamo.Nodes.DSFunction" nickname="Line.ByStartPointEndPoint" x="-23755.1545802998" y="-20044.7180525039" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point" />
+    <Dynamo.Nodes.DoubleInput guid="bc1ea099-1645-4e28-b574-19385b4d812b" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="-24609.192097963" y="-19857.4950514135" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="5" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DoubleInput guid="e8e066b3-31a0-48ad-bf0f-d5e0e27a1c20" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="-24609.192097963" y="-19586.6763754658" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="15" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DoubleInput guid="4f378cbb-3c5d-4496-b11b-e74d16300d48" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="-24609.192097963" y="-19704.0311350431" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="10" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DSFunction guid="64155f51-0808-47f8-be8d-0fb57485b1e3" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="-24469.5492826162" y="-19598.9498803032" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="e594468a-4123-44b4-8708-84b31915b703" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="-24470.1390765397" y="-19888.415696243" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="fb265a32-22b0-4d2a-b4f7-26b28bc90c10" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="-24471.4286892823" y="-19740.8597671717" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="918f7dc4-e6d0-4d6b-9b51-c329d02db2b2" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="-24471.4286892823" y="-20038.7078255326" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="fc159a46-e230-462d-91e7-ac387a527d64" start_index="0" end="8ba3309a-6ded-4059-a074-fa0c2b291919" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="fc159a46-e230-462d-91e7-ac387a527d64" start_index="0" end="835b1ec2-52ca-4b63-9a1f-2a0dde80b497" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="fc159a46-e230-462d-91e7-ac387a527d64" start_index="0" end="d200379e-5c8c-4f8b-968d-2f0887223d68" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="6e4f5b2b-2389-451b-9545-9dea13431b8b" start_index="0" end="8ba3309a-6ded-4059-a074-fa0c2b291919" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="835b1ec2-52ca-4b63-9a1f-2a0dde80b497" start_index="0" end="2c8d0d14-0440-438c-b81c-dcdeefc1b77e" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="7820af5f-481d-4af7-9b35-9e608a64b96d" start_index="0" end="2c8d0d14-0440-438c-b81c-dcdeefc1b77e" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="7979f6ce-63b6-4cfb-9872-9d05812a111c" start_index="0" end="eaae1aa1-4188-4897-8ae4-a743ac654a51" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="bc1ea099-1645-4e28-b574-19385b4d812b" start_index="0" end="e594468a-4123-44b4-8708-84b31915b703" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="e8e066b3-31a0-48ad-bf0f-d5e0e27a1c20" start_index="0" end="64155f51-0808-47f8-be8d-0fb57485b1e3" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="4f378cbb-3c5d-4496-b11b-e74d16300d48" start_index="0" end="fb265a32-22b0-4d2a-b4f7-26b28bc90c10" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="4f378cbb-3c5d-4496-b11b-e74d16300d48" start_index="0" end="fb265a32-22b0-4d2a-b4f7-26b28bc90c10" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="64155f51-0808-47f8-be8d-0fb57485b1e3" start_index="0" end="fc159a46-e230-462d-91e7-ac387a527d64" end_index="3" portType="0" />
+    <Dynamo.Models.ConnectorModel start="e594468a-4123-44b4-8708-84b31915b703" start_index="0" end="7979f6ce-63b6-4cfb-9872-9d05812a111c" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="e594468a-4123-44b4-8708-84b31915b703" start_index="0" end="fc159a46-e230-462d-91e7-ac387a527d64" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="fb265a32-22b0-4d2a-b4f7-26b28bc90c10" start_index="0" end="fc159a46-e230-462d-91e7-ac387a527d64" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="918f7dc4-e6d0-4d6b-9b51-c329d02db2b2" start_index="0" end="7979f6ce-63b6-4cfb-9872-9d05812a111c" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="918f7dc4-e6d0-4d6b-9b51-c329d02db2b2" start_index="0" end="fc159a46-e230-462d-91e7-ac387a527d64" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>

--- a/test/core/node2code/undo2.dyn
+++ b/test/core/node2code/undo2.dyn
@@ -1,0 +1,63 @@
+<Workspace Version="0.8.1.1401" X="-751.267541188747" Y="-14.8067112496868" zoom="0.384722275865884" Name="Home" RunType="Manual" RunPeriod="100" HasRunWithoutCrash="False">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DoubleInput guid="d0036752-d644-4511-9937-c17b4f152313" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="2122.37470588" y="834.676641352278" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="1..50..5" />
+    </Dynamo.Nodes.DoubleInput>
+    <DSCoreNodesUI.Input.DoubleSlider guid="7f7418c2-598d-4957-981b-aea1761ccc03" type="DSCoreNodesUI.Input.DoubleSlider" nickname="Number Slider" x="2030.73123184866" y="1135.76379458565" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double>28.6701555980507</System.Double>
+      <Range min="-10" max="60" step="0.1" />
+    </DSCoreNodesUI.Input.DoubleSlider>
+    <DSCoreNodesUI.Input.DoubleSlider guid="84fb372a-fa22-4d3b-8888-e794becddcc2" type="DSCoreNodesUI.Input.DoubleSlider" nickname="Number Slider" x="2031.67771968067" y="1209.82686895366" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double>11.5011100116203</System.Double>
+      <Range min="-10" max="60" step="0.1" />
+    </DSCoreNodesUI.Input.DoubleSlider>
+    <Dynamo.Nodes.DSFunction guid="8163332d-21ec-4257-9a5a-0b69462db44f" type="Dynamo.Nodes.DSFunction" nickname="Geometry.DistanceTo" x="2955.98929738001" y="1085.5216663381" isVisible="true" isUpstreamVisible="true" lacing="Longest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.DistanceTo@Autodesk.DesignScript.Geometry.Geometry" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="89a6dea1-9e7f-45c6-bd41-ab9599418d4f" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="3297.57176854913" y="1043.65634372244" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="x/15;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="ef3eaed0-7a8e-47a9-b06e-416bb30ec72f" type="Dynamo.Nodes.DSFunction" nickname="Cylinder.ByPointsRadius" x="4363.43485358554" y="839.196052945691" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Cylinder.ByPointsRadius@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point,double">
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="14f9df69-7ef3-4e31-808b-016d3bc301bb" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="3299.65733355256" y="1285.23650666788" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="x/2;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="f3292f8a-210f-42a8-b1e2-b3ee374027fe" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="2366.17715574377" y="830.57899335569" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="3f00be88-170f-4ebe-b81a-011c32ed2acb" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="2377.95534361404" y="1151.51909603367" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="0de075f3-6c86-4193-b479-2397c3bc988a" type="Dynamo.Nodes.DSFunction" nickname="Flatten" x="2679.03437205091" y="838.394648825246" isVisible="true" isUpstreamVisible="true" lacing="Disabled" assembly="" function="Flatten@var[]..[]" />
+    <Dynamo.Nodes.DSFunction guid="6f34eb44-42e1-41f1-8ed8-9682850e940a" type="Dynamo.Nodes.DSFunction" nickname="Point.Add" x="3953.0556412283" y="1172.46221176766" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector" />
+    <Dynamo.Nodes.DSFunction guid="e87affcb-cc80-492c-a247-048ed003f3ec" type="Dynamo.Nodes.DSFunction" nickname="Vector.ByCoordinates" x="3775.97736987941" y="1240.00432507557" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="a7072f75-e469-42d8-9fc8-81e45bd9bb6a" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="3666.18669476085" y="1240.05904891606" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="d0036752-d644-4511-9937-c17b4f152313" start_index="0" end="f3292f8a-210f-42a8-b1e2-b3ee374027fe" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d0036752-d644-4511-9937-c17b4f152313" start_index="0" end="f3292f8a-210f-42a8-b1e2-b3ee374027fe" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="7f7418c2-598d-4957-981b-aea1761ccc03" start_index="0" end="3f00be88-170f-4ebe-b81a-011c32ed2acb" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="84fb372a-fa22-4d3b-8888-e794becddcc2" start_index="0" end="3f00be88-170f-4ebe-b81a-011c32ed2acb" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="8163332d-21ec-4257-9a5a-0b69462db44f" start_index="0" end="89a6dea1-9e7f-45c6-bd41-ab9599418d4f" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="8163332d-21ec-4257-9a5a-0b69462db44f" start_index="0" end="14f9df69-7ef3-4e31-808b-016d3bc301bb" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="89a6dea1-9e7f-45c6-bd41-ab9599418d4f" start_index="0" end="ef3eaed0-7a8e-47a9-b06e-416bb30ec72f" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="14f9df69-7ef3-4e31-808b-016d3bc301bb" start_index="0" end="e87affcb-cc80-492c-a247-048ed003f3ec" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="f3292f8a-210f-42a8-b1e2-b3ee374027fe" start_index="0" end="0de075f3-6c86-4193-b479-2397c3bc988a" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="3f00be88-170f-4ebe-b81a-011c32ed2acb" start_index="0" end="8163332d-21ec-4257-9a5a-0b69462db44f" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="0de075f3-6c86-4193-b479-2397c3bc988a" start_index="0" end="8163332d-21ec-4257-9a5a-0b69462db44f" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="0de075f3-6c86-4193-b479-2397c3bc988a" start_index="0" end="ef3eaed0-7a8e-47a9-b06e-416bb30ec72f" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="0de075f3-6c86-4193-b479-2397c3bc988a" start_index="0" end="6f34eb44-42e1-41f1-8ed8-9682850e940a" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="6f34eb44-42e1-41f1-8ed8-9682850e940a" start_index="0" end="ef3eaed0-7a8e-47a9-b06e-416bb30ec72f" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="e87affcb-cc80-492c-a247-048ed003f3ec" start_index="0" end="6f34eb44-42e1-41f1-8ed8-9682850e940a" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="a7072f75-e469-42d8-9fc8-81e45bd9bb6a" start_index="0" end="e87affcb-cc80-492c-a247-048ed003f3ec" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="a7072f75-e469-42d8-9fc8-81e45bd9bb6a" start_index="0" end="e87affcb-cc80-492c-a247-048ed003f3ec" end_index="1" portType="0" />
+  </Connectors>
+  <Notes>
+    <Dynamo.Models.NoteModel guid="850ab670-5b92-4160-abcf-a59095d60ea6" text="" x="2536.33939921673" y="-1739.23475595505" />
+  </Notes>
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
### Purpose

New connectors that created in node to code still remain on the screen after undo node to code. That is because new output connectors are not added to undo recorder (input connectors are added twice!)

### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

- [x] @Benglin 

### FYIs

@lukechurch , it has been enabled.