### PR TITLE
Fix MAGN-7313 Recent file section messed up

### DIFF
--- a/src/DynamoCore/Core/PreferenceSettings.cs
+++ b/src/DynamoCore/Core/PreferenceSettings.cs
@@ -19,9 +19,11 @@ namespace Dynamo
     /// </summary>
     public class PreferenceSettings : NotificationObject, IPreferences
     {
+        public const int DefaultMaxNumRecentFiles = 10;
         public static string DynamoTestPath = null;
         private string numberFormat;
         private string lastUpdateDownloadPath;
+        private int maxNumRecentFiles;
         
         // Variables of the settings that will be persistent
 
@@ -74,8 +76,19 @@ namespace Dynamo
         /// </summary>
         public int MaxNumRecentFiles
         {
-            get { return 10; }
-            set { }
+            get { return maxNumRecentFiles; }
+            set
+            {
+                if (value > 0)
+                {
+                    maxNumRecentFiles = value;
+                }
+                else
+                {
+                    maxNumRecentFiles = DefaultMaxNumRecentFiles;
+                }
+                RaisePropertyChanged("MaxNumRecentFiles");
+            }
         }
 
         /// <summary>
@@ -155,6 +168,7 @@ namespace Dynamo
             NumberFormat = "f3";
             UseHardwareAcceleration = true;
             PackageDownloadTouAccepted = false;
+            maxNumRecentFiles = DefaultMaxNumRecentFiles;
 
             BackupInterval = 60000; // 1 minute
             BackupFilesCount = 1;

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1054,9 +1054,10 @@ namespace Dynamo.ViewModels
 
             RecentFiles.Insert(0, path);
 
-            if (RecentFiles.Count > Model.PreferenceSettings.MaxNumRecentFiles)
+            int maxNumRecentFiles = Model.PreferenceSettings.MaxNumRecentFiles;
+            if (RecentFiles.Count > maxNumRecentFiles)
             {
-                RecentFiles = new ObservableCollection<string>(RecentFiles.Take(Model.PreferenceSettings.MaxNumRecentFiles));
+                RecentFiles.RemoveRange(maxNumRecentFiles, RecentFiles.Count - maxNumRecentFiles);
             }
         }
 

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="PackageManager\PackageDependencyTests.cs" />
     <Compile Include="PackageManager\PackageManagerSearchViewModelTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RecentFileTests.cs" />
     <Compile Include="RecordedTests.cs" />
     <Compile Include="RunSettingsTests.cs" />
     <Compile Include="SearchMemberGroupTests.cs" />

--- a/test/DynamoCoreWpfTests/RecentFileTests.cs
+++ b/test/DynamoCoreWpfTests/RecentFileTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Dynamo.Models;
+using Dynamo.Nodes;
+using Dynamo.Search.SearchElements;
+using Dynamo.Wpf.ViewModels;
+
+using NUnit.Framework;
+
+namespace Dynamo.Tests
+{
+    public class RecentFileTests : DynamoViewModelUnitTest
+    {
+        [Test]
+        public void SavingFilesUpdateRecentFileList()
+        {
+            // Open a file
+            var examplePath = Path.Combine(TestDirectory, @"core\math", "Add.dyn");
+            ViewModel.OpenCommand.Execute(examplePath);
+
+            List<string> paths = new List<string>();
+
+            // Save the file as different files for (maxNum + 1) times
+            int maxNum = ViewModel.Model.PreferenceSettings.MaxNumRecentFiles;
+            for (int i = 0; i < maxNum + 1; i++)
+            {
+                var newPath = GetNewFileNameOnTempPath("dyn");
+                var res = ViewModel.Model.CurrentWorkspace.SaveAs(newPath, ViewModel.Model.EngineController.LiveRunnerRuntimeCore);
+                Assert.IsTrue(res);
+                paths.Add(newPath);
+            }
+
+            // Ensure the number of recent files reaches the maximum number
+            Assert.AreEqual(maxNum, ViewModel.Model.PreferenceSettings.RecentFiles.Count);
+
+            // Ensure the recent files are recent
+            for (int i = 0; i < maxNum; i++)
+            {
+                Assert.AreEqual(0, string.CompareOrdinal(paths.ElementAt(maxNum - i), ViewModel.Model.PreferenceSettings.RecentFiles[i]));
+            }
+
+            // Clear and delete the temporary files
+            ViewModel.RecentFiles.Clear();
+            foreach (var filePath in paths)
+            {
+                File.Delete(filePath);
+            }
+        }
+        
+        [Test]
+        public void SetMaxNumRecentFiles()
+        {
+            ViewModel.Model.PreferenceSettings.MaxNumRecentFiles = 0;
+
+            Assert.AreEqual(PreferenceSettings.DefaultMaxNumRecentFiles, ViewModel.Model.PreferenceSettings.MaxNumRecentFiles);
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

This submission is to fix MAGN-7313. There are two issues found:
1). The maximum number of recent files is hard-coded to 10. It won't change even the number is changed in the settings.
2). When the number of recent files is bigger than the maximum number, RecentFiles is updated to a new OberservableCollection. Thus the event handlers registered with the old collection will not be triggered when there are elements added or deleted in the new collection.

The submission fixes the first issue by adding a set handler for the MaxNumRecentFiles property, and when the new value is 0, it will set it to 10 which is now meant to be the default value. It fixes the second issue by removing elements from the original collection instead of creating a new one.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@aparajit-pratap 

### FYIs

@riteshchandawar 