### PR TITLE
Added tooltip suggestion to Excel.WriteToFile node

### DIFF
--- a/src/Libraries/DSOffice/Excel.cs
+++ b/src/Libraries/DSOffice/Excel.cs
@@ -288,8 +288,8 @@ namespace DSOffice
         ///     Write data to a Microsoft Excel spreadsheet. Data is written by row
         ///     with sublists to be written in successive rows. Rows and columns are
         ///     zero-indexed; for example, the value in the data list at [0,0] will
-        ///     be written to cell A1. This node requires Microsoft Excel to be
-        ///     installed.
+        ///     be written to cell A1. Null values are written to Excel as empty cells.
+        ///     This node requires Microsoft Excel to be installed. 
         /// </summary>
         /// <param name="filePath">File path to the Microsoft Excel spreadsheet.</param>
         /// <param name="sheetName">Name of the workseet to write data to.</param>


### PR DESCRIPTION
### Purpose

This PR adds tooltip text clarifying the output of the `Excel.WriteToFile` node with `null` values to the user. This addresses the issue: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7442

### Declarations
No testing impact.

### FYIs

@monikaprabhu @mccrone 