### PR TITLE
MAGN-7426 Group title can bleed outside the group's right side

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -213,10 +213,10 @@
                 <SolidColorBrush Color="{Binding Background}"></SolidColorBrush>
             </Rectangle.Fill>
         </Rectangle>
-        <Grid x:Name="TextBlockGrid" Grid.Row="0" Height="auto" MaxWidth="{Binding Width}" 
-              Margin="5,0,5,0"
+        <Grid x:Name="TextBlockGrid" Grid.Row="0" Height="auto" MaxWidth="{Binding Width}"             
               VerticalAlignment="Top">            
-            <TextBlock x:Name="GroupTextBlock"                                     
+            <TextBlock x:Name="GroupTextBlock" 
+                    Margin="10,0,10,0"
                     Text ="{Binding AnnotationText, Converter={StaticResource AnnotationTextConverter}}"    
                     Visibility="Visible"
                     MaxWidth="{Binding Width}"  
@@ -227,6 +227,7 @@
                     TextWrapping="Wrap">                  
             </TextBlock>
             <TextBox 
+                    Margin="10,0,10,0"
                     Name="GroupTextBox" 
                     Visibility="Collapsed"
                     Text ="{Binding AnnotationText,Converter={StaticResource AnnotationTextConverter}}"                                                    


### PR DESCRIPTION
### Purpose
 This PR fixes the issue with Margin on Title border.

### Declarations
- [x] The code base is in a better state after this PR.
        Updated the Title margin so that it looks like a "title".
- [] The level of testing this PR includes is appropriate
            
### Reviewers
- [ ] @pboyer