### PR TITLE
Fix failing test cases because view is not created

### DIFF
--- a/test/Libraries/SystemTestServices/SystemTestBase.cs
+++ b/test/Libraries/SystemTestServices/SystemTestBase.cs
@@ -100,7 +100,7 @@ namespace SystemTestServices
             //not having changes.
             ViewModel.HomeSpace.HasUnsavedChanges = false;
 
-            if (View.IsLoaded)
+            if (null != View && View.IsLoaded)
                 View.Close();
 
             if (ViewModel != null)


### PR DESCRIPTION
### Purpose

This is to fix failing test cases. The test cases are failing because a view is not created but it is used later. Thus there will be a null reference exception.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@aparajit-pratap 

### FYIs

@ikeough 

For some test cases, views are not created initially. So it will cause issues when using them. 