### PR TITLE
Fix ColorRange Unconnected Node Crash

### DIFF
--- a/src/Libraries/CoreNodeModels/ColorRange.cs
+++ b/src/Libraries/CoreNodeModels/ColorRange.cs
@@ -32,9 +32,6 @@ namespace DSCoreNodesUI
 
             RegisterAllPorts();
 
-
-            ArgumentLacing = LacingStrategy.Disabled;
-
             this.PropertyChanged += ColorRange_PropertyChanged; 
             
             ShouldDisplayPreviewCore = false;

--- a/test/DynamoCoreWpfTests/ColorRangeTests.cs
+++ b/test/DynamoCoreWpfTests/ColorRangeTests.cs
@@ -1,0 +1,24 @@
+﻿using SystemTestServices;
+using DSCoreNodesUI;
+using Dynamo.Models;
+using DynamoCoreWpfTests.Utility;
+using NUnit.Framework;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    class ColorRangeTests : SystemTestBase
+    {
+        [Test]
+        public void ColorRange_AddToHomespaceAndRun_NoException()
+        {
+            var homespace = Model.CurrentWorkspace as HomeWorkspaceModel;
+            Assert.NotNull(homespace, "The current workspace is not a HomeWorkspaceModel");
+            var colorRange = new ColorRange();
+            Model.AddNodeToCurrentWorkspace(colorRange, true);
+            homespace.Run();
+            Assert.DoesNotThrow(DispatcherUtil.DoEvents);
+            Assert.Pass();
+        }
+    }
+}

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="AnnotationViewModelTests.cs" />
     <Compile Include="AnnotationViewTests.cs" />
     <Compile Include="CodeBlockNodeTests.cs" />
+    <Compile Include="ColorRangeTests.cs" />
     <Compile Include="ConverterTests.cs" />
     <Compile Include="CoreUITests.cs" />
     <Compile Include="DropDownTests.cs" />


### PR DESCRIPTION
### Purpose

When a `ColorRange` node was added to the workspace without connections, an attempt to call `UpdateColorRange` would result in an out of bounds exceptions as we attempt to get the mirror data for upstream objects via their connectors, of which there are none when this node is disconnected. This PR adds a check for missing upstream connections and refactors the internals of `UpdateColorRange` for readability.

NOTE:
This crash occurs only on Revit. In sand box, the exception thrown in the `UpdateColorRange` method is handled in the `TryApplyCustomization` method. I am not sure why this is the case, but the added test, when Run on Revit should verify against this failure.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
  - Refactored the internals of the `UpdateColorRange` method for readability.
- [x] The level of testing this PR includes is appropriate
  - One new test added.  
### Reviewers

@ramramps 
