### PR TITLE
Dynamo lookup is refactored

### DIFF
--- a/src/DynamoCore/UpdateManager/UpdateManager.cs
+++ b/src/DynamoCore/UpdateManager/UpdateManager.cs
@@ -62,6 +62,11 @@ namespace Dynamo.UpdateManager
         /// installed on this system.
         /// </summary>
         IEnumerable<string> GetDynamoInstallLocations();
+
+        /// <summary>
+        /// Gets the version of latest installed product
+        /// </summary>
+        BinaryVersion LatestProduct { get; }
     }
 
     public interface IUpdateManagerConfiguration
@@ -1087,7 +1092,7 @@ namespace Dynamo.UpdateManager
         internal static void CheckForProductUpdate(IUpdateManager manager)
         {
             //If we already have higher version installed, don't look for product update.
-            if(new DynamoLookUpHelper(manager.Configuration.DynamoLookUp).LatestProduct > manager.ProductVersion)
+            if(manager.Configuration.DynamoLookUp != null && manager.Configuration.DynamoLookUp.LatestProduct > manager.ProductVersion)
                 return;
 
             var downloadUri = new Uri(manager.Configuration.DownloadSourcePath);
@@ -1098,14 +1103,8 @@ namespace Dynamo.UpdateManager
     /// <summary>
     /// Lookup for installed products
     /// </summary>
-    public class DynamoLookUpHelper
+    public abstract class DynamoLookUp : IDynamoLookUp
     {
-        private readonly IDynamoLookUp productLookUp = null;
-        public DynamoLookUpHelper(IDynamoLookUp lookUp)
-        {
-            productLookUp = lookUp;
-        }
-
         /// <summary>
         /// Gets the version of latest product
         /// </summary>
@@ -1129,14 +1128,11 @@ namespace Dynamo.UpdateManager
         /// Gets all dynamo install path on the system by looking into the Windows registry. 
         /// </summary>
         /// <returns>List of Dynamo install path</returns>
-        public IEnumerable<string> GetDynamoInstalls()
-        {
-            return productLookUp != null ? productLookUp.GetDynamoInstallLocations() : null;
-        }
-
+        public abstract IEnumerable<string> GetDynamoInstallLocations();
+        
         private BinaryVersion GetLatestInstallVersion()
         {
-            var dynamoInstallations = GetDynamoInstalls();
+            var dynamoInstallations = GetDynamoInstallLocations();
             if(null == dynamoInstallations)
                 return null;
 

--- a/src/DynamoCore/UpdateManager/UpdateManager.cs
+++ b/src/DynamoCore/UpdateManager/UpdateManager.cs
@@ -55,6 +55,15 @@ namespace Dynamo.UpdateManager
         void RegisterExternalApplicationProcessId(int id);
     }
 
+    public interface IDynamoLookUp
+    {
+        /// <summary>
+        /// Gets installation path for all version of this Dynamo Product
+        /// installed on this system.
+        /// </summary>
+        IEnumerable<string> GetDynamoInstallLocations();
+    }
+
     public interface IUpdateManagerConfiguration
     {
         /// <summary>
@@ -81,6 +90,11 @@ namespace Dynamo.UpdateManager
         /// Gets the base name of the installer to be used for upgrade.
         /// </summary>
         string InstallerNameBase { get; set; }
+
+        /// <summary>
+        /// Gets IDynamoLookUp interface to search Dynamo installations on the system.
+        /// </summary>
+        IDynamoLookUp DynamoLookUp { get; set; }
     }
 
     /// <summary>
@@ -237,6 +251,12 @@ namespace Dynamo.UpdateManager
         public string InstallerNameBase { get; set; }
 
         /// <summary>
+        /// Return file path for the overriding config file.
+        /// </summary>
+        [XmlIgnore]
+        public string ConfigFilePath { get; set; }
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         public UpdateManagerConfiguration()
@@ -264,7 +284,10 @@ namespace Dynamo.UpdateManager
                 var serializer = new XmlSerializer(typeof(UpdateManagerConfiguration));
                 using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read))
                 {
-                    return serializer.Deserialize(fs) as UpdateManagerConfiguration;
+                    var config = serializer.Deserialize(fs) as UpdateManagerConfiguration;
+                    if(null != config)
+                        config.ConfigFilePath = filePath;
+                    return config;
                 }
             }
             catch (Exception ex)
@@ -314,9 +337,10 @@ namespace Dynamo.UpdateManager
         /// <summary>
         /// Utility method to get the settings
         /// </summary>
+        /// <param name="lookUp">IDynamoLookUp instance</param>
         /// <param name="updateManager"></param>
         /// <returns></returns>
-        public static UpdateManagerConfiguration GetSettings(IUpdateManager updateManager = null)
+        public static UpdateManagerConfiguration GetSettings(IDynamoLookUp lookUp, IUpdateManager updateManager = null)
         {
             string filePath;
             var exists = TryGetConfigFilePath(out filePath);
@@ -326,11 +350,18 @@ namespace Dynamo.UpdateManager
             //to re-direct it to other download target for testing.
             if (!exists)
             {
-                var config = new UpdateManagerConfiguration();
-                config.Save(filePath, updateManager);
+                var umConfig = new UpdateManagerConfiguration();
+                umConfig.Save(filePath, updateManager);
             }
 #endif
-            return exists ? Load(filePath, updateManager) : new UpdateManagerConfiguration();
+            if (!exists) 
+                return new UpdateManagerConfiguration() { DynamoLookUp = lookUp };
+
+            var config = Load(filePath, updateManager);
+            if (null != config)
+                config.DynamoLookUp = lookUp;
+
+            return config;
         }
 
         /// <summary>
@@ -345,6 +376,9 @@ namespace Dynamo.UpdateManager
             filePath = Path.Combine(Path.GetDirectoryName(location), DEFAULT_CONFIG_FILE_S);
             return File.Exists(filePath);
         }
+
+        [XmlIgnore]
+        public IDynamoLookUp DynamoLookUp { get; set; }
     }
 
     /// <summary>
@@ -515,7 +549,7 @@ namespace Dynamo.UpdateManager
         {
             get 
             {
-                return configuration ?? (configuration = UpdateManagerConfiguration.GetSettings(this));
+                return configuration ?? (configuration = UpdateManagerConfiguration.GetSettings(null, this));
             }
         }
 
@@ -1053,7 +1087,7 @@ namespace Dynamo.UpdateManager
         internal static void CheckForProductUpdate(IUpdateManager manager)
         {
             //If we already have higher version installed, don't look for product update.
-            if(new DynamoLookUp().LatestProduct > manager.ProductVersion)
+            if(new DynamoLookUpHelper(manager.Configuration.DynamoLookUp).LatestProduct > manager.ProductVersion)
                 return;
 
             var downloadUri = new Uri(manager.Configuration.DownloadSourcePath);
@@ -1064,8 +1098,14 @@ namespace Dynamo.UpdateManager
     /// <summary>
     /// Lookup for installed products
     /// </summary>
-    public class DynamoLookUp
+    public class DynamoLookUpHelper
     {
+        private readonly IDynamoLookUp productLookUp = null;
+        public DynamoLookUpHelper(IDynamoLookUp lookUp)
+        {
+            productLookUp = lookUp;
+        }
+
         /// <summary>
         /// Gets the version of latest product
         /// </summary>
@@ -1089,28 +1129,17 @@ namespace Dynamo.UpdateManager
         /// Gets all dynamo install path on the system by looking into the Windows registry. 
         /// </summary>
         /// <returns>List of Dynamo install path</returns>
-        public virtual IEnumerable<string> GetDynamoInstalls()
+        public IEnumerable<string> GetDynamoInstalls()
         {
-            // TODO: We need a cleaner solution for this that makes the choice of os explicit (MAGN-7241)
-            if (Context.IsUnix)
-            {
-                return Enumerable.Empty<String>();
-            }
-
-            const string regKey64 = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\";
-            //Open HKLM for 64bit registry
-            var regKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
-            //Open Windows/CurrentVersion/Uninstall registry key
-            regKey = regKey.OpenSubKey(regKey64);
-
-            //Get "InstallLocation" value as string for all the subkey that starts with "Dynamo"
-            return regKey.GetSubKeyNames().Where(s => s.StartsWith("Dynamo")).Select(
-                (s) => regKey.OpenSubKey(s).GetValue("InstallLocation") as string);
+            return productLookUp != null ? productLookUp.GetDynamoInstallLocations() : null;
         }
 
         private BinaryVersion GetLatestInstallVersion()
         {
             var dynamoInstallations = GetDynamoInstalls();
+            if(null == dynamoInstallations)
+                return null;
+
             var latestVersion =
                 dynamoInstallations.Select(GetDynamoVersion).OrderBy(s => s).LastOrDefault();
             return latestVersion == null ? null : BinaryVersion.FromString(latestVersion.ToString());

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -134,9 +134,9 @@ namespace DynamoSandbox
         internal string CommandFilePath { get; set; }
     }
 
-    internal class SandboxLookUp : IDynamoLookUp
+    internal class SandboxLookUp : DynamoLookUp
     {
-        public IEnumerable<string> GetDynamoInstallLocations()
+        public override IEnumerable<string> GetDynamoInstallLocations()
         {
             const string regKey64 = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\";
             //Open HKLM for 64bit registry

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Documents;
@@ -12,11 +13,14 @@ using Dynamo.DynamoSandbox;
 using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.Services;
+using Dynamo.UpdateManager;
 using Dynamo.ViewModels;
 using DynamoShapeManager;
 using DynamoUtilities;
 using System.Threading;
 using System.Globalization;
+
+using Microsoft.Win32;
 
 namespace DynamoSandbox
 {
@@ -130,6 +134,22 @@ namespace DynamoSandbox
         internal string CommandFilePath { get; set; }
     }
 
+    internal class SandboxLookUp : IDynamoLookUp
+    {
+        public IEnumerable<string> GetDynamoInstallLocations()
+        {
+            const string regKey64 = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\";
+            //Open HKLM for 64bit registry
+            var regKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+            //Open Windows/CurrentVersion/Uninstall registry key
+            regKey = regKey.OpenSubKey(regKey64);
+
+            //Get "InstallLocation" value as string for all the subkey that starts with "Dynamo"
+            return regKey.GetSubKeyNames().Where(s => s.StartsWith("Dynamo")).Select(
+                (s) => regKey.OpenSubKey(s).GetValue("InstallLocation") as string);
+        }
+    }
+
     internal class Program
     {
         private static SettingsMigrationWindow migrationWindow;
@@ -142,11 +162,15 @@ namespace DynamoSandbox
 
             DynamoModel.RequestMigrationStatusDialog += MigrationStatusDialogRequested;
 
+            var umConfig = UpdateManagerConfiguration.GetSettings(new SandboxLookUp());
+            Debug.Assert(umConfig.DynamoLookUp != null);
+
             var model = DynamoModel.Start(
                 new DynamoModel.DefaultStartConfiguration()
                 {
                     PathResolver = new PathResolver(preloaderLocation),
-                    GeometryFactoryPath = geometryFactoryPath
+                    GeometryFactoryPath = geometryFactoryPath,
+                    UpdateManager = new UpdateManager(umConfig)
                 });
 
             viewModel = DynamoViewModel.Start(

--- a/test/DynamoCoreTests/UpdateManagerTests.cs
+++ b/test/DynamoCoreTests/UpdateManagerTests.cs
@@ -95,6 +95,24 @@ namespace Dynamo.Tests
         }
 
         [Test, Category("UnitTests")]
+        public void NoUpdateIsAvailableWhenHigherVersionDynamoIsInstalled()
+        {
+            var lookup = new Mock<DynamoLookUp>();
+            lookup.Setup(l => l.GetDynamoInstallLocations()).Returns(new[] { "A" });
+            lookup.Setup(l => l.GetDynamoVersion(It.IsAny<string>()))
+                .Returns<string>(s => Version.Parse("9.9.9.0"));
+
+            var um = new DynUpdateManager(NewConfiguration(false, false, lookup.Object));
+            Assert.IsNotNull(um);
+
+            DynUpdateManager.CheckForProductUpdate(um);
+            um.DownloadedUpdateInfo = um.UpdateInfo;
+
+            Assert.IsNull(um.UpdateInfo);
+            Assert.IsFalse(um.IsUpdateAvailable);
+        }
+
+        [Test, Category("UnitTests")]
         public void NoUpdateAvailableWhenUpdateInfoIsNotYetDownloaded()
         {
             var updateManager = new DynUpdateManager(NewConfiguration());
@@ -297,39 +315,24 @@ namespace Dynamo.Tests
                 { "D", new Version(0, 1, 3, 3) },
             };
 
-            var lookup = new Mock<IDynamoLookUp>();
+            var lookup = new Mock<DynamoLookUp>();
             lookup.Setup(l => l.GetDynamoInstallLocations()).Returns(products.Keys);
-            
-            var dynLookup = new Mock<DynamoLookUpHelper>(lookup.Object);
-            dynLookup.Setup(l => l.GetDynamoVersion(It.IsAny<string>()))
+            lookup.Setup(l => l.GetDynamoVersion(It.IsAny<string>()))
                 .Returns<string>(s => products[s]);
 
-            var latest = dynLookup.Object.LatestProduct;
+            var latest = lookup.Object.LatestProduct;
             Assert.AreEqual("1.2.0.0", latest.ToString());
         }
 
         [Test, Category("UnitTests")]
         public void NoLatestProductVersion()
         {
-            var lookup = new Mock<IDynamoLookUp>();
+            var lookup = new Mock<DynamoLookUp>();
             lookup.Setup(l => l.GetDynamoInstallLocations()).Returns(new[] { "A" });
-            
-            var dynLookup = new Mock<DynamoLookUpHelper>(lookup.Object);
-            dynLookup.Setup(l => l.GetDynamoVersion(It.IsAny<string>()))
+            lookup.Setup(l => l.GetDynamoVersion(It.IsAny<string>()))
                 .Returns<string>(null);
 
-            var latest = dynLookup.Object.LatestProduct;
-            Assert.AreEqual(null, latest);
-        }
-
-        [Test, Category("UnitTests")]
-        public void NoLatestProductVersionNullLokkup()
-        {
-            var dynLookup = new Mock<DynamoLookUpHelper>(null);
-            dynLookup.Setup(l => l.GetDynamoVersion(It.IsAny<string>()))
-                .Returns<string>(null);
-
-            var latest = dynLookup.Object.LatestProduct;
+            var latest = lookup.Object.LatestProduct;
             Assert.AreEqual(null, latest);
         }
 
@@ -344,13 +347,11 @@ namespace Dynamo.Tests
                 { "D", null },
             };
 
-            var lookup = new Mock<IDynamoLookUp>();
+            var lookup = new Mock<DynamoLookUp>();
             lookup.Setup(l => l.GetDynamoInstallLocations()).Returns(products.Keys);
-            
-            var dynLookup = new Mock<DynamoLookUpHelper>(lookup.Object);
-            dynLookup.Setup(l => l.GetDynamoVersion(It.IsAny<string>()))
+            lookup.Setup(l => l.GetDynamoVersion(It.IsAny<string>()))
                 .Returns<string>(s => products[s]);
-            var latest = dynLookup.Object.LatestProduct;
+            var latest = lookup.Object.LatestProduct;
             Assert.AreEqual("1.2.0.0", latest.ToString());
         }
     }


### PR DESCRIPTION
### Purpose

Update Manager skips update check if a higher version of Dynamo is installed. The Latest installed Dynamo is searched by DynamoLookUp class that makes use of Registry to lookup Dynamo installations. This implementation creates two problems, the Dynamo installation check was impacting other Dynamo product installations and also registry search is not available on Unix/Mac platforms. These issues are reported in
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7420 and
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7241

Following is done to resolve above mentioned issues.
- Defined IDynamoLookUp interface to get Dynamo Install Locations. Usually, this information is obtained by looking into the registry and different product may have different logic to find all installations of this product.
- IDynamoLookUp instance can be passed thru the IUpdateManagerConfiguration interface.
- The default implementation of UpdateManagerConfiguration has a property to return ConfigFilePath if this configuration was instantiated using a config file.
- UpdateManagerConfiguration.GetSettings() is modified to take IDynamoLookUp instance to initialize DynamoLookUp property.
- Abstract class DynamoLookUp implements IDynamoLookUp instance to get the Latest version of Dynamo product installed on the system.
- SandboxLookUp implements DynamoLookUp and overrides abstract method GetDynamoInstallLocations()

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

- [x] @aparajit-pratap 

- [ ] @pboyer 