### PR TITLE
InCanvasSearch: Place node where user entered

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -36,7 +36,7 @@ namespace Dynamo.UI.Controls
             get { return DataContext as SearchViewModel; }
         }
 
-        private WorkspaceView WorkspaceView;
+        private WorkspaceView workspaceView;
 
         public InCanvasSearchControl()
         {
@@ -44,8 +44,8 @@ namespace Dynamo.UI.Controls
 
             this.Loaded += (sender, e) =>
             {
-                if (WorkspaceView == null)
-                    WorkspaceView = WpfUtilities.FindUpVisualTree<WorkspaceView>(this.Parent);
+                if (workspaceView == null)
+                    workspaceView = WpfUtilities.FindUpVisualTree<WorkspaceView>(this.Parent);
             };
         }
 
@@ -81,9 +81,7 @@ namespace Dynamo.UI.Controls
             var searchElement = listBoxItem.DataContext as NodeSearchElementViewModel;
             if (searchElement != null)
             {
-                Point targetLocation = this.TranslatePoint(new Point(0, 0), WorkspaceView);
-
-                searchElement.Position = targetLocation;
+                searchElement.Position = TranslatePoint(new Point(), workspaceView);
                 searchElement.ClickedCommand.Execute(null);
             }
         }

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -16,6 +16,9 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using System.Windows.Threading;
 using Dynamo.Models;
+using Dynamo.Controls;
+using Dynamo.Utilities;
+using Dynamo.Views;
 
 namespace Dynamo.UI.Controls
 {
@@ -33,9 +36,17 @@ namespace Dynamo.UI.Controls
             get { return DataContext as SearchViewModel; }
         }
 
+        private WorkspaceView WorkspaceView;
+
         public InCanvasSearchControl()
         {
             InitializeComponent();
+
+            this.Loaded += (sender, e) =>
+            {
+                if (WorkspaceView == null)
+                    WorkspaceView = WpfUtilities.FindUpVisualTree<WorkspaceView>(this.Parent);
+            };
         }
 
         private void OnRequestShowInCanvasSearch(ShowHideFlags flags)
@@ -70,6 +81,9 @@ namespace Dynamo.UI.Controls
             var searchElement = listBoxItem.DataContext as NodeSearchElementViewModel;
             if (searchElement != null)
             {
+                Point targetLocation = this.TranslatePoint(new Point(0, 0), WorkspaceView);
+
+                searchElement.Position = targetLocation;
                 searchElement.ClickedCommand.Execute(null);
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -8,10 +8,9 @@ using Dynamo.UI;
 using Dynamo.ViewModels;
 using Microsoft.Practices.Prism.Commands;
 using Microsoft.Practices.Prism.ViewModel;
-using System;
 using Dynamo.Models;
-using Dynamo.ViewModels;
 using Dynamo.Search;
+using System.Windows;
 
 namespace Dynamo.Wpf.ViewModels
 {
@@ -169,15 +168,17 @@ namespace Dynamo.Wpf.ViewModels
             }
         }
 
+        public Point Position;
+
         public ICommand ClickedCommand { get; private set; }
 
-        public event Action<NodeModel> Clicked;
+        public event Action<NodeModel, Point> Clicked;
         protected virtual void OnClicked()
         {
             if (Clicked != null)
             {
                 var nodeModel = Model.CreateNode();
-                Clicked(nodeModel);
+                Clicked(nodeModel, Position);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -168,7 +168,7 @@ namespace Dynamo.Wpf.ViewModels
             }
         }
 
-        public Point Position;
+        internal Point Position { get; set; }
 
         public ICommand ClickedCommand { get; private set; }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -916,9 +916,12 @@ namespace Dynamo.ViewModels
             //SearchText = SearchResults[SelectedIndex].Model.Name;
         }
 
-        public void OnSearchElementClicked(NodeModel nodeModel)
+        public void OnSearchElementClicked(NodeModel nodeModel, Point position)
         {
-            dynamoViewModel.ExecuteCommand(new DynamoModel.CreateNodeCommand(nodeModel, 0, 0, true, true));
+            bool useDeafultPosition = position.X == 0 && position.Y == 0;
+
+            dynamoViewModel.ExecuteCommand(new DynamoModel.CreateNodeCommand(
+                nodeModel, position.X, position.Y, useDeafultPosition, true));
         }
         #endregion
 


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7410](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7410) Place node at point in workspace where user entered in-canvas search

Node is created at the same place, where InCanvasSearch was located.
![image](https://cloud.githubusercontent.com/assets/8158404/7796695/99dd2f1c-02ea-11e5-9d36-3a2350a2485e.png)

![image](https://cloud.githubusercontent.com/assets/8158404/7796702/abd159fa-02ea-11e5-807d-4dbdfaf12a8c.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@pboyer 
@Benglin 

### FYIs

@lillismith
@kronz 
