### PR TITLE
MAGN-7483 Remove surface colorization from the SurfaceData, PointData, and VectorData nodes.

### DIFF
--- a/src/Libraries/Analysis/Analysis.csproj
+++ b/src/Libraries/Analysis/Analysis.csproj
@@ -36,10 +36,6 @@
     <DocumentationFile>..\..\..\bin\AnyCPU\Release\$(UICulture)\Analysis.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MIConvexHull, Version=1.0.10.1021, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\extern\MIConvexHull\MIConvexHull.dll</HintPath>
-    </Reference>
     <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\extern\ProtoGeometry\ProtoGeometry.dll</HintPath>
@@ -79,10 +75,6 @@
       <Name>CoreNodes</Name>
       <Private>False</Private>
     </ProjectReference>
-    <ProjectReference Include="..\Tesellation\Tessellation.csproj">
-      <Project>{d6279651-d099-4f8d-a319-5bf12ed9f269}</Project>
-      <Name>Tessellation</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="AnalysisImages.resx" />
@@ -98,18 +90,16 @@
     <Copy SourceFiles="$(ProjectDir)Analysis_DynamoCustomization.xml" DestinationFiles="$(OutDir)Analysis_DynamoCustomization.xml" />
   </Target>
   <Target Name="AfterBuild" Condition=" '$(OS)' != 'Unix' ">
-	<!-- Get System.Drawing.dll -->
-	<GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v2.0">
-      	<Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
+    <!-- Get System.Drawing.dll -->
+    <GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v2.0">
+      <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
     </GetReferenceAssemblyPaths>
-	
-	<!-- Get assembly -->
-	<GetAssemblyIdentity AssemblyFiles="$(OutDir)$(TargetName).dll">
-		<Output TaskParameter="Assemblies" ItemName="AssemblyInfo"/>
-	</GetAssemblyIdentity>
-	
-	<!-- Generate customization dll -->
-	<GenerateResource UseSourcePath="true" Sources="$(ProjectDir)AnalysisImages.resx" OutputResources="$(ProjectDir)AnalysisImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
+    <!-- Get assembly -->
+    <GetAssemblyIdentity AssemblyFiles="$(OutDir)$(TargetName).dll">
+      <Output TaskParameter="Assemblies" ItemName="AssemblyInfo" />
+    </GetAssemblyIdentity>
+    <!-- Generate customization dll -->
+    <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)AnalysisImages.resx" OutputResources="$(ProjectDir)AnalysisImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
     <AL TargetType="library" EmbedResources="$(ProjectDir)AnalysisImages.resources" OutputAssembly="$(OutDir)Analysis.customization.dll" Version="%(AssemblyInfo.Version)" />
   </Target>
 </Project>

--- a/src/Libraries/Analysis/PointData.cs
+++ b/src/Libraries/Analysis/PointData.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using Autodesk.DesignScript.Geometry;
-using Autodesk.DesignScript.Interfaces;
-using Autodesk.DesignScript.Runtime;
 
 namespace Analysis
 {
@@ -63,34 +60,6 @@ namespace Analysis
             }
 
             return new PointData(points, values);
-        }
-
-        [IsVisibleInDynamoLibrary(false)]
-        public void Tessellate(IRenderPackage package, double tol = -1, int maxGridLines = 512)
-        {
-            if (!Values.Any() || Values == null)
-            {
-                return;
-            }
-
-            var min = Values.Min();
-            var max = Values.Max();
-            var normalizedValues = Values.Select(v => (v - min)/(max - min));
-
-            var colorRange = Utils.CreateAnalyticalColorRange();
-
-            var data = ValueLocations.Zip(
-                normalizedValues,
-                (p, v) => new Tuple<Point, double>(p, v));
-
-            foreach (var d in data)
-            {
-                var pt = d.Item1;
-
-                var color = colorRange.GetColorAtParameter(d.Item2);
-                package.AddPointVertex(pt.X, pt.Y, pt.Z);
-                package.AddPointVertexColor(color.Red, color.Green, color.Blue, color.Alpha);
-            }
         }
     }
 }

--- a/src/Libraries/Analysis/PointData.cs
+++ b/src/Libraries/Analysis/PointData.cs
@@ -11,7 +11,7 @@ namespace Analysis
     /// <summary>
     /// A class for storing structure point analysis data.
     /// </summary>
-    public class PointData : IStructuredData<Point, double>, IGraphicItem
+    public class PointData : IStructuredData<Point, double> //, IGraphicItem
     {
         /// <summary>
         /// A list of Points.

--- a/src/Libraries/Analysis/SurfaceData.cs
+++ b/src/Libraries/Analysis/SurfaceData.cs
@@ -15,7 +15,7 @@ namespace Analysis
     /// <summary>
     /// A class for storing structured surface analysis data.
     /// </summary>
-    public class SurfaceData : ISurfaceData<UV, double>, IGraphicItem
+    public class SurfaceData : ISurfaceData<UV, double> //, IGraphicItem
     {
         private Color[,] colorMap ;
         private const int COLOR_MAP_WIDTH = 100;

--- a/src/Libraries/Analysis/SurfaceData.cs
+++ b/src/Libraries/Analysis/SurfaceData.cs
@@ -3,24 +3,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Autodesk.DesignScript.Geometry;
-using Autodesk.DesignScript.Interfaces;
-using Autodesk.DesignScript.Runtime;
-using DSCore;
-using MIConvexHull;
-using Tessellation.Adapters;
-using Math = System.Math;
 
 namespace Analysis
 {
     /// <summary>
     /// A class for storing structured surface analysis data.
     /// </summary>
-    public class SurfaceData : ISurfaceData<UV, double> //, IGraphicItem
+    public class SurfaceData : ISurfaceData<UV, double>
     {
-        private Color[,] colorMap ;
-        private const int COLOR_MAP_WIDTH = 100;
-        private const int COLOR_MAP_HEIGHT = 100;
-
         /// <summary>
         /// The surface which contains the locations.
         /// </summary>
@@ -43,8 +33,6 @@ namespace Analysis
             //CalculationLocations = CullCalculationLocations(surface, calculationLocations);
             ValueLocations = valueLocations;
             Values = values;
-
-            colorMap = CreateColorMap();
         }
 
         /// <summary>
@@ -137,75 +125,7 @@ namespace Analysis
             return pts;
         }
 
-        private Color[,] CreateColorMap()
-        {
-            if (Values == null) return null;
-
-            // Find the minimum and the maximum for results
-            var max = Values.Max();
-            var min = Values.Min();
-
-            var colorRange = Utils.CreateAnalyticalColorRange();
-
-            // If the values are all the same, ex. max-min == 0.0,
-            // then return the color at the top of the range. Otherwise,
-            // return the color value at the specified parameter.
-            var analysisColors = Values.Select(v => ((max-min) == 0.0 ? colorRange.GetColorAtParameter(1): colorRange.GetColorAtParameter((v - min) / (max - min)))).ToList();
-
-            var colorRange2D = ColorRange2D.ByColorsAndParameters(analysisColors, ValueLocations.ToList());
-            return colorRange2D.CreateColorMap(COLOR_MAP_WIDTH, COLOR_MAP_HEIGHT);
-        }
-
         #endregion
-
-        [IsVisibleInDynamoLibrary(false)]
-        public void Tessellate(IRenderPackage package, double tol = -1, int maxGridLines = 512)
-        {
-            package.RequiresPerVertexColoration = true;
-
-            if (!Values.Any() || Values == null)
-            {
-                return;
-            }
-
-            var sw = new Stopwatch();
-            sw.Start();
-
-            DelaunayTesselate(Surface, package, 30, 30, ValueLocations);
-
-            DebugTime(sw, "Ellapsed for tessellation.");
-
-            var colorCount = 0;
-            var uvCount = 0;
-
-            var uvs = package.MeshTextureCoordinates.ToList();
-            var colors = package.MeshVertexColors.ToList();
-
-            var newColors = new byte[colors.Count];
-
-            for (var i = 0; i < colors.Count; i += 4)
-            {
-                var uvu = uvs[uvCount];
-                var uvv = uvs[uvCount + 1];
-
-                var uu = (int)(uvu * (COLOR_MAP_WIDTH - 1));
-                var vv = (int)(uvv * (COLOR_MAP_HEIGHT - 1));
-                var color = colorMap[uu,vv];
-
-                newColors[colorCount] = color.Red;
-                newColors[colorCount + 1] = color.Green;
-                newColors[colorCount + 2] = color.Blue;
-                newColors[colorCount + 3] = color.Alpha;
-
-                colorCount += 4;
-                uvCount += 2;
-            }
-
-            package.ApplyMeshVertexColors(newColors);
-
-            DebugTime(sw, "Ellapsed for setting colors on mesh.");
-            sw.Stop();
-        }
 
         private static void DebugTime(Stopwatch sw, string message)
         {
@@ -215,153 +135,6 @@ namespace Analysis
             sw.Start();
         }
 
-        /// <summary>
-        /// This method uses the MIConvexHull Delaunay triangulator to create a 
-        /// Delaunay tessellation of a given u and v distribution on the surface.
-        /// It adds to this tessellation all the points on the surface's trim
-        /// curves. Triangles are then deleted from the tessellation based on whether
-        /// the sum of their vertices' distances from the surface are greater than a
-        /// threshold.
-        /// </summary>
-        /// <param name="surface">The surface on which to apply the tessellation.</param>
-        /// <param name="package">The IRenderPackage object into which the graphics data will be pushed.</param>
-        /// <param name="uDiv">The number of divisions of the grid on the surface in the U direction.</param>
-        /// <param name="vDiv">The number of divisions of the grid on the surface in the V direction.</param>
-        private static void DelaunayTesselate(Surface surface, IRenderPackage package, int uDiv, int vDiv, IEnumerable<UV> additionalUVs)
-        {
-            var uvs = new List<UV>();
-            for (var i = 0; i <= uDiv; i += 1)
-            {
-                for (var j = 0; j <= vDiv; j += 1)
-                {
-                    var u = (double)i / uDiv;
-                    var v = (double)j / vDiv;
-                    var uv = UV.ByCoordinates(u, v);
-                    uvs.Add(uv);
-                }
-            }
-
-            uvs.AddRange(additionalUVs);
-
-            var curves = surface.PerimeterCurves();
-            var coords = GetEdgeCoordinates(curves, 100, surface);
-            curves.ForEach(c=>c.Dispose());
-
-            var verts = uvs.Select(Vertex2.FromUV).Concat(coords.Select(Vertex2.FromUV)).ToList();
-            var config = new TriangulationComputationConfig
-            {
-                PointTranslationType = PointTranslationType.TranslateInternal,
-                PlaneDistanceTolerance = 0.000001,
-                // the translation radius should be lower than PlaneDistanceTolerance / 2
-                PointTranslationGenerator = TriangulationComputationConfig.RandomShiftByRadius(0.0000001, 0)
-            };
-
-            var triangulation = DelaunayTriangulation<Vertex2, Cell2>.Create(verts, config);
-
-            foreach (var cell in triangulation.Cells)
-            {
-                var v1 = cell.Vertices[0].AsVector();
-                var pt1 = surface.PointAtParameter(v1.X, v1.Y);
-                var n1 = surface.NormalAtParameter(v1.X, v1.Y);
-
-                var v2 = cell.Vertices[1].AsVector();
-                var pt2 = surface.PointAtParameter(v2.X, v2.Y);
-                var n2 = surface.NormalAtParameter(v2.X, v2.Y);
-
-                var v3 = cell.Vertices[2].AsVector();
-                var pt3 = surface.PointAtParameter(v3.X, v3.Y);
-                var n3 = surface.NormalAtParameter(v3.X, v3.Y);
-
-                // Calculate the aggregate distance of all vertex 
-                // locations from the surface. Triangles not on the surface
-                // will have a higher aggregate value.
-                var sumDist = pt1.DistanceTo(surface) + pt2.DistanceTo(surface) + pt3.DistanceTo(surface);
-                if (sumDist > 0.05)
-                {
-                    continue;
-                }
-
-                package.AddTriangleVertex(pt1.X, pt1.Y, pt1.Z);
-                package.AddTriangleVertexNormal(n1.X, n1.Y, n1.Z);
-                package.AddTriangleVertexUV(v1.X, v1.Y);
-                package.AddTriangleVertexColor(0, 0, 0, 255);
-
-                package.AddTriangleVertex(pt2.X, pt2.Y, pt2.Z);
-                package.AddTriangleVertexNormal(n2.X, n2.Y, n2.Z);
-                package.AddTriangleVertexUV(v2.X, v2.Y);
-                package.AddTriangleVertexColor(0, 0, 0, 255);
-
-                package.AddTriangleVertex(pt3.X, pt3.Y, pt3.Z);
-                package.AddTriangleVertexNormal(n3.X, n3.Y, n3.Z);
-                package.AddTriangleVertexUV(v3.X, v3.Y);
-                package.AddTriangleVertexColor(0, 0, 0, 255);
-
-                package.AddLineStripVertex(pt1.X, pt1.Y, pt1.Z);
-                package.AddLineStripVertex(pt2.X, pt2.Y, pt2.Z);
-                package.AddLineStripVertexColor(100, 100, 100, 255);
-                package.AddLineStripVertexColor(100, 100, 100, 255);
-                package.AddLineStripVertexCount(2);
-
-                package.AddLineStripVertex(pt2.X, pt2.Y, pt2.Z);
-                package.AddLineStripVertex(pt3.X, pt3.Y, pt3.Z);
-                package.AddLineStripVertexColor(100, 100, 100, 255);
-                package.AddLineStripVertexColor(100, 100, 100, 255);
-                package.AddLineStripVertexCount(2);
-
-                package.AddLineStripVertex(pt3.X, pt3.Y, pt3.Z);
-                package.AddLineStripVertex(pt1.X, pt1.Y, pt1.Z);
-                package.AddLineStripVertexColor(100, 100, 100, 255);
-                package.AddLineStripVertexColor(100, 100, 100, 255);
-                package.AddLineStripVertexCount(2);
-
-                v1.Dispose(); v2.Dispose(); v3.Dispose();
-                pt1.Dispose(); pt2.Dispose(); pt3.Dispose();
-                n1.Dispose(); n2.Dispose(); n3.Dispose();
-            }
-        }
-
-        private static List<UV> GetEdgeCoordinates(IEnumerable<Curve> curves, int div, Surface surface)
-        {
-            var points = new List<UV>();
-            foreach (var curve in curves)
-            {
-                var line = curve as Line;
-                UV start, end;
-
-                if (line != null)
-                {
-                    start = surface.UVParameterAtPoint(line.PointAtParameter(0));
-                    end = surface.UVParameterAtPoint(line.PointAtParameter(1));
-                    points.Add(start);
-                    points.Add(end);
-                }
-                else
-                {
-                    var step = 1.0 / div;
-                    for (var t = 0.0; t < 1.0; t += step)
-                    {
-                        // Create a line segment
-                        var a = curve.PointAtParameter(t);
-                        var b = curve.PointAtParameter(t + step);
-                        start = surface.UVParameterAtPoint(a);
-                        end = surface.UVParameterAtPoint(b);
-                        if (start.IsAlmostEqualTo(end))
-                            continue;
-                        points.Add(start);
-
-                        // We don't always add the end point to
-                        // reduce the number of duplicate points.
-                        // We add it here, only if we're at the
-                        // end of the curve.
-                        if (t + step == 1.0)
-                        {
-                            points.Add(end);
-                        }
-                    }
-                }
-            }
-            return points;
-        }
     }
 
     public static class AnalysisExtensions

--- a/src/Libraries/Analysis/VectorData.cs
+++ b/src/Libraries/Analysis/VectorData.cs
@@ -11,7 +11,7 @@ namespace Analysis
     /// <summary>
     /// A class for storing structured vector analysis data.
     /// </summary>
-    public class VectorData : IStructuredData<Point, Vector>, IGraphicItem
+    public class VectorData : IStructuredData<Point, Vector> //, IGraphicItem
     {
         private const byte VectorColor = 120;
 

--- a/src/Libraries/Analysis/VectorData.cs
+++ b/src/Libraries/Analysis/VectorData.cs
@@ -1,17 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using Autodesk.DesignScript.Geometry;
-using Autodesk.DesignScript.Interfaces;
-using Autodesk.DesignScript.Runtime;
 
 namespace Analysis
 {
     /// <summary>
     /// A class for storing structured vector analysis data.
     /// </summary>
-    public class VectorData : IStructuredData<Point, Vector> //, IGraphicItem
+    public class VectorData : IStructuredData<Point, Vector>
     {
         private const byte VectorColor = 120;
 
@@ -66,38 +63,6 @@ namespace Analysis
             }
 
             return new VectorData(points, values);
-        }
-
-        [IsVisibleInDynamoLibrary(false)]
-        public void Tessellate(IRenderPackage package, double tol = -1, int maxGridLines = 512)
-        {
-            if (!Values.Any() || Values == null)
-            {
-                return;
-            }
-
-            var data = Values.Zip(ValueLocations, (v, p) => new Tuple<Vector, Point>(v, p));
-
-            foreach (var d in data)
-            {
-                DrawVector(d, package);
-            }
-        }
-
-        private void DrawVector(Tuple<Vector, Point> data, IRenderPackage package)
-        {
-            var p = data.Item2;
-            var v = data.Item1;
-
-            package.AddLineStripVertex(p.X, p.Y, p.Z);
-            package.AddLineStripVertexColor(VectorColor, VectorColor, VectorColor, 255);
-
-            var o = p.Add(v);
-
-            package.AddLineStripVertex(o.X, o.Y, o.Z);
-            package.AddLineStripVertexColor(VectorColor, VectorColor, VectorColor, 255);
-
-            package.AddLineStripVertexCount(2);
         }
     }
 }


### PR DESCRIPTION
### Purpose

This PR removes the `IGraphicItem` interface from `SurfaceData`, `PointData`, and `VectorData` per [MAGN-7483](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7483). This will prohibit these items from drawing custom visualizations.  

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
  - Removed a significant amount of code pertaining to rendering.
- [x] The level of testing this PR includes is appropriate
  - No tests added or removed as this affects visualization only.

### Reviewers

@ramramps 

### Cherry Picks

- [ ] RC0.8.1_master