### PR TITLE
Fix magn 7311: Create Custom node throws exception if Category is not entered

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/FunctionNamePrompt.xaml.cs
@@ -31,7 +31,22 @@ namespace Dynamo.Nodes
 
       void OK_Click(object sender, RoutedEventArgs e)
       {
-         this.DialogResult = true;
+          if (string.IsNullOrEmpty(Text))
+          {
+              MessageBox.Show(Dynamo.Wpf.Properties.Resources.MessageCustomNodeNoName,
+                  Dynamo.Wpf.Properties.Resources.CustomNodePropertyErrorMessageBoxTitle,
+                  MessageBoxButton.OK, MessageBoxImage.Error);
+          }
+          else if (string.IsNullOrEmpty(Category))
+          {
+              MessageBox.Show(Dynamo.Wpf.Properties.Resources.MessageCustomNodeNeedNewCategory,
+                  Dynamo.Wpf.Properties.Resources.CustomNodePropertyErrorMessageBoxTitle,
+                  MessageBoxButton.OK, MessageBoxImage.Error);
+          }
+          else
+          {
+              this.DialogResult = true;
+          }
       }
 
       void Cancel_Click(object sender, RoutedEventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -700,76 +700,45 @@ namespace Dynamo.Controls
         /// <returns></returns>
         public void ShowNewFunctionDialog(FunctionNamePromptEventArgs e)
         {
-            string error = "";
+            var categorized =
+                SearchCategoryUtil.CategorizeSearchEntries(
+                    dynamoViewModel.Model.SearchModel.SearchEntries,
+                    entry => entry.Categories);
 
-            do
+            var allCategories =
+                categorized.SubCategories.SelectMany(sub => sub.GetAllCategoryNames());
+
+            var dialog = new FunctionNamePrompt(allCategories)
             {
-                var categorized =
-                    SearchCategoryUtil.CategorizeSearchEntries(
-                        dynamoViewModel.Model.SearchModel.SearchEntries,
-                        entry => entry.Categories);
+                categoryBox = { Text = e.Category },
+                DescriptionInput = { Text = e.Description },
+                nameView = { Text = e.Name },
+                nameBox = { Text = e.Name },
+                // center the prompt
+                Owner = this,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
 
-                var allCategories =
-                    categorized.SubCategories.SelectMany(sub => sub.GetAllCategoryNames());
+            if (e.CanEditName)
+            {
+                dialog.nameBox.Visibility = Visibility.Visible;
+                dialog.nameView.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                dialog.nameView.Visibility = Visibility.Visible;
+                dialog.nameBox.Visibility = Visibility.Collapsed;
+            }
 
-                var dialog = new FunctionNamePrompt(allCategories)
-                {
-                    categoryBox = { Text = e.Category },
-                    DescriptionInput = { Text = e.Description },
-                    nameView = { Text = e.Name },
-                    nameBox = { Text = e.Name },
-                    // center the prompt
-                    Owner = this,
-                    WindowStartupLocation = WindowStartupLocation.CenterOwner
-                };
+            if (dialog.ShowDialog() != true)
+            {
+                e.Success = false;
+                return;
+            }
 
-                if (e.CanEditName)
-                {
-                    dialog.nameBox.Visibility = Visibility.Visible;
-                    dialog.nameView.Visibility = Visibility.Collapsed;
-                }
-                else
-                {
-                    dialog.nameView.Visibility = Visibility.Visible;
-                    dialog.nameBox.Visibility = Visibility.Collapsed;
-                }
-
-                if (dialog.ShowDialog() != true)
-                {
-                    e.Success = false;
-                    return;
-                }
-
-                if (String.IsNullOrEmpty(dialog.Text))
-                {
-                    MessageBox.Show(Dynamo.Wpf.Properties.Resources.MessageCustomNodeNoName,
-                        Dynamo.Wpf.Properties.Resources.CustomNodePropertyErrorMessageBoxTitle,
-                        MessageBoxButton.OK, MessageBoxImage.Error);
-                }
-
-                //else if (e.Name != dialog.Text && dynamoViewModel.Model.BuiltInTypesByNickname.ContainsKey(dialog.Text))
-                //{
-                //    error = "A built-in node with the given name already exists.";
-                //    MessageBox.Show(error, "Custom Node Property Error", MessageBoxButton.OK,
-                //                                   MessageBoxImage.Error);
-                //}
-
-                else if (dialog.Category.Equals(""))
-                {
-                    MessageBox.Show(Dynamo.Wpf.Properties.Resources.MessageCustomNodeNeedNewCategory,
-                        Dynamo.Wpf.Properties.Resources.CustomNodePropertyErrorMessageBoxTitle,
-                        MessageBoxButton.OK, MessageBoxImage.Error);
-                }
-                else
-                {
-                    error = "";
-                }
-
-                e.Name = dialog.Text;
-                e.Category = dialog.Category;
-                e.Description = dialog.Description;
-
-            } while (!error.Equals(""));
+            e.Name = dialog.Text;
+            e.Category = dialog.Category;
+            e.Description = dialog.Description;
 
             e.Success = true;
         }


### PR DESCRIPTION
### Purpose

This PR fixes defect [MAGN 7311: Create Custom node throws exception if Category is not entered](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7311).

If `Category` is not specified, `Custom Node Properties` dialog should still be open and ask for input instead of being closed and return empty `Category`. 

### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@Benglin  please take a look.