### PR TITLE
Improvement to MAGN-143 and add one test case

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1211,13 +1211,15 @@ namespace Dynamo.Models
                     var savePath = pathManager.GetBackupFilePath(workspace);
                     var oldFileName = workspace.FileName;
                     var oldName = workspace.Name;
+                    var oldHasUnsavedChanges = workspace.HasUnsavedChanges;
                     workspace.SaveAs(savePath, null);
                     workspace.FileName = oldFileName;
                     workspace.Name = oldName;
+                    workspace.HasUnsavedChanges = oldHasUnsavedChanges;
                     backupFilesDict.Add(workspace.Guid, savePath);
-                    Logger.Log("Backup file is saved: " + savePath);
                 }
                 PreferenceSettings.BackupFiles.AddRange(backupFilesDict.Values);
+                PreferenceSettings.SaveInternal(pathManager.PreferenceFilePath);
             });
         }
 

--- a/src/DynamoCore/Services/StabilityTracking.cs
+++ b/src/DynamoCore/Services/StabilityTracking.cs
@@ -174,12 +174,13 @@ namespace Dynamo.Services
         }
 
         /// <summary>
-        /// To check whether the last shutdown is clean(no crash)
+        /// To check whether the last shutdown is clean(no crash or unexpected shutdown happens)
         /// </summary>
         private static bool IsLastShutdownClean()
         {
             var ret = Registry.GetValue(REG_KEY, SHUTDOWN_TYPE_NAME, CRASHING_SHUTDOWN_VALUE) as string;
-            if (null != ret && string.CompareOrdinal(ret, CRASHING_SHUTDOWN_VALUE) == 0)
+            if (null != ret && (string.CompareOrdinal(ret, CRASHING_SHUTDOWN_VALUE) == 0
+                || string.CompareOrdinal(ret, ASSUMING_CRASHING_SHUTDOWN_VALUE) == 0))
                 return false;
 
             return true;

--- a/test/DynamoCoreTests/BackupFileCoreTests.cs
+++ b/test/DynamoCoreTests/BackupFileCoreTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Dynamo.Models;
+using DynamoShapeManager;
+using Microsoft.Win32;
+using NUnit.Framework;
+using TestServices;
+
+namespace Dynamo.Tests
+{
+    [TestFixture]
+    public class BackupFileCoreTests : DynamoModelTestBase
+    {
+        public static readonly string backupFileDir = @"core\backupFile";
+        public static readonly string testDynFile = @"addTwoNumbers.dyn";
+        public static readonly string testDyfFile = @"dyfFileToBeBackedup.dyf";
+
+        public static void StartBackupFilesTimer(DynamoModel model)
+        {
+            var isTest = DynamoModel.IsTestMode;
+            DynamoModel.IsTestMode = false;
+
+            model.PreferenceSettings.BackupInterval = 5000;
+            var type = typeof(DynamoModel);
+            MethodInfo m = type.GetMethod("StartBackupFilesTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+            m.Invoke(model, null);
+
+            DynamoModel.IsTestMode = isTest;
+        }
+
+        [Test]
+        public void AllWorkspaceFilesAreBackedup()
+        {
+            CurrentDynamoModel.PreferenceSettings.BackupFiles = new List<string>();
+            var path1 = Path.Combine(CurrentDynamoModel.PathManager.BackupDirectory, testDynFile);
+            if (File.Exists(path1))
+                File.Delete(path1);
+            var path2 = Path.Combine(CurrentDynamoModel.PathManager.BackupDirectory, testDyfFile);
+            if (File.Exists(path2))
+                File.Delete(path2);
+
+            var ws1 = Open<HomeWorkspaceModel>(TestDirectory, backupFileDir, testDynFile);
+            var ws2 = Open<CustomNodeWorkspaceModel>(TestDirectory, backupFileDir, testDyfFile);
+            StartBackupFilesTimer(CurrentDynamoModel);
+
+            System.Threading.Thread.Sleep(10000);
+
+            Assert.IsTrue(File.Exists(path1));
+            Assert.IsTrue(File.Exists(path2));
+            File.Delete(path1);
+            File.Delete(path2);
+        }
+    }
+}

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="AnnotationModelTest.cs" />
     <Compile Include="AstBuilderTest.cs" />
     <Compile Include="AsyncTaskExtensionsTests.cs" />
+    <Compile Include="BackupFileCoreTests.cs" />
     <Compile Include="CallsiteTests.cs" />
     <Compile Include="CrashProtectionTests.cs" />
     <Compile Include="DSEvaluationUnitTestBase.cs" />

--- a/test/core/backupFile/addTwoNumbers.dyn
+++ b/test/core/backupFile/addTwoNumbers.dyn
@@ -1,0 +1,14 @@
+<Workspace Version="0.8.1.1411" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="48fceaf2-eb86-4ac4-a002-d5beb2e1e5c9" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="161" y="150" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="1;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="b18b3ca3-c5f4-44bb-a2d0-06db45b297d1" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="163" y="263" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="2;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="4e31742e-6033-4dec-a3d4-98909e038341" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="337" y="201" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="x=a+b;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="48fceaf2-eb86-4ac4-a002-d5beb2e1e5c9" start_index="0" end="4e31742e-6033-4dec-a3d4-98909e038341" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="b18b3ca3-c5f4-44bb-a2d0-06db45b297d1" start_index="0" end="4e31742e-6033-4dec-a3d4-98909e038341" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>

--- a/test/core/backupFile/dyfFileToBeBackedup.dyf
+++ b/test/core/backupFile/dyfFileToBeBackedup.dyf
@@ -1,0 +1,22 @@
+<Workspace Version="0.8.1.1411" X="130.382794914826" Y="119.008772029704" zoom="0.954042924882813" Name="dyfFileToBeBackedup" ID="ae548391-1275-455e-a72f-17e7b2e381fa" Description="" Category="BackupFileTests">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="d2f97a54-b772-4b9f-9e68-8eae3f4a745d" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="250" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="x=a-b;" ShouldFocus="false" />
+    <Dynamo.Nodes.Symbol guid="8fad3209-1659-4d39-ab02-4c0dfaaf2e6d" type="Dynamo.Nodes.Symbol" nickname="Input" x="0" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="a" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol guid="24955ae7-8993-45fb-8444-fa9d37d52e20" type="Dynamo.Nodes.Symbol" nickname="Input" x="0" y="150" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="b" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Output guid="7f37a5c5-dbd8-41b9-a314-e938454558c9" type="Dynamo.Nodes.Output" nickname="Output" x="437" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="" />
+    </Dynamo.Nodes.Output>
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="d2f97a54-b772-4b9f-9e68-8eae3f4a745d" start_index="0" end="7f37a5c5-dbd8-41b9-a314-e938454558c9" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="8fad3209-1659-4d39-ab02-4c0dfaaf2e6d" start_index="0" end="d2f97a54-b772-4b9f-9e68-8eae3f4a745d" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="24955ae7-8993-45fb-8444-fa9d37d52e20" start_index="0" end="d2f97a54-b772-4b9f-9e68-8eae3f4a745d" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
### Purpose

The purpose of this submission is to make some improvements to the feature related to backing up files:
1). After a file is backed up, if it has unsaved changes before, then it will still be marked as to have unsaved changes after backed up.
2). The logic to determine whether the last session is closed normally is changed so now if the application ends unexpected without throwing an exception, next time when the application starts, there will be a list of backup files to be opened in the start page.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@aparajit-pratap 

### FYIs

@riteshchandawar and @elayabharath 