### PR TITLE
Should not clear execution status when execution is still going on

### DIFF
--- a/src/DynamoCoreWpf/Controls/NotificationsControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NotificationsControl.xaml.cs
@@ -24,19 +24,6 @@ namespace Dynamo.Wpf.Controls
         void NotificationsControl_Loaded(object sender, RoutedEventArgs e)
         {
             var window = WpfUtilities.FindUpVisualTree<DynamoView>(this);
-            window.PreviewMouseDown += window_PreviewMouseDown;
-        }
-
-        /// <summary>
-        /// Handle the DynamoView's PreviewMouseDown event.
-        /// When the user click anywhere in the view, clear the ViewModel's warning.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        void window_PreviewMouseDown(object sender, MouseButtonEventArgs e)
-        {
-            var hsvm = (HomeWorkspaceViewModel)((DynamoViewModel)DataContext).HomeSpaceViewModel;
-            hsvm.ClearWarning();
         }
     }
 }


### PR DESCRIPTION
### Purpose

When Dynamo starts executing the graph, it will display a message "Run started" on the bottom. When the execution completes, it will display a message "Run completed". 

![1](https://cloud.githubusercontent.com/assets/2600379/7832135/3fbcaed0-048f-11e5-9dbe-dddd2d602d65.png)

But clicking anywhere in the view during execution will clear the message so that we have no idea if the execution completes or not (or, user will think it already completes, see steps to reproduce of defect [MAGN-7148 Opening Manual execute dyn after running Auto execute dyn twice gives crash](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7148)). 

This PR adds a flag to avoid the message to be cleared off when the execution is still going on. 

### Declarations

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@ikeough please review the change.