### PR TITLE
Fix temporary variable from CBN not renamed issue in node2code

### DIFF
--- a/src/DynamoCore/DSEngine/NodeToCode.cs
+++ b/src/DynamoCore/DSEngine/NodeToCode.cs
@@ -634,6 +634,27 @@ namespace Dynamo.DSEngine
         }
 
         /// <summary>
+        /// Check if this identifier is a temporary variable that output from
+        /// other code block node. 
+        /// </summary>
+        /// <param name="ident"></param>
+        /// <param name="renamingMap"></param>
+        /// <returns></returns>
+        private static bool IsTempVarFromCodeBlockNode(string ident,
+            Dictionary<string, string> renamingMap)
+        {
+            if (!ident.StartsWith(Constants.kTempVarForNonAssignment))
+                return false;
+
+            string renamedVariable = string.Empty;
+            // ident is: Constants.TempVarForNonAssignment_guid
+            if (!renamingMap.TryGetValue(ident, out renamedVariable))
+                return false;
+
+            return renamedVariable.StartsWith(Constants.kTempVarForNonAssignment);
+        }
+
+        /// <summary>
         /// Renumber variables used in astNode.
         /// </summary>
         /// <param name="astNode"></param>
@@ -653,9 +674,11 @@ namespace Dynamo.DSEngine
             {
                 var ident = n.Value;
 
-                // This ident is from other node's output port, it is not necessary to 
-                // do renumbering.
-                if (inputMap.ContainsKey(ident))
+                // This ident is from external non-code block node's output 
+                // port, or it is from a temporary variable in code block node,
+                // it is not necessary to do renumbering because the name is 
+                // unique.
+                if (inputMap.ContainsKey(ident) || IsTempVarFromCodeBlockNode(ident, renamingMap))
                     return;
 
                 NumberingState ns; 

--- a/src/DynamoCore/DSEngine/NodeToCode.cs
+++ b/src/DynamoCore/DSEngine/NodeToCode.cs
@@ -150,7 +150,7 @@ namespace Dynamo.DSEngine
             public override void VisitIdentifierListNode(IdentifierListNode node)
             {
                 if ((node.LeftNode is IdentifierNode ||
-                    node.RightNode is IdentifierListNode) &&
+                    node.LeftNode is IdentifierListNode) &&
                     node.RightNode is FunctionCallNode)
                 {
                     var lhs = node.LeftNode.ToString();

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -360,6 +360,26 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void TestTemporaryVariableRenaming4()
+        {
+            OpenModel(@"core\node2code\tempVariable4.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+            var engine = CurrentDynamoModel.EngineController;
+
+            var result = engine.ConvertNodesToCode(nodes, nodes);
+            result = NodeToCodeUtils.ConstantPropagationForTemp(result, Enumerable.Empty<string>());
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.AstNodes);
+
+            NodeToCodeUtils.ReplaceWithUnqualifiedName(engine.LibraryServices.LibraryManagementCore, result.AstNodes);
+            Assert.AreEqual(2, result.AstNodes.Count());
+            Assert.True(result.AstNodes.All(n => n is BinaryExpressionNode));
+            var rhs = result.AstNodes.Cast<BinaryExpressionNode>().Select(n => n.RightNode.ToString());
+            Assert.AreEqual("Point.ByCoordinates(1, 2)", rhs.First());
+            Assert.AreEqual("Point.ByCoordinates(1, 3)", rhs.Last());
+        }
+
+        [Test]
         public void TestUnqualifiedNameReplacer1()
         {
             var functionCall = AstFactory.BuildFunctionCall(

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -495,6 +495,30 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void TestUnqualifiedNameReplacer7()
+        {
+            // Point.ByCoordinates(1,2,3);
+            // Point.ByCoordinates(1,2,3);
+            OpenModel(@"core\node2code\unqualifiedName6.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+            var engine = CurrentDynamoModel.EngineController;
+
+            var result = engine.ConvertNodesToCode(nodes, nodes);
+            result = NodeToCodeUtils.ConstantPropagationForTemp(result, Enumerable.Empty<string>());
+            NodeToCodeUtils.ReplaceWithUnqualifiedName(engine.LibraryServices.LibraryManagementCore, result.AstNodes);
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.AstNodes);
+
+            var expr1 = result.AstNodes.First() as BinaryExpressionNode;
+            var expr2 = result.AstNodes.Last() as BinaryExpressionNode;
+
+            Assert.IsNotNull(expr1);
+            Assert.IsNotNull(expr2);
+            Assert.AreEqual("Point.ByCoordinates(1, 2, 3)", expr1.RightNode.ToString());
+            Assert.AreEqual("Point.ByCoordinates(1, 2, 3)", expr2.RightNode.ToString());
+        }
+
+        [Test]
         public void TestBasicNode2CodeWorkFlow1()
         {
             // 1 -> a -> x

--- a/test/core/node2code/tempVariable4.dyn
+++ b/test/core/node2code/tempVariable4.dyn
@@ -1,0 +1,26 @@
+<Workspace Version="0.8.2.1470" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Line" resolvedName="Autodesk.DesignScript.Geometry.Line" assemblyName="ProtoGeometry.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="7b42d172-5892-4fa8-a4b3-455ca124685e" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="129" y="435" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="3;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="4839d799-c423-4bae-a547-a5345cd338f9" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="123" y="170" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="2;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="616e0431-2107-4077-926c-ddc315f06f1a" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="226.2" y="294.2" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="1;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="fddf9fd2-3844-41cd-a12a-cd37c3b2a04d" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="499.2" y="216.4" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="e9e81c81-9871-412d-8b82-c50da36c3958" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="502" y="340.6" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="7b42d172-5892-4fa8-a4b3-455ca124685e" start_index="0" end="e9e81c81-9871-412d-8b82-c50da36c3958" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="4839d799-c423-4bae-a547-a5345cd338f9" start_index="0" end="fddf9fd2-3844-41cd-a12a-cd37c3b2a04d" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="616e0431-2107-4077-926c-ddc315f06f1a" start_index="0" end="fddf9fd2-3844-41cd-a12a-cd37c3b2a04d" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="616e0431-2107-4077-926c-ddc315f06f1a" start_index="0" end="e9e81c81-9871-412d-8b82-c50da36c3958" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>

--- a/test/core/node2code/unqualifiedName6.dyn
+++ b/test/core/node2code/unqualifiedName6.dyn
@@ -1,0 +1,12 @@
+<Workspace Version="0.8.2.1470" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Point" resolvedName="Autodesk.DesignScript.Geometry.Point" assemblyName="ProtoGeometry.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="1a5fe0fe-e93e-45e6-974e-2cc00b79a4ef" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="102" y="199" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="Point.ByCoordinates(1,2,3);" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="576415a3-3e31-4045-99af-c3af0ba2c93d" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="106" y="88" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="Point.ByCoordinates(1,2,3);" ShouldFocus="false" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR fixes an issue in node2code that temporary variable from CBN not renamed properly, shown in the following picture:
![untitled](https://cloud.githubusercontent.com/assets/2600379/7851402/c4cb0508-0521-11e5-86a2-030e8a08b420.png)

### Reviewers

- [x] @Benglin 
