### PR TITLE
Copy TypeAlias property to rewritten Typed identifier node

### DIFF
--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -70,7 +70,8 @@ namespace ProtoCore.Namespace
             {
                 Name = node.Name,
                 Value = node.Name,
-                datatype = type
+                datatype = type,
+                TypeAlias = node.TypeAlias
             };
 
             NodeUtils.CopyNodeLocation(typedNode, node);


### PR DESCRIPTION
### Purpose

This is a minor fix where the AST for `TypedIdentifierNode` when rewritten in the `ElementRewriter` needs to copy over the `TypeAlias` property from the original AST.
