### PR TITLE
On context menu closed search text should be cleared.

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -76,6 +76,8 @@
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
+            <EventSetter Event="Closed"
+                         Handler="OnContextMenuClosed"/>
         </Style>
     </UserControl.Resources>
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -766,5 +766,10 @@ namespace Dynamo.Views
             outerCanvas.ContextMenu.IsOpen = false;
         }
 
+        private void OnContextMenuClosed(object sender, RoutedEventArgs e)
+        {
+            ViewModel.InCanvasSearchViewModel.SearchText = String.Empty;
+        }
+
     }
 }


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7499](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7499) context menu in-canvas search doesn't show other context menu items on next initiation

I've changed a little behavior of InCanvasSearch in ContextMenu. Now, when ContextMenu is closed, InCanvasSearch is cleared. 
Unlike InCanvasSearch called by Shift+DoubleClick. This search doesn't clear, when it is closed.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@pboyer 
@Benglin 

### FYIs

@lillismith
