### PR TITLE
Fix named variable not renamed to short name in node2code

### DIFF
--- a/src/DynamoCore/DSEngine/NodeToCode.cs
+++ b/src/DynamoCore/DSEngine/NodeToCode.cs
@@ -678,7 +678,7 @@ namespace Dynamo.DSEngine
                 // port, or it is from a temporary variable in code block node,
                 // it is not necessary to do renumbering because the name is 
                 // unique.
-                if (inputMap.ContainsKey(ident) || IsTempVarFromCodeBlockNode(ident, renamingMap))
+                if (inputMap.ContainsKey(ident) || /*IsTempVarFromCodeBlockNode(ident, renamingMap)*/ renamingMap.ContainsKey(ident))
                     return;
 
                 NumberingState ns; 

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -281,6 +281,33 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void TestVariableConfliction6()
+        {
+            // Test same name variables will be renamed in node to code
+            //
+            //   x = 1; --> Point.ByCoordinate()
+            //          --> Point.ByCoordinate()
+            OpenModel(@"core\node2code\sameNames5.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+            var engine = CurrentDynamoModel.EngineController;
+
+            var result = engine.ConvertNodesToCode(nodes, nodes);
+            NodeToCodeUtils.ReplaceWithUnqualifiedName(engine.LibraryServices.LibraryManagementCore, result.AstNodes);
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.AstNodes);
+            Assert.AreEqual(3, result.AstNodes.Count());
+            Assert.True(result.AstNodes.All(n => n is BinaryExpressionNode));
+
+            var rhs = result.AstNodes.Cast<BinaryExpressionNode>()
+                                     .Skip(1)
+                                     .Select(n => n.RightNode.ToString())
+                                     .ToList();
+            
+            Assert.AreEqual("Point.ByCoordinates(x, 0)", rhs[0]);
+            Assert.AreEqual("Point.ByCoordinates(x, 0)", rhs[1]);
+        }
+
+        [Test]
         public void TestTemporaryVariableRenaming1()
         {
             // Test temporary variables should be renamed

--- a/test/core/node2code/sameNames5.dyn
+++ b/test/core/node2code/sameNames5.dyn
@@ -1,0 +1,20 @@
+<Workspace Version="0.8.2.1472" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="2671923c-c00b-4a15-9547-4ec7c5d66450" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="411" y="280" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="e1f49741-b29e-4d2f-bf73-06bffdd818d4" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="405.5" y="101.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="72a4829c-4dbb-40fd-8b6f-7affb6d29363" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="199" y="206" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="x = 1;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="72a4829c-4dbb-40fd-8b6f-7affb6d29363" start_index="0" end="2671923c-c00b-4a15-9547-4ec7c5d66450" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="72a4829c-4dbb-40fd-8b6f-7affb6d29363" start_index="0" end="e1f49741-b29e-4d2f-bf73-06bffdd818d4" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
### Purpose

This is to fix issue that if a named variable in code block node connected to multiple inputs, only one uses short name. 