### PR TITLE
Part 1 of fixing MAGN-7251 [Regression from 0.7.5] Select elements will cause a crash after switching Revit documents

### DIFF
--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -458,6 +458,17 @@ namespace Dynamo.Models
         /// </summary>
         public void Run()
         {
+            // If the RunSettings.RunEnabled is set to false for some contexts, this
+            // method will not run if it is in the manual mode because the run button
+            // is disabled. But it is not the case in the automatic mode, even if the
+            // running of the graph will cause issues for some contexts. This is why
+            // the condition is added here so that if RunSettings.RunEnabled is set to
+            // false, this method will return.
+            if (!RunSettings.RunEnabled)
+            {
+                return;
+            }
+
             graphExecuted = true;
 
             // When Dynamo is shut down, the workspace is cleared, which results

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/SelectionBase.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/SelectionBase.cs
@@ -18,6 +18,12 @@ namespace Dynamo.Wpf.Nodes
         {
             Model = model;
             SelectCommand = new DelegateCommand(() => Model.Select(null), Model.CanBeginSelect);
+            Model.PropertyChanged += (s, e) => {
+                                                    if (e.PropertyName == "CanSelect")
+                                                    {
+                                                        SelectCommand.RaiseCanExecuteChanged();
+                                                    }
+                                               };
 
             var selectionControl = new ElementSelectionControl { DataContext = this };
             nodeView.inputGrid.Children.Add(selectionControl);

--- a/test/DynamoCoreWpfTests/RunSettingsTests.cs
+++ b/test/DynamoCoreWpfTests/RunSettingsTests.cs
@@ -13,6 +13,8 @@ using Dynamo.Nodes;
 using Dynamo.Wpf.ViewModels;
 
 using NUnit.Framework;
+using ProtoCore.Mirror;
+using System;
 
 namespace DynamoCoreWpfTests
 {
@@ -146,6 +148,22 @@ namespace DynamoCoreWpfTests
             homeSpace = GetHomeSpace();
             Assert.AreEqual(homeSpace.RunSettings.RunType, RunType.Periodic);
             Assert.AreEqual(homeSpace.RunSettings.RunPeriod, 10);
+        }
+
+        [Test]
+        public void RunSettingsDisableRun()
+        {
+            string openPath = Path.Combine(workingDirectory, @"..\..\..\test\core\math\Add.dyn");
+
+            Model.OpenFileFromPath(openPath);
+            var homeSpace = GetHomeSpace();
+            homeSpace.RunSettings.RunEnabled = false;
+            homeSpace.Run();
+
+            string varname = GetVarName("4c5889ac-7b91-4fb5-aaad-a2128b533279");
+            var mirror = GetRuntimeMirror(varname);
+
+            Assert.IsNull(mirror);
         }
 
         private RoutedEventArgs GetKeyboardEnterEventArgs(Visual visual)

--- a/test/Libraries/SystemTestServices/SystemTestBase.cs
+++ b/test/Libraries/SystemTestServices/SystemTestBase.cs
@@ -397,7 +397,7 @@ namespace SystemTestServices
             return objects;
         }
 
-        private string GetVarName(string guid)
+        protected string GetVarName(string guid)
         {
             var model = ViewModel.Model;
             var node = model.CurrentWorkspace.NodeFromWorkspace(guid);
@@ -405,7 +405,7 @@ namespace SystemTestServices
             return node.AstIdentifierBase;
         }
 
-        private RuntimeMirror GetRuntimeMirror(string varName)
+        protected RuntimeMirror GetRuntimeMirror(string varName)
         {
             RuntimeMirror mirror = null;
             Assert.DoesNotThrow(() => mirror = ViewModel.Model.EngineController.GetMirror(varName));


### PR DESCRIPTION
### Purpose

This is the first part to fix MAGN-7251. There are two changes here:
1). To ensure when the CanSelect property changes in SelectionBase, the UI updates.
2). When RunSettings.RunEnabled is false, the workspace should not run. This is already like this for the manual mode, because the run button is disabled. But for the automatic mode, the workspace's Run method can still be called. This submission will avoid this.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@Benglin 

### FYIs

