### PR TITLE
InCanvasSearch: over other window

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -37,6 +37,7 @@ namespace Dynamo.UI.Controls
         }
 
         private WorkspaceView workspaceView;
+        private DynamoView dynamoView;
 
         public InCanvasSearchControl()
         {
@@ -46,6 +47,12 @@ namespace Dynamo.UI.Controls
             {
                 if (workspaceView == null)
                     workspaceView = WpfUtilities.FindUpVisualTree<WorkspaceView>(this.Parent);
+                if (dynamoView == null)
+                {
+                    dynamoView = WpfUtilities.FindUpVisualTree<DynamoView>(this.Parent);
+                    if (dynamoView != null)
+                        dynamoView.Deactivated += (s, args) => { OnRequestShowInCanvasSearch(ShowHideFlags.Hide); };
+                }
             };
         }
 


### PR DESCRIPTION
### Purpose
Link to YouTrack:
[MAGN-7493](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7493) In canvas search appears over other windows.

Now, when main window is deactivated, in-canvas-search is hidden.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@pboyer 
@Benglin 

### FYIs

@lillismith
@ikeough 