### PR TITLE
Fixed defect with swapping of connectors in CBN

### DIFF
--- a/src/Engine/ProtoCore/CompilerUtils.cs
+++ b/src/Engine/ProtoCore/CompilerUtils.cs
@@ -422,6 +422,7 @@ namespace ProtoCore.Utils
                         {
                             // Add node as it is
                             astNodes.Add(node);
+                            index++;
                         }
                     }
                     else

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -289,6 +289,33 @@ b = c[w][x][y][z];";
         }
 
         [Test]
+        public void TestOutportConnectors_OnAssigningVariables_ToRetainConnections()
+        {
+            string openPath = Path.Combine(TestDirectory,
+                @"core\dsevaluation\TestOutportConnectors_OnAssigningVariables_ToRetainConnections.dyn");
+            OpenModel(openPath);
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count);
+
+            BeginRun();
+
+            var result = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSFunction>(
+                Guid.Parse("76b2289a-a814-44fc-97b1-397f8abea296"));
+
+            Assert.AreEqual(-10, result.CachedValue.Data);
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<CodeBlockNodeModel>(
+                Guid.Parse("3cd6cdb7-9e5c-4b61-bc8b-630e48b52fc0"));
+
+            Assert.IsNotNull(cbn);
+            string code = "a=10;20;";
+            UpdateCodeBlockNodeContent(cbn, code);
+
+            BeginRun();
+
+            Assert.AreEqual(-10, result.CachedValue.Data);
+        }
+
+        [Test]
         [Category("RegressionTests")]
         public void Defect_MAGN_4946()
         {

--- a/test/core/dsevaluation/TestOutportConnectors_OnAssigningVariables_ToRetainConnections.dyn
+++ b/test/core/dsevaluation/TestOutportConnectors_OnAssigningVariables_ToRetainConnections.dyn
@@ -1,0 +1,13 @@
+<Workspace Version="0.8.2.1471" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="3cd6cdb7-9e5c-4b61-bc8b-630e48b52fc0" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="112" y="179" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="10;&#xA;20;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="76b2289a-a814-44fc-97b1-397f8abea296" type="Dynamo.Nodes.DSFunction" nickname="-" x="351.5" y="96.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="-@var[]..[],var[]..[]" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="3cd6cdb7-9e5c-4b61-bc8b-630e48b52fc0" start_index="0" end="76b2289a-a814-44fc-97b1-397f8abea296" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="3cd6cdb7-9e5c-4b61-bc8b-630e48b52fc0" start_index="1" end="76b2289a-a814-44fc-97b1-397f8abea296" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR fixes the following issue: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5453
The issue was that when non-assignment statements were converted to named assignments, the output port names would get switched as they are named after the lhs variable names. This resulted in the output port connectors to get switched as well as they rely on the output port names. 

The outport names switched because the internally generated lhs variables for non-assignment statements are named by appending the GUID and the statement index in the CBN. This index was not being incremented for a named variable in the CBN and only incremented for internal variables. It is now being incremented in both cases, which fixes the issue.

 

### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@Benglin Reviewer 1  

