### PR TITLE
InCanvasSearch: fix context menu

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -29,6 +29,8 @@ namespace Dynamo.UI.Controls
     {
         ListBoxItem HighlightedItem;
 
+        public Point InCanvasSearchPosition; 
+
         internal event Action<ShowHideFlags> RequestShowInCanvasSearch;
 
         private SearchViewModel ViewModel
@@ -89,7 +91,7 @@ namespace Dynamo.UI.Controls
             var searchElement = listBoxItem.DataContext as NodeSearchElementViewModel;
             if (searchElement != null)
             {
-                searchElement.Position = TranslatePoint(new Point(), workspaceView);
+                searchElement.Position = InCanvasSearchPosition;
                 searchElement.ClickedCommand.Execute(null);
             }
         }

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -29,11 +29,9 @@ namespace Dynamo.UI.Controls
     {
         ListBoxItem HighlightedItem;
 
-        public Point InCanvasSearchPosition; 
-
         internal event Action<ShowHideFlags> RequestShowInCanvasSearch;
 
-        private SearchViewModel ViewModel
+        public SearchViewModel ViewModel
         {
             get { return DataContext as SearchViewModel; }
         }
@@ -91,7 +89,7 @@ namespace Dynamo.UI.Controls
             var searchElement = listBoxItem.DataContext as NodeSearchElementViewModel;
             if (searchElement != null)
             {
-                searchElement.Position = InCanvasSearchPosition;
+                searchElement.Position = ViewModel.InCanvasSearchPosition;
                 searchElement.ClickedCommand.Execute(null);
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -50,14 +50,9 @@ namespace Dynamo.ViewModels
         public bool IsSnapping { get; set; }
 
         /// <summary>
-        /// ViewModel that is used in InCanvasSearch in context menu.
+        /// ViewModel that is used in InCanvasSearch in context menu and called by Shift+DoubleClick.
         /// </summary>
-        public SearchViewModel InCanvasSearchContextMenuViewModel { get; private set; }
-
-        /// <summary>
-        /// ViewModel that is used in InCanvasSearchBar, called by Shift+DoubleClick.
-        /// </summary>
-        public SearchViewModel InCanvasSearchBarViewModel { get; private set; }
+        public SearchViewModel InCanvasSearchViewModel { get; private set; }
 
         /// <summary>
         /// For requesting registered workspace to zoom in center
@@ -324,11 +319,8 @@ namespace Dynamo.ViewModels
             foreach (var c in Model.Connectors)
                 Connectors_ConnectorAdded(c);
 
-            InCanvasSearchContextMenuViewModel = new SearchViewModel(DynamoViewModel, DynamoViewModel.Model.SearchModel);
-            InCanvasSearchContextMenuViewModel.Visible = true;
-
-            InCanvasSearchBarViewModel = new SearchViewModel(DynamoViewModel, DynamoViewModel.Model.SearchModel);
-            InCanvasSearchBarViewModel.Visible = true;
+            InCanvasSearchViewModel = new SearchViewModel(DynamoViewModel, DynamoViewModel.Model.SearchModel);
+            InCanvasSearchViewModel.Visible = true;
         }
 
         void RunSettingsViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -52,7 +52,12 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// ViewModel that is used in InCanvasSearch in context menu.
         /// </summary>
-        public SearchViewModel InCanvasSearchViewModel { get; private set; }
+        public SearchViewModel InCanvasSearchContextMenuViewModel { get; private set; }
+
+        /// <summary>
+        /// ViewModel that is used in InCanvasSearchBar, called by Shift+DoubleClick.
+        /// </summary>
+        public SearchViewModel InCanvasSearchBarViewModel { get; private set; }
 
         /// <summary>
         /// For requesting registered workspace to zoom in center
@@ -319,8 +324,11 @@ namespace Dynamo.ViewModels
             foreach (var c in Model.Connectors)
                 Connectors_ConnectorAdded(c);
 
-            InCanvasSearchViewModel = new SearchViewModel(DynamoViewModel, DynamoViewModel.Model.SearchModel);
-            InCanvasSearchViewModel.Visible = true;
+            InCanvasSearchContextMenuViewModel = new SearchViewModel(DynamoViewModel, DynamoViewModel.Model.SearchModel);
+            InCanvasSearchContextMenuViewModel.Visible = true;
+
+            InCanvasSearchBarViewModel = new SearchViewModel(DynamoViewModel, DynamoViewModel.Model.SearchModel);
+            InCanvasSearchBarViewModel.Visible = true;
         }
 
         void RunSettingsViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -63,6 +63,12 @@ namespace Dynamo.ViewModels
         public int MaxNumSearchResults { get; set; }
 
         /// <summary>
+        /// Position, where canvas was clicked. 
+        /// After node will be called, it will be created at the same place.
+        /// </summary>
+        public Point InCanvasSearchPosition; 
+
+        /// <summary>
         ///     Indicates whether the node browser is visible or not
         /// </summary>
         private bool browserVisibility = true;

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -57,13 +57,13 @@
                                         <Setter Property="Visibility"
                                                 Value="Collapsed" />
                                         <Style.Triggers>
-                                            <DataTrigger Binding="{Binding Path=InCanvasSearchViewModel.SearchRootCategories.Count}"
+                                            <DataTrigger Binding="{Binding Path=InCanvasSearchContextMenuViewModel.SearchRootCategories.Count}"
                                                          Value="0">
                                                 <Setter Property="Visibility"
                                                         Value="Visible" />
                                             </DataTrigger>
 
-                                            <DataTrigger Binding="{Binding Path=InCanvasSearchViewModel.CurrentMode,
+                                            <DataTrigger Binding="{Binding Path=InCanvasSearchContextMenuViewModel.CurrentMode,
                                                                            Converter={StaticResource LibraryViewModeToBoolConverter}}"
                                                          Value="True">
                                                 <Setter Property="Visibility"

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -35,7 +35,7 @@
                     <ControlTemplate TargetType="{x:Type ContextMenu}">
                         <StackPanel Margin="8,0,8,8"
                                     Width="250">
-                            <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchContextMenuViewModel}"
+                            <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}"
                                                       PreviewKeyDown="OnInCanvasSearchContextMenuKeyDown"
                                                       PreviewMouseUp="OnInCanvasSearchContextMenuMouseUp"
                                                       PreviewMouseDown="OnInCanvasSearchContextMenuMouseDown" />
@@ -57,13 +57,13 @@
                                         <Setter Property="Visibility"
                                                 Value="Collapsed" />
                                         <Style.Triggers>
-                                            <DataTrigger Binding="{Binding Path=InCanvasSearchContextMenuViewModel.SearchRootCategories.Count}"
+                                            <DataTrigger Binding="{Binding Path=InCanvasSearchViewModel.SearchRootCategories.Count}"
                                                          Value="0">
                                                 <Setter Property="Visibility"
                                                         Value="Visible" />
                                             </DataTrigger>
 
-                                            <DataTrigger Binding="{Binding Path=InCanvasSearchContextMenuViewModel.CurrentMode,
+                                            <DataTrigger Binding="{Binding Path=InCanvasSearchViewModel.CurrentMode,
                                                                            Converter={StaticResource LibraryViewModeToBoolConverter}}"
                                                          Value="True">
                                                 <Setter Property="Visibility"
@@ -77,8 +77,8 @@
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
-            <EventSetter Event="Closed"
-                         Handler="OnContextMenuClosed"/>
+            <EventSetter Event="Opened"
+                         Handler="OnContextMenuOpened"/>
         </Style>
     </UserControl.Resources>
 
@@ -398,7 +398,7 @@
                AllowsTransparency="True"
                IsOpen="False"
                Placement="MousePoint"
-               DataContext="{Binding InCanvasSearchBarViewModel}">
+               DataContext="{Binding InCanvasSearchViewModel}">
             <ui:InCanvasSearchControl />
         </Popup>
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -36,8 +36,9 @@
                         <StackPanel Margin="8,0,8,8"
                                     Width="250">
                             <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}"
-                                                      KeyDown="OnInCanvasSearchContextMenuKeyDown"
-                                                      PreviewMouseUp="OnInCanvasSearchContextMenuMouseUp"/>
+                                                      PreviewKeyDown="OnInCanvasSearchContextMenuKeyDown"
+                                                      PreviewMouseUp="OnInCanvasSearchContextMenuMouseUp"
+                                                      PreviewMouseDown="OnInCanvasSearchContextMenuMouseDown" />
                             <Border BorderThickness="1"
                                     Name="Border"
                                     Background="White"
@@ -82,7 +83,8 @@
     <Grid HorizontalAlignment="Stretch"
           VerticalAlignment="Stretch">
         <Canvas Name="outerCanvas"
-                ClipToBounds="True">
+                ClipToBounds="True"
+                PreviewMouseDown="OnCanvasClicked">
             <Canvas.IsHitTestVisible>
                 <Binding Path="DataContext.ShouldBeHitTestVisible"
                          RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type TabControl}}" />

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -37,7 +37,7 @@
                                     Width="250">
                             <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}"
                                                       KeyDown="OnInCanvasSearchContextMenuKeyDown"
-                                                      PreviewMouseDown="OnInCanvasSearchContextMenuMouseDown"/>
+                                                      PreviewMouseUp="OnInCanvasSearchContextMenuMouseUp"/>
                             <Border BorderThickness="1"
                                     Name="Border"
                                     Background="White"

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -35,7 +35,7 @@
                     <ControlTemplate TargetType="{x:Type ContextMenu}">
                         <StackPanel Margin="8,0,8,8"
                                     Width="250">
-                            <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}"
+                            <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchContextMenuViewModel}"
                                                       PreviewKeyDown="OnInCanvasSearchContextMenuKeyDown"
                                                       PreviewMouseUp="OnInCanvasSearchContextMenuMouseUp"
                                                       PreviewMouseDown="OnInCanvasSearchContextMenuMouseDown" />
@@ -395,7 +395,8 @@
                StaysOpen="True"
                AllowsTransparency="True"
                IsOpen="False"
-               Placement="MousePoint">
+               Placement="MousePoint"
+               DataContext="{Binding InCanvasSearchBarViewModel}">
             <ui:InCanvasSearchControl />
         </Popup>
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -93,11 +93,6 @@ namespace Dynamo.Views
 
             ViewModel.RequestShowInCanvasSearch += ShowHideInCanvasControl;
 
-            var searchViewModel = new SearchViewModel(this.ViewModel.DynamoViewModel, this.ViewModel.DynamoViewModel.Model.SearchModel);
-            searchViewModel.Visible = true;
-
-            InCanvasSearchBar.DataContext = searchViewModel;
-
             var ctrl = InCanvasSearchBar.Child as InCanvasSearchControl;
             if (ctrl != null)
             {
@@ -741,8 +736,7 @@ namespace Dynamo.Views
                 case ShowHideFlags.Show:
                     // Show InCanvas search just in case, when mouse is over workspace.
                     InCanvasSearchBar.IsOpen = this.IsMouseOver;
-                    var cntr = InCanvasSearchBar.Child as InCanvasSearchControl;
-                    cntr.InCanvasSearchPosition = inCanvasSearchPosition;
+                    ViewModel.InCanvasSearchBarViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
                     break;
             }
         }
@@ -763,8 +757,7 @@ namespace Dynamo.Views
         {
             if (e.Key == Key.Enter)
             {
-                var inCanvasSearch = sender as InCanvasSearchControl;
-                inCanvasSearch.InCanvasSearchPosition = inCanvasSearchPosition;
+                ViewModel.InCanvasSearchContextMenuViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
                 outerCanvas.ContextMenu.IsOpen = false;
             }
         }
@@ -785,7 +778,7 @@ namespace Dynamo.Views
         private void OnInCanvasSearchContextMenuMouseDown(object sender, MouseButtonEventArgs e)
         {
             var inCanvasSearch = sender as InCanvasSearchControl;
-            inCanvasSearch.InCanvasSearchPosition = inCanvasSearchPosition;
+            ViewModel.InCanvasSearchContextMenuViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -777,13 +777,12 @@ namespace Dynamo.Views
         /// </summary>
         private void OnInCanvasSearchContextMenuMouseDown(object sender, MouseButtonEventArgs e)
         {
-            var inCanvasSearch = sender as InCanvasSearchControl;
             ViewModel.InCanvasSearchContextMenuViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
         }
 
         /// <summary>
         /// Determines position of mouse, when user clicks on canvas.
-        /// Both left anf right mouse clicks.
+        /// Both left and right mouse clicks.
         /// </summary>
         private void OnCanvasClicked(object sender, MouseButtonEventArgs e)
         {

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -761,9 +761,10 @@ namespace Dynamo.Views
                 outerCanvas.ContextMenu.IsOpen = false;
         }
 
-        private void OnInCanvasSearchContextMenuMouseDown(object sender, MouseButtonEventArgs e)
+        private void OnInCanvasSearchContextMenuMouseUp(object sender, MouseButtonEventArgs e)
         {
-            outerCanvas.ContextMenu.IsOpen = false;
+            if (!(e.OriginalSource is System.Windows.Controls.Primitives.Thumb))
+                outerCanvas.ContextMenu.IsOpen = false;
         }
 
     }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -795,7 +795,7 @@ namespace Dynamo.Views
 
         private void OnContextMenuClosed(object sender, RoutedEventArgs e)
         {
-            ViewModel.InCanvasSearchViewModel.SearchText = String.Empty;
+            ViewModel.InCanvasSearchContextMenuViewModel.SearchText = String.Empty;
         }
 
     }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -736,7 +736,7 @@ namespace Dynamo.Views
                 case ShowHideFlags.Show:
                     // Show InCanvas search just in case, when mouse is over workspace.
                     InCanvasSearchBar.IsOpen = this.IsMouseOver;
-                    ViewModel.InCanvasSearchBarViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
+                    ViewModel.InCanvasSearchViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
                     break;
             }
         }
@@ -757,7 +757,7 @@ namespace Dynamo.Views
         {
             if (e.Key == Key.Enter)
             {
-                ViewModel.InCanvasSearchContextMenuViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
+                ViewModel.InCanvasSearchViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
                 outerCanvas.ContextMenu.IsOpen = false;
             }
         }
@@ -777,7 +777,7 @@ namespace Dynamo.Views
         /// </summary>
         private void OnInCanvasSearchContextMenuMouseDown(object sender, MouseButtonEventArgs e)
         {
-            ViewModel.InCanvasSearchContextMenuViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
+            ViewModel.InCanvasSearchViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
         }
 
         /// <summary>
@@ -793,9 +793,9 @@ namespace Dynamo.Views
             inCanvasSearchPosition = Mouse.GetPosition(this.WorkspaceElements);
         }
 
-        private void OnContextMenuClosed(object sender, RoutedEventArgs e)
+        private void OnContextMenuOpened(object sender, RoutedEventArgs e)
         {
-            ViewModel.InCanvasSearchContextMenuViewModel.SearchText = String.Empty;
+            ViewModel.InCanvasSearchViewModel.SearchText = String.Empty;
         }
 
     }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -729,6 +729,8 @@ namespace Dynamo.Views
             return HitTestResultBehavior.Continue;
         }
 
+        private Point inCanvasSearchPosition;
+
         private void ShowHideInCanvasControl(ShowHideFlags flag)
         {
             switch (flag)
@@ -739,6 +741,8 @@ namespace Dynamo.Views
                 case ShowHideFlags.Show:
                     // Show InCanvas search just in case, when mouse is over workspace.
                     InCanvasSearchBar.IsOpen = this.IsMouseOver;
+                    var cntr = InCanvasSearchBar.Child as InCanvasSearchControl;
+                    cntr.InCanvasSearchPosition = inCanvasSearchPosition;
                     break;
             }
         }
@@ -758,13 +762,32 @@ namespace Dynamo.Views
         private void OnInCanvasSearchContextMenuKeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Enter)
+            {
+                var inCanvasSearch = sender as InCanvasSearchControl;
+                inCanvasSearch.InCanvasSearchPosition = inCanvasSearchPosition;
                 outerCanvas.ContextMenu.IsOpen = false;
+            }
         }
 
         private void OnInCanvasSearchContextMenuMouseUp(object sender, MouseButtonEventArgs e)
         {
             if (!(e.OriginalSource is System.Windows.Controls.Primitives.Thumb))
                 outerCanvas.ContextMenu.IsOpen = false;
+        }
+
+        private void OnInCanvasSearchContextMenuMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            var inCanvasSearch = sender as InCanvasSearchControl;
+            inCanvasSearch.InCanvasSearchPosition = inCanvasSearchPosition;
+        }
+
+        private void OnCanvasClicked(object sender, MouseButtonEventArgs e)
+        {
+            var canvas = sender as FrameworkElement;
+            if (canvas == null)
+                return;
+
+            inCanvasSearchPosition = Mouse.GetPosition(this.WorkspaceElements);
         }
 
     }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -769,18 +769,29 @@ namespace Dynamo.Views
             }
         }
 
+        /// <summary>
+        /// MouseUp is used to close context menu. Only if original sender was Thumb(i.e. scroll bar),
+        /// then context menu is left open.
+        /// </summary>
         private void OnInCanvasSearchContextMenuMouseUp(object sender, MouseButtonEventArgs e)
         {
             if (!(e.OriginalSource is System.Windows.Controls.Primitives.Thumb))
                 outerCanvas.ContextMenu.IsOpen = false;
         }
 
+        /// <summary>
+        /// MouseDown is used to set place, where node will be created.
+        /// </summary>
         private void OnInCanvasSearchContextMenuMouseDown(object sender, MouseButtonEventArgs e)
         {
             var inCanvasSearch = sender as InCanvasSearchControl;
             inCanvasSearch.InCanvasSearchPosition = inCanvasSearchPosition;
         }
 
+        /// <summary>
+        /// Determines position of mouse, when user clicks on canvas.
+        /// Both left anf right mouse clicks.
+        /// </summary>
         private void OnCanvasClicked(object sender, MouseButtonEventArgs e)
         {
             var canvas = sender as FrameworkElement;


### PR DESCRIPTION
### Purpose

I found bug. InCanvasSearch, which is part of context menu, doesn't create node at the same place, where user clicked. That is because InCanvasSearch can't TranslatePoint properly, when its' parent is Context menu.

So, I have to add `InCanvasSearchPosition`, which stores position of mouse, when user clicked on canvas.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@Benglin 
@pboyer 
@ramramps 