### PR TITLE
InCanvasSearch: return focus to seach text box

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -35,10 +35,7 @@
                     <ControlTemplate TargetType="{x:Type ContextMenu}">
                         <StackPanel Margin="8,0,8,8"
                                     Width="250">
-                            <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}"
-                                                      PreviewKeyDown="OnInCanvasSearchContextMenuKeyDown"
-                                                      PreviewMouseUp="OnInCanvasSearchContextMenuMouseUp"
-                                                      PreviewMouseDown="OnInCanvasSearchContextMenuMouseDown" />
+                            <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}" />
                             <Border BorderThickness="1"
                                     Name="Border"
                                     Background="White"
@@ -79,6 +76,12 @@
             </Setter>
             <EventSetter Event="Opened"
                          Handler="OnContextMenuOpened"/>
+            <EventSetter Event="PreviewKeyDown"
+                         Handler="OnInCanvasSearchContextMenuKeyDown" />
+            <EventSetter Event="PreviewMouseUp"
+                         Handler="OnInCanvasSearchContextMenuMouseUp" />
+            <EventSetter Event="PreviewMouseDown"
+                         Handler="OnInCanvasSearchContextMenuMouseDown" />
         </Style>
     </UserControl.Resources>
 

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -755,10 +755,12 @@ namespace Dynamo.Views
 
         private void OnInCanvasSearchContextMenuKeyDown(object sender, KeyEventArgs e)
         {
+            var contextMenu = sender as ContextMenu;
             if (e.Key == Key.Enter)
             {
                 ViewModel.InCanvasSearchViewModel.InCanvasSearchPosition = inCanvasSearchPosition;
-                outerCanvas.ContextMenu.IsOpen = false;
+                if (contextMenu != null)
+                    contextMenu.IsOpen = false;
             }
         }
 
@@ -769,8 +771,10 @@ namespace Dynamo.Views
         /// </summary>
         private void OnInCanvasSearchContextMenuMouseUp(object sender, MouseButtonEventArgs e)
         {
-            if (!(e.OriginalSource is System.Windows.Controls.Primitives.Thumb) && !(e.OriginalSource is TextBox))
-                outerCanvas.ContextMenu.IsOpen = false;
+            var contextMenu = sender as ContextMenu;
+            if (!(e.OriginalSource is System.Windows.Controls.Primitives.Thumb) && !(e.OriginalSource is TextBox)
+                && contextMenu != null)
+                contextMenu.IsOpen = false;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -765,10 +765,11 @@ namespace Dynamo.Views
         /// <summary>
         /// MouseUp is used to close context menu. Only if original sender was Thumb(i.e. scroll bar),
         /// then context menu is left open.
+        /// Or if original sender was TextBox, then context menu is left open as well.
         /// </summary>
         private void OnInCanvasSearchContextMenuMouseUp(object sender, MouseButtonEventArgs e)
         {
-            if (!(e.OriginalSource is System.Windows.Controls.Primitives.Thumb))
+            if (!(e.OriginalSource is System.Windows.Controls.Primitives.Thumb) && !(e.OriginalSource is TextBox))
                 outerCanvas.ContextMenu.IsOpen = false;
         }
 


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7508](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7508) Can't return to search after browsing menu items in context menu

Solution to this bug is not close context menu, if original sender was TextBox.
This PR should be merged after https://github.com/DynamoDS/Dynamo/pull/4607

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@pboyer 
@Benglin 

### FYIs

@lillismith
