### PR TITLE
InCanvasSearch: jump + Horizontal scroll bar

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
@@ -9,7 +9,6 @@
              xmlns:resx="clr-namespace:Dynamo.Properties;assembly=DynamoCore"
              xmlns:viewmodels="clr-namespace:Dynamo.ViewModels;assembly=DynamoCoreWpf"
              mc:Ignorable="d"
-             MaxHeight="350"
              Width="250"
              IsVisibleChanged="OnInCanvasSearchControlVisibilityChanged">
     <UserControl.Resources>
@@ -105,7 +104,8 @@
                 Background="{StaticResource LibraryCommonBackground}"
                 Margin="1,2,1,0"
                 Grid.Row="1"
-                Name="FoundMembers">
+                Name="FoundMembers"
+                MaxHeight="250">
             <ScrollViewer>
                 <ListBox Name="MembersListBox"
                          Background="Transparent"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/SidebarGridStyleDictionary.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/SidebarGridStyleDictionary.xaml
@@ -85,7 +85,7 @@
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Top"
                 Width="Auto"
-                Height="3"
+                Height="5"
                 Background="#aaaaaa"
                 Opacity="0.5" />
     </ControlTemplate>


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7407](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7407) Add horizontal scroll bar for incanvas search results
[MAGN-7509](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7509) Context menu in-canvas search sometimes jumps around

Result of changing scroll bar:
![image](https://cloud.githubusercontent.com/assets/8158404/7909776/9a5193f8-0857-11e5-8943-14491255caf2.png)

About jump:
It's usual behavior for context menu to align itself, when it doesn't fit the screen(regarding [this article](https://msdn.microsoft.com/en-us/library/bb613596(v=vs.110).aspx)).
So, the fastest solution is to make for found members list the same height as context menu items. But if this solution is not good enough,  it's possible to create custom placement of context menu, so that it won't  align itself.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@Benglin 
@pboyer 

### FYIs

@lillismith