### PR TITLE
Fixed element rewriter for global functions and global classes

### DIFF
--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -81,7 +81,7 @@ namespace ProtoCore.Namespace
         public override AssociativeNode VisitIdentifierListNode(IdentifierListNode node)
         {
             // First pass attempt to resolve the node before traversing it deeper
-            IdentifierListNode newIdentifierListNode = null;
+            AssociativeNode newIdentifierListNode = null;
             if (IsMatchingResolvedName(node, out newIdentifierListNode))
                 return newIdentifierListNode;
 
@@ -104,14 +104,14 @@ namespace ProtoCore.Namespace
 
         #region private helper methods
 
-        private bool IsMatchingResolvedName(IdentifierListNode identifierList, out IdentifierListNode newIdentList)
+        private bool IsMatchingResolvedName(IdentifierListNode identifierList, out AssociativeNode newIdentList)
         {
             newIdentList = null;
             var resolvedName = ResolveClassName(identifierList);
             if (string.IsNullOrEmpty(resolvedName))
                 return false;
 
-            newIdentList = (IdentifierListNode)CoreUtils.CreateNodeFromString(resolvedName);
+            newIdentList = CoreUtils.CreateNodeFromString(resolvedName);
             
             var symbol = new Symbol(resolvedName);
             return symbol.Matches(identifierList.ToString());
@@ -123,6 +123,9 @@ namespace ProtoCore.Namespace
 
             string partialName = identListNode != null ?
                 CoreUtils.GetIdentifierExceptMethodName(identListNode) : identifierList.Name;
+            
+            if(string.IsNullOrEmpty(partialName))
+                return String.Empty;
 
             var resolvedName = elementResolver.LookupResolvedName(partialName);
             if (string.IsNullOrEmpty(resolvedName))
@@ -151,7 +154,6 @@ namespace ProtoCore.Namespace
                 return identifierList;
 
             var newIdentList = CoreUtils.CreateNodeFromString(resolvedName);
-            Validity.Assert(newIdentList is IdentifierListNode);
 
             // If the original input node matches with the resolved name, simply return 
             // the identifier list constructed from the resolved name
@@ -172,7 +174,6 @@ namespace ProtoCore.Namespace
             intermediateNodes.Insert(0, newIdentList);
 
             var lNode = CoreUtils.CreateNodeByCombiningIdentifiers(intermediateNodes);
-            Validity.Assert(lNode is IdentifierListNode);
 
             // The last ident list for the functioncall or identifier rhs
             var lastIdentList = new IdentifierListNode

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -649,30 +649,45 @@ namespace ProtoCore.Utils
         ///     Return: "A.B[0].C"
         /// Given: A().B (global function)
         ///     Return: empty string
+        /// Given: A.B[0].C()
+        ///     Return: "A.B[0]"
         /// </summary>
         /// <param name="identList"></param>
         /// <returns></returns>
         public static string GetIdentifierExceptMethodName(IdentifierListNode identList)
         {
             Validity.Assert(null != identList);
-            string identListString = identList.ToString();
-            int removeIndex = identListString.IndexOf('(');
-            if (removeIndex > 0)
-            {
-                identListString = identListString.Remove(removeIndex);
+            var leftNode = identList.LeftNode;
+            var rightNode = identList.RightNode;
 
-                int lastIndex = identListString.LastIndexOf('.');
-                if (lastIndex > 0)
+            var intermediateNodes = new List<AssociativeNode>();
+            if (!(rightNode is FunctionCallNode))
+            {
+                intermediateNodes.Insert(0, rightNode);
+            }
+
+            while (leftNode is IdentifierListNode)
+            {
+                rightNode = ((IdentifierListNode) leftNode).RightNode;
+                if (rightNode is FunctionCallNode)
                 {
-                    identListString = identListString.Remove(lastIndex);
+                    intermediateNodes.Clear();
                 }
                 else
                 {
-                    // global function case
-                    return string.Empty;
+                    intermediateNodes.Insert(0, ((IdentifierListNode)leftNode).RightNode);
                 }
+                leftNode = ((IdentifierListNode)leftNode).LeftNode;
+                
             }
-            return identListString;
+            if (leftNode is FunctionCallNode)
+            {
+                intermediateNodes.Clear();
+                return "";
+            }
+            intermediateNodes.Insert(0, leftNode);
+
+            return CreateNodeByCombiningIdentifiers(intermediateNodes).ToString();
         }
 
         /// <summary>

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -657,6 +657,7 @@ namespace ProtoCore.Utils
         public static string GetIdentifierExceptMethodName(IdentifierListNode identList)
         {
             Validity.Assert(null != identList);
+
             var leftNode = identList.LeftNode;
             var rightNode = identList.RightNode;
 
@@ -675,7 +676,7 @@ namespace ProtoCore.Utils
                 }
                 else
                 {
-                    intermediateNodes.Insert(0, ((IdentifierListNode)leftNode).RightNode);
+                    intermediateNodes.Insert(0, rightNode);
                 }
                 leftNode = ((IdentifierListNode)leftNode).LeftNode;
                 

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -647,10 +647,12 @@ namespace ProtoCore.Utils
         ///     Return: "A"
         /// Given: A.B[0].C
         ///     Return: "A.B[0].C"
+        /// Given: A().B (global function)
+        ///     Return: empty string
         /// </summary>
         /// <param name="identList"></param>
         /// <returns></returns>
-        public static string GetIdentifierExceptMethodName(ProtoCore.AST.AssociativeAST.IdentifierListNode identList)
+        public static string GetIdentifierExceptMethodName(IdentifierListNode identList)
         {
             Validity.Assert(null != identList);
             string identListString = identList.ToString();
@@ -658,7 +660,17 @@ namespace ProtoCore.Utils
             if (removeIndex > 0)
             {
                 identListString = identListString.Remove(removeIndex);
-                identListString = identListString.Remove(identListString.LastIndexOf('.'));
+
+                int lastIndex = identListString.LastIndexOf('.');
+                if (lastIndex > 0)
+                {
+                    identListString = identListString.Remove(lastIndex);
+                }
+                else
+                {
+                    // global function case
+                    return string.Empty;
+                }
             }
             return identListString;
         }

--- a/test/Engine/ProtoTest/UtilsTests/CoreUtilsTest.cs
+++ b/test/Engine/ProtoTest/UtilsTests/CoreUtilsTest.cs
@@ -132,5 +132,15 @@ namespace ProtoTest.UtilsTests
             expected = "";
             Assert.IsTrue(Test_GetIdentifierExceptMethodName(input, expected));
         }
+
+        [Test]
+        public void Test_GetIdentifierExceptMethodName_06()
+        {
+            // Given: A.B[0].C()
+            //     Return: "A.B[0]"
+            string input = "p = A.B[0].C();";
+            string expected = "A.B[0]";
+            Assert.IsTrue(Test_GetIdentifierExceptMethodName(input, expected));
+        }
     }
 }

--- a/test/Engine/ProtoTest/UtilsTests/CoreUtilsTest.cs
+++ b/test/Engine/ProtoTest/UtilsTests/CoreUtilsTest.cs
@@ -106,5 +106,31 @@ namespace ProtoTest.UtilsTests
             string expected = "A.B[0].C";
             Assert.IsTrue(Test_GetIdentifierExceptMethodName(input, expected));
         }
+
+        [Test]
+        public void Test_GetIdentifierExceptMethodName_05()
+        {
+            // Given: A().X (global function)
+            // Return: empty string
+            string input = "p = A().B;";
+            string expected = "";
+            Assert.IsTrue(Test_GetIdentifierExceptMethodName(input, expected));
+
+            input = "p = A().B[0].C;";
+            expected = "";
+            Assert.IsTrue(Test_GetIdentifierExceptMethodName(input, expected));
+
+            input = "p = A().B().C;";
+            expected = "";
+            Assert.IsTrue(Test_GetIdentifierExceptMethodName(input, expected));
+
+            input = "p = A().B.C();";
+            expected = "";
+            Assert.IsTrue(Test_GetIdentifierExceptMethodName(input, expected));
+
+            input = "p = A().B.C()[0];";
+            expected = "";
+            Assert.IsTrue(Test_GetIdentifierExceptMethodName(input, expected));
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This fixes the following issues with the AST rewriter used in resolving namespaces:
- http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7464
- http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7465

These issues were related to expressions using global functions and expressions using global classes that were not compiled properly in CBN. This was due to the AST rewriter throwing exceptions on not being able to handle such expressions. These issues have been fixed by loosening up restrictions on the AST rewriter to handle such expressions additionally.

### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@ke-yu  Reviewer 1  

### FYIs

@monikaprabhu 