### PR TITLE
InCanvasSearch: scrolling fix

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
@@ -106,29 +106,22 @@
                 Grid.Row="1"
                 Name="FoundMembers"
                 MaxHeight="250">
-            <ScrollViewer>
-                <ListBox Name="MembersListBox"
-                         Background="Transparent"
-                         BorderBrush="Transparent"
-                         ItemContainerStyle="{StaticResource SearchMemberStyle}"
-                         ItemsSource="{Binding SearchResults, NotifyOnTargetUpdated=True}"
-                         TargetUpdated="OnMembersListBoxUpdated">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <ScrollViewer Template="{StaticResource InCanvasScrollViewerControlTemplate}"
-                                          Style="{StaticResource InCanvasScrollViewerStyle}"
-                                          CanContentScroll="True">
-                                <ContentControl Template="{StaticResource MemberControlTemplate}" />
-                            </ScrollViewer>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                    <ListBox.Template>
-                        <ControlTemplate>
-                            <ItemsPresenter />
-                        </ControlTemplate>
-                    </ListBox.Template>
-                </ListBox>
-            </ScrollViewer>
+            <ListBox Name="MembersListBox"
+                     Background="Transparent"
+                     BorderBrush="Transparent"
+                     ItemContainerStyle="{StaticResource SearchMemberStyle}"
+                     ItemsSource="{Binding SearchResults, NotifyOnTargetUpdated=True}"
+                     TargetUpdated="OnMembersListBoxUpdated">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <ScrollViewer Template="{StaticResource InCanvasScrollViewerControlTemplate}"
+                                      Style="{StaticResource InCanvasScrollViewerStyle}"
+                                      CanContentScroll="True">
+                            <ContentControl Template="{StaticResource MemberControlTemplate}" />
+                        </ScrollViewer>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
 
             <Border.Style>
                 <Style TargetType="{x:Type Border}">

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
@@ -25,6 +25,12 @@
                 <EventSetter Event="PreviewMouseLeftButtonUp"
                              Handler="OnMouseLeftButtonUp" />
             </Style>
+            
+            <Style TargetType="{x:Type ScrollViewer}"
+                   BasedOn="{StaticResource LibraryScrollViewerStyle}">
+                <Setter Property="Template"
+                        Value="{StaticResource LibraryScrollViewerControlTemplate}" />
+            </Style>
 
         </ResourceDictionary>
     </UserControl.Resources>
@@ -111,12 +117,14 @@
                      BorderBrush="Transparent"
                      ItemContainerStyle="{StaticResource SearchMemberStyle}"
                      ItemsSource="{Binding SearchResults, NotifyOnTargetUpdated=True}"
-                     TargetUpdated="OnMembersListBoxUpdated">
+                     TargetUpdated="OnMembersListBoxUpdated"
+                     PreviewMouseWheel="OnMembersListBoxMouseWheel">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <ScrollViewer Template="{StaticResource InCanvasScrollViewerControlTemplate}"
                                       Style="{StaticResource InCanvasScrollViewerStyle}"
-                                      CanContentScroll="True">
+                                      CanContentScroll="True"
+                                      Width="250">
                             <ContentControl Template="{StaticResource MemberControlTemplate}" />
                         </ScrollViewer>
                     </DataTemplate>

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -226,11 +226,15 @@ namespace Dynamo.UI.Controls
         private void OnMembersListBoxMouseWheel(object sender, MouseWheelEventArgs e)
         {
             var listBox = sender as FrameworkElement;
+            if (listBox == null)
+                return;
 
             var scrollViewer = listBox.ChildOfType<ScrollViewer>();
+            if (scrollViewer == null)
+                return;
 
             // Make delta less to achieve smooth scrolling and not jump over other elements.
-            var delta = e.Delta/100;
+            var delta = e.Delta / 100;
             scrollViewer.ScrollToVerticalOffset(scrollViewer.VerticalOffset - delta);
         }
     }

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -126,6 +126,10 @@ namespace Dynamo.UI.Controls
                 Dispatcher.BeginInvoke(new Action(() =>
                 {
                     UpdateHighlightedItem(GetListItemByIndex(MembersListBox, 0));
+
+
+                    var scrollViewer = MembersListBox.ChildOfType<ScrollViewer>();
+                    scrollViewer.ScrollToTop();
                 }),
                     DispatcherPriority.Loaded);
             }
@@ -215,6 +219,17 @@ namespace Dynamo.UI.Controls
                 return selectedMemberIndex;
 
             return nextselectedMemberIndex;
+        }
+
+        private void OnMembersListBoxMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            var listBox = sender as FrameworkElement;
+
+            var scrollViewer = listBox.ChildOfType<ScrollViewer>();
+
+            // Make delta less to achieve smooth scrolling and not jump over other elements.
+            var delta = e.Delta/100;
+            scrollViewer.ScrollToVerticalOffset(scrollViewer.VerticalOffset - delta);
         }
     }
 }

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -125,11 +125,10 @@ namespace Dynamo.UI.Controls
                 MembersListBox.ItemContainerGenerator.StatusChanged -= OnMembersListBoxIcgStatusChanged;
                 Dispatcher.BeginInvoke(new Action(() =>
                 {
-                    UpdateHighlightedItem(GetListItemByIndex(MembersListBox, 0));
-
-
                     var scrollViewer = MembersListBox.ChildOfType<ScrollViewer>();
                     scrollViewer.ScrollToTop();
+
+                    UpdateHighlightedItem(GetListItemByIndex(MembersListBox, 0));
                 }),
                     DispatcherPriority.Loaded);
             }
@@ -148,7 +147,10 @@ namespace Dynamo.UI.Controls
 
             // Select new value.
             if (HighlightedItem != null)
+            {
                 HighlightedItem.IsSelected = true;
+                HighlightedItem.BringIntoView();
+            }
         }
 
         private ListBoxItem GetListItemByIndex(ListBox parent, int index)


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7522](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7522) Should be able to use mouse wheel to scroll in-canvas search

Reason of bug:
Horizontal scrollviewer(red arrow) handles all mouse wheel events.
![image](https://cloud.githubusercontent.com/assets/8158404/8004780/4027ce1a-0b8b-11e5-98a5-70877d150261.png)

To scroll vertical scrollviewer we have to change vertical offset manually.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@ramramps 
@pboyer 
@Benglin 

### FYIs

@lillismith 