### PR TITLE
InCanvasSearch: jump

### DIFF
--- a/src/DynamoCore/Utilities/Configurations.cs
+++ b/src/DynamoCore/Utilities/Configurations.cs
@@ -228,6 +228,12 @@ namespace Dynamo.UI
 
         #endregion
 
+        #region InCanvasSearch
+
+        public const double InCanvasSearchTextBoxHeigth = 40.0;
+
+        #endregion
+
         #region Backup
 
         public static string BackupFileNamePrefix = "backup";

--- a/src/DynamoCore/Utilities/Configurations.cs
+++ b/src/DynamoCore/Utilities/Configurations.cs
@@ -230,7 +230,7 @@ namespace Dynamo.UI
 
         #region InCanvasSearch
 
-        public const double InCanvasSearchTextBoxHeigth = 40.0;
+        public const double InCanvasSearchTextBoxHeight = 40.0;
 
         #endregion
 

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
@@ -9,7 +9,7 @@
              xmlns:resx="clr-namespace:Dynamo.Properties;assembly=DynamoCore"
              xmlns:viewmodels="clr-namespace:Dynamo.ViewModels;assembly=DynamoCoreWpf"
              mc:Ignorable="d"
-             Width="250"
+             MinWidth="250"
              IsVisibleChanged="OnInCanvasSearchControlVisibilityChanged">
     <UserControl.Resources>
         <ResourceDictionary>

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2298,7 +2298,7 @@ namespace Dynamo.Controls
             {
                 double actualContextMenuHeight = (double)value;
 
-                return actualContextMenuHeight + Configurations.InCanvasSearchTextBoxHeigth;
+                return actualContextMenuHeight + Configurations.InCanvasSearchTextBoxHeight;
             }
 
             public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2286,5 +2286,24 @@ namespace Dynamo.Controls
             {
                 throw new NotImplementedException();
             }
-        }    
-}
+        }
+
+        /// <summary>
+        /// Converter is used in WorkspaceView. It makes context menu longer.
+        /// Since context menu includes now inCanvasSearch, it should be align according its' new height.
+        /// </summary>
+        public class WorkspaceContextMenuHeightConverter : IValueConverter
+        {
+            public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            {
+                double actualContextMenuHeight = (double)value;
+
+                return actualContextMenuHeight + Configurations.InCanvasSearchTextBoxHeigth;
+            }
+
+            public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -150,4 +150,5 @@
     <controls:ElementTypeToShortConverter x:Key="ElementTypeToShortConverter" />
     <controls:GroupTitleVisibilityConverter x:Key="GroupTitleVisibilityConverter"/>
     <controls:LibraryViewModeToBoolConverter x:Key="LibraryViewModeToBoolConverter" />
+    <controls:WorkspaceContextMenuHeightConverter x:Key="WorkspaceContextMenuHeightConverter" />
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -34,10 +34,12 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type ContextMenu}">
                         <StackPanel Margin="8,0,8,8"
-                                    Width="250">
+                                    Width="250"
+                                    Height="{Binding ElementName=MenuItems, Path=ActualHeight, 
+                                                     Converter={StaticResource WorkspaceContextMenuHeightConverter}}">
                             <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}" />
                             <Border BorderThickness="1"
-                                    Name="Border"
+                                    Name="MenuItems"
                                     Background="White"
                                     BorderBrush="#bbbbbb"
                                     Padding="0,3,0,3"

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -34,10 +34,11 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type ContextMenu}">
                         <StackPanel Margin="8,0,8,8"
-                                    Width="250"
+                                    Name="ContextMenuPanel"
                                     Height="{Binding ElementName=MenuItems, Path=ActualHeight, 
                                                      Converter={StaticResource WorkspaceContextMenuHeightConverter}}">
-                            <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}" />
+                            <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}"
+                                                      Width="{Binding ElementName=ContextMenuPanel, Path=ActualWidth}" />
                             <Border BorderThickness="1"
                                     Name="MenuItems"
                                     Background="White"


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7509](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7509) Context menu in-canvas search sometimes jumps around

Reason of bug:
ContextMenu is Popup element. Popup element always tries to align itself to fit the screen. But since we added in-canvas-search, context menu became longer.And it should take more place than it took before.
I've added new converter, that adds to context-menu-actual-height in-canvas-search-text-height.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@ramramps 
@pboyer 
@Benglin 

### FYIs

@lillismith 