### PR TITLE
Fix input port of CBN for localized build

### DIFF
--- a/src/Engine/ProtoCore/CompilerUtils.cs
+++ b/src/Engine/ProtoCore/CompilerUtils.cs
@@ -507,7 +507,7 @@ namespace ProtoCore.Utils
             {
                 if (warningEntry.ID == ProtoCore.BuildData.WarningID.kIdUnboundIdentifier)
                 {
-                    var varName = warningEntry.Message.Split(' ')[1].Replace("'", "");
+                    var varName = warningEntry.UnboundVariableSymbolNode.name;
                     result.Add(new VariableLine()
                     {
                         variable = varName,


### PR DESCRIPTION
### Purpose
Fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7588
- Unbound variable name was obtained from warning message and for localized builds the warning messages are localized, so it 's hard to parse the warning message correctly to get the unbound variable name.
- Instead use UnboundVariableSymbolNode property of WarningEntry object to get the unbound variable name.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

- [x] @aparajit-pratap  

### FYIs
@junmendoza 
@monikaprabhu 