### PR TITLE
Rewrite default argument expressions with fully qualified names

### DIFF
--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -738,28 +738,6 @@ namespace Dynamo.DSEngine
             return defaultArgumentNode != null;
         }
 
-        //private AssociativeNode ResolveDefaultArgumentClass(ProtoCore.Type argType, AssociativeNode defaultArgNode)
-        //{
-        //    if (!(defaultArgNode is IdentifierListNode) && !(defaultArgNode is IdentifierNode)) 
-        //        return defaultArgNode;
-
-        //    var matchingClasses = CoreUtils.GetResolvedClassName(LibraryManagementCore.ClassTable, defaultArgNode);
-
-        //    if (matchingClasses.Length == 1)
-        //    {
-        //        var resolvedName = matchingClasses[0];
-        //        return ElementRewriter.RewriteIdentifierListNode(defaultArgNode, resolvedName);
-        //    }
-
-        //    if(matchingClasses.Length > 1)
-        //    {
-        //        string message = ProtoCore.Properties.Resources.kMultipleSymbolFoundFromName;
-        //        message += String.Join(", ", matchingClasses);
-        //        LogWarningMessageEvents.OnLogWarningMessage(message);
-        //    }
-        //    return defaultArgNode;
-        //}
-
         private void ImportProcedure(string library, ProcedureNode proc)
         {
             string procName = proc.name;
@@ -847,7 +825,6 @@ namespace Dynamo.DSEngine
                     }
                     if (defaultArgumentNode != null)
                     {
-                        //defaultArgumentNode = ResolveDefaultArgumentClass(argType, defaultArgumentNode);
                         var rewriter = new ElementRewriter(LibraryManagementCore);
                         defaultArgumentNode = defaultArgumentNode.Accept(rewriter);
                     }

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -1,17 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml;
-using System.Xml.Linq;
 
 using Dynamo.Interfaces;
 using Dynamo.Library;
 using Dynamo.Utilities;
-using DynamoServices;
-using DynamoUtilities;
 
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.BuildData;
@@ -19,11 +14,9 @@ using ProtoCore.DSASM;
 using ProtoCore.Utils;
 using ProtoFFI;
 
-using RestSharp;
 
 using Operator = ProtoCore.DSASM.Operator;
 using ProtoCore;
-using ProtoCore.Mirror;
 using ProtoCore.Namespace;
 
 namespace Dynamo.DSEngine

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -10,6 +10,7 @@ using System.Xml.Linq;
 using Dynamo.Interfaces;
 using Dynamo.Library;
 using Dynamo.Utilities;
+using DynamoServices;
 using DynamoUtilities;
 
 using ProtoCore.AST.AssociativeAST;
@@ -22,6 +23,8 @@ using RestSharp;
 
 using Operator = ProtoCore.DSASM.Operator;
 using ProtoCore;
+using ProtoCore.Mirror;
+using ProtoCore.Namespace;
 
 namespace Dynamo.DSEngine
 {
@@ -735,6 +738,28 @@ namespace Dynamo.DSEngine
             return defaultArgumentNode != null;
         }
 
+        //private AssociativeNode ResolveDefaultArgumentClass(ProtoCore.Type argType, AssociativeNode defaultArgNode)
+        //{
+        //    if (!(defaultArgNode is IdentifierListNode) && !(defaultArgNode is IdentifierNode)) 
+        //        return defaultArgNode;
+
+        //    var matchingClasses = CoreUtils.GetResolvedClassName(LibraryManagementCore.ClassTable, defaultArgNode);
+
+        //    if (matchingClasses.Length == 1)
+        //    {
+        //        var resolvedName = matchingClasses[0];
+        //        return ElementRewriter.RewriteIdentifierListNode(defaultArgNode, resolvedName);
+        //    }
+
+        //    if(matchingClasses.Length > 1)
+        //    {
+        //        string message = ProtoCore.Properties.Resources.kMultipleSymbolFoundFromName;
+        //        message += String.Join(", ", matchingClasses);
+        //        LogWarningMessageEvents.OnLogWarningMessage(message);
+        //    }
+        //    return defaultArgNode;
+        //}
+
         private void ImportProcedure(string library, ProcedureNode proc)
         {
             string procName = proc.name;
@@ -820,7 +845,12 @@ namespace Dynamo.DSEngine
                             defaultArgumentNode = binaryExpr.RightNode;
                         }
                     }
-
+                    if (defaultArgumentNode != null)
+                    {
+                        //defaultArgumentNode = ResolveDefaultArgumentClass(argType, defaultArgumentNode);
+                        var rewriter = new ElementRewriter(LibraryManagementCore);
+                        defaultArgumentNode = defaultArgumentNode.Accept(rewriter);
+                    }
                     return new TypedParameter(arg.Name, argType, defaultArgumentNode);
                 }).ToList();
 

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -818,7 +818,7 @@ namespace Dynamo.DSEngine
                     }
                     if (defaultArgumentNode != null)
                     {
-                        var rewriter = new ElementRewriter(LibraryManagementCore);
+                        var rewriter = new ElementRewriter(LibraryManagementCore.ClassTable, LibraryManagementCore.BuildStatus.LogSymbolConflictWarning);
                         defaultArgumentNode = defaultArgumentNode.Accept(rewriter);
                     }
                     return new TypedParameter(arg.Name, argType, defaultArgumentNode);

--- a/src/Engine/ProtoCore/CompilerUtils.cs
+++ b/src/Engine/ProtoCore/CompilerUtils.cs
@@ -304,7 +304,8 @@ namespace ProtoCore.Utils
                 // partial classnames with their fully qualified names in ASTs
                 // before passing them for pre-compilation. If partial class is not found in map, 
                 // update Resolution map in elementResolver with fully resolved name from compiler.
-                var reWrittenNodes = ElementRewriter.RewriteElementNames(core, parseParams.ElementResolver, astNodes);
+                var reWrittenNodes = ElementRewriter.RewriteElementNames(core.ClassTable,  
+                    parseParams.ElementResolver, astNodes, core.BuildStatus.LogSymbolConflictWarning);
 
                 // Clone a disposable copy of AST nodes for PreCompile() as Codegen mutates AST's
                 // while performing SSA transforms and we want to keep the original AST's

--- a/src/Engine/ProtoCore/CompilerUtils.cs
+++ b/src/Engine/ProtoCore/CompilerUtils.cs
@@ -304,7 +304,7 @@ namespace ProtoCore.Utils
                 // partial classnames with their fully qualified names in ASTs
                 // before passing them for pre-compilation. If partial class is not found in map, 
                 // update Resolution map in elementResolver with fully resolved name from compiler.
-                var reWrittenNodes = ElementRewriter.RewriteElementNames(core.ClassTable, parseParams.ElementResolver, astNodes);
+                var reWrittenNodes = ElementRewriter.RewriteElementNames(core, parseParams.ElementResolver, astNodes);
 
                 // Clone a disposable copy of AST nodes for PreCompile() as Codegen mutates AST's
                 // while performing SSA transforms and we want to keep the original AST's

--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -149,7 +149,7 @@ namespace ProtoCore.Namespace
             return resolvedName;
         }
 
-        public AssociativeNode RewriteIdentifierListNode(AssociativeNode identifierList)
+        private AssociativeNode RewriteIdentifierListNode(AssociativeNode identifierList)
         {
             var resolvedName = ResolveClassName(identifierList);
 

--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -1,13 +1,11 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using ProtoCore.AST;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM;
 using ProtoCore.SyntaxAnalysis;
 using ProtoCore.Utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using ProtoCore.Properties;
 
 namespace ProtoCore.Namespace
 {

--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -18,8 +18,6 @@ namespace ProtoCore.Namespace
 
         public delegate void SymbolConflictWarningHandler(string symbolName, string[] collidingSymbolNames);
 
-        //public event SymbolConflictWarningHandler LogSymbolConflictWarning;
-
         private void OnLogSymbolConflictWarning(string symbolName, string[] collidingSymbolNames)
         {
             if (symbolConflictHandler != null)

--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -7,20 +7,20 @@ using ProtoCore.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using ProtoCore.Properties;
 
 namespace ProtoCore.Namespace
 {
 
     public class ElementRewriter : AstReplacer
     {
-        private readonly ClassTable classTable;
+        private readonly Core core;
         private readonly ElementResolver elementResolver;
 
-        internal ElementRewriter(ClassTable classTable, ElementResolver resolver)
+        public ElementRewriter(Core core, ElementResolver resolver = null)
         {
-            this.classTable = classTable;
-            this.elementResolver = resolver;
+            this.core = core;
+            this.elementResolver = resolver ?? new ElementResolver();
         }
 
         /// <summary>
@@ -29,13 +29,13 @@ namespace ProtoCore.Namespace
         /// If partial class is not found in map, 
         /// update ResolutionMap with fully resolved name from compiler.
         /// </summary>
-        /// <param name="classTable"></param>
+        /// <param name="core"></param>
         /// <param name="elementResolver"></param>
         /// <param name="astNodes"> parent AST node </param>
-        public static IEnumerable<Node> RewriteElementNames(ClassTable classTable,
+        public static IEnumerable<Node> RewriteElementNames(Core core,
             ElementResolver elementResolver, IEnumerable<Node> astNodes)
         {
-            var elementRewriter = new ElementRewriter(classTable, elementResolver);
+            var elementRewriter = new ElementRewriter(core, elementResolver);
             return astNodes.OfType<AssociativeNode>().Select(astNode => astNode.Accept(elementRewriter)).Cast<Node>().ToList();
         }
 
@@ -62,7 +62,7 @@ namespace ProtoCore.Namespace
             var type = new Type
             {
                 Name = identListString,
-                UID = classTable.IndexOf(identListString),
+                UID = core.ClassTable.IndexOf(identListString),
                 rank = node.datatype.rank
             };
 
@@ -128,30 +128,35 @@ namespace ProtoCore.Namespace
                 return String.Empty;
 
             var resolvedName = elementResolver.LookupResolvedName(partialName);
-            if (string.IsNullOrEmpty(resolvedName))
+            if (!string.IsNullOrEmpty(resolvedName)) 
+                return resolvedName;
+            
+            // If namespace resolution map does not contain entry for partial name, 
+            // back up on compiler to resolve the namespace from partial name
+            var matchingClasses = CoreUtils.GetResolvedClassName(core.ClassTable, identifierList);
+
+            if (matchingClasses.Length == 1)
             {
-                // If namespace resolution map does not contain entry for partial name, 
-                // back up on compiler to resolve the namespace from partial name
-                var matchingClasses = CoreUtils.GetResolvedClassName(classTable, identifierList);
+                resolvedName = matchingClasses[0];
+                var assemblyName = CoreUtils.GetAssemblyFromClassName(core.ClassTable, resolvedName);
 
-                if (matchingClasses.Length == 1)
-                {
-                    resolvedName = matchingClasses[0];
-                    var assemblyName = CoreUtils.GetAssemblyFromClassName(classTable, resolvedName);
-
-                    elementResolver.AddToResolutionMap(partialName, resolvedName, assemblyName);
-                }
+                elementResolver.AddToResolutionMap(partialName, resolvedName, assemblyName);
+            }
+            else if (matchingClasses.Length > 1)
+            {
+                core.BuildStatus.LogSymbolConflictWarning(partialName, matchingClasses);
             }
             return resolvedName;
         }
 
-        private AssociativeNode RewriteIdentifierListNode(AssociativeNode identifierList)
+        public AssociativeNode RewriteIdentifierListNode(AssociativeNode identifierList)
         {
-            var identListNode = identifierList as IdentifierListNode;
             var resolvedName = ResolveClassName(identifierList);
 
             if (string.IsNullOrEmpty(resolvedName))
                 return identifierList;
+
+            var identListNode = identifierList as IdentifierListNode;
 
             var newIdentList = CoreUtils.CreateNodeFromString(resolvedName);
 

--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -10,26 +10,26 @@ using ProtoCore.Utils;
 namespace ProtoCore.Namespace
 {
 
-    public class ElementRewriter : AstReplacer, IDisposable
+    public class ElementRewriter : AstReplacer
     {
         private readonly ClassTable classTable;
         private readonly ElementResolver elementResolver;
-        private readonly SymbolConflictWarningHandler handler;
+        private readonly SymbolConflictWarningHandler symbolConflictHandler;
 
         public delegate void SymbolConflictWarningHandler(string symbolName, string[] collidingSymbolNames);
 
-        public event SymbolConflictWarningHandler LogSymbolConflictWarning;
+        //public event SymbolConflictWarningHandler LogSymbolConflictWarning;
 
         private void OnLogSymbolConflictWarning(string symbolName, string[] collidingSymbolNames)
         {
-            if (LogSymbolConflictWarning != null)
-                handler(symbolName, collidingSymbolNames);
+            if (symbolConflictHandler != null)
+                symbolConflictHandler(symbolName, collidingSymbolNames);
         }
 
-        public ElementRewriter(ClassTable classTable, SymbolConflictWarningHandler handler, ElementResolver resolver = null)
+        public ElementRewriter(ClassTable classTable, SymbolConflictWarningHandler warningHandler, ElementResolver resolver = null)
         {
             this.classTable = classTable;
-            this.handler = handler;
+            this.symbolConflictHandler = warningHandler;
             this.elementResolver = resolver ?? new ElementResolver();
         }
 
@@ -203,10 +203,5 @@ namespace ProtoCore.Namespace
         }
 
         #endregion
-
-        public void Dispose()
-        {
-            LogSymbolConflictWarning -= handler;
-        }
     }
 }

--- a/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
+++ b/src/Engine/ProtoCore/Namespace/ElementRewriter.cs
@@ -10,14 +10,26 @@ using ProtoCore.Utils;
 namespace ProtoCore.Namespace
 {
 
-    public class ElementRewriter : AstReplacer
+    public class ElementRewriter : AstReplacer, IDisposable
     {
-        private readonly Core core;
+        private readonly ClassTable classTable;
         private readonly ElementResolver elementResolver;
+        private readonly SymbolConflictWarningHandler handler;
 
-        public ElementRewriter(Core core, ElementResolver resolver = null)
+        public delegate void SymbolConflictWarningHandler(string symbolName, string[] collidingSymbolNames);
+
+        public event SymbolConflictWarningHandler LogSymbolConflictWarning;
+
+        private void OnLogSymbolConflictWarning(string symbolName, string[] collidingSymbolNames)
         {
-            this.core = core;
+            if (LogSymbolConflictWarning != null)
+                handler(symbolName, collidingSymbolNames);
+        }
+
+        public ElementRewriter(ClassTable classTable, SymbolConflictWarningHandler handler, ElementResolver resolver = null)
+        {
+            this.classTable = classTable;
+            this.handler = handler;
             this.elementResolver = resolver ?? new ElementResolver();
         }
 
@@ -27,13 +39,14 @@ namespace ProtoCore.Namespace
         /// If partial class is not found in map, 
         /// update ResolutionMap with fully resolved name from compiler.
         /// </summary>
-        /// <param name="core"></param>
+        /// <param name="classTable"></param>
+        /// <param name="handler"></param>
         /// <param name="elementResolver"></param>
         /// <param name="astNodes"> parent AST node </param>
-        public static IEnumerable<Node> RewriteElementNames(Core core,
-            ElementResolver elementResolver, IEnumerable<Node> astNodes)
+        public static IEnumerable<Node> RewriteElementNames(ClassTable classTable, 
+            ElementResolver elementResolver, IEnumerable<Node> astNodes, SymbolConflictWarningHandler handler = null)
         {
-            var elementRewriter = new ElementRewriter(core, elementResolver);
+            var elementRewriter = new ElementRewriter(classTable, handler, elementResolver);
             return astNodes.OfType<AssociativeNode>().Select(astNode => astNode.Accept(elementRewriter)).Cast<Node>().ToList();
         }
 
@@ -60,7 +73,7 @@ namespace ProtoCore.Namespace
             var type = new Type
             {
                 Name = identListString,
-                UID = core.ClassTable.IndexOf(identListString),
+                UID = classTable.IndexOf(identListString),
                 rank = node.datatype.rank
             };
 
@@ -131,18 +144,18 @@ namespace ProtoCore.Namespace
             
             // If namespace resolution map does not contain entry for partial name, 
             // back up on compiler to resolve the namespace from partial name
-            var matchingClasses = CoreUtils.GetResolvedClassName(core.ClassTable, identifierList);
+            var matchingClasses = CoreUtils.GetResolvedClassName(classTable, identifierList);
 
             if (matchingClasses.Length == 1)
             {
                 resolvedName = matchingClasses[0];
-                var assemblyName = CoreUtils.GetAssemblyFromClassName(core.ClassTable, resolvedName);
+                var assemblyName = CoreUtils.GetAssemblyFromClassName(classTable, resolvedName);
 
                 elementResolver.AddToResolutionMap(partialName, resolvedName, assemblyName);
             }
             else if (matchingClasses.Length > 1)
             {
-                core.BuildStatus.LogSymbolConflictWarning(partialName, matchingClasses);
+                OnLogSymbolConflictWarning(partialName, matchingClasses);
             }
             return resolvedName;
         }
@@ -190,5 +203,10 @@ namespace ProtoCore.Namespace
         }
 
         #endregion
+
+        public void Dispose()
+        {
+            LogSymbolConflictWarning -= handler;
+        }
     }
 }

--- a/test/DynamoCoreTests/DefaultArgumentTests.cs
+++ b/test/DynamoCoreTests/DefaultArgumentTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Dynamo.Nodes;
+using NUnit.Framework;
+using ProtoCore.Utils;
+
+namespace Dynamo.Tests
+{
+    class DefaultArgumentTests : DynamoModelTestBase
+    {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("ProtoGeometry.dll");
+            libraries.Add("DSCoreNodes.dll");
+            
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        [Test]
+        public void TestDefaultArgumentExpressionResolution()
+        {
+            // Simulate loading of external libraries in Dynamo by importing
+            // FFITarget AFTER preloading the standard set of libraries above
+            // By this time the default expressions using ProtoGeometry classes have already been resolved
+            string libraryPath = "FFITarget.dll";
+            
+            CurrentDynamoModel.LibraryServices.ImportLibrary(libraryPath);
+
+            string openPath = Path.Combine(TestDirectory,
+                @"core\dsevaluation\TestDefaultArgumentExpressionResolution.dyn");
+            OpenModel(openPath);
+
+            BeginRun();
+
+            // Assert that all nodes that use default argument expressions evaluate 
+            var result = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSFunction>(
+                Guid.Parse("3039c01a-a6cc-45db-a8c7-5b5369538456"));
+
+            Assert.IsTrue(result.CachedValue.Data != null);
+
+            result = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSFunction>(
+                Guid.Parse("d15314f9-0903-4709-b183-0f3c6b40a95f"));
+
+            Assert.IsTrue(result.CachedValue.Data != null);
+
+            result = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSFunction>(
+                Guid.Parse("f7620e76-3177-415b-9de5-939c47a727d7"));
+
+            Assert.IsTrue(result.CachedValue.Data != null);
+            
+            result = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSFunction>(
+                Guid.Parse("3b92db37-3646-429a-9ec0-2fc09d0d5643"));
+
+            Assert.IsTrue(result.CachedValue.Data != null);
+            
+        }
+
+        [Test]
+        public void TestDefaultArgumentExpressionResolutionWithConflict()
+        {
+            // Simulate loading of external libraries in Dynamo by importing
+            // FFITarget AFTER preloading the standard set of libraries above
+            // By this time the default expressions using ProtoGeometry classes have already been resolved
+            string libraryPath = "FFITarget.dll";
+
+            CurrentDynamoModel.LibraryServices.ImportLibrary(libraryPath);
+
+            string openPath = Path.Combine(TestDirectory,
+                @"core\dsevaluation\TestDefaultArgumentExpressionWithConflict.dyn");
+            OpenModel(openPath);
+
+            BeginRun();
+
+            // Assert that node using default argument expression with fully qualified Point class evaluates
+            var result = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSFunction>(
+                Guid.Parse("7335190b-f50b-4e99-8dc6-de9ff45426fe"));
+
+            Assert.IsTrue(result.CachedValue.Data != null);
+
+            // Assert that node using default argument expression with unqualified Point class throws warning
+            // due to conflicts in Point class
+            result = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSFunction>(
+                Guid.Parse("40623ca5-8bbb-427a-b014-a9ac40378b51"));
+
+            Assert.IsTrue(result.State == Models.ElementState.Warning);
+        }
+    }
+}

--- a/test/DynamoCoreTests/DefaultArgumentTests.cs
+++ b/test/DynamoCoreTests/DefaultArgumentTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using Dynamo.Nodes;
 using NUnit.Framework;
-using ProtoCore.Utils;
 
 namespace Dynamo.Tests
 {

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="CallsiteTests.cs" />
     <Compile Include="CrashProtectionTests.cs" />
     <Compile Include="DefaultArgumentMigrationTests.cs" />
+    <Compile Include="DefaultArgumentTests.cs" />
     <Compile Include="DSEvaluationUnitTestBase.cs" />
     <Compile Include="DynamoModelTestBase.cs" />
     <Compile Include="MessageLogTests.cs" />

--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -216,27 +216,6 @@ namespace Dynamo.Tests
             }
         }
 
-        [Test]
-        [Category("UnitTests")]
-        public void TestDefaultArgumentAttribute()
-        {
-            string libraryPath = "FFITarget.dll";
-            if (!libraryServices.IsLibraryLoaded(libraryPath))
-            {
-                libraryServices.ImportLibrary(libraryPath);
-            }
-
-            // Get function groups for ClassFunctionality Class
-            var functions = libraryServices.GetFunctionGroups(libraryPath)
-                                            .SelectMany(x => x.Functions)
-                                            .Where(y => y.ClassName.Contains("FFITarget.TestData") && y.FunctionName.Equals("GetCircleArea"));
-
-            Assert.IsTrue(functions.Any());
-            var func = functions.First();
-
-            Assert.IsTrue(func.Parameters.First().DefaultValue.ToString().Equals("TestData.GetFloat()"));
-        }
-
         #endregion
     }
 }

--- a/test/Engine/FFITarget/FFITarget.csproj
+++ b/test/Engine/FFITarget/FFITarget.csproj
@@ -36,6 +36,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -68,6 +70,7 @@
     <Compile Include="OverloadTarget.cs" />
     <Compile Include="ProtoFFITests.cs" />
     <Compile Include="RegressionTargets.cs" />
+    <Compile Include="TestDefaultArgumentAttributes.cs" />
     <Compile Include="TestMessageLog.cs" />
     <Compile Include="TestNamespaceConflict.cs" />
     <Compile Include="TestNamespaceResolution.cs" />

--- a/test/Engine/FFITarget/FFITarget.csproj
+++ b/test/Engine/FFITarget/FFITarget.csproj
@@ -36,8 +36,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -939,6 +939,11 @@ namespace FFITarget
                 return p;
             }
 
+            public static Point ByCoordinates(double x, double y, double z)
+            {
+                return XYZ(x, y, z);
+            }
+
             public double dX { get; set; }
             public double dY { get; set; }
             public double dZ { get; set; }

--- a/test/Engine/FFITarget/TestDefaultArgumentAttributes.cs
+++ b/test/Engine/FFITarget/TestDefaultArgumentAttributes.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Autodesk.DesignScript.Runtime;
+
+namespace FFITarget
+{
+    public class ArgumentClass
+    {
+        public static float GetFloat()
+        {
+            return 2.5F;
+        }    
+    }
+
+    public class TestDefaultArgumentAttributes
+    {
+        public static double GetCircleArea([DefaultArgument("ArgumentClass.GetFloat()")]double radius)
+        {
+            return radius * radius * Math.PI;
+        }
+    }
+}

--- a/test/Engine/FFITarget/TestDefaultArgumentAttributes.cs
+++ b/test/Engine/FFITarget/TestDefaultArgumentAttributes.cs
@@ -3,20 +3,19 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Autodesk.DesignScript.Runtime;
+using FFITarget.DesignScript;
 
 namespace FFITarget
 {
-    public class ArgumentClass
-    {
-        public static float GetFloat()
-        {
-            return 2.5F;
-        }    
-    }
-
+   
     public class TestDefaultArgumentAttributes
     {
-        public static double GetCircleArea([DefaultArgument("ArgumentClass.GetFloat()")]double radius)
+        public static double ComputeCircle([DefaultArgument("FFITarget.DesignScript.Point.ByCoordinates(0, 0, 0)")]Point centerPoint, double radius = 1)
+        {
+            return radius * radius * Math.PI;
+        }
+
+        public static double ComputeCircleConflict([DefaultArgument("Point.ByCoordinates(0, 0, 0)")]Point centerPoint, double radius = 1)
         {
             return radius * radius * Math.PI;
         }

--- a/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
+++ b/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
@@ -20,7 +20,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual(string.Format("d = {0}.{1};\n", fullName, functionOrProperty), newNodes.ElementAt(0).ToString());
 
@@ -44,7 +44,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(0, 0, 0);\n", newNodes.ElementAt(0).ToString());
         }
@@ -61,7 +61,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("d = FFITarget.ElementResolverTarget.ElementResolverTarget();\n", newNodes.ElementAt(0).ToString());
 
@@ -87,7 +87,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("d = FFITarget.ElementResolverTarget.Create().Property.Method();\n", newNodes.ElementAt(0).ToString());
 
@@ -113,7 +113,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("d = FFITarget.ElementResolverTarget.Create().Property.Method(FFITarget.ElementResolverTarget.Create().Property);\n", newNodes.ElementAt(0).ToString());
 
@@ -139,7 +139,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("d = FFITarget.ElementResolverTarget.StaticProperty.Method(FFITarget.ElementResolverTarget.Create().Property.Method(FFITarget.ElementResolverTarget.Create().Property));\n", newNodes.ElementAt(0).ToString());
 
@@ -166,7 +166,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual(
                 string.Format("d = {0}.Property.Method({1}.Create().Property.Method({0}.Property.Property));\n", fullName1, fullName2), 
@@ -184,7 +184,7 @@ namespace ProtoTest.FFITests
 
             elementResolver = new ElementResolver();
 
-            newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
+            newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual(
                 string.Format("d = {0}.Property.Method({1}.Create().Property.Method({0}.Property.Property));\n", fullName1, fullName2),
@@ -359,7 +359,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("d : FFITarget.ElementResolverTarget", newNodes.ElementAt(0).ToString());
 
@@ -379,7 +379,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
         }
@@ -392,7 +392,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
 
@@ -402,7 +402,7 @@ namespace ProtoTest.FFITests
             elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.DS.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
 
@@ -412,7 +412,7 @@ namespace ProtoTest.FFITests
             elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.DS.Geometry.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
         }
@@ -425,7 +425,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
         }
@@ -438,7 +438,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
 
@@ -449,7 +449,7 @@ namespace ProtoTest.FFITests
             elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
             elementResolver.AddToResolutionMap("Autodesk.DS.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
 
@@ -460,7 +460,7 @@ namespace ProtoTest.FFITests
             elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
             elementResolver.AddToResolutionMap("Autodesk.DS.Geometry.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
         }
@@ -473,7 +473,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
         }
@@ -486,7 +486,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
 
@@ -495,7 +495,7 @@ namespace ProtoTest.FFITests
             elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.DS.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
 
@@ -504,7 +504,7 @@ namespace ProtoTest.FFITests
             elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.DS.Geometry.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
+            ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
 
             Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
         }
@@ -516,7 +516,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes).ToList();
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes).ToList();
 
             Assert.AreEqual("a = Flatten(a).DifferenceAll(Flatten(b));\n", newNodes[0].ToString());
         }
@@ -532,13 +532,13 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes).ToList();
+            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes).ToList();
 
             Assert.AreEqual("a = GlobalClass.GlobalClass(a);\n", newNodes[0].ToString());
 
             astNodes = CoreUtils.BuildASTList(testCore, "a : GlobalClass;");
 
-            newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes).ToList();
+            newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes).ToList();
 
             Assert.AreEqual("a : GlobalClass", newNodes[0].ToString());
 
@@ -557,7 +557,7 @@ namespace ProtoTest.FFITests
         {
             var astNodes = CoreUtils.BuildASTList(core, "p : int;");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core, new ElementResolver(), astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, new ElementResolver(), astNodes);
 
             Assert.AreEqual("p : int", newNodes.ElementAt(0).ToString());
         }

--- a/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
+++ b/test/Engine/ProtoTest/FFITests/ElementRewriterTests.cs
@@ -20,7 +20,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
 
             Assert.AreEqual(string.Format("d = {0}.{1};\n", fullName, functionOrProperty), newNodes.ElementAt(0).ToString());
 
@@ -44,7 +44,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(0, 0, 0);\n", newNodes.ElementAt(0).ToString());
         }
@@ -61,7 +61,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
 
             Assert.AreEqual("d = FFITarget.ElementResolverTarget.ElementResolverTarget();\n", newNodes.ElementAt(0).ToString());
 
@@ -87,7 +87,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
 
             Assert.AreEqual("d = FFITarget.ElementResolverTarget.Create().Property.Method();\n", newNodes.ElementAt(0).ToString());
 
@@ -113,7 +113,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
 
             Assert.AreEqual("d = FFITarget.ElementResolverTarget.Create().Property.Method(FFITarget.ElementResolverTarget.Create().Property);\n", newNodes.ElementAt(0).ToString());
 
@@ -139,7 +139,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
 
             Assert.AreEqual("d = FFITarget.ElementResolverTarget.StaticProperty.Method(FFITarget.ElementResolverTarget.Create().Property.Method(FFITarget.ElementResolverTarget.Create().Property));\n", newNodes.ElementAt(0).ToString());
 
@@ -166,7 +166,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
 
             Assert.AreEqual(
                 string.Format("d = {0}.Property.Method({1}.Create().Property.Method({0}.Property.Property));\n", fullName1, fullName2), 
@@ -184,7 +184,7 @@ namespace ProtoTest.FFITests
 
             elementResolver = new ElementResolver();
 
-            newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+            newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
 
             Assert.AreEqual(
                 string.Format("d = {0}.Property.Method({1}.Create().Property.Method({0}.Property.Property));\n", fullName1, fullName2),
@@ -359,7 +359,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes);
 
             Assert.AreEqual("d : FFITarget.ElementResolverTarget", newNodes.ElementAt(0).ToString());
 
@@ -379,7 +379,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
         }
@@ -392,7 +392,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
 
@@ -402,7 +402,7 @@ namespace ProtoTest.FFITests
             elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.DS.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
 
@@ -412,7 +412,7 @@ namespace ProtoTest.FFITests
             elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.DS.Geometry.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X;\n", newNodes.ElementAt(0).ToString());
         }
@@ -425,7 +425,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
         }
@@ -438,7 +438,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
 
@@ -449,7 +449,7 @@ namespace ProtoTest.FFITests
             elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
             elementResolver.AddToResolutionMap("Autodesk.DS.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
 
@@ -460,7 +460,7 @@ namespace ProtoTest.FFITests
             elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
             elementResolver.AddToResolutionMap("Autodesk.DS.Geometry.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p = Autodesk.DS.Geometry.Point.ByCoordinates(Autodesk.DS.Geometry.Point.ByCoordinates(x, y, z).X, y, z).X;\n", newNodes.ElementAt(0).ToString());
         }
@@ -473,7 +473,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
         }
@@ -486,7 +486,7 @@ namespace ProtoTest.FFITests
             var elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
 
@@ -495,7 +495,7 @@ namespace ProtoTest.FFITests
             elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.DS.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
 
@@ -504,7 +504,7 @@ namespace ProtoTest.FFITests
             elementResolver = new ElementResolver();
             elementResolver.AddToResolutionMap("Autodesk.DS.Geometry.Point", "Autodesk.DS.Geometry.Point", "Protogeometry.dll");
 
-            ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes);
+            ElementRewriter.RewriteElementNames(core, elementResolver, astNodes);
 
             Assert.AreEqual("p : Autodesk.DS.Geometry.Point", newNodes.ElementAt(0).ToString());
         }
@@ -516,7 +516,7 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, elementResolver, astNodes).ToList();
+            var newNodes = ElementRewriter.RewriteElementNames(core, elementResolver, astNodes).ToList();
 
             Assert.AreEqual("a = Flatten(a).DifferenceAll(Flatten(b));\n", newNodes[0].ToString());
         }
@@ -532,13 +532,13 @@ namespace ProtoTest.FFITests
 
             var elementResolver = new ElementResolver();
 
-            var newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes).ToList();
+            var newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes).ToList();
 
             Assert.AreEqual("a = GlobalClass.GlobalClass(a);\n", newNodes[0].ToString());
 
             astNodes = CoreUtils.BuildASTList(testCore, "a : GlobalClass;");
 
-            newNodes = ElementRewriter.RewriteElementNames(testCore.ClassTable, elementResolver, astNodes).ToList();
+            newNodes = ElementRewriter.RewriteElementNames(testCore, elementResolver, astNodes).ToList();
 
             Assert.AreEqual("a : GlobalClass", newNodes[0].ToString());
 
@@ -557,7 +557,7 @@ namespace ProtoTest.FFITests
         {
             var astNodes = CoreUtils.BuildASTList(core, "p : int;");
 
-            var newNodes = ElementRewriter.RewriteElementNames(core.ClassTable, new ElementResolver(), astNodes);
+            var newNodes = ElementRewriter.RewriteElementNames(core, new ElementResolver(), astNodes);
 
             Assert.AreEqual("p : int", newNodes.ElementAt(0).ToString());
         }

--- a/test/core/dsevaluation/TestDefaultArgumentExpressionResolution.dyn
+++ b/test/core/dsevaluation/TestDefaultArgumentExpressionResolution.dyn
@@ -1,0 +1,29 @@
+<Workspace Version="0.8.2.1592" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="3b92db37-3646-429a-9ec0-2fc09d0d5643" type="Dynamo.Nodes.DSFunction" nickname="Point.XYZ" x="280.5" y="450.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="..\..\..\bin\AnyCPU\Debug\FFITarget.dll" function="FFITarget.DesignScript.Point.XYZ@double,double,double" />
+    <Dynamo.Nodes.DSFunction guid="3039c01a-a6cc-45db-a8c7-5b5369538456" type="Dynamo.Nodes.DSFunction" nickname="Sphere.ByCenterPointRadius" x="108.5" y="33.5" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="d15314f9-0903-4709-b183-0f3c6b40a95f" type="Dynamo.Nodes.DSFunction" nickname="Circle.ByCenterPointRadius" x="175.5" y="254.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="f7620e76-3177-415b-9de5-939c47a727d7" type="Dynamo.Nodes.DSFunction" nickname="Curve.Extrude" x="663.5" y="403.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.Extrude@Autodesk.DesignScript.Geometry.Vector,double">
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="ef945d97-685a-4d0f-8d63-46788e275f99" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="70" y="461" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="1;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="db3f0d31-09e0-46d4-900d-e730e030b467" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="21" y="601" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="2;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="d85390ad-e4d0-462c-a25a-bd03b223ab02" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="115" y="686" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="3;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="d15314f9-0903-4709-b183-0f3c6b40a95f" start_index="0" end="f7620e76-3177-415b-9de5-939c47a727d7" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="ef945d97-685a-4d0f-8d63-46788e275f99" start_index="0" end="3b92db37-3646-429a-9ec0-2fc09d0d5643" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="db3f0d31-09e0-46d4-900d-e730e030b467" start_index="0" end="3b92db37-3646-429a-9ec0-2fc09d0d5643" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d85390ad-e4d0-462c-a25a-bd03b223ab02" start_index="0" end="3b92db37-3646-429a-9ec0-2fc09d0d5643" end_index="2" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>

--- a/test/core/dsevaluation/TestDefaultArgumentExpressionWithConflict.dyn
+++ b/test/core/dsevaluation/TestDefaultArgumentExpressionWithConflict.dyn
@@ -1,0 +1,16 @@
+<Workspace Version="0.8.2.1592" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="7335190b-f50b-4e99-8dc6-de9ff45426fe" type="Dynamo.Nodes.DSFunction" nickname="TestDefaultArgumentAttributes.ComputeCircle" x="375.5" y="319.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="..\..\..\bin\AnyCPU\Debug\FFITarget.dll" function="FFITarget.TestDefaultArgumentAttributes.ComputeCircle@FFITarget.DesignScript.Point,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="40623ca5-8bbb-427a-b014-a9ac40378b51" type="Dynamo.Nodes.DSFunction" nickname="TestDefaultArgumentAttributes.ComputeCircleConflict" x="181.5" y="509.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="..\..\..\bin\AnyCPU\Debug\FFITarget.dll" function="FFITarget.TestDefaultArgumentAttributes.ComputeCircleConflict@FFITarget.DesignScript.Point,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
### Purpose

This submission addresses the [defect] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7577) with some default argument nodes erroring in the presence of external libraries that introduce namespace conflicts. 

Default argument expressions like `Vector.ByCoordinates(0, 0, 1)` such as in the following code:
```
public Surface Extrude([DefaultArgumentAttribute("Vector.ByCoordinates(0, 0, 1)")] Vector direction, Double distance = 1)
{
	... 
}
```
can potentially fail for such nodes if there is a namespace conflict with the class `Vector`. In order to solve this issue, we try to resolve the class name in the compiler and replace its short name with its fully qualified name in the default argument expression. This is done using the `ElementRewriter` just like in the case of CBN. Thus in the above example, the expression `Vector.ByCoordinates(0, 0, 1)` is rewritten as `Autodesk.DesignScript.Geometry.Vector.ByCoordinates(0, 0, 1)`. Now if you import a new library/package with the same class name, the node will continue to function as the default argument has already been fully resolved.

### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@Benglin  Reviewer 1  

Note: There are still some limitations using default argument expressions in nodes. In the case of the [defect] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7577), since we are dealing only with `ProtoGeometry` nodes like `Point.ByCoordinates` not working in the presence  of `Rhynamo`, we don't have an issue now, since we are able to resolve the default argument `ProtoGeometry` class `Point` and rewrite the expression before `Rhynamo` is even loaded. 

However, zero touch programmers need to be aware that if they are introducing new classes in their libraries that can potentially conflict with existing node classes, they need to explicitly prefix the correct namespace(s) before the class name in the default argument expression in order for the node to execute readily. For example, in the above zero touch node example, if there is a conflict with `Autodesk.Vector` and `Rhino.Vector` AND the user wishes to use `Rhino.Vector` in the default expression, he would need to write it explicitly like:
```
public Surface Extrude([DefaultArgumentAttribute("Rhino.Vector.ByCoordinates(0, 0, 1)")] Rhino.Vector direction, Double distance = 1)
{
	...
}
```

Tested with self-service CI with no regressions.
Once approved needs merging in 0.8.1 branch.

### FYIs
@sharadkjaiswal 
@kronz 
@riteshchandawar 
@monikaprabhu (for testing)