### PR TITLE
Library Search: remove alphabetical order in categories

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -744,9 +744,6 @@ namespace Dynamo.ViewModels
             else
                 UpdateTopResult(null);
 
-            // Order found categories by name.
-            searchRootCategories = new ObservableCollection<SearchCategory>(searchRootCategories.OrderBy(x => x.Name));
-
             SortSearchCategoriesChildren();
         }
 


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7580](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7580) Remove Category alphabetization from library search

As I've said it's not hard task. Just remove 1 line.
Is it what we are expecting to see?
![image](https://cloud.githubusercontent.com/assets/8158404/8053207/fc884ff4-0e96-11e5-9b3f-164946130f42.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@pboyer 

### FYIs

@lillismith 