### PR TITLE
Fixed wonky execution issues

### DIFF
--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -458,17 +458,6 @@ namespace Dynamo.Models
         /// </summary>
         public void Run()
         {
-            // If the RunSettings.RunEnabled is set to false for some contexts, this
-            // method will not run if it is in the manual mode because the run button
-            // is disabled. But it is not the case in the automatic mode, even if the
-            // running of the graph will cause issues for some contexts. This is why
-            // the condition is added here so that if RunSettings.RunEnabled is set to
-            // false, this method will return.
-            if (!RunSettings.RunEnabled)
-            {
-                return;
-            }
-
             graphExecuted = true;
 
             // When Dynamo is shut down, the workspace is cleared, which results

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1418,6 +1418,36 @@ namespace DynamoCoreWpfTests
 
         #region Defect Verifications Test Cases
 
+        [Test, RequiresSTA]
+        public void UpdatingCbnShouldCauseDownstreamExecution()
+        {
+            // This test is meant to verify the fix for MAGN-7575 where updating
+            // a code block node causes downstream addition node to result in "null"
+            // instead of retaining its value of "16". Modifying the code block node
+            // in this case should not have caused such issue.
+            // 
+            RunCommandsFromFile("UpdatingCbnShouldCauseDownstreamExecution.xml", (commandTag) =>
+            {
+                switch (commandTag)
+                {
+                    case "AfterFileOpen":
+                        DynamoModel.IsTestMode = false; // Simulate normal UI interaction mode.
+                        AssertPreviewValue("556efc56-6043-4f96-8012-e5b716174d62", 16); // Addition node.
+                        AssertPreviewValue("505023ef-9b86-4220-a1f2-e0bf7cf415f1", 8);  // Code block node.
+                        break;
+
+                    case "CbnUpdatedTo9":
+                        AssertPreviewValue("556efc56-6043-4f96-8012-e5b716174d62", 17); // Addition node.
+                        AssertPreviewValue("505023ef-9b86-4220-a1f2-e0bf7cf415f1", 9);  // Code block node.
+                        break;
+
+                    case "CbnUpdatedTo12":
+                        AssertPreviewValue("556efc56-6043-4f96-8012-e5b716174d62", 20); // Addition node.
+                        AssertPreviewValue("505023ef-9b86-4220-a1f2-e0bf7cf415f1", 12); // Code block node.
+                        break;
+                }
+            });
+        }
 
         [Test, RequiresSTA, Category("RegressionTests")]
         public void Defect_MAGN_1956()

--- a/test/core/recorded/UpdatingCbnShouldCauseDownstreamExecution.dyn
+++ b/test/core/recorded/UpdatingCbnShouldCauseDownstreamExecution.dyn
@@ -1,0 +1,17 @@
+<Workspace Version="0.8.2.1465" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="556efc56-6043-4f96-8012-e5b716174d62" type="Dynamo.Nodes.DSFunction" nickname="+" x="431" y="70" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="+@var[]..[],var[]..[]" />
+    <Dynamo.Nodes.DoubleInput guid="64105f76-a498-4e3d-a3d7-f1709441234b" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="133" y="58.0000000000004" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="8.000" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="505023ef-9b86-4220-a1f2-e0bf7cf415f1" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="271.333333333333" y="139.333333333334" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="x;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="64105f76-a498-4e3d-a3d7-f1709441234b" start_index="0" end="556efc56-6043-4f96-8012-e5b716174d62" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="64105f76-a498-4e3d-a3d7-f1709441234b" start_index="0" end="505023ef-9b86-4220-a1f2-e0bf7cf415f1" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="505023ef-9b86-4220-a1f2-e0bf7cf415f1" start_index="0" end="556efc56-6043-4f96-8012-e5b716174d62" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>

--- a/test/core/recorded/UpdatingCbnShouldCauseDownstreamExecution.xml
+++ b/test/core/recorded/UpdatingCbnShouldCauseDownstreamExecution.xml
@@ -1,0 +1,12 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <OpenFileCommand XmlFilePath=".\UpdatingCbnShouldCauseDownstreamExecution.dyn" />
+  <PausePlaybackCommand Tag="AfterFileOpen" PauseDurationInMs="200" />
+  <UpdateModelValueCommand Name="Code" Value="9;" WorkspaceGuid="ea8a14dc-70ba-4ff6-9dea-28dfc82dd3c4">
+    <ModelGuid>505023ef-9b86-4220-a1f2-e0bf7cf415f1</ModelGuid>
+  </UpdateModelValueCommand>
+  <PausePlaybackCommand Tag="CbnUpdatedTo9" PauseDurationInMs="200" />
+  <UpdateModelValueCommand Name="Code" Value="12;" WorkspaceGuid="ea8a14dc-70ba-4ff6-9dea-28dfc82dd3c4">
+    <ModelGuid>505023ef-9b86-4220-a1f2-e0bf7cf415f1</ModelGuid>
+  </UpdateModelValueCommand>
+  <PausePlaybackCommand Tag="CbnUpdatedTo12" PauseDurationInMs="200" />
+</Commands>


### PR DESCRIPTION
### Purpose

This pull request is meant to fix multiple *wonky Dynamo execution* issues that have recently been reported. The crux of the issue lies with multiple execution requests have been dropped due to an incorrect condition that guards against further execution in `HomeWorkspaceModel.Run`. Take for example the following graph:

![update-0](https://cloud.githubusercontent.com/assets/5086849/8077142/c19c37b2-0f85-11e5-8507-77d4d8018546.png)

When the code block node is updated from `x` to `9`, the following calls take place in sequence (they indirectly invoke `HomeWorkspaceModel.Run` method):

1. `Dynamo.Nodes.CodeBlockNodeModel.SaveAndDeleteConnectors(...)`
2. `Dynamo.Nodes.CodeBlockNodeModel.LoadAndCreateConnectors(...)`
3. `Dynamo.Nodes.CodeBlockNodeModel.SetCodeContent(...)`

Since step `1` sets `RunSettings.RunEnabled = true`, subsequently steps `2` and `3` do not result in `UpdateGraphAsyncTask` being scheduled (even though `HomeWorkspaceModel.Run` is called, it returns prematurely). Step `3` is crucial because it ultimately generates AST node with the right value for execution, without that, downstream node executes with wrong input:

![update-1](https://cloud.githubusercontent.com/assets/5086849/8077146/cbc0fdea-0f85-11e5-9f12-3d2e5b6336c3.png)

The same sequence of events take place when code block node is then updated to `5`, except the fact that downstream node no longer get any input (which turned it into a partially applied `_SingleFunctionObject`):

![update-2](https://cloud.githubusercontent.com/assets/5086849/8077150/d40f76ca-0f85-11e5-916a-da9d0787ba53.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

Hi @sharadkjaiswal, as discussed, please have a look.

### FYIs

Hi @lukechurch, @ikeough, @Randy-Ma feel free to comment on this. If the review is completed earlier, I will merge this in for wider testing.

Hi @monikaprabhu, this pull request effectively reverts the code changes in [another pull request](https://github.com/DynamoDS/Dynamo/pull/4594). For that, I have verified the fix for `MAGN-7251` remained fixed (since selection nodes get disabled when Revit document changes), but please perform more thorough tests on relevant scenarios. Thanks!