### PR TITLE
InCanvasSearch: width

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
@@ -9,6 +9,7 @@
              xmlns:resx="clr-namespace:Dynamo.Properties;assembly=DynamoCore"
              xmlns:viewmodels="clr-namespace:Dynamo.ViewModels;assembly=DynamoCoreWpf"
              mc:Ignorable="d"
+             MinWidth="250"
              IsVisibleChanged="OnInCanvasSearchControlVisibilityChanged">
     <UserControl.Resources>
         <ResourceDictionary>

--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml
@@ -9,7 +9,6 @@
              xmlns:resx="clr-namespace:Dynamo.Properties;assembly=DynamoCore"
              xmlns:viewmodels="clr-namespace:Dynamo.ViewModels;assembly=DynamoCoreWpf"
              mc:Ignorable="d"
-             Width="250"
              IsVisibleChanged="OnInCanvasSearchControlVisibilityChanged">
     <UserControl.Resources>
         <ResourceDictionary>

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -33,9 +33,10 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type ContextMenu}">
-                        <StackPanel Margin="8,0,8,8"
-                                    Width="250">
-                            <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}" />
+                        <StackPanel Margin="8,0,8,8">
+                            <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}"
+                                                      Width="{Binding Path=ActualWidth, 
+                                                      RelativeSource={RelativeSource AncestorType=StackPanel}}" />
                             <Border BorderThickness="1"
                                     Name="Border"
                                     Background="White"

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -33,10 +33,10 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type ContextMenu}">
-                        <StackPanel Margin="8,0,8,8">
+                        <StackPanel Margin="8,0,8,8"
+                                    Name="ContextMenuPanel">
                             <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}"
-                                                      Width="{Binding Path=ActualWidth, 
-                                                      RelativeSource={RelativeSource AncestorType=StackPanel}}" />
+                                                      Width="{Binding ElementName=ContextMenuPanel, Path=ActualWidth}" />
                             <Border BorderThickness="1"
                                     Name="Border"
                                     Background="White"


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7632](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7632) GLOB: Contextual Menu:: Truncated contextual menu items

I had to bind InCanvasSearch width to context menu width.
Now context menu items are not truncated.

![image](https://cloud.githubusercontent.com/assets/8158404/8126038/a2475080-10f3-11e5-9e20-2ef3f21967d9.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@Benglin 
### FYIs

@monikaprabhu 