### PR TITLE
New search algorithm (experimental, don't merge)

### DIFF
--- a/src/DynamoCore/Search/SearchDictionary.cs
+++ b/src/DynamoCore/Search/SearchDictionary.cs
@@ -230,19 +230,24 @@ namespace Dynamo.Search
         /// <returns></returns>
         private static bool MatchWithQueryString(string key, string[] subPatterns)
         {
-            int index = 0;
-            int currPattern = 0;
-            while (index < key.Length && currPattern < subPatterns.Length)
-            {
-                index = key.IndexOf(subPatterns[currPattern], index);
-                if (index == -1)
-                    return false;
+            int numberOfMatchSymbols = 0;
+            int numberOfAllSymbols = 0;
 
-                index += subPatterns[currPattern].Length;
-                currPattern++;
+            foreach (var subPattern in subPatterns)
+            {
+                for (int i = subPattern.Length; i >= 1; i--)
+                {
+                    var part = subPattern.Substring(0, i);
+                    if (key.IndexOf(part) != -1)
+                    {
+                        numberOfMatchSymbols += part.Length;
+                        break;
+                    }
+                }
+                numberOfAllSymbols += subPattern.Length;
             }
 
-            return currPattern == subPatterns.Length;
+            return (double)numberOfMatchSymbols / numberOfAllSymbols > 0.8;
         }
 
         private static string[] SplitOnWhiteSpace(string s)


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7286](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7286) These similar search terms (singular/plural, upper/lower case) do not give expected results

I have been thinking how can we add plural search. E.g. if we search for "sliders", we should get "slider". Problem is that we don't actually have "sliderS" as key word and we don't want to add new keywords.

Maybe, it's bad solution. But I thought it would be great if we give search response  based on some percent. I.e. if we search for "sliders" and we have key word "slider", then these words match for 85%. Because "slider" has length 6 and "sliders" - 7. 6/7 = 85%

For now we add member to search, if its' key match with search text for 80%.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@pboyer 

### FYIs

@lillismith 