### PR TITLE
MAGN-7568 Cannot open dyn file from German user

### DIFF
--- a/src/DynamoCore/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Nodes/DummyNode.cs
@@ -48,6 +48,10 @@ namespace DSCoreNodesUI
             var helper = new XmlElementHelper(originalElement);
             X = helper.ReadDouble("x", 0.0);
             Y = helper.ReadDouble("y", 0.0);
+
+            //Take the GUID from the old node (dummy nodes should have their
+            //GUID's. This will allow the Groups to work as expected. MAGN-7568)
+            GUID = helper.ReadGuid("guid", this.GUID);
         }
 
         private void LoadNode(XmlNode nodeElement)

--- a/test/DynamoCoreWpfTests/AnnotationViewTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -27,6 +28,15 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, annotationViewOfType.Count(), "Expected a single Annotation View with guid: " + guid);
 
             return annotationViewOfType.First();
+        }
+
+        public NodeView NodeModelViewWithGuid(string guid)
+        {
+            var nodeViews = View.NodeViewsInFirstWorkspace();
+            var nodeViewsOfType = nodeViews.Where(x => x.ViewModel.NodeLogic.GUID.ToString() == guid);
+            Assert.AreEqual(1, nodeViewsOfType.Count(), "Expected a single NodeView with guid: " + guid);
+
+            return nodeViewsOfType.First();
         }
 
         public override void Open(string path)
@@ -91,6 +101,23 @@ namespace DynamoCoreWpfTests
             //Group textblock should be visible.
             Assert.IsTrue(annotationView.GroupTextBlock.IsVisible);
 
+        }
+
+        [Test]
+        public void TestAnnotationOnDummyNodes()
+        {
+            Open(@"UI\GroupDummyNodes.dyn");
+           
+            //check whether the Dummy nodes have the same GUID.
+            var nodeView = NodeModelViewWithGuid("de745c17-d6ef-4ff8-ac09-0d1703f58de5");
+            Assert.IsNotNull(nodeView);
+
+            //check whether there is a GROUP around Dummy nodes.
+            var annotationView = NodeViewWithGuid("ce97bb23-ad59-461b-ae81-17e8c48cf8de");
+            Assert.IsNotNull(annotationView);
+
+            var modelCount = annotationView.ViewModel.AnnotationModel.SelectedModels.Count();
+            Assert.AreEqual(1,modelCount);
         }
     }
 }

--- a/test/UI/GroupDummyNodes.dyn
+++ b/test/UI/GroupDummyNodes.dyn
@@ -1,0 +1,14 @@
+<Workspace Version="0.8.2.1465" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <DSRevitNodesUI.FamilyTypes guid="071c6c11-5f7b-45f2-84e9-bd4c03a11f68" type="DSRevitNodesUI.FamilyTypes" nickname="Family Types" x="1634.67143029212" y="384.534732754884" isVisible="true" isUpstreamVisible="true" lacing="Disabled" index="39:Space Planning - Rectangle:Space Planning - Rectangle" />
+    <DSRevitNodesUI.ElementsOfCategory guid="de745c17-d6ef-4ff8-ac09-0d1703f58de5" type="DSRevitNodesUI.ElementsOfCategory" nickname="All Elements of Category" x="516.827951415609" y="221.723530753818" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations>
+    <Dynamo.Models.AnnotationModel guid="ce97bb23-ad59-461b-ae81-17e8c48cf8de" annotationText="&lt;Click here to edit the group title&gt;" left="506.827951415609" top="191.723530753818" width="264.8" height="136.2" fontSize="14" InitialTop="221.723530753818" InitialHeight="136.2" TextblockHeight="20" backgrouund="#FFC1D676">
+      <Models ModelGuid="de745c17-d6ef-4ff8-ac09-0d1703f58de5" />
+    </Dynamo.Models.AnnotationModel>
+  </Annotations>
+</Workspace>


### PR DESCRIPTION
### Purpose
For any Groups around Dummy Nodes, Dynamo Crashes silently. If the group is created on Dynamo, then this is not an issue. But if the same group is created around a different compiler, say Revit, then opening the same file in Dynamo , all the Revit nodes (dummy nodes in Dynamo) will get a new GUID. Ideally, the GUID's have to be preserved (like how the positions are preserved today).

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
       GUID's are preserved for Dummy nodes.
- [ ] The level of testing this PR includes is appropriate

### Reviewers
@pboyer 