### PR TITLE
Fixes for publish package failure

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -728,7 +728,7 @@ namespace Dynamo.Models
 
             var uploadBuilder = new PackageUploadBuilder(dirBuilder, new MutatingFileCompressor());
 
-            return new PackageManagerClient( new GregClient(provider, url), uploadBuilder );
+            return new PackageManagerClient( new GregClient(provider, url), uploadBuilder, rootDirectory );
         }
 
         private void InitializeCustomNodeManager()

--- a/src/DynamoCore/PackageManager/PackageManagerClient.cs
+++ b/src/DynamoCore/PackageManager/PackageManagerClient.cs
@@ -29,6 +29,9 @@ namespace Dynamo.PackageManager
         private readonly IAuthProvider authProvider;
         private readonly IPackageUploadBuilder uploadBuilder;
 
+        /// <summary>
+        ///     The directory where all packages are to be stored for this session.
+        /// </summary>
         private readonly string packagesDirectory;
        
         public event Action<LoginState> LoginStateChanged;
@@ -67,8 +70,9 @@ namespace Dynamo.PackageManager
 
         #endregion
 
-        internal PackageManagerClient(IGregClient client, IPackageUploadBuilder builder)
+        internal PackageManagerClient(IGregClient client, IPackageUploadBuilder builder, string packagesDirectory)
         {
+            this.packagesDirectory = packagesDirectory;
             this.uploadBuilder = builder;
             this.client = client;
 

--- a/src/DynamoCore/PackageManager/RealFileInfo.cs
+++ b/src/DynamoCore/PackageManager/RealFileInfo.cs
@@ -17,7 +17,7 @@ namespace Dynamo.PackageManager
 
         public string Name
         {
-            get { return fileInfo.Name;  }
+            get { return fileInfo.FullName;  }
         }
 
         public long Length

--- a/test/DynamoCoreTests/PackageManager/PackageManagerClientTests.cs
+++ b/test/DynamoCoreTests/PackageManager/PackageManagerClientTests.cs
@@ -33,7 +33,7 @@ namespace Dynamo.PackageManager.Tests
                 x.ExecuteAndDeserializeWithContent<List<PackageHeader>>(It.IsAny<HeaderCollectionDownload>()))
                 .Returns(mpl);
 
-            var m = new PackageManagerClient(c.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var m = new PackageManagerClient(c.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var pl = m.ListAll();
             Assert.AreNotEqual(0, pl.Count());
@@ -48,7 +48,7 @@ namespace Dynamo.PackageManager.Tests
                 x.ExecuteAndDeserializeWithContent<List<PackageHeader>>(It.IsAny<HeaderCollectionDownload>()))
                 .Throws(new Exception("Fail!"));
 
-            var m = new PackageManagerClient(c.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var m = new PackageManagerClient(c.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var pl = m.ListAll();
             Assert.AreEqual(0, pl.Count());
@@ -79,7 +79,7 @@ namespace Dynamo.PackageManager.Tests
                 x.ExecuteAndDeserializeWithContent<PackageHeader>(It.IsAny<HeaderDownload>()))
                 .Returns(mp);
 
-            var pc = new PackageManagerClient(c.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(c.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             PackageHeader header;
             var res = pc.DownloadPackageHeader(id, out header);
@@ -97,7 +97,7 @@ namespace Dynamo.PackageManager.Tests
                 x.ExecuteAndDeserializeWithContent<PackageHeader>(It.IsAny<HeaderDownload>()))
                 .Throws<Exception>();
 
-            var pc = new PackageManagerClient(c.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(c.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             PackageHeader header;
             var res = pc.DownloadPackageHeader("1", out header);
@@ -120,7 +120,7 @@ namespace Dynamo.PackageManager.Tests
             //var gc = new Mock<IGregClient>();
             //gc.Setup(x => x.Execute(It.IsAny<PackageDownload>())).Returns( Mockable
 
-            //var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            //var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
         }
 
         [Test]
@@ -129,7 +129,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.Execute(It.IsAny<PackageDownload>())).Throws(new Exception("Failed to get your package!"));
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             string downloadPath;
             var res = pc.DownloadPackage("1", "0.1", out downloadPath);
@@ -151,7 +151,7 @@ namespace Dynamo.PackageManager.Tests
                 success = true
             });
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.Upvote("id");
 
@@ -164,7 +164,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.ExecuteAndDeserialize(It.IsAny<Upvote>())).Throws<Exception>();
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.Upvote("id");
 
@@ -184,7 +184,7 @@ namespace Dynamo.PackageManager.Tests
                 success = true
             });
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.Downvote("id");
 
@@ -197,7 +197,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.ExecuteAndDeserialize(It.IsAny<Downvote>())).Throws<Exception>();
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.Downvote("id");
 
@@ -222,7 +222,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.ExecuteAndDeserializeWithContent<TermsOfUseStatus>(It.IsAny<TermsOfUse>())).Returns(resp);
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.GetTermsOfUseAcceptanceStatus();
 
@@ -243,7 +243,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.ExecuteAndDeserializeWithContent<TermsOfUseStatus>(It.IsAny<TermsOfUse>())).Returns(resp);
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.GetTermsOfUseAcceptanceStatus();
 
@@ -257,7 +257,7 @@ namespace Dynamo.PackageManager.Tests
             gc.Setup(x => x.ExecuteAndDeserializeWithContent<TermsOfUseStatus>(It.IsAny<TermsOfUse>()))
                 .Throws<Exception>();
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.GetTermsOfUseAcceptanceStatus();
 
@@ -282,7 +282,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.ExecuteAndDeserializeWithContent<TermsOfUseStatus>(It.IsAny<TermsOfUse>())).Returns(resp);
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.SetTermsOfUseAcceptanceStatus();
 
@@ -295,7 +295,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.ExecuteAndDeserializeWithContent<TermsOfUseStatus>(It.IsAny<TermsOfUse>())).Throws<Exception>();
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.SetTermsOfUseAcceptanceStatus();
 
@@ -316,7 +316,7 @@ namespace Dynamo.PackageManager.Tests
                     success = true
                 });
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var pkg = new Package("", "Package", "0.1.0", "MIT");
 
@@ -336,7 +336,7 @@ namespace Dynamo.PackageManager.Tests
                     success = true
                 });
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var pkg = new Package("", "Package", "0.1.0", "MIT");
 
@@ -352,7 +352,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.ExecuteAndDeserialize(It.IsAny<PackageUpload>())).Throws<Exception>();
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var pkg = new Package("", "Package", "0.1.0", "MIT");
 
@@ -375,7 +375,7 @@ namespace Dynamo.PackageManager.Tests
                 success = true
             });
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.Deprecate("id");
 
@@ -391,7 +391,7 @@ namespace Dynamo.PackageManager.Tests
                 success = false // set to false
             });
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.Deprecate("id");
 
@@ -404,7 +404,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.ExecuteAndDeserialize(It.IsAny<Deprecate>())).Throws(new Exception());
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.Deprecate("id");
 
@@ -424,7 +424,7 @@ namespace Dynamo.PackageManager.Tests
                 success = true
             });
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.Undeprecate("id");
 
@@ -440,7 +440,7 @@ namespace Dynamo.PackageManager.Tests
                 success = false // set to false
             });
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.Undeprecate("id");
 
@@ -453,7 +453,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.ExecuteAndDeserialize(It.IsAny<Undeprecate>())).Throws(new Exception());
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             var res = pc.Undeprecate("id");
 
@@ -475,7 +475,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.AuthProvider).Returns(ap.Object);
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             pc.Logout();
 
@@ -497,7 +497,7 @@ namespace Dynamo.PackageManager.Tests
             var gc = new Mock<IGregClient>();
             gc.Setup(x => x.AuthProvider).Returns(ap.Object);
 
-            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>());
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
 
             pc.Login();
 


### PR DESCRIPTION
### Purpose

This fixes two small regressions when publishing a new package.  The `PackageManagerClient` was not receiving the `packagesDirectory` argument. Also, the `RealFileInfo` class should return the `FileInfo.FullName` field, rather than `FileInfo.Name`.  

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@ikeough 