### PR TITLE
Fix DYN file version to complete the test.

### DIFF
--- a/test/core/recorded/UpdatingCbnShouldCauseDownstreamExecution.dyn
+++ b/test/core/recorded/UpdatingCbnShouldCauseDownstreamExecution.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="0.8.2.1465" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+<Workspace Version="0.8.1.1465" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
     <Dynamo.Nodes.DSFunction guid="556efc56-6043-4f96-8012-e5b716174d62" type="Dynamo.Nodes.DSFunction" nickname="+" x="431" y="70" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="+@var[]..[],var[]..[]" />


### PR DESCRIPTION
### Purpose

This PR fixes the file version of DYN file in 0.8.1 branch.

- Opening a 0.8.2 DYN file in RC0.8.1_master branch will show up a warning dialog, which will make this test hung.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers
@Benglin 