### PR TITLE
Fix magn-7574: Custom node creation with curve input sets type to "double"

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -12,6 +12,7 @@ using Dynamo.Utilities;
 using ProtoCore.AST;
 using ProtoCore.Namespace;
 using Symbol = Dynamo.Nodes.Symbol;
+using Dynamo.Library;
 
 namespace Dynamo.Core
 {
@@ -922,6 +923,7 @@ namespace Dynamo.Core
                         // two kinds of nodes whose input type are available:
                         // function node and custom node. 
                         List<Library.TypedParameter> parameters = null;
+
                         if (inputReceiverNode is Function) 
                         {
                             var func = inputReceiverNode as Function; 
@@ -930,7 +932,16 @@ namespace Dynamo.Core
                         else if (inputReceiverNode is DSFunctionBase)
                         {
                             var dsFunc = inputReceiverNode as DSFunctionBase;
-                            parameters = dsFunc.Controller.Definition.Parameters.ToList(); 
+                            var funcDesc = dsFunc.Controller.Definition;
+                            parameters = dsFunc.Controller.Definition.Parameters.ToList();
+
+                            if (funcDesc.Type == DSEngine.FunctionType.InstanceMethod ||
+                                funcDesc.Type == DSEngine.FunctionType.InstanceProperty)
+                            {
+                                var dummyType = new ProtoCore.Type() { Name = funcDesc.ClassName };
+                                var instanceParam = new TypedParameter(funcDesc.ClassName, dummyType);
+                                parameters.Insert(0, instanceParam);
+                            }
                         }
 
                         // so the input of custom node has format 

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -933,7 +933,7 @@ namespace Dynamo.Core
                         {
                             var dsFunc = inputReceiverNode as DSFunctionBase;
                             var funcDesc = dsFunc.Controller.Definition;
-                            parameters = dsFunc.Controller.Definition.Parameters.ToList();
+                            parameters = funcDesc.Parameters.ToList();
 
                             if (funcDesc.Type == DSEngine.FunctionType.InstanceMethod ||
                                 funcDesc.Type == DSEngine.FunctionType.InstanceProperty)

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -865,5 +865,46 @@ namespace Dynamo.Tests
             //Check whether the group is copied to custom workspace
             Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Annotations.Count); 
         }
+
+        [Test]
+        public void TestCustomNodeInputType2()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\collapse\collapse-input-type.dyn");
+            OpenModel(openPath);
+
+            var nodesToCollapse = new[]
+            {
+                "fb066324-1ca0-400f-8dee-cbb0e1d27719", 
+            };
+
+            foreach (
+                var node in
+                    nodesToCollapse.Select(CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace))
+            {
+                CurrentDynamoModel.AddToSelection(node);
+            }
+
+            var ws = CurrentDynamoModel.CustomNodeManager.Collapse(
+                DynamoSelection.Instance.Selection.OfType<NodeModel>(),
+                CurrentDynamoModel.CurrentWorkspace,
+                true,
+                new FunctionNamePromptEventArgs
+                {
+                    Category = "Testing",
+                    Description = "",
+                    Name = "__CollapseTestForInputType1__",
+                    Success = true
+                });
+
+            CurrentDynamoModel.AddCustomNodeWorkspace(ws);
+            CurrentDynamoModel.OpenCustomNodeWorkspace(ws.CustomNodeId);
+            var inputs = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<Symbol>();
+            Assert.IsNotNull(inputs);
+
+            var curveParam = inputs.FirstOrDefault();
+            Assert.IsNotNull(curveParam);
+
+            Assert.AreEqual("Curve", curveParam.Parameter.DisplayTypeName);
+        }
     }
 }

--- a/test/core/collapse/collapse-input-type.dyn
+++ b/test/core/collapse/collapse-input-type.dyn
@@ -1,0 +1,16 @@
+<Workspace Version="0.8.0.1671" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Point" resolvedName="Autodesk.DesignScript.Geometry.Point" assemblyName="ProtoGeometry.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="fb066324-1ca0-400f-8dee-cbb0e1d27719" type="Dynamo.Nodes.DSFunction" nickname="Curve.Extrude" x="623.5" y="256.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.Extrude@Autodesk.DesignScript.Geometry.Vector">
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="155323bb-ebf0-4fa6-88f6-b2d606aa6acc" type="Dynamo.Nodes.DSFunction" nickname="Line.ByStartPointEndPoint" x="328.5" y="198.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="155323bb-ebf0-4fa6-88f6-b2d606aa6acc" start_index="0" end="fb066324-1ca0-400f-8dee-cbb0e1d27719" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR ties to fix defect [MAGN-7574 Custom node creation with curve input sets type to "double"] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7574#)

It is because the selected node is an instance method, so its input parameter is not real function parameter. For example, the signature of `Curve.Extrude()` is 
```
Extrude(distance:double = 1);
```
whereas the node should have an input for curve instance:

![untitled](https://cloud.githubusercontent.com/assets/2600379/8200335/154b2fce-14f6-11e5-9646-ad97088845e5.png)

So when converting this kind of node to custom node, creating input types based on real function's parameters is not enough, we should check if it is an instance method/property or not and provide an extra input for them. 

### Reviewers

@sharadkjaiswal PTAL.