### PR TITLE
Fix unable to find localized GalleryContents issue

### DIFF
--- a/src/DynamoCore/Core/PathManager.cs
+++ b/src/DynamoCore/Core/PathManager.cs
@@ -419,18 +419,17 @@ namespace Dynamo.Core
             var uiCulture = CultureInfo.CurrentUICulture.ToString();
             var galleryDirectory = Path.Combine(commonDataDir, "gallery", uiCulture);
 
-            // If the localized samples directory does not exist then fall back 
-            // to using the en-US samples folder. Do an additional check to see 
+            // If the localized gallery directory does not exist then fall back 
+            // to using the en-US gallery folder. Do an additional check to see 
             // if the localized folder is available but is empty.
             // 
             var di = new DirectoryInfo(galleryDirectory);
             if (!Directory.Exists(galleryDirectory) ||
-                !di.GetDirectories().Any() ||
-                !di.GetFiles().Any())
+                !di.GetFiles("*.xml",SearchOption.TopDirectoryOnly).Any())
             {
-                var neturalCommonSamples = Path.Combine(commonDataDir, "gallery", "en-US");
-                if (Directory.Exists(neturalCommonSamples))
-                    galleryDirectory = neturalCommonSamples;
+                var neutralCommonGallery = Path.Combine(commonDataDir, "gallery", "en-US");
+                if (Directory.Exists(neutralCommonGallery))
+                    galleryDirectory = neutralCommonGallery;
             }
 
             return galleryDirectory;


### PR DESCRIPTION
### Purpose

- The localized Dynamo is not able to find the localized GalleryContents. (YT issue: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7681)

- This is because the ```GetGalleryDirectory``` method in the PathManager checks whether there are sub-directories inside the ```gallery/<locale>``` (following the sample implementation), whereas there is no sub-directory inside.

- This fix removes the checking of the sub-directories and checks whether there is an xml file inside the ```gallery/<locale>```

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@Benglin