### PR TITLE
Fix to shorten default argument tooltip names

### DIFF
--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -816,14 +816,14 @@ namespace Dynamo.DSEngine
                             defaultArgumentNode = binaryExpr.RightNode;
                         }
                     }
-                    AssociativeNode shortDefaultArgNode = null;
+                    string shortName = null;
                     if (defaultArgumentNode != null)
                     {
-                        shortDefaultArgNode = NodeUtils.Clone(defaultArgumentNode);
+                        shortName = defaultArgumentNode.ToString();
                         var rewriter = new ElementRewriter(LibraryManagementCore.ClassTable, LibraryManagementCore.BuildStatus.LogSymbolConflictWarning);
                         defaultArgumentNode = defaultArgumentNode.Accept(rewriter);
                     }
-                    return new TypedParameter(arg.Name, argType, defaultArgumentNode, shortDefaultArgNode);
+                    return new TypedParameter(arg.Name, argType, defaultArgumentNode, shortName);
                 }).ToList();
 
             IEnumerable<string> returnKeys = null;

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -816,12 +816,14 @@ namespace Dynamo.DSEngine
                             defaultArgumentNode = binaryExpr.RightNode;
                         }
                     }
+                    AssociativeNode shortDefaultArgNode = null;
                     if (defaultArgumentNode != null)
                     {
+                        shortDefaultArgNode = NodeUtils.Clone(defaultArgumentNode);
                         var rewriter = new ElementRewriter(LibraryManagementCore.ClassTable, LibraryManagementCore.BuildStatus.LogSymbolConflictWarning);
                         defaultArgumentNode = defaultArgumentNode.Accept(rewriter);
                     }
-                    return new TypedParameter(arg.Name, argType, defaultArgumentNode);
+                    return new TypedParameter(arg.Name, argType, defaultArgumentNode, shortDefaultArgNode);
                 }).ToList();
 
             IEnumerable<string> returnKeys = null;

--- a/src/DynamoCore/Library/TypedParameter.cs
+++ b/src/DynamoCore/Library/TypedParameter.cs
@@ -11,8 +11,9 @@ namespace Dynamo.Library
     public class TypedParameter
     {
         private string summary = null; // Indicating that it is not initialized.
+        private string defaultValueString;
 
-        public TypedParameter(string parameter, ProtoCore.Type type, AssociativeNode defaultValue = null)
+        public TypedParameter(string parameter, ProtoCore.Type type, AssociativeNode defaultValue = null, AssociativeNode shortDefaultValue = null)
         {
             if (parameter == null)
                 throw new ArgumentNullException("parameter");
@@ -20,6 +21,13 @@ namespace Dynamo.Library
             Name = parameter;
             Type = type;
             DefaultValue = defaultValue;
+            
+            if (DefaultValue != null)
+            {
+                defaultValueString = shortDefaultValue != null
+                    ? shortDefaultValue.ToString()
+                    : DefaultValue.ToString();
+            }
         }
 
         public FunctionDescriptor Function { get; private set; }
@@ -47,11 +55,13 @@ namespace Dynamo.Library
 
                 description = description + DisplayTypeName;
 
-                if (DefaultValue != null)
-                    description = String.Format("{0}\n{1} : {2}", 
-                                                description, 
-                                                Properties.Resources.DefaultValue, 
-                                                DefaultValue.ToString());
+                if (defaultValueString != null)
+                {
+                    description = String.Format("{0}\n{1} : {2}",
+                        description,
+                        Properties.Resources.DefaultValue,
+                        defaultValueString);
+                }
 
                 return description;
             }
@@ -74,9 +84,9 @@ namespace Dynamo.Library
         public override string ToString()
         {
             string str = Name + ": " + DisplayTypeName;
-            if (DefaultValue != null)
+            if (defaultValueString != null)
             {
-                str = str + " = " + DefaultValue.ToString();
+                str = str + " = " + defaultValueString;
             }
 
             return str;

--- a/src/DynamoCore/Library/TypedParameter.cs
+++ b/src/DynamoCore/Library/TypedParameter.cs
@@ -11,9 +11,9 @@ namespace Dynamo.Library
     public class TypedParameter
     {
         private string summary = null; // Indicating that it is not initialized.
-        private string defaultValueString;
+        private readonly string defaultValueString;
 
-        public TypedParameter(string parameter, ProtoCore.Type type, AssociativeNode defaultValue = null, AssociativeNode shortDefaultValue = null)
+        public TypedParameter(string parameter, ProtoCore.Type type, AssociativeNode defaultValue = null, string shortArgumentName = null)
         {
             if (parameter == null)
                 throw new ArgumentNullException("parameter");
@@ -21,13 +21,8 @@ namespace Dynamo.Library
             Name = parameter;
             Type = type;
             DefaultValue = defaultValue;
-            
-            if (DefaultValue != null)
-            {
-                defaultValueString = shortDefaultValue != null
-                    ? shortDefaultValue.ToString()
-                    : DefaultValue.ToString();
-            }
+
+            defaultValueString = shortArgumentName;
         }
 
         public FunctionDescriptor Function { get; private set; }


### PR DESCRIPTION
### Purpose

This PR fixes the [defect] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7673) with default argument expressions appearing as fully resolved names in tooltips and library view.

This was a regression after the fix made in #4659. This fix took the AST generated from the default argument expression written in the `DefaultArgumentAttribute`, resolved the class name and rewrote the AST with the fully resolved name. Since the rewritten AST's `ToString()` output was used as the tooltip, it resulted in long fully qualified names.

The fix used here is to pass in the original AST's `ToString()` (before rewriting it) to `TypedParameter` ctor so that it can be used as the short name.

### Declarations

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@ke-yu  Reviewer 1 
@Benglin Reviewer 2

### FYIs

@riteshchandawar 