### PR TITLE
Fix testcase Callsite_RunWithTraceDataFromUnresolvedNodes_DoesNotCrash

### DIFF
--- a/test/DynamoCoreTests/CallsiteTests.cs
+++ b/test/DynamoCoreTests/CallsiteTests.cs
@@ -130,7 +130,7 @@ namespace Dynamo.Tests
 
             // The number of connectors is less than what we would expect
             // beause several of the nodes load as un-commented dummy nodes.
-            Assert.AreEqual(46, ws.Connectors.Count());
+            Assert.AreEqual(49, ws.Connectors.Count());
 
             // The guard added around deserialization of types that
             // can't be resolved will prevent a crash. This test

--- a/test/DynamoCoreTests/CallsiteTests.cs
+++ b/test/DynamoCoreTests/CallsiteTests.cs
@@ -127,9 +127,6 @@ namespace Dynamo.Tests
 
             // check all the nodes and connectors are loaded
             Assert.AreEqual(42, ws.Nodes.Count);
-
-            // The number of connectors is less than what we would expect
-            // beause several of the nodes load as un-commented dummy nodes.
             Assert.AreEqual(49, ws.Connectors.Count());
 
             // The guard added around deserialization of types that


### PR DESCRIPTION
### Purpose

This PR update test case `Callsite_RunWithTraceDataFromUnresolvedNodes_DoesNotCrash` which tries to verify the number of connector is 46, but it is 49 instead. 

### Reviewers 

@sharadkjaiswal 