### PR TITLE
fix parameters description not used in tooltip and help dialog

### DIFF
--- a/src/DynamoCore/Library/TypedParameter.cs
+++ b/src/DynamoCore/Library/TypedParameter.cs
@@ -32,8 +32,10 @@ namespace Dynamo.Library
             get
             {
                 // If 'summary' data member is 'null', it means its value has 
-                // to be repopulated. 
-                return summary ?? this.GetDescription();
+                // to be repopulated.
+                if (string.IsNullOrEmpty(summary))
+                    summary = this.GetDescription();
+                return summary;
             }
         }
 
@@ -41,11 +43,7 @@ namespace Dynamo.Library
         {
             get
             {
-                string description = string.Empty;
-                if (!string.IsNullOrEmpty(summary))
-                    description = description + summary + "\n\n";
-
-                description = description + DisplayTypeName;
+                string description = Summary + "\n\n" + DisplayTypeName;
 
                 if (DefaultValue != null)
                     description = String.Format("{0}\n{1} : {2}", 


### PR DESCRIPTION
### Purpose

This PR addresses the missing input parameters' description coming from XML ([MAGN-7642](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7642)).

The property `Summary` is never used so the function GetDescription is never called. And since the variable `summary` is only assigned to `null`, the input parameters' description is missing.

### Reviewers
@ke-yu PTAL


### FYIs
@aparajit-pratap 