### PR TITLE
typedParameter Summary Fix for customNode typesparams

### DIFF
--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -71,8 +71,13 @@ namespace Dynamo.DSEngine
             DocumentElementType property,
             string paramName = "")
         {
+            //customNodeDefinitions typedParameters don't have functionDescriptors
+            if (function == null)
+            {
+                return string.Empty;
+            }
             var assemblyName = function.Assembly;
-
+            
             if (string.IsNullOrEmpty(assemblyName) || (function.Type == FunctionType.GenericFunction))
                 return String.Empty; // Operators, or generic global function in DS script.
 


### PR DESCRIPTION
### Purpose

to fix tests,
when a custom node definition is created its ports define some TypedParameters objects, but these parameters do not have functions set. Later when typed parameter is asked to lookup a description, the Summary property getter is called, and there is no function, and an exception is thrown in xmlDocumentationExtensions.

Instead just check if function is null and return an empty string.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

### FYIs
@riteshchandawar 
@nguyen-binh-minh 


