### PR TITLE
MAGN-7523 Z-buffer not calibrated to display building-sized elements when Revit units are mm

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -437,7 +437,7 @@ namespace Dynamo.Controls
             // http: //www.sjbaker.org/steve/omniv/love_your_z_buffer.html
             var sceneBounds = watch_view.FindBounds();
             var maxDim = Math.Max(Math.Max(sceneBounds.SizeX, sceneBounds.Y), sceneBounds.SizeZ);
-            Camera.NearPlaneDistance = CalculateNearClipPlane(maxDim);
+            Camera.NearPlaneDistance = Math.Max(CalculateNearClipPlane(maxDim), 0.1);
         }
 
         private double CalculateNearClipPlane(double maxDim)

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -59,6 +59,7 @@ namespace Dynamo.Controls
         private double lightAzimuthDegrees = 45.0;
         private double lightElevationDegrees = 35.0;
         private int renderingTier;
+        private const double NearPlaneDistanceFactor = 0.0001;
 
 #if DEBUG
         private Stopwatch renderTimer = new Stopwatch();
@@ -284,15 +285,20 @@ namespace Dynamo.Controls
             // camera setup
             Camera = new PerspectiveCamera
             {
-                Position = new Point3D(10, 15, 10),
-                LookDirection = new Vector3D(-10, -10, -10),
                 UpDirection = new Vector3D(0, 1, 0),
-                NearPlaneDistance = .1,
                 FarPlaneDistance = 10000000,
-                
             };
 
+            ResetCamera();
+
             DrawGrid();
+        }
+
+        private void ResetCamera()
+        {
+            Camera.Position = new Point3D(10, 15, 10);
+            Camera.LookDirection = new Vector3D(-10, -10, -10);
+            Camera.NearPlaneDistance = CalculateNearClipPlane(1000000);
         }
 
         private static MeshGeometry3D DrawTestMesh()
@@ -418,6 +424,25 @@ namespace Dynamo.Controls
             {
                 DirectionalLightDirection = v; 
             }
+
+            UpdateNearClipPlaneForSceneBounds();
+        }
+
+        /// <summary>
+        /// This method attempts to maximize the near clip plane in order to 
+        /// achiever higher z-buffer precision.
+        /// </summary>
+        private void UpdateNearClipPlaneForSceneBounds()
+        {
+            // http: //www.sjbaker.org/steve/omniv/love_your_z_buffer.html
+            var sceneBounds = watch_view.FindBounds();
+            var maxDim = Math.Max(Math.Max(sceneBounds.SizeX, sceneBounds.Y), sceneBounds.SizeZ);
+            Camera.NearPlaneDistance = CalculateNearClipPlane(maxDim);
+        }
+
+        private double CalculateNearClipPlane(double maxDim)
+        {
+            return maxDim * NearPlaneDistanceFactor;
         }
 
         /// <summary>
@@ -721,7 +746,7 @@ namespace Dynamo.Controls
 
             if (!mesh.Positions.Any())
                 mesh = null;
-
+        
 #if DEBUG
             renderTimer.Stop();
             Debug.WriteLine(string.Format("RENDER: {0} ellapsed for compiling assets for rendering.", renderTimer.Elapsed));


### PR DESCRIPTION
### Purpose

This PR addresses [MAGN-7523](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7523)

Here is an image of the behavior in Revit, with a moderately large sized project whose Project Units are set to millimeters.
![nearclipplanedistance](https://cloud.githubusercontent.com/assets/1139788/8243914/6740da92-15d0-11e5-81db-6c15998c8ee3.PNG)

Here is an image in stand-alone where we have made a circle with a radius of 1m units. There is no degradation in the visualization as the near plane has been re-calculated to a larger value as the size the of the scene was increased.
![image](https://cloud.githubusercontent.com/assets/1139788/8243933/99d8e198-15d0-11e5-9f29-ef0f4f3ee1cd.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
  - Calculation of the near clip plane has been factored into several private methods.
- [x] The level of testing this PR includes is appropriate
  - No new tests are added as this is a visual effect only.  

### Reviewers

@ramramps 
