### PR TITLE
Fix for rewriting AST's in function definition nodes

### DIFF
--- a/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
@@ -134,7 +134,7 @@ namespace ProtoCore.SyntaxAnalysis
 
         public virtual void VisitFunctionDefinitionNode(FunctionDefinitionNode node)
         {
-            DefaultVisit(node); ;
+            DefaultVisit(node);
         }
 
         public virtual void VisitIfStatementNode(IfStatementNode node)
@@ -346,7 +346,7 @@ namespace ProtoCore.SyntaxAnalysis
 
         public virtual TResult VisitFunctionDefinitionNode(FunctionDefinitionNode node)
         {
-            return DefaultVisit(node); ;
+            return DefaultVisit(node);
         }
 
         public virtual TResult VisitIfStatementNode(IfStatementNode node)
@@ -474,6 +474,13 @@ namespace ProtoCore.SyntaxAnalysis
                     node.ArrayDimensions = newArrayDimensions as ArrayNode;
             }
 
+            return node;
+        }
+
+        public override AssociativeNode VisitFunctionDefinitionNode(FunctionDefinitionNode node)
+        {
+            var nodeList = node.FunctionBody.Body.Select(astNode => astNode.Accept(this)).ToList();
+            node.FunctionBody.Body = nodeList;
             return node;
         }
 


### PR DESCRIPTION
### Purpose

This is a fix for [defect] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7674) with function definitions in code block nodes not executing when using classes having namespace conflicts.

This was because function definition nodes were simply being ignored. The fix now processes function def'n nodes as well.

![image](https://cloud.githubusercontent.com/assets/5710686/8249023/8114d072-1698-11e5-95e8-612c7685173e.png)


### Declarations

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

Self-service CI passes

### Reviewers

@ke-yu Reviewer 1  

### FYIs

@riteshchandawar as this has already been fixed, please assess if it can go in RC0.8.1