### PR TITLE
Revert "fix parameters description not used in tooltip and help dialog"

### DIFF
--- a/src/DynamoCore/Library/TypedParameter.cs
+++ b/src/DynamoCore/Library/TypedParameter.cs
@@ -32,10 +32,8 @@ namespace Dynamo.Library
             get
             {
                 // If 'summary' data member is 'null', it means its value has 
-                // to be repopulated.
-                if (string.IsNullOrEmpty(summary))
-                    summary = this.GetDescription();
-                return summary;
+                // to be repopulated. 
+                return summary ?? this.GetDescription();
             }
         }
 
@@ -43,7 +41,11 @@ namespace Dynamo.Library
         {
             get
             {
-                string description = Summary + "\n\n" + DisplayTypeName;
+                string description = string.Empty;
+                if (!string.IsNullOrEmpty(summary))
+                    description = description + summary + "\n\n";
+
+                description = description + DisplayTypeName;
 
                 if (DefaultValue != null)
                     description = String.Format("{0}\n{1} : {2}", 


### PR DESCRIPTION
Reverts DynamoDS/Dynamo#4744, it cause StackOverflow exception from test case DynamoCoreWpfTests.RecordedTestsDsEngine.recursion_6415.

FYIs
@nguyen-binh-minh please investigate why the test case fails and resend my PR for bug fixing.
@holyjewsus thanks for identifying the issue!