### PR TITLE
REACH-290 Reach crashes unexpectedly when adding code block

### DIFF
--- a/src/DynamoCore/Core/Threading/AggregateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/AggregateRenderPackageAsyncTask.cs
@@ -42,7 +42,7 @@ namespace Dynamo.Core.Threading
             get { return selectedRenderPackages; }
         }
 
-        internal override TaskPriority Priority
+        public override TaskPriority Priority
         {
             get { return TaskPriority.Normal; }
         }

--- a/src/DynamoCore/Core/Threading/AsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/AsyncTask.cs
@@ -24,7 +24,7 @@ namespace Dynamo.Core.Threading
     {
         #region Private Class Data Members
 
-        internal enum TaskPriority
+        public enum TaskPriority
         {
             Critical,
             Highest,
@@ -80,7 +80,7 @@ namespace Dynamo.Core.Threading
         /// tasks having the same priority.
         /// </summary>
         /// 
-        internal abstract TaskPriority Priority { get; }
+        public abstract TaskPriority Priority { get; }
 
         /// <summary>
         /// This event is raised when the AsyncTask is completed. The event is 
@@ -88,7 +88,7 @@ namespace Dynamo.Core.Threading
         /// access that is needed should be dispatched onto the UI dispatcher.
         /// </summary>
         /// 
-        internal event AsyncTaskCompletedHandler Completed;
+        public event AsyncTaskCompletedHandler Completed;
 
         /// <summary>
         /// Raised if the AsyncTask is discarded by an IScheduler and will not be executed

--- a/src/DynamoCore/Core/Threading/CompileCustomNodeAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/CompileCustomNodeAsyncTask.cs
@@ -24,7 +24,7 @@ namespace Dynamo.Core.Threading
         private GraphSyncData graphSyncData;
         private EngineController engineController;
 
-        internal override TaskPriority Priority
+        public override TaskPriority Priority
         {
             get { return TaskPriority.AboveNormal; }
         }

--- a/src/DynamoCore/Core/Threading/DelegateBasedAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/DelegateBasedAsyncTask.cs
@@ -11,7 +11,7 @@ namespace Dynamo.Core.Threading
     {
         private Action actionToPerform;
 
-        internal override TaskPriority Priority
+        public override TaskPriority Priority
         {
             get { return TaskPriority.Normal; }
         }

--- a/src/DynamoCore/Core/Threading/NotifyRenderPackagesReadyAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/NotifyRenderPackagesReadyAsyncTask.cs
@@ -11,7 +11,7 @@
     /// 
     class NotifyRenderPackagesReadyAsyncTask : AsyncTask
     {
-        internal override TaskPriority Priority
+        public override TaskPriority Priority
         {
             get { return TaskPriority.Normal; }
         }

--- a/src/DynamoCore/Core/Threading/PreviewGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/PreviewGraphAsyncTask.cs
@@ -23,7 +23,7 @@ namespace Dynamo.Core.Threading
         private bool verboseLogging;
         public List<Guid> previewGraphData;
         
-        internal override TaskPriority Priority
+        public override TaskPriority Priority
         {
             get { return TaskPriority.Normal; }
         }

--- a/src/DynamoCore/Core/Threading/QueryMirrorDataAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/QueryMirrorDataAsyncTask.cs
@@ -21,7 +21,7 @@ namespace Dynamo.Core.Threading
         private MirrorData cachedMirrorData;
         private readonly EngineController engineController;
 
-        internal override TaskPriority Priority
+        public override TaskPriority Priority
         {
             get { return TaskPriority.Normal; }
         }

--- a/src/DynamoCore/Core/Threading/SetTraceDataAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/SetTraceDataAsyncTask.cs
@@ -12,7 +12,7 @@ namespace Dynamo.Core.Threading
         private EngineController engineController;
         private IEnumerable<KeyValuePair<Guid, List<string>>> traceData;
 
-        internal override TaskPriority Priority
+        public override TaskPriority Priority
         {
             get { return TaskPriority.Highest; }
         }

--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -20,7 +20,7 @@ namespace Dynamo.Core.Threading
         private EngineController engineController;
         private bool verboseLogging;
 
-        internal override TaskPriority Priority
+        public override TaskPriority Priority
         {
             get { return TaskPriority.AboveNormal; }
         }

--- a/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
@@ -59,7 +59,7 @@ namespace Dynamo.Core.Threading
             get { return renderPackages; }
         }
 
-        internal override TaskPriority Priority
+        public override TaskPriority Priority
         {
             get { return TaskPriority.Normal; }
         }

--- a/test/DynamoCoreTests/SchedulerTests.cs
+++ b/test/DynamoCoreTests/SchedulerTests.cs
@@ -73,7 +73,7 @@ namespace Dynamo.Tests
     {
         private List<string> results;
 
-        override internal TaskPriority Priority
+        public override TaskPriority Priority
         {
             get { return TaskPriority.Normal; }
         }
@@ -113,7 +113,7 @@ namespace Dynamo.Tests
     {
         internal int CurrPriority { get; private set; }
 
-        override internal TaskPriority Priority
+        override public TaskPriority Priority
         {
             get { return TaskPriority.AboveNormal; }
         }
@@ -160,7 +160,7 @@ namespace Dynamo.Tests
     {
         internal int Punch { get; private set; }
 
-        override internal TaskPriority Priority
+        override public TaskPriority Priority
         {
             get { return TaskPriority.BelowNormal; }
         }
@@ -216,7 +216,7 @@ namespace Dynamo.Tests
     {
         internal int Value { get; private set; }
 
-        override internal TaskPriority Priority
+        override public TaskPriority Priority
         {
             // Same as PrioritizedAsyncTask.
             get { return TaskPriority.AboveNormal; }


### PR DESCRIPTION
### Purpose

Make some properties public to have an ability to inherit from AsyncTask outside DynamoCore. It needs to use in Reach for implementation of obtaining executed nodes in Scheduler thread.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Task link

[REACH-290 Reach crashes unexpectedly when adding code block](http://adsk-oss.myjetbrains.com/youtrack/issue/REACH-290)

### Reviewers

@pboyer 