### PR TITLE
Fix for incorrect results from Newton root-finding nodes

### DIFF
--- a/src/Libraries/CoreNodes/Optimize.ds
+++ b/src/Libraries/CoreNodes/Optimize.ds
@@ -9,7 +9,7 @@ def NewtonRootFind1DNoDeriv(objFunc: _FunctionObject, start: double, maxIters: i
 		maxChange = 0.00001;
 		h = 0.00001;
 
-		while(count < maxIters && change > maxChange)
+		while(count < maxIters && Math.Abs( change ) > maxChange)
 		{
 			fx = __Apply(objFunc, start);
 			fxh = __Apply(objFunc, start+h);
@@ -34,7 +34,7 @@ def NewtonRootFind1DWithDeriv(objFunc: _FunctionObject, derivFunc: _FunctionObje
 		change = 10000000000;
 		maxChange = 0.00001;
 
-		while(count < maxIters && change > maxChange)
+		while(count < maxIters && Math.Abs( change ) > maxChange)
 		{
 			fx = __Apply(objFunc, start);
 			dfx = __Apply(derivFunc, start);


### PR DESCRIPTION
### Purpose

@nguyen-binh-minh discovered that the Newton method nodes were giving incorrect results.  This had to do with a missing `Math.Abs` call.  They should now give reliable results.

![newtonfix](https://cloud.githubusercontent.com/assets/916345/8295005/9d627d1a-190e-11e5-851c-5d21d2167805.PNG)

@nguyen-binh-minh has already started some regression tests, so this PR should allow him to complete those.    

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@Benglin 