### PR TITLE
Fix tests due to new search algorithm

### DIFF
--- a/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
+++ b/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
@@ -55,7 +55,7 @@ namespace Dynamo.Tests
             OpenTestFile(@"core\combine", "Sequence2.dyf");
             
             var res = CurrentDynamoModel.SearchModel.Search("Sequence2");
-            Assert.AreEqual(1, res.Count());
+            Assert.AreEqual(6, res.Count());
             Assert.AreEqual("Sequence2", res.First().Name);
         }
     }


### PR DESCRIPTION
Since new search algorithm can return more members, this tests is incorrect now. Currently number of found elements increased from 1 to 6 members.

New search algorithm can be found https://github.com/DynamoDS/Dynamo/pull/4707

@pboyer 
or
@Benglin 

could you, please, help to merge it?
Thanks.