### PR TITLE
MAGN-7725 Dynamo throws exception when started in Revit

### DIFF
--- a/tools/install/CreateInstallers.bat
+++ b/tools/install/CreateInstallers.bat
@@ -24,6 +24,7 @@ IF EXIST %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\Revit_2016 (
 
 
 robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\nodes %cwd%\temp\bin\nodes *.dll *.xml /e
+robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\extensions %cwd%\temp\bin\extensions *.xml /e
 robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\UI %cwd%\temp\bin\UI /E
 copy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\DSCoreNodes_DynamoCustomization.xml %cwd%\temp\bin\DSCoreNodes_DynamoCustomization.xml
 copy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\ProtoGeometry_DynamoCustomization.xml %cwd%\temp\bin\ProtoGeometry_DynamoCustomization.xml

--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -45,6 +45,7 @@ Name: "{app}\libg_220"
 Name: "{app}\libg_221"
 Name: "{app}\libg_locale"
 Name: "{app}\nodes"
+Name: "{app}\extensions"
 Name: "{userappdata}\Dynamo\{#Major}.{#Minor}\definitions"
 Name: "{userappdata}\Dynamo\{#Major}.{#Minor}\Logs"
 Name: "{userappdata}\Dynamo\{#Major}.{#Minor}\packages"
@@ -66,6 +67,7 @@ Source: "Extra\DynamoAddinGenerator.exe"; Flags: dontcopy
 ;Core Files
 Source: temp\bin\*; DestDir: {app}; Flags: ignoreversion overwritereadonly; Components: DynamoCore
 Source: temp\bin\nodes\*; DestDir: {app}\nodes; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
+Source: temp\bin\extensions\*; DestDir: {app}\extensions; Flags: ignoreversion overwritereadonly; Components: DynamoCore
 Source: temp\bin\lang\*; DestDir: {app}\; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 Source: Extra\IronPython-2.7.3.msi; DestDir: {tmp}; Flags: deleteafterinstall;
 Source: temp\bin\README.txt; DestDir: {app}\; Flags: onlyifdoesntexist isreadme ignoreversion; Components: DynamoCore


### PR DESCRIPTION
### Purpose

`extentions` folder is included into the installer, so package manager is correctly loaded during Dynamo starting from Revit. 
[Task link](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7725)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@pboyer 