### PR TITLE
Fix missing DSCoreNodesUI issue in tests

### DIFF
--- a/test/Libraries/WorkflowTests/Setup.cs
+++ b/test/Libraries/WorkflowTests/Setup.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using Dynamo.Utilities;
+using NUnit.Framework;
+
+namespace Dynamo.Tests
+{
+    [SetUpFixture]
+    public class Setup
+    {
+        private AssemblyHelper assemblyHelper;
+
+        [SetUp]
+        public void RunBeforeAllTests()
+        {
+            var assemblyPath = Assembly.GetExecutingAssembly().Location;
+            var moduleRootFolder = Path.GetDirectoryName(assemblyPath);
+
+            var resolutionPaths = new[]
+            {
+                // These tests need "DSCoreNodesUI.dll" under "nodes" folder.
+                Path.Combine(moduleRootFolder, "nodes")
+            };
+
+            assemblyHelper = new AssemblyHelper(moduleRootFolder, resolutionPaths);
+            AppDomain.CurrentDomain.AssemblyResolve += assemblyHelper.ResolveAssembly;
+        }
+
+        [TearDown]
+        public void RunAfterAllTests()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve -= assemblyHelper.ResolveAssembly;
+            assemblyHelper = null;
+        }
+    }
+}

--- a/test/Libraries/WorkflowTests/WorkflowTests.csproj
+++ b/test/Libraries/WorkflowTests/WorkflowTests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="ComplexTests.cs" />
     <Compile Include="PackageValidationTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Setup.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\DynamoCoreWpf\DynamoCoreWpf.csproj">
@@ -73,6 +74,10 @@
       <Project>{7858fa8c-475f-4b8e-b468-1f8200778cf8}</Project>
       <Name>DynamoCore</Name>
       <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\DynamoUtilities\DynamoUtilities.csproj">
+      <Project>{b5f435cb-0d8a-40b1-a4f7-5ecb3ce792a9}</Project>
+      <Name>DynamoUtilities</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\src\Libraries\CoreNodeModels\CoreNodeModels.csproj">
       <Project>{d8262d40-4880-41e4-91e4-af8f480c8637}</Project>


### PR DESCRIPTION
### Purpose

This pull request is meant to fix two Excel test cases that only fail on build machines:

    Dynamo.Tests.DynamoSamples.ImportExport_CSV_to_Stuff
    Dynamo.Tests.DynamoSamples.ImportExport_Data_To_Excel

The proposed fix introduces a new class `Dynamo.Tests.Setup` that has necessary assembly path resolving logic internally, pretty much like most other test assemblies. This class adds `nodes` folder into search path that can be used in the entire `WorkflowTests.dll` test assembly.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

Hi @nguyen-binh-minh, please take a look, thanks.

### FYIs

Hi @ke-yu, @aparajit-pratap the same old issue we have encountered before.