### PR TITLE
Disable some command when executing graph

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1192,7 +1192,7 @@ namespace Dynamo.ViewModels
 
         private bool CanShowOpenDialogAndOpenResultCommand(object parameter)
         {
-            return true;
+            return HomeSpace.RunSettings.RunEnabled;
         }
 
         private void OpenRecent(object path)
@@ -1202,7 +1202,7 @@ namespace Dynamo.ViewModels
 
         private bool CanOpenRecent(object path)
         {
-            return true;
+            return HomeSpace.RunSettings.RunEnabled;
         }
 
         /// <summary>
@@ -1574,7 +1574,7 @@ namespace Dynamo.ViewModels
 
         internal bool CanMakeNewHomeWorkspace(object parameter)
         {
-            return true;
+            return HomeSpace.RunSettings.RunEnabled;
         }
 
         private void CloseHomeWorkspace(object parameter)
@@ -1589,7 +1589,7 @@ namespace Dynamo.ViewModels
 
         private bool CanCloseHomeWorkspace(object parameter)
         {
-            return true;
+            return HomeSpace.RunSettings.RunEnabled;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
@@ -256,13 +256,16 @@ namespace Dynamo.Wpf.ViewModels
                     RaisePropertyChanged("RunEnabled");
                     RaisePropertyChanged("RunButtonEnabled");
                     RaisePropertyChanged("RunButtonToolTip");
-                    Application.Current.Dispatcher.Invoke(new Action(() =>
+                    if (Application.Current != null)
                     {
-                        dynamoViewModel.ShowOpenDialogAndOpenResultCommand.RaiseCanExecuteChanged();
-                        dynamoViewModel.NewHomeWorkspaceCommand.RaiseCanExecuteChanged();
-                        dynamoViewModel.OpenRecentCommand.RaiseCanExecuteChanged();
-                        dynamoViewModel.CloseHomeWorkspaceCommand.RaiseCanExecuteChanged();
-                    }));
+                        Application.Current.Dispatcher.Invoke(new Action(() =>
+                        {
+                            dynamoViewModel.ShowOpenDialogAndOpenResultCommand.RaiseCanExecuteChanged();
+                            dynamoViewModel.NewHomeWorkspaceCommand.RaiseCanExecuteChanged();
+                            dynamoViewModel.OpenRecentCommand.RaiseCanExecuteChanged();
+                            dynamoViewModel.CloseHomeWorkspaceCommand.RaiseCanExecuteChanged();
+                        }));
+                    }
                     break;
                 case "RunPeriod":
                 case "RunType":

--- a/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
@@ -256,6 +256,13 @@ namespace Dynamo.Wpf.ViewModels
                     RaisePropertyChanged("RunEnabled");
                     RaisePropertyChanged("RunButtonEnabled");
                     RaisePropertyChanged("RunButtonToolTip");
+                    Application.Current.Dispatcher.Invoke(new Action(() =>
+                    {
+                        dynamoViewModel.ShowOpenDialogAndOpenResultCommand.RaiseCanExecuteChanged();
+                        dynamoViewModel.NewHomeWorkspaceCommand.RaiseCanExecuteChanged();
+                        dynamoViewModel.OpenRecentCommand.RaiseCanExecuteChanged();
+                        dynamoViewModel.CloseHomeWorkspaceCommand.RaiseCanExecuteChanged();
+                    }));
                     break;
                 case "RunPeriod":
                 case "RunType":

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -637,7 +637,8 @@
                               Focusable="False">
                         <MenuItem Focusable="False"
                                   Header="{x:Static p:Resources.DynamoViewHepMenuSamples}"
-                                  Name="SamplesMenu">
+                                  Name="SamplesMenu"
+                                  IsEnabled="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunButtonEnabled}">
                             <MenuItem.Icon>
                                 <Image Source="/DynamoCoreWpf;component/UI/Images/OpenSelectedItemHS.png"
                                        Width="14"


### PR DESCRIPTION
### Purpose

This PR is to partially fix defect [MAGN 7148 Opening Manual execute dyn after running Auto execute dyn twice gives crash](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7148) by disabling some commands when executing graph.

The crash is because while the first execution (of some zero touch function) is still running, open operation tries to reset the VM. To avoid this race condition, here are some solutions, but none of them is satisfying:
  * Kill the current execution. It may cause some resources that allocated in zero touch function not be released properly, so the following Run operations might fail. 
  * Queue the open operation. The problem is, user is not able to know whether open operations are successful or not (no response from UI). And worse, these operations would be handled in short time if each file needs very few time to execute. 
  * Isolate each executions by putting them in different sandboxes. It is the most flexible solution, but requires big change.  

So a workaround is disabling some UI commands. They include
  * Open file
  * Open recent file
  * Create new Home Workspace
  * Close current Home Workspace

### Reviewers

@Benglin  could you please take a look? I don't create unit test because `RaiseCanExecuteChanged` from `RunSettingsViewModel` has to be called from UI thread, but `Application.Current` is null in nunit.  
