### PR TITLE
Fix MAGN-7770 Multiple instances of Custom Node are getting displayed because of Auto Save

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -331,6 +331,16 @@ namespace Dynamo.Core
         /// </summary>
         private void SetNodeInfo(CustomNodeInfo newInfo)
         {
+            var guids = NodeInfos.Where(x =>
+                        {
+                            return string.Compare(x.Value.Path, newInfo.Path, StringComparison.OrdinalIgnoreCase) == 0;
+                        }).Select(x => x.Key).ToList();
+
+            foreach (var guid in guids)
+            {
+                NodeInfos.Remove(guid);
+            }
+
             NodeInfos[newInfo.FunctionId] = newInfo;
             OnInfoUpdated(newInfo);
         }

--- a/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
@@ -202,6 +202,7 @@ namespace Dynamo.Models
             // custom node with a new function id
             if (originalPath != newPath)
             {
+                FileName = newPath;
                 // If it is a newly created node, no need to generate a new guid
                 if (!string.IsNullOrEmpty(originalPath))
                     CustomNodeId = Guid.NewGuid();

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -750,6 +750,22 @@ namespace Dynamo.Models
                 if (customNodeSearchRegistry.Contains(info.FunctionId))
                     return;
 
+                var elements = SearchModel.SearchEntries.OfType<CustomNodeSearchElement>().Where(
+                                x =>
+                                {
+                                    return string.Compare(x.Path, info.Path, StringComparison.OrdinalIgnoreCase) == 0;
+                                }).ToList();
+
+                if (elements.Any())
+                {
+                    foreach (var element in elements)
+                    {
+                        element.SyncWithCustomNodeInfo(info);
+                        SearchModel.Update(element);
+                    }
+                    return;
+                }
+
                 customNodeSearchRegistry.Add(info.FunctionId);
                 var searchElement = new CustomNodeSearchElement(CustomNodeManager, info);
                 SearchModel.Add(searchElement);

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -940,6 +940,41 @@ namespace Dynamo.Tests
                 Assert.AreEqual(node.ID, newId);
             }
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void CustomNodeWorkspaceSavedToSamePlaceNotCausingDuplicatedLibraryItems()
+        {
+            // open file
+            // save to the temporary folder
+            // save to another temporary folder
+            // save to the old temporary folder
+            // there should be only two library items instead of three
+
+            var dynamoModel = ViewModel.Model;
+            var nodeName = Guid.NewGuid().ToString();
+            var catName = "Custom Nodes";
+
+            var def = dynamoModel.CustomNodeManager.CreateCustomNode(nodeName, catName, "");
+
+            var tempPath1 = Path.Combine(TempFolder, nodeName + ".dyf");
+            var tempPath2 = Path.Combine(TempFolder, nodeName, nodeName + ".dyf");
+
+            var res = def.SaveAs(tempPath1, ViewModel.Model.EngineController.LiveRunnerRuntimeCore);
+            Assert.IsTrue(res);
+            Thread.Sleep(1);
+
+            res = def.SaveAs(tempPath2, ViewModel.Model.EngineController.LiveRunnerRuntimeCore);
+            Assert.IsTrue(res);
+            Thread.Sleep(1);
+
+            res = def.SaveAs(tempPath1, ViewModel.Model.EngineController.LiveRunnerRuntimeCore);
+            Assert.IsTrue(res);
+
+            var count = dynamoModel.SearchModel.SearchEntries.OfType<CustomNodeSearchElement>().Where(
+                            x => string.CompareOrdinal(x.Name, nodeName) == 0).Count();
+            Assert.AreEqual(count, 2);
+        }
         #endregion
     }
 }


### PR DESCRIPTION
### Purpose

This submission is to fix MAGN-7770. The reason of the defect is that every time a custom node file is saved to a different path. The file will be assigned a new GUID and a new entry will be added in the library. This is because custom node files with the same name should be differentiated by something - GUIDs in the implementation.

But if the same file is saved at path A, then path B, and then back to path A. Ideally there will only be two items in the library. But unfortunately there is no mechanism to check the first one in the library is the same with the third one.

The fix here is to check whether an entry with the same file path is already there. If so, the old ones will be removed.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@Benglin 

