### PR TITLE
move uninstallation of older version out of setup initialize

### DIFF
--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -170,7 +170,6 @@ var
   j: Cardinal;
   sUnInstPath: String;
   sUninstallString: String;
-  sUnInstallParam: String;
   revision: Cardinal;
   iResultCode: Integer;
   exeVersion: String;
@@ -232,12 +231,23 @@ begin
 				MsgBox(sMsg + #13#10#13#10 + sMsg2, mbInformation, MB_OK);
 				result := false
 			end
-		else
-			begin
-				RegQueryStringValue(HKLM64, sUnInstPath, 'UnInstallParam', sUninstallParam);
-				Exec(sUnInstallString, sUnInstallParam, '', SW_HIDE, ewWaitUntilTerminated, iResultCode);
-			end
 	end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var 
+  sUnInstPath: String;
+  sUninstallString: String;
+  sUnInstallParam: String;
+  iResultCode: Integer;
+begin
+  if (CurStep=ssInstall) then
+    begin
+        sUnInstPath := ExpandConstant('Software\Microsoft\Windows\CurrentVersion\Uninstall\{#ProductName} {#Major}.{#Minor}');
+        RegQueryStringValue(HKLM64, sUnInstPath, 'UnInstallString', sUninstallString);
+        RegQueryStringValue(HKLM64, sUnInstPath, 'UnInstallParam', sUninstallParam);
+        Exec(sUnInstallString, sUnInstallParam, '', SW_HIDE, ewWaitUntilTerminated, iResultCode);
+    end;
 end;
 
 // check if the components exists, if they do enable the component for installation


### PR DESCRIPTION
This PR move the uninstall of older version out of setup initialization step so that cancellation before clicking "Install" will preserve the older version.

@sharadkjaiswal PTAL