### PR TITLE
Library search: 4-letters words increase %

### DIFF
--- a/src/DynamoCore/Search/SearchDictionary.cs
+++ b/src/DynamoCore/Search/SearchDictionary.cs
@@ -247,7 +247,20 @@ namespace Dynamo.Search
                 numberOfAllSymbols += subPattern.Length;
             }
 
-            return (double)numberOfMatchSymbols / numberOfAllSymbols > 0.8;
+            double similarity = (double)numberOfMatchSymbols / numberOfAllSymbols;
+
+            switch (numberOfAllSymbols)
+            {
+                case 3:
+                    // If there is just 3 letters(e.g. UVs), threshold should be lower.
+                    return similarity >= 0.6;
+                case 4:
+                    // The same for 4 letters.
+                    return similarity >= 0.75;
+                default:
+                    // By default threshold is 80% similarity.
+                    return similarity >= 0.8;
+            }
         }
 
         private static string[] SplitOnWhiteSpace(string s)


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7775](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7775#tab=Comments) 4-letter search terms like "cubes" and "cones" still return nothing in search

I'm afraid of increasing % more that 80. That's why I've created several cases, that depend on length of search query.

More I think about plural search, more I want to try just adding plural endings.
I've created alternative PR with plural endings: https://github.com/DynamoDS/Dynamo/pull/4814

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@lillismith
@pboyer 