### PR TITLE
MAGN-7667 Backup files should not be listed in the Recent files list on the startup page.

### DIFF
--- a/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
@@ -194,7 +194,7 @@ namespace Dynamo.Models
             if (handler != null) handler(oldId);
         }
 
-        public override bool SaveAs(string newPath, ProtoCore.RuntimeCore runtimeCore)
+        public override bool SaveAs(string newPath, ProtoCore.RuntimeCore runtimeCore, bool isBackUp = false)
         {
             var originalPath = FileName;
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1216,7 +1216,7 @@ namespace Dynamo.Models
                     var savePath = pathManager.GetBackupFilePath(workspace);
                     var oldFileName = workspace.FileName;
                     var oldName = workspace.Name;
-                    workspace.SaveAs(savePath, null);
+                    workspace.SaveAs(savePath, null, true);
                     workspace.FileName = oldFileName;
                     workspace.Name = oldName;
                     backupFilesDict.Add(workspace.Guid, savePath);

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -562,14 +562,16 @@ namespace Dynamo.Models
         /// </summary>
         /// <param name="newPath">The path to save to</param>
         /// <param name="core"></param>
-        public virtual bool SaveAs(string newPath, ProtoCore.RuntimeCore runtimeCore)
+        /// <param name="isBackup">Indicates whether saved workspace is backup or not. If it's not backup,
+        /// we should add it to recent files. Otherwise leave it.</param>
+        public virtual bool SaveAs(string newPath, ProtoCore.RuntimeCore runtimeCore, bool isBackup = false)
         {
             if (String.IsNullOrEmpty(newPath)) return false;
 
             Log(String.Format(Resources.SavingInProgress, newPath));
             try
             {
-                if (SaveInternal(newPath, runtimeCore))
+                if (SaveInternal(newPath, runtimeCore) && !isBackup)
                     OnWorkspaceSaved();
             }
             catch (Exception ex)


### PR DESCRIPTION
### Purpose

_Note: critical for 0.8.1_

Link to YouTrack:
[MAGN-7667](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7667) Backup files should not be listed in the Recent files list on the startup page.

Backup saving uses the same `SaveAs` as any other file. Inside of `SaveAs` there is `OnWorkspaceSaved`, that adds every saved file to recent files.

What I've done:

I added `isBackup` to `SaveAs`, which is by default false. But if it is true, then file is not added to recent files.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@Benglin 

### FYIs

@kronz 
@Randy-Ma 