### PR TITLE
Do not remove node info whose path is an empty string

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -333,7 +333,8 @@ namespace Dynamo.Core
         {
             var guids = NodeInfos.Where(x =>
                         {
-                            return string.Compare(x.Value.Path, newInfo.Path, StringComparison.OrdinalIgnoreCase) == 0;
+                            return !string.IsNullOrEmpty(x.Value.Path) &&
+                                string.Compare(x.Value.Path, newInfo.Path, StringComparison.OrdinalIgnoreCase) == 0;
                         }).Select(x => x.Key).ToList();
 
             foreach (var guid in guids)


### PR DESCRIPTION
### Purpose

This is to fix one test case with error. The error is caused by removing an unsaved custom node when a new custom node is added.

The fix is to add a condition to check whether the file path is an null or empty string. If so, the custom node information will not be removed.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@aparajit-pratap 

### FYIs

@Benglin 
