### PR TITLE
MAGN-7800 Edges stay colored after deselecting a node.

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -962,7 +962,8 @@ namespace Dynamo.Controls
                             Color = SharpDX.Color.White,
                             Figure = PointGeometryModel3D.PointFigure.Ellipse,
                             Size = DefaultPointSize,
-                            IsHitTestVisible = true
+                            IsHitTestVisible = true,
+                            IsSelected = rp.IsSelected
                         };
                         model3DDictionary.Add(id, pointGeometry3D);
                     }
@@ -973,10 +974,6 @@ namespace Dynamo.Controls
                     points.Positions.AddRange(p.Positions);
                     points.Colors.AddRange(p.Colors.Any() ? p.Colors : Enumerable.Repeat(defaultPointColor, points.Positions.Count));
                     points.Indices.AddRange(p.Indices.Select(i => i + startIdx));
-
-                    var endIdx = points.Positions.Count;
-
-                    pointGeometry3D.IsSelected = rp.IsSelected;
 
                     if (rp.DisplayLabels)
                     {
@@ -1009,7 +1006,8 @@ namespace Dynamo.Controls
                             Transform = Model1Transform,
                             Color = SharpDX.Color.White,
                             Thickness = 0.5,
-                            IsHitTestVisible = true
+                            IsHitTestVisible = true,
+                            IsSelected = rp.IsSelected
                         };
 
                         model3DDictionary.Add(id, lineGeometry3D);
@@ -1021,10 +1019,6 @@ namespace Dynamo.Controls
                     lineSet.Positions.AddRange(l.Positions);
                     lineSet.Colors.AddRange(l.Colors.Any() ? l.Colors : Enumerable.Repeat(defaultLineColor, l.Positions.Count));
                     lineSet.Indices.AddRange(l.Indices.Any() ? l.Indices.Select(i => i + startIdx) : Enumerable.Range(startIdx, startIdx + l.Positions.Count));
-
-                    var endIdx = lineSet.Positions.Count;
-
-                    lineGeometry3D.IsSelected = rp.IsSelected;
 
                     if (rp.DisplayLabels)
                     {

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -976,13 +976,7 @@ namespace Dynamo.Controls
 
                     var endIdx = points.Positions.Count;
 
-                    if (rp.IsSelected)
-                    {
-                        for (var i = startIdx; i < endIdx; i++)
-                        {
-                            points.Colors[i] = selectionColor;
-                        }
-                    }
+                    pointGeometry3D.IsSelected = rp.IsSelected;
 
                     if (rp.DisplayLabels)
                     {
@@ -1030,13 +1024,7 @@ namespace Dynamo.Controls
 
                     var endIdx = lineSet.Positions.Count;
 
-                    if (rp.IsSelected)
-                    {
-                        for (var i = startIdx; i < endIdx; i++)
-                        {
-                            lineSet.Colors[i] = selectionColor;
-                        }
-                    }
+                    lineGeometry3D.IsSelected = rp.IsSelected;
 
                     if (rp.DisplayLabels)
                     {

--- a/test/DynamoCoreWpfTests/VisualizationManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/VisualizationManagerUITests.cs
@@ -27,6 +27,8 @@ namespace DynamoCoreWpfTests
         {
             libraries.Add("ProtoGeometry.dll");
             libraries.Add("DSIronPython.dll");
+            libraries.Add("DSCoreNodes.dll");
+            libraries.Add("Display.dll");
             base.GetLibrariesToPreload(libraries);
         }
 
@@ -632,6 +634,36 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(0, ws.TotalLinesToRender());
         }
 
+        [Test]
+        public void Display_ByGeometryColor_HasColoredMesh()
+        {
+            var openPath = Path.Combine(
+                GetTestDirectory(ExecutingDirectory),
+                @"core\visualization\Display.ByGeometryColor.dyn");
+            OpenAndRunDynamoDefinition(openPath);
+
+            var ws = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
+
+            RunCurrentModel();
+
+            Assert.True(ws.HasAnyVertexColoredMeshesOfColor(new Color4(new Color3(1.0f,0,1.0f))));
+        }
+
+        [Test]
+        public void Display_BySurfaceColors_HasColoredMesh()
+        {
+            var openPath = Path.Combine(
+                GetTestDirectory(ExecutingDirectory),
+                @"core\visualization\Display.BySurfaceColors.dyn");
+            OpenAndRunDynamoDefinition(openPath);
+
+            var ws = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
+
+            RunCurrentModel();
+
+            Assert.True(ws.HasAnyColorMappedMeshes());
+        }
+
         private void Open(string relativePath)
         {
             OpenDynamoDefinition(relativePath);
@@ -640,6 +672,25 @@ namespace DynamoCoreWpfTests
 
     internal static class WorkspaceExtensions
     {
+        public static bool HasAnyVertexColoredMeshesOfColor(this WorkspaceModel workspace, Color4 color)
+        {
+            var colorMeshCount = workspace.Nodes.
+                SelectMany(n => n.RenderPackages).
+                Where(rp => rp.RequiresPerVertexColoration).
+                Where(rp => rp.MeshVertexColors.IsArrayOfColor(color));
+
+            return colorMeshCount.Any();
+        }
+
+        public static bool HasAnyColorMappedMeshes(this WorkspaceModel workspace)
+        {
+            var colorMeshCount = workspace.Nodes.
+                SelectMany(n => n.RenderPackages).
+                Where(rp => rp.Colors != null);
+
+            return colorMeshCount.Any();
+        }
+
         public static int TotalLinesOfColorToRender(this WorkspaceModel workspace, Color4 color)
         {
             var colorLineCount = workspace.Nodes.

--- a/test/core/visualization/Display.ByGeometryColor.dyn
+++ b/test/core/visualization/Display.ByGeometryColor.dyn
@@ -1,0 +1,21 @@
+<Workspace Version="0.8.2.1465" X="-2326.83755850225" Y="-1375.97616638675" zoom="1.703916824555" Name="Home" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Color" resolvedName="DSCore.Color" assemblyName="DSCoreNodes.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="306ae204-edf0-4412-8141-c46648498034" type="Dynamo.Nodes.DSFunction" nickname="Cuboid.ByLengths" x="1463.96947396582" y="845.271229544414" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Cuboid.ByLengths@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="5198b471-e7c1-4bea-9728-f2a7ebb4c262" type="Dynamo.Nodes.DSFunction" nickname="Display.ByGeometryColor" x="1871.96947396582" y="930.271229544414" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="Display.dll" function="Display.Display.ByGeometryColor@Autodesk.DesignScript.Geometry.Geometry,DSCore.Color" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="6eda9cfc-eab3-4c0c-a2b1-248677b4df50" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1527" y="1100" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="Color.ByARGB(255,255,0,255);" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="306ae204-edf0-4412-8141-c46648498034" start_index="0" end="5198b471-e7c1-4bea-9728-f2a7ebb4c262" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="6eda9cfc-eab3-4c0c-a2b1-248677b4df50" start_index="0" end="5198b471-e7c1-4bea-9728-f2a7ebb4c262" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+</Workspace>

--- a/test/core/visualization/Display.BySurfaceColors.dyn
+++ b/test/core/visualization/Display.BySurfaceColors.dyn
@@ -1,0 +1,26 @@
+<Workspace Version="0.8.2.1465" X="-1415.80353968752" Y="-710.685989821976" zoom="1.1113575327695" Name="Home" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Color" resolvedName="DSCore.Color" assemblyName="DSCoreNodes.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="d14d71c0-98dd-4449-aa7a-74ae5bce18b8" type="Dynamo.Nodes.DSFunction" nickname="Rectangle.ByWidthLength" x="1421.96947396582" y="852.271229544414" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Rectangle.ByWidthLength@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="d0c24423-3ae2-422a-bf4d-201dcec6c15c" type="Dynamo.Nodes.DSFunction" nickname="Display.BySurfaceColors" x="2005.78820460875" y="927.972295289965" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="Display.dll" function="Display.Display.BySurfaceColors@Autodesk.DesignScript.Geometry.Surface,DSCore.Color[][]" />
+    <Dynamo.Nodes.DSFunction guid="4e319825-3167-4eb3-bda5-2e7ddc4b829b" type="Dynamo.Nodes.DSFunction" nickname="Surface.ByPatch" x="1693.96947396582" y="895.271229544414" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByPatch@Autodesk.DesignScript.Geometry.Curve" />
+    <Dynamo.Nodes.DoubleInput guid="22ec4bff-a5cd-40de-805f-8f3ecc796f4c" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="1366.05805881335" y="993.954202394641" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double value="0..255..5" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="00049459-0a90-4448-a6c7-7e0a031d4b6b" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1493.29085924851" y="993.512676905556" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="Color.ByARGB(255,input&lt;1&gt;,input&lt;2&gt;,0);" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="d14d71c0-98dd-4449-aa7a-74ae5bce18b8" start_index="0" end="4e319825-3167-4eb3-bda5-2e7ddc4b829b" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="4e319825-3167-4eb3-bda5-2e7ddc4b829b" start_index="0" end="d0c24423-3ae2-422a-bf4d-201dcec6c15c" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="22ec4bff-a5cd-40de-805f-8f3ecc796f4c" start_index="0" end="00049459-0a90-4448-a6c7-7e0a031d4b6b" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="00049459-0a90-4448-a6c7-7e0a031d4b6b" start_index="0" end="d0c24423-3ae2-422a-bf4d-201dcec6c15c" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR addresses [MAGN-7800](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7800). 

Points and curves were not correctly de-selecting after their initial placement. This is because we were not setting the `IsSelected` flag on the `GeometryModel3D` objects representing the points and the curves. In addition, we were still using the old mechanism for selection coloration, coloring the point and lines' vertices with the selection color instead of letting the shader do the work :) I've removed the selection color-setting code, and added code to set the `GeometryModel3D`'s `IsSelected` property to that of the `RenderPackage`, when the object is first created.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
  - Two new tests are added for `Display.ByGeometryColor` and `Display.BySurfaceColors` to ensure against regressions of coloration.

### Reviewers

@ramramps 