### PR TITLE
Color Range Improvements

### DIFF
--- a/src/Libraries/CoreNodeModels/ColorRange.cs
+++ b/src/Libraries/CoreNodeModels/ColorRange.cs
@@ -16,20 +16,29 @@ namespace DSCoreNodesUI
     [NodeDescription("ColorRangeDescription",typeof(DSCoreNodesUI.Properties.Resources))]
     public class ColorRange : NodeModel
     {
-        public event EventHandler RequestChangeColorRange;
-        protected virtual void OnRequestChangeColorRange(object sender, EventArgs e)
+        public event Action RequestChangeColorRange;
+        protected virtual void OnRequestChangeColorRange()
         {
             if (RequestChangeColorRange != null)
-                RequestChangeColorRange(sender, e);
+                RequestChangeColorRange();
         }
 
         public ColorRange()
         {
             InitializePorts();
 
-            this.PropertyChanged += ColorRange_PropertyChanged; 
-            
+            this.PropertyChanged += ColorRange_PropertyChanged;
+            foreach (var port in InPorts)
+            {
+                port.Connectors.CollectionChanged += Connectors_CollectionChanged;
+            }
+
             ShouldDisplayPreviewCore = false;
+        }
+
+        void Connectors_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            OnRequestChangeColorRange();
         }
 
         protected virtual void InitializePorts()
@@ -50,7 +59,7 @@ namespace DSCoreNodesUI
             if (InPorts.Any(x => x.Connectors.Count == 0))
                 return;
 
-            OnRequestChangeColorRange(this, EventArgs.Empty);
+            OnRequestChangeColorRange();
         }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)

--- a/src/Libraries/CoreNodeModels/ColorRange.cs
+++ b/src/Libraries/CoreNodeModels/ColorRange.cs
@@ -64,8 +64,6 @@ namespace DSCoreNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            OnRequestChangeColorRange();
-
             var buildColorRangeNode =
                 AstFactory.BuildFunctionCall(
                     new Func<List<Color>, List<double>, ColorRange1D>(ColorRange1D.ByColorsAndParameters),

--- a/src/Libraries/CoreNodeModels/ColorRange.cs
+++ b/src/Libraries/CoreNodeModels/ColorRange.cs
@@ -64,6 +64,8 @@ namespace DSCoreNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
+            OnRequestChangeColorRange();
+
             var buildColorRangeNode =
                 AstFactory.BuildFunctionCall(
                     new Func<List<Color>, List<double>, ColorRange1D>(ColorRange1D.ByColorsAndParameters),

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
@@ -57,12 +57,7 @@ namespace Dynamo.Wpf.Nodes
                 }
                 else
                 {
-                    colors = new List<Color>()
-                    {
-                        Color.ByARGB(255,255,100,100), // orange
-                        Color.ByARGB(255,255,255,0), // yellow
-                        Color.ByARGB(255,0,255,255) // cyan
-                    };
+                    colors = DefaultColorRanges.Analysis;
                 }
 
                 // If there are indices supplied

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
@@ -79,7 +79,9 @@ namespace Dynamo.Wpf.Nodes
                     parameters = CreateParametersForColors(colors);
                 }
 
-                bmp = CreateColorRangeBitmap(colors, parameters); 
+                var colorRange = ColorRange1D.ByColorsAndParameters(colors, parameters);
+
+                bmp = CreateColorRangeBitmap(colorRange); 
 
                 drawPlane.Source = bmp;
             });
@@ -151,15 +153,13 @@ namespace Dynamo.Wpf.Nodes
         public void Dispose() {}
 
         //http://gaggerostechnicalnotes.blogspot.com/2012/01/wpf-colors-scale.html
-        private WriteableBitmap CreateColorRangeBitmap(List<Color> colors, List<double> parameters)
+        private WriteableBitmap CreateColorRangeBitmap(ColorRange1D colorRange)
         {
             const int width = 64;
             const int height = 1;
 
             var bitmap = new WriteableBitmap(width, height, 96, 96, PixelFormats.Bgra32, null);
             var pixels = new uint[width * height];
-
-            var colorRange = DSCore.ColorRange1D.ByColorsAndParameters(colors, parameters);
 
             for (var i = 1; i <= width; i++)
             {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
@@ -7,12 +7,15 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Threading;
 using DSCore;
 using Dynamo.Controls;
 using Dynamo.UI;
 
 using DSCoreNodesUI;
+using Dynamo.Core.Threading;
 using Dynamo.Models;
+using Dynamo.ViewModels;
 using ProtoCore.Mirror;
 using Color = DSCore.Color;
 
@@ -20,66 +23,88 @@ namespace Dynamo.Wpf.Nodes
 {
     public class ColorRangeNodeViewCustomization : INodeViewCustomization<ColorRange>
     {
+        private DynamoViewModel dynamoViewModel;
+        private DispatcherSynchronizationContext syncContext;
+        private ColorRange colorRangeNode;
+        private DynamoModel dynamoModel;
+        private System.Windows.Controls.Image gradientImage;
+        private ColorRange1D colorRange;
+
         public void CustomizeView(ColorRange model, NodeView nodeView)
         {
-            var drawPlane = new Image
+            dynamoModel = nodeView.ViewModel.DynamoViewModel.Model;
+            dynamoViewModel = nodeView.ViewModel.DynamoViewModel;
+            syncContext = new DispatcherSynchronizationContext(nodeView.Dispatcher);
+            colorRangeNode = model;
+
+            gradientImage = new Image
             {
                 Stretch = Stretch.Fill,
                 Width = 200,
                 Height = Configurations.PortHeightInPixels * 3
             };
 
-            var dm = nodeView.ViewModel.DynamoViewModel.Model;
+            nodeView.inputGrid.Children.Add(gradientImage);
 
-            nodeView.inputGrid.Children.Add(drawPlane);
+            colorRangeNode.RequestChangeColorRange += UpdateColorRange;
 
-            model.RequestChangeColorRange += delegate { UpdateColorRange(model, dm, drawPlane); };
-
-            UpdateColorRange(model, dm, drawPlane);
+            UpdateColorRange();
         }
 
-        private void UpdateColorRange(ColorRange model, DynamoModel dm, Image drawPlane)
+        private void UpdateColorRange()
         {
-            model.DispatchOnUIThread(delegate
+            var s = dynamoViewModel.Model.Scheduler;
+
+            // prevent data race by running on scheduler
+            var t = new DelegateBasedAsyncTask(s, () =>
             {
-                WriteableBitmap bmp;
-                List<Color> colors;
-                List<double> parameters;
-
-                // If there are colors supplied
-                if (model.InPorts[0].Connectors.Any())
-                {
-                    var colorsNode = model.InPorts[0].Connectors[0].Start.Owner;
-                    var colorsIndex = model.InPorts[0].Connectors[0].Start.Index;
-                    var startId = colorsNode.GetAstIdentifierForOutputIndex(colorsIndex).Name;
-                    var colorsMirror = dm.EngineController.GetMirror(startId);
-                    colors = GetColorsFromMirrorData(colorsMirror);
-                }
-                else
-                {
-                    colors = DefaultColorRanges.Analysis;
-                }
-
-                // If there are indices supplied
-                if (model.InPorts[1].Connectors.Any())
-                {
-                    var valuesNode = model.InPorts[1].Connectors[0].Start.Owner;
-                    var valuesIndex = model.InPorts[1].Connectors[0].Start.Index;
-                    var endId = valuesNode.GetAstIdentifierForOutputIndex(valuesIndex).Name;
-                    var valuesMirror = dm.EngineController.GetMirror(endId);
-                    parameters = GetValuesFromMirrorData(valuesMirror);
-                }
-                else
-                {
-                    parameters = CreateParametersForColors(colors);
-                }
-
-                var colorRange = ColorRange1D.ByColorsAndParameters(colors, parameters);
-
-                bmp = CreateColorRangeBitmap(colorRange); 
-
-                drawPlane.Source = bmp;
+                colorRange = ComputeColorRange();
             });
+
+            // then update on the ui thread
+            t.ThenPost((_) =>
+            {
+                var bmp = CreateColorRangeBitmap(colorRange);
+                gradientImage.Source = bmp;
+            }, syncContext);
+
+            s.ScheduleForExecution(t);
+        }
+
+        private ColorRange1D ComputeColorRange()
+        {
+            List<Color> colors;
+            List<double> parameters;
+
+            // If there are colors supplied
+            if (colorRangeNode.InPorts[0].Connectors.Any())
+            {
+                var colorsNode = colorRangeNode.InPorts[0].Connectors[0].Start.Owner;
+                var colorsIndex = colorRangeNode.InPorts[0].Connectors[0].Start.Index;
+                var startId = colorsNode.GetAstIdentifierForOutputIndex(colorsIndex).Name;
+                var colorsMirror = dynamoModel.EngineController.GetMirror(startId);
+                colors = GetColorsFromMirrorData(colorsMirror);
+            }
+            else
+            {
+                colors = DefaultColorRanges.Analysis;
+            }
+
+            // If there are indices supplied
+            if (colorRangeNode.InPorts[1].Connectors.Any())
+            {
+                var valuesNode = colorRangeNode.InPorts[1].Connectors[0].Start.Owner;
+                var valuesIndex = colorRangeNode.InPorts[1].Connectors[0].Start.Index;
+                var endId = valuesNode.GetAstIdentifierForOutputIndex(valuesIndex).Name;
+                var valuesMirror = dynamoModel.EngineController.GetMirror(endId);
+                parameters = GetValuesFromMirrorData(valuesMirror);
+            }
+            else
+            {
+                parameters = CreateParametersForColors(colors);
+            }
+
+            return ColorRange1D.ByColorsAndParameters(colors, parameters);
         }
 
         private static List<double> CreateParametersForColors(List<Color> colors)

--- a/src/Libraries/CoreNodes/Color.cs
+++ b/src/Libraries/CoreNodes/Color.cs
@@ -355,9 +355,6 @@ namespace DSCore
         public static ColorRange1D ByColorsAndParameters(
             List<Color> colors, List<double> parameters)
         {
-            var blue = Color.ByARGB(255, 0, 0, 255);
-            var red = Color.ByARGB(255, 255, 0, 0);
-
             if (colors == null)
                 colors = new List<Color>();
 
@@ -415,7 +412,8 @@ namespace DSCore
                 var diff = colors.Count() - parameters.Count();
                 for (var i = 0; i < diff; i++)
                 {
-                    parameters.Add(1.0);
+                    // Put the color in the middle
+                    parameters.Add(0.5);
                 }
             }
             // If the number of parameters is greater than the
@@ -425,7 +423,7 @@ namespace DSCore
                 var diff = parameters.Count() - colors.Count();
                 for (var i = 0; i < diff; i++)
                 {
-                    colors.Add(blue);
+                    colors.Add(DefaultColorRanges.Analysis.Last());
                 }
             }
 

--- a/src/Libraries/CoreNodes/Color.cs
+++ b/src/Libraries/CoreNodes/Color.cs
@@ -372,7 +372,7 @@ namespace DSCore
             // a red->blue gradient.
             if (!colors.Any())
             {
-                colors = new List<Color>(){ red, blue};
+                colors = DefaultColorRanges.Analysis;
             }
 
             // If there's no parameters supplied, then set the parameters
@@ -474,6 +474,18 @@ namespace DSCore
 
             return Color.Lerp(c1.Color, c2.Color, (parameter - c1.Parameter) / (c2.Parameter - c1.Parameter));
         }
+
+    }
+
+    [IsVisibleInDynamoLibrary(false)]
+    public static class DefaultColorRanges
+    {
+        public static List<Color> Analysis = new List<Color>
+        {
+            Color.ByARGB(255,255,100,100), // orange
+            Color.ByARGB(255,255,255,0), // yellow
+            Color.ByARGB(255,0,255,255) // cyan
+        };
     }
 
     [IsVisibleInDynamoLibrary(true)]

--- a/test/Libraries/CoreNodesTests/ColorRangeTests.cs
+++ b/test/Libraries/CoreNodesTests/ColorRangeTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-
+using System.Linq;
 using DSCore;
 
 using NUnit.Framework;
@@ -32,12 +32,12 @@ namespace Dynamo.Tests
         public void ColorRange1D_ByColorsAndParameters_HasSomeColorsIfNoneProvided()
         {
             var colors = new List<Color>();
-            var parameters = new List<double>{ 0.0, 1.0 };
+            var parameters = new List<double>{ 0.0, 0.5, 1.0 };
 
             var range = ColorRange1D.ByColorsAndParameters(colors, parameters);
 
-            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,0), red);
-            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,1), blue);
+            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,0), DefaultColorRanges.Analysis.First());
+            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,1), DefaultColorRanges.Analysis.Last());
         }
 
         [Test]
@@ -60,8 +60,8 @@ namespace Dynamo.Tests
 
             var range = ColorRange1D.ByColorsAndParameters(colors, parameters);
 
-            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,0), red);
-            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,1), blue);
+            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,0), DefaultColorRanges.Analysis.First());
+            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,1), DefaultColorRanges.Analysis.Last());
         }
 
         [Test]
@@ -107,8 +107,8 @@ namespace Dynamo.Tests
 
             var range = ColorRange1D.ByColorsAndParameters(null, parameters);
 
-            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,0), red);
-            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,1), blue);
+            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,0), DefaultColorRanges.Analysis.First());
+            Assert.AreEqual(ColorRange1D.GetColorAtParameter(range,1), DefaultColorRanges.Analysis.Last());
         }
 
     }


### PR DESCRIPTION
### Purpose

This PR adds some necessary updates to the `ColorRange` node to make it work as one would expect. 
- Compute the color range on the scheduler, then update the UI on the `DispatcherSynchronizationContext`. This avoids a race condition whereby, the values of the color range were changed, and an execution occurred, but the node didn't update.
- Updates the default color range for a little more punch.
- If a greater number of colors than parameters are specified, it inserts extra parameters at 0.5, instead of 1.0. This solves the problem with having a thin slice of color on the far right of the range.
- Responds to connector add/remove events and updates the color range, setting it back to the fault, or recalculating it based on the inputs.

No colors or parameters are specified. The color range still works and has a kickass default color scheme.
![image](https://cloud.githubusercontent.com/assets/1139788/8467007/b7e54644-200d-11e5-854b-8cd09172beef.png)

No parameters are specified. The parameters are mapped equally over the range 0.0->1.0.
![image](https://cloud.githubusercontent.com/assets/1139788/8466996/91b68da2-200d-11e5-9b4d-111e4c3e23cc.png)

Unequal number of parameters (2) and colors (3). The extra color (white) is dropped in at 0.5. 
![image](https://cloud.githubusercontent.com/assets/1139788/8466975/6952975c-200d-11e5-9c2c-065a6b756497.png)

Single color is provided. No surprise here, you get a single color.
![image](https://cloud.githubusercontent.com/assets/1139788/8467024/e72035cc-200d-11e5-833a-6cdb5902bd13.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
  - `ColorRangeNodeViewCustomization` and `ColorRange1D` now share the same logic for getting the default color range.
- [ ] The level of testing this PR includes is appropriate
  - All `ColorRangeTests` have been updated and pass.

### Reviewers

@ramramps 

### FYIs

@lillismith @kronz 