### PR TITLE
Avoid to update the libary if the file is backed up automatically

### DIFF
--- a/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
@@ -196,6 +196,9 @@ namespace Dynamo.Models
 
         public override bool SaveAs(string newPath, ProtoCore.RuntimeCore runtimeCore, bool isBackUp = false)
         {
+            if (isBackUp)
+                return base.SaveAs(newPath, runtimeCore, isBackUp);
+
             var originalPath = FileName;
 
             // A SaveAs to an existing function id prompts the creation of a new 
@@ -212,7 +215,7 @@ namespace Dynamo.Models
                 SetInfo(Path.GetFileNameWithoutExtension(newPath));
             }
 
-            return base.SaveAs(newPath, runtimeCore);
+            return base.SaveAs(newPath, runtimeCore, isBackUp);
         }
 
         protected override bool PopulateXmlDocument(XmlDocument document)


### PR DESCRIPTION
### Purpose

This submission is to fix an issue found related to backing up custom nodes. The issue is that every time there is an change to the custom node and when it is automatically backed up, there will be a new item in the library. The fix is part of MAGN-7770.

The fix here is to avoid updating the custom node when it is found the custom node is automatically saved to the backup folder.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers
@Benglin 
@riteshchandawar 