### PR TITLE
Node to code test framework

### DIFF
--- a/test/DynamoCoreTests/NodeMigrationTests.cs
+++ b/test/DynamoCoreTests/NodeMigrationTests.cs
@@ -2079,7 +2079,7 @@ namespace Dynamo.Tests
 
         private string GetDynPath(string sourceDynFile)
         {
-            string sourceDynPath = this.TestDirectory;
+            string sourceDynPath = TestDirectory;
             sourceDynPath = Path.Combine(sourceDynPath, @"core\migration\");
             return Path.Combine(sourceDynPath, sourceDynFile);
         }

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -919,10 +919,8 @@ namespace Dynamo.Tests
 
         private static string[] GetDynFiles(string folder)
         {
-            var execDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var directory = new DirectoryInfo(execDirectory);
-            var undoFileDirectory = Path.Combine(directory.Parent.Parent.Parent.FullName, @"test\core\node2code\" + folder);
-            var files = Directory.GetFiles(undoFileDirectory, "*.dyn");
+            var dir = Path.Combine(TestDirectory, @"core\node2code\" + folder);
+            var files = Directory.GetFiles(dir, "*.dyn");
             return files;
         }
 

--- a/test/DynamoCoreTests/UnitTestBase.cs
+++ b/test/DynamoCoreTests/UnitTestBase.cs
@@ -8,10 +8,50 @@ namespace Dynamo
 {
     public class UnitTestBase
     {
-        protected string ExecutingDirectory { get; set; }
+        private static string executingDirectory;
+        protected static string ExecutingDirectory 
+        { 
+            get 
+            {
+                if (executingDirectory == null)
+                {
+                    executingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                }
+                return executingDirectory;
+            }
+        }
+
+        private static string sampleDirectory;
+        public static string SampleDirectory 
+        { 
+            get
+            {
+                if (sampleDirectory == null)
+                {
+                    var directory = new FileInfo(ExecutingDirectory);
+                    string assemblyDir = directory.DirectoryName;
+                    string sampleLocation = Path.Combine(assemblyDir, @"..\..\doc\distrib\Samples\");
+                    sampleDirectory = Path.GetFullPath(sampleLocation);
+                }
+                return sampleDirectory;
+            }
+        }
+
         protected string TempFolder { get; private set; }
-        public string SampleDirectory { get; private set; }
-        public string TestDirectory { get; private set; }
+
+        private static string testDirectory;
+        public static string TestDirectory 
+        { 
+            get
+            {
+                if (testDirectory == null)
+                {
+                    var directory = new DirectoryInfo(ExecutingDirectory);
+                    testDirectory = Path.Combine(directory.Parent.Parent.Parent.FullName, "test");
+                }
+                return testDirectory;
+            }
+        }
 
         [SetUp]
         public virtual void Setup()
@@ -45,7 +85,6 @@ namespace Dynamo
 
         protected void SetupDirectories()
         {
-            ExecutingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             string tempPath = Path.GetTempPath();
 
             TempFolder = Path.Combine(tempPath, "dynamoTmp\\" + Guid.NewGuid().ToString("N"));
@@ -55,25 +94,6 @@ namespace Dynamo
 
             // Setup Temp PreferenceSetting Location for testing
             PreferenceSettings.DynamoTestPath = Path.Combine(TempFolder, "UserPreferenceTest.xml");
-
-            SampleDirectory = GetSampleDirectory();
-
-            TestDirectory = GetTestDirectory();
-        }
-
-        private string GetSampleDirectory()
-        {
-            var directory = new FileInfo(ExecutingDirectory);
-            string assemblyDir = directory.DirectoryName;
-            string sampleLocation = Path.Combine(assemblyDir, @"..\..\doc\distrib\Samples\");
-            string samplePath = Path.GetFullPath(sampleLocation);
-            return samplePath;
-        }
-
-        private string GetTestDirectory()
-        {
-            var directory = new DirectoryInfo(ExecutingDirectory);
-            return Path.Combine(directory.Parent.Parent.Parent.FullName, "test");
         }
     }
 }

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -7,7 +7,7 @@ namespace Dynamo.PackageManager.Tests
 {
     class PackageLoaderTests : DynamoModelTestBase
     {
-        public string PackagesDirectory { get { return Path.Combine(this.TestDirectory, "pkgs"); } }
+        public string PackagesDirectory { get { return Path.Combine(TestDirectory, "pkgs"); } }
 
         [Test]
         public void ScanPackageDirectoryReturnsPackageForValidDirectory()

--- a/test/core/node2code/mutation/mutationTest1.dyn
+++ b/test/core/node2code/mutation/mutationTest1.dyn
@@ -1,0 +1,20 @@
+<Workspace Version="0.8.2.1870" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="35ee4299-3858-48e2-837b-9b51cddf117b" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="280" y="279" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="100;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="6872602f-8a49-411b-9592-abfdbf5f86f2" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="476" y="288" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="y;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="dca924d2-1513-4970-8ad5-a46b604d66a9" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="483.5" y="417.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="b95739da-16df-493e-b3f8-1604af7ed25a" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="302" y="469" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="1..5;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="35ee4299-3858-48e2-837b-9b51cddf117b" start_index="0" end="6872602f-8a49-411b-9592-abfdbf5f86f2" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="35ee4299-3858-48e2-837b-9b51cddf117b" start_index="0" end="dca924d2-1513-4970-8ad5-a46b604d66a9" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="b95739da-16df-493e-b3f8-1604af7ed25a" start_index="0" end="dca924d2-1513-4970-8ad5-a46b604d66a9" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+</Workspace>

--- a/test/core/node2code/undo/undotest1.dyn
+++ b/test/core/node2code/undo/undotest1.dyn
@@ -1,0 +1,20 @@
+<Workspace Version="0.8.2.1870" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="35ee4299-3858-48e2-837b-9b51cddf117b" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="280" y="279" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="100;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="6872602f-8a49-411b-9592-abfdbf5f86f2" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="476" y="288" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="y;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="dca924d2-1513-4970-8ad5-a46b604d66a9" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="483.5" y="417.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="b95739da-16df-493e-b3f8-1604af7ed25a" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="302" y="469" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="1..5;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="35ee4299-3858-48e2-837b-9b51cddf117b" start_index="0" end="6872602f-8a49-411b-9592-abfdbf5f86f2" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="35ee4299-3858-48e2-837b-9b51cddf117b" start_index="0" end="dca924d2-1513-4970-8ad5-a46b604d66a9" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="b95739da-16df-493e-b3f8-1604af7ed25a" start_index="0" end="dca924d2-1513-4970-8ad5-a46b604d66a9" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR adds node to code test framework.

It adds two kinds of tests: undo test and mutation test:
  * For undo test, the test framework will iterate all .dyn files in test folder, and for each .dyn file, it will firstly run the graph to get all nodes' preview values (in string representation). Next step is to convert all nodes to code, run the graph and undo node to code operation, and re-run the graph. Then the test framework collects all nodes' current preview values and compare them with the previous values. This is to make sure undo operation will always bring the graph back to original state.
  * Mutation test does the similar thing. But for each .dyn file, it will iterate all nodes. For each iteration, it converts all nodes to code except the one that it chooses, and compares the preview value of this one with its original preview value. This is to make sure node to code generate same result.

To add test cases, just drop some .dyn files either in `test\core\node2code\undo` or in `test\core\node2code\mutation`. Test framework will pick it up, see the picture below:

![temp](https://cloud.githubusercontent.com/assets/2600379/8538747/df4c0ce6-24a3-11e5-83b3-068ffc461d7b.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@monikaprabhu, @riteshchandawar 
