### PR TITLE
Add Display project to Dynamo.Mono.2013.sln

### DIFF
--- a/src/Dynamo.Mono.2013.sln
+++ b/src/Dynamo.Mono.2013.sln
@@ -140,12 +140,19 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamoShapeManager", "Tools
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamoPackages", "DynamoPackages\DynamoPackages.csproj", "{47533B7C-0E1A-44A4-8511-B438645F052A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Display", "Libraries\Display\Display.csproj", "{A50C198C-DA6E-4081-BC53-0F44D287F207}"
+EndProject
 Global
+
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A50C198C-DA6E-4081-BC53-0F44D287F207}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A50C198C-DA6E-4081-BC53-0F44D287F207}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A50C198C-DA6E-4081-BC53-0F44D287F207}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A50C198C-DA6E-4081-BC53-0F44D287F207}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7858FA8C-475F-4B8E-B468-1F8200778CF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7858FA8C-475F-4B8E-B468-1F8200778CF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7858FA8C-475F-4B8E-B468-1F8200778CF8}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
### Purpose

When moved, this project was not added to the Mono solution.  This is a hotfix.  Correspondingly, there are no reviewers listed.  Reach wasn't fixed either, which was handled in a separate PR. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

None.

### FYIs

@ikeough @ramramps 