### PR TITLE
Samples menu item fix

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
@@ -129,19 +129,9 @@ namespace Dynamo.Wpf.ViewModels
 
         }
 
-        public bool RunEnabled
-        {
-            get { return Model.RunEnabled; }
-        }
-
         public bool RunButtonEnabled
         {
-            get
-            {
-                return Model.RunEnabled &&
-                    Model.RunType != RunType.Automatic &&
-                    Model.RunType != RunType.Periodic;
-            }
+            get { return Model.RunEnabled; }
         }
 
         public string RunButtonToolTip

--- a/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/RunSettingsViewModel.cs
@@ -129,9 +129,19 @@ namespace Dynamo.Wpf.ViewModels
 
         }
 
-        public bool RunButtonEnabled
+        public bool RunEnabled
         {
             get { return Model.RunEnabled; }
+        }
+
+        public bool RunButtonEnabled
+        {
+            get
+            {
+                return Model.RunEnabled &&
+                    Model.RunType != RunType.Automatic &&
+                    Model.RunType != RunType.Periodic;
+            }
         }
 
         public string RunButtonToolTip

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -638,7 +638,7 @@
                         <MenuItem Focusable="False"
                                   Header="{x:Static p:Resources.DynamoViewHepMenuSamples}"
                                   Name="SamplesMenu"
-                                  IsEnabled="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunEnabled}">
+                                  IsEnabled="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunButtonEnabled}">
                             <MenuItem.Icon>
                                 <Image Source="/DynamoCoreWpf;component/UI/Images/OpenSelectedItemHS.png"
                                        Width="14"

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -638,7 +638,7 @@
                         <MenuItem Focusable="False"
                                   Header="{x:Static p:Resources.DynamoViewHepMenuSamples}"
                                   Name="SamplesMenu"
-                                  IsEnabled="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunButtonEnabled}">
+                                  IsEnabled="{Binding Path=HomeSpaceViewModel.RunSettingsViewModel.RunEnabled}">
                             <MenuItem.Icon>
                                 <Image Source="/DynamoCoreWpf;component/UI/Images/OpenSelectedItemHS.png"
                                        Width="14"


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7805](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7805) Help, Samples menu item is disabled, when Run type is Automatic.

There were two properties: `RunEnabled` and `RunButtonEnabled`. The second was limited if Run mode was Automatic or Periodic.

So, I used `RunEnabled`.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@jnealb , What should happen on click Samples menu item? I assume we should open samples folder, don't we? Now nothing happens, I can fix it as well.

### FYIs

@pboyer 