### PR TITLE
Revert back to naive mark and sweep to fix Revit regressions

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -498,8 +498,10 @@ namespace ProtoCore.Lang
                     ret = StackValue.Null;
                     break;
                 case BuiltInMethods.MethodID.kGC:
+#if !NAIVE_MARK_AND_SWEEP
                     var gcRoots = interpreter.runtime.RuntimeCore.CurrentExecutive.CurrentDSASMExec.CollectGCRoots();
                     rmem.Heap.FullGC(gcRoots, interpreter.runtime);
+#endif
                     ret = StackValue.Null;
                     break;
                 default:

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -84,10 +84,10 @@
     <AssemblyOriginatorKeyFile>ProtoCore.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NAIVE_MARK_AND_SWEEP</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NAIVE_MARK_AND_SWEEP</DefineConstants>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
### Purpose

Revit test cases have regression because of PR #4847 Revert GC method to original until I solve the regression. 

### Reviewers

@lukechurch (pending): I'll merge it now so that test could pass and monitor Revit test result.