### PR TITLE
MAGN-7761 Presets can not be saved after node disconnect/connect sequence and app X

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -666,7 +666,7 @@ namespace Dynamo.Models
         /// </summary>
         protected virtual void NodeModified(NodeModel node)
         {
-
+            HasUnsavedChanges = true;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose
 This PR fixes the issue with Dirty flag on Connector added / removed.

YT: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7761

### Declarations
- [x] The code base is in a better state after this PR
Added the dirty flag to true on OnNodeModified event.
          
- [x] The level of testing this PR includes is appropriate
Added a test to PresetTests. This test tests the Connectors and Preset dirty flag.
           

### Reviewers
- [ ] @pboyer 