### PR TITLE
Re-eanble tri-color GC

### DIFF
--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -84,10 +84,10 @@
     <AssemblyOriginatorKeyFile>ProtoCore.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NAIVE_MARK_AND_SWEEP</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <DefineConstants>TRACE;NAIVE_MARK_AND_SWEEP</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1657,12 +1657,12 @@ namespace ProtoScript.Runners
             return succeeded;
         }
 
-        private ProtoRunner.ProtoVMState Execute(bool isCodeCompiled)
+        private ProtoRunner.ProtoVMState Execute(bool isCodeCompiled, bool forceGC)
         {
             try
             {
                 SetupRuntimeCoreForExecution(isCodeCompiled);
-                runner.ExecuteLive(runnerCore, runtimeCore);
+                runner.ExecuteLive(runnerCore, runtimeCore, forceGC);
             }
             catch (ProtoCore.Exceptions.ExecutionCancelledException)
             {
@@ -1680,7 +1680,7 @@ namespace ProtoScript.Runners
             if (succeeded)
             {
                 runtimeCore.RunningBlock = blockId;
-                vmState = Execute(!string.IsNullOrEmpty(code));
+                vmState = Execute(!string.IsNullOrEmpty(code), false);
             }
             return succeeded;
         }
@@ -1693,7 +1693,7 @@ namespace ProtoScript.Runners
             if (succeeded)
             {
                 runtimeCore.RunningBlock = blockId;
-                vmState = Execute(astList.Count > 0);
+                vmState = Execute(astList.Count > 0, false);
             }
             return succeeded;
         }
@@ -1731,7 +1731,7 @@ namespace ProtoScript.Runners
             {
                 ResetForDeltaExecution();
                 runnerCore.Options.ApplyUpdate = true;
-                Execute(true);
+                Execute(true, true);
             }
         }
 

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1657,12 +1657,12 @@ namespace ProtoScript.Runners
             return succeeded;
         }
 
-        private ProtoRunner.ProtoVMState Execute(bool isCodeCompiled, bool forceGC)
+        private ProtoRunner.ProtoVMState Execute(bool isCodeCompiled)
         {
             try
             {
                 SetupRuntimeCoreForExecution(isCodeCompiled);
-                runner.ExecuteLive(runnerCore, runtimeCore, forceGC);
+                runner.ExecuteLive(runnerCore, runtimeCore);
             }
             catch (ProtoCore.Exceptions.ExecutionCancelledException)
             {
@@ -1680,7 +1680,7 @@ namespace ProtoScript.Runners
             if (succeeded)
             {
                 runtimeCore.RunningBlock = blockId;
-                vmState = Execute(!string.IsNullOrEmpty(code), false);
+                vmState = Execute(!string.IsNullOrEmpty(code));
             }
             return succeeded;
         }
@@ -1693,7 +1693,7 @@ namespace ProtoScript.Runners
             if (succeeded)
             {
                 runtimeCore.RunningBlock = blockId;
-                vmState = Execute(astList.Count > 0, false);
+                vmState = Execute(astList.Count > 0);
             }
             return succeeded;
         }
@@ -1725,13 +1725,20 @@ namespace ProtoScript.Runners
             runnerCore.DSExecutable.UpdatedSymbols.Clear();
         }
 
+        private void ForceGC()
+        {
+            var gcRoots = runtimeCore.CurrentExecutive.CurrentDSASMExec.CollectGCRoots();
+            runtimeCore.RuntimeMemory.Heap.FullGC(gcRoots, runtimeCore.CurrentExecutive.CurrentDSASMExec);
+        }
+
         private void ApplyUpdate()
         {
             if (ProtoCore.AssociativeEngine.Utils.IsGlobalScopeDirty(runnerCore.DSExecutable))
             {
                 ResetForDeltaExecution();
                 runnerCore.Options.ApplyUpdate = true;
-                Execute(true, true);
+                Execute(true);
+                ForceGC();
             }
         }
 

--- a/src/Engine/ProtoScript/Runners/ProtoScriptTestRunner.cs
+++ b/src/Engine/ProtoScript/Runners/ProtoScriptTestRunner.cs
@@ -190,7 +190,7 @@ namespace ProtoScript.Runners
         /// <param name="staticContext"></param>
         /// <param name="runtimeContext"></param>
         /// <returns></returns>
-        public ProtoCore.RuntimeCore ExecuteLive(ProtoCore.Core core, ProtoCore.RuntimeCore runtimeCore, bool forceGC)
+        public ProtoCore.RuntimeCore ExecuteLive(ProtoCore.Core core, ProtoCore.RuntimeCore runtimeCore)
         {
             try
             {
@@ -224,12 +224,6 @@ namespace ProtoScript.Runners
                     runtimeCore.StartPC, 
                     stackFrame,
                     locals);
-
-                if (forceGC)
-                {
-                    var gcRoots = runtimeCore.CurrentExecutive.CurrentDSASMExec.CollectGCRoots();
-                    runtimeCore.RuntimeMemory.Heap.FullGC(gcRoots, runtimeCore.CurrentExecutive.CurrentDSASMExec);
-                }
 
                 runtimeCore.NotifyExecutionEvent(ProtoCore.ExecutionStateEventArgs.State.kExecutionEnd);
             }

--- a/src/Engine/ProtoScript/Runners/ProtoScriptTestRunner.cs
+++ b/src/Engine/ProtoScript/Runners/ProtoScriptTestRunner.cs
@@ -190,7 +190,7 @@ namespace ProtoScript.Runners
         /// <param name="staticContext"></param>
         /// <param name="runtimeContext"></param>
         /// <returns></returns>
-        public ProtoCore.RuntimeCore ExecuteLive(ProtoCore.Core core, ProtoCore.RuntimeCore runtimeCore)
+        public ProtoCore.RuntimeCore ExecuteLive(ProtoCore.Core core, ProtoCore.RuntimeCore runtimeCore, bool forceGC)
         {
             try
             {
@@ -224,6 +224,12 @@ namespace ProtoScript.Runners
                     runtimeCore.StartPC, 
                     stackFrame,
                     locals);
+
+                if (forceGC)
+                {
+                    var gcRoots = runtimeCore.CurrentExecutive.CurrentDSASMExec.CollectGCRoots();
+                    runtimeCore.RuntimeMemory.Heap.FullGC(gcRoots, runtimeCore.CurrentExecutive.CurrentDSASMExec);
+                }
 
                 runtimeCore.NotifyExecutionEvent(ProtoCore.ExecutionStateEventArgs.State.kExecutionEnd);
             }


### PR DESCRIPTION
### Purpose

This PR re-enables tri-color GC which was introduced in PR #4847 and caused some Revit regressions. 

The regressions are because new GC won't do full memory scan for assignment, therefore the objects won't be guaranteed to be disposed timely. This PR forces live runner to do full cycle GC after the execution. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@junmendoza 