### PR TITLE
Always do full cycle GC after each delta execution

### DIFF
--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1738,8 +1738,8 @@ namespace ProtoScript.Runners
                 ResetForDeltaExecution();
                 runnerCore.Options.ApplyUpdate = true;
                 Execute(true);
-                ForceGC();
             }
+            ForceGC();
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

This PR is to fix revit Regression MAGN_5160. Previously full cycle GC is invoked when there are some graph nodes are marked as dirty, but for the following case they aren't:

1. Create a `Point.ByCoordinates(0,0)` and a CBN with "null"
2. Connect "null" to any input of `Point.ByCoordinates()`

Although the output of `Point.ByCoordinates()` is null, but `LiveRunner.ApplyUpdate()` doesn't find any dirty node, therefore `ForceGC()` not invoked.

Temporarily move `ForceGC()` out of `ApplyUpdate()` checking. @junmendoza may help to investigate why graph node is not dirty.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@junmendoza , PTAL.