### PR TITLE
Fixed defect in migrating user data causing existing files to be overwritten

### DIFF
--- a/src/DynamoCore/Core/DynamoMigrator.cs
+++ b/src/DynamoCore/Core/DynamoMigrator.cs
@@ -319,14 +319,22 @@ namespace Dynamo.Core
             // Copy each file into the new directory.
             foreach (FileInfo fi in source.GetFiles())
             {
-                fi.CopyTo(Path.Combine(target.FullName, fi.Name), true);
+                var targetFilePath = Path.Combine(target.FullName, fi.Name);
+                if (File.Exists(targetFilePath) == false)
+                {
+                    fi.CopyTo(Path.Combine(target.FullName, fi.Name), true);
+                }
             }
 
             // Copy each subdirectory using recursion.
             foreach (DirectoryInfo diSourceSubDir in source.GetDirectories())
             {
-                DirectoryInfo nextTargetSubDir = target.CreateSubdirectory(diSourceSubDir.Name);
-                CopyAll(diSourceSubDir, nextTargetSubDir);
+                var targetSubDirPath = Path.Combine(target.FullName, diSourceSubDir.Name);
+                if (Directory.Exists(targetSubDirPath) == false)
+                {
+                    DirectoryInfo nextTargetSubDir = target.CreateSubdirectory(diSourceSubDir.Name);
+                    CopyAll(diSourceSubDir, nextTargetSubDir);
+                }
             }
         }
 

--- a/src/DynamoCore/Core/DynamoMigrator.cs
+++ b/src/DynamoCore/Core/DynamoMigrator.cs
@@ -257,7 +257,7 @@ namespace Dynamo.Core
         /// <param name="pathResolver"></param>
         /// <param name="fromVersion"> source Dynamo version from which to migrate </param>
         /// <param name="toVersion"> target Dynamo version into which to migrate </param>
-        /// <returns> new migrator instance after migration </returns>
+        /// <returns> new migrator instance after migration, null if there's no migration </returns>
         internal static DynamoMigratorBase Migrate(IPathResolver pathResolver, FileVersion fromVersion, FileVersion toVersion)
         {
             // Create concrete DynamoMigratorBase object using previousVersion and reflection
@@ -279,7 +279,7 @@ namespace Dynamo.Core
 
                 return targetMigrator.MigrateFrom(sourceMigrator);
             }
-            return targetMigrator;
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

This fixes a [defect] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7866) with user data migration causing existing packages and custom node definitions to be overwritten. So say a user has 070 and 080 installed and then upgrades to 081 or higher. On first run of the newly installed 081 version, migration will kick in which will try to copy 070 files from `C:\Users\<user>\AppData\Roaming\Dynamo\0.7` to `C:\Users\<user>\AppData\Roaming\Dynamo\0.8`. This invariably can overwrite existing 080 packages & custom nodes with 070 files again. Obviously in such a case we would like existing files to remain intact and only copy any packages/custom nodes from 070 that are not already there in the `C:\Users\<user>\AppData\Roaming\Dynamo\0.8` folder. 

The fix here is to check if there are existing files and directories with the same names. If so, they are left intact and not overwritten.

### Declarations


- [x] The code base is in a better state after this PR

- [ ] The level of testing this PR includes is appropriate


### Reviewers

@Benglin Reviewer 1 
