### PR TITLE
Graphnode Parent-children structure

### DIFF
--- a/src/Engine/ProtoCore/AssociativeGraph.cs
+++ b/src/Engine/ProtoCore/AssociativeGraph.cs
@@ -155,7 +155,6 @@ namespace ProtoCore.AssociativeEngine
                         }
 
                         currentNode.PushChildNode(gnode);
-                        gnode.PushParentNode(currentNode);
                     }
                 }
             }
@@ -952,6 +951,7 @@ namespace ProtoCore.AssociativeGraph
         ///     b = a <- the parent of this graphnode is 'a = 1'
         /// </summary>
         public List<GraphNode> ParentNodes { get; set; }
+
         public bool allowDependents { get; set; }
         public bool isIndexingLHS { get; set; }
         public bool isLHSNode { get; set; }
@@ -1054,20 +1054,11 @@ namespace ProtoCore.AssociativeGraph
                     return;
                 }
             }
-            ChildrenNodes.Add(child);
-        }
 
-        public void PushParentNode(GraphNode parent)
-        {
-            // Do not add if it already contains this parent
-            foreach (GraphNode node in ParentNodes)
-            {
-                if (node.UID == parent.UID)
-                {
-                    return;
-                }
-            }
-            ParentNodes.Add(parent);
+            ChildrenNodes.Add(child);
+
+            // The this graphnode to be the parent of the child node
+            child.ParentNodes.Add(this);
         }
 
         public void PushDependent(GraphNode dependent)

--- a/src/Engine/ProtoCore/AssociativeGraph.cs
+++ b/src/Engine/ProtoCore/AssociativeGraph.cs
@@ -154,7 +154,8 @@ namespace ProtoCore.AssociativeEngine
                             continue;
                         }
 
-                        currentNode.PushGraphNodeToExecute(gnode);
+                        currentNode.PushChildNode(gnode);
+                        gnode.PushParentNode(currentNode);
                     }
                 }
             }
@@ -937,7 +938,20 @@ namespace ProtoCore.AssociativeGraph
         public bool ProcedureOwned { get; set; }       // This graphnode's immediate scope is within a function (as opposed to languageblock or construct)
         public UpdateBlock updateBlock { get; set; }
         public List<GraphNode> dependentList { get; set; }
-        public List<GraphNode> graphNodesToExecute { get; set; }
+
+        /// <summary>
+        /// Children nodes are nodes that will be marked dirty if this graphnode is executed
+        ///     a = 1 <- the child of this graphnode is 'b = a'
+        ///     b = a 
+        /// </summary>
+        public List<GraphNode> ChildrenNodes { get; set; }
+
+        /// <summary>
+        /// Parent nodes are the nodes that this graphnode is dependent on
+        ///     a = 1
+        ///     b = a <- the parent of this graphnode is 'a = 1'
+        /// </summary>
+        public List<GraphNode> ParentNodes { get; set; }
         public bool allowDependents { get; set; }
         public bool isIndexingLHS { get; set; }
         public bool isLHSNode { get; set; }
@@ -1003,7 +1017,8 @@ namespace ProtoCore.AssociativeGraph
             classIndex = Constants.kInvalidIndex;
             updateBlock = new UpdateBlock();
             dependentList = new List<GraphNode>();
-            graphNodesToExecute = new List<GraphNode>();
+            ChildrenNodes = new List<GraphNode>();
+            ParentNodes = new List<GraphNode>();
             allowDependents = true;
             isIndexingLHS = false;
             isLHSNode = false;
@@ -1029,17 +1044,30 @@ namespace ProtoCore.AssociativeGraph
         }
 
 
-        public void PushGraphNodeToExecute(GraphNode dependent)
+        public void PushChildNode(GraphNode child)
         {
-            // Do not add if it already contains this dependent
-            foreach (GraphNode node in graphNodesToExecute)
+            // Do not add if it already contains this child
+            foreach (GraphNode node in ChildrenNodes)
             {
-                if (node.UID == dependent.UID)
+                if (node.UID == child.UID)
                 {
                     return;
                 }
             }
-            graphNodesToExecute.Add(dependent);
+            ChildrenNodes.Add(child);
+        }
+
+        public void PushParentNode(GraphNode parent)
+        {
+            // Do not add if it already contains this parent
+            foreach (GraphNode node in ParentNodes)
+            {
+                if (node.UID == parent.UID)
+                {
+                    return;
+                }
+            }
+            ParentNodes.Add(parent);
         }
 
         public void PushDependent(GraphNode dependent)

--- a/src/Engine/ProtoCore/AssociativeGraph.cs
+++ b/src/Engine/ProtoCore/AssociativeGraph.cs
@@ -1057,7 +1057,7 @@ namespace ProtoCore.AssociativeGraph
 
             ChildrenNodes.Add(child);
 
-            // The this graphnode to be the parent of the child node
+            // Set this graphnode to be the parent of the child node
             child.ParentNodes.Add(this);
         }
 

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -1630,7 +1630,7 @@ namespace ProtoCore.DSASM
                 // Data flow execution prototype
                 // Dependency has already been resolved at compile time
                 // Get the reachable nodes directly from the executingGraphNode
-                reachableGraphNodes = new List<AssociativeGraph.GraphNode>(Properties.executingGraphNode.graphNodesToExecute);
+                reachableGraphNodes = new List<AssociativeGraph.GraphNode>(Properties.executingGraphNode.ChildrenNodes);
             }
             else
             {


### PR DESCRIPTION
### Purpose

Graphnodes are refactored to reflect parent-child relation
1. Graphnode.ParentNodes - Parent nodes are the nodes that this graphnode is dependent on
    
a = 1
b = a <- the parent of this graphnode is 'a = 1'

2. Graphnode.ChildrenNodes - Children nodes are nodes that will be marked dirty if this graphnode is executed.


      a = 1 <- the child of this graphnode is 'b = a'
      b = a 


### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ke-yu PTAL

No regressions