### PR TITLE
REACH-295 Flood erroneously sends GetNodeGeometryMessage when unrelated node is added

### DIFF
--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -490,6 +490,12 @@ namespace Dynamo.Models
                 task.Completed += OnUpdateGraphCompleted;
                 RunSettings.RunEnabled = false; // Disable 'Run' button.
 
+                // Reset node states
+                foreach (var node in Nodes)
+                {
+                    node.IsUpdated = false;
+                }
+
                 // The workspace has been built for the first time
                 silenceNodeModifications = false;
 


### PR DESCRIPTION
### Purpose

Marking modified nodes is already implemented in Dynamo. But there is no resetting `IsUpdated` property for the other nodes. In this PR `IsUpdated` property is reset right before re-evaluation. After re-evaluation is done, `IsUpdated` property will be set to true only for modified nodes, so it will have correct value.

The second try :)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

@pboyer 

### FYI

@Benglin 