### PR TITLE
An example of obsolete message localization

### DIFF
--- a/src/Libraries/CoreNodes/Files.cs
+++ b/src/Libraries/CoreNodes/Files.cs
@@ -152,7 +152,7 @@ namespace DSCore.IO
 
         #region Obsolete Methods
 
-        [Obsolete("Use File.FromPath -> Image.ReadFromFile -> Image.Pixels nodes instead.")]
+        [NodeObsoleteAttribute("ReadImageObsolete", typeof(DSCore.Properties.Resources))]
         public static Color[] ReadImage(string path, int xSamples, int ySamples)
         {
             var info = FromPath(path);

--- a/src/Libraries/CoreNodes/Files.cs
+++ b/src/Libraries/CoreNodes/Files.cs
@@ -152,7 +152,7 @@ namespace DSCore.IO
 
         #region Obsolete Methods
 
-        [NodeObsoleteAttribute("ReadImageObsolete", typeof(DSCore.Properties.Resources))]
+        [NodeObsolete("ReadImageObsolete", typeof(DSCore.Properties.Resources))]
         public static Color[] ReadImage(string path, int xSamples, int ySamples)
         {
             var info = FromPath(path);

--- a/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
@@ -158,5 +158,14 @@ namespace DSCore.Properties {
                 return ResourceManager.GetString("QuadtreeConstructionNullUVSetMessage", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use File.FromPath -&gt; Image.ReadFromFile -&gt; Image.Pixels nodes instead..
+        /// </summary>
+        internal static string ReadImageObsolete {
+            get {
+                return ResourceManager.GetString("ReadImageObsolete", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
@@ -150,4 +150,7 @@
   <data name="QuadtreeConstructionNullUVSetMessage" xml:space="preserve">
     <value>A Quadtree cannot be constructed from a null set of UVs.</value>
   </data>
+  <data name="ReadImageObsolete" xml:space="preserve">
+    <value>Use File.FromPath -&gt; Image.ReadFromFile -&gt; Image.Pixels nodes instead.</value>
+  </data>
 </root>

--- a/src/Libraries/CoreNodes/Properties/Resources.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.resx
@@ -150,4 +150,7 @@
   <data name="QuadtreeConstructionNullUVSetMessage" xml:space="preserve">
     <value>A Quadtree cannot be constructed from a null set of UVs.</value>
   </data>
+  <data name="ReadImageObsolete" xml:space="preserve">
+    <value>Use File.FromPath -&gt; Image.ReadFromFile -&gt; Image.Pixels nodes instead.</value>
+  </data>
 </root>


### PR DESCRIPTION
### Purpose

This PR gives an example of how to localize node's `Obsolete` attribute's message. It uses `NodeObsoleteAttribute` that defined in PR #4902 to read message from resource file.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Randy-Ma please take a look.

### FYIs

@zora-wang , could you finish the remaining obsolete messages?