### PR TITLE
Parse and display returns field in XML documentation for zero-touch node output ports

### DIFF
--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -187,6 +187,17 @@ namespace Dynamo.DSEngine
             get { return !String.IsNullOrEmpty(Summary) ? Summary : string.Empty; }
         }
 
+        private IEnumerable<Tuple<string, string>> returns; 
+
+        /// <summary>
+        ///     If the XML documentation for the function includes a returns field,
+        ///     this parameter contains a collection of tuples of output names to
+        ///     descriptions.
+        /// 
+        ///     Otherwise, this list will be empty.
+        /// </summary>
+        public IEnumerable<Tuple<string, string>> Returns { get { return returns ?? (returns = this.GetReturns()); } }
+
         /// <summary>
         ///     Inputs for Node
         /// </summary>

--- a/src/DynamoCore/Library/MemberDocumentNode.cs
+++ b/src/DynamoCore/Library/MemberDocumentNode.cs
@@ -9,6 +9,7 @@ namespace Dynamo.DSEngine
         private string summary = String.Empty;
         private string searchTags = String.Empty;
         private readonly Dictionary<string, string> parameters;
+        private readonly List<Tuple<string, string>> returns;
 
         public string FullyQualifiedName { get { return fullyQualifiedName; } }
 
@@ -40,6 +41,11 @@ namespace Dynamo.DSEngine
             }
         }
 
+        public IList<Tuple<string,string>> Returns
+        {
+            get { return returns; }
+        }
+
         public IDictionary<string, string> Parameters { get { return parameters; } }
 
         /// <summary>
@@ -64,6 +70,7 @@ namespace Dynamo.DSEngine
 
             fullyQualifiedName = MakeFullyQualifiedName(assemblyName, memberName);
             parameters = new Dictionary<string, string>();
+            returns = new List<Tuple<string, string>>();
         }
 
         internal void AddParameter(string name, string description)

--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -44,7 +44,12 @@ namespace Dynamo.DSEngine
 
         public static IEnumerable<Tuple<string, string>> GetReturns(this FunctionDescriptor member, XmlReader xml = null)
         {
-            return GetMemberDocumentNode(member, xml).Returns;
+            var node = GetMemberDocumentNode(member, xml);
+            if (node == null)
+            {
+                return Enumerable.Empty<Tuple<string,string>>();
+            }
+            return node.Returns;
         }
 
         #endregion

--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -42,6 +42,11 @@ namespace Dynamo.DSEngine
                 .Where(x => x != String.Empty);
         }
 
+        public static IEnumerable<Tuple<string, string>> GetReturns(this FunctionDescriptor member, XmlReader xml = null)
+        {
+            return GetMemberDocumentNode(member, xml).Returns;
+        }
+
         #endregion
 
         #region Helpers
@@ -65,21 +70,19 @@ namespace Dynamo.DSEngine
             return sb.ToString();
         }
 
-        private static string GetMemberElement(
+        private static MemberDocumentNode GetMemberDocumentNode(
             FunctionDescriptor function,
-            XmlReader xml,
-            DocumentElementType property,
-            string paramName = "")
+            XmlReader xml )
         {
             //customNodeDefinitions typedParameters don't have functionDescriptors
             if (function == null)
             {
-                return string.Empty;
+                return null;
             }
             var assemblyName = function.Assembly;
 
             if (string.IsNullOrEmpty(assemblyName))
-                return String.Empty;
+                return null;
 
             var fullyQualifiedName = MemberDocumentNode.MakeFullyQualifiedName
                 (assemblyName, GetMemberElementName(function));
@@ -100,11 +103,22 @@ namespace Dynamo.DSEngine
                         Where(key => key.Contains(function.ClassName + "." + function.FunctionName)).FirstOrDefault();
 
                 if (overloadedName == null)
-                    return String.Empty;
+                    return null;
                 if (documentNodes.ContainsKey(overloadedName))
                     documentNode = documentNodes[overloadedName];
             }
-            
+
+            return documentNode;
+        }
+
+        private static string GetMemberElement(
+            FunctionDescriptor function,
+            XmlReader xml,
+            DocumentElementType property,
+            string paramName = "")
+        {
+            var documentNode = GetMemberDocumentNode(function, xml);
+
             if (documentNode == null)
                 return String.Empty;
             if (property.Equals(DocumentElementType.Description) && !documentNode.Parameters.ContainsKey(paramName))
@@ -214,7 +228,8 @@ namespace Dynamo.DSEngine
             Member,
             Summary,
             Parameter,
-            SearchTags
+            SearchTags,
+            Returns
         }
 
         private enum DocumentElementType
@@ -262,6 +277,18 @@ namespace Dynamo.DSEngine
                                 currentTag = XmlTagType.Parameter;
                                 break;
 
+                            case "returns":
+                                if (reader.MoveToAttribute("name"))
+                                {
+                                    currentParamName = reader.Value;
+                                }
+                                else
+                                {
+                                    currentParamName = null;
+                                }
+                                currentTag = XmlTagType.Returns;
+                                break;
+
                             case "search":
                                 currentTag = XmlTagType.SearchTags;
                                 break;
@@ -282,6 +309,9 @@ namespace Dynamo.DSEngine
                                 break;
                             case XmlTagType.Parameter:
                                 currentDocNode.Parameters.Add(currentParamName, reader.Value.CleanUpDocString());
+                                break;
+                            case XmlTagType.Returns:
+                                currentDocNode.Returns.Add(new Tuple<string,string>(currentParamName, reader.Value.CleanUpDocString()));
                                 break;
                             case XmlTagType.SearchTags:
                                 currentDocNode.SearchTags = reader.Value.CleanUpDocString();

--- a/src/DynamoCore/Nodes/ZeroTouch/DSFunctionBase.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSFunctionBase.cs
@@ -159,6 +159,17 @@ namespace Dynamo.Nodes
                 string displayReturnType = IsConstructor()
                     ? Definition.UnqualifedClassName
                     : Definition.ReturnType;
+
+                var returns = Definition.Returns;
+
+                if (returns.Any())
+                {
+                    model.OutPortData.Add(new PortData(
+                        returns.ElementAt(0).Item1 ?? displayReturnType,
+                        returns.ElementAt(0).Item2 ?? displayReturnType));
+                    return;
+                }
+
                 model.OutPortData.Add(new PortData(displayReturnType, displayReturnType));
             }
         }

--- a/src/DynamoCore/Nodes/ZeroTouch/DSFunctionBase.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSFunctionBase.cs
@@ -149,19 +149,19 @@ namespace Dynamo.Nodes
             // Returns a dictionary
             if (Definition.ReturnKeys != null && Definition.ReturnKeys.Any())
             {
-                var returns = Definition.Returns.ToList();
-                var numReturns = returns.Count();
+                var returns = Definition.Returns.ToList(); // for performance reasons
+                var numReturns = returns.Count;
 
                 var i = 0;
 
                 foreach (var key in Definition.ReturnKeys)
                 {
                     var portName = i < numReturns
-                        ? returns.ElementAt(i).Item1 ?? key // return name is optional
+                        ? returns[i].Item1 ?? key // return name is optional
                         : key;
 
                     var portDesc = i < numReturns
-                        ? returns.ElementAt(i).Item2
+                        ? returns[i].Item2
                         : "var";
                     
                     model.OutPortData.Add(new PortData(portName, portDesc));

--- a/src/DynamoCore/Nodes/ZeroTouch/DSFunctionBase.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSFunctionBase.cs
@@ -149,9 +149,23 @@ namespace Dynamo.Nodes
             // Returns a dictionary
             if (Definition.ReturnKeys != null && Definition.ReturnKeys.Any())
             {
+                var returns = Definition.Returns.ToList();
+                var numReturns = returns.Count();
+
+                var i = 0;
+
                 foreach (var key in Definition.ReturnKeys)
                 {
-                    model.OutPortData.Add(new PortData(key, "var"));
+                    var portName = i < numReturns
+                        ? returns.ElementAt(i).Item1 ?? key // return name is optional
+                        : key;
+
+                    var portDesc = i < numReturns
+                        ? returns.ElementAt(i).Item2
+                        : "var";
+                    
+                    model.OutPortData.Add(new PortData(portName, portDesc));
+                    i++;
                 }
             }
             else

--- a/test/DynamoCoreTests/XmlDocumentationTests.cs
+++ b/test/DynamoCoreTests/XmlDocumentationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using System.IO;
@@ -30,7 +31,7 @@ namespace Dynamo.Tests
             <search>
             move,push
             </search>
-            <returns>Transformed Geometry.</returns>
+            <returns name=""foo"">Transformed Geometry.</returns>
         </member>
         <member name=""M:MyNamespace.MyClass.#ctor"">
             <summary>
@@ -135,6 +136,19 @@ namespace Dynamo.Tests
             var summary = method.GetSummary(SampleDocument);
 
             Assert.AreEqual("Constructor summary.", summary);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void GetReturnKeys_FromMyMethod()
+        {
+            var method = GetMyMethod();
+
+            var returns = method.GetReturns(SampleDocument);
+
+            Assert.AreEqual(1, returns.Count());
+            Assert.AreEqual("foo", returns.ElementAt(0).Item1);
+            Assert.AreEqual("Transformed Geometry.", returns.ElementAt(0).Item2);
         }
 
     }


### PR DESCRIPTION
### Purpose

Recently, @mccrone put a bunch of work into improving our XML documentation.  In particular, he annotated the returns field for much of the CoreNodes library.

However, there was no code to actually parse and display this work in Dynamo.  Now there is.

![xmlreturns](https://cloud.githubusercontent.com/assets/916345/8656179/0cc579f4-2964-11e5-83bc-be1fc2da6dca.png)

![xmlreturns2](https://cloud.githubusercontent.com/assets/916345/8656180/0e4a09f2-2964-11e5-8976-35662a4c8bc8.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ramramps 

### FYI

@jnealb 