### PR TITLE
Register the newly added code block node in node to code

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -1105,7 +1105,7 @@ namespace Dynamo.Core
                 var collapsedNode = CreateCustomNodeInstance(newId, isTestMode: isTestMode);
                 collapsedNode.X = avgX;
                 collapsedNode.Y = avgY;
-                currentWorkspace.AddNode(collapsedNode, centered: false);
+                currentWorkspace.AddAndRegisterNode(collapsedNode, centered: false);
                 undoRecorder.RecordCreationForUndo(collapsedNode);
 
                 foreach (var connector in

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1465,7 +1465,7 @@ namespace Dynamo.Models
         /// <param name="centered"></param>
         public void AddNodeToCurrentWorkspace(NodeModel node, bool centered)
         {
-            CurrentWorkspace.AddNode(node, centered);
+            CurrentWorkspace.AddAndRegisterNode(node, centered);
 
             //TODO(Steve): This should be moved to WorkspaceModel.AddNode when all workspaces have their own selection -- MAGN-5707
             DynamoSelection.Instance.ClearSelection();
@@ -1596,7 +1596,7 @@ namespace Dynamo.Models
             // Add the new NodeModel's to the Workspace
             foreach (var newNode in newNodeModels)
             {
-                CurrentWorkspace.AddNode(newNode, false);
+                CurrentWorkspace.AddAndRegisterNode(newNode, false);
                 createdModels.Add(newNode);
                 AddToSelection(newNode);
             }

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -305,7 +305,7 @@ namespace Dynamo.Models
         }
 
 
-        public void AddNode(NodeModel node)
+        private void AddNode(NodeModel node)
         {
             lock (nodes)
             {
@@ -315,7 +315,7 @@ namespace Dynamo.Models
             OnNodeAdded(node);
         }
 
-        public void ClearNodes()
+        private void ClearNodes()
         {
             lock (nodes)
             {

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1266,7 +1266,7 @@ namespace Dynamo.Models
                         totalY / nodeCount, engineController.LibraryServices);
                     undoHelper.RecordCreation(codeBlockNode);
                    
-                    AddNode(codeBlockNode);
+                    AddNode(codeBlockNode, false);
                     codeBlockNodes.Add(codeBlockNode);
                     #endregion
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -645,7 +645,7 @@ namespace Dynamo.Models
         /// <summary>
         ///     Adds a node to this workspace.
         /// </summary>
-        public void AddNode(NodeModel node, bool centered = false)
+        public void AddAndRegisterNode(NodeModel node, bool centered = false)
         {
             if (nodes.Contains(node))
                 return;
@@ -1266,7 +1266,7 @@ namespace Dynamo.Models
                         totalY / nodeCount, engineController.LibraryServices);
                     undoHelper.RecordCreation(codeBlockNode);
                    
-                    AddNode(codeBlockNode, false);
+                    AddAndRegisterNode(codeBlockNode, false);
                     codeBlockNodes.Add(codeBlockNode);
                     #endregion
 

--- a/test/DynamoCoreTests/AnnotationModelTest.cs
+++ b/test/DynamoCoreTests/AnnotationModelTest.cs
@@ -20,7 +20,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -46,7 +46,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -85,7 +85,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -126,7 +126,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -171,7 +171,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -212,7 +212,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -246,7 +246,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -292,7 +292,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -313,7 +313,7 @@ namespace Dynamo.Tests
             //Create Another node
             //Add a Node            
             var secondNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(secondNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(secondNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 2);
 
             DynamoSelection.Instance.ClearSelection();
@@ -359,7 +359,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -388,7 +388,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -423,7 +423,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -453,7 +453,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -482,7 +482,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -515,7 +515,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -561,7 +561,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -599,7 +599,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -649,7 +649,7 @@ namespace Dynamo.Tests
             //Add a Node
             var model = CurrentDynamoModel;
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
 
             //Add a Note 
@@ -670,7 +670,7 @@ namespace Dynamo.Tests
             //Create Another node
             //Add a Node            
             var secondNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
-            model.CurrentWorkspace.AddNode(secondNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(secondNode, false);
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 2);
 
             DynamoSelection.Instance.ClearSelection();

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -39,7 +39,7 @@ namespace Dynamo.Tests
         public void CanAddANodeByName()
         {
             var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-            CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             Assert.AreEqual(CurrentDynamoModel.CurrentWorkspace.Nodes.Count(), 1);
         }
 
@@ -80,7 +80,7 @@ namespace Dynamo.Tests
             for (int i = 0; i < numNodes; i++)
             {
                 var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-                CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
+                CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
                 Assert.AreEqual(i + 1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
@@ -118,9 +118,9 @@ namespace Dynamo.Tests
             Assert.AreEqual(0, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
             var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-            CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
-            CurrentDynamoModel.CurrentWorkspace.AddNode(new DoubleInput(), false);
-            CurrentDynamoModel.CurrentWorkspace.AddNode(new DoubleInput(), false);
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(new DoubleInput(), false);
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(new DoubleInput(), false);
             Assert.AreEqual(3, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
             CurrentDynamoModel.ClearCurrentWorkspace();
@@ -137,7 +137,7 @@ namespace Dynamo.Tests
             for (int i = 0; i < numNodes; i++)
             {
                 var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-                CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
+                CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
                 Assert.AreEqual(i + 1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
                 CurrentDynamoModel.AddToSelection(CurrentDynamoModel.CurrentWorkspace.Nodes.Last());
@@ -152,7 +152,7 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void ValidateConnectionsDoesNotClearError()
         {
-            CurrentDynamoModel.CurrentWorkspace.AddNode(
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(
                 new CodeBlockNodeModel("30", 100.0, 100.0, CurrentDynamoModel.LibraryServices),
                 false);
 
@@ -200,7 +200,7 @@ namespace Dynamo.Tests
             for (int i = 0; i < numNodes; i++)
             {
                 var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-                CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
+                CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
                 Assert.AreEqual(i + 1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
                 CurrentDynamoModel.AddToSelection(CurrentDynamoModel.CurrentWorkspace.Nodes.Last());
@@ -224,7 +224,7 @@ namespace Dynamo.Tests
             for (int i = 0; i < numNodes; i++)
             {
                 var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-                CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
+                CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
                 Assert.AreEqual(i + 1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
                 CurrentDynamoModel.AddToSelection(addNode);
@@ -248,7 +248,7 @@ namespace Dynamo.Tests
             for (int i = 0; i < numNodes; i++)
             {
                 var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-                CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
+                CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
                 Assert.AreEqual(i + 1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
                 CurrentDynamoModel.AddToSelection(CurrentDynamoModel.CurrentWorkspace.Nodes.Last());
@@ -279,7 +279,7 @@ namespace Dynamo.Tests
             for (int i = 0; i < numNodes; i++)
             {
                 var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-                CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
+                CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
                 Assert.AreEqual(i + 1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
@@ -299,7 +299,7 @@ namespace Dynamo.Tests
 
             const string dsVarArgFunctionName = "DSCore.String.Split@string,string[]";
             var node = new DSVarArgFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor(dsVarArgFunctionName));
-            CurrentDynamoModel.CurrentWorkspace.AddNode(node, false);
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(node, false);
 
             // Here we check to see if we do get a DSVarArgFunction node (which
             // is what this test case is written for, other nodes will render the 
@@ -424,7 +424,7 @@ namespace Dynamo.Tests
             for (int i = 0; i < numNodes; i++)
             {
                 var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-                CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
+                CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
                 Assert.AreEqual(i + 1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
             }
 
@@ -459,7 +459,7 @@ namespace Dynamo.Tests
             for (int i = 0; i < numNodes; i++)
             {
                 var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-                CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
+                CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
                 Assert.AreEqual(i + 1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
             }
 
@@ -567,10 +567,10 @@ namespace Dynamo.Tests
         public void CanSumTwoNumbers()
         {
             var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-            CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
-            CurrentDynamoModel.CurrentWorkspace.AddNode(new CodeBlockNodeModel("2", 100.0, 100.0, CurrentDynamoModel.LibraryServices), false);
-            CurrentDynamoModel.CurrentWorkspace.AddNode(new CodeBlockNodeModel("2", 100.0, 100.0, CurrentDynamoModel.LibraryServices), false);
-            CurrentDynamoModel.CurrentWorkspace.AddNode(new Watch { X = 100, Y = 300 }, false);
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(new CodeBlockNodeModel("2", 100.0, 100.0, CurrentDynamoModel.LibraryServices), false);
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(new CodeBlockNodeModel("2", 100.0, 100.0, CurrentDynamoModel.LibraryServices), false);
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(new Watch { X = 100, Y = 300 }, false);
 
             ConnectorModel.Make(CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(1), CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(0), 0, 0);
             ConnectorModel.Make(CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(2), CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(0), 0, 1);
@@ -613,7 +613,7 @@ namespace Dynamo.Tests
             for (int i = 0; i < numNodes; i++)
             {
                 var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-                CurrentDynamoModel.CurrentWorkspace.AddNode(addNode, false);
+                CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
                 Assert.AreEqual(i + 1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
                 CurrentDynamoModel.AddToSelection(CurrentDynamoModel.CurrentWorkspace.Nodes.Last());

--- a/test/DynamoCoreTests/PeriodicEvaluationTests.cs
+++ b/test/DynamoCoreTests/PeriodicEvaluationTests.cs
@@ -102,7 +102,7 @@ namespace Dynamo.Tests
 
             var count = 0;
 
-            Workspace.AddNode(new ActionNodeModel(() =>
+            Workspace.AddAndRegisterNode(new ActionNodeModel(() =>
             {
                 count++;
             }, true));
@@ -125,7 +125,7 @@ namespace Dynamo.Tests
 
             var count = 0;
 
-            Workspace.AddNode(new ActionNodeModel(() =>
+            Workspace.AddAndRegisterNode(new ActionNodeModel(() =>
             {
                 count++;
                 Thread.Sleep(200);

--- a/test/DynamoCoreTests/PresetsTests.cs
+++ b/test/DynamoCoreTests/PresetsTests.cs
@@ -34,8 +34,8 @@ namespace Dynamo.Tests
             var numberNode2 = new DoubleInput();
             numberNode2.Value = "2";
 
-            model.CurrentWorkspace.AddNode(numberNode1, false);
-            model.CurrentWorkspace.AddNode(numberNode2, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode1, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode2, false);
        
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 2);
 
@@ -62,8 +62,8 @@ namespace Dynamo.Tests
             var numberNode2 = new DoubleInput();
             numberNode2.Value = "2";
 
-            model.CurrentWorkspace.AddNode(numberNode1, false);
-            model.CurrentWorkspace.AddNode(numberNode2, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode1, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode2, false);
 
             Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 2);
 
@@ -100,9 +100,9 @@ namespace Dynamo.Tests
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
 
             //add the nodes
-            model.CurrentWorkspace.AddNode(numberNode1, false);
-            model.CurrentWorkspace.AddNode(numberNode2, false);
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode1, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode2, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
            //connect them up
            ConnectorModel.Make(numberNode1,addNode, 0, 0);
@@ -165,9 +165,9 @@ namespace Dynamo.Tests
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
 
             //add the nodes
-            model.CurrentWorkspace.AddNode(numberNode1, false);
-            model.CurrentWorkspace.AddNode(numberNode2, false);
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode1, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode2, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //connect them up
             ConnectorModel.Make(numberNode1, addNode, 0, 0);
@@ -239,9 +239,9 @@ namespace Dynamo.Tests
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
 
             //add the nodes
-            model.CurrentWorkspace.AddNode(numberNode1, false);
-            model.CurrentWorkspace.AddNode(numberNode2, false);
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode1, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode2, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //connect them up
             ConnectorModel.Make(numberNode1, addNode, 0, 0);
@@ -383,9 +383,9 @@ namespace Dynamo.Tests
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
 
             //add the nodes
-            model.CurrentWorkspace.AddNode(numberNode1, false);
-            model.CurrentWorkspace.AddNode(numberNode2, false);
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode1, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode2, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //connect them up
             ConnectorModel.Make(numberNode1, addNode, 0, 0);
@@ -436,9 +436,9 @@ namespace Dynamo.Tests
               var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
             
               //add the nodes
-              model.CurrentWorkspace.AddNode(numberNode1, false);
-              model.CurrentWorkspace.AddNode(numberNode2, false);
-              model.CurrentWorkspace.AddNode(addNode, false);
+              model.CurrentWorkspace.AddAndRegisterNode(numberNode1, false);
+              model.CurrentWorkspace.AddAndRegisterNode(numberNode2, false);
+              model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
               //connect them up
               ConnectorModel.Make(numberNode1, addNode, 0, 0);
@@ -526,9 +526,9 @@ namespace Dynamo.Tests
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
              
             //add the nodes
-            model.CurrentWorkspace.AddNode(numberNode1, false);
-            model.CurrentWorkspace.AddNode(numberNode2, false);
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode1, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode2, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             //connect them up
             ConnectorModel.Make(numberNode1, addNode, 0, 0);
             ConnectorModel.Make(numberNode2, addNode, 0, 1);
@@ -578,9 +578,9 @@ namespace Dynamo.Tests
             var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
 
              //add the nodes
-            model.CurrentWorkspace.AddNode(numberNode1, false);
-            model.CurrentWorkspace.AddNode(numberNode2, false);
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode1, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode2, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             //connect them up
             ConnectorModel.Make(numberNode1, addNode, 0, 0);
             ConnectorModel.Make(numberNode2, addNode, 0, 1);
@@ -624,9 +624,9 @@ namespace Dynamo.Tests
             Assert.AreEqual(model.CurrentWorkspace.HasUnsavedChanges,false);
 
             //add the nodes
-            model.CurrentWorkspace.AddNode(numberNode1, false);
-            model.CurrentWorkspace.AddNode(numberNode2, false);
-            model.CurrentWorkspace.AddNode(addNode, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode1, false);
+            model.CurrentWorkspace.AddAndRegisterNode(numberNode2, false);
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //Check for Dirty flag
             Assert.AreEqual(model.CurrentWorkspace.HasUnsavedChanges, true);

--- a/test/DynamoCoreTests/SchedulerTests.cs
+++ b/test/DynamoCoreTests/SchedulerTests.cs
@@ -1253,7 +1253,7 @@ namespace Dynamo.Tests
             var workspace = dynamoModel.CurrentWorkspace;
             foreach (var node in nodes)
             {
-                workspace.AddNode(node, false);
+                workspace.AddAndRegisterNode(node, false);
             }
 
             Assert.AreEqual(3, workspace.Nodes.Count());

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -29,7 +29,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
            
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -64,7 +64,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -96,7 +96,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -115,7 +115,7 @@ namespace DynamoCoreWpfTests
             DynamoSelection.Instance.ClearSelection();
 
             var secondNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(secondNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(secondNode, false);
 
             //verify the node was created
             Assert.AreEqual(2, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -135,7 +135,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -154,7 +154,7 @@ namespace DynamoCoreWpfTests
             DynamoSelection.Instance.ClearSelection();
 
             var secondNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(secondNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(secondNode, false);
 
             //verify the node was created
             Assert.AreEqual(2, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -172,7 +172,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -191,7 +191,7 @@ namespace DynamoCoreWpfTests
             DynamoSelection.Instance.ClearSelection();
 
             var secondNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(secondNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(secondNode, false);
           
             //Select the node 
             DynamoSelection.Instance.Selection.Add(secondNode);
@@ -206,7 +206,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -228,7 +228,7 @@ namespace DynamoCoreWpfTests
             DynamoSelection.Instance.Selection.Add(annotation);
 
             var secondNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(secondNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(secondNode, false);
 
             //Select the node 
             DynamoSelection.Instance.Selection.Add(secondNode);
@@ -243,7 +243,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -275,7 +275,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
            
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -555,7 +555,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -586,7 +586,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -621,7 +621,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -665,7 +665,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -420,7 +420,7 @@ namespace DynamoCoreWpfTests
         {
             // Create number node
             var numNode = new DoubleInput { X = 100, Y = 100 };
-            ViewModel.Model.CurrentWorkspace.AddNode(numNode, true);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(numNode, true);
         }
 
         #endregion
@@ -678,7 +678,7 @@ namespace DynamoCoreWpfTests
         public void TestDraggedNode()
         {
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+")) { X = 16, Y = 32 };
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
             NodeModel locatable = ViewModel.Model.CurrentWorkspace.Nodes.First();
 
             var startPoint = new Point2D(8, 64);

--- a/test/DynamoCoreWpfTests/PresetViewModelTest.cs
+++ b/test/DynamoCoreWpfTests/PresetViewModelTest.cs
@@ -26,7 +26,7 @@ namespace DynamoCoreWpfTests
         {
             //Create a Node
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
-            ViewModel.Model.CurrentWorkspace.AddNode(addNode, false);
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
 
             //verify the node was created
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());

--- a/test/DynamoCoreWpfTests/RunSettingsTests.cs
+++ b/test/DynamoCoreWpfTests/RunSettingsTests.cs
@@ -67,7 +67,7 @@ namespace DynamoCoreWpfTests
             var node = new DoubleInput { CanUpdatePeriodically = true };
 
             var homeSpace = GetHomeSpace();
-            homeSpace.AddNode(node, true);
+            homeSpace.AddAndRegisterNode(node, true);
             
             var item = View.RunSettingsControl.RunTypesComboBox.Items[2] as RunTypeItem;
             Assert.True(item.Enabled);

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -451,7 +451,7 @@ namespace Dynamo.Tests
 
             // make change
             var node = new DSFunction(dynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-            dynamoModel.CurrentWorkspace.AddNode(node, false);
+            dynamoModel.CurrentWorkspace.AddAndRegisterNode(node, false);
             Assert.IsTrue(ViewModel.Model.CurrentWorkspace.HasUnsavedChanges);
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
 
@@ -481,7 +481,7 @@ namespace Dynamo.Tests
             Assert.IsFalse(def.HasUnsavedChanges);
 
             var node = new DSFunction(dynamoModel.LibraryServices.GetFunctionDescriptor("+"));
-            def.AddNode(node, false);
+            def.AddAndRegisterNode(node, false);
             Assert.IsTrue(def.HasUnsavedChanges);
             Assert.AreEqual(1, def.Nodes.Count() );
             
@@ -640,7 +640,7 @@ namespace Dynamo.Tests
             model.CurrentWorkspace = ViewModel.HomeSpace;
             var newCustNodeInstance =
                 model.CustomNodeManager.CreateCustomNodeInstance(nodeWorkspace.CustomNodeId);
-            model.CurrentWorkspace.AddNode(newCustNodeInstance, false);
+            model.CurrentWorkspace.AddAndRegisterNode(newCustNodeInstance, false);
 
             // run expression
             Assert.AreEqual(1, model.CurrentWorkspace.Nodes.Count());
@@ -721,7 +721,7 @@ namespace Dynamo.Tests
             foreach (var _ in Enumerable.Range(0, 10))
             {
                 var node = model.CustomNodeManager.CreateCustomNodeInstance(oldId);
-                model.CurrentWorkspace.AddNode(node, false);
+                model.CurrentWorkspace.AddAndRegisterNode(node, false);
             }
 
             // SaveAs


### PR DESCRIPTION
### Purpose

This PR is to fix defect [After N2C nodes with lacing doesn't contain connections to the inputs](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7870). 

The root cause is the newly created code block node in N2C doesn't have connector event handler so that although connection is restored, but the connector isn't redrawn on the canvas. 

Further, that's because `WorkspaceModel.AddNode()` has two overload functions: 
  - `AddNode(NodeModel nodeModel)`
  - `AddNode(NodeModel nodeModel, bool isCenter = false)`

Only the second will add the node to workspace model *and* register connector event handler. It is really error-prone as the second one has a default argument and the first one is only for internal use, therefore this PR marks the first one as private and rename the second one to `AddAndRegisterNode`. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 