### PR TITLE
Localize core nodes' Obsolete message. 

### DIFF
--- a/src/Libraries/CoreNodes/Files.cs
+++ b/src/Libraries/CoreNodes/Files.cs
@@ -152,7 +152,7 @@ namespace DSCore.IO
 
         #region Obsolete Methods
 
-        [Obsolete("Use File.FromPath -> Image.ReadFromFile -> Image.Pixels nodes instead.")]
+        [NodeObsolete("ReadImageObsolete", typeof(Properties.Resources))]
         public static Color[] ReadImage(string path, int xSamples, int ySamples)
         {
             var info = FromPath(path);
@@ -160,19 +160,19 @@ namespace DSCore.IO
             return Image.Pixels(image, xSamples, ySamples).SelectMany(x => x).ToArray();
         }
 
-        [Obsolete("Use File.FromPath -> Image.ReadFromFile nodes instead.")]
+        [NodeObsolete("LoadImageFromPathObsolete", typeof(Properties.Resources))]
         public static Bitmap LoadImageFromPath(string path)
         {
             return Image.ReadFromFile(FromPath(path));
         }
 
-        [Obsolete("Use File.FromPath -> File.ReadText nodes instead.")]
+        [NodeObsolete("ReadTextObsolete", typeof(Properties.Resources))]
         public static string ReadText(string path)
         {
             return ReadText(FromPath(path));
         }
 
-        [Obsolete("Use Image.WriteToFile node instead.")]
+        [NodeObsolete("WriteImageObsolete", typeof(Properties.Resources))]
         public static bool WriteImage(string filePath, string fileName, Bitmap image)
         {
             fileName = Path.ChangeExtension(fileName, "png");
@@ -180,7 +180,7 @@ namespace DSCore.IO
             return true;
         }
 
-        [Obsolete("Use CSV.WriteToFile node instead.")]
+        [NodeObsolete("ExportToCSVObsolete", typeof(Properties.Resources))]
         public static void ExportToCSV(string filePath, object[][] data)
         {
             CSV.WriteToFile(filePath, data);

--- a/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodes/Properties/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace DSCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use CSV.WriteToFile node instead.
+        /// </summary>
+        internal static string ExportToCSVObsolete {
+            get {
+                return ResourceManager.GetString("ExportToCSVObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You must provide a center point..
         /// </summary>
         internal static string FindPointsWithinRadiusNullPointMessage {
@@ -142,6 +151,24 @@ namespace DSCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This node is obsolete, please use &quot;String from Object&quot;.
+        /// </summary>
+        internal static string FromObjectObsolete {
+            get {
+                return ResourceManager.GetString("FromObjectObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use File.FromPath -&gt;  Image.ReadFromFile nodes instead.
+        /// </summary>
+        internal static string LoadImageFromPathObsolete {
+            get {
+                return ResourceManager.GetString("LoadImageFromPathObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You cannot construct a quadtree from an empty set of points..
         /// </summary>
         internal static string QuadtreeConstructionEmptyUVSetMessage {
@@ -156,6 +183,33 @@ namespace DSCore.Properties {
         internal static string QuadtreeConstructionNullUVSetMessage {
             get {
                 return ResourceManager.GetString("QuadtreeConstructionNullUVSetMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use File.FromPath -&gt;  Image.ReadFromFile -&gt;  Image.Pixels nodes instead.
+        /// </summary>
+        internal static string ReadImageObsolete {
+            get {
+                return ResourceManager.GetString("ReadImageObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use File.FromPath -&gt;  File.ReadText nodes instead..
+        /// </summary>
+        internal static string ReadTextObsolete {
+            get {
+                return ResourceManager.GetString("ReadTextObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use Image.WriteToFile node instead.
+        /// </summary>
+        internal static string WriteImageObsolete {
+            get {
+                return ResourceManager.GetString("WriteImageObsolete", resourceCulture);
             }
         }
     }

--- a/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.en-US.resx
@@ -138,16 +138,34 @@
   <data name="EnumDateOfWeekWednesday" xml:space="preserve">
     <value>Wednesday</value>
   </data>
+  <data name="ExportToCSVObsolete" xml:space="preserve">
+    <value>Use CSV.WriteToFile node instead</value>
+  </data>
   <data name="FindPointsWithinRadiusNullPointMessage" xml:space="preserve">
     <value>You must provide a center point.</value>
   </data>
   <data name="FindPointsWithinRadiusSearchRadiusMessage" xml:space="preserve">
     <value>The search radius cannot be zero.</value>
   </data>
+  <data name="FromObjectObsolete" xml:space="preserve">
+    <value>This node is obsolete, please use "String from Object"</value>
+  </data>
+  <data name="LoadImageFromPathObsolete" xml:space="preserve">
+    <value>Use File.FromPath -&gt;  Image.ReadFromFile nodes instead</value>
+  </data>
   <data name="QuadtreeConstructionEmptyUVSetMessage" xml:space="preserve">
     <value>You cannot construct a quadtree from an empty set of points.</value>
   </data>
   <data name="QuadtreeConstructionNullUVSetMessage" xml:space="preserve">
     <value>A Quadtree cannot be constructed from a null set of UVs.</value>
+  </data>
+  <data name="ReadImageObsolete" xml:space="preserve">
+    <value>Use File.FromPath -&gt; Image.ReadFromFile -&gt;  Image.Pixels nodes instead</value>
+  </data>
+  <data name="ReadTextObsolete" xml:space="preserve">
+    <value>Use File.FromPath -&gt;  File.ReadText nodes instead.</value>
+  </data>
+  <data name="WriteImageObsolete" xml:space="preserve">
+    <value>Use Image.WriteToFile node instead</value>
   </data>
 </root>

--- a/src/Libraries/CoreNodes/Properties/Resources.resx
+++ b/src/Libraries/CoreNodes/Properties/Resources.resx
@@ -138,16 +138,34 @@
   <data name="EnumDateOfWeekWednesday" xml:space="preserve">
     <value>Wednesday</value>
   </data>
+  <data name="ExportToCSVObsolete" xml:space="preserve">
+    <value>Use CSV.WriteToFile node instead</value>
+  </data>
   <data name="FindPointsWithinRadiusNullPointMessage" xml:space="preserve">
     <value>You must provide a center point.</value>
   </data>
   <data name="FindPointsWithinRadiusSearchRadiusMessage" xml:space="preserve">
     <value>The search radius cannot be zero.</value>
   </data>
+  <data name="FromObjectObsolete" xml:space="preserve">
+    <value>This node is obsolete, please use "String from Object"</value>
+  </data>
+  <data name="LoadImageFromPathObsolete" xml:space="preserve">
+    <value>Use File.FromPath -&gt;  Image.ReadFromFile nodes instead</value>
+  </data>
   <data name="QuadtreeConstructionEmptyUVSetMessage" xml:space="preserve">
     <value>You cannot construct a quadtree from an empty set of points.</value>
   </data>
   <data name="QuadtreeConstructionNullUVSetMessage" xml:space="preserve">
     <value>A Quadtree cannot be constructed from a null set of UVs.</value>
+  </data>
+  <data name="ReadImageObsolete" xml:space="preserve">
+    <value>Use File.FromPath -&gt;  Image.ReadFromFile -&gt;  Image.Pixels nodes instead</value>
+  </data>
+  <data name="ReadTextObsolete" xml:space="preserve">
+    <value>Use File.FromPath -&gt;  File.ReadText nodes instead.</value>
+  </data>
+  <data name="WriteImageObsolete" xml:space="preserve">
+    <value>Use Image.WriteToFile node instead</value>
   </data>
 </root>

--- a/src/Libraries/CoreNodes/String.cs
+++ b/src/Libraries/CoreNodes/String.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Autodesk.DesignScript.Runtime;
-
+using Dynamo.Models;
 namespace DSCore
 {
     /// <summary>
@@ -14,7 +14,7 @@ namespace DSCore
     {
         // It has been moved to String.FromObject UI node, which is compiled 
         // to built-in function __ToStringFromObject().
-        [Obsolete("This node is obsolete, please use \"String from Object\"")]
+        [NodeObsolete("FromObjectObsolete", typeof(Properties.Resources))]
         public static string FromObject(object obj)
         {
             return obj.ToString();

--- a/src/Libraries/DSOffice/DSOffice.csproj
+++ b/src/Libraries/DSOffice/DSOffice.csproj
@@ -98,6 +98,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.en-US.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <ProjectReference Include="..\..\DynamoCore\DynamoCore.csproj">
+      <Project>{7858fa8c-475f-4b8e-b468-1f8200778cf8}</Project>
+      <Name>DynamoCore</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Engine\ProtoCore\ProtoCore.csproj">
       <Project>{7a9e0314-966f-4584-baa3-7339cbb849d1}</Project>
       <Name>ProtoCore</Name>

--- a/src/Libraries/DSOffice/Excel.cs
+++ b/src/Libraries/DSOffice/Excel.cs
@@ -9,7 +9,7 @@ using Microsoft.Office.Interop.Excel;
 using DynamoServices;
 using Autodesk.DesignScript.Runtime;
 using ProtoCore.DSASM;
-
+using Dynamo.Models;
 namespace DSOffice
 {
     internal class ExcelCloseEventArgs : EventArgs
@@ -281,7 +281,7 @@ namespace DSOffice
             return ws.Data;
         }
 
-        [Obsolete("Use File.FromPath -> Excel.ReadFromFile node instead.")]
+        [NodeObsolete("ReadObsolete", typeof(Properties.Resources))]
         public static object[][] Read(string filePath, string sheetName)
         {
             return ReadFromFile(new FileInfo(filePath), sheetName);

--- a/src/Libraries/DSOffice/Properties/Resources.Designer.cs
+++ b/src/Libraries/DSOffice/Properties/Resources.Designer.cs
@@ -86,5 +86,14 @@ namespace DSOffice.Properties {
                 return ResourceManager.GetString("kMethodResolutionFailureWithTypes", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use File.FromPath -&gt; Excel.ReadFromFile node instead..
+        /// </summary>
+        internal static string ReadObsolete {
+            get {
+                return ResourceManager.GetString("ReadObsolete", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Libraries/DSOffice/Properties/Resources.en-US.resx
+++ b/src/Libraries/DSOffice/Properties/Resources.en-US.resx
@@ -126,4 +126,7 @@
   <data name="kMethodResolutionFailureWithTypes" xml:space="preserve">
     <value>One or more of the input types are not matching. Couldn't find a version of {0} that takes arguments of type {1}</value>
   </data>
+  <data name="ReadObsolete" xml:space="preserve">
+    <value>Use File.FromPath -&gt; Excel.ReadFromFile node instead.</value>
+  </data>
 </root>

--- a/src/Libraries/DSOffice/Properties/Resources.resx
+++ b/src/Libraries/DSOffice/Properties/Resources.resx
@@ -126,4 +126,7 @@
   <data name="kMethodResolutionFailureWithTypes" xml:space="preserve">
     <value>One or more of the input types are not matching. Couldn't find a version of {0} that takes arguments of type {1}</value>
   </data>
+  <data name="ReadObsolete" xml:space="preserve">
+    <value>Use File.FromPath -&gt; Excel.ReadFromFile node instead.</value>
+  </data>
 </root>


### PR DESCRIPTION
### Purpose
* Localize Obsolete Attribute 

* Situations: when the user opens old files that contain obsolete nodes, nodes will show the obsolete warning message and notify users to use the new valid nodes instead. This PR is to localize these warning messages.


### Declarations
- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewer
@ke-yu  PTAL

Thx