### PR TITLE
MAGN-7776 No message is given by the ui when creating a Preset with an already assigned name

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/PresetPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/PresetPrompt.xaml.cs
@@ -64,7 +64,7 @@ namespace Dynamo.Nodes
 
         public string Text
         {
-            get { return this.nameBox.Text; }
+            get { return this.nameBox.Text.Trim(); }
         }
 
         public string Description


### PR DESCRIPTION
### Purpose
 This PR fixes the issue with same preset names. Added a trim() for preset text

YT: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7776

### Declarations
- [x] The code base is in a better state after this PR
Added a new "overwrite" dialog window that ensures Preset names are unique.
          
- [] The level of testing this PR includes is appropriate
No tests were added. The changes are made on the View.
           

### Reviewers
- [x] @holyjewsus 