### PR TITLE
MAGN-7879: Dynamo crash because of InCanvasSearch

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2054,6 +2054,12 @@ namespace Dynamo.Controls
 
             var textBlock = values[0] as TextBlock;
             var viewModel = values[1] as SearchViewModel;
+
+            // In some cases viewModel can be null. Mostly it's because workspace has not loaded yet.
+            // But converter has been already called.
+            if (viewModel == null)
+                return new Thickness(0, 0, textBlock.ActualWidth, textBlock.ActualHeight); ;
+
             var searchText = viewModel.SearchText;
             var typeface = viewModel.RegularTypeface;
             var fullText = textBlock.Text;

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2058,7 +2058,9 @@ namespace Dynamo.Controls
             // In some cases viewModel can be null. Mostly it's because workspace has not loaded yet.
             // But converter has been already called.
             if (viewModel == null)
-                return new Thickness(0, 0, textBlock.ActualWidth, textBlock.ActualHeight); ;
+            {
+                return new Thickness(0, 0, textBlock.ActualWidth, textBlock.ActualHeight);
+            }
 
             var searchText = viewModel.SearchText;
             var typeface = viewModel.RegularTypeface;


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7879](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7879) Graph populated with in-canvas search gives crash after it is re-opened from Recent Files

It's really interesting bug. To reproduce it you need:
1) Call `InCanvasSearch` by Shift+DoubleClick and type something. You even do not need to create any node. Just type and click somewhere out of InCanvasSearch.
2) Open any `.dyn` file.
3) Get exception.

The reason of exception lies in the `SearchHighlightMarginConverter`. This converter is used in `LibrarySearchView` and in `InCanvasSearchControl`. It used for margin this tiny grey rectangle.

![image](https://cloud.githubusercontent.com/assets/8158404/8693400/821005fe-2adf-11e5-9243-3107879c0836.png)

For every Workspace it's used its' own `InCanvasSearch`. So, when new workspace is created, incanvas-search is created as well.
`SearchHighlightMarginConverter` needs `SearchViewModel`. This is ViewModel, that is used for InCanvasSearch. I don't know why it does work for context-menu InCanvasSearch and doesn't work for double-click InCanvasSearch...
BUT `SearchHighlightMarginConverter` for double-click `InCanvasSearch` is called, when ViewModel is null. I.e. `DataContext` has NOT been initialized yet. Maybe context-menu and popup use different algorithm of calling converters.

So, what I meant to say. The easiest solution is just add additional null-check in `SearchHighlightMarginConverter`. And let it wait until `DataContext` is initialized.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@pboyer 
or
@Benglin 

### FYIs

@kronz 