### PR TITLE
Add missing Resources.en-US.resx to Analysis project

### DIFF
--- a/src/Libraries/Analysis/Analysis.csproj
+++ b/src/Libraries/Analysis/Analysis.csproj
@@ -96,6 +96,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <EmbeddedResource Include="Properties\Resources.en-US.resx" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
### Purpose

Dynamo can't start up because `Analysis` project fails to load resource string.

That's because in Zora's PR #4926 `Resources.en-US.resx` not added to the project.