### PR TITLE
Fix regression that connector to the node is missing after undoing delete operation

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1612,7 +1612,7 @@ namespace Dynamo.Models
             {
                 NodeModel nodeModel = NodeFactory.CreateNodeFromXml(modelData, SaveContext.Undo);
                 
-                AddNode(nodeModel);
+                AddAndRegisterNode(nodeModel);
                 
                 //check whether this node belongs to a group
                 foreach (var annotation in Annotations)


### PR DESCRIPTION
### Purpose

This PR is to fix regression [MAGN 7884 that connector to the node is missing after undoing delete operation](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7884#).

The root cause is similar to defect  [MAGN-7870 After N2C nodes with lacing doesn't contain connections to the inputs](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7870) which was fixed in PR #4924 - basically, an overload function `AddNode()` is added to `WorkspaceModel`, and this function overloads the other (but correct) function `AddNode()` (details see PR #4924). 

The fix is to call the original function, which is renamed to `AddAndRegisterNode()`. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers
@Randy-Ma  PTAL.
