### PR TITLE
MAGN-7844 Search is throwing a lot of BindingExpressionErrors

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/SearchCategory.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchCategory.cs
@@ -11,7 +11,7 @@ using Dynamo.UI.Commands;
 
 namespace Dynamo.Search
 {
-    public class SearchCategory : NotificationObject
+    public class SearchCategory : NotificationObject, ISearchEntryViewModel
     {
         private readonly ObservableCollection<NodeCategoryViewModel> classes;
         private readonly List<SearchMemberGroup> memberGroups;
@@ -116,6 +116,32 @@ namespace Dynamo.Search
             // TODO(Vladimir): classes functionality.
             //Classes.ToList().ForEach(x => x.RecursivelySort());
             MemberGroups.ToList().ForEach(x => x.Sort());
+        }
+
+
+        public bool Visibility
+        {
+            get { return true; }
+        }
+
+        public bool IsSelected
+        {
+            get { return true; }
+        }
+
+        public string Description
+        {
+            get { return String.Empty; }
+        }
+
+        public ElementTypes ElementType
+        {
+            get { return ElementTypes.None; }
+        }
+
+        public void Dispose()
+        {
+
         }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchMemberGroup.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchMemberGroup.cs
@@ -3,10 +3,11 @@ using System.Linq;
 using Dynamo.Core;
 using Dynamo.UI;
 using Dynamo.Wpf.ViewModels;
+using System;
 
 namespace Dynamo.Search
 {
-    public class SearchMemberGroup : NotificationObject
+    public class SearchMemberGroup : NotificationObject, ISearchEntryViewModel
     {
         private List<NodeSearchElementViewModel> members;
 
@@ -94,6 +95,40 @@ namespace Dynamo.Search
         internal void Sort()
         {
             members = members.OrderBy(x => x.Name).ToList();
+        }
+
+        public string Name
+        {
+            get { return String.Empty; }
+        }
+
+        public bool Visibility
+        {
+            get { return true; }
+        }
+
+        public bool IsSelected
+        {
+            get { return true; }
+        }
+
+        public string Description
+        {
+            get { return String.Empty; }
+        }
+
+        public System.Windows.Input.ICommand ClickedCommand
+        {
+            get { return null; }
+        }
+
+        public ElementTypes ElementType
+        {
+            get { return ElementTypes.None; }
+        }
+
+        public void Dispose()
+        {
         }
     }
 }


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7844](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7844) Search is throwing a lot of BindingExpressionErrors

These binding expression errors come because of tree view. The reason is that every tree view item expects, that its' data context will be `SearchEntryViewModel`. But `SearchCategory` and `SearchMemberGroup` are done without implementing `ISearchEntryViewModel`.
To fix binding errors I had to implement this common interface.

### Declarations

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

?

### FYIs

@jnealb 