### PR TITLE
Class name truncation

### DIFF
--- a/src/DynamoCore/Nodes/NodeCategories.cs
+++ b/src/DynamoCore/Nodes/NodeCategories.cs
@@ -548,9 +548,10 @@ namespace Dynamo.Nodes
                     continue;
                 }
 
-                if (row != lastRow)
+                if (row != lastRow || rows.Count() == 1)
                 {
                     // Rows other than the last get dots appended to the end.
+                    // Or if there is only one row.
                     results.Add(row.Substring(0, maxAfterTruncate) + Configurations.TwoDots);
                 }
                 else

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -696,6 +696,7 @@ namespace Dynamo.Tests
             //6. When original is ("Rectangle"), maxCharacters = 9
             //7. When original is ("By", "Geometry", "Coordinate", "System"), maxCharacters = 9
             //8. When original is ("By Geometry", "Coordinate System"), maxCharacters = 9
+            //9. When original is ("Application"), maxCharacters = 9
 
             // case 1
             Assert.Throws<ArgumentException>(() =>
@@ -737,6 +738,11 @@ namespace Dynamo.Tests
             original = new List<string>() { "By Geometry", "Coordinate System" };
             result = Dynamo.Nodes.Utilities.TruncateRows(original, 9);
             Assert.AreEqual(new List<string>() { "By Geom..", ".. System" }, result);
+
+            // case 9
+            original = new List<string>() { "Application" };
+            result = Dynamo.Nodes.Utilities.TruncateRows(original, 9);
+            Assert.AreEqual(new List<string>() { "Applica.." }, result);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7886](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7886) Class name truncation in Library should happen from the end not from the start.

Result:
![image](https://cloud.githubusercontent.com/assets/8158404/8773696/e1b9eb20-2ede-11e5-874c-356a6e866c49.png) => ![image](https://cloud.githubusercontent.com/assets/8158404/8773655/8d12df50-2ede-11e5-80d5-658adb373149.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

?

### FYIs

@riteshchandawar 
