### PR TITLE
implement ViewModel for PackagePath dialog

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -223,6 +223,7 @@
     <Compile Include="ViewModels\Core\DynamoViewModelBranding.cs" />
     <Compile Include="ViewModels\Core\GalleryViewModel.cs" />
     <Compile Include="ViewModels\Core\HomeWorkspaceViewModel.cs" />
+    <Compile Include="ViewModels\PackageManager\PackagePathViewModel.cs" />
     <Compile Include="ViewModels\RunSettingsViewModel.cs" />
     <Compile Include="ViewModels\Search\BrowserInternalElementViewModel.cs" />
     <Compile Include="ViewModels\Search\BrowserItemViewModel.cs" />

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using Dynamo.Interfaces;
+using DelegateCommand = Dynamo.UI.Commands.DelegateCommand;
+
+
+namespace Dynamo.ViewModels
+{
+    public class PackagePathEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Indicate whether user wants to add the current path to the list
+        /// </summary>
+        public bool Cancel { get; set; }
+
+        /// <summary>
+        /// Indicate the path to the custom packages folder
+        /// </summary>
+        public string Path { get; set; }
+    }
+
+    public class PackagePathViewModel : ViewModelBase
+    {
+        public ObservableCollection<string> RootLocations { get; private set; }
+        private int selectedIndex;
+        public int SelectedIndex
+        {
+            get
+            {
+                return selectedIndex;
+            }
+            set
+            {
+                selectedIndex = value;
+                RaisePropertyChanged("SelectedIndex");
+                RaiseCanExecuteChanged();
+            }
+        }
+
+        public event EventHandler<PackagePathEventArgs> RequestShowFileDialog;
+        public virtual void OnRequestShowFileDialog(object sender, PackagePathEventArgs e)
+        {
+            if (RequestShowFileDialog != null)
+            {
+                RequestShowFileDialog(sender, e);
+            }
+        }
+
+        private readonly IPreferences setting;
+
+
+        public DelegateCommand AddPathCommand { get; private set; }
+        public DelegateCommand DeletePathCommand { get; private set; }
+        public DelegateCommand MovePathUpCommand { get; private set; }
+        public DelegateCommand MovePathDownCommand { get; private set; }
+        public DelegateCommand UpdatePathCommand { get; private set; }
+        public DelegateCommand SaveSettingCommand { get; private set; }
+
+        public PackagePathViewModel(IPreferences setting)
+        {
+            RootLocations = new ObservableCollection<string>(setting.CustomPackageFolders);
+            this.setting = setting;
+
+            AddPathCommand = new DelegateCommand(p => InsertPath());
+            DeletePathCommand = new DelegateCommand(p => RemovePathAt((int) p), CanDelete);
+            MovePathUpCommand = new DelegateCommand(p => SwapPath((int) p, ((int) p) - 1), CanMoveUp);
+            MovePathDownCommand = new DelegateCommand(p => SwapPath((int) p, ((int) p) + 1), CanMoveDown);
+            UpdatePathCommand = new DelegateCommand(p => UpdatePathAt((int) p));
+            SaveSettingCommand = new DelegateCommand(CommitChanges);
+
+            SelectedIndex = 0;
+        }
+
+        private void RaiseCanExecuteChanged()
+        {
+            MovePathDownCommand.RaiseCanExecuteChanged();
+            MovePathUpCommand.RaiseCanExecuteChanged();
+            AddPathCommand.RaiseCanExecuteChanged();
+            DeletePathCommand.RaiseCanExecuteChanged();
+        }
+
+        private bool CanDelete(object param)
+        {
+            return RootLocations.Count > 1;
+        }
+
+        private bool CanMoveUp(object param)
+        {
+            return SelectedIndex > 0;
+        }
+
+        private bool CanMoveDown(object param)
+        {
+            return SelectedIndex < RootLocations.Count - 1;
+        }
+
+        // The position of the selected entry must always be the first parameter.
+        private void SwapPath(int x, int y)
+        {
+            if (x < 0 || y < 0 || x >= RootLocations.Count || y >= RootLocations.Count)
+                return;
+
+            var tempPath = RootLocations[x];
+            RootLocations[x] = RootLocations[y];
+            RootLocations[y] = tempPath;
+
+            SelectedIndex = y;
+        }
+
+        private void InsertPath()
+        {
+            var args = new PackagePathEventArgs();
+
+            ShowFileDialog(args);
+
+            if (args.Cancel)
+                return;
+
+            RootLocations.Insert(RootLocations.Count, args.Path);
+
+            RaiseCanExecuteChanged();
+        }
+
+        private void ShowFileDialog(PackagePathEventArgs e)
+        {
+            OnRequestShowFileDialog(this, e);
+
+            if (e.Cancel == false && RootLocations.Contains(e.Path))
+                e.Cancel = true;
+        }
+
+        private void UpdatePathAt(int index)
+        {
+            var args = new PackagePathEventArgs
+            {
+                Path = RootLocations[SelectedIndex]
+            };
+
+            ShowFileDialog(args);
+
+            if (args.Cancel)
+                return;
+
+            RootLocations[index] = args.Path;
+        }
+
+        private void RemovePathAt(int index)
+        {
+            RootLocations.RemoveAt(index);
+
+            if (index <= SelectedIndex && SelectedIndex > 0)
+                SelectedIndex--;
+
+            RaiseCanExecuteChanged();
+        }
+
+        private void CommitChanges(object param)
+        {
+            setting.CustomPackageFolders = new List<string>(RootLocations);
+        }
+
+    }
+}

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="LibraryTests.cs" />
     <Compile Include="NodePreviewTests.cs" />
     <Compile Include="NodeViewCustomizationTests.cs" />
+    <Compile Include="PackagePathTests.cs" />
     <Compile Include="PackageManagerUITests.cs" />
     <Compile Include="PackageManager\PackageDependencyTests.cs" />
     <Compile Include="PackageManager\PackageManagerSearchViewModelTests.cs" />

--- a/test/DynamoCoreWpfTests/PackagePathTests.cs
+++ b/test/DynamoCoreWpfTests/PackagePathTests.cs
@@ -1,0 +1,101 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Windows;
+
+using SystemTestServices;
+using Dynamo;
+using Dynamo.ViewModels;
+using NUnit.Framework;
+
+
+namespace DynamoCoreWpfTests
+{
+    public class PackagePathTests : SystemTestBase
+    {
+        #region PackagePathViewModelTests
+        [Test]
+        public void CannotDeletePathIfThereIsOnlyOne()
+        {
+            var setting = new PreferenceSettings
+            {
+                CustomPackageFolders = { @"C:\" }
+            };
+            var vm = new PackagePathViewModel(setting);
+
+            Assert.AreEqual(1, vm.RootLocations.Count);
+            Assert.IsFalse(vm.DeletePathCommand.CanExecute(null));
+        }
+
+        [Test]
+        public void ReorderingPathsTest()
+        {
+            var setting = new PreferenceSettings
+            {
+                CustomPackageFolders = { @"C:\", @"D:\", @"E:\" }
+            };
+
+            var vm = new PackagePathViewModel(setting);
+
+            Assert.AreEqual(0, vm.SelectedIndex);
+            Assert.IsTrue(vm.MovePathDownCommand.CanExecute(null));
+            Assert.IsFalse(vm.MovePathUpCommand.CanExecute(null));
+
+            vm.SelectedIndex = 2;
+            Assert.AreEqual(2, vm.SelectedIndex);
+            Assert.IsTrue(vm.MovePathUpCommand.CanExecute(null));
+            Assert.IsFalse(vm.MovePathDownCommand.CanExecute(null));
+
+            vm.SelectedIndex = 1;
+            Assert.AreEqual(1, vm.SelectedIndex);
+            Assert.IsTrue(vm.MovePathUpCommand.CanExecute(null));
+            Assert.IsTrue(vm.MovePathDownCommand.CanExecute(null));
+
+            vm.MovePathUpCommand.Execute(vm.SelectedIndex);
+
+            Assert.AreEqual(0, vm.SelectedIndex);
+            Assert.AreEqual(@"D:\", vm.RootLocations[0]);
+            Assert.AreEqual(@"C:\", vm.RootLocations[1]);
+            Assert.AreEqual(@"E:\", vm.RootLocations[2]);
+
+            vm.SelectedIndex = 1;
+            vm.MovePathDownCommand.Execute(vm.SelectedIndex);
+
+            Assert.AreEqual(2, vm.SelectedIndex);
+            Assert.AreEqual(@"D:\", vm.RootLocations[0]);
+            Assert.AreEqual(@"E:\", vm.RootLocations[1]);
+            Assert.AreEqual(@"C:\", vm.RootLocations[2]);
+        }
+
+        [Test]
+        public void AddRemovePathsTest()
+        {
+            var setting = new PreferenceSettings()
+            {
+                CustomPackageFolders = { @"Z:\" }
+            };
+
+            var vm = new PackagePathViewModel(setting);
+
+            var path = string.Empty;
+            vm.RequestShowFileDialog += (sender, args) => { args.Path = path; };
+
+            path = @"C:\";
+            vm.AddPathCommand.Execute(null);
+            path = @"D:\";
+            vm.AddPathCommand.Execute(null);
+
+            Assert.AreEqual(0, vm.SelectedIndex);
+            Assert.AreEqual(@"C:\", vm.RootLocations[1]);
+            Assert.AreEqual(@"D:\", vm.RootLocations[2]);
+
+            vm.SelectedIndex = 2;
+            vm.DeletePathCommand.Execute(0);
+
+            Assert.AreEqual(1, vm.SelectedIndex);
+            Assert.AreEqual(@"C:\", vm.RootLocations[0]);
+            Assert.AreEqual(@"D:\", vm.RootLocations[1]);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
### Purpose

This PR implements the ViewModel for PackagePath dialog. This is dialog is used for managing extra locations where packages will be loaded.
Tracking task: [MAGN-7823](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7823)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 