### PR TITLE
Update "Function not found" warning message

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -3812,7 +3812,7 @@ namespace ProtoCore.DSASM
                         if (CoreUtils.TryGetPropertyName(procName, out property))
                         {
                             string classname = exe.classTable.ClassNodes[type].name;
-                            string message = String.Format(Resources.kPropertyOfClassNotFound, classname, property);
+                            string message = String.Format(Resources.kPropertyOfClassNotFound, property, classname);
                             runtimeCore.RuntimeStatus.LogWarning(WarningID.kMethodResolutionFailure, message);
                         }
                         else

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -652,9 +652,9 @@ namespace ProtoCore
         /// <param name="core"></param>
         /// <param name="arguments"></param>
         /// <returns></returns>
-        private StackValue ReportFunctionGroupNotFound(RuntimeCore runtimeCore)
+        private StackValue ReportFunctionGroupNotFound(RuntimeCore runtimeCore, List<StackValue> arguments)
         {
-            runtimeCore.RuntimeStatus.LogFunctionGroupNotFoundWarning(methodName);
+            runtimeCore.RuntimeStatus.LogFunctionGroupNotFoundWarning(methodName, classScope, arguments);
             return StackValue.Null;
         }
 
@@ -1447,7 +1447,7 @@ namespace ProtoCore
                 if (runtimeCore.Options.DumpFunctionResolverLogic)
                     runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
 
-                return ReportFunctionGroupNotFound(runtimeCore);
+                return ReportFunctionGroupNotFound(runtimeCore, arguments);
             }
 
 

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -449,7 +449,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No function called {0} on a {1} could be found..
+        ///   Looks up a localized string similar to No function called {0} on a {1} could be found.
         /// </summary>
         public static string FunctionGroupNotFound {
             get {
@@ -458,7 +458,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No function called {0} on a {1} that takes {2} could be found..
+        ///   Looks up a localized string similar to No function called {0} on a {1} that takes {2} could be found.
         /// </summary>
         public static string FunctionGroupWithParameterNotFound {
             get {
@@ -1439,7 +1439,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Class &apos;{0}&apos; does not have a property &apos;{1}&apos;.
+        ///   Looks up a localized string similar to No property called {0} on {1} could be found.
         /// </summary>
         public static string kPropertyOfClassNotFound {
             get {

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -431,15 +431,6 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No function called {0} could be found. Please check the name of the function.
-        /// </summary>
-        public static string FUNCTION_GROUP_RESOLUTION_FAILURE {
-            get {
-                return ResourceManager.GetString("FUNCTION_GROUP_RESOLUTION_FAILURE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to A function call is not allowed on the left hand side of an assignment.
         /// </summary>
         public static string FunctionCallCannotBeAtLeftSide {
@@ -454,6 +445,24 @@ namespace ProtoCore.Properties {
         public static string FunctionDispatchFailed {
             get {
                 return ResourceManager.GetString("FunctionDispatchFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No function called {0} on a {1} could be found..
+        /// </summary>
+        public static string FunctionGroupNotFound {
+            get {
+                return ResourceManager.GetString("FunctionGroupNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No function called {0} on a {1} that takes {2} could be found..
+        /// </summary>
+        public static string FunctionGroupWithParameterNotFound {
+            get {
+                return ResourceManager.GetString("FunctionGroupWithParameterNotFound", resourceCulture);
             }
         }
         

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -159,9 +159,6 @@
   <data name="FunctionCallCannotBeAtLeftSide" xml:space="preserve">
     <value>A function call is not allowed on the left hand side of an assignment</value>
   </data>
-  <data name="FUNCTION_GROUP_RESOLUTION_FAILURE" xml:space="preserve">
-    <value>No function called {0} could be found. Please check the name of the function</value>
-  </data>
   <data name="GetKeys" xml:space="preserve">
     <value>Gets all keys from the specified key-value pair list</value>
   </data>
@@ -895,5 +892,11 @@
   <data name="ArgumentNullException" xml:space="preserve">
     <value>Value cannot be null.
 Parameter name: {0}</value>
+  </data>
+  <data name="FunctionGroupNotFound" xml:space="preserve">
+    <value>No function called {0} on a {1} could be found.</value>
+  </data>
+  <data name="FunctionGroupWithParameterNotFound" xml:space="preserve">
+    <value>No function called {0} on a {1} that takes {2} could be found.</value>
   </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -346,7 +346,7 @@
     <value>Property '{0}' not found</value>
   </data>
   <data name="kPropertyOfClassNotFound" xml:space="preserve">
-    <value>Class '{0}' does not have a property '{1}'</value>
+    <value>No property called {0} on {1} could be found</value>
   </data>
   <data name="kRangeExpressionConflictOperator" xml:space="preserve">
     <value>An amount operator cannot be used together with a step operator</value>
@@ -894,9 +894,9 @@
 Parameter name: {0}</value>
   </data>
   <data name="FunctionGroupNotFound" xml:space="preserve">
-    <value>No function called {0} on a {1} could be found.</value>
+    <value>No function called {0} on a {1} could be found</value>
   </data>
   <data name="FunctionGroupWithParameterNotFound" xml:space="preserve">
-    <value>No function called {0} on a {1} that takes {2} could be found.</value>
+    <value>No function called {0} on a {1} that takes {2} could be found</value>
   </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -159,8 +159,8 @@
   <data name="FunctionCallCannotBeAtLeftSide" xml:space="preserve">
     <value>A function call is not allowed on the left hand side of an assignment</value>
   </data>
-  <data name="FUNCTION_GROUP_RESOLUTION_FAILURE" xml:space="preserve">
-    <value>No function called {0} could be found. Please check the name of the function</value>
+  <data name="FunctionGroupNotFound" xml:space="preserve">
+    <value>No function called {0} on a {1} could be found.</value>
   </data>
   <data name="GetKeys" xml:space="preserve">
     <value>Gets all keys from the specified key-value pair list</value>
@@ -895,5 +895,8 @@
   <data name="ArgumentNullException" xml:space="preserve">
     <value>Value cannot be null.
 Parameter name: {0}</value>
+  </data>
+  <data name="FunctionGroupWithParameterNotFound" xml:space="preserve">
+    <value>No function called {0} on a {1} that takes {2} could be found.</value>
   </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -160,7 +160,7 @@
     <value>A function call is not allowed on the left hand side of an assignment</value>
   </data>
   <data name="FunctionGroupNotFound" xml:space="preserve">
-    <value>No function called {0} on a {1} could be found.</value>
+    <value>No function called {0} on a {1} could be found</value>
   </data>
   <data name="GetKeys" xml:space="preserve">
     <value>Gets all keys from the specified key-value pair list</value>
@@ -349,7 +349,7 @@
     <value>Property '{0}' not found</value>
   </data>
   <data name="kPropertyOfClassNotFound" xml:space="preserve">
-    <value>Class '{0}' does not have a property '{1}'</value>
+    <value>No property called {0} on {1} could be found</value>
   </data>
   <data name="kRangeExpressionConflictOperator" xml:space="preserve">
     <value>An amount operator cannot be used together with a step operator</value>
@@ -897,6 +897,6 @@
 Parameter name: {0}</value>
   </data>
   <data name="FunctionGroupWithParameterNotFound" xml:space="preserve">
-    <value>No function called {0} on a {1} that takes {2} could be found.</value>
+    <value>No function called {0} on a {1} that takes {2} could be found</value>
   </data>
 </root>

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -319,11 +319,37 @@ namespace ProtoCore
         /// Report that a function group couldn't be found
         /// </summary>
         /// <param name="methodName">The method that can't be found</param>
-        public void LogFunctionGroupNotFoundWarning(
-            string methodName)
+        public void LogFunctionGroupNotFoundWarning(string methodName,
+            int classScope,
+            List<StackValue> arguments)
         {
-            String message = string.Format(Resources.FUNCTION_GROUP_RESOLUTION_FAILURE, methodName);
-            LogWarning(WarningID.kMethodResolutionFailure, message);
+            string className = runtimeCore.DSExecutable.classTable.ClassNodes[classScope].name;
+
+            List<string> argumentTypes = new List<string>();
+            if (arguments == null || arguments.Count == 0)
+            {
+                string propertyName;
+                if (CoreUtils.TryGetPropertyName(methodName, out propertyName))
+                {
+                    string message = string.Format(Resources.kPropertyOfClassNotFound, propertyName, className);
+                    LogWarning(WarningID.kMethodResolutionFailure, message);
+                }
+                else
+                {
+                    string message = string.Format(Resources.FunctionGroupNotFound, methodName, className);
+                    LogWarning(WarningID.kMethodResolutionFailure, message);
+                }
+            }
+            else
+            {
+                foreach (var argument in arguments)
+                {
+                    ProtoCore.Type type = runtimeCore.DSExecutable.TypeSystem.BuildTypeObject(argument.metaData.type, 0);
+                    argumentTypes.Add(type.ToShortString());
+                }
+                string message = string.Format(Resources.FunctionGroupWithParameterNotFound, methodName, className, string.Join(",", argumentTypes));
+                LogWarning(WarningID.kMethodResolutionFailure, message);
+            }
         }
 
 
@@ -340,7 +366,7 @@ namespace ProtoCore
                 if (classScope != Constants.kGlobalScope)
                 {
                     string classname = runtimeCore.DSExecutable.classTable.ClassNodes[classScope].name;
-                    message = string.Format(Resources.kPropertyOfClassNotFound, classname, propertyName);
+                    message = string.Format(Resources.kPropertyOfClassNotFound, propertyName, classname);
                 }
                 else
                 {

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -316,9 +316,11 @@ namespace ProtoCore
         }
 
         /// <summary>
-        /// Report that a function group couldn't be found
+        /// Report that the method cannot be found.
         /// </summary>
-        /// <param name="methodName">The method that can't be found</param>
+        /// <param name="methodName">The method that cannot be found</param>
+        /// <param name="classScope">The class scope of object</param>
+        /// <param name="arguments">Arguments</param>
         public void LogFunctionGroupNotFoundWarning(string methodName,
             int classScope,
             List<StackValue> arguments)


### PR DESCRIPTION
### Purpose

Update "No function called XXX could be found" warning message to "No function called XXX on YYY could be found".

This is to fix defect [MAGN 5518](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5518#).

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@junmendoza 

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs
