### PR TITLE
Fix defect that closing a custom workspace hides all other custom workspaces

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1437,7 +1437,8 @@ namespace Dynamo.Controls
 
         private void WorkspaceTabs_TargetUpdated(object sender, DataTransferEventArgs e)
         {
-            ToggleWorkspaceTabVisibility(WorkspaceTabs.SelectedIndex);
+            if (WorkspaceTabs.SelectedIndex >= 0)
+                ToggleWorkspaceTabVisibility(WorkspaceTabs.SelectedIndex);
         }
 
         private void WorkspaceTabs_SizeChanged(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
### Purpose

Fix [defect 7858](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7858) that closing a custom workspace hides all other custom workspaces. 

When a custom workspace is closed, the corresponding workspace model will be removed from `DynamoViewModel.Workspaces`, which consequently triggers `DynamoView.WorkspaceTabs_TargetUpdated()` event. 

As at this moment current workspace hasn't been set yet (still in `Workspaces.Remove()`), `WorkspaceTabs.SelectedIndex` is [-1] (https://msdn.microsoft.com/en-us/library/system.windows.forms.tabcontrol.selectedindex(v=vs.110).aspx), `DynamoView.ToggleWorkspaceTabVisibility(-1)` hides all other custom workspaces.

Add validity check to `DynamoView.WorkspaceTabs_TargetUpdated()` to fix the defect.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 