### PR TITLE
ViewExtension folder is not copied with installer

### DIFF
--- a/tools/install/CreateInstallers.bat
+++ b/tools/install/CreateInstallers.bat
@@ -25,6 +25,7 @@ IF EXIST %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\Revit_2016 (
 
 robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\nodes %cwd%\temp\bin\nodes *.dll *.xml /e
 robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\extensions %cwd%\temp\bin\extensions *.xml /e
+robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\viewExtensions %cwd%\temp\bin\viewExtensions *.dll *.xml /e
 robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\UI %cwd%\temp\bin\UI /E
 copy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\DSCoreNodes_DynamoCustomization.xml %cwd%\temp\bin\DSCoreNodes_DynamoCustomization.xml
 copy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\ProtoGeometry_DynamoCustomization.xml %cwd%\temp\bin\ProtoGeometry_DynamoCustomization.xml

--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -46,6 +46,7 @@ Name: "{app}\libg_221"
 Name: "{app}\libg_locale"
 Name: "{app}\nodes"
 Name: "{app}\extensions"
+Name: "{app}\viewExtensions"
 Name: "{userappdata}\Dynamo\{#Major}.{#Minor}\definitions"
 Name: "{userappdata}\Dynamo\{#Major}.{#Minor}\Logs"
 Name: "{userappdata}\Dynamo\{#Major}.{#Minor}\packages"
@@ -68,6 +69,7 @@ Source: "Extra\DynamoAddinGenerator.exe"; Flags: dontcopy
 Source: temp\bin\*; DestDir: {app}; Flags: ignoreversion overwritereadonly; Components: DynamoCore
 Source: temp\bin\nodes\*; DestDir: {app}\nodes; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 Source: temp\bin\extensions\*; DestDir: {app}\extensions; Flags: ignoreversion overwritereadonly; Components: DynamoCore
+Source: temp\bin\viewExtensions\*; DestDir: {app}\viewExtensions; Flags: ignoreversion overwritereadonly; Components: DynamoCore
 Source: temp\bin\lang\*; DestDir: {app}\; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 Source: Extra\IronPython-2.7.3.msi; DestDir: {tmp}; Flags: deleteafterinstall;
 Source: temp\bin\README.txt; DestDir: {app}\; Flags: onlyifdoesntexist isreadme ignoreversion; Components: DynamoCore


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7961](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7961) ViewExtension folder is not copied with installer

I've added viewExtensions folder in installer as it's done in https://github.com/DynamoDS/Dynamo/pull/4775

### Declarations

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@pboyer 

### FYIs

@lillismith 