### PR TITLE
List.Join should accept single item as input

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
@@ -726,8 +726,10 @@ namespace ProtoFFI
         }
 
         /// <summary>
-        /// Gets marshaler for the given clrType and if it fails
+        /// If clrType is IEnumerable, returns a CollectionMarshaler, otherwise
+        /// gets marshaler for the given clrType and if it fails
         /// to get one, it tries to get primitive marshaler based on dsType.
+        /// 
         /// We want to get correct marshaler specific to the input type because
         /// more than one type gets map to same type in DS.
         /// </summary>

--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
@@ -711,7 +711,7 @@ namespace ProtoFFI
             Validity.Assert(dsObject.IsPointer || dsObject.IsFunctionPointer, 
                 string.Format("Operand type {0} not supported for marshalling", 
                 dsObject.optype));
-            
+
             //Search in the DSObjectMap, for corresponding clrObject.
             object clrObject = null;
             if (DSObjectMap.TryGetValue(dsObject, out clrObject))
@@ -738,10 +738,6 @@ namespace ProtoFFI
         /// <returns>FFIObjectMarshler or null</returns>
         private FFIObjectMarshler GetMarshalerForCLRType(Type clrType, AddressType dsType)
         {
-            //If the input ds object is pointer type then it can't be marshaled as primitive.
-            if (dsType == AddressType.Pointer)
-                return null;
-
             FFIObjectMarshler marshaler = null;
             //Expected CLR type is object, get marshaled clrType from dsType
             Type expectedType = clrType;
@@ -757,11 +753,17 @@ namespace ProtoFFI
             if (typeof(string) != expectedType && typeof(IEnumerable).IsAssignableFrom(expectedType))
                 collection = true;
 
+            // If the expected type is collection, always marshal to collection
             if (collection)
             {
                 ProtoCore.Type type = PrimitiveMarshler.CreateType(ProtoCore.PrimitiveType.kTypeVar);
                 type.rank = ProtoCore.DSASM.Constants.kArbitraryRank;
                 return new CollectionMarshaler(this, type);
+            }
+            // If the input ds object is pointer type then it can't be marshaled as primitive.
+            else if (dsType == AddressType.Pointer)
+            {
+                return null;
             }
 
             if (!mPrimitiveMarshalers.TryGetValue(expectedType, out marshaler))

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -995,6 +995,15 @@ namespace Dynamo.Tests
             AssertPreviewValue("980dcd47-84e7-412c-8d9e-d66f166d2370", new object[] { new object[] { false }, new object[] { false }, new object[] { false }, new object[] { false }, new object[] { false } });
 
         }
+
+        [Test]
+        [Category("RegressionTests")]
+        public void TestListJoin()
+        {
+            var dynFilePath = Path.Combine(TestDirectory, @"core\list\ListJoin.dyn");
+            RunModel(dynFilePath);
+            AssertPreviewValue("ea031ca8-9c49-4d14-a702-54022cb60e0f", 5);
+        }
     }
 
     [Category("DSCustomNode")]
@@ -1144,6 +1153,5 @@ namespace Dynamo.Tests
 
             AssertPreviewValue("42693721-622d-475e-a82e-bfe793ddc153", new object[] {2, 3, 4, 5, 6});
         }
-        
     }
 }

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -110,6 +110,14 @@ namespace FFITarget
             return x + y;
         }
 
+        public static IList JoinList(params IList[] lists)
+        {
+            var result = new ArrayList();
+            foreach (IList list in lists)
+                result.AddRange(list);
+            return result;
+        }
+
         public object[] GetMixedObjects()
         {
             object[] objs = { new DerivedDummy(), new Derived1(), new TestDispose(), new DummyDispose() };

--- a/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFIDataMarshalingTest.cs
@@ -630,5 +630,29 @@ d2 = TestData.SumList({1, 2, {3, 4}, {5, {6, {7}}}});
             ValidationData[] data = { new ValidationData { ValueName = "value", ExpectedValue = 42, BlockIndex = 0 } };
             ExecuteAndVerify(code, data);
         }
+
+        [Test]
+        public void Test_MarshlingPointerToCollection()
+        {
+            String code =
+            @"                import (TestData from ""FFITarget.dll"");
+
+                d = TestData.TestData();
+                arr1 = TestData.JoinList({d, {1,2,3}});
+                arr2 = TestData.JoinList({d, d, d});
+
+                type1 = ToString(arr1[0]);
+                rank1 = Rank(arr1);
+
+                type2 = ToString(arr2[0]);
+                rank2 = Rank(arr2);
+            ";
+            ValidationData[] data = { 
+                new ValidationData { ValueName = "type1", ExpectedValue = "FFITarget.TestData", BlockIndex = 0 }, 
+                new ValidationData { ValueName = "rank1", ExpectedValue = 1, BlockIndex = 0 }, 
+                new ValidationData { ValueName = "type2", ExpectedValue = "FFITarget.TestData", BlockIndex = 0 }, 
+                new ValidationData { ValueName = "rank2", ExpectedValue = 1, BlockIndex = 0 } };
+            ExecuteAndVerify(code, data);
+        }
     }
 }

--- a/test/core/list/ListJoin.dyn
+++ b/test/core/list/ListJoin.dyn
@@ -1,0 +1,27 @@
+<Workspace Version="0.8.2.1957" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSVarArgFunction guid="5f64d1bf-89af-4331-9403-2d9c1e4ef1b7" type="Dynamo.Nodes.DSVarArgFunction" nickname="List.Join" x="709.5" y="246.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="DSCoreNodes.dll" function="DSCore.List.Join@var[]..[]" inputcount="2" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="979cc5ef-cfbd-441c-b01e-c93f0555c4e8" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="535" y="312" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="{1,2,3};" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="d4d4a034-ee3b-4af3-bd0b-04afce1a6d38" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="502.5" y="135.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="7652db7a-81de-40b8-b6fd-bdf9c23764bf" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="300" y="153" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="5;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="e92cc929-a553-442a-a3f6-e6be748556d2" type="Dynamo.Nodes.DSFunction" nickname="List.FirstItem" x="905.5" y="280.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]" />
+    <Dynamo.Nodes.DSFunction guid="ea031ca8-9c49-4d14-a702-54022cb60e0f" type="Dynamo.Nodes.DSFunction" nickname="Point.X" x="1083.5" y="291.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.X" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="5f64d1bf-89af-4331-9403-2d9c1e4ef1b7" start_index="0" end="e92cc929-a553-442a-a3f6-e6be748556d2" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="979cc5ef-cfbd-441c-b01e-c93f0555c4e8" start_index="0" end="5f64d1bf-89af-4331-9403-2d9c1e4ef1b7" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d4d4a034-ee3b-4af3-bd0b-04afce1a6d38" start_index="0" end="5f64d1bf-89af-4331-9403-2d9c1e4ef1b7" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="7652db7a-81de-40b8-b6fd-bdf9c23764bf" start_index="0" end="d4d4a034-ee3b-4af3-bd0b-04afce1a6d38" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="e92cc929-a553-442a-a3f6-e6be748556d2" start_index="0" end="ea031ca8-9c49-4d14-a702-54022cb60e0f" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="background_preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR is to fix defect [MAGN 7888 List.Join should accept single item as input](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7888). 

If the target function expects a collection but we pass a non-collection DS object to it, FFI only promote objects whose type could be mapped to CLR primitive types (like `int`, `double`, etc) to collection. This PR extends it to all types.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers
@sharadkjaiswal 