### PR TITLE
Fix Revit installer

### DIFF
--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -69,7 +69,7 @@ Source: "Extra\DynamoAddinGenerator.exe"; Flags: dontcopy
 Source: temp\bin\*; DestDir: {app}; Flags: ignoreversion overwritereadonly; Components: DynamoCore
 Source: temp\bin\nodes\*; DestDir: {app}\nodes; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 Source: temp\bin\extensions\*; DestDir: {app}\extensions; Flags: ignoreversion overwritereadonly; Components: DynamoCore
-Source: temp\bin\viewExtensions\*; DestDir: {app}\viewExtensions; Flags: ignoreversion overwritereadonly; Components: DynamoCore
+Source: temp\bin\viewExtensions\*; DestDir: {app}\viewExtensions; Flags: ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 Source: temp\bin\lang\*; DestDir: {app}\; Flags:skipifsourcedoesntexist ignoreversion overwritereadonly recursesubdirs; Components: DynamoCore
 Source: Extra\IronPython-2.7.3.msi; DestDir: {tmp}; Flags: deleteafterinstall;
 Source: temp\bin\README.txt; DestDir: {app}\; Flags: onlyifdoesntexist isreadme ignoreversion; Components: DynamoCore


### PR DESCRIPTION
Forgot to add `recursesubdirs`, which adds subfolders.

@pboyer , please, help to merge it. Thanks!