### PR TITLE
Avoid asm library to be initialized twice

### DIFF
--- a/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
+++ b/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
@@ -12,7 +12,18 @@ namespace ProtoFFI
         System.Collections.Hashtable mExtensionApps = new System.Collections.Hashtable();
         string mProtoInterface = string.Empty;
 
-        internal ExtensionAppLoader()
+        private static ExtensionAppLoader mInstance;
+        public static ExtensionAppLoader Instance
+        {
+            get
+            {
+                if (null == mInstance)
+                    mInstance = new ExtensionAppLoader();
+                return mInstance;
+            }
+        }
+
+        private ExtensionAppLoader()
         {
             mProtoInterface = typeof(IExtensionApplication).Assembly.GetName().Name;
             Initialize();
@@ -79,6 +90,7 @@ namespace ProtoFFI
             }
             mExtensionApps.Clear();
             mAssemblies.Clear();
+            mInstance = null;
         }
 
         private Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)

--- a/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
+++ b/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
@@ -12,15 +12,11 @@ namespace ProtoFFI
         System.Collections.Hashtable mExtensionApps = new System.Collections.Hashtable();
         string mProtoInterface = string.Empty;
 
-        private static ExtensionAppLoader mInstance;
+        // http://csharpindepth.com/articles/general/singleton.aspx
+        private static readonly Lazy<ExtensionAppLoader> lazy = new Lazy<ExtensionAppLoader>(() => new ExtensionAppLoader());
         public static ExtensionAppLoader Instance
         {
-            get
-            {
-                if (null == mInstance)
-                    mInstance = new ExtensionAppLoader();
-                return mInstance;
-            }
+            get { return lazy.Value; }
         }
 
         private ExtensionAppLoader()
@@ -90,7 +86,6 @@ namespace ProtoFFI
             }
             mExtensionApps.Clear();
             mAssemblies.Clear();
-            mInstance = null;
         }
 
         private Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)

--- a/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
+++ b/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
@@ -15,7 +15,7 @@ namespace ProtoFFI
         }
 
         Dictionary<RuntimeCore, FFIExecutionSession> mSessions = new Dictionary<RuntimeCore, FFIExecutionSession>();
-        ExtensionAppLoader mApploader = new ExtensionAppLoader();
+        ExtensionAppLoader mApploader = ExtensionAppLoader.Instance;
 
         static FFIExecutionManager mSelf;
 


### PR DESCRIPTION
### Purpose

This PR is to fix defect [MAGN-7927 AccessViolationException is thrown out when shutting down asm library](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7927#) and [MAGN-7915 LibG throws exception when it is shutdown in Extension loader](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7915#)

The root cause is asm library is initialized twice. More details:

`ProtoFFI.ExtensionAppLoader` will monitor app domain's `AssemblyLoad` and `AssemblyResolve` event, and for any loaded assembly, if the assembly implements `IExtensionApplication` interface, call `StartUp()` method on the `IExtensionApplication` instance (and call `ShutDown()` if the process exits). 

As it is not a singleton (`FFIExectionManager` has a `ExtensionAppLoader` member), we finally have multiple `ExtensionAppLoader` instances, will cause asm library is initialized twice when LibG is loaded. 
This PR makes it as a singleton.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@aparajit-pratap 