### PR TITLE
fix disposing FolderBrowser dialog too early resulting in crash

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoOpenFileDialog.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoOpenFileDialog.cs
@@ -124,19 +124,19 @@ namespace Dynamo.UI
                 // IShellItem GUID
                 Guid guid = new Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE");
                 int hresult = SHCreateItemFromParsingName(SelectedPath, IntPtr.Zero, ref guid, out shellItem);
-                if (hresult != 0)
-                    throw new System.ComponentModel.Win32Exception(hresult);
+                if ((uint)hresult != (uint)HRESULT.S_OK)
+                    throw Marshal.GetExceptionForHR(hresult);
                 dialog.SetFolder((IShellItem)shellItem);
 
                 dialog.SetOptions(FOS.FOS_PICKFOLDERS | FOS.FOS_FORCEFILESYSTEM | FOS.FOS_FILEMUSTEXIST);
 
                 IntPtr hWnd = new WindowInteropHelper(Owner).Handle;
-                var result = dialog.Show(hWnd);
-                if (result < 0)
+                hresult = dialog.Show(hWnd);
+                if (hresult < 0)
                 {
-                    if ((uint)result == (uint)HRESULT.E_CANCELLED)
+                    if ((uint)hresult == (uint)HRESULT.E_CANCELLED)
                         return DialogResult.Cancel;
-                    throw Marshal.GetExceptionForHR(result);
+                    throw Marshal.GetExceptionForHR(hresult);
                 }
 
                 string path;

--- a/src/DynamoCoreWpf/Views/Core/DynamoOpenFileDialog.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoOpenFileDialog.cs
@@ -107,46 +107,29 @@ namespace Dynamo.UI
 
     class DynamoFolderBrowserDialog
     {
-        private readonly NativeFileOpenDialog dialog;
-        private string selectedPath = string.Empty;
-
-        public string Title
-        {
-            set { dialog.SetTitle(value); }
-        }
-
+        public string Title { get; set; }
         public Window Owner { get; set; }
-
-        public string SelectedPath
-        {
-            get
-            {
-                return selectedPath;
-            }
-            set
-            {
-                selectedPath = value;
-                object item;
-                // IShellItem GUID
-                Guid guid = new Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE");
-                int hresult = SHCreateItemFromParsingName(value, IntPtr.Zero, ref guid, out item);
-                if (hresult != 0)
-                    throw new System.ComponentModel.Win32Exception(hresult);
-
-                dialog.SetFolder((IShellItem)item);
-            }
-        }
-
-        public DynamoFolderBrowserDialog()
-        {
-            dialog = new NativeFileOpenDialog();
-            dialog.SetOptions(FOS.FOS_PICKFOLDERS | FOS.FOS_FORCEFILESYSTEM | FOS.FOS_FILEMUSTEXIST);
-        }
+        public string SelectedPath { get; set; }
 
         public DialogResult ShowDialog()
         {
+            NativeFileOpenDialog dialog = null;
             try
             {
+                dialog = new NativeFileOpenDialog();
+
+                dialog.SetTitle(Title);
+
+                object shellItem;
+                // IShellItem GUID
+                Guid guid = new Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE");
+                int hresult = SHCreateItemFromParsingName(SelectedPath, IntPtr.Zero, ref guid, out shellItem);
+                if (hresult != 0)
+                    throw new System.ComponentModel.Win32Exception(hresult);
+                dialog.SetFolder((IShellItem)shellItem);
+
+                dialog.SetOptions(FOS.FOS_PICKFOLDERS | FOS.FOS_FORCEFILESYSTEM | FOS.FOS_FILEMUSTEXIST);
+
                 IntPtr hWnd = new WindowInteropHelper(Owner).Handle;
                 var result = dialog.Show(hWnd);
                 if (result < 0)

--- a/src/DynamoCoreWpf/Views/Core/DynamoOpenFileDialog.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoOpenFileDialog.cs
@@ -108,6 +108,7 @@ namespace Dynamo.UI
     class DynamoFolderBrowserDialog
     {
         private readonly NativeFileOpenDialog dialog;
+        private string selectedPath = string.Empty;
 
         public string Title
         {
@@ -120,14 +121,11 @@ namespace Dynamo.UI
         {
             get
             {
-                string selectedPath;
-                IShellItem item;
-                dialog.GetResult(out item);
-                item.GetDisplayName(SIGDN.SIGDN_FILESYSPATH, out selectedPath);
                 return selectedPath;
             }
             set
             {
+                selectedPath = value;
                 object item;
                 // IShellItem GUID
                 Guid guid = new Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE");
@@ -157,6 +155,12 @@ namespace Dynamo.UI
                         return DialogResult.Cancel;
                     throw Marshal.GetExceptionForHR(result);
                 }
+
+                string path;
+                IShellItem item;
+                dialog.GetResult(out item);
+                item.GetDisplayName(SIGDN.SIGDN_FILESYSPATH, out path);
+                SelectedPath = path;
 
                 return DialogResult.OK;
             }


### PR DESCRIPTION
### Purpose

The FolderBrowserDialog was implemented in #4969 but the call to `FinalReleaseComObject` is too early so when trying to access the `SelectedPath` property to get the result, the dialog is already disposed. Thus, right before disposing the dialog, cache the path for later access.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@sharadkjaiswal 