### PR TITLE
Unescape file path when convert File Path node to code

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/File.cs
+++ b/src/Libraries/CoreNodeModels/Input/File.cs
@@ -26,6 +26,14 @@ namespace DSCore.File
 
             Value = "";
         }
+
+        internal override IEnumerable<AssociativeNode> BuildAst(List<AssociativeNode> inputAstNodes, AstBuilder.CompilationContext context)
+        {
+            if (context == AstBuilder.CompilationContext.NodeToCode)
+                Value = Value.Replace(@"\", @"\\");
+
+            return base.BuildAst(inputAstNodes, context);
+        }
     }
 
     [NodeName("File Path")]
@@ -39,20 +47,6 @@ namespace DSCore.File
         {
             ShouldDisplayPreviewCore = false;
         }
-
-        internal override IEnumerable<AssociativeNode> BuildAst(List<AssociativeNode> inputAstNodes, AstBuilder.CompilationContext context)
-        {
-            if (context == AstBuilder.CompilationContext.NodeToCode)
-            {
-                var rhs = AstFactory.BuildStringNode(Value.Replace(@"\", @"\\"));
-                var assignment = AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), rhs);
-                return new[] { assignment };
-            }
-            else
-            {
-                return base.BuildAst(inputAstNodes, context);
-            }
-       }
     }
 
     [NodeName("Directory Path")]

--- a/src/Libraries/CoreNodeModels/Input/File.cs
+++ b/src/Libraries/CoreNodeModels/Input/File.cs
@@ -30,9 +30,15 @@ namespace DSCore.File
         internal override IEnumerable<AssociativeNode> BuildAst(List<AssociativeNode> inputAstNodes, AstBuilder.CompilationContext context)
         {
             if (context == AstBuilder.CompilationContext.NodeToCode)
-                Value = Value.Replace(@"\", @"\\");
-
-            return base.BuildAst(inputAstNodes, context);
+            {
+                var rhs = AstFactory.BuildStringNode(Value.Replace(@"\", @"\\"));
+                var assignment = AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), rhs);
+                return new[] { assignment };
+            }
+            else
+            {
+                return base.BuildAst(inputAstNodes, context);
+            }
         }
     }
 

--- a/src/Libraries/CoreNodeModels/Input/File.cs
+++ b/src/Libraries/CoreNodeModels/Input/File.cs
@@ -11,6 +11,7 @@ using DSCoreNodesUI.Properties;
 using Autodesk.DesignScript.Runtime;
 using ProtoCore.AST.AssociativeAST;
 using VMDataBridge;
+using Dynamo.DSEngine;
 
 namespace DSCore.File
 {
@@ -38,6 +39,20 @@ namespace DSCore.File
         {
             ShouldDisplayPreviewCore = false;
         }
+
+        internal override IEnumerable<AssociativeNode> BuildAst(List<AssociativeNode> inputAstNodes, AstBuilder.CompilationContext context)
+        {
+            if (context == AstBuilder.CompilationContext.NodeToCode)
+            {
+                var rhs = AstFactory.BuildStringNode(Value.Replace(@"\", @"\\"));
+                var assignment = AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), rhs);
+                return new[] { assignment };
+            }
+            else
+            {
+                return base.BuildAst(inputAstNodes, context);
+            }
+       }
     }
 
     [NodeName("Directory Path")]

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1000,6 +1000,22 @@ namespace Dynamo.Tests
             Assert.IsTrue(binaryExpr.RightNode is RangeExprNode); ;
         }
 
+        [Test]
+        public void TestFilePathToCode()
+        {
+            OpenModel(@"core\node2code\filepath.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+
+            SelectAll(nodes);
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+
+            Assert.IsTrue(cbn.Code.Contains(@"D:\\foo\\bar"));
+        }
+
         private void SelectAll(IEnumerable<NodeModel> nodes)
         {
             DynamoSelection.Instance.ClearSelection();

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1016,6 +1016,23 @@ namespace Dynamo.Tests
             Assert.IsTrue(cbn.Code.Contains(@"D:\\foo\\bar"));
         }
 
+        [Test]
+        public void TestDirectoryToCode()
+        {
+            OpenModel(@"core\node2code\directory.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+
+            SelectAll(nodes);
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+
+            Assert.IsTrue(cbn.Code.Contains(@"D:\\foo\\bar"));
+        }
+
+
         private void SelectAll(IEnumerable<NodeModel> nodes)
         {
             DynamoSelection.Instance.ClearSelection();

--- a/test/core/node2code/directory.dyn
+++ b/test/core/node2code/directory.dyn
@@ -1,0 +1,15 @@
+<Workspace Version="0.8.2.1957" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <DSCore.File.Directory guid="a5e2794e-86c9-4626-84b3-e0f904f89264" type="DSCore.File.Directory" nickname="Directory Path" x="608.5" y="339" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
+      <System.String>D:\foo\bar</System.String>
+    </DSCore.File.Directory>
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="background_preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" />
+  </Cameras>
+</Workspace>

--- a/test/core/node2code/filepath.dyn
+++ b/test/core/node2code/filepath.dyn
@@ -1,0 +1,15 @@
+<Workspace Version="0.8.2.1957" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <DSCore.File.Filename guid="83d0a63f-95df-42da-bcdf-bff64306f4ff" type="DSCore.File.Filename" nickname="File Path" x="608.5" y="339" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
+      <System.String>D:\foo\bar</System.String>
+    </DSCore.File.Filename>
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="background_preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR is to fix defect [MAGN-7985 When File Path is converted to N2C , the string has only single "\" in the path, which fails File.FromPath node](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7985) by replacing "\" with "\\" in node to code context:

![untitled](https://cloud.githubusercontent.com/assets/2600379/8870243/0465b8c8-321f-11e5-8039-a71d81b869f0.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 