### PR TITLE
Fix String.Split's node to code issue

### DIFF
--- a/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
@@ -117,7 +117,7 @@ namespace Dynamo.Nodes
             if (!model.IsPartiallyApplied)
             {
                 var paramCount = Definition.Parameters.Count();
-                var packId = "__var_arg_pack_" + model.GUID;
+                var packId = "__var_arg_pack_" + model.GUID.ToString().Replace("-", string.Empty);
                 resultAst.Add(
                     AstFactory.BuildAssignment(
                         AstFactory.BuildIdentifier(packId),

--- a/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
@@ -117,16 +117,9 @@ namespace Dynamo.Nodes
             if (!model.IsPartiallyApplied)
             {
                 var paramCount = Definition.Parameters.Count();
-                var packId = "__var_arg_pack_" + model.GUID.ToString().Replace("-", string.Empty);
-                resultAst.Add(
-                    AstFactory.BuildAssignment(
-                        AstFactory.BuildIdentifier(packId),
-                        AstFactory.BuildExprList(inputAstNodes.Skip(paramCount - 1).ToList())));
-
-                inputAstNodes =
-                    inputAstNodes.Take(paramCount - 1)
-                        .Concat(new[] { AstFactory.BuildIdentifier(packId) })
-                        .ToList();
+                var argPack = AstFactory.BuildExprList(inputAstNodes.Skip(paramCount - 1).ToList()); 
+                inputAstNodes = inputAstNodes.Take(paramCount - 1).ToList();
+                inputAstNodes.Add(argPack);
             }
 
             base.BuildOutputAst(model, inputAstNodes, resultAst);

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1000,6 +1000,24 @@ namespace Dynamo.Tests
             Assert.IsTrue(binaryExpr.RightNode is RangeExprNode); ;
         }
 
+        [Test]
+        public void TestNodeWithVarArgument()
+        {
+            OpenModel(@"core\node2code\stringsplit.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+            SelectAll(nodes);
+
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+            CurrentDynamoModel.ForceRun();
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+
+            var guid = cbn.GUID.ToString();
+            AssertPreviewValue(guid, new [] {"foo", "bar", "qux"});
+        }
+
         private void SelectAll(IEnumerable<NodeModel> nodes)
         {
             DynamoSelection.Instance.ClearSelection();

--- a/test/core/node2code/stringsplit.dyn
+++ b/test/core/node2code/stringsplit.dyn
@@ -1,0 +1,18 @@
+<Workspace Version="0.8.2.1957" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSVarArgFunction guid="bf58e21f-3634-43bf-9dc9-ed216b2801d9" type="Dynamo.Nodes.DSVarArgFunction" nickname="String.Split" x="608.5" y="404.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="DSCoreNodes.dll" function="DSCore.String.Split@string,string[]" inputcount="2" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="a854de75-374b-4b23-822d-4f1988b56e0f" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="252" y="392" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="&quot;foo,bar,qux&quot;;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="50e2a704-cb90-4d9f-b455-78d29b2c1b03" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="321" y="494" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="&quot;,&quot;;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="a854de75-374b-4b23-822d-4f1988b56e0f" start_index="0" end="bf58e21f-3634-43bf-9dc9-ed216b2801d9" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="50e2a704-cb90-4d9f-b455-78d29b2c1b03" start_index="0" end="bf58e21f-3634-43bf-9dc9-ed216b2801d9" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="background_preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR is to fix [node to code issue](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7887#) for `String.Split` node.

It is because the temporary variable that created in `String.Split` node has some invalid character "-" so that the parser rejects it after node to code. We could safely remove this temporary variable. 

Regression test case added.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 
