### PR TITLE
Fix String.Split's node to code issue

### DIFF
--- a/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
@@ -117,6 +117,17 @@ namespace Dynamo.Nodes
             if (!model.IsPartiallyApplied)
             {
                 var paramCount = Definition.Parameters.Count();
+
+                // Suppose a fucntion foo() with var args, its signature is:
+                //
+                //    foo(x1, x2, ..., xn, params y)
+                //
+                // so paramCount == n + 1 here, and suppose inputs are
+                //
+                //        i1, i2, ...., in, y1, y2, ..., ym
+                //
+                // Here we pack all var arguments in an array {y1, y2, ..., ym}
+                // (skipping the first n == paramCount - 1 inputs)
                 var argPack = AstFactory.BuildExprList(inputAstNodes.Skip(paramCount - 1).ToList()); 
                 inputAstNodes = inputAstNodes.Take(paramCount - 1).ToList();
                 inputAstNodes.Add(argPack);

--- a/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
@@ -117,7 +117,7 @@ namespace Dynamo.Nodes
             if (!model.IsPartiallyApplied)
             {
                 var paramCount = Definition.Parameters.Count();
-                var packId = "__var_arg_pack_" + model.GUID;
+                var packId = "__var_arg_pack_" + model.GUID.ToString().Replace("-", string.Empty);
                 resultAst.Add(
                     AstFactory.BuildAssignment(
                         AstFactory.BuildIdentifier(packId),

--- a/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
@@ -117,16 +117,9 @@ namespace Dynamo.Nodes
             if (!model.IsPartiallyApplied)
             {
                 var paramCount = Definition.Parameters.Count();
-                var packId = "__var_arg_pack_" + model.GUID.ToString().Replace("-", string.Empty);
-                resultAst.Add(
-                    AstFactory.BuildAssignment(
-                        AstFactory.BuildIdentifier(packId),
-                        AstFactory.BuildExprList(inputAstNodes.Skip(paramCount - 1).ToList())));
-
-                inputAstNodes =
-                    inputAstNodes.Take(paramCount - 1)
-                        .Concat(new[] { AstFactory.BuildIdentifier(packId) })
-                        .ToList();
+                var argPack = AstFactory.BuildExprList(inputAstNodes.Skip(paramCount - 1).ToList()); 
+                inputAstNodes = inputAstNodes.Take(paramCount - 1).ToList();
+                inputAstNodes.Add(argPack);
             }
 
             base.BuildOutputAst(model, inputAstNodes, resultAst);

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1032,6 +1032,23 @@ namespace Dynamo.Tests
             Assert.IsTrue(cbn.Code.Contains(@"D:\\foo\\bar"));
         }
 
+        [Test]
+        public void TestNodeWithVarArgument()
+        {
+            OpenModel(@"core\node2code\splitstring.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+            SelectAll(nodes);
+
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+            CurrentDynamoModel.ForceRun();
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+
+            var guid = cbn.GUID.ToString();
+            AssertPreviewValue(guid, new[] { "foo", "bar", "qux" });
+        }
 
         private void SelectAll(IEnumerable<NodeModel> nodes)
         {

--- a/test/core/node2code/splitstring.dyn
+++ b/test/core/node2code/splitstring.dyn
@@ -1,0 +1,19 @@
+<Workspace Version="0.8.2.1957" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="11d59acc-86b0-42c5-852e-df9b4be72f46" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="390" y="428" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="&quot;,&quot;;&#xA;&quot;.&quot;;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSVarArgFunction guid="0e3566f6-e230-4892-ab34-5cfacffd9b3b" type="Dynamo.Nodes.DSVarArgFunction" nickname="String.Split" x="608.5" y="339" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="DSCoreNodes.dll" function="DSCore.String.Split@string,string[]" inputcount="3" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="f1ca8d01-029d-45b1-afc2-4ada1e92791e" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="382" y="330" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="&quot;foo,bar.qux&quot;;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="11d59acc-86b0-42c5-852e-df9b4be72f46" start_index="0" end="0e3566f6-e230-4892-ab34-5cfacffd9b3b" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="11d59acc-86b0-42c5-852e-df9b4be72f46" start_index="1" end="0e3566f6-e230-4892-ab34-5cfacffd9b3b" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="f1ca8d01-029d-45b1-afc2-4ada1e92791e" start_index="0" end="0e3566f6-e230-4892-ab34-5cfacffd9b3b" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="background_preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR is to fix [node to code issue](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7887#) for `String.Split` node (and all nodes with variable inputs).

It is because the temporary variable that created in `String.Split` node has some invalid character "-" so that the parser rejects it after node to code. We could safely remove this temporary variable. That is, previously we generate
```
__var_arg_pack_ = {input1, input2, ..., inputN};
var_guid = String.Split(inputS, __var_arg_pack);
```
Now we generate
```
var_guid = String.Split(inputS, {input1, input2, ..., inputN});
```

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 
