### PR TITLE
Added fallback mechanism to look for ASM

### DIFF
--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -58,6 +58,22 @@ namespace DynamoShapeManager
                         return (LibraryVersion)install.Value.Item1;
                     }
                 }
+
+                //Fallback mechanism, look inside libg folders if any of them
+                //contain ASM dlls.
+                var rootDir = new DirectoryInfo(rootFolder);
+                var dirs = rootDir.GetDirectories("libg_*");
+                foreach (var dir in dirs)
+                {
+                    var files = dir.GetFiles("ASMAHL*.dll");
+                    if (files.Any())
+                    {
+                        location = dir.FullName;
+                        return
+                            versions.FirstOrDefault(
+                                v => dir.Name.Equals(string.Format("libg_{0}", (int)v)));
+                    }
+                }                
             }
             catch (Exception)
             {

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -61,18 +61,19 @@ namespace DynamoShapeManager
 
                 //Fallback mechanism, look inside libg folders if any of them
                 //contain ASM dlls.
-                var rootDir = new DirectoryInfo(rootFolder);
-                var dirs = rootDir.GetDirectories("libg_*");
-                foreach (var dir in dirs)
+                foreach (var v in versions)
                 {
+                    var folderName = string.Format("libg_{0}", (int)v);
+                    var dir = new DirectoryInfo(Path.Combine(rootFolder, folderName));
+                    if (!dir.Exists)
+                        continue;
+
                     var files = dir.GetFiles("ASMAHL*.dll");
-                    if (files.Any())
-                    {
-                        location = dir.FullName;
-                        return
-                            versions.FirstOrDefault(
-                                v => dir.Name.Equals(string.Format("libg_{0}", (int)v)));
-                    }
+                    if (!files.Any())
+                        continue;
+
+                    location = dir.FullName;
+                    return v; // Found version.
                 }                
             }
             catch (Exception)


### PR DESCRIPTION
### Purpose
- Test were failing on DS because it was not able to find ASM, so Sharad has added fallback mechanism. (This is required for running test on INSTALLED version of DS or Dynamo)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin .

### FYIs

@sharadkjaiswal 
