### PR TITLE
Fixed a crash in DynamoFolderBrowserDialog

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoOpenFileDialog.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoOpenFileDialog.cs
@@ -114,8 +114,16 @@ namespace Dynamo.UI
         public DialogResult ShowDialog()
         {
             NativeFileOpenDialog dialog = null;
+
             try
             {
+                // If the caller did not specify a starting path, or set it to null,
+                // it is not healthy as it causes SHCreateItemFromParsingName to 
+                // throw E_INVALIDARG (0x80070057). Setting it to an empty string.
+                // 
+                if (SelectedPath == null)
+                    SelectedPath = string.Empty;
+
                 dialog = new NativeFileOpenDialog();
 
                 dialog.SetTitle(Title);


### PR DESCRIPTION
### Purpose

@kronz found that when clicking on the `+` sign on `Manage Nodes and Packages Paths` dialog, it crashes. This is because `SelectedPath` is set to `null` before it was passed to  `SHCreateItemFromParsingName` method, causing it to return `E_INVALIDARG 0x80070057` and throw an exception. For a fix, the value of `SelectedPath` is validated right before the call, if the caller specifies a `null` value, it is set to `string.Empty` instead.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@nguyen-binh-minh please take a look.

### FYIs

@riteshchandawar