### PR TITLE
Not to replace property name in node to code

### DIFF
--- a/src/DynamoCore/DSEngine/NodeToCode.cs
+++ b/src/DynamoCore/DSEngine/NodeToCode.cs
@@ -152,17 +152,23 @@ namespace Dynamo.DSEngine
 
             public override void VisitIdentifierListNode(IdentifierListNode node)
             {
-                if ((node.LeftNode is IdentifierNode ||
-                    node.LeftNode is IdentifierListNode) &&
-                    node.RightNode is FunctionCallNode)
+                if (node.LeftNode is IdentifierNode || node.LeftNode is IdentifierListNode)
                 {
-                    var lhs = node.LeftNode.ToString();
-                    if (core.ClassTable.IndexOf(lhs) < 0)
+                    if (node.RightNode is FunctionCallNode)
+                    {
+                        var lhs = node.LeftNode.ToString();
+                        if (core.ClassTable.IndexOf(lhs) < 0)
+                        {
+                            node.LeftNode.Accept(this);
+                        }
+                        node.RightNode.Accept(this);
+                        return;
+                    }
+                    else if (node.RightNode is IdentifierNode)
                     {
                         node.LeftNode.Accept(this);
+                        return;
                     }
-                    node.RightNode.Accept(this);
-                    return;
                 }
                 base.VisitIdentifierListNode(node);
             }

--- a/src/DynamoCore/DSEngine/NodeToCode.cs
+++ b/src/DynamoCore/DSEngine/NodeToCode.cs
@@ -154,19 +154,17 @@ namespace Dynamo.DSEngine
             {
                 if (node.LeftNode is IdentifierNode || node.LeftNode is IdentifierListNode)
                 {
-                    if (node.RightNode is FunctionCallNode)
+                    if (node.RightNode is FunctionCallNode || node.RightNode is IdentifierNode)
                     {
                         var lhs = node.LeftNode.ToString();
                         if (core.ClassTable.IndexOf(lhs) < 0)
                         {
                             node.LeftNode.Accept(this);
                         }
-                        node.RightNode.Accept(this);
-                        return;
-                    }
-                    else if (node.RightNode is IdentifierNode)
-                    {
-                        node.LeftNode.Accept(this);
+
+                        if (!(node.RightNode is IdentifierNode))
+                            node.RightNode.Accept(this);
+
                         return;
                     }
                 }

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -819,14 +819,7 @@ namespace Dynamo.Tests
         [Test]
         public void TestPropertyWontBeReplaced1()
         {
-            /*
-            string libraryPath = "FFITarget.dll";
-            if (!CurrentDynamoModel.LibraryServices.IsLibraryLoaded(libraryPath))
-            {
-                CurrentDynamoModel.LibraryServices.ImportLibrary(libraryPath);
-            }
-            */
-
+            // Point.X; Point.X;
             OpenModel(@"core\node2code\property.dyn");
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
             var engine = CurrentDynamoModel.EngineController;
@@ -839,6 +832,29 @@ namespace Dynamo.Tests
             var rhs = result.AstNodes.Skip(1).Select(b => (b as BinaryExpressionNode).RightNode.ToString().EndsWith(".X"));
             Assert.IsTrue(rhs.All(r => r));
         }
+
+        [Test]
+        public void TestPropertyWontBeReplaced2()
+        {
+            string libraryPath = "FFITarget.dll";
+            if (!CurrentDynamoModel.LibraryServices.IsLibraryLoaded(libraryPath))
+            {
+                CurrentDynamoModel.LibraryServices.ImportLibrary(libraryPath);
+            }
+
+            OpenModel(@"core\node2code\staticproperty.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+            var engine = CurrentDynamoModel.EngineController;
+
+            var result = engine.ConvertNodesToCode(nodes, nodes);
+            result = NodeToCodeUtils.ConstantPropagationForTemp(result, Enumerable.Empty<string>());
+            NodeToCodeUtils.ReplaceWithShortestQualifiedName(engine.LibraryServices.LibraryManagementCore.ClassTable, result.AstNodes);
+            Assert.IsTrue(result != null && result.AstNodes != null);
+
+            var rhs = result.AstNodes.Skip(1).Select(b => (b as BinaryExpressionNode).RightNode.ToString().EndsWith("ElementResolverTarget.StaticProperty"));
+            Assert.IsTrue(rhs.All(r => r));
+        }
+ 
 
         private void TestNodeToCodeUndoBase(string filePath)
         {

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -816,6 +816,30 @@ namespace Dynamo.Tests
             Assert.AreEqual("Autodesk.Point.ByCoordinates(t1, 0)", expr.RightNode.ToString());
         }
 
+        [Test]
+        public void TestPropertyWontBeReplaced1()
+        {
+            /*
+            string libraryPath = "FFITarget.dll";
+            if (!CurrentDynamoModel.LibraryServices.IsLibraryLoaded(libraryPath))
+            {
+                CurrentDynamoModel.LibraryServices.ImportLibrary(libraryPath);
+            }
+            */
+
+            OpenModel(@"core\node2code\property.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+            var engine = CurrentDynamoModel.EngineController;
+
+            var result = engine.ConvertNodesToCode(nodes, nodes);
+            result = NodeToCodeUtils.ConstantPropagationForTemp(result, Enumerable.Empty<string>());
+            NodeToCodeUtils.ReplaceWithShortestQualifiedName(engine.LibraryServices.LibraryManagementCore.ClassTable, result.AstNodes);
+            Assert.IsTrue(result != null && result.AstNodes != null);
+
+            var rhs = result.AstNodes.Skip(1).Select(b => (b as BinaryExpressionNode).RightNode.ToString().EndsWith(".X"));
+            Assert.IsTrue(rhs.All(r => r));
+        }
+
         private void TestNodeToCodeUndoBase(string filePath)
         {
             // Verify after undo all nodes and connectors should be resotored back

--- a/test/core/node2code/property.dyn
+++ b/test/core/node2code/property.dyn
@@ -1,0 +1,22 @@
+<Workspace Version="0.8.2.1957" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="3264fb12-f32c-41fd-b12f-65df8a8c3a8c" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="608.5" y="339" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="8c169e2d-c859-4f07-8454-eebe2a6cd1a2" type="Dynamo.Nodes.DSFunction" nickname="Point.X" x="787.5" y="271" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.X" />
+    <Dynamo.Nodes.DSFunction guid="601353b4-9c1a-47af-80b3-2ca50124e211" type="Dynamo.Nodes.DSFunction" nickname="Point.X" x="797.5" y="392" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.X" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="3264fb12-f32c-41fd-b12f-65df8a8c3a8c" start_index="0" end="8c169e2d-c859-4f07-8454-eebe2a6cd1a2" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="3264fb12-f32c-41fd-b12f-65df8a8c3a8c" start_index="0" end="601353b4-9c1a-47af-80b3-2ca50124e211" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="background_preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" />
+  </Cameras>
+</Workspace>

--- a/test/core/node2code/staticproperty.dyn
+++ b/test/core/node2code/staticproperty.dyn
@@ -1,0 +1,16 @@
+<Workspace Version="0.8.2.1957" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="ElementResolverTarget.StaticProperty" resolvedName="FFITarget.ElementResolverTarget" assemblyName="FFITarget.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="2a5a771b-b1b8-4d0e-b1d8-973e0768de1e" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="141" y="238" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="ElementResolverTarget.StaticProperty;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="5cdb4097-b8d2-4739-84b3-462a42dd5398" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="146" y="122" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="ElementResolverTarget.StaticProperty;" ShouldFocus="false" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="background_preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR is to fix defect that [property is renamed in node to code](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7984). It is a defect in `NodeToCodeUtil.IdentifierVisitor` which doesn't consider the case of property, so it renumbers all identifiers including properties. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@aparajit-pratap PTAL.