### PR TITLE
Fix the defect of outport in node 'Select Model Element'

### DIFF
--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -103,7 +103,9 @@ namespace Dynamo.Nodes
             this.selectionType = selectionType;
             this.selectionObjectType = selectionObjectType;
 
-            OutPortData.Add(new PortData("Elements", Resources.SelectionPortDataResultToolTip));       
+            string portName = (selectionType == SelectionType.One )? "Element" : "Elements";
+            OutPortData.Add(new PortData(portName, Resources.SelectionPortDataResultToolTip));
+
             RegisterAllPorts();
 
             Prefix = prefix;


### PR DESCRIPTION
### Purpose
Fix the defect of outport in node 'Select Model element';
Previously it was "Elements", but we need to change it to "Element" due to only one element selected.
[MAGN-7861](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7861)


![element](https://cloud.githubusercontent.com/assets/10494236/8898711/04ace772-345c-11e5-9638-81b623170b08.PNG)

### Reviewer
@ke-yu 
