### PR TITLE
Fix undo crash in node to code

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -112,14 +112,19 @@ namespace Dynamo.Core.Threading
             // Comparing to another UpdateGraphAsyncTask, verify 
             // that they are updating a similar set of nodes.
 
+            var deletedNodes = graphSyncData.DeletedSubtrees ?? Enumerable.Empty<Subtree>();
+            var otherDeletedNodes = theOtherTask.graphSyncData.DeletedSubtrees ?? Enumerable.Empty<Subtree>();
+
             // Other node is either equal or a superset of this task
-            if (ModifiedNodes.All(x => theOtherTask.ModifiedNodes.Contains(x)))
+            if (ModifiedNodes.All(theOtherTask.ModifiedNodes.Contains) &&
+                deletedNodes.All(otherDeletedNodes.Contains))
             {
                 return TaskMergeInstruction.KeepOther;
             }
 
             // This node is a superset of the other
-            if (theOtherTask.ModifiedNodes.All(x => ModifiedNodes.Contains(x)))
+            if (theOtherTask.ModifiedNodes.All(ModifiedNodes.Contains) &&
+                otherDeletedNodes.All(deletedNodes.Contains))
             {
                 return TaskMergeInstruction.KeepThis;
             }

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1250,7 +1250,7 @@ namespace Dynamo.Models
                         totalY += node.Y;
                         undoHelper.RecordDeletion(node);
                         RemoveNode(node);
-                        #endregion 
+                        #endregion
                     }
                     #endregion
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1250,7 +1250,8 @@ namespace Dynamo.Models
                         totalY += node.Y;
                         undoHelper.RecordDeletion(node);
                         RemoveNode(node);
-                        #endregion
+                        RequestRun();
+                        #endregion 
                     }
                     #endregion
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1250,7 +1250,6 @@ namespace Dynamo.Models
                         totalY += node.Y;
                         undoHelper.RecordDeletion(node);
                         RemoveNode(node);
-                        RequestRun();
                         #endregion 
                     }
                     #endregion

--- a/test/core/node2code/undo/regress7864.dyn
+++ b/test/core/node2code/undo/regress7864.dyn
@@ -1,0 +1,24 @@
+<Workspace Version="0.8.2.1957" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.Watch guid="0232ef07-34fe-48e0-b1a9-416bad23668d" type="Dynamo.Nodes.Watch" nickname="Watch" x="994.5" y="275" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" />
+    <Dynamo.Nodes.DSFunction guid="56a68a08-02d9-404e-bdbb-58221d61b7cb" type="Dynamo.Nodes.DSFunction" nickname="+" x="733.5" y="295" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="Operators" function="+@var[]..[],var[]..[]" />
+    <Dynamo.Nodes.DoubleInput guid="d3ddfacc-40c3-47f0-b667-237238493cb1" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="545.5" y="381" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
+      <System.Double value="0" />
+    </Dynamo.Nodes.DoubleInput>
+    <Dynamo.Nodes.DoubleInput guid="a1e51e64-9e02-4ae4-bc70-45ba6330913f" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="528.5" y="277" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
+      <System.Double value="1" />
+    </Dynamo.Nodes.DoubleInput>
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="56a68a08-02d9-404e-bdbb-58221d61b7cb" start_index="0" end="0232ef07-34fe-48e0-b1a9-416bad23668d" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d3ddfacc-40c3-47f0-b667-237238493cb1" start_index="0" end="56a68a08-02d9-404e-bdbb-58221d61b7cb" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="a1e51e64-9e02-4ae4-bc70-45ba6330913f" start_index="0" end="56a68a08-02d9-404e-bdbb-58221d61b7cb" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="background_preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR is to fix [undo crash in node to code](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7864#).

During node to code, connectors and nodes will be deleted and a series of `UpdateGraphAsyncTask` will be scheduled to task queue. But when task queue is processing task, it may cancel one `UpdateGraphAsyncTask` if one is the subset of the other one by only comparing modified node models in two tasks. So if the previous one contains node deletions, node deletions won't get executed in LiveRunner. 

This PR checks deleted nodes as well. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 