### PR TITLE
bug re-size setting dialog's height to zero

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -19,6 +19,7 @@
              IsHitTestVisible="{Binding IsCurrentSpace}"
              AllowDrop="True"
              Drop="OnWorkspaceDrop">
+
     <UserControl.Resources>
         <Style TargetType="{x:Type ContextMenu}"
                x:Key="WorkspaceContextMenuStyle">
@@ -78,7 +79,7 @@
                 </Setter.Value>
             </Setter>
             <EventSetter Event="Opened"
-                         Handler="OnContextMenuOpened"/>
+                         Handler="OnContextMenuOpened" />
             <EventSetter Event="PreviewKeyDown"
                          Handler="OnInCanvasSearchContextMenuKeyDown" />
             <EventSetter Event="PreviewMouseUp"
@@ -202,18 +203,17 @@
                         </MenuItem>
                     </MenuItem>
 
-
                     <MenuItem IsEnabled="{Binding Path=HasSelection}"
                               Header="{x:Static  p:Resources.ContextMenuShowAllGeometry}"
                               Command="{Binding Path=ShowHideAllGeometryPreviewCommand}"
                               CommandParameter="true"
-                              Visibility="{Binding Path=AnyNodeVisible, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}"/>
+                              Visibility="{Binding Path=AnyNodeVisible, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
 
                     <MenuItem IsEnabled="{Binding Path=HasSelection}"
                               Header="{x:Static p:Resources.ContextMenuHideAllGeometry}"
                               Command="{Binding Path=ShowHideAllGeometryPreviewCommand}"
                               CommandParameter="false"
-                              Visibility="{Binding Path=AnyNodeVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"/>
+                              Visibility="{Binding Path=AnyNodeVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
                     <MenuItem IsEnabled="{Binding Path=HasSelection}"
                               Header="{x:Static  p:Resources.ContextMenuShowUpstreamPreview}"
@@ -259,15 +259,15 @@
                                Command="{Binding NodeFromSelectionCommand}" />
 
                     <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuCreatePreset}"
-                              Command="{Binding DynamoViewModel.ShowNewPresetsDialogCommand}" />
+                               Command="{Binding DynamoViewModel.ShowNewPresetsDialogCommand}" />
 
                     <MenuItem  Header="{x:Static p:Resources.ContextMenuNodeToCode}"
-                               Command="{Binding NodeToCodeCommand}" 
-                               Visibility="{Binding Path=CanRunNodeToCode, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"/>
+                               Command="{Binding NodeToCodeCommand}"
+                               Visibility="{Binding Path=CanRunNodeToCode, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
-                    <MenuItem  Header="{x:Static p:Resources.ContextCreateGroupFromSelection}"                                 
+                    <MenuItem  Header="{x:Static p:Resources.ContextCreateGroupFromSelection}"
                                Command="{Binding DynamoViewModel.AddAnnotationCommand}" />
-                    
+
                     <MenuItem  Header="{x:Static p:Resources.ContextMenuNodesFromGeometry}"
                                Visibility="{Binding Path=CanFindNodesFromElements, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
                                Command="{Binding FindNodesFromSelectionCommand}" />
@@ -381,8 +381,7 @@
                               Margin="4,4,0,4"
                               StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-geom-states.png"
                               CheckImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-geom-check.png"
-                              ToolTip="{x:Static p:Resources.InCanvasGeomButtonToolTip}"
-                              >
+                              ToolTip="{x:Static p:Resources.InCanvasGeomButtonToolTip}">
                 <ui:ImageCheckBox.IsChecked>
                     <Binding Path="DataContext.CanNavigateBackground"
                              RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />

--- a/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml
@@ -12,7 +12,7 @@
         Height="450"
         Width="550"
         MinWidth="550"
-        MaxWidth="550"
+        MinHeight="450"
         d:DesignHeight="300"
         d:DesignWidth="300"
         Background="#515151"


### PR DESCRIPTION
### Purpose

- Specify minimum height so that user can't resize the dialog height to zero.
Tracking task: (MAGN-8003)[http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8003]

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 