### PR TITLE
Basic resurrection of the mutation tester

### DIFF
--- a/src/DynamoCoreWpf/TestInfrastructure/AbstractMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/AbstractMutator.cs
@@ -3,6 +3,7 @@ using Dynamo.ViewModels;
 using System;
 using System.IO;
 using Dynamo.DSEngine;
+using System.Threading;
 
 namespace Dynamo.TestInfrastructure
 {
@@ -33,9 +34,37 @@ namespace Dynamo.TestInfrastructure
             return typeof(NodeModel);
         }
 
+        /// <summary>
+        /// Number of times to repeat a specific mutation
+        /// </summary>
         public virtual int NumberOfLaunches
         {
-            get { return 1000; }
+            get { return 10; }
+        }
+
+
+
+
+        // TODO(lukechurch): Move this to a support class
+        protected void ExecuteAndWait()
+        {
+            DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
+            {
+                DynamoModel.RunCancelCommand runCancel =
+                    new DynamoModel.RunCancelCommand(false, false);
+                DynamoViewModel.ExecuteCommand(runCancel);
+            }));
+
+            SpinWaitForExecution();
+        }
+
+        // TODO(lukechurch): Move this to use event waiting rather than spin waiting
+        protected void SpinWaitForExecution()
+        {
+            while (!DynamoViewModel.HomeSpace.RunSettings.RunEnabled)
+            {
+                Thread.Sleep(10);
+            }
         }
     }
 }

--- a/src/DynamoCoreWpf/TestInfrastructure/CodeBlockNodeMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/CodeBlockNodeMutator.cs
@@ -47,7 +47,7 @@ namespace Dynamo.TestInfrastructure
             writer.WriteLine("### - Deletion target: " + node.GUID);
 
             int numberOfUndosNeeded = Mutate(node);
-            Thread.Sleep(100);
+            Thread.Sleep(0);
 
             writer.WriteLine("### - delete complete");
             writer.Flush();
@@ -61,7 +61,7 @@ namespace Dynamo.TestInfrastructure
 
                 DynamoViewModel.ExecuteCommand(runCancel);
             }));
-            Thread.Sleep(100);
+            Thread.Sleep(0);
 
             writer.WriteLine("### - re-exec complete");
             writer.Flush();
@@ -79,25 +79,14 @@ namespace Dynamo.TestInfrastructure
                     DynamoViewModel.ExecuteCommand(undoCommand);
                 }));
             }
-            Thread.Sleep(100);
+            Thread.Sleep(0);
 
             writer.WriteLine("### - undo complete");
             writer.Flush();
 
             writer.WriteLine("### - Beginning re-exec");
 
-            DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
-            {
-                DynamoModel.RunCancelCommand runCancel =
-                    new DynamoModel.RunCancelCommand(false, false);
-
-                DynamoViewModel.ExecuteCommand(runCancel);
-            }));
-            Thread.Sleep(10);
-            while (!DynamoViewModel.HomeSpace.RunSettings.RunEnabled)
-            {
-                Thread.Sleep(10);
-            }
+            ExecuteAndWait();
 
             writer.WriteLine("### - re-exec complete");
             writer.Flush();

--- a/src/DynamoCoreWpf/TestInfrastructure/ConnectorMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/ConnectorMutator.cs
@@ -55,7 +55,7 @@ namespace Dynamo.TestInfrastructure
 
             int numberOfUndosNeeded = Mutate(node);
 
-            Thread.Sleep(100);
+            Thread.Sleep(0);
 
             IEnumerable<NodeModel> nodesAfterMutate = DynamoViewModel.Model.CurrentWorkspace.Nodes;
 
@@ -79,7 +79,7 @@ namespace Dynamo.TestInfrastructure
                     DynamoViewModel.ExecuteCommand(undoCommand);
                 }));
             }
-            Thread.Sleep(100);
+            Thread.Sleep(0);
 
             IEnumerable<NodeModel> nodesAfterUndo = DynamoViewModel.Model.CurrentWorkspace.Nodes;
 

--- a/src/DynamoCoreWpf/TestInfrastructure/CopyNodeMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/CopyNodeMutator.cs
@@ -30,7 +30,7 @@ namespace Dynamo.TestInfrastructure
             int nodesCountBeforeCopying = nodes.Count();
 
             int numberOfUndosNeeded = this.Mutate(node);
-            Thread.Sleep(100);
+            Thread.Sleep(10);
 
             writer.WriteLine("### - Beginning undo");
             for (int iUndo = 0; iUndo < numberOfUndosNeeded; iUndo++)
@@ -42,21 +42,12 @@ namespace Dynamo.TestInfrastructure
                     DynamoViewModel.ExecuteCommand(undoCommand);
 
                 }));
-                Thread.Sleep(100);
+                Thread.Sleep(0);
             }
             writer.WriteLine("### - undo complete");
             writer.Flush();
 
-            DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
-            {
-                DynamoModel.RunCancelCommand runCancel =
-                    new DynamoModel.RunCancelCommand(false, false);
-                DynamoViewModel.ExecuteCommand(runCancel);
-            }));
-            while (!DynamoViewModel.HomeSpace.RunSettings.RunEnabled)
-            {
-                Thread.Sleep(10);
-            }
+            ExecuteAndWait();
 
             writer.WriteLine("### - Beginning test of CopyNode");
             if (node.OutPorts.Count > 0)

--- a/src/DynamoCoreWpf/TestInfrastructure/DeleteNodeMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/DeleteNodeMutator.cs
@@ -26,7 +26,7 @@ namespace Dynamo.TestInfrastructure
 
             var nodes = DynamoViewModel.Model.CurrentWorkspace.Nodes;
             if (nodes.Count() == 0)
-                return pass;
+                return true;
 
             int nodesCountBeforeDelete = nodes.Count();
 
@@ -37,7 +37,7 @@ namespace Dynamo.TestInfrastructure
 
             int numberOfUndosNeeded = Mutate(node);
 
-            Thread.Sleep(100);
+            Thread.Sleep(0);
 
             writer.WriteLine("### - delete complete");
             writer.Flush();
@@ -51,7 +51,7 @@ namespace Dynamo.TestInfrastructure
 
                 DynamoViewModel.ExecuteCommand(runCancel);
             }));
-            Thread.Sleep(100);
+            Thread.Sleep(0);
 
             writer.WriteLine("### - re-exec complete");
             writer.Flush();
@@ -72,25 +72,14 @@ namespace Dynamo.TestInfrastructure
 
                         DynamoViewModel.ExecuteCommand(undoCommand);
                     }));
-                    Thread.Sleep(100);
+                    Thread.Sleep(0);
                 }
                 writer.WriteLine("### - undo complete");
                 writer.Flush();
 
                 writer.WriteLine("### - Beginning re-exec");
 
-                DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
-                {
-                    DynamoModel.RunCancelCommand runCancel =
-                        new DynamoModel.RunCancelCommand(false, false);
-
-                    DynamoViewModel.ExecuteCommand(runCancel);
-                }));
-                Thread.Sleep(10);
-                while (!DynamoViewModel.HomeSpace.RunSettings.RunEnabled)
-                {
-                    Thread.Sleep(10);
-                }
+                ExecuteAndWait();
                 writer.WriteLine("### - re-exec complete");
                 writer.Flush();
 

--- a/src/DynamoCoreWpf/TestInfrastructure/DirectoryPathMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/DirectoryPathMutator.cs
@@ -64,18 +64,7 @@ namespace Dynamo.TestInfrastructure
             writer.Flush();
             writer.WriteLine("### - Beginning re-exec");
 
-            DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
-            {
-                DynamoModel.RunCancelCommand runCancel =
-                    new DynamoModel.RunCancelCommand(false, false);
-
-                DynamoViewModel.ExecuteCommand(runCancel);
-            }));
-            Thread.Sleep(10);
-            while (!DynamoViewModel.HomeSpace.RunSettings.RunEnabled)
-            {
-                Thread.Sleep(10);
-            }
+            ExecuteAndWait();
             writer.WriteLine("### - re-exec complete");
             writer.Flush();
 

--- a/src/DynamoCoreWpf/TestInfrastructure/DoubleSliderMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/DoubleSliderMutator.cs
@@ -44,7 +44,7 @@ namespace Dynamo.TestInfrastructure
             }
 
             int numberOfUndosNeeded = Mutate(node);
-            Thread.Sleep(100);
+            Thread.Sleep(10);
 
             writer.WriteLine("### - Beginning undo");
             for (int iUndo = 0; iUndo < numberOfUndosNeeded; iUndo++)
@@ -57,7 +57,7 @@ namespace Dynamo.TestInfrastructure
 
                     DynamoViewModel.ExecuteCommand(undoCommand);
                 }));
-                Thread.Sleep(100);
+                Thread.Sleep(10);
             }
             writer.WriteLine("### - undo complete");
             writer.Flush();
@@ -66,19 +66,7 @@ namespace Dynamo.TestInfrastructure
             writer.Flush();
             writer.WriteLine("### - Beginning re-exec");
 
-            DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
-            {
-                DynamoModel.RunCancelCommand runCancel =
-                    new DynamoModel.RunCancelCommand(false, false);
-
-                DynamoViewModel.ExecuteCommand(runCancel);
-            }));
-            Thread.Sleep(10);
-
-            while (!DynamoViewModel.HomeSpace.RunSettings.RunEnabled)
-            {
-                Thread.Sleep(10);
-            }
+            ExecuteAndWait();
             writer.WriteLine("### - re-exec complete");
             writer.Flush();
             writer.WriteLine("### - Beginning readback");

--- a/src/DynamoCoreWpf/TestInfrastructure/FilePathMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/FilePathMutator.cs
@@ -44,7 +44,7 @@ namespace Dynamo.TestInfrastructure
             }
 
             int numberOfUndosNeeded = Mutate(node);
-            Thread.Sleep(100);
+            Thread.Sleep(10);
 
             writer.WriteLine("### - Beginning undo");
             for (int iUndo = 0; iUndo < numberOfUndosNeeded; iUndo++)
@@ -63,18 +63,7 @@ namespace Dynamo.TestInfrastructure
             writer.Flush();
             writer.WriteLine("### - Beginning re-exec");
 
-            DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
-            {
-                DynamoModel.RunCancelCommand runCancel =
-                    new DynamoModel.RunCancelCommand(false, false);
-
-                DynamoViewModel.ExecuteCommand(runCancel);
-            }));
-            Thread.Sleep(10);
-            while (!DynamoViewModel.HomeSpace.RunSettings.RunEnabled)
-            {
-                Thread.Sleep(10);
-            }
+            ExecuteAndWait();
 
             writer.WriteLine("### - re-exec complete");
             writer.Flush();

--- a/src/DynamoCoreWpf/TestInfrastructure/IntegerSliderMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/IntegerSliderMutator.cs
@@ -58,26 +58,14 @@ namespace Dynamo.TestInfrastructure
 
                     DynamoViewModel.ExecuteCommand(undoCommand);
                 }));
-                Thread.Sleep(100);
+                Thread.Sleep(10);
             }
             writer.WriteLine("### - undo complete");
             writer.Flush();
 
             writer.WriteLine("### - Beginning re-exec");
 
-            DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
-            {
-                DynamoModel.RunCancelCommand runCancel =
-                    new DynamoModel.RunCancelCommand(false, false);
-
-                DynamoViewModel.ExecuteCommand(runCancel);
-            }));
-            Thread.Sleep(10);
-            while (!DynamoViewModel.HomeSpace.RunSettings.RunEnabled)
-            {
-                Thread.Sleep(10);
-            }
-
+            ExecuteAndWait();
             writer.WriteLine("### - re-exec complete");
             writer.Flush();
 

--- a/src/DynamoCoreWpf/TestInfrastructure/ListMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/ListMutator.cs
@@ -55,7 +55,7 @@ namespace Dynamo.TestInfrastructure
             }
 
             int numberOfUndosNeeded = Mutate(node);
-            Thread.Sleep(100);
+            Thread.Sleep(10);
 
             writer.WriteLine("### - Beginning undo");
             for (int iUndo = 0; iUndo < numberOfUndosNeeded; iUndo++)
@@ -72,17 +72,7 @@ namespace Dynamo.TestInfrastructure
             writer.WriteLine("### - undo complete");
             writer.Flush();
 
-            DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
-            {
-                DynamoModel.RunCancelCommand runCancel =
-                    new DynamoModel.RunCancelCommand(false, false);
-
-                DynamoViewModel.ExecuteCommand(runCancel);
-            }));
-            while (!DynamoViewModel.HomeSpace.RunSettings.RunEnabled)
-            {
-                Thread.Sleep(10);
-            }
+            ExecuteAndWait();
 
             writer.WriteLine("### - Beginning test of List");
             if (node.OutPorts.Count > 0)

--- a/src/DynamoCoreWpf/TestInfrastructure/MutationTestAttribute.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/MutationTestAttribute.cs
@@ -3,7 +3,7 @@
 namespace Dynamo.TestInfrastructure
 {
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-    public class MutationTestAttribute : Attribute
+    internal class MutationTestAttribute : Attribute
     {
         private string caption;
 

--- a/src/DynamoCoreWpf/TestInfrastructure/MutatorDriver.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/MutatorDriver.cs
@@ -15,6 +15,11 @@ namespace Dynamo.TestInfrastructure
     /// </summary>
     public class MutatorDriver
     {
+        /// <summary>
+        /// Number of mutations to run
+        /// </summary>
+        private const int NUMBER_OF_CYCLES = 1000;
+
         private readonly DynamoViewModel dynamoViewModel;
 
         public MutatorDriver(DynamoViewModel dynamoViewModel)
@@ -34,6 +39,8 @@ namespace Dynamo.TestInfrastructure
 
             new Thread(() =>
             {
+                Random rand = new Random(1);
+
                 try
                 {
                     Assembly assembly = Assembly.GetExecutingAssembly();
@@ -51,8 +58,14 @@ namespace Dynamo.TestInfrastructure
                         }
                     }
 
-                    foreach (var mutator in mutators)
+                    System.Diagnostics.Debug.WriteLine("Mutators list: " + mutators.ToList());
+
+                    for (int cycleCounter = 0; cycleCounter < NUMBER_OF_CYCLES; cycleCounter++)
+                    {
+                        int mutatorIndex = rand.Next(0, mutators.Count);
+                        var mutator = mutators[mutatorIndex];
                         InvokeTest(mutator, writer);
+                    }
                 }
                 finally
                 {
@@ -79,10 +92,14 @@ namespace Dynamo.TestInfrastructure
 
             var nodes = dynamoViewModel.Model.CurrentWorkspace.Nodes.ToList();
             if (type != typeof(NodeModel))
-                nodes = dynamoViewModel.Model.CurrentWorkspace.Nodes.Where(t => t.GetType() == type).ToList();
+                nodes = nodes.Where(t => t.GetType() == type).ToList();
 
             if (nodes.Count == 0)
+            {
+                writer.WriteLine("No nodes for mutator: " + mutator.GetType());
                 return;
+
+            }
 
             try
             {

--- a/src/DynamoCoreWpf/TestInfrastructure/NumberRangeMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/NumberRangeMutator.cs
@@ -126,9 +126,6 @@ namespace Dynamo.TestInfrastructure
             {
                 Guid guidNumber = Guid.NewGuid();
 
-                double coordinatesX = 120;
-                double coordinatesY = 180;
-
                 DynamoModel.CreateNodeCommand createNodeCmd1 = null;
                     //new DynamoModel.AddNodeCommand(guidNumber, "Number", coordinatesX,
                     //    coordinatesY, false, true);

--- a/src/DynamoCoreWpf/TestInfrastructure/NumberSequenceMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/NumberSequenceMutator.cs
@@ -53,7 +53,7 @@ namespace Dynamo.TestInfrastructure
             }
 
             int numberOfUndosNeeded = Mutate(node);
-            Thread.Sleep(100);
+            Thread.Sleep(10);
 
             writer.WriteLine("### - Beginning undo");
             for (int iUndo = 0; iUndo < numberOfUndosNeeded; iUndo++)
@@ -65,23 +65,12 @@ namespace Dynamo.TestInfrastructure
 
                     DynamoViewModel.ExecuteCommand(undoCommand);
                 }));
-                Thread.Sleep(100);
+                Thread.Sleep(10);
             }
             writer.WriteLine("### - undo complete");
             writer.Flush();
 
-            DynamoViewModel.UIDispatcher.Invoke(new Action(() =>
-            {
-                DynamoModel.RunCancelCommand runCancel =
-                    new DynamoModel.RunCancelCommand(false, false);
-
-                DynamoViewModel.ExecuteCommand(runCancel);
-            }));
-            while (!DynamoViewModel.HomeSpace.RunSettings.RunEnabled)
-            {
-                Thread.Sleep(10);
-            }
-
+            ExecuteAndWait();
             writer.WriteLine("### - Beginning test of NumberSequence");
             if (node.OutPorts.Count > 0)
             {

--- a/src/DynamoCoreWpf/TestInfrastructure/StringInputMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/StringInputMutator.cs
@@ -52,7 +52,7 @@ namespace Dynamo.TestInfrastructure
 
                     DynamoViewModel.ExecuteCommand(undoCommand);
                 }));
-                Thread.Sleep(100);
+                Thread.Sleep(10);
             }
             writer.WriteLine("### - undo complete");
             writer.Flush();


### PR DESCRIPTION
### Purpose

This does some basic cleanup of the test infrastructure. It is by no means perfect, but is in a better place for bug discovery after these changes land. Running these tests for a few seconds results in bugs being discovered.

The primary changes are:

- Removal of a false positive caused if there were no 
- Tighten the timings up so that more mutations can run
- First set of refactorings to localise functionality 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

(FILL ME IN) @pboyer 
