### PR TITLE
Remove renderPackageFactoryAssembly from DynamoCore's App.config

### DIFF
--- a/src/DynamoCore/App.config
+++ b/src/DynamoCore/App.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="renderPackageFactoryAssembly" value="DynamoCoreWpf.dll"/>
   </appSettings>
 </configuration>


### PR DESCRIPTION
### Purpose

This isn't used, so I thought I'd remove it. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough
