### PR TITLE
MAGN-8013 Library ui freezes after first node selection

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.2.2075")]
+[assembly: AssemblyVersion("0.8.2.2096")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.2.2075")]
+[assembly: AssemblyFileVersion("0.8.2.2096")]

--- a/src/DynamoCoreWpf/Utilities/LibraryDragAndDrop.cs
+++ b/src/DynamoCoreWpf/Utilities/LibraryDragAndDrop.cs
@@ -29,7 +29,7 @@ namespace Dynamo.Wpf.Utilities
 
         internal void HandleMouseMove(FrameworkElement sender, Point currentPosition)
         {
-            if (isDragging)
+            if (isDragging || nodeViewModel == null)
                 return;
 
             // If item was dragged enough, then fire DoDragDrop. 
@@ -37,14 +37,12 @@ namespace Dynamo.Wpf.Utilities
             var deltaX = System.Math.Abs(currentPosition.X - startPosition.X);
             if (deltaX < SystemParameters.MinimumHorizontalDragDistance)
             {
-                isDragging = false;
-                return;
+               return;
             }
 
             var deltaY = System.Math.Abs(currentPosition.Y - startPosition.Y);
             if (deltaY < SystemParameters.MinimumVerticalDragDistance)
-            {
-                isDragging = false;
+            {                
                 return;
             }
 

--- a/src/DynamoCoreWpf/Utilities/LibraryDragAndDrop.cs
+++ b/src/DynamoCoreWpf/Utilities/LibraryDragAndDrop.cs
@@ -29,18 +29,24 @@ namespace Dynamo.Wpf.Utilities
 
         internal void HandleMouseMove(FrameworkElement sender, Point currentPosition)
         {
-            if (isDragging || nodeViewModel == null)
+            if (isDragging)
                 return;
 
             // If item was dragged enough, then fire DoDragDrop. 
             // Otherwise it means user click on item and there is no need to fire DoDragDrop.
             var deltaX = System.Math.Abs(currentPosition.X - startPosition.X);
             if (deltaX < SystemParameters.MinimumHorizontalDragDistance)
+            {
+                isDragging = false;
                 return;
+            }
 
             var deltaY = System.Math.Abs(currentPosition.Y - startPosition.Y);
             if (deltaY < SystemParameters.MinimumVerticalDragDistance)
+            {
+                isDragging = false;
                 return;
+            }
 
             StartDrag(sender, nodeViewModel);
 

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -308,7 +308,10 @@ namespace Dynamo.UI.Views
                 return;
 
             var senderButton = e.OriginalSource as FrameworkElement;
-            dragDropHelper.HandleMouseMove(senderButton, e.GetPosition(null));
+            var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
+            if (searchElementVM != null)
+                dragDropHelper.HandleMouseMove(senderButton, e.GetPosition(null)); 
+
         }
 
         #endregion

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -298,6 +298,8 @@ namespace Dynamo.UI.Views
             var senderButton = e.OriginalSource as FrameworkElement;
             var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
 
+            //sender can be RootSearchElementVM or ClassInformationViewModel. 
+            //And we should just fire HandleMouseLeftButtonDown, when ViewModel is NodeSearchElementViewModel
             if (searchElementVM != null)
                 dragDropHelper.HandleMouseDown(e.GetPosition(null), searchElementVM);
         }
@@ -309,6 +311,8 @@ namespace Dynamo.UI.Views
 
             var senderButton = e.OriginalSource as FrameworkElement;
             var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
+            //sender can be RootSearchElementVM or ClassInformationViewModel. 
+            //And we should just fire HandleMouseMove, when ViewModel is NodeSearchElementViewModel
             if (searchElementVM != null)
                 dragDropHelper.HandleMouseMove(senderButton, e.GetPosition(null)); 
 


### PR DESCRIPTION
### Purpose

This PR fixes the issue with Library UI freeze.  The main issue is with Drag and Drop of node elements. Every click on Node element is issued a drag operation, but the flag was not set correctly if it is not a drag operation. Updated the isDragging flag at places if it is not a drag operation.

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8013

### Declarations

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 
@pboyer 

FYI @aosyatnik 