### PR TITLE
Fix MAGN-5055 Navigation jumps to geometry mode after switching between windows

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -29,6 +29,7 @@
         AllowsTransparency="False"
         KeyDown="DynamoView_KeyDown"
         KeyUp="DynamoView_KeyUp"
+        LostFocus="DynamoView_LostFocus"
         Background="#FF353535"
         SnapsToDevicePixels="True"
         ResizeMode="CanResizeWithGrip"

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -963,7 +963,16 @@ namespace Dynamo.Controls
 
         void DynamoView_KeyUp(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Escape)
+            if (e.Key == Key.Escape && dynamoViewModel.WatchEscapeIsDown)
+            {
+                dynamoViewModel.WatchEscapeIsDown = false;
+                dynamoViewModel.EscapeCommand.Execute(null);
+            }
+        }
+
+        void DynamoView_LostFocus(object sender, EventArgs e)
+        {
+            if (dynamoViewModel.WatchEscapeIsDown)
             {
                 dynamoViewModel.WatchEscapeIsDown = false;
                 dynamoViewModel.EscapeCommand.Execute(null);


### PR DESCRIPTION
### Purpose

This is to Fix MAGN-5055. Normally if we press the ESC key, the application will get a key down event for the ESC key and WatchEscapeIsDown is modified to be true; and later we release the ESC key, the application will get a key up event and WatchEscapeIsDown is modified to be false. However if we press the ESC key when the Dynamo window is the active window, but then somehow change the active window by clicking the mouse and release the ESC key, the Dynamo window will not receive the key up event for the ESC key and hence will not set WatchEscapeIsDown to false. 

This submission fixes this issue by adding a new event handler: DynamoView_LostFocus. So when the active window is switched to other window and if WatchEscapeIsDown  is true, it will be set to false.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@Benglin PTAL
