### PR TITLE
Fix regression TestTaskQueuePreProcessing00

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -112,8 +112,12 @@ namespace Dynamo.Core.Threading
             // Comparing to another UpdateGraphAsyncTask, verify 
             // that they are updating a similar set of nodes.
 
-            if ((graphSyncData.DeletedSubtrees != null && graphSyncData.DeletedSubtrees.Any()) ||
-                (theOtherTask.graphSyncData.DeletedSubtrees != null && theOtherTask.graphSyncData.DeletedSubtrees.Any()))
+            if ((graphSyncData != null && 
+                graphSyncData.DeletedSubtrees != null && 
+                graphSyncData.DeletedSubtrees.Any()) ||
+                (theOtherTask.graphSyncData != null &&
+                 theOtherTask.graphSyncData.DeletedSubtrees != null && 
+                 theOtherTask.graphSyncData.DeletedSubtrees.Any()))
                 return TaskMergeInstruction.KeepBoth;
 
             // Other node is either equal or a superset of this task


### PR DESCRIPTION
### Purpose

Fix regression `TestTaskQueuePreProcessing00`. This is because the test case creates a derived class `FakeUpdateGraphAsyncTask` from `UpdateGrapyAsyncTask` but doesn't have any graph sync data, so null access exception is thrown out. 

Add null check in `UpdateGraphAsyncTask.CanMergeWithCore()`. 