### PR TITLE
Fixed failing CanSaveImage test case

### DIFF
--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -15,6 +15,7 @@ using Dynamo.Services;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using NUnit.Framework;
+using DynamoCoreWpfTests.Utility;
 
 namespace DynamoCoreWpfTests
 {
@@ -27,8 +28,14 @@ namespace DynamoCoreWpfTests
         [Category("DynamoUI")]
         public void CanSaveImage()
         {
-            string path = Path.Combine(TempFolder, "output.png");
+            // Save image command now requires the workspace to be not empty.
+            var testPath = GetTestDirectory(ExecutingDirectory);
+            var openPath = Path.Combine(testPath, @"core\nodeLocationTest.dyn");
 
+            OpenDynamoDefinition(openPath);
+            DispatcherUtil.DoEvents(); // Allows visual tree to be reconstructed.
+
+            string path = Path.Combine(TempFolder, "output.png");
             ViewModel.SaveImageCommand.Execute(path);
 
             Assert.True(File.Exists(path));


### PR DESCRIPTION
### Purpose

This pull request is meant to fix a failing `DynamoCoreWpfTests.CoreUserInterfaceTests.CanSaveImage` test case introduced by my previous pull request:

- [Revamped background grid implementation](https://github.com/DynamoDS/Dynamo/pull/5017)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

None, meant for fixing build issues.

### FYIs

@riteshchandawar, thanks for highlighting this to me.