### PR TITLE
Fix issue that Node to Code is still enabled when selection is empty

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -560,7 +560,7 @@ namespace Dynamo.ViewModels
 
         internal bool CanNodeToCode(object parameters)
         {
-            return DynamoSelection.Instance.Selection.Count > 0;
+            return DynamoSelection.Instance.Selection.OfType<NodeModel>().Any();
         }
 
         internal void SelectInRegion(Rect2D region, bool isCrossSelect)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -141,6 +141,7 @@ namespace Dynamo.Views
         {
             if (ViewModel == null) return;
             ViewModel.NodeFromSelectionCommand.RaiseCanExecuteChanged();
+            ViewModel.NodeToCodeCommand.RaiseCanExecuteChanged();
             ViewModel.DynamoViewModel.AddAnnotationCommand.RaiseCanExecuteChanged();
             ViewModel.DynamoViewModel.UngroupAnnotationCommand.RaiseCanExecuteChanged();
             ViewModel.DynamoViewModel.UngroupModelCommand.RaiseCanExecuteChanged();

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -85,6 +85,7 @@
       <Link>AssemblySharedInfo.cs</Link>
     </Compile>
     <Compile Include="DateTimeTests.cs" />
+    <Compile Include="NodeToCodeTests.cs" />
     <Compile Include="PresetPromptTests.cs" />
     <Compile Include="AnnotationViewModelTests.cs" />
     <Compile Include="AnnotationViewTests.cs" />

--- a/test/DynamoCoreWpfTests/NodeToCodeTests.cs
+++ b/test/DynamoCoreWpfTests/NodeToCodeTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using NUnit.Framework;
+using Dynamo.Tests;
+using Dynamo.Selection;
+using Dynamo.Nodes;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    public class NodeToCodeTests : DynamoViewModelUnitTest
+    {
+        [Test]
+        public void TestNodeToCodeCommandState()
+        {
+            DynamoSelection.Instance.ClearSelection();
+            Assert.IsFalse(ViewModel.CurrentSpaceViewModel.NodeToCodeCommand.CanExecute(null));
+
+            var node = new DoubleInput();
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(node, false);
+            DynamoSelection.Instance.Selection.Add(node);
+            Assert.IsTrue(ViewModel.CurrentSpaceViewModel.NodeToCodeCommand.CanExecute(null));
+
+            DynamoSelection.Instance.ClearSelection();
+            Assert.IsFalse(ViewModel.CurrentSpaceViewModel.NodeToCodeCommand.CanExecute(null));
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

This PR is to fix defect [MAGN 8044 N2C is enabled even when no node is selected on standalone] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8044):

![untitled](https://cloud.githubusercontent.com/assets/2600379/9032356/5ed28038-39f0-11e5-99fb-2872efa0a15c.png)

The fix is to call `NodeToCodeCommand.RaiseCanExecuteChanged()` when selection changed so that the state of context menu will be updated accordingly.  

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@aparajit-pratap 