### PR TITLE
Fix issue that "New node from selection" still enabled after creating custom node

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -850,6 +850,7 @@ namespace Dynamo.Core
                     currentWorkspace.Connectors.Where(
                         conn =>
                             selectedNodeSet.Contains(conn.Start.Owner)
+
                                 || selectedNodeSet.Contains(conn.End.Owner)).ToList();
 
                 foreach (var connector in partiallySelectedConns)
@@ -896,7 +897,10 @@ namespace Dynamo.Core
                     group.SelectedModels = group.DeletedModelBases;
                     newAnnotations.Add(group);
                 }
-
+                
+                // Now all selected nodes already moved to custom workspace,
+                // clear the selection.
+                DynamoSelection.Instance.ClearSelection();
 
                 foreach (var conn in fullySelectedConns)
                 {
@@ -1142,7 +1146,8 @@ namespace Dynamo.Core
                 {
                     undoRecorder.RecordCreationForUndo(connector);
                 }
-            }
+            } 
+
             return newWorkspace;
         }
 

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -850,7 +850,6 @@ namespace Dynamo.Core
                     currentWorkspace.Connectors.Where(
                         conn =>
                             selectedNodeSet.Contains(conn.Start.Owner)
-
                                 || selectedNodeSet.Contains(conn.End.Owner)).ToList();
 
                 foreach (var connector in partiallySelectedConns)
@@ -1147,7 +1146,6 @@ namespace Dynamo.Core
                     undoRecorder.RecordCreationForUndo(connector);
                 }
             } 
-
             return newWorkspace;
         }
 

--- a/test/DynamoCoreWpfTests/CustomNodeTests.cs
+++ b/test/DynamoCoreWpfTests/CustomNodeTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Dynamo.Tests;
+using Dynamo.Nodes;
+using Dynamo.Selection;
+using Dynamo.Models;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    class CustomNodeTests :  DynamoViewModelUnitTest
+    {
+        [Test]
+        public void TestNewNodeFromSelectionCommandState()
+        {
+            Assert.IsFalse(ViewModel.CurrentSpaceViewModel.NodeFromSelectionCommand.CanExecute(null));
+
+            var node = new DoubleInput();
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(node, false);
+            ViewModel.Model.AddToSelection(node);
+            Assert.IsTrue(ViewModel.CurrentSpaceViewModel.NodeFromSelectionCommand.CanExecute(null));
+
+            var ws = ViewModel.Model.CustomNodeManager.Collapse(
+                DynamoSelection.Instance.Selection.OfType<NodeModel>(),
+                ViewModel.Model.CurrentWorkspace,
+                true,
+                new FunctionNamePromptEventArgs
+                {
+                    Category = "Testing",
+                    Description = "",
+                    Name = "__CollapseTest2__",
+                    Success = true
+                });
+
+            Assert.IsFalse(ViewModel.CurrentSpaceViewModel.NodeFromSelectionCommand.CanExecute(null));
+        }
+    }
+}

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="..\..\src\AssemblySharedInfoGenerator\AssemblySharedInfo.cs">
       <Link>AssemblySharedInfo.cs</Link>
     </Compile>
+    <Compile Include="CustomNodeTests.cs" />
     <Compile Include="DateTimeTests.cs" />
     <Compile Include="PresetPromptTests.cs" />
     <Compile Include="AnnotationViewModelTests.cs" />


### PR DESCRIPTION
### Purpose

This PR is to fix defect [MAGN 7425 "New Node from Selection" crashes when run twice for the same selection] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7425).

As creating custom node from selection will remove all nodes in current workspace, Dynamo selection should be cleaned up after the command. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@aparajit-pratap 
