### PR TITLE
Clean codeblocks when a function is redefined

### DIFF
--- a/src/Engine/ProtoCore/Core.cs
+++ b/src/Engine/ProtoCore/Core.cs
@@ -444,9 +444,15 @@ namespace ProtoCore
 
             if (null != procNode)
             {
+                // Remove codeblock defined in procNode from CodeBlockList and CompleteCodeBlockList
                 foreach (int cbID in procNode.ChildCodeBlocks)
                 {
                     CompleteCodeBlockList.RemoveAll(x => x.codeBlockId == cbID);
+
+                    foreach (CodeBlock cb in CodeBlockList)
+                    {
+                        cb.children.RemoveAll(x => x.codeBlockId == cbID);
+                    }
                 }
             }
 

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -1126,6 +1126,51 @@ namespace ProtoTest.LiveRunner
             AssertValue("y", 2);
         }
 
+        [Test]
+        public void TestFunctionDefinitionWithLanguageblocks02()
+        {
+            List<string> codes = new List<string>() 
+            {
+@"
+def f() 
+{
+    return = [Imperative]
+    {
+        return = 1;
+    }
+}
+",
+
+@"
+def f() 
+{
+    return = 2;
+}
+",
+
+ @" p = f();"
+            };
+
+            Guid guid1 = System.Guid.NewGuid();
+            Guid guid2 = System.Guid.NewGuid();
+
+            List<Subtree> added = new List<Subtree>();
+            added.Add(ProtoTestFx.TD.TestFrameWork.CreateSubTreeFromCode(guid1, codes[0]));
+            added.Add(ProtoTestFx.TD.TestFrameWork.CreateSubTreeFromCode(guid2, codes[2]));
+
+            var syncData = new GraphSyncData(null, added, null);
+            liveRunner.UpdateGraph(syncData);
+            AssertValue("p", 1);
+
+            // Modify function def - removed imperative block
+            List<Subtree> modified = new List<Subtree>();
+            modified.Add(ProtoTestFx.TD.TestFrameWork.CreateSubTreeFromCode(guid1, codes[1]));
+
+           syncData = new GraphSyncData(null, null, modified);
+           liveRunner.UpdateGraph(syncData);
+           AssertValue("p", 2);
+        }
+
 
         [Test]
         public void TestFunctionModification01()


### PR DESCRIPTION
### Purpose

This fixes the issue of function redefinition.
The codeblocks need to be cleaned up when a function is redefined.

This fixes issues related to redefining a function with imperative blocks
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7928

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@ke-yu 

### FYI
All exisiting tests pass