### PR TITLE
MAGN-8045 [CRASH] Custom nodes with same name but different category

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -781,11 +781,15 @@ namespace Dynamo.Models
                 if (customNodeSearchRegistry.Contains(info.FunctionId))
                     return;
 
-                var elements = SearchModel.SearchEntries.OfType<CustomNodeSearchElement>().Where(
-                                x =>
-                                {
-                                    return string.Compare(x.Path, info.Path, StringComparison.OrdinalIgnoreCase) == 0;
-                                }).ToList();
+                var elements = SearchModel.SearchEntries.OfType<CustomNodeSearchElement>().
+                    // First search for common paths.
+                                Where(x =>
+                                        {
+                                            return string.Compare(x.Path, info.Path, StringComparison.OrdinalIgnoreCase) == 0;
+                                        }).
+                    // Then get rid of empty paths. It can be empty just in case it's just created node.
+                                Where(x => !String.IsNullOrEmpty(x.Path)).
+                                ToList();
 
                 if (elements.Any())
                 {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -782,14 +782,13 @@ namespace Dynamo.Models
                     return;
 
                 var elements = SearchModel.SearchEntries.OfType<CustomNodeSearchElement>().
-                    // First search for common paths.
                                 Where(x =>
                                         {
-                                            return string.Compare(x.Path, info.Path, StringComparison.OrdinalIgnoreCase) == 0;
-                                        }).
-                    // Then get rid of empty paths. It can be empty just in case it's just created node.
-                                Where(x => !String.IsNullOrEmpty(x.Path)).
-                                ToList();
+                                            // Search for common paths and get rid of empty paths.
+                                            // It can be empty just in case it's just created node.
+                                            return String.Compare(x.Path, info.Path, StringComparison.OrdinalIgnoreCase) == 0 &&
+                                                !String.IsNullOrEmpty(x.Path);
+                                        }).ToList();
 
                 if (elements.Any())
                 {

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -906,5 +906,18 @@ namespace Dynamo.Tests
 
             Assert.AreEqual("Curve", curveParam.Parameter.DisplayTypeName);
         }
+
+        [Test]
+        public void CanAddNodesWithTheSameNameAndEmptyPath2Times()
+        {
+            const string nodeName = "NodeName";
+            const string catName1 = "CatName1";
+            const string catName2 = "CatName2";
+
+            CurrentDynamoModel.CustomNodeManager.CreateCustomNode(nodeName, catName1, "");
+            CurrentDynamoModel.CustomNodeManager.CreateCustomNode(nodeName, catName2, "");
+
+            Assert.AreEqual(2, CurrentDynamoModel.SearchModel.SearchEntries.Where(entry => entry.Name == nodeName).Count());
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8045](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8045) [CRASH] Creating multiple Custom nodes with same name but having different category causing a crash.

#### Reason of crash
Reason of crash lies in `InfoUpdated` of `CustomNodeManager`. That is because of search entries with common paths. 

If path is empty this code will return this entry as well as other entries with common paths. Empty path can be just in case, if it's just created custom node.
```c#
string.Compare(x.Path, info.Path, StringComparison.OrdinalIgnoreCase) == 0
```
This results in crash in View Model. Because VM tries update another entry, which is not our new created node.

So, as solution I can propose add one more check: 
```c#
Where(x => !String.IsNullOrEmpty(x.Path))
```

### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ramramps 

### FYIs

@Randy-Ma 
@riteshchandawar 
