### PR TITLE
MAGN-8036 After library ui search a left mouse click does not always populate the canvas with a node

### DIFF
--- a/src/DynamoCoreWpf/Utilities/LibraryDragAndDrop.cs
+++ b/src/DynamoCoreWpf/Utilities/LibraryDragAndDrop.cs
@@ -27,6 +27,12 @@ namespace Dynamo.Wpf.Utilities
             nodeViewModel = node;
         }
 
+        internal void Clear()
+        {
+            startPosition = new Point();
+            nodeViewModel = null;
+        } 
+
         internal void HandleMouseMove(FrameworkElement sender, Point currentPosition)
         {
             if (isDragging || nodeViewModel == null)

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -957,6 +957,8 @@ namespace Dynamo.ViewModels
 
             dynamoViewModel.ExecuteCommand(new DynamoModel.CreateNodeCommand(
                 nodeModel, position.X, position.Y, useDeafultPosition, true));
+
+            dynamoViewModel.ReturnFocusToSearch();
         }
         #endregion
 

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -241,7 +241,8 @@
                    ItemContainerStyle="{StaticResource LibraryTreeViewItem}"
                    ScrollViewer.CanContentScroll="True"
                    VirtualizingStackPanel.IsVirtualizing="True"
-                   VirtualizingStackPanel.VirtualizationMode="Recycling" />
+                   VirtualizingStackPanel.VirtualizationMode="Recycling" >           
+          </TreeView>
 
         <uicontrols:LibraryToolTipPopup x:Name="libraryToolTipPopup"
                                         StaysOpen="True"

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -121,8 +121,7 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type TreeViewItem}">
-                            <Button Command="{Binding ClickedCommand}"
-                                    Focusable="False"
+                            <Button Command="{Binding ClickedCommand}"                                    
                                     MouseEnter="OnMemberMouseEnter"
                                     MouseLeave="OnPopupMouseLeave"
                                     PreviewMouseLeftButtonDown="OnButtonMouseLeftButtonDown"

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -131,7 +131,11 @@ namespace Dynamo.UI.Views
                 return;
 
             var senderButton = e.OriginalSource as FrameworkElement;
-            dragDropHelper.HandleMouseMove(senderButton, e.GetPosition(null));
+            var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
+            if (searchElementVM != null)
+                dragDropHelper.HandleMouseDown(e.GetPosition(null), searchElementVM);
+            else
+                dragDropHelper.Clear();
         }
 
         #endregion

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -38,12 +38,22 @@ namespace Dynamo.UI.Views
         private void OnLibrarySearchViewLoaded(object sender, RoutedEventArgs e)
         {
             viewModel = DataContext as SearchViewModel;
-
+            viewModel.SearchTextChanged +=viewModel_SearchTextChanged;
             // RequestReturnFocusToSearch calls, when workspace was clicked.
             // We should hide tooltip.
             viewModel.RequestReturnFocusToSearch += OnRequestCloseToolTip;
             // When workspace was changed, we should hide tooltip. 
             viewModel.RequestCloseSearchToolTip += OnRequestCloseToolTip;
+        }
+
+        private void viewModel_SearchTextChanged(object sender, EventArgs e)
+        {
+            //Get the scrollview and scroll to top on every text entered
+            var scroll = CategoryTreeView.ChildOfType<ScrollViewer>();
+            if (scroll != null)
+            {               
+                scroll.ScrollToTop();
+            }
         }
 
         private void OnNoMatchFoundButtonClick(object sender, RoutedEventArgs e)

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -116,10 +116,13 @@ namespace Dynamo.UI.Views
         private void OnButtonMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             var senderButton = e.OriginalSource as FrameworkElement;
-            var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
+            if (senderButton != null)
+            {
+                var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
 
-            if (searchElementVM != null)
-                dragDropHelper.HandleMouseDown(e.GetPosition(null), searchElementVM);
+                if (searchElementVM != null)
+                    dragDropHelper.HandleMouseDown(e.GetPosition(null), searchElementVM);
+            }          
         }
 
         private void OnButtonPreviewMouseMove(object sender, MouseEventArgs e)


### PR DESCRIPTION
### Purpose

This PR has the changes that  creates a node on first click (after Library Search)

Link to YouTrack:
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8036
### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@holyjewsus 