### PR TITLE
Shift double click calls InCanvasSearch and creates CBN

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -525,8 +525,12 @@ namespace Dynamo.ViewModels
                             // a code block node being created, in which case we
                             // should keep the input focus on the code block to 
                             // avoid it being dismissed (with empty content).
-                            // 
-                            CreateCodeBlockNode(mouseDownPos);
+                            //
+                            // If Shift is pressed, CBN shouldn't be created.
+                            // Shift Modifier indicates, that user tries to call InCanvasSearch
+                            // by using Shift + DoubleClick.
+                            if (Keyboard.Modifiers != ModifierKeys.Shift)
+                                CreateCodeBlockNode(mouseDownPos);
 
                             returnFocusToSearch = false;
                         }


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8053](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8053) Shift double click pops up an unwanted cbn along with the in-canvas search

This is a regression. I definitely remember, that `DragCanvas` used to handle `MouseLeftButtonDown` click. Long time ago I wrote check for keyboard modifiers, so that if it's pressed Shift, CBN(code block node) is not created.

But now `DragCanvas` doesn't handle mouse click. I added check for keyboard modifiers in `StateMachine.cs`.

I couldn't find the reason why we don't use `DragCanvas` now.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 

### FYIs

@jnealb 