### PR TITLE
Fix false warnings

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -126,6 +126,7 @@ namespace ProtoCore.DSASM
                 fi = rmem.CurrentStackFrame.FunctionScope;
             }
             graphNodesInProgramScope = istream.dependencyGraph.GetGraphNodesAtScope(ci, fi);
+            graphNodesInProgramScope.RemoveAll(g => !g.isActive);
         }
 
         /// <summary>

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -126,7 +126,10 @@ namespace ProtoCore.DSASM
                 fi = rmem.CurrentStackFrame.FunctionScope;
             }
             graphNodesInProgramScope = istream.dependencyGraph.GetGraphNodesAtScope(ci, fi);
-            graphNodesInProgramScope.RemoveAll(g => !g.isActive);
+            if (graphNodesInProgramScope.Count > 0)
+            {
+                graphNodesInProgramScope.RemoveAll(g => !g.isActive);
+            }
         }
 
         /// <summary>

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -126,10 +126,6 @@ namespace ProtoCore.DSASM
                 fi = rmem.CurrentStackFrame.FunctionScope;
             }
             graphNodesInProgramScope = istream.dependencyGraph.GetGraphNodesAtScope(ci, fi);
-            if (graphNodesInProgramScope != null)
-            {
-                graphNodesInProgramScope.RemoveAll(g => !g.isActive);
-            }
         }
 
         /// <summary>
@@ -1462,6 +1458,11 @@ namespace ProtoCore.DSASM
 
             foreach (ProtoCore.AssociativeGraph.GraphNode graphNode in graphNodesInProgramScope)
             {
+                if (!graphNode.isActive)
+                {
+                    continue;
+                }
+
                 if (runtimeCore.Options.IsDeltaExecution)
                 {
                     // COmment Jun: start from graphnodes whose update blocks are in the range of the entry point

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -126,7 +126,7 @@ namespace ProtoCore.DSASM
                 fi = rmem.CurrentStackFrame.FunctionScope;
             }
             graphNodesInProgramScope = istream.dependencyGraph.GetGraphNodesAtScope(ci, fi);
-            if (graphNodesInProgramScope.Count > 0)
+            if (graphNodesInProgramScope != null)
             {
                 graphNodesInProgramScope.RemoveAll(g => !g.isActive);
             }


### PR DESCRIPTION
### Purpose

The UI is reporting false errors that is due to inactive graphnodes being executed.
1. The VM should only process active graphnodes
2. Added a LiveRunner test that simulates the false warning


This fixes issues in:
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7759

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### FYI testing
All existing tests pass. Added a live runner test that simulates the warnings.
@monikaprabhu as discussed, pls help to add other tests for the warning on these cases.
Refer to: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7759

### Reviewers
@ke-yu 
