### PR TITLE
Fixed voronoi node

### DIFF
--- a/src/Libraries/Tesellation/Adapters/Cell2.cs
+++ b/src/Libraries/Tesellation/Adapters/Cell2.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Autodesk.DesignScript.Geometry;
 using Autodesk.DesignScript.Runtime;
 using MIConvexHull;
@@ -17,42 +18,41 @@ namespace Tessellation.Adapters
         {
             // From MathWorld: http://mathworld.wolfram.com/Circumcircle.html
 
-            //var points = Vertices;
+            var points = Vertices;
 
-            //var m = new double[3, 3];
+            var m = new double[3, 3];
 
-            //// x, y, 1
-            //for (int i = 0; i < 3; i++)
-            //{
-            //    m[i, 0] = points[i].Position[0];
-            //    m[i, 1] = points[i].Position[1];
-            //    m[i, 2] = 1;
-            //}
-            //var a = StarMath.determinant(m);
+            // x, y, 1
+            for (int i = 0; i < 3; i++)
+            {
+                m[i, 0] = points[i].Position[0];
+                m[i, 1] = points[i].Position[1];
+                m[i, 2] = 1;
+            }
+            var a = StarMath.determinant(m);
 
-            //// size, y, 1
-            //for (int i = 0; i < 3; i++)
-            //{
-            //    m[i, 0] = StarMath.norm2(points[i].Position, 2, true);
-            //}
-            //var dx = -StarMath.determinant(m);
+            // size, y, 1
+            for (int i = 0; i < 3; i++)
+            {
+                m[i, 0] = StarMath.norm2(points[i].Position, true);
+            }
+            var dx = -StarMath.determinant(m);
 
-            //// size, x, 1
-            //for (int i = 0; i < 3; i++)
-            //{
-            //    m[i, 1] = points[i].Position[0];
-            //}
-            //var dy = StarMath.determinant(m);
+            // size, x, 1
+            for (int i = 0; i < 3; i++)
+            {
+                m[i, 1] = points[i].Position[0];
+            }
+            var dy = StarMath.determinant(m);
 
-            //// size, x, y
-            //for (int i = 0; i < 3; i++)
-            //{
-            //    m[i, 2] = points[i].Position[1];
-            //}
+            // size, x, y
+            for (int i = 0; i < 3; i++)
+            {
+                m[i, 2] = points[i].Position[1];
+            }
 
-            //var s = -1.0 / (2.0 * a);
-            //return Point.ByCoordinates(s * dx, s * dy);
-            return null;
+            var s = -1.0 / (2.0 * a);
+            return Point.ByCoordinates(s * dx, s * dy);
         }
 
         Point GetCentroid()


### PR DESCRIPTION
### Purpose

This PR fixes a regression in the Voronoi node `Voronoi.ByParametersOnSurface`, defect: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8039. Code was commented out [here] (https://github.com/DynamoDS/Dynamo/commit/4335df8729a88fed544c7c0bf9bb146230ef0112#diff-0ce26fd289a4bb2d10c920d2528c2872R12) by @ikeough due to which this node regressed. This has simply been uncommented here in this submission and needs to be reviewed to clarify if this is okay. 

### Declarations

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough  Reviewer 1  