### PR TITLE
MAGN-8031 Top search resulted item doesn't get placed if user hit enter.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -50,7 +50,7 @@ namespace Dynamo.Wpf.ViewModels
         public NodeSearchElementViewModel(NodeSearchElementViewModel copyElement)
         {
             if (copyElement == null)
-                return;
+                throw new ArgumentNullException();
 
             Model = copyElement.Model;
             Clicked = copyElement.Clicked;

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -44,6 +44,20 @@ namespace Dynamo.Wpf.ViewModels
             ClickedCommand = new DelegateCommand(OnClicked);            
         }
 
+        /// <summary>
+        /// Creates a copy of NodeSearchElementViewModel.
+        /// </summary>
+        public NodeSearchElementViewModel(NodeSearchElementViewModel copyElement)
+        {
+            if (copyElement == null)
+                return;
+
+            Model = copyElement.Model;
+            Clicked = copyElement.Clicked;
+            RequestBitmapSource = copyElement.RequestBitmapSource;
+            ClickedCommand = copyElement.ClickedCommand;
+        }
+
         private void ModelOnVisibilityChanged()
         {           
             RaisePropertyChanged("Visibility");

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -697,7 +697,6 @@ namespace Dynamo.ViewModels
             SearchResults = new ObservableCollection<NodeSearchElementViewModel>(foundNodes);
             RaisePropertyChanged("SearchResults");
 
-            selectionNavigator.UpdateRootCategories(SearchRootCategories);
         }
 
 
@@ -888,7 +887,7 @@ namespace Dynamo.ViewModels
             topMemberGroup.AddMember(topNode);
             TopResult = topMemberGroup;
 
-            selectionNavigator.UpdateTopResult(topNode);
+            selectionNavigator.UpdateRootCategories(SearchRootCategories, topNode);            
         }
 
         internal void ExecuteSelectedMember()

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -858,7 +858,7 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                return selectionNavigator.CurrentlySelection;
+                return selectionNavigator.CurrentSelection;
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -697,7 +697,7 @@ namespace Dynamo.ViewModels
             SearchResults = new ObservableCollection<NodeSearchElementViewModel>(foundNodes);
             RaisePropertyChanged("SearchResults");
 
-            selectionNavigator.UpdateRootCategories(SearchRootCategories);
+            selectionNavigator.UpdateRootCategories(SearchRootCategories, foundNodes.FirstOrDefault());
         }
 
 

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -697,7 +697,7 @@ namespace Dynamo.ViewModels
             SearchResults = new ObservableCollection<NodeSearchElementViewModel>(foundNodes);
             RaisePropertyChanged("SearchResults");
 
-            selectionNavigator.UpdateRootCategories(SearchRootCategories, foundNodes.FirstOrDefault());
+            selectionNavigator.UpdateRootCategories(SearchRootCategories);
         }
 
 
@@ -880,9 +880,15 @@ namespace Dynamo.ViewModels
             }
 
             var topMemberGroup = new SearchMemberGroup(memberGroup.FullyQualifiedName);
-            topMemberGroup.AddMember(memberGroup.Members.First());
 
+            // Clone top node.
+            var topNode = new NodeSearchElementViewModel(memberGroup.Members.FirstOrDefault());
+            topNode.IsSelected = true;            
+
+            topMemberGroup.AddMember(topNode);
             TopResult = topMemberGroup;
+
+            selectionNavigator.UpdateTopResult(topNode);
         }
 
         internal void ExecuteSelectedMember()

--- a/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
@@ -37,7 +37,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Currently selected member.
         /// </summary>
-        public NodeSearchElementViewModel CurrentlySelection
+        public NodeSearchElementViewModel CurrentSelection
         {
             get
             {
@@ -72,25 +72,19 @@ namespace Dynamo.ViewModels
             if (root == null || !root.Any())
                 return;
 
-            if (CurrentlySelection == topResult)
+            if (CurrentSelection == topResult)
             {
                 // We can only move forward...
                 if (direction == NavigationDirection.Forward)
-                {
                     SelectItem(0, 0, 0);
-                    return;
-                }
-                else
-                    // Selected element is top result.
-                    // There is no way to move backward.
-                    return;
+                return;
             }
 
             var selectedCategory = root.ElementAt(selectedCategoryIndex);
             var selectedMemberGroup = selectedCategory.MemberGroups.ElementAt(selectedMemberGroupIndex);
 
             // Clear the current selection, no matter what.
-            CurrentlySelection.IsSelected = false;
+            CurrentSelection.IsSelected = false;
 
             if (direction == NavigationDirection.Backward)
             {
@@ -157,7 +151,7 @@ namespace Dynamo.ViewModels
             }
 
             // Get the new selection and mark it as selected.
-            CurrentlySelection.IsSelected = true;
+            CurrentSelection.IsSelected = true;
         }
 
         private NodeSearchElementViewModel GetSelectionFromIndices()

--- a/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
@@ -32,7 +32,6 @@ namespace Dynamo.ViewModels
 
         private IEnumerable<SearchCategory> root = null;
 
-        private NodeSearchElementViewModel selection = null;
         private NodeSearchElementViewModel topResult = null;
 
         /// <summary>
@@ -42,7 +41,7 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                return selection ?? topResult;
+                return GetSelectionFromIndices();
             }
         }
 
@@ -57,7 +56,6 @@ namespace Dynamo.ViewModels
 
             if (root == null || !root.Any())
             {
-                selection = null;
                 topResult = null;
                 return;
             }
@@ -67,7 +65,6 @@ namespace Dynamo.ViewModels
             selectedMemberIndex = -1;
 
             this.topResult = topResult;
-            this.selection = topResult;
         }
 
         internal void MoveSelection(NavigationDirection direction)
@@ -75,18 +72,12 @@ namespace Dynamo.ViewModels
             if (root == null || !root.Any())
                 return;
 
-            if (selection == topResult)
+            if (CurrentlySelection == topResult)
             {
                 // We can only move forward...
                 if (direction == NavigationDirection.Forward)
                 {
-                    selectedCategoryIndex = 0;
-                    selectedMemberGroupIndex = 0;
-                    selectedMemberIndex = 0;
-
-                    selection.IsSelected = false;
-                    selection = GetSelectionFromIndices();
-                    selection.IsSelected = true;
+                    SelectItem(0, 0, 0);
                     return;
                 }
                 else
@@ -99,8 +90,7 @@ namespace Dynamo.ViewModels
             var selectedMemberGroup = selectedCategory.MemberGroups.ElementAt(selectedMemberGroupIndex);
 
             // Clear the current selection, no matter what.
-            selection.IsSelected = false;
-            selection = null;
+            CurrentlySelection.IsSelected = false;
 
             if (direction == NavigationDirection.Backward)
             {
@@ -134,15 +124,7 @@ namespace Dynamo.ViewModels
                         }
                         else // No place to move back. Clear selection. Select top result.
                         {
-                            selection = GetSelectionFromIndices();
-                            selection.IsSelected = false;
-
-                            selectedCategoryIndex = -1;
-                            selectedMemberGroupIndex = -1;
-                            selectedMemberIndex = -1;
-
-                            selection = GetSelectionFromIndices();
-                            selection.IsSelected = true;
+                            SelectItem(-1, -1, -1);
                             return;
                         }
                     }
@@ -175,7 +157,7 @@ namespace Dynamo.ViewModels
             }
 
             // Get the new selection and mark it as selected.
-            selection = GetSelectionFromIndices();
+            var selection = GetSelectionFromIndices();
             selection.IsSelected = true;
         }
 
@@ -199,6 +181,24 @@ namespace Dynamo.ViewModels
 
             var selectedMember = selectedMemberGroup.Members.ElementAt(selectedMemberIndex);
             return selectedMember;
+        }
+
+        private void SelectItem(int categoryIndex, int memberGroupIndex, int memberIndex)
+        {
+            if (categoryIndex == selectedCategoryIndex &&
+                memberGroupIndex == selectedMemberGroupIndex &&
+                memberIndex == selectedMemberIndex)
+                return; // No selection change.
+
+            var selection = GetSelectionFromIndices();
+            selection.IsSelected = false;
+
+            selectedCategoryIndex = categoryIndex;
+            selectedMemberGroupIndex = memberGroupIndex;
+            selectedMemberIndex = memberIndex;
+
+            selection = GetSelectionFromIndices();
+            selection.IsSelected = true;
         }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
@@ -84,7 +84,7 @@ namespace Dynamo.ViewModels
                     selectedMemberGroupIndex = 0;
                     selectedMemberIndex = 0;
 
-                    topResult.IsSelected = false;
+                    selection.IsSelected = false;
                     selection = GetSelectionFromIndices();
                     selection.IsSelected = true;
                     return;
@@ -141,8 +141,8 @@ namespace Dynamo.ViewModels
                             selectedMemberGroupIndex = -1;
                             selectedMemberIndex = -1;
 
-                            selection = topResult;
-                            topResult.IsSelected = true;
+                            selection = GetSelectionFromIndices();
+                            selection.IsSelected = true;
                             return;
                         }
                     }

--- a/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
@@ -51,26 +51,23 @@ namespace Dynamo.ViewModels
             UpdateRootCategories(rootTree);
         }
 
-        internal void UpdateRootCategories(IEnumerable<SearchCategory> rootTree)
+        internal void UpdateRootCategories(IEnumerable<SearchCategory> rootTree, NodeSearchElementViewModel topResult = null)
         {
             root = rootTree;
 
             if (root == null || !root.Any())
             {
                 selection = null;
+                topResult = null;
                 return;
             }
 
-            selectedCategoryIndex = 0;
-            selectedMemberGroupIndex = 0;
-            selectedMemberIndex = 0;
+            selectedCategoryIndex = -1;
+            selectedMemberGroupIndex = -1;
+            selectedMemberIndex = -1;
 
-            selection = null;
-        }
-
-        internal void UpdateTopResult(NodeSearchElementViewModel topRes)
-        {
-            topResult = topRes;
+            this.topResult = topResult;
+            this.selection = null;
         }
 
         internal void MoveSelection(NavigationDirection direction)
@@ -81,11 +78,16 @@ namespace Dynamo.ViewModels
             // Selection can be null, if user just searched and currently selected element is top result.
             if (selection == null)
             {
+                // We can only move forward...
                 if (direction == NavigationDirection.Forward)
                 {
+                    selectedCategoryIndex = 0;
+                    selectedMemberGroupIndex = 0;
+                    selectedMemberIndex = 0;
+
+                    topResult.IsSelected = false;
                     selection = GetSelectionFromIndices();
                     selection.IsSelected = true;
-                    topResult.IsSelected = false;
                     return;
                 }
                 else
@@ -175,6 +177,14 @@ namespace Dynamo.ViewModels
 
         private NodeSearchElementViewModel GetSelectionFromIndices()
         {
+            if ((selectedCategoryIndex == -1) &&
+                (selectedMemberGroupIndex == -1) &&
+                (selectedMemberIndex == -1))
+            {
+                // No selection, return topResult instead.
+                return topResult;
+            }
+
             var selectedCategory = root.ElementAt(selectedCategoryIndex);
             if (selectedCategory == null)
                 return null;

--- a/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
@@ -75,7 +75,6 @@ namespace Dynamo.ViewModels
             if (root == null || !root.Any())
                 return;
 
-            // Selection can be null, if user just searched and currently selected element is top result.
             if (selection == topResult)
             {
                 // We can only move forward...

--- a/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
@@ -67,7 +67,7 @@ namespace Dynamo.ViewModels
             selectedMemberIndex = -1;
 
             this.topResult = topResult;
-            this.selection = null;
+            this.selection = topResult;
         }
 
         internal void MoveSelection(NavigationDirection direction)
@@ -76,7 +76,7 @@ namespace Dynamo.ViewModels
                 return;
 
             // Selection can be null, if user just searched and currently selected element is top result.
-            if (selection == null)
+            if (selection == topResult)
             {
                 // We can only move forward...
                 if (direction == NavigationDirection.Forward)
@@ -137,7 +137,12 @@ namespace Dynamo.ViewModels
                         {
                             selection = GetSelectionFromIndices();
                             selection.IsSelected = false;
-                            selection = null;
+
+                            selectedCategoryIndex = -1;
+                            selectedMemberGroupIndex = -1;
+                            selectedMemberIndex = -1;
+
+                            selection = topResult;
                             topResult.IsSelected = true;
                             return;
                         }

--- a/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
@@ -157,8 +157,7 @@ namespace Dynamo.ViewModels
             }
 
             // Get the new selection and mark it as selected.
-            var selection = GetSelectionFromIndices();
-            selection.IsSelected = true;
+            CurrentlySelection.IsSelected = true;
         }
 
         private NodeSearchElementViewModel GetSelectionFromIndices()

--- a/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
@@ -51,7 +51,7 @@ namespace Dynamo.ViewModels
             UpdateRootCategories(rootTree);
         }
 
-        internal void UpdateRootCategories(IEnumerable<SearchCategory> rootTree, NodeSearchElementViewModel topRes = null)
+        internal void UpdateRootCategories(IEnumerable<SearchCategory> rootTree)
         {
             root = rootTree;
 
@@ -66,6 +66,10 @@ namespace Dynamo.ViewModels
             selectedMemberIndex = 0;
 
             selection = null;
+        }
+
+        internal void UpdateTopResult(NodeSearchElementViewModel topRes)
+        {
             topResult = topRes;
         }
 
@@ -81,6 +85,7 @@ namespace Dynamo.ViewModels
                 {
                     selection = GetSelectionFromIndices();
                     selection.IsSelected = true;
+                    topResult.IsSelected = false;
                     return;
                 }
                 else
@@ -126,11 +131,12 @@ namespace Dynamo.ViewModels
                             var group = category.MemberGroups.ElementAt(selectedMemberGroupIndex);
                             selectedMemberIndex = group.Members.Count() - 1;
                         }
-                        else // No place to move back. Clear selection.
+                        else // No place to move back. Clear selection. Select top result.
                         {
                             selection = GetSelectionFromIndices();
                             selection.IsSelected = false;
                             selection = null;
+                            topResult.IsSelected = true;
                             return;
                         }
                     }

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -197,7 +197,6 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-
         </ResourceDictionary>
     </UserControl.Resources>
 

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -198,12 +198,6 @@
                 </Setter>
             </Style>
 
-            <Style x:Key="TopLibraryTreeViewItem"
-                   TargetType="{x:Type TreeViewItem}"
-                   BasedOn="{StaticResource LibraryTreeViewItem}">
-                <Setter Property="IsSelected"
-                        Value="True" />
-            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -225,7 +219,7 @@
             <TreeView x:Name="topResultTreeView"
                       Background="Transparent"
                       BorderBrush="Transparent"
-                      ItemContainerStyle="{StaticResource TopLibraryTreeViewItem}"
+                      ItemContainerStyle="{StaticResource LibraryTreeViewItem}"
                       ScrollViewer.HorizontalScrollBarVisibility="Hidden"
                       ItemsSource="{Binding Members,NotifyOnTargetUpdated=True}">
                 <TreeView.ItemTemplate>

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -197,6 +197,13 @@
                     </Setter.Value>
                 </Setter>
             </Style>
+
+            <Style x:Key="TopLibraryTreeViewItem"
+                   TargetType="{x:Type TreeViewItem}"
+                   BasedOn="{StaticResource LibraryTreeViewItem}">
+                <Setter Property="IsSelected"
+                        Value="True" />
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -218,7 +225,7 @@
             <TreeView x:Name="topResultTreeView"
                       Background="Transparent"
                       BorderBrush="Transparent"
-                      ItemContainerStyle="{StaticResource LibraryTreeViewItem}"
+                      ItemContainerStyle="{StaticResource TopLibraryTreeViewItem}"
                       ScrollViewer.HorizontalScrollBarVisibility="Hidden"
                       ItemsSource="{Binding Members,NotifyOnTargetUpdated=True}">
                 <TreeView.ItemTemplate>

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -651,11 +651,19 @@ namespace Dynamo.Tests
 
             Assert.Greater(viewModel.SearchResults.Count, 0);
             Assert.AreEqual(2, viewModel.SearchRootCategories.Count);
+
+            // Top result is selected.
             Assert.AreEqual("A", viewModel.CurrentlySelectedMember.Name);
 
+            // First node is selected.
+            viewModel.MoveSelection(NavigationDirection.Forward);
+            Assert.AreEqual("A", viewModel.CurrentlySelectedMember.Name);
+
+            // Second node is selected.
             viewModel.MoveSelection(NavigationDirection.Forward);
             Assert.AreEqual("AA", viewModel.CurrentlySelectedMember.Name);
 
+            // Third node is selected.
             viewModel.MoveSelection(NavigationDirection.Forward);
             Assert.AreEqual("AAA", viewModel.CurrentlySelectedMember.Name);
         }
@@ -678,6 +686,8 @@ namespace Dynamo.Tests
 
             Assert.Greater(viewModel.SearchResults.Count, 0);
             Assert.AreEqual(2, viewModel.SearchRootCategories.Count);
+
+            // Top result is selected.
             Assert.AreEqual("A", viewModel.CurrentlySelectedMember.Name);
 
             viewModel.MoveSelection(NavigationDirection.Forward);
@@ -685,9 +695,12 @@ namespace Dynamo.Tests
             viewModel.MoveSelection(NavigationDirection.Backward);
             Assert.AreEqual("A", viewModel.CurrentlySelectedMember.Name);
 
+            // Jump to third node.
+            viewModel.MoveSelection(NavigationDirection.Forward);
             viewModel.MoveSelection(NavigationDirection.Forward);
             viewModel.MoveSelection(NavigationDirection.Forward);
 
+            // Back to second node.
             viewModel.MoveSelection(NavigationDirection.Backward);
             Assert.AreEqual("AA", viewModel.CurrentlySelectedMember.Name);
         }


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8031](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8031) top search resulted item doesn't get placed if user hit enter.

#### Reason of bug
`selectionNavigator` updates its' categories after every search. But in update method selected indexes are set to 0. I.e. selected category, group and element are 0,0,0. That means selected element is not top result, but FIRST result.
E.g. if we search for "poi"
![image](https://cloud.githubusercontent.com/assets/8158404/9109836/7c53508a-3c41-11e5-9da4-8eecf9d834f9.png)

Top result is ByCoordinates, but selected item is ByCastesianCoordinates. That's why, when you hit enter, ByCastesianCoordinates is created.

I propose to add `topResult` to `SelectionNavigator`. And do not set selection to the first element.

### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 

### FYIs

@riteshchandawar 
@Racel 