### PR TITLE
MAGN-7779 Preset can floor slider fields to 0 when numbers are in scientific notation

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/SliderBase.cs
+++ b/src/Libraries/CoreNodeModels/Input/SliderBase.cs
@@ -94,7 +94,7 @@ namespace DSCoreNodesUI.Input
         internal static double ConvertStringToDouble(string value)
         {
             double result = 0.0;
-            System.Double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out result);
+            System.Double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
             return result;
         }
 

--- a/test/Libraries/CoreNodesTests/NodeWithUITests.cs
+++ b/test/Libraries/CoreNodesTests/NodeWithUITests.cs
@@ -57,6 +57,18 @@ namespace DSCoreNodesTests
         }
 
         [Test]
+        public void SliderMaxValueWithBigNum()
+        {
+            var sliderNode = new DoubleSlider() { Value = 500 };
+            var updateValueParams = new UpdateValueParams("Max", "2.14748364712346E+15");
+            sliderNode.UpdateValue(updateValueParams);
+
+            Assert.AreEqual(
+                 2.14748364712346E+15,
+                 sliderNode.Max);           
+        }
+
+        [Test]
         public void IntegerSliderMaxValue()
         {
             var integerSliderNode = new IntegerSlider() { Value = 500 };


### PR DESCRIPTION
### Purpose

This PR fixes the issue with BigNumbers on Double Sliders.

Link to YouTrack:
 http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7779

### Declarations

- [x] The code base is in a better state after this PR
- [ x ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@holyjewsus 