### PR TITLE
Operator search tags are not found in Dynamo on Revit

### DIFF
--- a/src/DynamoCore/Core/PathManager.cs
+++ b/src/DynamoCore/Core/PathManager.cs
@@ -78,6 +78,11 @@ namespace Dynamo.Core
 
         #region IPathManager Interface Implementation
 
+        public string DynamoCoreDirectory
+        {
+            get { return dynamoCoreDir; }
+        }
+
         public string UserDataDirectory
         {
             get { return userDataDir; }

--- a/src/DynamoCore/Interfaces/IPathResolver.cs
+++ b/src/DynamoCore/Interfaces/IPathResolver.cs
@@ -60,7 +60,7 @@ namespace Dynamo.Interfaces
     public interface IPathManager
     {
         /// <summary>
-        /// The main dynamo directory.
+        /// The directory in which DynamoCore.dll is guaranteed to be found.
         /// </summary>
         string DynamoCoreDirectory { get; }
 

--- a/src/DynamoCore/Interfaces/IPathResolver.cs
+++ b/src/DynamoCore/Interfaces/IPathResolver.cs
@@ -60,6 +60,11 @@ namespace Dynamo.Interfaces
     public interface IPathManager
     {
         /// <summary>
+        /// The main dynamo directory.
+        /// </summary>
+        string DynamoCoreDirectory { get; }
+
+        /// <summary>
         /// The local directory that contains user specific data files.
         /// </summary>
         string UserDataDirectory { get; }

--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -46,6 +46,7 @@ namespace Dynamo.DSEngine
         private static bool ResolveForAssembly(string assemblyLocation,
             IPathManager pathManager, ref string documentationPath)
         {
+            var assemblyName = Path.GetFileNameWithoutExtension(assemblyLocation);
             if (pathManager != null)
             {
                 pathManager.ResolveLibraryPath(ref assemblyLocation);
@@ -65,7 +66,7 @@ namespace Dynamo.DSEngine
                 baseDir = Path.GetDirectoryName(Path.GetFullPath(assemblyLocation));
             }
 
-            var xmlFileName = Path.GetFileNameWithoutExtension(assemblyLocation) + ".xml";
+            var xmlFileName = assemblyName + ".xml";
 
             var language = System.Threading.Thread.CurrentThread.CurrentUICulture.ToString();
             var localizedResPath = Path.Combine(baseDir, language);

--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -58,7 +58,12 @@ namespace Dynamo.DSEngine
                 assemblyLocation = cashedAssemblyLocation;
             }
 
-            var baseDir = pathManager.DynamoCoreDirectory;
+            string baseDir;
+            if (File.Exists(assemblyLocation))
+                baseDir = Path.GetDirectoryName(Path.GetFullPath(assemblyLocation));
+            else
+                baseDir = pathManager.DynamoCoreDirectory;
+
             var xmlFileName = Path.GetFileNameWithoutExtension(assemblyLocation) + ".xml";
 
             var language = System.Threading.Thread.CurrentThread.CurrentUICulture.ToString();

--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -46,28 +46,24 @@ namespace Dynamo.DSEngine
         private static bool ResolveForAssembly(string assemblyLocation,
             IPathManager pathManager, ref string documentationPath)
         {
-            string cashedAssemblyLocation = assemblyLocation;
             if (pathManager != null)
             {
                 pathManager.ResolveLibraryPath(ref assemblyLocation);
             }
 
-            // Some nodes don't have assembly, e.g. operators, but they do have xml file.
-            if (String.IsNullOrEmpty(assemblyLocation))
+            string baseDir = String.Empty;
+            if (String.IsNullOrEmpty(assemblyLocation) || !File.Exists(assemblyLocation))
             {
-                assemblyLocation = cashedAssemblyLocation;
-            }
-
-            string baseDir;
-
-            if (File.Exists(assemblyLocation))
-                // There are 2 cases: if assembly exists, then we will use assembly path and try 
-                // to find xml file there.
-                baseDir = Path.GetDirectoryName(Path.GetFullPath(assemblyLocation));
-            else
-                // If assembly does not exist, then we will use dynamo directory and try
-                // to find xml file there.
+                // Some nodes do not have a corresponding assembly, but their documentation 
+                // xml file resides alongside DynamoCore.dll. If the assembly could not be 
+                // located, fall back onto using DynamoCoreDirectory.
                 baseDir = pathManager.DynamoCoreDirectory;
+            }
+            else
+            {
+                // Found the assembly location, search for documentation alongside it.
+                baseDir = Path.GetDirectoryName(Path.GetFullPath(assemblyLocation));
+            }
 
             var xmlFileName = Path.GetFileNameWithoutExtension(assemblyLocation) + ".xml";
 

--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -59,9 +59,14 @@ namespace Dynamo.DSEngine
             }
 
             string baseDir;
+
             if (File.Exists(assemblyLocation))
+                // There are 2 cases: if assembly exists, then we will use assembly path and try 
+                // to find xml file there.
                 baseDir = Path.GetDirectoryName(Path.GetFullPath(assemblyLocation));
             else
+                // If assembly does not exist, then we will use dynamo directory and try
+                // to find xml file there.
                 baseDir = pathManager.DynamoCoreDirectory;
 
             var xmlFileName = Path.GetFileNameWithoutExtension(assemblyLocation) + ".xml";

--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -58,10 +58,8 @@ namespace Dynamo.DSEngine
                 assemblyLocation = cashedAssemblyLocation;
             }
 
-            var assemblyPath = Path.GetFullPath(assemblyLocation);
-
-            var baseDir = Path.GetDirectoryName(assemblyPath);
-            var xmlFileName = Path.GetFileNameWithoutExtension(assemblyPath) + ".xml";
+            var baseDir = pathManager.DynamoCoreDirectory;
+            var xmlFileName = Path.GetFileNameWithoutExtension(assemblyLocation) + ".xml";
 
             var language = System.Threading.Thread.CurrentThread.CurrentUICulture.ToString();
             var localizedResPath = Path.Combine(baseDir, language);


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8083](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8083) Library search for "add" gives incorrect top hit with Dynamo/Revit: the List.AddIemToFront node

#### Reason of bug

This code
```c#
var assemblyPath = Path.GetFullPath(assemblyLocation);
```
if we run Dynamo Standalone gives next result:
D:\Dynamo\bin\AnyCPU\Debug\Operators

but if we run on top of Revit:
C:\Program Files\Autodesk\Revit Architecture 2014\Operators

To fix it, I added `DynamoCoreDirectory` to `PathManager`.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

?

### FYIs

@jnealb 
