### PR TITLE
Dynamo fails to load if no "bin" or "extra" folders exist

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -579,8 +579,15 @@ namespace Dynamo.Models
                     if (logSource != null)
                         logSource.MessageLogged += LogMessage;
 
-                    ext.Startup(startupParams);
-                    ext.Load(preferences, pathManager);
+                    try
+                    {
+                        ext.Startup(startupParams);
+                        ext.Load(preferences, pathManager);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log(ex.Message);                       
+                    }                   
                     ExtensionManager.Add(ext);
                 }
             }


### PR DESCRIPTION
### Purpose

This PR fixes the issue with Dynamo Crash if Bin or Extra folders not present inside packages directory,

### Fix
 Added a try catch block around Extension Startup. If the directory is not found, it will be logged and dynamo will continue to run.

Link to YouTrack:
 http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7988

### Declarations

- [x] The code base is in a better state after this PR
- [ x ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@pboyer 