### PR TITLE
Fixed a crash of contextual menu in custom workspace

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1482,8 +1482,11 @@ namespace Dynamo.Models
             {
                 if (!Workspaces.OfType<CustomNodeWorkspaceModel>().Contains(customNodeWorkspace))
                     AddWorkspace(customNodeWorkspace);
+
                 CurrentWorkspace = customNodeWorkspace;
+                return true;
             }
+
             return false;
         }
 

--- a/src/DynamoCoreWpf/Commands/WorkspaceCommands.cs
+++ b/src/DynamoCoreWpf/Commands/WorkspaceCommands.cs
@@ -229,6 +229,21 @@ namespace Dynamo.ViewModels
             get { return DynamoSelection.Instance.Selection.Count > 0; }
         }
 
+        public bool IsGeometryOperationEnabled
+        {
+            get
+            {
+                if (DynamoSelection.Instance.Selection.Count <= 0)
+                    return false; // No selection.
+
+                // Menu options that are specific to geometry (show/hide all 
+                // geometry previews, upstream previews, etc.) are only enabled
+                // in the home workspace.
+                // 
+                return (this.Model is HomeWorkspaceModel);
+            }
+        }
+
         public LacingStrategy SelectionArgumentLacing
         {
             // TODO We may need a better way to do this

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1145,6 +1145,7 @@ namespace Dynamo.ViewModels
             ShowHideAllGeometryPreviewCommand.RaiseCanExecuteChanged();
             SetArgumentLacingCommand.RaiseCanExecuteChanged();
             RaisePropertyChanged("HasSelection");
+            RaisePropertyChanged("IsGeometryOperationEnabled");
             RaisePropertyChanged("AnyNodeVisible");
             RaisePropertyChanged("AnyNodeUpstreamVisible");
             RaisePropertyChanged("SelectionArgumentLacing");

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -134,25 +134,25 @@
                     </MenuItem>
                 </MenuItem>
 
-                <MenuItem IsEnabled="{Binding Path=HasSelection}"
+                <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
                           Header="{x:Static  p:Resources.ContextMenuShowAllGeometry}"
                           Command="{Binding Path=ShowHideAllGeometryPreviewCommand}"
                           CommandParameter="true"
                           Visibility="{Binding Path=AnyNodeVisible, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
 
-                <MenuItem IsEnabled="{Binding Path=HasSelection}"
+                <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
                           Header="{x:Static p:Resources.ContextMenuHideAllGeometry}"
                           Command="{Binding Path=ShowHideAllGeometryPreviewCommand}"
                           CommandParameter="false"
                           Visibility="{Binding Path=AnyNodeVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
-                <MenuItem IsEnabled="{Binding Path=HasSelection}"
+                <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
                           Header="{x:Static  p:Resources.ContextMenuShowUpstreamPreview}"
                           Command="{Binding Path=ShowHideAllUpstreamPreviewCommand}"
                           CommandParameter="true"
                           Visibility="{Binding Path=AnyNodeUpstreamVisible, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
 
-                <MenuItem IsEnabled="{Binding Path=HasSelection}"
+                <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
                           Header="{x:Static p:Resources.ContextMenuHideUpstreamPreview}"
                           Command="{Binding Path=ShowHideAllUpstreamPreviewCommand}"
                           CommandParameter="false"

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -129,6 +129,7 @@
     <Compile Include="VisualizationManagerUITests.cs" />
     <Compile Include="WatchNodeTests.cs" />
     <Compile Include="WebRequestTests.cs" />
+    <Compile Include="WorkspaceGeneralOperations.cs" />
     <Compile Include="WorkspaceOpeningTests.cs" />
     <Compile Include="WorkspaceSaving.cs" />
   </ItemGroup>

--- a/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using NUnit.Framework;
+using Dynamo.Selection;
+using Dynamo.Nodes;
+using Dynamo.Models;
+using System.IO;
+
+namespace Dynamo.Tests
+{
+    public class WorkspaceGeneralOperations : DynamoViewModelUnitTest
+    {
+        [Test]
+        public void SwitchingToCustomWorkspaceWithSelectionShouldNotAllowGeometricOperations()
+        {
+            var model = ViewModel.Model; // The current DynamoModel instance.
+
+            // Step 0: Create a new node in Home workspace.
+            var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
+            model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 1);
+
+            // Step 1: Select the newly node, geometry operation should be enabled.
+            DynamoSelection.Instance.Selection.Add(addNode);
+            Assert.AreEqual(true, ViewModel.CurrentSpaceViewModel.HasSelection);
+            Assert.AreEqual(true, ViewModel.CurrentSpaceViewModel.IsGeometryOperationEnabled);
+
+            // Step 2: Open a Custom workspace.
+            var customNodePath = Path.Combine(TestDirectory, @"core\CustomNodes\NoInput.dyf");
+            ViewModel.OpenCommand.Execute(customNodePath);
+            var customWorkspace = model.Workspaces.FirstOrDefault(x => x is CustomNodeWorkspaceModel);
+            Assert.IsNotNull(customWorkspace);
+
+            // Step 3: Switch over from home workspace to custom workspace.
+            Assert.IsTrue(ViewModel.CurrentSpaceViewModel.Model is HomeWorkspaceModel);
+            ViewModel.CurrentWorkspaceIndex = 1;
+            Assert.IsTrue(ViewModel.CurrentSpaceViewModel.Model is CustomNodeWorkspaceModel);
+
+            // Step 4: Verify that the geometry operations are 
+            // disabled despite the fact that there is still selection.
+            Assert.AreEqual(true, ViewModel.CurrentSpaceViewModel.HasSelection);
+            Assert.AreEqual(false, ViewModel.CurrentSpaceViewModel.IsGeometryOperationEnabled);
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

This pull request is meant to fix a crash of contextual menu brought up in custom workspace. The details of this crash can be found in an internally tracked defect:

- [MAGN-7695](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7695) Hide all geometries contextual menu item crashes Dynamo in custom workspace

The following geometry specific menu options should not have been enabled in the first place (regardless of the presence of a selection set) for custom workspace:

- Show all geometry preview
- Show upstream geometry preview
- Hide all geometry preview
- Hide upstream geometry preview

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

Hi @aparajit-pratap, please take a look. If you are too occupied please let me know and I'll reassign. Thanks!

### FYIs

@riteshchandawar
