### PR TITLE
Restored LoginState and UserName properties in PkgMgrClientViewModel

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -167,6 +167,22 @@ namespace Dynamo.ViewModels
         public AuthenticationManager AuthenticationManager { get; set; }
         internal PackageManagerClient Model { get; private set; }
 
+        public LoginState LoginState
+        {
+            get
+            {
+                return AuthenticationManager.LoginState;
+            }
+        }
+
+        public string Username
+        {
+            get
+            {
+                return AuthenticationManager.Username;
+            }
+        }
+
         #endregion
 
         public ICommand ToggleLoginStateCommand { get; private set; }


### PR DESCRIPTION
### Purpose

This fixes defect: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7868.
The Login button states regressed for Dynamo Studio [here] (https://github.com/DynamoDS/Dynamo/commit/d0eb082ca3c7ea84ca6c3877c59c37fc18ab396c). The Login button is bound to the `LoginState` and the `UserName` properties in `PackageManagerClientViewModel` (which is its `DataContext`), which cannot be removed.

### Declarations

- [X] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin Reviewer 1
@pboyer  Reviewer 2

### FYIs

@pbidenko 