### PR TITLE
Crash when displaying shallow nested recent files saved on network drive

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1580,41 +1580,42 @@ namespace Dynamo.Controls
 
             // if the number of directories deep exceeds threshold
             if (str.Length - str.Replace(@"\", "").Length >= 5)
-            {
-                //directories to go down under the root
-                var threshold = 2;
-                var name = Path.GetFileName(str);
-                
-                var currentDirInfo = new DirectoryInfo(Path.GetDirectoryName(str));
-                var root = currentDirInfo.Root;
-                var rootName = root.FullName;
-
-                var collapsed = new List<string>();
-                collapsed.Add(name);
-                
-                var count = 0;
-                while(count < threshold)
-                {
-                    if (currentDirInfo.Parent == null)
-                    {
-                        break;
-                    }
-
-                    collapsed.Insert(0,currentDirInfo.Name);
-                    currentDirInfo = currentDirInfo.Parent;
-                    count ++;
-                }
-                //if the next parent is the root then we don't want to add ... to the string
-                if ( (currentDirInfo.Parent !=null) && (currentDirInfo.Parent!= root))
-                {
-                    rootName = rootName + "...";
-                }
-                collapsed.Insert(0,rootName);
-             
-                return string.Join(@"\", collapsed);
-            }
+                return ShortenNestedFilePath(str);
 
             return str;
+        }
+
+        internal static string ShortenNestedFilePath(string str)
+        {
+            //directories to go down under the root
+            const int MAX_FOLDER_DEPTH = 2;
+            var name = Path.GetFileName(str);
+
+            var currentDirInfo = new DirectoryInfo(Path.GetDirectoryName(str));
+            var root = currentDirInfo.Root;
+            var rootName = root.FullName;
+
+            var collapsed = new List<string>();
+            collapsed.Add(name);
+
+            for (int count = 0; count < MAX_FOLDER_DEPTH; count++)
+            {
+                if (currentDirInfo.Parent == null)
+                {
+                    break;
+                }
+
+                collapsed.Insert(0, currentDirInfo.Name);
+                currentDirInfo = currentDirInfo.Parent;
+            }
+            //if the next parent is the root then we don't want to add ... to the string
+            if ((currentDirInfo.Parent != null) && (currentDirInfo.Parent != root))
+            {
+                rootName = rootName + "...";
+            }
+            collapsed.Insert(0, rootName);
+
+            return string.Join(@"\", collapsed);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1580,7 +1580,9 @@ namespace Dynamo.Controls
 
             // if the number of directories deep exceeds threshold
             if (str.Length - str.Replace(@"\", "").Length >= 5)
+            {
                 return ShortenNestedFilePath(str);
+            }
 
             return str;
         }

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1581,20 +1581,36 @@ namespace Dynamo.Controls
             // if the number of directories deep exceeds threshold
             if (str.Length - str.Replace(@"\", "").Length >= 5)
             {
-                var root = Path.GetPathRoot(str);
+                //directories to go down under the root
+                var threshold = 2;
                 var name = Path.GetFileName(str);
+                
+                var currentDirInfo = new DirectoryInfo(Path.GetDirectoryName(str));
+                var root = currentDirInfo.Root;
+                var rootName = root.FullName;
 
-                var dirInfo = new DirectoryInfo(Path.GetDirectoryName(str));
-
-                var collapsed = new[]
+                var collapsed = new List<string>();
+                collapsed.Add(name);
+                
+                var count = 0;
+                while(count < threshold)
                 {
-                    root + "...",
-                    dirInfo.Parent.Parent.Name,
-                    dirInfo.Parent.Name,
-                    dirInfo.Name,
-                    name
-                };
+                    if (currentDirInfo.Parent == null)
+                    {
+                        break;
+                    }
 
+                    collapsed.Insert(0,currentDirInfo.Name);
+                    currentDirInfo = currentDirInfo.Parent;
+                    count ++;
+                }
+                //if the next parent is the root then we don't want to add ... to the string
+                if ( (currentDirInfo.Parent !=null) && (currentDirInfo.Parent!= root))
+                {
+                    rootName = rootName + "...";
+                }
+                collapsed.Insert(0,rootName);
+             
                 return string.Join(@"\", collapsed);
             }
 

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1592,8 +1592,14 @@ namespace Dynamo.Controls
             //directories to go down under the root
             const int MAX_FOLDER_DEPTH = 2;
             var name = Path.GetFileName(str);
+            var path = Path.GetDirectoryName(str);
 
-            var currentDirInfo = new DirectoryInfo(Path.GetDirectoryName(str));
+            if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(name))
+            {
+                return str;
+            }
+
+            var currentDirInfo = new DirectoryInfo(path);
             var root = currentDirInfo.Root;
             var rootName = root.FullName;
 

--- a/test/DynamoCoreWpfTests/ConverterTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterTests.cs
@@ -599,22 +599,24 @@ namespace Dynamo.Tests
         {
             var converter = new FilePathDisplayConverter();
 
-            Assert.DoesNotThrow(() => converter.Convert("\\\\psf\\Home\\Desktop\\somedyn.dyn",null,null,null));
-            Assert.DoesNotThrow(() => converter.Convert("\\\\\\\\\\\\\\\\psf\\Home\\Desktop\\somedyn.dyn", null, null, null));
-            Assert.DoesNotThrow(() => converter.Convert("\\\\psf\\Home\\somedyn.dyn", null, null, null));
-            Assert.DoesNotThrow(() => converter.Convert("\\\\psf\\somedyn.dyn", null, null, null));
-            Assert.AreEqual("\\\\psf\\Home\\Desktop\\somedyn.dyn",converter.Convert("\\\\psf\\Home\\Desktop\\somedyn.dyn", null, null, null));
-            Assert.AreEqual("\\\\psf\\Home...\\anotherlevel\\andanother\\somedyn.dyn", converter.Convert("\\\\psf\\Home\\Desktop\\anotherlevel\\andanother\\somedyn.dyn", null, null, null));
+            Assert.DoesNotThrow(() => converter.Convert(@"\\psf\Home\Desktop\somedyn.dyn",null,null,null));
+            Assert.DoesNotThrow(() => converter.Convert(@"\\\\\\\\psf\Home\Desktop\somedyn.dyn", null, null, null));
+            Assert.DoesNotThrow(() => converter.Convert(@"\\psf\Home\somedyn.dyn", null, null, null));
+            Assert.DoesNotThrow(() => converter.Convert(@"\\\\psf\Home\somedyn.dyn", null, null, null));
+            Assert.DoesNotThrow(() => converter.Convert(@"\\\\psf\\Home\\somedyn.dyn", null, null, null));
+            Assert.DoesNotThrow(() => converter.Convert(@"\\psf\somedyn.dyn", null, null, null));
+            Assert.AreEqual(@"\\psf\Home\Desktop\somedyn.dyn",converter.Convert(@"\\psf\Home\Desktop\somedyn.dyn", null, null, null));
+            Assert.AreEqual(@"\\psf\Home...\anotherlevel\andanother\somedyn.dyn", converter.Convert(@"\\psf\Home\Desktop\anotherlevel\andanother\somedyn.dyn", null, null, null));
         }
 
         [Test]
         public void FilePathDisplayConverterInternalDoesNotThrow()
         {
-            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath("\\\\psf\\Home\\Desktop\\somedyn.dyn"));
-            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath("\\\\\\\\\\\\\\\\psf\\Home\\Desktop\\somedyn.dyn"));
-            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath("\\\\psf\\Home\\somedyn.dyn"));
-            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath("\\\\psf\\somedyn.dyn"));
-            Assert.AreEqual("\\\\psf\\Home\\Desktop\\somedyn.dyn", FilePathDisplayConverter.ShortenNestedFilePath("\\\\psf\\Home\\Desktop\\somedyn.dyn"));
+            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath(@"\\psf\Home\Desktop\somedyn.dyn")); 
+            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath(@"\\\\\\\\psf\Home\Desktop\somedyn.dyn"));
+            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath(@"\\psf\\Home\somedyn.dyn"));
+            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath(@"\\psf\somedyn.dyn"));
+            Assert.AreEqual(@"\\psf\Home\Desktop\somedyn.dyn", FilePathDisplayConverter.ShortenNestedFilePath(@"\\psf\Home\Desktop\somedyn.dyn"));
         }
     }
 }

--- a/test/DynamoCoreWpfTests/ConverterTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterTests.cs
@@ -593,5 +593,28 @@ namespace Dynamo.Tests
             result = converter.Convert(SearchViewModel.ViewMode.LibrarySearchView, null, null, null);
             Assert.IsFalse((bool)result);
         }
+
+        [Test]
+        public void FilePathDisplayConverterTest()
+        {
+            var converter = new FilePathDisplayConverter();
+
+            Assert.DoesNotThrow(() => converter.Convert("\\\\psf\\Home\\Desktop\\somedyn.dyn",null,null,null));
+            Assert.DoesNotThrow(() => converter.Convert("\\\\\\\\\\\\\\\\psf\\Home\\Desktop\\somedyn.dyn", null, null, null));
+            Assert.DoesNotThrow(() => converter.Convert("\\\\psf\\Home\\somedyn.dyn", null, null, null));
+            Assert.DoesNotThrow(() => converter.Convert("\\\\psf\\somedyn.dyn", null, null, null));
+            Assert.AreEqual("\\\\psf\\Home\\Desktop\\somedyn.dyn",converter.Convert("\\\\psf\\Home\\Desktop\\somedyn.dyn", null, null, null));
+            Assert.AreEqual("\\\\psf\\Home...\\anotherlevel\\andanother\\somedyn.dyn", converter.Convert("\\\\psf\\Home\\Desktop\\anotherlevel\\andanother\\somedyn.dyn", null, null, null));
+        }
+
+        [Test]
+        public void FilePathDisplayConverterInternalDoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath("\\\\psf\\Home\\Desktop\\somedyn.dyn"));
+            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath("\\\\\\\\\\\\\\\\psf\\Home\\Desktop\\somedyn.dyn"));
+            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath("\\\\psf\\Home\\somedyn.dyn"));
+            Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath("\\\\psf\\somedyn.dyn"));
+            Assert.AreEqual("\\\\psf\\Home\\Desktop\\somedyn.dyn", FilePathDisplayConverter.ShortenNestedFilePath("\\\\psf\\Home\\Desktop\\somedyn.dyn"));
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This PR changes the file path converter for displaying recent file paths in the recent file submenu in the file menu. Because network drives or servers file paths include extra '\'s and don't return roots the same as regular file paths this code broke on shallowly nested paths. (< 3 directories) 
 Instead of querying for directory.parent and parent.parent we loop some threshold and return when we encounter a null parent.

I have set this threshold to 2 directories under the root directory, this seems to be similar the original intent of filtering by 5 slashes. (which are escaped to `\\`)

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7929

![screen shot 2015-08-11 at 4 02 58 pm](https://cloud.githubusercontent.com/assets/508936/9209589/5fd931ba-4045-11e5-9f30-4a027d2f2145.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

@lukechurch 

### FYIs

@pboyer - just want to make sure I interpreted the intent of the original code correctly.