### PR TITLE
Added bool variable firstTimeErrorMessage in PublishViewModel.

### DIFF
--- a/src/DynamoPublish/Models/PublishModel.cs
+++ b/src/DynamoPublish/Models/PublishModel.cs
@@ -278,6 +278,12 @@ namespace Dynamo.Publish.Models
             }
             return result;
         }
+
+        internal void ClearState()
+        {
+            State = UploadState.Uninitialized;
+            Error = UploadErrorType.None;
+        }
     }
 
 }

--- a/src/DynamoPublish/ViewModels/PublishViewModel.cs
+++ b/src/DynamoPublish/ViewModels/PublishViewModel.cs
@@ -20,6 +20,11 @@ namespace Dynamo.Publish.ViewModels
     {
         #region Properties
 
+        /// <summary>
+        ///     Helps to show error message just 1 time.
+        /// </summary>
+        private bool firstTimeErrorMessage = true;
+
         private string name;
         public string Name
         {
@@ -151,6 +156,7 @@ namespace Dynamo.Publish.ViewModels
         private void OnModelStateChanged(PublishModel.UploadState state)
         {
             IsUploading = state == PublishModel.UploadState.Uploading;
+            firstTimeErrorMessage = state == PublishModel.UploadState.Failed;
             BeginInvoke(() => PublishCommand.RaiseCanExecuteChanged());
         }
 
@@ -190,11 +196,22 @@ namespace Dynamo.Publish.ViewModels
 
             if (model.State == PublishModel.UploadState.Failed)
             {
-                GenerateErrorMessage();
-                IsReadyToUpload = false;
-                // Even if there is error, user can try submit one more time.
-                // E.g. user typed wrong login or password.
-                return true;
+                if (firstTimeErrorMessage)
+                {
+                    GenerateErrorMessage();
+                    IsReadyToUpload = false;
+
+                    // We should show error message just one time.
+                    firstTimeErrorMessage = false;
+
+                    // Even if there is error, user can try submit one more time.
+                    // E.g. user typed wrong login or password.
+                    return true;
+                }
+                else
+                {
+                    model.ClearState();
+                }
             }
 
             UploadStateMessage = Resources.ReadyForPublishMessage;


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7834](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7834) Show error messages, upload status in customizer publish dialog.

Error message should be shown just one time. I.e.
1. User set name.
2. User set description.
3. User sent workspace, but there was error during sending.
4. User saw error.
5. User changed name/description.
6. User should see, that workspace is ready for upload.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@pboyer 

### FYIs

@Racel 