### PR TITLE
MAGN-7224 Move ZeroTouchEssentials library into Dynamo repository

### DIFF
--- a/doc/examples/ZeroTouchEssentials/CreateExampleObject.dyn
+++ b/doc/examples/ZeroTouchEssentials/CreateExampleObject.dyn
@@ -1,0 +1,35 @@
+<Workspace Version="0.7.0.21303" X="-348.421464160364" Y="-55.9888810586649" zoom="0.747692817123325" Description="" Category="" Name="Home">
+  <Elements>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="b8b8fd4f-a73d-486d-a3bb-dbde4d352320" nickname="ZeroTouchEssentials.ByTwoDoubles" x="627.2435752235" y="320.835322366661" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ZeroTouchEssentials\bin\Release\ZeroTouchEssentials.dll" function="ZeroTouchEssentials.ZeroTouchEssentials.ByTwoDoubles@double,double" />
+    <Dynamo.Nodes.DoubleSlider type="Dynamo.Nodes.DoubleSlider" guid="31fd8954-af25-4bdd-9a94-d2f4deaf61da" nickname="Double Slider" x="400.769106758193" y="286.953315273426" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double>33.0824287188193</System.Double>
+      <Range min="0" max="100" />
+    </Dynamo.Nodes.DoubleSlider>
+    <Dynamo.Nodes.DoubleSlider type="Dynamo.Nodes.DoubleSlider" guid="4795bd09-9ce4-4f3e-8919-6696aa6254c1" nickname="Double Slider" x="402.552370289416" y="438.530715427372" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <System.Double>63.8007217242715</System.Double>
+      <Range min="0" max="100" />
+    </Dynamo.Nodes.DoubleSlider>
+    <Dynamo.Nodes.Watch type="Dynamo.Nodes.Watch" guid="43114736-adea-4fd6-ac08-db0e5771da05" nickname="Watch" x="962.497119093404" y="171.041185743938" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="beb28694-43ca-416d-8df6-7e28785d3b90" nickname="ZeroTouchEssentials.A" x="983.896281468079" y="442.097242489818" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ZeroTouchEssentials\bin\Release\ZeroTouchEssentials.dll" function="ZeroTouchEssentials.ZeroTouchEssentials.A" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="164b9cef-e231-4b71-be76-1b88f795b576" nickname="ZeroTouchEssentials.B" x="985.679544999302" y="320.835322366661" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ZeroTouchEssentials\bin\Release\ZeroTouchEssentials.dll" function="ZeroTouchEssentials.ZeroTouchEssentials.B" />
+    <Dynamo.Nodes.Watch type="Dynamo.Nodes.Watch" guid="e5a78d5c-add2-4dd5-9e88-2574c9c00ebc" nickname="Watch" x="1299.53392649453" y="197.790138712282" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.Watch type="Dynamo.Nodes.Watch" guid="46ae01f5-5ba9-4f9c-89c4-75f3ee3d5550" nickname="Watch" x="1310.23350768187" y="647.172548580451" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="78933c44-3d8f-4d1a-bd17-06bac3457ab2" nickname="ZeroTouchEssentials.ReturnMultiExample" x="1381.56404893078" y="349.367538866228" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ZeroTouchEssentials\bin\Release\ZeroTouchEssentials.dll" function="ZeroTouchEssentials.ZeroTouchEssentials.ReturnMultiExample@double,double" />
+    <Dynamo.Nodes.Watch type="Dynamo.Nodes.Watch" guid="646d8b54-e860-4d2d-80c1-7b025399ebcb" nickname="Watch" x="1759.61591755004" y="434.964188364927" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.Watch type="Dynamo.Nodes.Watch" guid="525d1df2-5591-42b0-a1d9-ec4c82c18894" nickname="Watch" x="1756.04939048759" y="310.135741179324" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="b8b8fd4f-a73d-486d-a3bb-dbde4d352320" start_index="0" end="43114736-adea-4fd6-ac08-db0e5771da05" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="b8b8fd4f-a73d-486d-a3bb-dbde4d352320" start_index="0" end="164b9cef-e231-4b71-be76-1b88f795b576" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="b8b8fd4f-a73d-486d-a3bb-dbde4d352320" start_index="0" end="beb28694-43ca-416d-8df6-7e28785d3b90" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="31fd8954-af25-4bdd-9a94-d2f4deaf61da" start_index="0" end="b8b8fd4f-a73d-486d-a3bb-dbde4d352320" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="4795bd09-9ce4-4f3e-8919-6696aa6254c1" start_index="0" end="b8b8fd4f-a73d-486d-a3bb-dbde4d352320" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="beb28694-43ca-416d-8df6-7e28785d3b90" start_index="0" end="46ae01f5-5ba9-4f9c-89c4-75f3ee3d5550" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="beb28694-43ca-416d-8df6-7e28785d3b90" start_index="0" end="78933c44-3d8f-4d1a-bd17-06bac3457ab2" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="164b9cef-e231-4b71-be76-1b88f795b576" start_index="0" end="e5a78d5c-add2-4dd5-9e88-2574c9c00ebc" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="164b9cef-e231-4b71-be76-1b88f795b576" start_index="0" end="78933c44-3d8f-4d1a-bd17-06bac3457ab2" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="78933c44-3d8f-4d1a-bd17-06bac3457ab2" start_index="0" end="525d1df2-5591-42b0-a1d9-ec4c82c18894" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="78933c44-3d8f-4d1a-bd17-06bac3457ab2" start_index="1" end="646d8b54-e860-4d2d-80c1-7b025399ebcb" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>

--- a/doc/examples/ZeroTouchEssentials/UseGeometryObject.dyn
+++ b/doc/examples/ZeroTouchEssentials/UseGeometryObject.dyn
@@ -1,0 +1,22 @@
+<Workspace Version="0.7.0.21303" X="112.911869172969" Y="57.3444522746684" zoom="0.747692817123325" Description="" Category="" Name="Home">
+  <Elements>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="d1f5dc91-d611-44ba-b3b9-3b017b6bb224" nickname="ZeroTouchEssentials.DoubleLength" x="867.783263531223" y="204.301814854872" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ZeroTouchEssentials\bin\Release\ZeroTouchEssentials.dll" function="ZeroTouchEssentials.ZeroTouchEssentials.DoubleLength@Autodesk.DesignScript.Geometry.Curve" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="05ff98bc-9454-4d85-8cb9-738ecc4ba309" nickname="Code Block" x="137.333333333333" y="259.666666666667" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="Point.ByCoordinates(0, 0);&#xA;Point.ByCoordinates(10, 10);&#xA;Point.ByCoordinates(0, 20);" ShouldFocus="false" />
+    <DSCoreNodesUI.CreateList type="DSCoreNodesUI.CreateList" guid="3fd059c7-65e2-458e-8b69-326d25830cff" nickname="List.Create" x="406" y="266.666666666667" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="3" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="39049981-bd64-456e-9856-b49fd81c60b9" nickname="Curve.Length" x="865.635891897989" y="351.967481101601" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.Length" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="51e1223f-4de4-4801-a771-884d0b7a36c5" nickname="NurbsCurve.ByPoints" x="590" y="269.333333333333" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
+    <Dynamo.Nodes.Watch type="Dynamo.Nodes.Watch" guid="7cfb7491-1bed-4036-9d5a-e6d4cab71ccf" nickname="Watch" x="1160.62620463444" y="352.302355734714" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.Watch type="Dynamo.Nodes.Watch" guid="71a23230-1f62-4984-a80a-cfcf15785d7e" nickname="Watch" x="1161.62151312512" y="205.255569516025" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="d1f5dc91-d611-44ba-b3b9-3b017b6bb224" start_index="0" end="71a23230-1f62-4984-a80a-cfcf15785d7e" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="05ff98bc-9454-4d85-8cb9-738ecc4ba309" start_index="0" end="3fd059c7-65e2-458e-8b69-326d25830cff" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="05ff98bc-9454-4d85-8cb9-738ecc4ba309" start_index="1" end="3fd059c7-65e2-458e-8b69-326d25830cff" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="05ff98bc-9454-4d85-8cb9-738ecc4ba309" start_index="2" end="3fd059c7-65e2-458e-8b69-326d25830cff" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="3fd059c7-65e2-458e-8b69-326d25830cff" start_index="0" end="51e1223f-4de4-4801-a771-884d0b7a36c5" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="39049981-bd64-456e-9856-b49fd81c60b9" start_index="0" end="7cfb7491-1bed-4036-9d5a-e6d4cab71ccf" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="51e1223f-4de4-4801-a771-884d0b7a36c5" start_index="0" end="d1f5dc91-d611-44ba-b3b9-3b017b6bb224" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="51e1223f-4de4-4801-a771-884d0b7a36c5" start_index="0" end="39049981-bd64-456e-9856-b49fd81c60b9" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>

--- a/doc/examples/ZeroTouchEssentials/ZeroTouchEssentials.sln
+++ b/doc/examples/ZeroTouchEssentials/ZeroTouchEssentials.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZeroTouchEssentials", "ZeroTouchEssentials\ZeroTouchEssentials.csproj", "{056AD524-5D1A-451F-9761-BAD23D7E9DA3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{056AD524-5D1A-451F-9761-BAD23D7E9DA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{056AD524-5D1A-451F-9761-BAD23D7E9DA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{056AD524-5D1A-451F-9761-BAD23D7E9DA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{056AD524-5D1A-451F-9761-BAD23D7E9DA3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/doc/examples/ZeroTouchEssentials/ZeroTouchEssentials/Properties/AssemblyInfo.cs
+++ b/doc/examples/ZeroTouchEssentials/ZeroTouchEssentials/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ZeroTouchEssentials")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ZeroTouchEssentials")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6b579fb4-73d9-4b8f-bb07-b1f8b77d7f4f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/doc/examples/ZeroTouchEssentials/ZeroTouchEssentials/ZeroTouchEssentials.cs
+++ b/doc/examples/ZeroTouchEssentials/ZeroTouchEssentials/ZeroTouchEssentials.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Autodesk.DesignScript.Runtime;
+using Autodesk.DesignScript.Interfaces;
+using Autodesk.DesignScript.Geometry;
+
+///////////////////////////////////////////////////////////////////
+/// NOTE: This project requires references to the ProtoInterface
+/// and ProtoGeometry DLLs. These are found in the Dynamo install
+/// directory.
+///////////////////////////////////////////////////////////////////
+
+namespace ZeroTouchEssentials
+{
+    public class ZeroTouchEssentials
+    {
+        // Two private variables for example purposes
+        private double _a;
+        private double _b;
+
+        // We make the constructor for this object internal because the 
+        // Dynamo user should construct an object through a static method
+        internal ZeroTouchEssentials(double a, double b)
+        {
+            _a = a;
+            _b = b;
+        }
+
+        /// <summary>
+        /// An example of how to construct an object via a static method.
+        /// This is needed as Dynamo lacks a "new" keyword to construct a 
+        /// new object
+        /// </summary>
+        /// <param name="a">1st number. This will be stored in the Class.</param>
+        /// <param name="b">2nd number. This will be stored in the Class</param>
+        /// <returns>A newly-constructed ZeroTouchEssentials object</returns>
+        public static ZeroTouchEssentials ByTwoDoubles(double a, double b)
+        {
+            return new ZeroTouchEssentials(a, b);
+        }
+
+        /// <summary>
+        /// Example property returning the value _a inside the object
+        /// </summary>
+        public double A
+        {
+            get { return _a; }
+        }
+
+        /// <summary>
+        /// Example property returning the value _b inside the object
+        /// </summary>
+        public double B
+        {
+            get { return _b; }
+        }
+
+        /// <summary>
+        ///     An example showing how to return multiple values from a Zero-Touch imported node
+        ///     The names in the attribute should match the keys in the returned dictionary.
+        /// </summary>
+        /// <param name="a">First number.</param>
+        /// <param name="b">Second number.</param>
+        /// <returns name="add">Number created by adding two inputs together.</returns>
+        /// <returns name="mult">Number created by multiplying two inputs together.</returns>
+        /// <search>example,multi</search>
+        [MultiReturn(new[] { "add", "mult" })]
+        public static Dictionary<string, object> ReturnMultiExample(double a, double b)
+        {
+            return new Dictionary<string, object>
+            {
+                { "add", (a + b) },
+                { "mult", (a * b) }
+            };
+        }
+
+        /// <summary>
+        /// This method demonstrates how to use a native geometry object from Dynamo
+        /// in a custom method
+        /// </summary>
+        /// <param name="curve">Input Curve. This can be of any type deriving from Curve, such as NurbsCurve, Arc, Circle, etc</param>
+        /// <returns>The twice the length of the Curve </returns>
+        public static double DoubleLength(Autodesk.DesignScript.Geometry.Curve curve)
+        {
+            return curve.Length * 2.0;
+        }
+
+
+
+
+    }
+}

--- a/doc/examples/ZeroTouchEssentials/ZeroTouchEssentials/ZeroTouchEssentials.csproj
+++ b/doc/examples/ZeroTouchEssentials/ZeroTouchEssentials/ZeroTouchEssentials.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{056AD524-5D1A-451F-9761-BAD23D7E9DA3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ZeroTouchEssentials</RootNamespace>
+    <AssemblyName>ZeroTouchEssentials</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ProtoGeometry">
+      <HintPath>..\..\Dynamo\extern\ProtoGeometry\ProtoGeometry.dll</HintPath>
+    </Reference>
+    <Reference Include="ProtoInterface">
+      <HintPath>..\..\Dynamo\extern\ProtoGeometry\ProtoInterface.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ZeroTouchEssentials.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
### Purpose

This PR is to resolve [MAGN-7224: Move the Zero-touch essentials library in DynamoDS/Dynamo](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7224).

All the files in this PR are taken from @ptierney's [ZeroTouchEssentials repository](https://github.com/ptierney/ZeroTouchEssentials).
The new location in this repository is /doc/examples/ZeroTouchEssentials/.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@sharadkjaiswal @Benglin 