### PR TITLE
MAGN-7994 Display.ByGeometryColor nodes created in 0.8.1 need to be migrated in 0.8.2

### DIFF
--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -149,7 +149,13 @@ namespace Dynamo.DSEngine
 
         public void AddAdditionalAttributesToNode(string functionSignature, XmlElement nodeElement)
         {
-            var upgradeHint = priorNameHints[functionSignature];
+            var shortKey = GetQualifiedFunction(functionSignature);
+            if (!FunctionSignatureNeedsAdditionalAttributes(functionSignature)
+                && !FunctionSignatureNeedsAdditionalAttributes(shortKey)) return;
+
+            var upgradeHint = FunctionSignatureNeedsAdditionalAttributes(functionSignature)
+                ? priorNameHints[functionSignature]
+                : priorNameHints[shortKey];
 
             foreach (string key in upgradeHint.AdditionalAttributes.Keys)
             {
@@ -167,7 +173,13 @@ namespace Dynamo.DSEngine
 
         public void AddAdditionalElementsToNode(string functionSignature, XmlElement nodeElement)
         {
-            var upgradeHint = priorNameHints[functionSignature];
+            var shortKey = GetQualifiedFunction(functionSignature);
+            if (!FunctionSignatureNeedsAdditionalElements(functionSignature)
+                && !FunctionSignatureNeedsAdditionalElements(shortKey)) return;
+
+            var upgradeHint = FunctionSignatureNeedsAdditionalElements(functionSignature)
+                ? priorNameHints[functionSignature]
+                : priorNameHints[shortKey];
 
             foreach (XmlElement elem in upgradeHint.AdditionalElements)
             {
@@ -235,6 +247,22 @@ namespace Dynamo.DSEngine
             string newName = priorNameHints[qualifiedFunction].UpgradeName;
 
             return newName + "@" + splitted[1];
+        }
+
+        private string GetQualifiedFunction(string functionSignature)
+        {
+            // if the hint is not explicit, we try the function name without parameters
+            string[] splitted = functionSignature.Split('@');
+
+            if (splitted.Length < 2 || String.IsNullOrEmpty(splitted[0]) || String.IsNullOrEmpty(splitted[1]))
+                return null;
+
+            string qualifiedFunction = splitted[0];
+
+            if (!priorNameHints.ContainsKey(qualifiedFunction))
+                return null;
+
+            return qualifiedFunction;
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/NodeLoaders/ZeroTouchNodeLoader.cs
+++ b/src/DynamoCore/Models/NodeLoaders/ZeroTouchNodeLoader.cs
@@ -51,11 +51,8 @@ namespace Dynamo.Models.NodeLoaders
                     function = hintedSigniture;
 
                     // if the node needs additional parameters, add them here
-                    if (libraryServices.FunctionSignatureNeedsAdditionalAttributes(xmlSignature))
-                        libraryServices.AddAdditionalAttributesToNode(xmlSignature, nodeElement);
-
-                    if (libraryServices.FunctionSignatureNeedsAdditionalElements(xmlSignature))
-                        libraryServices.AddAdditionalElementsToNode(xmlSignature, nodeElement);
+                    libraryServices.AddAdditionalAttributesToNode(xmlSignature, nodeElement);
+                    libraryServices.AddAdditionalElementsToNode(xmlSignature, nodeElement);
                 }
                 else
                 {

--- a/src/Libraries/CoreNodes/DSCoreNodes.Migrations.xml
+++ b/src/Libraries/CoreNodes/DSCoreNodes.Migrations.xml
@@ -24,4 +24,14 @@
     <oldName>DSCore.File.ExportToCSV</oldName>
     <newName>DSCore.IO.File.ExportToCSV</newName>
   </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.Display.ByGeometryColor</oldName>
+    <newName>Display.Display.ByGeometryColor</newName>
+    <additionalAttributes>
+      <attribute>
+        <name>assembly</name>
+        <value>Display.dll</value>
+      </attribute>
+    </additionalAttributes>
+  </priorNameHint>
 </migrations>


### PR DESCRIPTION
### Purpose

Correctly load `Display.ByGeometryColor` from old-version file using migration mechanism

### Reviewers

@pboyer 