### PR TITLE
Temporary visualization fixes...

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.2.2240")]
+[assembly: AssemblyVersion("0.8.2.2244")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.2.2240")]
+[assembly: AssemblyFileVersion("0.8.2.2244")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.2.2096")]
+[assembly: AssemblyVersion("0.8.2.2240")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.2.2096")]
+[assembly: AssemblyFileVersion("0.8.2.2240")]

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -70,7 +70,7 @@ namespace Dynamo.Controls
         private double lightAzimuthDegrees = 45.0;
         private double lightElevationDegrees = 35.0;
         private int renderingTier;
-        private IWatchViewModel viewModel;
+        private IWatchViewModel context;
         private double nearPlaneDistanceFactor = 0.01;
         internal readonly Vector3D defaultCameraLookDirection = new Vector3D(-10, -10, -10);
         internal readonly Point3D defaultCameraPosition = new Point3D(10, 15, 10);
@@ -397,39 +397,39 @@ namespace Dynamo.Controls
         {
             UnregisterButtonHandlers();
 
-            if (viewModel == null) return;
+            if (context == null) return;
 
             UnregisterVisualizationManagerEventHandlers();
 
-            viewModel.ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+            context.ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
 
             CompositionTarget.Rendering -= CompositionTarget_Rendering;
 
-            UnregisterModelEventHandlers(viewModel.ViewModel.Model);
+            UnregisterModelEventHandlers(context.ViewModel.Model);
 
-            UnregisterWorkspaceEventHandlers(viewModel.ViewModel.Model);
+            UnregisterWorkspaceEventHandlers(context.ViewModel.Model);
         }
 
         private void OnViewLoaded(object sender, RoutedEventArgs e)
         {
-            viewModel = DataContext as IWatchViewModel;
+            context = DataContext as IWatchViewModel;
 
             CompositionTarget.Rendering += CompositionTarget_Rendering;
 
             RegisterButtonHandlers();
 
             //check this for null so the designer can load the preview
-            if (viewModel == null) return;
+            if (context == null) return;
 
             RegisterVisualizationManagerEventHandlers();
 
             LogVisualizationCapabilities();
 
-            viewModel.ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+            context.ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
-            RegisterModelEventhandlers(viewModel.ViewModel.Model);
+            RegisterModelEventhandlers(context.ViewModel.Model);
 
-            RegisterWorkspaceEventHandlers(viewModel.ViewModel.Model);  
+            RegisterWorkspaceEventHandlers(context.ViewModel.Model);  
         }
 
         private void RegisterButtonHandlers()
@@ -456,7 +456,7 @@ namespace Dynamo.Controls
             var softwareEffectSupported = RenderCapability.IsShaderEffectSoftwareRenderingSupported;
             var maxTextureSize = RenderCapability.MaxHardwareTextureSize;
 
-            var logger = viewModel.ViewModel.Model.Logger;
+            var logger = context.ViewModel.Model.Logger;
 
             logger.Log(string.Format("RENDER : Rendering Tier: {0}", renderingTier), LogLevel.File);
             logger.Log(string.Format("RENDER : Pixel Shader 3 Supported: {0}", pixelShader3Supported),
@@ -471,20 +471,20 @@ namespace Dynamo.Controls
 
         private void RegisterVisualizationManagerEventHandlers()
         {
-            viewModel.VisualizationManager.RenderComplete += VisualizationManagerRenderComplete;
-            viewModel.VisualizationManager.ResultsReadyToVisualize += VisualizationManager_ResultsReadyToVisualize;
-            viewModel.VisualizationManager.SelectionHandled += VisualizationManager_SelectionHandled;
-            viewModel.VisualizationManager.DeletionHandled += VisualizationManager_DeletionHandled;
-            viewModel.VisualizationManager.WorkspaceOpenedClosedHandled += VisualizationManager_WorkspaceOpenedClosedHandled;
+            context.VisualizationManager.RenderComplete += VisualizationManagerRenderComplete;
+            context.VisualizationManager.ResultsReadyToVisualize += VisualizationManager_ResultsReadyToVisualize;
+            context.VisualizationManager.SelectionHandled += VisualizationManager_SelectionHandled;
+            context.VisualizationManager.DeletionHandled += VisualizationManager_DeletionHandled;
+            context.VisualizationManager.WorkspaceOpenedClosedHandled += VisualizationManager_WorkspaceOpenedClosedHandled;
         }
 
         private void UnregisterVisualizationManagerEventHandlers()
         {
-            viewModel.VisualizationManager.RenderComplete -= VisualizationManagerRenderComplete;
-            viewModel.VisualizationManager.ResultsReadyToVisualize -= VisualizationManager_ResultsReadyToVisualize;
-            viewModel.VisualizationManager.SelectionHandled -= VisualizationManager_SelectionHandled;
-            viewModel.VisualizationManager.DeletionHandled -= VisualizationManager_DeletionHandled;
-            viewModel.VisualizationManager.WorkspaceOpenedClosedHandled -= VisualizationManager_WorkspaceOpenedClosedHandled;
+            context.VisualizationManager.RenderComplete -= VisualizationManagerRenderComplete;
+            context.VisualizationManager.ResultsReadyToVisualize -= VisualizationManager_ResultsReadyToVisualize;
+            context.VisualizationManager.SelectionHandled -= VisualizationManager_SelectionHandled;
+            context.VisualizationManager.DeletionHandled -= VisualizationManager_DeletionHandled;
+            context.VisualizationManager.WorkspaceOpenedClosedHandled -= VisualizationManager_WorkspaceOpenedClosedHandled;
         }
 
         private void RegisterModelEventhandlers(DynamoModel model)
@@ -1346,7 +1346,7 @@ namespace Dynamo.Controls
 
         private void LogCameraWarning(string msg, Exception ex)
         {
-            var logger = viewModel.ViewModel.Model.Logger;
+            var logger = context.ViewModel.Model.Logger;
 
             logger.Log(msg, LogLevel.Console);
             logger.Log(msg, LogLevel.File);

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -70,7 +70,7 @@ namespace Dynamo.Controls
         private double lightAzimuthDegrees = 45.0;
         private double lightElevationDegrees = 35.0;
         private int renderingTier;
-        private DynamoViewModel viewModel;
+        private IWatchViewModel viewModel;
         private double nearPlaneDistanceFactor = 0.01;
         internal readonly Vector3D defaultCameraLookDirection = new Vector3D(-10, -10, -10);
         internal readonly Point3D defaultCameraPosition = new Point3D(10, 15, 10);
@@ -401,18 +401,18 @@ namespace Dynamo.Controls
 
             UnregisterVisualizationManagerEventHandlers();
 
-            viewModel.PropertyChanged -= ViewModel_PropertyChanged;
+            viewModel.ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
 
             CompositionTarget.Rendering -= CompositionTarget_Rendering;
 
-            UnregisterModelEventHandlers(viewModel.Model);
+            UnregisterModelEventHandlers(viewModel.ViewModel.Model);
 
-            UnregisterWorkspaceEventHandlers(viewModel.Model);
+            UnregisterWorkspaceEventHandlers(viewModel.ViewModel.Model);
         }
 
         private void OnViewLoaded(object sender, RoutedEventArgs e)
         {
-            viewModel = DataContext as DynamoViewModel;
+            viewModel = DataContext as IWatchViewModel;
 
             CompositionTarget.Rendering += CompositionTarget_Rendering;
 
@@ -425,11 +425,11 @@ namespace Dynamo.Controls
 
             LogVisualizationCapabilities();
 
-            viewModel.PropertyChanged += ViewModel_PropertyChanged;
+            viewModel.ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
-            RegisterModelEventhandlers(viewModel.Model);
+            RegisterModelEventhandlers(viewModel.ViewModel.Model);
 
-            RegisterWorkspaceEventHandlers(viewModel.Model);  
+            RegisterWorkspaceEventHandlers(viewModel.ViewModel.Model);  
         }
 
         private void RegisterButtonHandlers()
@@ -456,14 +456,16 @@ namespace Dynamo.Controls
             var softwareEffectSupported = RenderCapability.IsShaderEffectSoftwareRenderingSupported;
             var maxTextureSize = RenderCapability.MaxHardwareTextureSize;
 
-            viewModel.Model.Logger.Log(string.Format("RENDER : Rendering Tier: {0}", renderingTier), LogLevel.File);
-            viewModel.Model.Logger.Log(string.Format("RENDER : Pixel Shader 3 Supported: {0}", pixelShader3Supported),
+            var logger = viewModel.ViewModel.Model.Logger;
+
+            logger.Log(string.Format("RENDER : Rendering Tier: {0}", renderingTier), LogLevel.File);
+            logger.Log(string.Format("RENDER : Pixel Shader 3 Supported: {0}", pixelShader3Supported),
                 LogLevel.File);
-            viewModel.Model.Logger.Log(string.Format("RENDER : Pixel Shader 4 Supported: {0}", pixelShader4Supported),
+            logger.Log(string.Format("RENDER : Pixel Shader 4 Supported: {0}", pixelShader4Supported),
                 LogLevel.File);
-            viewModel.Model.Logger.Log(
+            logger.Log(
                 string.Format("RENDER : Software Effect Rendering Supported: {0}", softwareEffectSupported), LogLevel.File);
-            viewModel.Model.Logger.Log(string.Format("RENDER : Maximum hardware texture size: {0}", maxTextureSize),
+            logger.Log(string.Format("RENDER : Maximum hardware texture size: {0}", maxTextureSize),
                 LogLevel.File);
         }
 
@@ -1344,9 +1346,11 @@ namespace Dynamo.Controls
 
         private void LogCameraWarning(string msg, Exception ex)
         {
-            viewModel.Model.Logger.Log(msg, LogLevel.Console);
-            viewModel.Model.Logger.Log(msg, LogLevel.File);
-            viewModel.Model.Logger.Log(ex.Message, LogLevel.File);
+            var logger = viewModel.ViewModel.Model.Logger;
+
+            logger.Log(msg, LogLevel.Console);
+            logger.Log(msg, LogLevel.File);
+            logger.Log(ex.Message, LogLevel.File);
         }
 
         #endregion


### PR DESCRIPTION
### Purpose

This commit introduces two fixes for visualization to be included in the 0.8.2 release. These are fixes which will be superceded by those in [this PR](https://github.com/DynamoDS/Dynamo/pull/4931).

- MAGN-7891. Watch3D nodes were not rendering as their model event handlers were not registered. This was due to an invalid cast of the DataContext to DynamoViewModel. The viewModel field has been updated to be of type IWatchViewModel, and all references updated accordingly. The need to call `viewModel.ViewModel.Model...` on `Watch3DView` is really ugly and confusing and is fixed in the PR mentioned above which refactors a food portion of this work. This PR is just to get this working again.
- MAGN-7965. The fix for MAGN-7891 also fixed an issue with the addition of a watch3D node to the scene causing the default light to become detached.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
  - The code is in the same state.
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
  - No new strings added.

### Reviewers

@ramramps 