### PR TITLE
MAGN-7891 Watch3d node display is blank with geometry sample

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -1257,7 +1257,9 @@ namespace Dynamo.Controls
             if (args == null) return;
             if (args.Viewport == null) return;
 
-            var viewModel = DataContext as DynamoViewModel;
+            var contextViewModel = DataContext as IWatchViewModel;
+            var viewModel = contextViewModel.ViewModel;
+            
             foreach (var node in viewModel.Model.CurrentWorkspace.Nodes)
             {
                 var foundNode = node.AstIdentifierBase.Contains(((GeometryModel3D) e.OriginalSource).Name);


### PR DESCRIPTION
### Purpose

This PR fixes the bug related to Crash on Mouse Down Event inside watch3D node.

Link to YouTrack:
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7891
### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough 