### PR TITLE
MAGN-8120 Migration category not to be displayed when user opens old file containing a migrated custom node

### DIFF
--- a/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/CustomNodeWorkspaceModel.cs
@@ -59,6 +59,7 @@ namespace Dynamo.Models
             CustomNodeId = Guid.Parse(info.ID);
             Category = info.Category;
             Description = info.Description;
+            IsVisibleInDynamoLibrary = info.IsVisibleInDynamoLibrary;
             PropertyChanged += OnPropertyChanged;
         }
 
@@ -110,7 +111,7 @@ namespace Dynamo.Models
         {
             get
             {
-                return new CustomNodeInfo(CustomNodeId, Name, Category, Description, FileName);
+                return new CustomNodeInfo(CustomNodeId, Name, Category, Description, FileName, IsVisibleInDynamoLibrary);
             }
         }
 
@@ -156,6 +157,19 @@ namespace Dynamo.Models
             }
         }
         private string description;
+
+        /// <summary>
+        ///     Custom node visibility in the Dynamo library
+        /// </summary>
+        public bool IsVisibleInDynamoLibrary
+        {
+            get { return isVisibleInDynamoLibrary; }
+            set
+            {
+                isVisibleInDynamoLibrary = value;
+            }
+        }
+        private bool isVisibleInDynamoLibrary;
 
         protected override void RequestRun()
         {


### PR DESCRIPTION
### Purpose

This PR is to resolve [MAGN-8120: Migration Category shouldn't be displayed if user opens old file which uses custom node from migration category.](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8120)

The category "Migration" will now not be displayed in the Dynamo library after user opens any file containing a migrated custom node. This is done in order to avoid users creating new instances of these obsolete nodes in the library.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ke-yu 

### FYIs

@riteshchandawar @sharadkjaiswal 