### PR TITLE
Fixed code block output port alignment issue

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -1084,39 +1084,30 @@ namespace Dynamo.Models
         }
 
         /// <summary>
-        ///     Since the ports can have a margin (offset) so that they can moved vertically from its
-        ///     initial position, the center of the port needs to be calculted differently and not only
-        ///     based on the index. The function adds the height of other nodes as well as their margins
+        /// If a "PortModel.LineIndex" property isn't "-1", then it is a PortModel
+        /// meant to match up with a line in code block node. A code block node may 
+        /// contain empty lines in it, resulting in one PortModel being spaced out 
+        /// from another one. In such cases, the vertical position of PortModel is 
+        /// dependent of its "LineIndex".
+        /// 
+        /// If a "PortModel.LineIndex" property is "-1", then it is a regular 
+        /// PortModel. Regular PortModel stacks up on one another with equal spacing,
+        /// so their positions are based solely on "PortModel.Index".
         /// </summary>
-        /// <param name="portModel"> The portModel whose height is to be found</param>
-        /// <returns> Returns the offset of the given port from the top of the ports </returns>
+        /// <param name="portModel">The portModel whose vertical offset is to be computed.</param>
+        /// <returns>Returns the offset of the given port from the top of the ports</returns>
         //TODO(Steve): This kind of UI calculation should probably live on the VM. -- MAGN-5711
         internal double GetPortVerticalOffset(PortModel portModel)
         {
             double verticalOffset = 2.9;
-            int index = portModel.Index;
+            int index = portModel.LineIndex == -1 ? portModel.Index : portModel.LineIndex;
 
             //If the port was not found, then it should have just been deleted. Return from function
             if (index == -1)
                 return verticalOffset;
 
             double portHeight = portModel.Height;
-
-            switch (portModel.PortType)
-            {
-                case PortType.Input:
-                    for (int i = 0; i < index; i++)
-                        verticalOffset += inPorts[i].MarginThickness.Top + portHeight;
-                    verticalOffset += inPorts[index].MarginThickness.Top;
-                    break;
-                case PortType.Output:
-                    for (int i = 0; i < index; i++)
-                        verticalOffset += outPorts[i].MarginThickness.Top + portHeight;
-                    verticalOffset += outPorts[index].MarginThickness.Top;
-                    break;
-            }
-
-            return verticalOffset;
+            return verticalOffset + index * portModel.Height;
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/PortModel.cs
+++ b/src/DynamoCore/Models/PortModel.cs
@@ -75,6 +75,11 @@ namespace Dynamo.Models
             get { return Owner.GetPortModelIndex(this); }
         }
 
+        public int LineIndex
+        {
+            get { return portData.LineIndex; }
+        }
+
         public bool IsConnected
         {
             get; private set;

--- a/src/DynamoCore/Models/PortModel.cs
+++ b/src/DynamoCore/Models/PortModel.cs
@@ -150,11 +150,7 @@ namespace Dynamo.Models
 
             SetPortData(data);
 
-            if (PortType == Models.PortType.Input)
-                MarginThickness = new Thickness(0);
-            else
-                MarginThickness = new Thickness(0, data.VerticalMargin, 0, 0);
-
+            MarginThickness = new Thickness(0);
             Height = Math.Abs(data.Height) < 0.001 ? Configurations.PortHeightInPixels : data.Height;
         }
 
@@ -258,7 +254,7 @@ namespace Dynamo.Models
         public string NickName { get; set; }
         public string ToolTipString { get; set; }
         public AssociativeNode DefaultValue { get; set; }
-        public double VerticalMargin { get; set; }
+        public int LineIndex { get; set; }
 
         public double Height { get; set; }
 
@@ -269,7 +265,7 @@ namespace Dynamo.Models
             NickName = nickName;
             ToolTipString = toolTipString;
             DefaultValue = defaultValue;
-            VerticalMargin = 0;
+            LineIndex = -1;
             Height = 0;
         }
     }

--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -573,30 +573,17 @@ namespace Dynamo.Nodes
             if (allDefs.Any() == false)
                 return;
 
-            double prevPortBottom = 0.0;
             foreach (var def in allDefs)
             {
-                var logicalIndex = def.Value - 1;
-
                 string tooltip = def.Key;
                 if (tempVariables.Contains(def.Key))
                     tooltip = Formatting.TOOL_TIP_FOR_TEMP_VARIABLE;
 
-                double portCoordsY = Formatting.INITIAL_MARGIN;
-                portCoordsY += logicalIndex * Configurations.CodeBlockPortHeightInPixels;
-
                 OutPortData.Add(new PortData(string.Empty, tooltip)
                 {
-                    VerticalMargin = portCoordsY - prevPortBottom,
+                    LineIndex = def.Value - 1, // Logical line index.
                     Height = Configurations.CodeBlockPortHeightInPixels
                 });
-
-                // Since we compute the "delta" between the top of the current 
-                // port to the bottom of the previous port, we need to record 
-                // down the bottom coordinate value before proceeding to the next 
-                // port.
-                // 
-                prevPortBottom = portCoordsY + Configurations.CodeBlockPortHeightInPixels;
             }
         }
 

--- a/src/DynamoCore/Utilities/Configurations.cs
+++ b/src/DynamoCore/Utilities/Configurations.cs
@@ -145,7 +145,7 @@ namespace Dynamo.UI
 
         #region CodeBlockNode
 
-        public static readonly double CodeBlockPortHeightInPixels = 17.593333333333336;
+        public static readonly double CodeBlockPortHeightInPixels = 17.573333333333336;
         public static readonly int CBNMaxPortNameLength = 24;
         public static readonly string HighlightingFile =
             "DesignScript.Resources.SyntaxHighlighting.xshd";

--- a/src/DynamoCore/Utilities/Configurations.cs
+++ b/src/DynamoCore/Utilities/Configurations.cs
@@ -145,7 +145,7 @@ namespace Dynamo.UI
 
         #region CodeBlockNode
 
-        public static readonly double CodeBlockPortHeightInPixels = 17.563333333333336;
+        public static readonly double CodeBlockPortHeightInPixels = 17.593333333333336;
         public static readonly int CBNMaxPortNameLength = 24;
         public static readonly string HighlightingFile =
             "DesignScript.Resources.SyntaxHighlighting.xshd";

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Services\LoginService.cs" />
     <Compile Include="UI\DefaultBrandingResourceProvider.cs" />
     <Compile Include="UI\FrozenResources.cs" />
+    <Compile Include="UI\InOutPortPanel.cs" />
     <Compile Include="UI\LibraryTreeTemplateSelector.cs" />
     <Compile Include="UI\LibraryWrapPanel.cs" />
     <Compile Include="UI\Prompts\PresetOverwritePrompt.xaml.cs">
@@ -1213,6 +1214,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-        <MakeDir Directories="$(OutputPath)\viewExtensions\" /> 
+    <MakeDir Directories="$(OutputPath)\viewExtensions\" />
   </Target>
 </Project>

--- a/src/DynamoCoreWpf/UI/InOutPortPanel.cs
+++ b/src/DynamoCoreWpf/UI/InOutPortPanel.cs
@@ -29,12 +29,10 @@ namespace Dynamo.UI.Controls
                 var portVm = generator.ItemFromContainer(child) as PortViewModel;
                 var lineIndex = portVm.PortModel.LineIndex;
                 var multiplier = ((lineIndex == -1) ? itemIndex : lineIndex);
+                var portHeight = portVm.PortModel.Height;
 
-                var childSize = child.DesiredSize;
-                y = multiplier * (childSize.Height == 26 ? childSize.Height :
-                    Configurations.CodeBlockPortHeightInPixels);
-
-                child.Arrange(new Rect(x, y, arrangeSize.Width, childSize.Height));
+                y = multiplier * portHeight;
+                child.Arrange(new Rect(x, y, arrangeSize.Width, portHeight));
                 itemIndex = itemIndex + 1;
             }
 

--- a/src/DynamoCoreWpf/UI/InOutPortPanel.cs
+++ b/src/DynamoCoreWpf/UI/InOutPortPanel.cs
@@ -2,11 +2,51 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace Dynamo.UI.Controls
 {
-    public class InOutPortPanel : StackPanel
+    public class InOutPortPanel : Panel
     {
+        protected override Size ArrangeOverride(Size arrangeSize)
+        {
+            int count = 0;
+            double x = 0, y = 0;
+            foreach (UIElement child in this.Children)
+            {
+                var childSize = child.DesiredSize;
+                y = count * (childSize.Height == 26 ? childSize.Height :
+                    Configurations.CodeBlockPortHeightInPixels);
+
+                child.Arrange(new Rect(x, y, arrangeSize.Width, childSize.Height));
+                count = count + 1;
+            }
+
+            return base.ArrangeOverride(arrangeSize);
+        }
+
+        protected override Size MeasureOverride(Size constraint)
+        {
+            if (this.Children.Count <= 0)
+                return new Size(0, 0);
+
+            var cumulative = new Size(0, 0);
+            foreach (UIElement child in this.Children)
+            {
+                // Default behavior of getting each child to measure.
+                child.Measure(constraint);
+
+                // All children should be stacked from top to bottom, so we 
+                // will take the largest child's width as the final width.
+                if (cumulative.Width < child.DesiredSize.Width)
+                    cumulative.Width = child.DesiredSize.Width;
+
+                // Having one child item stack on top of another.
+                cumulative.Height += child.DesiredSize.Height;
+            }
+
+            return cumulative;
+        }
     }
 }

--- a/src/DynamoCoreWpf/UI/InOutPortPanel.cs
+++ b/src/DynamoCoreWpf/UI/InOutPortPanel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Controls;
+
+namespace Dynamo.UI.Controls
+{
+    public class InOutPortPanel : StackPanel
+    {
+    }
+}

--- a/src/DynamoCoreWpf/UI/InOutPortPanel.cs
+++ b/src/DynamoCoreWpf/UI/InOutPortPanel.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Dynamo.Utilities;
+using Dynamo.ViewModels;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,16 +13,29 @@ namespace Dynamo.UI.Controls
     {
         protected override Size ArrangeOverride(Size arrangeSize)
         {
-            int count = 0;
+            if (this.Children.Count <= 0)
+            {
+                // A port list without any port in it.
+                return base.ArrangeOverride(arrangeSize);
+            }
+
+            var itemsControl = WpfUtilities.FindUpVisualTree<ItemsControl>(this);
+            var generator = itemsControl.ItemContainerGenerator;
+
+            int itemIndex = 0;
             double x = 0, y = 0;
             foreach (UIElement child in this.Children)
             {
+                var portVm = generator.ItemFromContainer(child) as PortViewModel;
+                var lineIndex = portVm.PortModel.LineIndex;
+                var multiplier = ((lineIndex == -1) ? itemIndex : lineIndex);
+
                 var childSize = child.DesiredSize;
-                y = count * (childSize.Height == 26 ? childSize.Height :
+                y = multiplier * (childSize.Height == 26 ? childSize.Height :
                     Configurations.CodeBlockPortHeightInPixels);
 
                 child.Arrange(new Rect(x, y, arrangeSize.Width, childSize.Height));
-                count = count + 1;
+                itemIndex = itemIndex + 1;
             }
 
             return base.ArrangeOverride(arrangeSize);

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -1571,8 +1571,7 @@
         <Setter Property="ItemsPanel">
             <Setter.Value>
                 <ItemsPanelTemplate>
-                    <dynui:InOutPortPanel Orientation="Horizontal"
-                                          VerticalAlignment="Center"
+                    <dynui:InOutPortPanel VerticalAlignment="Stretch"
                                           HorizontalAlignment="Center" />
                 </ItemsPanelTemplate>
             </Setter.Value>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -1566,6 +1566,19 @@
         </Setter>
     </Style>
 
+    <Style x:Key="InOutPortControlStyle"
+           TargetType="ItemsControl">
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <dynui:InOutPortPanel Orientation="Horizontal"
+                                          VerticalAlignment="Center"
+                                          HorizontalAlignment="Center" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="{x:Type dynui:ImageCheckBox}"
            TargetType="{x:Type dynui:ImageCheckBox}">
         <Setter Property="SnapsToDevicePixels"

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -14,7 +14,7 @@
              KeyUp="OnKeyUp"
              PreviewKeyUp="OnPreviewKeyUp"
              MouseLeftButtonDown="topControl_MouseLeftButtonDown"
-             MouseRightButtonDown="topControl_MouseRightButtonDown"              
+             MouseRightButtonDown="topControl_MouseRightButtonDown"
              Canvas.Left="{Binding Left, Mode=TwoWay}"
              Canvas.Top="{Binding Top, Mode=TwoWay}">
     <Grid Name="grid"
@@ -40,7 +40,7 @@
 
         <Grid.ContextMenu>
             <ContextMenu Name="MainContextMenu"
-                         x:FieldModifier="public">               
+                         x:FieldModifier="public">
                 <MenuItem Name="deleteElem_cm"
                           Header="{x:Static p:Resources.ContextMenuDelete}"
                           Command="{Binding Path=DeleteCommand}" />
@@ -95,9 +95,9 @@
                 <MenuItem Name="enablePeriodicUpdate"
                           Header="{x:Static p:Resources.NodeContextMenuEnablePeriodicUpdate}"
                           IsCheckable="True"
-                          IsChecked="{Binding Path=EnablePeriodicUpdate, Mode=OneWay}" 
+                          IsChecked="{Binding Path=EnablePeriodicUpdate, Mode=OneWay}"
                           Visibility="{Binding PeriodicUpdateVisibility}"
-                          IsEnabled="False"/>
+                          IsEnabled="False" />
                 <MenuItem Name="rename_cm"
                           Header="{x:Static p:Resources.NodeContextMenuRenameNode}"
                           Command="{Binding Path=RenameCommand}" />
@@ -226,32 +226,23 @@
             </TextBlock.Foreground>
         </TextBlock>
 
-        <!-- INPUT PORTS -->        
-        <DockPanel Name="inPortGrid"
-                   Grid.Row="2"
-                   Grid.Column="0"
-                   VerticalAlignment="Stretch"
-                   IsHitTestVisible="True"
-                   Margin="0"
-                   Background="Transparent"
-                   Canvas.ZIndex="20">
-            <ItemsControl ItemsSource="{Binding Path=InPorts}"
-                          HorizontalContentAlignment="Stretch">
-            </ItemsControl>
-        </DockPanel>
+        <!-- INPUT PORTS -->
+        <ItemsControl Name="inputPortControl"
+                      Grid.Row="2"
+                      Grid.Column="0"
+                      Canvas.ZIndex="20"
+                      HorizontalContentAlignment="Stretch"
+                      ItemsSource="{Binding Path=InPorts}">
+        </ItemsControl>
 
         <!-- OUTPUT PORTS -->
-
-        <DockPanel Name="outPortGrid"
-                   Grid.Row="2"
-                   Grid.Column="2"
-                   VerticalAlignment="Top"
-                   IsHitTestVisible="True"
-                   Background="Transparent"
-                   Canvas.ZIndex="20">
-            <ItemsControl ItemsSource="{Binding Path=OutPorts}">
-            </ItemsControl>
-        </DockPanel>
+        <ItemsControl Name="outputPortControl"
+                      Grid.Row="2"
+                      Grid.Column="2"
+                      Canvas.ZIndex="20"
+                      HorizontalContentAlignment="Stretch"
+                      ItemsSource="{Binding Path=OutPorts}">
+        </ItemsControl>
 
         <Grid Name="centralGrid"
               Grid.Column="1"
@@ -271,15 +262,22 @@
                   VerticalAlignment="Stretch"
                   HorizontalAlignment="Stretch"
                   Canvas.ZIndex="21"
-                  IsEnabled="{Binding Path=IsInteractionEnabled}" MinHeight="{Binding Source={x:Static dynamo1:Configurations.PortHeightInPixels}}">
+                  IsEnabled="{Binding Path=IsInteractionEnabled}"
+                  MinHeight="{Binding Source={x:Static dynamo1:Configurations.PortHeightInPixels}}">
             </Grid>
 
         </Grid>
-        
-        <StackPanel Name="GlyphStackPanel" HorizontalAlignment="Right" Orientation="Horizontal" 
-                    Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="3" Canvas.ZIndex="30" Height="25"
+
+        <StackPanel Name="GlyphStackPanel"
+                    HorizontalAlignment="Right"
+                    Orientation="Horizontal"
+                    Grid.Column="0"
+                    Grid.Row="3"
+                    Grid.ColumnSpan="3"
+                    Canvas.ZIndex="30"
+                    Height="25"
                     Visibility="{Binding ShouldShowGlyphBar, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-            
+
             <Canvas x:Name="previewIcon"
                     Width="25"
                     Height="25"
@@ -409,8 +407,13 @@
                 Background="Blue">
         </Canvas>
 
-        <Canvas ClipToBounds="False" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3" Visibility="{Binding ShowDebugASTs, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-            <Label Content="{Binding ASTText}" HorizontalContentAlignment="Center"></Label>
+        <Canvas ClipToBounds="False"
+                Grid.Row="4"
+                Grid.Column="0"
+                Grid.ColumnSpan="3"
+                Visibility="{Binding ShowDebugASTs, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+            <Label Content="{Binding ASTText}"
+                   HorizontalContentAlignment="Center"></Label>
         </Canvas>
     </Grid>
 </UserControl>

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -232,6 +232,7 @@
                       Grid.Column="0"
                       Canvas.ZIndex="20"
                       HorizontalContentAlignment="Stretch"
+                      Style="{StaticResource InOutPortControlStyle}"
                       ItemsSource="{Binding Path=InPorts}">
         </ItemsControl>
 
@@ -241,6 +242,7 @@
                       Grid.Column="2"
                       Canvas.ZIndex="20"
                       HorizontalContentAlignment="Stretch"
+                      Style="{StaticResource InOutPortControlStyle}"
                       ItemsSource="{Binding Path=OutPorts}">
         </ItemsControl>
 

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -539,6 +539,66 @@ b = c[w][x][y][z];";
 
         [Test]
         [Category("RegressionTests")]
+        public void PortIndicesShouldProduceCorrectConnectorOffsets()
+        {
+            var code =
+@"var00 = a;
+
+var01 = b;
+var02 = c;
+
+
+var03 = d;
+var04 = e;
+var05 = f;
+
+
+
+var06 = g;
+";
+
+            var codeBlockNode = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(codeBlockNode, code);
+
+            Assert.AreEqual(7, codeBlockNode.InPortData.Count);
+            Assert.AreEqual(7, codeBlockNode.OutPortData.Count);
+
+            // Input ports are regular ports that do not depend on LineIndex.
+            Assert.AreEqual(-1, codeBlockNode.InPortData[0].LineIndex);
+            Assert.AreEqual(-1, codeBlockNode.InPortData[1].LineIndex);
+            Assert.AreEqual(-1, codeBlockNode.InPortData[2].LineIndex);
+            Assert.AreEqual(-1, codeBlockNode.InPortData[3].LineIndex);
+            Assert.AreEqual(-1, codeBlockNode.InPortData[4].LineIndex);
+            Assert.AreEqual(-1, codeBlockNode.InPortData[5].LineIndex);
+            Assert.AreEqual(-1, codeBlockNode.InPortData[6].LineIndex);
+
+            // Output ports are smaller ports that depend on LineIndex.
+            Assert.AreEqual(0, codeBlockNode.OutPortData[0].LineIndex);
+            Assert.AreEqual(2, codeBlockNode.OutPortData[1].LineIndex);
+            Assert.AreEqual(3, codeBlockNode.OutPortData[2].LineIndex);
+            Assert.AreEqual(6, codeBlockNode.OutPortData[3].LineIndex);
+            Assert.AreEqual(7, codeBlockNode.OutPortData[4].LineIndex);
+            Assert.AreEqual(8, codeBlockNode.OutPortData[5].LineIndex);
+            Assert.AreEqual(12, codeBlockNode.OutPortData[6].LineIndex);
+
+            // Ensure that "NodeModel.GetPortVerticalOffset" does not regress.
+            // This is the way connector position is calculated.
+            var verticalOffset = 2.9;
+            var lastOutPort = codeBlockNode.OutPorts[6];
+            var expectedOffset = verticalOffset + lastOutPort.LineIndex * lastOutPort.Height;
+            var actualOffset = codeBlockNode.GetPortVerticalOffset(lastOutPort);
+            Assert.AreEqual(expectedOffset, actualOffset);
+
+            // Input ports are regular portst that should depend on "Index" instead.
+            var lastInPort = codeBlockNode.InPorts[6];
+            expectedOffset = verticalOffset + lastInPort.Index * lastInPort.Height;
+            actualOffset = codeBlockNode.GetPortVerticalOffset(lastInPort);
+            Assert.AreEqual(6, lastInPort.Index);
+            Assert.AreEqual(expectedOffset, actualOffset);
+        }
+
+        [Test]
+        [Category("RegressionTests")]
         public void InPort_WithInlineConditionNonAssignment_Creation()
         {
             // Create the initial code block node.

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -514,8 +514,8 @@ b = c[w][x][y][z];";
             Assert.AreEqual(2, codeBlockNode.InPortData.Count);
             Assert.AreEqual(1, codeBlockNode.OutPortData.Count);
 
-            Assert.AreEqual(2 * Configurations.CodeBlockPortHeightInPixels, codeBlockNode.OutPortData[0].VerticalMargin, tolerance);
-            
+            Assert.AreEqual(2, codeBlockNode.OutPortData[0].LineIndex);
+
             code = "c+ \n d; \n /* comment \n */ \n a+b;";
             UpdateCodeBlockNodeContent(codeBlockNode, code);
 
@@ -523,19 +523,18 @@ b = c[w][x][y][z];";
             Assert.AreEqual(2, codeBlockNode.OutPortData.Count);
 
             // The first output port should be at the first line
-            Assert.AreEqual(0 * Configurations.CodeBlockPortHeightInPixels, codeBlockNode.OutPortData[0].VerticalMargin, tolerance);
+            Assert.AreEqual(0, codeBlockNode.OutPortData[0].LineIndex);
 
             // The second output port should be at the 4th line, which is also 3 lines below the first
-            Assert.AreEqual(3 * Configurations.CodeBlockPortHeightInPixels, codeBlockNode.OutPortData[1].VerticalMargin, tolerance);
-            
+            Assert.AreEqual(4, codeBlockNode.OutPortData[1].LineIndex);
+
             code = "/*comment \n */ \n a[0]+b;";
             UpdateCodeBlockNodeContent(codeBlockNode, code);
 
             Assert.AreEqual(2, codeBlockNode.InPortData.Count);
             Assert.AreEqual(1, codeBlockNode.OutPortData.Count);
 
-            Assert.AreEqual(2 * Configurations.CodeBlockPortHeightInPixels, codeBlockNode.OutPortData[0].VerticalMargin, tolerance);
-
+            Assert.AreEqual(2, codeBlockNode.OutPortData[0].LineIndex);
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -200,8 +200,8 @@ namespace DynamoCoreWpfTests
             var eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
             Assert.AreEqual(2, eles.Count());
 
-            var inPortGrid = nodeView.inPortGrid;
-            Assert.AreEqual(3, inPortGrid.ChildrenOfType<TextBlock>().Count());
+            var inputPortControl = nodeView.inputPortControl;
+            Assert.AreEqual(3, inputPortControl.ChildrenOfType<TextBlock>().Count());
         }
 
         [Test]
@@ -214,8 +214,8 @@ namespace DynamoCoreWpfTests
             var eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
             Assert.AreEqual(2, eles.Count());
 
-            var inPortGrid = nodeView.inPortGrid;
-            Assert.AreEqual(4, inPortGrid.ChildrenOfType<TextBlock>().Count());
+            var inputPortControl = nodeView.inputPortControl;
+            Assert.AreEqual(4, inputPortControl.ChildrenOfType<TextBlock>().Count());
         }
 
         [Test]
@@ -303,24 +303,24 @@ namespace DynamoCoreWpfTests
             var eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
             Assert.AreEqual(2, eles.Count());
 
-            var inPortGrid = nodeView.inPortGrid;
-            Assert.AreEqual(3, inPortGrid.ChildrenOfType<TextBlock>().Count());
+            var inputPortControl = nodeView.inputPortControl;
+            Assert.AreEqual(3, inputPortControl.ChildrenOfType<TextBlock>().Count());
 
             nodeView = NodeViewWithGuid("2f031397-539e-4df4-bfca-d94d0bd02bc1"); // String.Concat node
 
             eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
             Assert.AreEqual(2, eles.Count());
 
-            inPortGrid = nodeView.inPortGrid;
-            Assert.AreEqual(2, inPortGrid.ChildrenOfType<TextBlock>().Count());
+            inputPortControl = nodeView.inputPortControl;
+            Assert.AreEqual(2, inputPortControl.ChildrenOfType<TextBlock>().Count());
 
             nodeView = NodeViewWithGuid("0cb04cce-1b05-47e0-a73f-ee81af4b7f43"); // List.Join node
 
             eles = nodeView.inputGrid.ChildrenOfType<DynamoNodeButton>();
             Assert.AreEqual(2, eles.Count());
 
-            inPortGrid = nodeView.inPortGrid;
-            Assert.AreEqual(2, inPortGrid.ChildrenOfType<TextBlock>().Count());
+            inputPortControl = nodeView.inputPortControl;
+            Assert.AreEqual(2, inputPortControl.ChildrenOfType<TextBlock>().Count());
         }
 
         [Test]


### PR DESCRIPTION
This pull request represents a rebased version of [the same work that has already been reviewed](https://github.com/DynamoDS/Dynamo/pull/5119), it will be easier to cross-merge to release branch if this needs to be taken in for 0.8.2.

### Purpose

This pull request is meant to fix a problem where output ports of a code block node do not completely lined up with their corresponding statements. The defect is being tracked internally as:

- [MAGN-7391](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7391) Code block output ports do not align with their corresponding statements

This problem is introduced by slight offset accumulated along the way as output ports are placed in their container `ItemsControl`. This accumulative error is unavoidable as one `double` value counts on another previous `double` value.

To address this problem, instead of having the default `StackPanel` (inside an `ItemsControl`) arranging each output port, we now make use of a new `Panel` derived class: `InOutPortPanel`. This panel is aware of each `PortViewModel` (and indirectly, `PortModel` and `PortData`) object it contains so it is capable of arranging the ports accurately.

In order not to lose any precision, the vertical offset values are no longer computed in an accumulative way:

```csharp
double offset = 0.0;
foreach (var port in ports)
{
    // Adding double values accumulates error.
    offset = offset + port.Height;
}
```

Instead, a new property `PortModel.LineIndex` (replacing `PortModel.VerticalMargin` property) is introduced for lossless offset computation. The value of `PortModel.LineIndex` is assigned when `CodeBlockNodeModel` generates its output ports (i.e. when it has the knowledge of statement indices too). Error on a port does not get carried over for calculating offset of the next port:

```csharp
foreach (var port in ports)
{
    double offset = port.LineIndex * port.Height;
}
```

This is how it looks after the fix:

<img width="250" alt="port-alignment" src="https://cloud.githubusercontent.com/assets/5086849/9286933/56e7f7da-4333-11e5-9d52-5900a5cfb236.png">

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

Hi @aparajit-pratap, since you were previously dealing with this, please take a look. Thanks!

### FYIs

@riteshchandawar, it's done!
