### PR TITLE
Scroll top result

### DIFF
--- a/src/DynamoCoreWpf/UI/LibraryTreeTemplateSelector.cs
+++ b/src/DynamoCoreWpf/UI/LibraryTreeTemplateSelector.cs
@@ -52,9 +52,13 @@ namespace Dynamo.Controls
             if (item is SearchCategory)
             {
                 if ((item as SearchCategory).IsTopCategory)
+                {
                     return TopCategoryTemplate;
+                }
                 else
+                {
                     return CategoryTemplate;
+                }
             }
 
             const string message = "Unknown object bound to collection";

--- a/src/DynamoCoreWpf/UI/LibraryTreeTemplateSelector.cs
+++ b/src/DynamoCoreWpf/UI/LibraryTreeTemplateSelector.cs
@@ -43,6 +43,12 @@ namespace Dynamo.Controls
             if (item is SearchMemberGroup)
                 return MemberGroupsTemplate;
 
+            // "Top Result" is no longer a standalone panel on the library view. A SearchCategory 
+            // is created based off the first item in search results, and inserted into the results 
+            // just like any other SearchCategory objects. The only difference is, "IsTopCategory"
+            // property will be set to "true". This is where the right template is selected so that 
+            // top result item appears to look different from other categories in results.
+
             if (item is SearchCategory)
             {
                 if ((item as SearchCategory).IsTopCategory)

--- a/src/DynamoCoreWpf/UI/LibraryTreeTemplateSelector.cs
+++ b/src/DynamoCoreWpf/UI/LibraryTreeTemplateSelector.cs
@@ -30,6 +30,7 @@ namespace Dynamo.Controls
 
     public class LibrarySearchTreeTemplateSelector : DataTemplateSelector
     {
+        public DataTemplate TopCategoryTemplate { get; set; }
         public DataTemplate CategoryTemplate { get; set; }
         public DataTemplate MemberGroupsTemplate { get; set; }
         public DataTemplate MemberTemplate { get; set; }
@@ -43,7 +44,12 @@ namespace Dynamo.Controls
                 return MemberGroupsTemplate;
 
             if (item is SearchCategory)
-                return CategoryTemplate;
+            {
+                if ((item as SearchCategory).IsTopCategory)
+                    return TopCategoryTemplate;
+                else
+                    return CategoryTemplate;
+            }
 
             const string message = "Unknown object bound to collection";
             throw new InvalidOperationException(message);

--- a/src/DynamoCoreWpf/UI/Themes/Modern/SidebarGridStyleDictionary.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/SidebarGridStyleDictionary.xaml
@@ -232,6 +232,9 @@
         <StackPanel Name="ImageAndNodeName"
                     Orientation="Horizontal"
                     VerticalAlignment="Center">
+            <Border BorderBrush="Yellow"
+                    BorderThickness="2,0,0,0"
+                    Visibility="{Binding IsTopResult, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <Image HorizontalAlignment="Left"
                    Height="32"
                    Margin="16,0,16,0"
@@ -258,7 +261,7 @@
                            VerticalAlignment="Top"
                            Foreground="{StaticResource CommonSidebarTextColor}"
                            FontSize="13" />
-            </Grid>            
+            </Grid>
         </StackPanel>
     </DataTemplate>
 

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -19,6 +19,12 @@ namespace Dynamo.Wpf.ViewModels
         private bool isSelected;
         private SearchViewModel searchViewModel;
 
+        public bool IsTopResult
+        {
+            get;
+            set;
+        }
+
         public event RequestBitmapSourceHandler RequestBitmapSource;
         public void OnRequestBitmapSource(IconRequestEventArgs e)
         {

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchCategory.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchCategory.cs
@@ -21,6 +21,9 @@ namespace Dynamo.Search
         private bool isExpanded;
         public bool IsExpanded { get { return isExpanded; } }
 
+        private bool isTopCategory;
+        public bool IsTopCategory { get { return isTopCategory; } }
+
         // TODO: classes functionality.
         //       All functionality marked as 'classes functionality'
         //       Should be implemented as classes are shown in search results.
@@ -43,12 +46,13 @@ namespace Dynamo.Search
             RaisePropertyChanged("IsExpanded");
         }
 
-        internal SearchCategory(string name)
+        internal SearchCategory(string name, bool isTopResult = false)
         {
             Name = name;
             classes = new ObservableCollection<NodeCategoryViewModel>();
             memberGroups = new List<SearchMemberGroup>();
             isExpanded = true;
+            isTopCategory = isTopResult;
 
             ClickedCommand = new DelegateCommand(OnClicked);
         }

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchCategory.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchCategory.cs
@@ -130,7 +130,7 @@ namespace Dynamo.Search
 
         public bool IsSelected
         {
-            get { return true; }
+            get { return false; }
         }
 
         public string Description

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchMemberGroup.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchMemberGroup.cs
@@ -109,7 +109,7 @@ namespace Dynamo.Search
 
         public bool IsSelected
         {
-            get { return true; }
+            get { return false; }
         }
 
         public string Description

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -742,7 +742,7 @@ namespace Dynamo.ViewModels
 
             SortSearchCategoriesChildren();
 
-            var topCategory = new SearchCategory("Top Result", true);
+            var topCategory = new SearchCategory(Dynamo.Wpf.Properties.Resources.SearchViewTopResult, true);
             topCategory.AddMemberToGroup(topNode);
             searchRootCategories.Insert(0, topCategory);
 

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -738,14 +738,15 @@ namespace Dynamo.ViewModels
 
             // Clone top node.
             var topNode = new NodeSearchElementViewModel(MakeNodeSearchElementVM(nodes.First()));
-            topNode.IsSelected = true;
-            selectionNavigator.UpdateRootCategories(SearchRootCategories, topNode);          
+            topNode.IsTopResult = true;
 
             SortSearchCategoriesChildren();
 
             var topCategory = new SearchCategory("Top Result", true);
             topCategory.AddMemberToGroup(topNode);
             searchRootCategories.Insert(0, topCategory);
+
+            selectionNavigator.UpdateRootCategories(SearchRootCategories);
         }
 
         private void SortSearchCategoriesChildren()

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -99,17 +99,6 @@ namespace Dynamo.ViewModels
             }
         }
 
-        private SearchMemberGroup topResult;
-        public SearchMemberGroup TopResult
-        {
-            get { return topResult; }
-            set
-            {
-                topResult = value;
-                RaisePropertyChanged("TopResult");
-            }
-        }
-
         /// <summary>
         ///     SearchIconAlignment property
         /// </summary>
@@ -744,13 +733,19 @@ namespace Dynamo.ViewModels
                 category.AddMemberToGroup(elementVM);
             }
 
-            // Update top result before we do not sort categories.
-            if (searchRootCategories.Any())
-                UpdateTopResult(searchRootCategories.FirstOrDefault().MemberGroups.FirstOrDefault());
-            else
-                UpdateTopResult(null);
+            if (nodes.Count() == 0)
+                return;
+
+            // Clone top node.
+            var topNode = new NodeSearchElementViewModel(MakeNodeSearchElementVM(nodes.First()));
+            topNode.IsSelected = true;
+            selectionNavigator.UpdateRootCategories(SearchRootCategories, topNode);          
 
             SortSearchCategoriesChildren();
+
+            var topCategory = new SearchCategory("Top Result", true);
+            topCategory.AddMemberToGroup(topNode);
+            searchRootCategories.Insert(0, topCategory);
         }
 
         private void SortSearchCategoriesChildren()
@@ -868,26 +863,6 @@ namespace Dynamo.ViewModels
         public void MoveSelection(NavigationDirection direction)
         {
             selectionNavigator.MoveSelection(direction);
-        }
-
-        private void UpdateTopResult(SearchMemberGroup memberGroup)
-        {
-            if (memberGroup == null)
-            {
-                TopResult = null;
-                return;
-            }
-
-            var topMemberGroup = new SearchMemberGroup(memberGroup.FullyQualifiedName);
-
-            // Clone top node.
-            var topNode = new NodeSearchElementViewModel(memberGroup.Members.FirstOrDefault());
-            topNode.IsSelected = true;            
-
-            topMemberGroup.AddMember(topNode);
-            TopResult = topMemberGroup;
-
-            selectionNavigator.UpdateRootCategories(SearchRootCategories, topNode);            
         }
 
         internal void ExecuteSelectedMember()

--- a/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
@@ -174,7 +174,7 @@ namespace Dynamo.ViewModels
             selection = GetSelectionFromIndices();
             if (selection != null)
             {
-                selection.IsSelected = false;
+                selection.IsSelected = true;
             }
         }
     }

--- a/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
@@ -32,8 +32,6 @@ namespace Dynamo.ViewModels
 
         private IEnumerable<SearchCategory> root = null;
 
-        private NodeSearchElementViewModel topResult = null;
-
         /// <summary>
         /// Currently selected member.
         /// </summary>
@@ -50,35 +48,25 @@ namespace Dynamo.ViewModels
             UpdateRootCategories(rootTree);
         }
 
-        internal void UpdateRootCategories(IEnumerable<SearchCategory> rootTree, NodeSearchElementViewModel topResult = null)
+        internal void UpdateRootCategories(IEnumerable<SearchCategory> rootTree)
         {
             root = rootTree;
 
             if (root == null || !root.Any())
             {
-                topResult = null;
+                selectedCategoryIndex = -1;
+                selectedMemberGroupIndex = -1;
+                selectedMemberIndex = -1;
                 return;
             }
 
-            selectedCategoryIndex = -1;
-            selectedMemberGroupIndex = -1;
-            selectedMemberIndex = -1;
-
-            this.topResult = topResult;
+            SelectItem(0, 0, 0);
         }
 
         internal void MoveSelection(NavigationDirection direction)
         {
             if (root == null || !root.Any())
                 return;
-
-            if (CurrentSelection == topResult)
-            {
-                // We can only move forward...
-                if (direction == NavigationDirection.Forward)
-                    SelectItem(0, 0, 0);
-                return;
-            }
 
             var selectedCategory = root.ElementAt(selectedCategoryIndex);
             var selectedMemberGroup = selectedCategory.MemberGroups.ElementAt(selectedMemberGroupIndex);
@@ -115,11 +103,6 @@ namespace Dynamo.ViewModels
 
                             var group = category.MemberGroups.ElementAt(selectedMemberGroupIndex);
                             selectedMemberIndex = group.Members.Count() - 1;
-                        }
-                        else // No place to move back. Clear selection. Select top result.
-                        {
-                            SelectItem(-1, -1, -1);
-                            return;
                         }
                     }
                 }
@@ -160,8 +143,8 @@ namespace Dynamo.ViewModels
                 (selectedMemberGroupIndex == -1) &&
                 (selectedMemberIndex == -1))
             {
-                // No selection, return topResult instead.
-                return topResult;
+                // No selection.
+                return null;
             }
 
             var selectedCategory = root.ElementAt(selectedCategoryIndex);
@@ -178,13 +161,9 @@ namespace Dynamo.ViewModels
 
         private void SelectItem(int categoryIndex, int memberGroupIndex, int memberIndex)
         {
-            if (categoryIndex == selectedCategoryIndex &&
-                memberGroupIndex == selectedMemberGroupIndex &&
-                memberIndex == selectedMemberIndex)
-                return; // No selection change.
-
             var selection = GetSelectionFromIndices();
-            selection.IsSelected = false;
+            if (selection != null)
+                selection.IsSelected = false;
 
             selectedCategoryIndex = categoryIndex;
             selectedMemberGroupIndex = memberGroupIndex;

--- a/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SelectionNavigator.cs
@@ -163,14 +163,19 @@ namespace Dynamo.ViewModels
         {
             var selection = GetSelectionFromIndices();
             if (selection != null)
+            {
                 selection.IsSelected = false;
+            }
 
             selectedCategoryIndex = categoryIndex;
             selectedMemberGroupIndex = memberGroupIndex;
             selectedMemberIndex = memberIndex;
 
             selection = GetSelectionFromIndices();
-            selection.IsSelected = true;
+            if (selection != null)
+            {
+                selection.IsSelected = false;
+            }
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -99,6 +99,23 @@
                 </Border>
             </HierarchicalDataTemplate>
 
+            <DataTemplate x:Key="TopCategoryDataTemplate">
+                <Border Background="{StaticResource LibraryItemHostBackground}"
+                        DataContext="{Binding Path=MemberGroups[0]}">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{Binding FullyQualifiedName}"
+                                   Foreground="{StaticResource NestedMemberTextColor}"
+                                   FontSize="12"
+                                   Margin="16,8,0,8" />
+                        <Border BorderBrush="Yellow"
+                                BorderThickness="2,0,0,0">
+                            <ContentPresenter Content="{Binding Members[0]}"
+                                              ContentTemplate="{StaticResource MemberTemplate}" />
+                        </Border>
+                    </StackPanel>
+                </Border>
+            </DataTemplate>
+
             <Style BasedOn="{StaticResource LibraryScrollViewerStyle}"
                    TargetType="{x:Type ScrollViewer}">
                 <Setter Property="Template"
@@ -108,7 +125,8 @@
             <controls:LibrarySearchTreeTemplateSelector x:Key="LibrarySearchTreeTemplateSelector"
                                                         MemberTemplate="{StaticResource MemberTemplate}"
                                                         MemberGroupsTemplate="{StaticResource MemberGroupsDataTemplate}"
-                                                        CategoryTemplate="{StaticResource NestedCategoryDataTemplate}" />
+                                                        CategoryTemplate="{StaticResource NestedCategoryDataTemplate}"
+                                                        TopCategoryTemplate="{StaticResource TopCategoryDataTemplate}" />
 
             <Style x:Key="LibraryTreeViewItem"
                    TargetType="{x:Type TreeViewItem}">
@@ -121,7 +139,7 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type TreeViewItem}">
-                            <Button Command="{Binding ClickedCommand}"                                    
+                            <Button Command="{Binding ClickedCommand}"
                                     MouseEnter="OnMemberMouseEnter"
                                     MouseLeave="OnPopupMouseLeave"
                                     PreviewMouseLeftButtonDown="OnButtonMouseLeftButtonDown"
@@ -170,7 +188,7 @@
                                                 Value="{StaticResource LibraryMemberOnHover}" />
                                     </MultiTrigger.Setters>
                                 </MultiTrigger>
-                                
+
                                 <MultiTrigger>
                                     <MultiTrigger.Conditions>
                                         <Condition Property="IsSelected"
@@ -201,39 +219,8 @@
     </UserControl.Resources>
 
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-
-        <StackPanel x:Name="topResultPanel"
-                    DataContext="{Binding TopResult}">
-            <StackPanel.Visibility>
-                <Binding Converter="{StaticResource NullValueToCollapsedConverter}" />
-            </StackPanel.Visibility>
-            <TextBlock Text="{Binding FullyQualifiedName}"
-                       Margin="16,8,0,8"
-                       Foreground="{StaticResource NestedMemberTextColor}"
-                       FontSize="12" />
-            <TreeView x:Name="topResultTreeView"
-                      Background="Transparent"
-                      BorderBrush="Transparent"
-                      ItemContainerStyle="{StaticResource LibraryTreeViewItem}"
-                      ScrollViewer.HorizontalScrollBarVisibility="Hidden"
-                      ItemsSource="{Binding Members,NotifyOnTargetUpdated=True}">
-                <TreeView.ItemTemplate>
-                    <DataTemplate>
-                        <Border BorderThickness="2,0,0,0"
-                                BorderBrush="Yellow">
-                            <ContentPresenter ContentTemplate="{StaticResource MemberTemplate}" />
-                        </Border>
-                    </DataTemplate>
-                </TreeView.ItemTemplate>
-            </TreeView>
-        </StackPanel>
 
         <TreeView  Name="CategoryTreeView"
-                   Grid.Row="1"
                    Background="{StaticResource LibraryItemHostBackground}"
                    BorderThickness="0"
                    ItemsSource="{Binding SearchRootCategories}"
@@ -241,8 +228,7 @@
                    ItemContainerStyle="{StaticResource LibraryTreeViewItem}"
                    ScrollViewer.CanContentScroll="True"
                    VirtualizingStackPanel.IsVirtualizing="True"
-                   VirtualizingStackPanel.VirtualizationMode="Recycling" >           
-          </TreeView>
+                   VirtualizingStackPanel.VirtualizationMode="Recycling" />
 
         <uicontrols:LibraryToolTipPopup x:Name="libraryToolTipPopup"
                                         StaysOpen="True"

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -99,22 +99,8 @@
                 </Border>
             </HierarchicalDataTemplate>
 
-            <DataTemplate x:Key="TopCategoryDataTemplate">
-                <Border Background="{StaticResource LibraryItemHostBackground}"
-                        DataContext="{Binding Path=MemberGroups[0]}">
-                    <StackPanel Orientation="Vertical">
-                        <TextBlock Text="{Binding FullyQualifiedName}"
-                                   Foreground="{StaticResource NestedMemberTextColor}"
-                                   FontSize="12"
-                                   Margin="16,8,0,8" />
-                        <Border BorderBrush="Yellow"
-                                BorderThickness="2,0,0,0">
-                            <ContentPresenter Content="{Binding Members[0]}"
-                                              ContentTemplate="{StaticResource MemberTemplate}" />
-                        </Border>
-                    </StackPanel>
-                </Border>
-            </DataTemplate>
+            <HierarchicalDataTemplate x:Key="TopCategoryDataTemplate"
+                                      ItemsSource="{Binding Path=MemberGroups}" />
 
             <Style BasedOn="{StaticResource LibraryScrollViewerStyle}"
                    TargetType="{x:Type ScrollViewer}">


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8078](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8078) Scroll should be for entire library instead of just the category tree view

#### Purpose of this PR
Enable top result scrolling. I.e. if user scrolls search results, then top result should be scrolled as any other search result.

#### Reason why top result didn't scroll
Since we want to use virtualization (show a lot of items without lags in UI), we should use only 1 collection. It used to be 2 collections: top result and other results. Now we remove top result and add it as the first member of the whole collection. After that we can scroll top node as usual collection + we can use virtualization to get rid of search lags.

Also I had to remove top result from `SelectionNavigator`, because now top result is not separate member. I'm sorry about the unnecessary changes, that I've done before.  There wasn't any need to add top result to the navigator separately.

### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 

### FYIs

@Racel 