### PR TITLE
Dispose temporary edges to avoid a crash

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
@@ -185,11 +185,13 @@ namespace Dynamo.Core.Threading
                         var solid = graphicItem as Solid;
                         if (solid != null)
                         {
-                            foreach (var geom in solid.Edges.Select(edge => edge.CurveGeometry))
+                            var edges = solid.Edges;
+                            foreach (var geom in edges.Select(edge => edge.CurveGeometry))
                             {
                                 geom.Tessellate(package, factory.TessellationParameters);
                                 geom.Dispose();
                             }
+                            edges.ForEach(x => x.Dispose());
                         }
                     }
                     


### PR DESCRIPTION
### Purpose

This is serving as part of fix to MAGN-7931. In the process of fixing this defect, a crash is found to be caused by edges which are disposed not in the main thread.

The fix here is to dipose the edges immediately after they are used.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers
@aparajit-pratap PTAL
