### PR TITLE
Fix double value's node to code issue in different locales

### DIFF
--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -10,6 +10,7 @@ using ProtoCore.DSDefinitions;
 using ProtoCore.Lang;
 using ProtoCore.Utils;
 using ProtoCore.SyntaxAnalysis;
+using System.Globalization;
 
 namespace ProtoCore.AST.AssociativeAST
 {
@@ -553,7 +554,7 @@ namespace ProtoCore.AST.AssociativeAST
 
         public override string ToString()
         {
-            return Value.ToString();
+            return Value.ToString(CultureInfo.InvariantCulture);
         }
 
         public override void Accept(AssociativeAstVisitor visitor)
@@ -601,7 +602,7 @@ namespace ProtoCore.AST.AssociativeAST
 
         public override string ToString()
         {
-            return Value.ToString();
+            return Value.ToString(CultureInfo.InvariantCulture);
         }
 
         public override void Accept(AssociativeAstVisitor visitor)

--- a/src/Engine/ProtoCore/Parser/ImperativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/ImperativeAST.cs
@@ -6,6 +6,7 @@ using System.Text;
 using ProtoCore.Utils;
 using ProtoCore.DSASM;
 using ProtoCore.AST.AssociativeAST;
+using System.Globalization;
 
 namespace ProtoCore.AST.ImperativeAST
 {
@@ -230,7 +231,7 @@ namespace ProtoCore.AST.ImperativeAST
 
         public override string ToString()
         {
-            return Value.ToString();
+            return Value.ToString(CultureInfo.InvariantCulture);
         }
     }
 
@@ -259,7 +260,7 @@ namespace ProtoCore.AST.ImperativeAST
 
         public override string ToString()
         {
-            return Value.ToString();
+            return Value.ToString(CultureInfo.InvariantCulture);
         }
     }
 

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -11,6 +11,8 @@ using Dynamo.Nodes;
 using Dynamo.DSEngine;
 using ProtoCore.AST.AssociativeAST;
 using System.Reflection;
+using System.Threading;
+using System.Globalization;
 
 
 namespace Dynamo.Tests
@@ -1115,6 +1117,34 @@ namespace Dynamo.Tests
         {
             DynamoSelection.Instance.ClearSelection();
             nodes.ToList().ForEach((ele) => DynamoSelection.Instance.Selection.Add(ele));
+        }
+
+        [Test]
+        [Category("RegressionTests")]
+        public void TestDoubleValueInDifferentCulture()
+        {
+            var frCulture = CultureInfo.CreateSpecificCulture("fr-FR");
+            
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            Thread.CurrentThread.CurrentCulture = frCulture;
+            Thread.CurrentThread.CurrentUICulture = frCulture;
+
+            // manually verified s="1,234";
+            double d = 1.234;
+            string s = d.ToString();
+
+            DoubleNode d1 = new DoubleNode(1.234);
+            string s1 = d1.ToString();
+            Assert.AreEqual(s1, "1.234");
+
+            ProtoCore.AST.ImperativeAST.DoubleNode d2 = new ProtoCore.AST.ImperativeAST.DoubleNode(1.234);
+            string s2 = d2.ToString();
+            Assert.AreEqual(s2, "1.234");
+
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+            Thread.CurrentThread.CurrentUICulture = currentUICulture;
         }
     }
 


### PR DESCRIPTION
### Purpose

This PR is to fix [double value's node to code issue in difference locale](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8206). For example, in other locales, the decimal part might be separated by `,` (e.g., `1,234`) instead of `.`, so when converting a AST `DoubleNode` to code (string), `.ToString()` should be called with `CultureInfo.InvariantCulture`. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin PTAL.