### PR TITLE
Implement context menu UI for choosing package download location

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3399,7 +3399,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Install latest version to directory....
+        ///   Looks up a localized string similar to Install latest version to folder....
         /// </summary>
         public static string PackageSearchViewInstallLatestVersionTo {
             get {
@@ -3417,7 +3417,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Install this version to directory....
+        ///   Looks up a localized string similar to Install this version to folder....
         /// </summary>
         public static string PackageSearchViewInstallThisVersionTo {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3390,11 +3390,38 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Install This Version.
+        ///   Looks up a localized string similar to Install latest version.
         /// </summary>
-        public static string PackageSearchViewInstallButtonTooltip {
+        public static string PackageSearchViewInstallLatestVersion {
             get {
-                return ResourceManager.GetString("PackageSearchViewInstallButtonTooltip", resourceCulture);
+                return ResourceManager.GetString("PackageSearchViewInstallLatestVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Install latest version to directory....
+        /// </summary>
+        public static string PackageSearchViewInstallLatestVersionTo {
+            get {
+                return ResourceManager.GetString("PackageSearchViewInstallLatestVersionTo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Install this version.
+        /// </summary>
+        public static string PackageSearchViewInstallThisVersion {
+            get {
+                return ResourceManager.GetString("PackageSearchViewInstallThisVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Install this version to directory....
+        /// </summary>
+        public static string PackageSearchViewInstallThisVersionTo {
+            get {
+                return ResourceManager.GetString("PackageSearchViewInstallThisVersionTo", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1257,8 +1257,17 @@ You will get a chance to save your work.</value>
     <value>⇓ Install</value>
     <comment>To install package</comment>
   </data>
-  <data name="PackageSearchViewInstallButtonTooltip" xml:space="preserve">
-    <value>Install This Version</value>
+  <data name="PackageSearchViewInstallLatestVersion" xml:space="preserve">
+    <value>Install latest version</value>
+  </data>
+  <data name="PackageSearchViewInstallLatestVersionTo" xml:space="preserve">
+    <value>Install latest version to directory...</value>
+  </data>
+  <data name="PackageSearchViewInstallThisVersion" xml:space="preserve">
+    <value>Install this version</value>
+  </data>
+  <data name="PackageSearchViewInstallThisVersionTo" xml:space="preserve">
+    <value>Install this version to directory...</value>
   </data>
   <data name="PackageSearchViewKeywords" xml:space="preserve">
     <value>Keywords</value>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1261,13 +1261,13 @@ You will get a chance to save your work.</value>
     <value>Install latest version</value>
   </data>
   <data name="PackageSearchViewInstallLatestVersionTo" xml:space="preserve">
-    <value>Install latest version to directory...</value>
+    <value>Install latest version to folder...</value>
   </data>
   <data name="PackageSearchViewInstallThisVersion" xml:space="preserve">
     <value>Install this version</value>
   </data>
   <data name="PackageSearchViewInstallThisVersionTo" xml:space="preserve">
-    <value>Install this version to directory...</value>
+    <value>Install this version to folder...</value>
   </data>
   <data name="PackageSearchViewKeywords" xml:space="preserve">
     <value>Keywords</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1257,8 +1257,17 @@ You will get a chance to save your work.</value>
     <value>⇓ Install</value>
     <comment>To install package</comment>
   </data>
-  <data name="PackageSearchViewInstallButtonTooltip" xml:space="preserve">
-    <value>Install This Version</value>
+  <data name="PackageSearchViewInstallLatestVersion" xml:space="preserve">
+    <value>Install latest version</value>
+  </data>
+  <data name="PackageSearchViewInstallLatestVersionTo" xml:space="preserve">
+    <value>Install latest version to directory...</value>
+  </data>
+  <data name="PackageSearchViewInstallThisVersion" xml:space="preserve">
+    <value>Install this version</value>
+  </data>
+  <data name="PackageSearchViewInstallThisVersionTo" xml:space="preserve">
+    <value>Install this version to directory...</value>
   </data>
   <data name="PackageSearchViewKeywords" xml:space="preserve">
     <value>Keywords</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1261,13 +1261,13 @@ You will get a chance to save your work.</value>
     <value>Install latest version</value>
   </data>
   <data name="PackageSearchViewInstallLatestVersionTo" xml:space="preserve">
-    <value>Install latest version to directory...</value>
+    <value>Install latest version to folder...</value>
   </data>
   <data name="PackageSearchViewInstallThisVersion" xml:space="preserve">
     <value>Install this version</value>
   </data>
   <data name="PackageSearchViewInstallThisVersionTo" xml:space="preserve">
-    <value>Install this version to directory...</value>
+    <value>Install this version to folder...</value>
   </data>
   <data name="PackageSearchViewKeywords" xml:space="preserve">
     <value>Keywords</value>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -492,6 +492,57 @@
         </Setter>
     </Style>
 
+    <Style x:Key="PackageManagerDownloadVersionButton"
+           TargetType="{x:Type Border}">
+        <Setter Property="Background" Value="#55000000" />
+        <Setter Property="CornerRadius" Value="3" />
+        <Setter Property="Margin" Value="3" />
+
+        <Style.Resources>
+            <Style TargetType="{x:Type Button}">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate>
+
+                            <Border x:Name="container"
+                            Background="Transparent">
+                                <TextBlock x:Name="text"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Margin="3"
+                                    FontSize="11"
+                                    Foreground="#BBB"
+                                    FontWeight="Bold"
+                                    Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content}" />
+                            </Border>
+
+                            <ControlTemplate.Triggers>
+
+                                <Trigger Property="Button.IsMouseOver"
+                                 Value="true">
+                                    <Setter TargetName="container"
+                                    Property="Background"
+                                    Value="#88000000" />
+                                </Trigger>
+
+                                <Trigger Property="IsEnabled"
+                                 Value="false">
+                                    <Setter TargetName="text"
+                                    Property="Foreground"
+                                    Value="#666" />
+                                </Trigger>
+
+                            </ControlTemplate.Triggers>
+
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+        </Style.Resources>
+
+    </Style>
+
     <Style x:Key="SDarkTextBox"
            BasedOn="{StaticResource {x:Type TextBox}}"
            TargetType="{x:Type TextBox}">

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -494,8 +494,7 @@
 
     <Style x:Key="PackageManagerDownloadVersionButton"
            TargetType="{x:Type Border}">
-        <Setter Property="Background" Value="#55000000" />
-        <Setter Property="CornerRadius" Value="3" />
+        <Setter Property="Background" Value="#000000" />
         <Setter Property="Margin" Value="3" />
 
         <Style.Resources>
@@ -509,7 +508,7 @@
                                 <TextBlock x:Name="text"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
-                                    Margin="3"
+                                    Margin="4,0"
                                     FontSize="11"
                                     Foreground="#BBB"
                                     FontWeight="Bold"
@@ -522,7 +521,7 @@
                                  Value="true">
                                     <Setter TargetName="container"
                                     Property="Background"
-                                    Value="#88000000" />
+                                    Value="#333333" />
                                 </Trigger>
 
                                 <Trigger Property="IsEnabled"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -492,56 +492,6 @@
         </Setter>
     </Style>
 
-    <Style x:Key="PackageManagerDownloadVersionButton"
-           TargetType="{x:Type Border}">
-        <Setter Property="Background" Value="#000000" />
-        <Setter Property="Margin" Value="3" />
-
-        <Style.Resources>
-            <Style TargetType="{x:Type Button}">
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate>
-
-                            <Border x:Name="container"
-                            Background="Transparent">
-                                <TextBlock x:Name="text"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Margin="4,0"
-                                    FontSize="11"
-                                    Foreground="#BBB"
-                                    FontWeight="Bold"
-                                    Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content}" />
-                            </Border>
-
-                            <ControlTemplate.Triggers>
-
-                                <Trigger Property="Button.IsMouseOver"
-                                 Value="true">
-                                    <Setter TargetName="container"
-                                    Property="Background"
-                                    Value="#333333" />
-                                </Trigger>
-
-                                <Trigger Property="IsEnabled"
-                                 Value="false">
-                                    <Setter TargetName="text"
-                                    Property="Foreground"
-                                    Value="#666" />
-                                </Trigger>
-
-                            </ControlTemplate.Triggers>
-
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-        </Style.Resources>
-
-    </Style>
-
     <Style x:Key="SDarkTextBox"
            BasedOn="{StaticResource {x:Type TextBox}}"
            TargetType="{x:Type TextBox}">

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -182,24 +182,37 @@
                                 </TextBlock>
 
                                 <StackPanel Orientation="Horizontal" Margin="1" Width="450">
-   
-                                    <Button Name="DownloadButton" Style="{StaticResource FlatButton}" Command="{Binding DownloadLatestCommand }" Foreground="#666">
+
+                                    <StackPanel Orientation="Horizontal">
+                                        <Button Name="DownloadButton" Style="{StaticResource FlatButton}" Command="{Binding DownloadLatestCommand }" Foreground="#888" Margin="0">
                                             <Grid Width="40" Height="64">
                                                 <TextBlock IsHitTestVisible="True" Background="Transparent" FontSize="30" Padding="12">⬇</TextBlock>
-                                                <Ellipse
-                                                            Fill="Transparent"
-                                                            Height="36"
-                                                            Width="36"
-                                                            StrokeThickness="3"
-                                                            Stroke="#666" />
+                                                <Ellipse Fill="Transparent"
+                                                         Height="36"
+                                                         Width="36"
+                                                         StrokeThickness="3"
+                                                         Stroke="#666" />
                                             </Grid>
                                         </Button>
+
+                                        <Button Name="DownloadButtonDropDown" Style="{StaticResource FlatButton}" Click="InstallLatestButtonDropDown_OnClick" Foreground="#888" Margin="0" Padding="0">
+                                            <Grid Width="10" Height="64" Background="Transparent" >
+                                                <TextBlock IsHitTestVisible="True" Background="Transparent" FontSize="16" HorizontalAlignment="Center" VerticalAlignment="Center">▾</TextBlock>
+                                            </Grid>
+                                            <Button.ContextMenu>
+                                                <ContextMenu>
+                                                    <MenuItem Header="Install latest version" Command="{Binding DownloadLatestCommand}" />
+                                                    <MenuItem Header="Install latest version to directory..." />
+                                                </ContextMenu>
+                                            </Button.ContextMenu>
+                                        </Button>
+                                    </StackPanel>
 
                                     <StackPanel Orientation="Vertical">
                                         <StackPanel Orientation="Horizontal">
                                             <Button Style="{StaticResource FlatButton}" Command="{Binding ToggleIsExpandedCommand }" Background="#333">
 
-                                                <StackPanel Width="350" IsHitTestVisible="True" >
+                                                <StackPanel Width="340" IsHitTestVisible="True" >
                                                     <TextBlock FontSize="14"  Name="name" Text="{Binding Path=Model.Name}" Margin="5,0,0,0" HorizontalAlignment="Left" Foreground="WhiteSmoke" />
 
                                                     <StackPanel Orientation="Horizontal" Margin="0,6,0,2">
@@ -295,7 +308,7 @@
                                                                         Command="{Binding Path=Item2}" />
                                                                 <Button Name="DownloadVersionButtonDropDown"  
                                                                         Content="▾" 
-                                                                        Click="InstallButtonDropDown_OnClick">
+                                                                        Click="InstallVersionButtonDropDown_OnClick">
                                                                     <Button.ContextMenu>
                                                                         <ContextMenu>
                                                                             <MenuItem Header="Install this version" Command="{Binding Path=Item2}" />

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -9,14 +9,14 @@
         xmlns:viewModels="clr-namespace:Dynamo.PackageManager.ViewModels"
         mc:Ignorable="d" 
         Title="{x:Static p:Resources.PackageSearchViewTitle}" Name="PackageSearch"  Height="600" Width="490" MinWidth="490" MaxWidth="490">
-    
+
     <Window.Resources>
         <ResourceDictionary>
             <!-- An unstyled button -->
             <Style x:Key="FlatButton" TargetType="Button">
                 <Setter Property="Background" Value="{x:Null}" />
                 <Setter Property="BorderBrush" Value="{x:Null}" />
-                
+
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type Button}">
@@ -39,7 +39,7 @@
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
-                
+
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
                         <Setter Property="Background" Value="#44000000" />
@@ -50,7 +50,44 @@
                         <Setter Property="FontWeight" Value="Normal" />
                     </Trigger>
                 </Style.Triggers>
-                
+
+            </Style>
+
+            <Style x:Key="DownloadVersionButton" TargetType="{x:Type Button}">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate>
+
+                            <Border x:Name="container" Background="Transparent">
+                                <TextBlock x:Name="text"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           Margin="4,0"
+                                           FontSize="11"
+                                           Foreground="#BBB"
+                                           FontWeight="Bold"
+                                           Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content}" />
+                            </Border>
+
+                            <ControlTemplate.Triggers>
+
+                                <Trigger Property="Button.IsMouseOver" Value="true">
+                                    <Setter TargetName="container"
+                                            Property="Background"
+                                            Value="#333333" />
+                                </Trigger>
+
+                                <Trigger Property="IsEnabled" Value="false">
+                                    <Setter TargetName="text"
+                                            Property="Foreground"
+                                            Value="#666" />
+                                </Trigger>
+
+                            </ControlTemplate.Triggers>
+
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
             </Style>
 
             <controls:EmptyStringToCollapsedConverter x:Key="EmptyStringToCollapsedConverter" />
@@ -62,18 +99,18 @@
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}"/>
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
-            
+
         </ResourceDictionary>
     </Window.Resources>
-    
-        <Grid>
 
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="2"/>
-                <RowDefinition Height="Auto"/> 
-            </Grid.RowDefinitions>
+    <Grid>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="2"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
 
         <Grid Background="Black" Grid.Row="1" MinHeight="200">
 
@@ -85,7 +122,7 @@
             <TextBlock Grid.Row ="1" Grid.ZIndex ="1" FontSize="13" HorizontalAlignment="Center" Foreground="Gray" VerticalAlignment="Center" Name="NoResultsIndicator" TextAlignment="Center" Margin="20" Text="{Binding Path=SearchState, Converter={StaticResource PackageSearchStateToStringConverter}}"/>
 
             <Grid Name="RSearchBoxStackPanel" Grid.Row="0">
-                
+
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"></ColumnDefinition>
                     <ColumnDefinition Width="Auto"></ColumnDefinition>
@@ -101,13 +138,13 @@
                            Visibility="{Binding Path=SearchText, Converter={StaticResource NonEmptyStringToCollapsedConverter}}"
                            Text="{x:Static p:Resources.PackageSearchViewSearchTextBox}"/>
 
-                <Button Width="auto" MinWidth="80" Grid.Column="1" Click="SortButton_OnClick"
+                <Button Width="auto" MinWidth="80" Grid.Column="1" Click="OnSortButtonClicked"
                         Style="{DynamicResource ResourceKey=STextButton}" Content="{x:Static p:Resources.PackageSearchViewSortByButton}">
 
                     <Button.ContextMenu>
 
                         <ContextMenu>
-                            
+
                             <MenuItem Command="{Binding Path=SetSortingKeyCommand}" CommandParameter="Name" Margin="3" 
                                       IsCheckable="True" Header="{x:Static p:Resources.PackageSearchViewContextMenuSortByName}"
                                       IsChecked="{Binding Path=SortingKey, Converter={StaticResource EnumToBoolConverter},ConverterParameter=Name, Mode=TwoWay}" />
@@ -196,14 +233,17 @@
                                             </Grid>
                                         </Button>
 
-                                        <Button Name="DownloadButtonDropDown" Style="{StaticResource FlatButton}" Click="InstallLatestButtonDropDown_OnClick" Foreground="#888">
+                                        <Button Name="DownloadButtonDropDown" Style="{StaticResource FlatButton}" Click="OnInstallLatestButtonDropDownClicked" Foreground="#888">
                                             <Grid Width="10" Height="64" Background="Transparent" >
                                                 <TextBlock IsHitTestVisible="True" Background="Transparent" FontSize="16" HorizontalAlignment="Center" VerticalAlignment="Center">▾</TextBlock>
                                             </Grid>
                                             <Button.ContextMenu>
                                                 <ContextMenu>
-                                                    <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallLatestVersion}" Command="{Binding DownloadLatestCommand}" />
-                                                    <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallLatestVersionTo}" />
+                                                    <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallLatestVersion}"
+                                                              Command="{Binding DownloadLatestCommand}" />
+                                                    <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallLatestVersionTo}"
+                                                              Command="{Binding DownloadLatestToCustomPathCommand}"
+                                                              CommandParameter="{Binding Path=Model.LatestVersion}"/>
                                                 </ContextMenu>
                                             </Button.ContextMenu>
                                         </Button>
@@ -300,25 +340,33 @@
                                                     <StackPanel Orientation="Horizontal">
                                                         <TextBlock Text="{Binding Path=Item1.version}" MinWidth="50" Margin="5"  Foreground="WhiteSmoke" />
                                                         <TextBlock Text="{Binding Path=Item1.created, Converter={StaticResource PrettyDateConverter}}" MinWidth="100" Margin="24,5,5,5"  Foreground="DarkGray" />
-                                                        
-                                                        <Border Style="{StaticResource PackageManagerDownloadVersionButton}">
+
+                                                        <Border Background="#000000" Margin="3">
                                                             <StackPanel Orientation="Horizontal">
                                                                 <Button Name="DownloadVersionButtonText"  
+                                                                        Style="{StaticResource DownloadVersionButton}"
                                                                         ToolTip="{x:Static p:Resources.PackageSearchViewInstallThisVersion}" 
                                                                         Content="{x:Static p:Resources.PackageSearchViewInstallButton}" 
                                                                         Command="{Binding Path=Item2}" />
                                                                 <Button Name="DownloadVersionButtonDropDown"  
+                                                                        Style="{StaticResource DownloadVersionButton}"
                                                                         Content="▾" 
-                                                                        Click="InstallVersionButtonDropDown_OnClick">
+                                                                        Click="OnInstallVersionButtonDropDownClicked">
                                                                     <Button.ContextMenu>
                                                                         <ContextMenu>
-                                                                            <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallThisVersion}" Command="{Binding Path=Item2}" />
-                                                                            <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallThisVersionTo}" />
+                                                                            <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallThisVersion}"
+                                                                                      Command="{Binding Path=Item2}"
+                                                                                      CommandParameter="false"/>
+                                                                            <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallThisVersionTo}"
+                                                                                      Command="{Binding Path=Item2}"
+                                                                                      CommandParameter="true"/>
                                                                         </ContextMenu>
                                                                     </Button.ContextMenu>
                                                                 </Button>
                                                             </StackPanel>
                                                         </Border>
+
+
                                                     </StackPanel>
                                                 </DataTemplate>
                                             </ListBox.ItemTemplate>
@@ -395,9 +443,9 @@
                             <Border BorderBrush="DimGray" BorderThickness="0,0,0,1">
 
                                 <StackPanel Orientation="Horizontal" Name="SearchEle" >
-                                    
+
                                     <StackPanel Width ="270" >
-                                        
+
                                         <TextBlock FontSize="14" Name="name" Text="{Binding Path=Name}" Foreground="White" Padding="5"/>
                                         <TextBlock FontSize="10" Name="error" Text="{Binding Path=ErrorString}" Foreground="White"  Padding="5"/>
 
@@ -409,50 +457,50 @@
                                         <TextBlock FontSize="11" Name="version" Text="{Binding Path=VersionName}" Foreground="White"  Padding="5"/>
 
                                     </StackPanel>
-                                    
+
                                 </StackPanel>
-                                
+
                             </Border>
 
                             <DataTemplate.Triggers>
 
-                                    <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Unknown">
-                                        <DataTrigger.Setters>
-                                                    <Setter Property="Background" Value="#CC000000" TargetName="SearchEle" />
-                                        </DataTrigger.Setters>
-                                     </DataTrigger>
+                                <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Unknown">
+                                    <DataTrigger.Setters>
+                                        <Setter Property="Background" Value="#CC000000" TargetName="SearchEle" />
+                                    </DataTrigger.Setters>
+                                </DataTrigger>
 
-                                    <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Downloaded">
-                                        <DataTrigger.Setters>
-                                            <Setter Property="Background" Value="Gray" TargetName="SearchEle" />
-                                        </DataTrigger.Setters>
-                                    </DataTrigger>
+                                <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Downloaded">
+                                    <DataTrigger.Setters>
+                                        <Setter Property="Background" Value="Gray" TargetName="SearchEle" />
+                                    </DataTrigger.Setters>
+                                </DataTrigger>
 
-                                    <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Downloading">
-                                        <DataTrigger.Setters>
-                                            <Setter Property="Background" Value="Gray" TargetName="SearchEle" />
-                                        </DataTrigger.Setters>
-                                     </DataTrigger>
+                                <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Downloading">
+                                    <DataTrigger.Setters>
+                                        <Setter Property="Background" Value="Gray" TargetName="SearchEle" />
+                                    </DataTrigger.Setters>
+                                </DataTrigger>
 
-                                    <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Error">
-                                        <DataTrigger.Setters>
-                                            <Setter Property="Background" Value="LightCoral" TargetName="SearchEle" />
-                                        </DataTrigger.Setters>
-                                    </DataTrigger>
+                                <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Error">
+                                    <DataTrigger.Setters>
+                                        <Setter Property="Background" Value="LightCoral" TargetName="SearchEle" />
+                                    </DataTrigger.Setters>
+                                </DataTrigger>
 
-                                    <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Installed">
-                                        <DataTrigger.Setters>
-                                            <Setter Property="Background" Value="LightBlue" TargetName="SearchEle" />
-                                        </DataTrigger.Setters>
-                                    </DataTrigger>
+                                <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Installed">
+                                    <DataTrigger.Setters>
+                                        <Setter Property="Background" Value="LightBlue" TargetName="SearchEle" />
+                                    </DataTrigger.Setters>
+                                </DataTrigger>
 
-                                    <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Installing">
-                                        <DataTrigger.Setters>
-                                            <Setter Property="Background" Value="Gray" TargetName="SearchEle" />
-                                        </DataTrigger.Setters>
-                                    </DataTrigger>
+                                <DataTrigger Binding="{Binding ElementName=downloadState, Path=Text}" Value="Installing">
+                                    <DataTrigger.Setters>
+                                        <Setter Property="Background" Value="Gray" TargetName="SearchEle" />
+                                    </DataTrigger.Setters>
+                                </DataTrigger>
 
-                                </DataTemplate.Triggers>
+                            </DataTemplate.Triggers>
 
                         </DataTemplate>
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -184,7 +184,8 @@
                                 <StackPanel Orientation="Horizontal" Margin="1" Width="450">
 
                                     <StackPanel Orientation="Horizontal">
-                                        <Button Name="DownloadButton" Style="{StaticResource FlatButton}" Command="{Binding DownloadLatestCommand }" Foreground="#888" Margin="0">
+                                        <Button Name="DownloadButton" Style="{StaticResource FlatButton}" Command="{Binding DownloadLatestCommand }" Foreground="#888"
+                                                ToolTip="{x:Static p:Resources.PackageSearchViewInstallLatestVersion}">
                                             <Grid Width="40" Height="64">
                                                 <TextBlock IsHitTestVisible="True" Background="Transparent" FontSize="30" Padding="12">⬇</TextBlock>
                                                 <Ellipse Fill="Transparent"
@@ -195,14 +196,14 @@
                                             </Grid>
                                         </Button>
 
-                                        <Button Name="DownloadButtonDropDown" Style="{StaticResource FlatButton}" Click="InstallLatestButtonDropDown_OnClick" Foreground="#888" Margin="0" Padding="0">
+                                        <Button Name="DownloadButtonDropDown" Style="{StaticResource FlatButton}" Click="InstallLatestButtonDropDown_OnClick" Foreground="#888">
                                             <Grid Width="10" Height="64" Background="Transparent" >
                                                 <TextBlock IsHitTestVisible="True" Background="Transparent" FontSize="16" HorizontalAlignment="Center" VerticalAlignment="Center">▾</TextBlock>
                                             </Grid>
                                             <Button.ContextMenu>
                                                 <ContextMenu>
-                                                    <MenuItem Header="Install latest version" Command="{Binding DownloadLatestCommand}" />
-                                                    <MenuItem Header="Install latest version to directory..." />
+                                                    <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallLatestVersion}" Command="{Binding DownloadLatestCommand}" />
+                                                    <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallLatestVersionTo}" />
                                                 </ContextMenu>
                                             </Button.ContextMenu>
                                         </Button>
@@ -303,7 +304,7 @@
                                                         <Border Style="{StaticResource PackageManagerDownloadVersionButton}">
                                                             <StackPanel Orientation="Horizontal">
                                                                 <Button Name="DownloadVersionButtonText"  
-                                                                        ToolTip="{x:Static p:Resources.PackageSearchViewInstallButtonTooltip}" 
+                                                                        ToolTip="{x:Static p:Resources.PackageSearchViewInstallThisVersion}" 
                                                                         Content="{x:Static p:Resources.PackageSearchViewInstallButton}" 
                                                                         Command="{Binding Path=Item2}" />
                                                                 <Button Name="DownloadVersionButtonDropDown"  
@@ -311,8 +312,8 @@
                                                                         Click="InstallVersionButtonDropDown_OnClick">
                                                                     <Button.ContextMenu>
                                                                         <ContextMenu>
-                                                                            <MenuItem Header="Install this version" Command="{Binding Path=Item2}" />
-                                                                            <MenuItem Header="Install this version to directory..." />
+                                                                            <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallThisVersion}" Command="{Binding Path=Item2}" />
+                                                                            <MenuItem Header="{x:Static p:Resources.PackageSearchViewInstallThisVersionTo}" />
                                                                         </ContextMenu>
                                                                     </Button.ContextMenu>
                                                                 </Button>

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -285,12 +285,26 @@
                                                 <DataTemplate>
                                                     <StackPanel Orientation="Horizontal">
                                                         <TextBlock Text="{Binding Path=Item1.version}" MinWidth="50" Margin="5"  Foreground="WhiteSmoke" />
-                                                        <Button Name="DownloadVersionButton"  
-                                                                ToolTip="{x:Static p:Resources.PackageSearchViewInstallButtonTooltip}" 
-                                                                Content="{x:Static p:Resources.PackageSearchViewInstallButton}" 
-                                                                Command="{Binding Path=Item2}" 
-                                                                Style="{StaticResource SBadgeButton}" />
-                                                        <TextBlock Text="{Binding Path=Item1.created, Converter={StaticResource PrettyDateConverter}}" MinWidth="120" Margin="24,5,5,5"  Foreground="DarkGray" />
+                                                        <TextBlock Text="{Binding Path=Item1.created, Converter={StaticResource PrettyDateConverter}}" MinWidth="100" Margin="24,5,5,5"  Foreground="DarkGray" />
+                                                        
+                                                        <Border Style="{StaticResource PackageManagerDownloadVersionButton}">
+                                                            <StackPanel Orientation="Horizontal">
+                                                                <Button Name="DownloadVersionButtonText"  
+                                                                        ToolTip="{x:Static p:Resources.PackageSearchViewInstallButtonTooltip}" 
+                                                                        Content="{x:Static p:Resources.PackageSearchViewInstallButton}" 
+                                                                        Command="{Binding Path=Item2}" />
+                                                                <Button Name="DownloadVersionButtonDropDown"  
+                                                                        Content="▾" 
+                                                                        Click="InstallButtonDropDown_OnClick">
+                                                                    <Button.ContextMenu>
+                                                                        <ContextMenu>
+                                                                            <MenuItem Header="Install this version" Command="{Binding Path=Item2}" />
+                                                                            <MenuItem Header="Install this version to directory..." />
+                                                                        </ContextMenu>
+                                                                    </Button.ContextMenu>
+                                                                </Button>
+                                                            </StackPanel>
+                                                        </Border>
                                                     </StackPanel>
                                                 </DataTemplate>
                                             </ListBox.ItemTemplate>

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
@@ -37,5 +37,12 @@ namespace Dynamo.PackageManager.UI
             button.ContextMenu.DataContext = button.DataContext;
             button.ContextMenu.IsOpen = true;
         }
+
+        private void InstallButtonDropDown_OnClick(object sender, RoutedEventArgs e)
+        {
+            var button = (Button)sender;
+            button.ContextMenu.DataContext = button.DataContext;
+            button.ContextMenu.IsOpen = true;
+        }
     }
 }

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
@@ -32,7 +32,7 @@ namespace Dynamo.PackageManager.UI
             viewModel.Model.IsExpanded = !viewModel.Model.IsExpanded;
         }
 
-        private void ShowContextMenuFromLeftClick(object sender, RoutedEventArgs e)
+        private void OnShowContextMenuFromLeftClicked(object sender, RoutedEventArgs e)
         {
             var button = (Button)sender;
             button.ContextMenu.DataContext = button.DataContext;
@@ -41,19 +41,20 @@ namespace Dynamo.PackageManager.UI
             button.ContextMenu.IsOpen = true;
         }
 
-        private void SortButton_OnClick(object sender, RoutedEventArgs e)
+        private void OnSortButtonClicked(object sender, RoutedEventArgs e)
         {
-            ShowContextMenuFromLeftClick(sender, e);
+            OnShowContextMenuFromLeftClicked(sender, e);
         }
 
-        private void InstallLatestButtonDropDown_OnClick(object sender, RoutedEventArgs e)
+        private void OnInstallLatestButtonDropDownClicked(object sender, RoutedEventArgs e)
         {
-            ShowContextMenuFromLeftClick(sender, e);
+            OnShowContextMenuFromLeftClicked(sender, e);
         }
 
-        private void InstallVersionButtonDropDown_OnClick(object sender, RoutedEventArgs e)
+        private void OnInstallVersionButtonDropDownClicked(object sender, RoutedEventArgs e)
         {
-            ShowContextMenuFromLeftClick(sender, e);
+            OnShowContextMenuFromLeftClicked(sender, e);
         }
+
     }
 }

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using Dynamo.PackageManager.ViewModels;
 
 namespace Dynamo.PackageManager.UI
@@ -35,6 +36,8 @@ namespace Dynamo.PackageManager.UI
         {
             var button = (Button)sender;
             button.ContextMenu.DataContext = button.DataContext;
+            button.ContextMenu.PlacementTarget = button;
+            button.ContextMenu.Placement = PlacementMode.Bottom;
             button.ContextMenu.IsOpen = true;
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
@@ -31,18 +31,26 @@ namespace Dynamo.PackageManager.UI
             viewModel.Model.IsExpanded = !viewModel.Model.IsExpanded;
         }
 
-        private void SortButton_OnClick(object sender, RoutedEventArgs e)
+        private void ShowContextMenuFromLeftClick(object sender, RoutedEventArgs e)
         {
             var button = (Button)sender;
             button.ContextMenu.DataContext = button.DataContext;
             button.ContextMenu.IsOpen = true;
         }
 
-        private void InstallButtonDropDown_OnClick(object sender, RoutedEventArgs e)
+        private void SortButton_OnClick(object sender, RoutedEventArgs e)
         {
-            var button = (Button)sender;
-            button.ContextMenu.DataContext = button.DataContext;
-            button.ContextMenu.IsOpen = true;
+            ShowContextMenuFromLeftClick(sender, e);
+        }
+
+        private void InstallLatestButtonDropDown_OnClick(object sender, RoutedEventArgs e)
+        {
+            ShowContextMenuFromLeftClick(sender, e);
+        }
+
+        private void InstallVersionButtonDropDown_OnClick(object sender, RoutedEventArgs e)
+        {
+            ShowContextMenuFromLeftClick(sender, e);
         }
     }
 }


### PR DESCRIPTION
### Purpose

Reference: [MAGN-8192](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8192)

This is the UI sub-task of [MAGN-7766](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7766): As a User, I want to specify the location of Packages at the time of download.

Clicking on a small drop-down button on the right side of an Install button will show a context menu:
- To download the package to the default location
- To choose a custom directory

![image](https://cloud.githubusercontent.com/assets/6386550/9380333/38bba22e-4762-11e5-8385-a19fb482704a.png)

Drop-down context menu for the *default* install button:
- Install latest version
- Install latest version to directory...

Drop-down context menu for the *version-specific* install button:
- Install this version
- Install this version to directory...

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 

### FYIs

@lillismith @Racel @riteshchandawar 