### PR TITLE
Publish Customizer... window causes library tooltip to pop up

### DIFF
--- a/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
+++ b/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
@@ -382,6 +382,7 @@ namespace Dynamo.UI.Controls
             {
                 this.DataContext = null;
                 IsOpen = false;
+                toolTipTimer.Stop();
             };
         }
 


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8165](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8165) Publish Customizer... window causes library tooltip to pop up erroneously as "topmost" window

#### Reason of this bug
When user clicks on "Publish Customizer" menu item, mouse is above search node, like filepath or any other. This bug should be reproducible on any search result. So, when user clicks on "Publish Customizer", there is tiny time span between dynamo window deactivates and publish window shows. During this time span datacontext is set to tooltip, but because of timer tooltip is shown a little bit after dynamo deactivates.

The easiest fix is to stop timer as soon as dynamo window has been deactivated.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

?

### FYIs

@jnealb 
