### PR TITLE
Not to dispose Revit elements in clearing workspace

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -591,9 +591,15 @@ namespace Dynamo.Models
 
             DynamoSelection.Instance.ClearSelection();
 
+            // The deletion of connectors in the following step will trigger a
+            // lot of graph executions. As connectors are deleted, nodes will 
+            // have invalid inputs, so these executions are meaningless and may
+            // cause invalid GC. See comments in MAGN-7229.
+            foreach (NodeModel el in Nodes)
+                e1.RaiseModificationEvents = false;
+
             foreach (NodeModel el in Nodes)
             {
-                el.RaisesModificationEvents = false;
                 el.Dispose();
 
                 foreach (PortModel p in el.InPorts)

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -595,8 +595,8 @@ namespace Dynamo.Models
             // lot of graph executions. As connectors are deleted, nodes will 
             // have invalid inputs, so these executions are meaningless and may
             // cause invalid GC. See comments in MAGN-7229.
-            foreach (NodeModel el in Nodes)
-                e1.RaiseModificationEvents = false;
+            foreach (NodeModel node in Nodes)
+                node.RaisesModificationEvents = false;
 
             foreach (NodeModel el in Nodes)
             {


### PR DESCRIPTION
### Purpose

This issue partially fixed in PR #5091, details about why Revit elements are disposed in wrong way when clearing workspace could be found in comments of defect [MAGN 7229 - Opening a new file while running auto deletes all Revit elements made with previous file in same Dynamo session](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7229). 

Basically, clearing workspace will delete all connectors and nodes. The deletion of connector will trigger node modification event on nodes on both side, and each node modification event may finally trigger graph execution. As connector is already deleted, node will get invalid input and in Revit it causes Revit element is cleaned up. In PR #5091 it makes nodes be silent during deletion, but that's not enough. This PR makes all nodes be silent before deleting any connectors.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@riteshchandawar has played test locally. 