### PR TITLE
Make WorkspaceModel.Groups, Notes IEnumerable's

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1265,7 +1265,7 @@ namespace Dynamo.Models
                     if (!workspace.HasUnsavedChanges)
                     {
                         if (workspace.Nodes.Any() &&
-                            workspace.Notes.Count == 0)
+                            !workspace.Notes.Any())
                             continue;
 
                         if (tempDict.ContainsKey(workspace.Guid))

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -384,7 +384,7 @@ namespace Dynamo.Models
         ///     All of the notes currently in the workspace.
         /// </summary>
         public IEnumerable<NoteModel> Notes
-        {            
+        {
             get
             {
                 IEnumerable<NoteModel> notesClone;

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -183,6 +183,9 @@ namespace Dynamo.Models
             if (handler != null) handler(node);
         }
 
+        /// <summary>
+        ///     Event that is fired when nodes are cleared from the workspace.
+        /// </summary>
         public event Action NodesCleared;
         protected virtual void OnNodesCleared()
         {
@@ -210,6 +213,9 @@ namespace Dynamo.Models
             if (handler != null) handler(note);
         }
 
+        /// <summary>
+        ///     Event that is fired when notes are cleared from the workspace.
+        /// </summary>
         public event Action NotesCleared;
         protected virtual void OnNotesCleared()
         {
@@ -237,6 +243,9 @@ namespace Dynamo.Models
             if (handler != null) handler(annotation);
         }
 
+        /// <summary>
+        ///     Event that is fired when annotations are cleared from the workspace.
+        /// </summary>
         public event Action AnnotationsCleared;
         protected virtual void OnAnnotationsCleared()
         {

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -864,7 +864,7 @@ namespace Dynamo.Models
                 annotations.Add(annotation);
             }
 
-            //OnAnnotationAdded(annotation);
+            OnAnnotationAdded(annotation);
         }
 
         public void ClearAnnotations()
@@ -874,7 +874,7 @@ namespace Dynamo.Models
                 annotations.Clear();
             }
 
-            //OnAnnotationsCleared();
+            OnAnnotationsCleared();
         }
 
         private void RemoveAnnotation(AnnotationModel annotation)
@@ -883,7 +883,7 @@ namespace Dynamo.Models
             {
                 if (!annotations.Remove(annotation)) return;
             }
-            //OnAnnotationRemoved(annotation);
+            OnAnnotationRemoved(annotation);
         }
 
         public void AddAnnotation(AnnotationModel annotationModel)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -304,12 +304,15 @@ namespace Dynamo.ViewModels
             Model.NoteRemoved += Model_NoteRemoved;
             Model.NotesCleared += Model_NotesCleared;
 
-            Model.Annotations.CollectionChanged +=Annotations_CollectionChanged;
+            Model.AnnotationAdded += Model_AnnotationAdded;
+            Model.AnnotationRemoved += Model_AnnotationRemoved;
+            Model.AnnotationsCleared += Model_AnnotationsCleared;
+
             Model.ConnectorAdded += Connectors_ConnectorAdded;
             Model.ConnectorDeleted += Connectors_ConnectorDeleted;
             Model.PropertyChanged += ModelPropertyChanged;
 
-            DynamoSelection.Instance.Selection.CollectionChanged += 
+            DynamoSelection.Instance.Selection.CollectionChanged +=
                 (sender, e) => RefreshViewOnSelectionChange();
 
             // sync collections
@@ -317,15 +320,12 @@ namespace Dynamo.ViewModels
 
             foreach (NodeModel node in Model.Nodes) Model_NodeAdded(node);
             foreach (NoteModel note in Model.Notes) Model_NoteAdded(note);
-
-            Annotations_CollectionChanged(null, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, Model.Annotations));
-            foreach (var c in Model.Connectors)
-                Connectors_ConnectorAdded(c);
+            foreach (AnnotationModel annotation in Model.Annotations) Model_AnnotationAdded(annotation);
+            foreach (ConnectorModel connector in Model.Connectors) Connectors_ConnectorAdded(connector);
 
             InCanvasSearchViewModel = new SearchViewModel(DynamoViewModel);
             InCanvasSearchViewModel.Visible = true;
         }
-
 
         void RunSettingsViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
@@ -376,27 +376,20 @@ namespace Dynamo.ViewModels
             _notes.Clear();
         }
 
-        void Annotations_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void Model_AnnotationAdded(AnnotationModel annotation)
         {
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                    foreach (var item in e.NewItems)
-                    {                     
-                        var viewModel = new AnnotationViewModel(this, item as AnnotationModel);
-                        _annotations.Add(viewModel);
-                    }
-                    break;
-                case NotifyCollectionChangedAction.Reset:
-                    _annotations.Clear();
-                    break;
-                case NotifyCollectionChangedAction.Remove:
-                    foreach (var item in e.OldItems)
-                    {
-                        _annotations.Remove(_annotations.First(x => x.AnnotationModel == item));
-                    }
-                    break;
-            }
+            var viewModel = new AnnotationViewModel(this, annotation);
+            _annotations.Add(viewModel);
+        }
+
+        private void Model_AnnotationRemoved(AnnotationModel annotation)
+        {
+            _annotations.Remove(_annotations.First(x => x.AnnotationModel == annotation));
+        }
+
+        private void Model_AnnotationsCleared()
+        {
+            _annotations.Clear();
         }
 
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -300,7 +300,10 @@ namespace Dynamo.ViewModels
             Model.NodeRemoved += Model_NodeRemoved;
             Model.NodesCleared += Model_NodesCleared;
 
-            Model.Notes.CollectionChanged += Notes_CollectionChanged;
+            Model.NoteAdded += Model_NoteAdded;
+            Model.NoteRemoved += Model_NoteRemoved;
+            Model.NotesCleared += Model_NotesCleared;
+
             Model.Annotations.CollectionChanged +=Annotations_CollectionChanged;
             Model.ConnectorAdded += Connectors_ConnectorAdded;
             Model.ConnectorDeleted += Connectors_ConnectorDeleted;
@@ -311,9 +314,10 @@ namespace Dynamo.ViewModels
 
             // sync collections
 
-            
+
             foreach (NodeModel node in Model.Nodes) Model_NodeAdded(node);
-            Notes_CollectionChanged(null, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, Model.Notes));
+            foreach (NoteModel note in Model.Notes) Model_NoteAdded(note);
+
             Annotations_CollectionChanged(null, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, Model.Annotations));
             foreach (var c in Model.Connectors)
                 Connectors_ConnectorAdded(c);
@@ -356,28 +360,20 @@ namespace Dynamo.ViewModels
                 _connectors.Remove(connector);
         }
 
-        void Notes_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void Model_NoteAdded(NoteModel note)
         {
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                    foreach (var item in e.NewItems)
-                    {
-                        //add a corresponding note
-                        var viewModel = new NoteViewModel(this, item as NoteModel);
-                        _notes.Add(viewModel);
-                    }
-                    break;
-                case NotifyCollectionChangedAction.Reset:
-                    _notes.Clear();
-                    break;
-                case NotifyCollectionChangedAction.Remove:
-                    foreach (var item in e.OldItems)
-                    {
-                        _notes.Remove(_notes.First(x => x.Model == item));
-                    }
-                    break;
-            }
+            var viewModel = new NoteViewModel(this, note);
+            _notes.Add(viewModel);
+        }
+
+        private void Model_NoteRemoved(NoteModel note)
+        {
+            _notes.Remove(_notes.First(x => x.Model == note));
+        }
+
+        private void Model_NotesCleared()
+        {
+            _notes.Clear();
         }
 
         void Annotations_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/test/DynamoCoreTests/AnnotationModelTest.cs
+++ b/test/DynamoCoreTests/AnnotationModelTest.cs
@@ -35,7 +35,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
         }
 
@@ -61,7 +61,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             //Update the Annotation Text
@@ -100,7 +100,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             var modelToDelete = new List<ModelBase> { addNode };
@@ -141,7 +141,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             var modelsToDelete = new List<ModelBase> { addNote, addNode };
@@ -186,7 +186,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             var modelToUngroup = new List<ModelBase> { addNode };
@@ -227,7 +227,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             var modelsToUngroup = new List<ModelBase> { addNote, addNode };
@@ -261,7 +261,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             var modelsToUngroup = new List<ModelBase> { addNote, addNode };
@@ -307,7 +307,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             //Create Another node
@@ -374,7 +374,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             //Check the default color - it should be green
@@ -403,7 +403,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             //Check the default color - it should be green
@@ -438,7 +438,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             //now change the text
@@ -468,7 +468,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             //Check the default font size
@@ -497,7 +497,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             //Check the default font size
@@ -530,7 +530,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             var modelToDelete = new List<ModelBase> { addNode };
@@ -576,7 +576,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             //Add the group  selection
@@ -589,7 +589,7 @@ namespace Dynamo.Tests
             model.Paste();
 
             //there should be 2 groups in the workspace
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 2);         
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 2);         
         }
 
         [Test]
@@ -614,7 +614,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             //Add the group  selection
@@ -627,19 +627,19 @@ namespace Dynamo.Tests
             model.Paste();
 
             //there should be 2 groups in the workspace
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 2);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 2);
 
             //Undo the paste
             model.CurrentWorkspace.Undo();
 
             //there should be 1 groups in the workspace
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
 
             //Redo the Undo
             model.CurrentWorkspace.Redo();
 
             //there should be 2 groups in the workspace
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 2);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 2);
         }
 
         [Test]
@@ -664,7 +664,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes and notes
             Guid groupid = Guid.NewGuid();
             var annotation = model.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreNotEqual(0, annotation.Width);
 
             //Create Another node

--- a/test/DynamoCoreTests/AnnotationModelTest.cs
+++ b/test/DynamoCoreTests/AnnotationModelTest.cs
@@ -26,7 +26,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -52,7 +52,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -91,7 +91,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -132,7 +132,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -177,7 +177,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -218,7 +218,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -252,7 +252,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -298,7 +298,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -336,7 +336,7 @@ namespace Dynamo.Tests
             //Add a new note
             id = Guid.NewGuid();
             var secondNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 2);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 2);
 
             //Select the group and newly created note
             DynamoSelection.Instance.Selection.Add(annotation);
@@ -365,7 +365,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -394,7 +394,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -429,7 +429,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -459,7 +459,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -488,7 +488,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -521,7 +521,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -567,7 +567,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -605,7 +605,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -655,7 +655,7 @@ namespace Dynamo.Tests
             //Add a Note 
             Guid id = Guid.NewGuid();
             var addNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 1);
 
             //Select the node and notes
             DynamoSelection.Instance.Selection.Add(addNode);
@@ -693,7 +693,7 @@ namespace Dynamo.Tests
             //Add a new note
             id = Guid.NewGuid();
             var secondNote = model.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(model.CurrentWorkspace.Notes.Count, 2);
+            Assert.AreEqual(model.CurrentWorkspace.Notes.Count(), 2);
 
             //Select the group and newly created note
             DynamoSelection.Instance.Selection.Add(annotation);

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -50,7 +50,7 @@ namespace Dynamo.Tests
             // Create some test note data
             Guid id = Guid.NewGuid();
             CurrentDynamoModel.CurrentWorkspace.AddNote(false, 200, 200, "This is a test note", id);
-            Assert.AreEqual(CurrentDynamoModel.CurrentWorkspace.Notes.Count, 1);
+            Assert.AreEqual(CurrentDynamoModel.CurrentWorkspace.Notes.Count(), 1);
         }
 
 

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -839,7 +839,7 @@ namespace Dynamo.Tests
             //create the group around selected nodes
             Guid groupid = Guid.NewGuid();
             var annotation = CurrentDynamoModel.CurrentWorkspace.AddAnnotation("This is a test group", groupid);
-            Assert.AreEqual(CurrentDynamoModel.CurrentWorkspace.Annotations.Count, 1);
+            Assert.AreEqual(CurrentDynamoModel.CurrentWorkspace.Annotations.Count(), 1);
             Assert.AreEqual(CurrentDynamoModel.CurrentWorkspace.Annotations.First().SelectedModels.Count(), 3);
 
             CurrentDynamoModel.AddToSelection(annotation);
@@ -863,7 +863,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(6, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
             //Check whether the group is copied to custom workspace
-            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Annotations.Count); 
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Annotations.Count()); 
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -313,7 +313,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(note);
 
             //verify the note was created
-            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count());
 
             //Select the note for group
             DynamoSelection.Instance.Selection.Add(note);
@@ -343,7 +343,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(note);
 
             //verify the note was created
-            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count());
 
             //Create a Group around that note
             ViewModel.AddAnnotationCommand.Execute(null);
@@ -362,7 +362,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(0, ViewModel.Model.CurrentWorkspace.Annotations.Count);
 
             //verify only annotation was deleted and not the note
-            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count());
         }
 
         [Test]
@@ -375,7 +375,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(note);
 
             //verify the note was created
-            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count());
 
             //Select the note for group
             DynamoSelection.Instance.Selection.Add(note);
@@ -407,7 +407,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(note);
 
             //verify the note was created
-            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count());
 
             //Select the node for group
             DynamoSelection.Instance.Selection.Add(note);
@@ -428,7 +428,7 @@ namespace DynamoCoreWpfTests
 
 
             //verify the node was created
-            Assert.AreEqual(2, ViewModel.Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(2, ViewModel.Model.CurrentWorkspace.Notes.Count());
 
             //Select the notes again 
             DynamoSelection.Instance.Selection.Add(note);
@@ -448,7 +448,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(note);
 
             //verify the note was created
-            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count());
 
             //Select the note for group
             DynamoSelection.Instance.Selection.Add(note);
@@ -468,7 +468,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(secondnote);
 
             //verify the node was created
-            Assert.AreEqual(2, ViewModel.Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(2, ViewModel.Model.CurrentWorkspace.Notes.Count());
 
             //Select the note
             DynamoSelection.Instance.Selection.Add(secondnote);
@@ -487,7 +487,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(note);
 
             //verify the note was created
-            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count());
 
             //Select the note for group
             DynamoSelection.Instance.Selection.Add(note);
@@ -527,7 +527,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(note);
 
             //verify the note was created
-            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count());
 
             //Select the note for group
             DynamoSelection.Instance.Selection.Add(note);

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -289,7 +289,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(annotation);
 
             //verify that group was created
-            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Annotations.Count);
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Annotations.Count());
 
             //select the group for deletion
             DynamoSelection.Instance.Selection.Add(annotation);
@@ -297,7 +297,7 @@ namespace DynamoCoreWpfTests
 
             //delete the note
             ViewModel.DeleteCommand.Execute(null);
-            Assert.AreEqual(0, ViewModel.Model.CurrentWorkspace.Annotations.Count);
+            Assert.AreEqual(0, ViewModel.Model.CurrentWorkspace.Annotations.Count());
 
             //verify only annotation was deleted and not the note
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
@@ -324,7 +324,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(annotation);
 
             //verify that group was created
-            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Annotations.Count);
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Annotations.Count());
 
             //verify whether group is not empty
             Assert.AreNotEqual(0, annotation.Y);
@@ -351,7 +351,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(annotation);
 
             //verify that group was created
-            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Annotations.Count);
+            Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Annotations.Count());
 
             //select the group for deletion
             DynamoSelection.Instance.Selection.Add(annotation);
@@ -359,7 +359,7 @@ namespace DynamoCoreWpfTests
 
             //delete the note
             ViewModel.DeleteCommand.Execute(null);
-            Assert.AreEqual(0, ViewModel.Model.CurrentWorkspace.Annotations.Count);
+            Assert.AreEqual(0, ViewModel.Model.CurrentWorkspace.Annotations.Count());
 
             //verify only annotation was deleted and not the note
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Notes.Count());

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -649,7 +649,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(note);
             
             //verify the note was created
-            Assert.AreEqual(1, Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(1, Model.CurrentWorkspace.Notes.Count());
 
             ViewModel.CurrentSpaceViewModel.Model.HasUnsavedChanges = false;
         }
@@ -663,7 +663,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(note);
 
             //verify the note was created
-            Assert.AreEqual(1, Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(1, Model.CurrentWorkspace.Notes.Count());
 
             //select the note for deletion
             DynamoSelection.Instance.Selection.Add(note);
@@ -671,7 +671,7 @@ namespace DynamoCoreWpfTests
 
             //delete the note
             ViewModel.DeleteCommand.Execute(null);
-            Assert.AreEqual(0,Model.CurrentWorkspace.Notes.Count);
+            Assert.AreEqual(0,Model.CurrentWorkspace.Notes.Count());
 
             ViewModel.CurrentSpaceViewModel.Model.HasUnsavedChanges = false;
            

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -862,7 +862,7 @@ namespace DynamoCoreWpfTests
             RunCommandsFromFile("TestCreateNoteCommandWithMultiGuids.xml");
 
             // Should be only 1 note
-            Assert.AreEqual(1, workspace.Notes.Count);
+            Assert.AreEqual(1, workspace.Notes.Count());
 
             // Check if guid correct
             var node = GetNode("682adbae-629f-4c15-b1b4-8af22c2f850c");
@@ -1581,7 +1581,7 @@ namespace DynamoCoreWpfTests
             // Same XML can be used for this test case as well.
             RunCommandsFromFile("Defect_MAGN_478.xml");
 
-            Assert.AreEqual(1, workspace.Notes.Count);
+            Assert.AreEqual(1, workspace.Notes.Count());
         }
 
         [Test, RequiresSTA]
@@ -3669,7 +3669,7 @@ namespace DynamoCoreWpfTests
             // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-478
             RunCommandsFromFile("Defect_MAGN_478.xml");
 
-            Assert.AreEqual(1, workspace.Notes.Count);
+            Assert.AreEqual(1, workspace.Notes.Count());
         }
 
         [Test]
@@ -3821,7 +3821,7 @@ namespace DynamoCoreWpfTests
         {
             RunCommandsFromFile("UpdateNodeCaptions.xml");
             Assert.AreEqual(0, workspace.Connectors.Count());
-            Assert.AreEqual(1, workspace.Notes.Count);
+            Assert.AreEqual(1, workspace.Notes.Count());
             Assert.AreEqual(2, workspace.Nodes.Count());
 
             var number = GetNode("a9762506-2ab6-4b50-8166-138de5b0c704") as DoubleInput;


### PR DESCRIPTION
### Purpose

Link To YouTrack:
[MAGN-7862](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7862) Make WorkspaceModel.Groups, Notes IEnumerable's

I changed `ObservableCollection`'s to `IEnumerable`'s. In task it is said, that I should change `Note` and `Group` collections, but I didn't find `Group` collection. I assume that Groups are Annotations.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@lukechurch 

### FYIs

@pboyer 