### PR TITLE
MAGN-8177 Request customizer invite gives erroneous message when submission fails

### DIFF
--- a/src/DynamoPublish/Models/InviteModel.cs
+++ b/src/DynamoPublish/Models/InviteModel.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using Dynamo.Publish.Properties;
 using RestSharp;
@@ -122,12 +123,18 @@ namespace Dynamo.Publish.Models
 
                 var response = restClient.Execute(request);
 
-                if (response.ErrorException == null)
+                if (response.ErrorException == null && response.StatusCode == HttpStatusCode.OK)
+                {
                     OnUpdateStatusMessage(Resources.InviteRequestSuccess, false);
+                }
                 else
                 {
                     OnUpdateStatusMessage(Resources.InviteRequestFailed, true);
-                    Log(LogMessage.Error(response.ErrorException));
+                    if (response.ErrorException != null)
+                    {
+                        Log(LogMessage.Error(response.ErrorException));
+                    }
+
                     return false;
                 }
             }

--- a/src/DynamoPublish/Views/InviteView.xaml
+++ b/src/DynamoPublish/Views/InviteView.xaml
@@ -52,7 +52,7 @@
                     Grid.Row="0"
                     Grid.ColumnSpan="2" Margin="0,0,-0.2,62">
 
-            <TextBlock Name ="Indicator" Foreground="{StaticResource PublishViewTextColor}" Padding="0,15,0,15" FontSize="15"
+            <TextBlock Name ="Indicator" Foreground="{StaticResource PublishViewTextColor}" Padding="15,15,0,15" FontSize="15"
                        Text ="{x:Static resx:Resources.InviteMenuText}"/>
             <Button x:Name="okButton"
                     Content="{x:Static resx:Resources.InviteMenuButtonText}"   


### PR DESCRIPTION
### Purpose

Server errors are handled and the message is aligned:
![sign up](https://cloud.githubusercontent.com/assets/7658189/9412397/240bfa68-4834-11e5-9185-bd689127650d.png)

### Reviewers

@pboyer 
