### PR TITLE
Fix Presets moving nodes in localized windows (fr)

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -920,8 +920,8 @@ namespace Dynamo.Models
                         var originalpos = node.Position;
                         var serializedNode = state.SerializedNodes.ToList().Find(x => Guid.Parse(x.GetAttribute("guid")) == node.GUID);
                         //overwrite the xy coords of the serialized node with the current position, so the node is not moved
-                        serializedNode.SetAttribute("x", originalpos.X.ToString());
-                        serializedNode.SetAttribute("y", originalpos.Y.ToString());
+                        serializedNode.SetAttribute("x", originalpos.X.ToString(CultureInfo.InvariantCulture));
+                        serializedNode.SetAttribute("y", originalpos.Y.ToString(CultureInfo.InvariantCulture));
 
                         this.undoRecorder.RecordModificationForUndo(node);
                         this.ReloadModel(serializedNode);


### PR DESCRIPTION
### Purpose

before a preset is applied to a node we record the current position of the node by writing into the XML of the preset, this was being done without a culture invariant string formatter, this PR fixes that so the x and y positions of the node are not misinterpreted. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files


Note this PR requires being merge to .82RC
### Reviewers

@ramramps 

### FYIs

@jnealb 