### PR TITLE
Various null checks in `MouseUp` callbacks

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.2.2244")]
+[assembly: AssemblyVersion("0.8.2.2326")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.2.2244")]
+[assembly: AssemblyFileVersion("0.8.2.2326")]

--- a/src/DynamoCoreWpf/Controls/ZoomBorder.cs
+++ b/src/DynamoCoreWpf/Controls/ZoomBorder.cs
@@ -157,6 +157,7 @@ namespace Dynamo.Controls
         private void child_MouseUp(object sender, MouseButtonEventArgs e)
         {
             if (child != null &&
+                e != null && 
                 (e.ChangedButton == MouseButton.Middle
                 || e.ChangedButton == MouseButton.Left && IsInPanMode()))
             {
@@ -169,6 +170,9 @@ namespace Dynamo.Controls
             if ((child == null) || !child.IsMouseCaptured)
                 return;
 
+            var vm = DataContext as WorkspaceViewModel;
+            if (vm == null) return;
+
             // Change ZoomBorder's child translation
             Vector v = start - e.GetPosition(this);
             SetTranslateTransformOrigin(new Point2D
@@ -176,8 +180,6 @@ namespace Dynamo.Controls
                 X = origin.X - v.X,
                 Y = origin.Y - v.Y
             });
-
-            WorkspaceViewModel vm = DataContext as WorkspaceViewModel;
 
             // Update WorkspaceModel without triggering property changed
             vm.SetCurrentOffsetCommand.Execute(GetTranslateTransformOrigin());
@@ -189,7 +191,9 @@ namespace Dynamo.Controls
 
         private bool IsInPanMode()
         {
-            return ((DataContext as WorkspaceViewModel).IsPanning);
+            var ws = DataContext as WorkspaceViewModel;
+            if (ws == null) return false;
+            return ws.IsPanning;
         }
 
         private void NotifyViewSettingsChanged(double x, double y, double zoom)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -487,8 +487,12 @@ namespace Dynamo.Views
 
         private void OnMouseRelease(object sender, MouseButtonEventArgs e)
         {
+            if (e == null) return; // in certain bizarre cases, e can be null
+
             this.snappedPort = null;
-            WorkspaceViewModel wvm = (DataContext as WorkspaceViewModel);
+
+            var wvm = (DataContext as WorkspaceViewModel);
+            if (wvm == null) return;
             wvm.HandleMouseRelease(this.WorkBench, e);
         }
 


### PR DESCRIPTION
### Purpose

Bizarrely, `MouseButtonEventArgs` is sometimes `null` when opening files in Revit 2015 and 2016. I've never repro'ed this myself, but @jnealb was able to validate the fixes I put in. I also hardened various other usages of `as`.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough 
