### PR TITLE
Fix test case causing CI CompleteInstall failure

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.3.2312")]
+[assembly: AssemblyVersion("0.8.3.2286")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.3.2312")]
+[assembly: AssemblyFileVersion("0.8.3.2286")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.3.2286")]
+[assembly: AssemblyVersion("0.8.3.2312")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.3.2286")]
+[assembly: AssemblyFileVersion("0.8.3.2312")]

--- a/test/core/messagelog/testwarningmessage.dyn
+++ b/test/core/messagelog/testwarningmessage.dyn
@@ -1,7 +1,7 @@
 <Workspace Version="0.8.0.743" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="100">
   <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.DSFunction guid="ffffc759-6e3e-4a06-8494-a36584638804" type="Dynamo.Nodes.DSFunction" nickname="TestLogWarning.Ctor" x="250.5" y="200.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="..\..\..\bin\AnyCPU\Debug\FFITarget.dll" function="FFITarget.TestLogWarning.Ctor" />
+    <Dynamo.Nodes.DSFunction guid="ffffc759-6e3e-4a06-8494-a36584638804" type="Dynamo.Nodes.DSFunction" nickname="TestLogWarning.Ctor" x="250.5" y="200.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="FFITarget.dll" function="FFITarget.TestLogWarning.Ctor" />
   </Elements>
   <Connectors />
   <Notes />

--- a/test/core/messagelog/testwarningmessage.dyn
+++ b/test/core/messagelog/testwarningmessage.dyn
@@ -1,7 +1,7 @@
 <Workspace Version="0.8.0.743" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="100">
   <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.DSFunction guid="ffffc759-6e3e-4a06-8494-a36584638804" type="Dynamo.Nodes.DSFunction" nickname="TestLogWarning.Ctor" x="250.5" y="200.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="FFITarget.dll" function="FFITarget.TestLogWarning.Ctor" />
+    <Dynamo.Nodes.DSFunction guid="ffffc759-6e3e-4a06-8494-a36584638804" type="Dynamo.Nodes.DSFunction" nickname="TestLogWarning.Ctor" x="250.5" y="200.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="..\..\..\bin\AnyCPU\Debug\FFITarget.dll" function="FFITarget.TestLogWarning.Ctor" />
   </Elements>
   <Connectors />
   <Notes />


### PR DESCRIPTION
### Purpose

This PR fixes a test DYN file that was causing CI test failure for test: `Dynamo.Tests.MessageLogTests.TestWarningMessageLog`. The path to `FFITarget.dll` has been updated so as not to refer to the `Debug` folder that is not present on CI machines.

### Declarations

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

No review required.

