### PR TITLE
Cleanup node layout on single function objects

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1058,23 +1058,23 @@ namespace Dynamo.ViewModels
             var graph = new GraphLayout.Graph();
             var models = new Dictionary<ModelBase, UndoRedoRecorder.UserAction>();
 
-            foreach (AnnotationModel x in Model.Annotations)
+            foreach (AnnotationModel n in Model.Annotations)
             {
                 // Treat a group as a graph layout node/vertex
-                graph.AddNode(x.GUID, x.Width, x.Height, x.Y);
-                models.Add(x, UndoRedoRecorder.UserAction.Modification);
+                graph.AddNode(n.GUID, n.Width, n.Height, n.Y);
+                models.Add(n, UndoRedoRecorder.UserAction.Modification);
             }
 
-            foreach (NodeModel x in Model.Nodes)
+            foreach (NodeModel n in Model.Nodes)
             {
                 AnnotationModel group = Model.Annotations.Where(
-                    s => s.SelectedModels.Contains(x)).ToList().FirstOrDefault();
+                    s => s.SelectedModels.Contains(n)).ToList().FirstOrDefault();
 
                 // Do not process nodes within groups
                 if (group == null)
                 {
-                    graph.AddNode(x.GUID, x.Width, x.Height, x.Y, x.InPorts.Count);
-                    models.Add(x, UndoRedoRecorder.UserAction.Modification);
+                    graph.AddNode(n.GUID, n.Width, n.Height, n.Y, n.InPorts.Count);
+                    models.Add(n, UndoRedoRecorder.UserAction.Modification);
                 }
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1073,7 +1073,7 @@ namespace Dynamo.ViewModels
                 // Do not process nodes within groups
                 if (group == null)
                 {
-                    graph.AddNode(x.GUID, x.Width, x.Height, x.Y);
+                    graph.AddNode(x.GUID, x.Width, x.Height, x.Y, x.InPorts.Count);
                     models.Add(x, UndoRedoRecorder.UserAction.Modification);
                 }
             }

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -6,12 +6,15 @@ using System.Threading.Tasks;
 
 namespace GraphLayout
 {
+    /// <summary>
+    /// Represents the graph object (a set of nodes and edges) in the GraphLayout algorithm.
+    /// </summary>
     public class Graph
     {
-        public const int MAX_LAYER_HEIGHT = 20;
-        public const double HORIZONTAL_NODE_DISTANCE = 100;
-        public const double VERTICAL_NODE_DISTANCE = 30;
-        public const double INFINITE = 1000000;
+        private const int MaxLayerHeight = 20;
+        private const double HorizontalNodeDistance = 100;
+        private const double VerticalNodeDistance = 30;
+        private const double Infinite = 1000000;
 
         public HashSet<Node> Nodes = new HashSet<Node>();
         public HashSet<Edge> Edges = new HashSet<Edge>();
@@ -20,6 +23,14 @@ namespace GraphLayout
 
         #region Helper methods
 
+        /// <summary>
+        /// Adds a new node to the graph object.
+        /// </summary>
+        /// <param name="guid">The guid as a unique identifier of the node.</param>
+        /// <param name="width">The width of the node view.</param>
+        /// <param name="height">The height of the node view.</param>
+        /// <param name="y">The y coordinate of the node view.</param>
+        /// <param name="inPortCount">The number of input ports of the node.</param>
         public void AddNode(Guid guid, double width, double height, double y, int inPortCount = 0)
         {
             var node = new Node(guid, width, height, y, this);
@@ -27,28 +38,59 @@ namespace GraphLayout
             Nodes.Add(node);
         }
 
+        /// <summary>
+        /// Adds a new edge to the graph object.
+        /// </summary>
+        /// <param name="startId">The guid of the starting node.</param>
+        /// <param name="endId">The guid of the ending node.</param>
+        /// <param name="startY">The y coordinate of the connector's left end point.</param>
+        /// <param name="endY">The y coordinate of the connector's right end point.</param>
         public void AddEdge(Guid startId, Guid endId, double startY, double endY)
         {
             var edge = new Edge(startId, endId, startY, endY, this);
             Edges.Add(edge);
         }
 
+        /// <summary>
+        /// Finds a node from its unique guid.
+        /// </summary>
+        /// <param name="guid">The node's guid.</param>
+        /// <returns>The node object.</returns>
         public Node FindNode(Guid guid)
         {
             foreach (Node node in Nodes)
+            {
                 if (guid.Equals(node.Id))
+                {
                     return node;
+                }
+            }
             return null;
         }
 
+        /// <summary>
+        /// Finds an edge between two nodes.
+        /// </summary>
+        /// <param name="start">Start node.</param>
+        /// <param name="end">End node.</param>
+        /// <returns>The edge object.</returns>
         public Edge FindEdge(Node start, Node end)
         {
             foreach (Edge edge in Edges.Where(x => x.Active))
+            {
                 if (start.Equals(edge.StartNode) && end.Equals(edge.EndNode))
+                {
                     return edge;
+                }
+            }
             return null;
         }
 
+        /// <summary>
+        /// Assigns a node into a vertical layer in the graph.
+        /// </summary>
+        /// <param name="n">The node.</param>
+        /// <param name="currentLayer">The number of the layer, starting from 0 for the rightmost layer.</param>
         public void AddToLayer(Node n, int currentLayer)
         {
             while (Layers.Count <= currentLayer)
@@ -58,12 +100,20 @@ namespace GraphLayout
             n.Layer = currentLayer;
         }
 
+        /// <summary>
+        /// Assigns a list of nodes into a vertical layer in the graph.
+        /// </summary>
+        /// <param name="list">The list of nodes.</param>
+        /// <param name="currentLayer">The number of the layer, starting from 0 for the rightmost layer.</param>
         public void AddToLayer(List<Node> list, int currentLayer)
         {
             foreach (Node n in list)
                 AddToLayer(n, currentLayer);
         }
 
+        /// <summary>
+        /// Removes any transitive edges in the graph.
+        /// </summary>
         public void RemoveTransitiveEdges()
         {
             // Check for transitive edges using an adjacency matrix.
@@ -92,17 +142,25 @@ namespace GraphLayout
                         if (y == z) continue;
 
                         if (conn[xi, yi] == 0)
+                        {
                             conn[xi, yi] = FindEdge(x, y) != null ? 1 : -1;
+                        }
 
                         if (conn[yi, zi] == 0)
+                        {
                             conn[yi, zi] = FindEdge(y, z) != null ? 1 : -1;
+                        }
 
                         Edge e = FindEdge(x, z);
                         if (conn[xi, zi] == 0)
+                        {
                             conn[xi, zi] = e != null ? 1 : -1;
+                        }
 
                         if (e != null && conn[xi, yi] + conn[yi, zi] + conn[xi, zi] == 3)
+                        {
                             e.Active = false;
+                        }
 
                     }
                 }
@@ -198,10 +256,14 @@ namespace GraphLayout
             // The rightmost layer is ordered based on the original vertical
             // position of the nodes.
             if (Edges.Count > 0)
+            {
                 AddToLayer(Nodes.Where(x => x.RightEdges.Count == 0
                     && x.LeftEdges.Count > 0).OrderBy(x => x.Y).ToList(), 0);
+            }
             else
+            {
                 AddToLayer(Nodes.OrderBy(x => x.Y).ToList(), 0);
+            }
 
             // Label the rest of the nodes based on the number of incoming edges.
             List<Node> OrderedNodes = Nodes.Where(x => x.LeftEdges.Count > 0)
@@ -230,13 +292,17 @@ namespace GraphLayout
                         x.LeftEdges.Count(e => e.Active) > 0);
 
                     if (n == null)
+                    {
                         n = selected.OrderByDescending(x => x.LeftEdges.Count).First();
+                    }
 
                     if (n.LeftEdges.Count == 0)
                     {
                         Node temp = OrderedNodes.FirstOrDefault(x => x.Layer < 0 && x.LeftEdges.Count > 0);
                         if (temp != null)
+                        {
                             n = temp;
+                        }
                     }
                 }
                 else
@@ -248,7 +314,7 @@ namespace GraphLayout
                 }
 
                 // Add a new layer when needed
-                if ((Layers.Count > 0 && Layers[currentLayer].Count >= MAX_LAYER_HEIGHT) ||
+                if ((Layers.Count > 0 && Layers[currentLayer].Count >= MaxLayerHeight) ||
                     !n.RightEdges.All(e => e.EndNode.Layer < currentLayer) ||
                     (currentLayer > 0 && n.LeftEdges.Count == 0 && !isFinalLayer))
                 {
@@ -257,14 +323,18 @@ namespace GraphLayout
                     layerWidth = 0;
 
                     if (n.LeftEdges.Count == 0)
+                    {
                         isFinalLayer = true;
+                    }
                 }
 
                 AddToLayer(n, currentLayer);
                 processed++;
 
                 if (n.Width > layerWidth)
+                {
                     layerWidth = n.Width;
+                }
             }
 
             // Put all input nodes and isolated nodes on the leftmost layer
@@ -290,7 +360,7 @@ namespace GraphLayout
             foreach (List<Node> layer in Layers)
             {
                 foreach (Node node in layer)
-                    node.Y = INFINITE;
+                    node.Y = Infinite;
             }
             double y = 0;
             foreach (Node node in Layers.First())
@@ -311,7 +381,7 @@ namespace GraphLayout
                     if (layer.First().Layer > 0)
                     {
                         List<Edge> neighborEdges = n.RightEdges
-                            .Where(x => x.EndNode.Y < INFINITE).OrderBy(x => x.EndY).ToList();
+                            .Where(x => x.EndNode.Y < Infinite).OrderBy(x => x.EndY).ToList();
 
                         if (neighborEdges.Count > 1 && neighborEdges.Count % 2 == 0)
                         {
@@ -345,17 +415,18 @@ namespace GraphLayout
         /// Vertical coordinates for the nodes in a layer is assigned right after the
         /// order of nodes in that particular layer is determined.
         /// </summary>
+        /// <param name="layer">The nodes in a layer to be assigned their coordinates.</param>
         public void AssignCoordinates(List<Node> layer)
         {
             // Assign vertical coordinates to the main nodes
-            List<Node> nodes = layer.Where(x => x.Y < INFINITE).OrderBy(x => x.Y).ToList();
+            List<Node> nodes = layer.Where(x => x.Y < Infinite).OrderBy(x => x.Y).ToList();
 
-            double minDistance = INFINITE;
+            double minDistance = Infinite;
             int minNodeIndex = -1;
             for (int i = 1; i < nodes.Count; i++)
             {
                 double distance = nodes[i].Y - nodes[i - 1].Y - nodes[i - 1].Height;
-                if (distance < VERTICAL_NODE_DISTANCE)
+                if (distance < VerticalNodeDistance)
                 {
                     if (distance < minDistance)
                     {
@@ -370,12 +441,12 @@ namespace GraphLayout
                 nodes[minNodeIndex].Y += 1;
                 nodes[minNodeIndex - 1].Y -= 1;
 
-                minDistance = INFINITE;
+                minDistance = Infinite;
                 minNodeIndex = -1;
                 for (int i = 1; i < nodes.Count; i++)
                 {
                     double distance = nodes[i].Y - nodes[i - 1].Y - nodes[i - 1].Height;
-                    if (distance < VERTICAL_NODE_DISTANCE)
+                    if (distance < VerticalNodeDistance)
                     {
                         if (distance < minDistance)
                         {
@@ -388,14 +459,14 @@ namespace GraphLayout
 
             // Assign vertical coordinates to the rest of the nodes
             double lastY = (nodes.Count == 0) ? 0 :
-                nodes.Last().Y + nodes.Last().Height + VERTICAL_NODE_DISTANCE;
+                nodes.Last().Y + nodes.Last().Height + VerticalNodeDistance;
 
-            nodes = layer.Where(x => x.Y >= INFINITE).ToList();
+            nodes = layer.Where(x => x.Y >= Infinite).ToList();
 
             foreach (Node n in nodes)
             {
                 n.Y = lastY;
-                lastY += n.Height + VERTICAL_NODE_DISTANCE;
+                lastY += n.Height + VerticalNodeDistance;
             }
 
             foreach (Node n in layer)
@@ -430,48 +501,93 @@ namespace GraphLayout
                 foreach (Node x in layer)
                     x.X = previousLayerX;
 
-                previousLayerX = layer.First().X + layerWidth + HORIZONTAL_NODE_DISTANCE;
+                previousLayerX = layer.First().X + layerWidth + HorizontalNodeDistance;
 
-                double maxY = (layer.Min(x => x.Y) >= INFINITE) ?
+                double maxY = (layer.Min(x => x.Y) >= Infinite) ?
                     0 : layer.Min(x => x.Y);
 
                 foreach (Node n in layer.OrderBy(x => x.Y))
                 {
                     n.Y += offsetY;
 
-                    if (n.Y >= INFINITE + offsetY)
+                    if (n.Y >= Infinite + offsetY)
+                    {
                         n.Y = maxY;
-                    
+                    }
+
                     if (n.Y + n.Height > maxY)
-                        maxY = n.Y + n.Height + VERTICAL_NODE_DISTANCE;
+                    {
+                        maxY = n.Y + n.Height + VerticalNodeDistance;
+                    }
                 }
             }
         }
 
     }
 
+    /// <summary>
+    /// Represents a node/vertex object in the GraphLayout algorithm.
+    /// </summary>
     public class Node
     {
+        /// <summary>
+        /// The graph object which owns the node.
+        /// </summary>
         private Graph OwnerGraph;
 
+        /// <summary>
+        /// The unique identifier of the node.
+        /// </summary>
         public Guid Id;
 
+        /// <summary>
+        /// The width of the node view.
+        /// </summary>
         public double Width;
+
+        /// <summary>
+        /// The height of the node view.
+        /// </summary>
         public double Height;
 
+        /// <summary>
+        /// The x coordinate of the node view.
+        /// </summary>
         public double X;
+
+        /// <summary>
+        /// The y coordinate of the node view.
+        /// </summary>
         public double Y;
 
+        /// <summary>
+        /// The layer of the node within the graph, starting from layer 0 for the rightmost layer.
+        /// </summary>
         public int Layer = -1;
+
+        /// <summary>
+        /// The number of input ports of the node.
+        /// </summary>
         public int InPortCount;
 
+        /// <summary>
+        /// The set of edges connected to the input ports the node.
+        /// </summary>
+        public HashSet<Edge> LeftEdges = new HashSet<Edge>();
+
+        /// <summary>
+        /// The set of edges connected to the output ports of the node.
+        /// </summary>
+        public HashSet<Edge> RightEdges = new HashSet<Edge>();
+
+        /// <summary>
+        /// Gets a Boolean value of whether the node has any unconnected input ports.
+        /// </summary>
+        /// <value>True if the node has at least one unconnected input port, otherwise false.</value>
         public bool HasUnconnectedInPort
         {
             get { return LeftEdges.Count < InPortCount; }
         }
-
-        public HashSet<Edge> LeftEdges = new HashSet<Edge>();
-        public HashSet<Edge> RightEdges = new HashSet<Edge>();
 
         public Node(Guid guid, double width, double height, double y, Graph ownerGraph)
         {
@@ -483,19 +599,44 @@ namespace GraphLayout
         }
     }
 
+    /// <summary>
+    /// Represents an edge/link object in the GraphLayout algorithm.
+    /// </summary>
     public class Edge
     {
+        /// <summary>
+        /// The graph object which owns the edge.
+        /// </summary>
         private Graph OwnerGraph;
 
-        public Guid Id;
-
+        /// <summary>
+        /// The node connected to the edge's left end.
+        /// </summary>
         public Node StartNode;
+
+        /// <summary>
+        /// The node connected to the edge's right end.
+        /// </summary>
         public Node EndNode;
 
+        /// <summary>
+        /// The y coordinate of the edge's right end.
+        /// </summary>
         public double EndY;
+
+        /// <summary>
+        /// The y distance between the edge's left end and the start node's top-right corner.
+        /// </summary>
         public double StartOffsetY;
+
+        /// <summary>
+        /// The y distance between the edge's right end and the end node's top-left corner.
+        /// </summary>
         public double EndOffsetY;
 
+        /// <summary>
+        /// A flag for the GraphLayout algorithm.
+        /// </summary>
         public bool Active = true;
 
         public Edge(Guid startId, Guid endId, double startY, double endY, Graph ownerGraph)
@@ -505,11 +646,15 @@ namespace GraphLayout
 
             StartNode = OwnerGraph.FindNode(startId);
             if (StartNode != null)
+            {
                 StartNode.RightEdges.Add(this);
+            }
 
             EndNode = OwnerGraph.FindNode(endId);
             if (EndNode != null)
+            {
                 EndNode.LeftEdges.Add(this);
+            }
 
             StartOffsetY = startY - StartNode.Y;
             EndOffsetY = endY - EndNode.Y;


### PR DESCRIPTION
### Purpose

References:
- [MAGN-8128](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8128): Cleanup node layout on single function objects
- #1920: Should functions be aligned on the very left?

Single function object nodes or nodes with unconnected input ports should not be put on the leftmost column after running Graph Layout algorithm. Instead, these nodes should be put on the layer before its leftmost output node.

![image](https://cloud.githubusercontent.com/assets/6386550/9462184/80c61256-4b46-11e5-980c-d7010912f691.png)

This PR includes newly added documentation for the Graph Layout project.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@aparajit-pratap 

### FYIs

@riteshchandawar @sharadkjaiswal 