### PR TITLE
Set default options

### DIFF
--- a/src/Engine/ProtoCore/RuntimeCore.cs
+++ b/src/Engine/ProtoCore/RuntimeCore.cs
@@ -64,13 +64,15 @@ namespace ProtoCore
     /// </summary>
     public class RuntimeCore
     {
-        public RuntimeCore(Heap heap)
+        public RuntimeCore(Heap heap, Options options = null)
         {
             // The heap is initialized by the core and is used to allocate strings
             // Use the that heap for runtime
             Validity.Assert(heap != null);
             this.Heap = heap;
             RuntimeMemory = new RuntimeMemory(Heap);
+
+            this.Options = options;
 
             InterpreterProps = new Stack<InterpreterProperties>();
             ReplicationGuides = new List<List<ReplicationGuide>>();

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1279,7 +1279,7 @@ namespace ProtoScript.Runners
         /// </summary>
         private void CreateRuntimeCore()
         {
-            runtimeCore = new ProtoCore.RuntimeCore(runnerCore.Heap);
+            runtimeCore = new ProtoCore.RuntimeCore(runnerCore.Heap, runnerCore.Options);
             runtimeCore.FFIPropertyChangedMonitor.FFIPropertyChangedEventHandler += FFIPropertyChanged;
         }
 


### PR DESCRIPTION
### Purpose

This fixes the failing test: TestWarningMessageLog
This makes sure that an Option member of runtime core exists.

However, this does not fix the underlying issue where the liverunner is possibly created twice during NUnit test runs. 

Added a task for the investiagation work
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8233

The fix is required so builds can be posted again.

### Declarations

Check these if you believe they are true

- [x] The level of testing this PR includes is appropriate

### Reviewers

@aparajit-pratap 

### FYIs

@Benglin 