### PR TITLE
MAGN-8179 Watch3DViewModel.Active set to false on navigation in background preview.

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.3.2365")]
+[assembly: AssemblyVersion("0.8.3.2367")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.3.2365")]
+[assembly: AssemblyFileVersion("0.8.3.2367")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.3.2327")]
+[assembly: AssemblyVersion("0.8.3.2365")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.3.2327")]
+[assembly: AssemblyFileVersion("0.8.3.2365")]

--- a/src/DynamoCoreWpf/Controls/NotificationsControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NotificationsControl.xaml.cs
@@ -24,6 +24,11 @@ namespace Dynamo.Wpf.Controls
         void NotificationsControl_Loaded(object sender, RoutedEventArgs e)
         {
             var window = WpfUtilities.FindUpVisualTree<DynamoView>(this);
+            if (window == null)
+            {
+                return;
+            }
+
             window.PreviewMouseDown += window_PreviewMouseDown;
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -310,7 +310,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private bool canNavigateBackground = false;
         public bool CanNavigateBackground
         {
-            get { return canNavigateBackground; }
+            get { return canNavigateBackground || navigationKeyIsDown; }
             set
             {
                 canNavigateBackground = value;
@@ -318,6 +318,17 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
         }
 
+        private bool navigationKeyIsDown = false;
+        public bool NavigationKeyIsDown
+        {
+            get { return navigationKeyIsDown; }
+            set { 
+                navigationKeyIsDown = value;
+                RaisePropertyChanged("NavigationKeyIsDown");
+                RaisePropertyChanged("CanNavigateBackground");
+            }
+        }
+        
         #endregion
 
         protected HelixWatch3DViewModel(Watch3DViewModelStartupParams parameters) : base(parameters)

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -310,7 +310,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private bool canNavigateBackground = false;
         public bool CanNavigateBackground
         {
-            get { return canNavigateBackground || navigationKeyIsDown; }
+            get
+            {
+                return canNavigateBackground || navigationKeyIsDown; 
+            }
             set
             {
                 canNavigateBackground = value;
@@ -322,7 +325,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         public bool NavigationKeyIsDown
         {
             get { return navigationKeyIsDown; }
-            set { 
+            set 
+            { 
                 navigationKeyIsDown = value;
                 RaisePropertyChanged("NavigationKeyIsDown");
                 RaisePropertyChanged("CanNavigateBackground");

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1011,25 +1011,27 @@ namespace Dynamo.Controls
         void DynamoView_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Escape)
-                dynamoViewModel.BackgroundPreviewViewModel.CanNavigateBackground = true;
+            {
+                dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown = true;
+            }
         }
 
         void DynamoView_KeyUp(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Escape && dynamoViewModel.BackgroundPreviewViewModel.CanNavigateBackground)
             {
-                dynamoViewModel.BackgroundPreviewViewModel.CanNavigateBackground = false;
+                dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown = false;
                 dynamoViewModel.EscapeCommand.Execute(null);
             }
         }
 
         void DynamoView_LostFocus(object sender, EventArgs e)
         {
-            //if (dynamoViewModel.BackgroundPreviewViewModel.CanNavigateBackground)
-            //{
-            //    dynamoViewModel.BackgroundPreviewViewModel.CanNavigateBackground = false;
-            //    dynamoViewModel.EscapeCommand.Execute(null);
-            //}
+            if (dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown)
+            {
+                dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown = false;
+                dynamoViewModel.EscapeCommand.Execute(null);
+            }
         }
 
         private void WorkspaceTabs_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1010,9 +1010,10 @@ namespace Dynamo.Controls
         // passes it to thecurrent workspace
         void DynamoView_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Escape)
+            if (e.Key == Key.Escape && this.IsMouseOver)
             {
                 dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown = true;
+                e.Handled = true;
             }
         }
 
@@ -1022,6 +1023,7 @@ namespace Dynamo.Controls
             {
                 dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown = false;
                 dynamoViewModel.EscapeCommand.Execute(null);
+                e.Handled = true;
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1025,11 +1025,11 @@ namespace Dynamo.Controls
 
         void DynamoView_LostFocus(object sender, EventArgs e)
         {
-            if (dynamoViewModel.BackgroundPreviewViewModel.CanNavigateBackground)
-            {
-                dynamoViewModel.BackgroundPreviewViewModel.CanNavigateBackground = false;
-                dynamoViewModel.EscapeCommand.Execute(null);
-            }
+            //if (dynamoViewModel.BackgroundPreviewViewModel.CanNavigateBackground)
+            //{
+            //    dynamoViewModel.BackgroundPreviewViewModel.CanNavigateBackground = false;
+            //    dynamoViewModel.EscapeCommand.Execute(null);
+            //}
         }
 
         private void WorkspaceTabs_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -377,7 +377,7 @@
                              RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
                 </ui:ImageCheckBox.IsChecked>
                 <ui:ImageCheckBox.Visibility>
-                    <Binding Path="DataContext.BackgroundPreviewViewModel.IsOrbiting"
+                    <Binding Path="DataContext.BackgroundPreviewViewModel.CanNavigateBackground"
                              Converter="{StaticResource BooleanToVisibilityConverter}"
                              RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
                 </ui:ImageCheckBox.Visibility>


### PR DESCRIPTION
### Purpose

This PR fixes two regressions introduced as a result of the addition of the `Watch3DViewModel` class. 
- The visibility binding was incorrect for the orbit icon. The orbit icon would not display when the background preview was enabled. [MAGN-8179](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8179)
- @Randy-Ma's fix for [MAGN-5055](https://github.com/DynamoDS/Dynamo/pull/5023/files), came in at the same time as `Watch3DViewModel`. Although it seemed like his fix could be ported, it could not. Originally, we had a `WatchEscapeIsDown` property which acted independently of the `CanNavigateBackground` property. With the creation of `Watch3DViewModel`, these two properties were merged, but _they did different things_. In this PR, we re-introduce a property, `NavigationKeyIsDown` which acts independently of `CanNavigateBackground` and maintains the fix originally applied by Randy.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
  - No new tests added. We don't currently do any mouse testing.
- [ ] User facing strings, if any, are extracted into `*.resx` files
  - No additional user facing strings are added.

### Reviewers

@pboyer 

### FYIs

@Randy-Ma @jnealb 