### PR TITLE
ShareLink cleared when publish window is closed

### DIFF
--- a/src/DynamoPublish/ViewModels/PublishViewModel.cs
+++ b/src/DynamoPublish/ViewModels/PublishViewModel.cs
@@ -258,6 +258,11 @@ namespace Dynamo.Publish.ViewModels
             UIDispatcher.BeginInvoke(action);
         }
 
+        internal void ClearShareLink()
+        {
+            ShareLink = String.Empty;
+        }
+
         #endregion
     }
 }

--- a/src/DynamoPublish/Views/PublishView.xaml.cs
+++ b/src/DynamoPublish/Views/PublishView.xaml.cs
@@ -52,7 +52,7 @@ namespace Dynamo.Publish.Views
         {
             textBoxName.Clear();
             textBoxDescription.Clear();
-            textBoxShareLink.Clear();
+            viewModel.ClearShareLink();
         }
     }
 }


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8209](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8209) Name and Description fields are not cleared after a successful Publish Customizer for the next Publish attempt

I was inattentive. ShareLink TextBox has `OneWay` binding, that means if we clear textbox it doesn't clear view model property. I added `ClearShareLink` to clear it, when window is closed.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@pboyer 

### FYIs

@jnealb 
