### PR TITLE
Fast fix.

### DIFF
--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -141,6 +141,10 @@ namespace Dynamo.UI.Views
                 return;
 
             var senderButton = e.OriginalSource as FrameworkElement;
+
+            if (senderButton == null)
+                return;
+
             var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
             if (searchElementVM != null)
                 dragDropHelper.HandleMouseMove(senderButton, e.GetPosition(null));


### PR DESCRIPTION
Crash was found by @Racel . The reason of crash is that sometimes `e.OriginalSource` is `FrameworkElement`, and sometimes it's `Run`, which is not `FrameworkElement`. I don't know why `OriginalSource` is different, this needs more investigation. But for now we can add this fast fix in 0.8.2.