### PR TITLE
Create custom view model, if search element is custom node.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -243,6 +243,12 @@ namespace Dynamo.Wpf.ViewModels
             Path = Model.Path;
         }
 
+        public CustomNodeSearchElementViewModel(CustomNodeSearchElementViewModel copyElement)
+            : base(copyElement)
+        {
+            Path = copyElement.Path;
+        }
+
         public string Path
         {
             get { return path; }

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -737,7 +737,17 @@ namespace Dynamo.ViewModels
                 return;
 
             // Clone top node.
-            var topNode = new NodeSearchElementViewModel(MakeNodeSearchElementVM(nodes.First()));
+            NodeSearchElementViewModel topNode;
+            var firstNode = MakeNodeSearchElementVM(nodes.First());
+            if (firstNode is CustomNodeSearchElementViewModel)
+            {
+                topNode = new CustomNodeSearchElementViewModel(firstNode as CustomNodeSearchElementViewModel);
+            }
+            else
+            {
+                topNode = new NodeSearchElementViewModel(firstNode);
+            }
+
             topNode.IsTopResult = true;
 
             SortSearchCategoriesChildren();

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -705,6 +705,30 @@ namespace Dynamo.Tests
             Assert.AreEqual("AA", viewModel.CurrentlySelectedMember.Name);
         }
 
+
+        [Test]
+        [Category("UnitTests")]
+        public void TopResultIsFirstCategory()
+        {
+            var element = CreateCustomNode("Node1", "Category1");
+            model.Add(element);
+
+            element = CreateCustomNode("Node2", "Category2");
+            model.Add(element);
+
+            viewModel.Visible = true;
+            viewModel.SearchAndUpdateResults("node");
+
+            Assert.Greater(viewModel.SearchResults.Count, 0);
+            Assert.AreEqual(3, viewModel.SearchRootCategories.Count);
+
+            // Top result is first categor.
+            Assert.AreEqual("Top Result", viewModel.SearchRootCategories.First().Name);
+            // Top node is custom node.
+            Assert.IsTrue(viewModel.SearchRootCategories.First().MemberGroups.First().Members.First()
+                is CustomNodeSearchElementViewModel);
+        }
+
         #endregion
 
         #region Helpers


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8250](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8250) Top Search item doesn't show Icon for custom node but that custom node actually have the icon in below list.

When we create copy of top node, it should be `NodeSearchElementViewModel`, if it's usual node and `CustomNodeSearchElementViewModel` if it's custom node.

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

?

### FYIs

@riteshchandawar 
