### PR TITLE
Fix issue that typed identifier in CBN can't generate background geometry

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -1690,7 +1690,7 @@ namespace Dynamo.Models
         private string GetDrawableId(int outPortIndex)
         {
             var output = GetAstIdentifierForOutputIndex(outPortIndex);
-            return output == null ? null : output.ToString();
+            return output == null ? null : output.Value;
         }
 
         #endregion

--- a/test/DynamoCoreWpfTests/HelixWatch3DViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/HelixWatch3DViewModelTests.cs
@@ -767,6 +767,16 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(9, BackgroundPreviewGeometry.TotalPoints());
         }
 
+        [Test]
+        [Category("RegressionTests")]
+        public void TestTypedIdentifierInCodeBlockNode()
+        {
+            // Regression test for MAGN-7518 that expression "x : Point = Point.ByCoordinate()" in CBN
+            // doesn't generate background preview.
+            OpenVisualizationTest("TypedIdentifierInCBN.dyn");
+            Assert.AreEqual(2, BackgroundPreviewGeometry.TotalPoints());
+        }
+
         private Watch3DView FindFirstWatch3DNodeView()
         {
             var views = View.ChildrenOfType<Watch3DView>();

--- a/test/DynamoCoreWpfTests/HelixWatch3DViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/HelixWatch3DViewModelTests.cs
@@ -769,7 +769,7 @@ namespace DynamoCoreWpfTests
 
         [Test]
         [Category("RegressionTests")]
-        public void TestTypedIdentifierInCodeBlockNode()
+        public void TypedIdentifierInCodeBlockNode()
         {
             // Regression test for MAGN-7518 that expression "x : Point = Point.ByCoordinate()" in CBN
             // doesn't generate background preview.

--- a/test/core/visualization/TypedIdentifierInCBN.dyn
+++ b/test/core/visualization/TypedIdentifierInCBN.dyn
@@ -1,0 +1,16 @@
+<Workspace Version="0.8.3.2421" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Point" resolvedName="Autodesk.DesignScript.Geometry.Point" assemblyName="ProtoGeometry.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="4aee0897-2213-4c6d-8eef-d9384cd7c1ae" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="212" y="121" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="x = Point.ByCoordinates(1, 1, 1);" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="706d796d-26b5-437c-adcb-dfd9022ffc6a" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="209.4" y="241" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="y: Point = Point.ByCoordinates(2, 2, 2);" ShouldFocus="false" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR is to fix defect [MAGN 7518 that typed identifier in CBN can't generate background geometry](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7518).

That is because in `NodeModel.GetDrawableId()`, we use `IdentifierNode.ToString()` to get variable name instead of using `IdentifierNode.Value`, so for typed identifier, e.g., `a : Ponit = ...`, the returned variable is `a : Point` instead of `a`.  

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@aparajit-pratap PTAL.