### PR TITLE
Fix issue that parameter name doesn't shadow function name

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -4446,8 +4446,8 @@ namespace ProtoAssociative
             ProtoCore.Type type = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, 0);
 
             bool isAccessible = false;
-
-            if (null == t.ArrayDimensions)
+            bool isAllocated = VerifyAllocation(t.Name, globalClassIndex, globalProcIndex, out symbolnode, out isAccessible);
+            if (!isAllocated && null == t.ArrayDimensions)
             {
                 //check if it is a function instance
                 ProtoCore.DSASM.ProcedureNode procNode = null;
@@ -4473,11 +4473,9 @@ namespace ProtoAssociative
                         }
                         return;
                     }
-                }
-            }
          
-            bool isAllocated = VerifyAllocation(t.Name, globalClassIndex, globalProcIndex, out symbolnode, out isAccessible);
-            
+                }
+            }            
 
             // If its executing in interpreter mode - attempt to find and anubond identifer in a child block
             // Remove this, because if we are watching cases like:

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -8510,20 +8510,12 @@ namespace ProtoAssociative
                     leftNodeGlobalRef = GetUpdatedNodeRef(bnode.LeftNode);
 
                     // check whether the variable name is a function name
-                    bool isAccessibleFp;
-                    int realType;
-                    ProtoCore.DSASM.ProcedureNode procNode = null;
                     if (globalClassIndex != ProtoCore.DSASM.Constants.kGlobalScope)
                     {
-                        procNode = core.ClassTable.ClassNodes[globalClassIndex].GetMemberFunction(t.Name, null, globalClassIndex, out isAccessibleFp, out realType);
-                    }
-                    if (procNode == null)
-                    {
-                        procNode = CoreUtils.GetFirstVisibleProcedure(t.Name, null, codeBlock);
-                    }
-                    if (procNode != null)
-                    {
-                        if (ProtoCore.DSASM.Constants.kInvalidIndex != procNode.procId && emitDebugInfo)
+                        bool isAccessibleFp;
+                        int realType;
+                        var procNode = core.ClassTable.ClassNodes[globalClassIndex].GetMemberFunction(t.Name, null, globalClassIndex, out isAccessibleFp, out realType);
+                        if (procNode != null && procNode.procId != Constants.kInvalidIndex && emitDebugInfo)
                         {
                             buildStatus.LogSemanticError(String.Format(Resources.FunctionAsVariableError, t.Name), core.CurrentDSFileName, t.line, t.col);
                         }

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -1040,7 +1040,7 @@ namespace ProtoImperative
             //bool isVisible = isAllocated && core.runtimeTableIndex >= localAllocBlock;
             bool isAccessible = false;
             bool isAllocated = VerifyAllocation(t.Value, globalClassIndex, globalProcIndex, out symbolnode, out isAccessible);
-            if (null == t.ArrayDimensions)
+            if (!isAllocated && null == t.ArrayDimensions)
             {
                 //check if it is a function instance
                 ProtoCore.DSASM.ProcedureNode procNode = null;

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -2110,25 +2110,15 @@ namespace ProtoImperative
                 }
                 else
                 {
+                    // check whether the variable name is a function name
+                    if (globalClassIndex != ProtoCore.DSASM.Constants.kGlobalScope)
                     {
-                        // check whether the variable name is a function name
                         bool isAccessibleFp;
                         int realType;
-                        ProtoCore.DSASM.ProcedureNode procNode = null;
-                        if (globalClassIndex != ProtoCore.DSASM.Constants.kGlobalScope)
+                        var procNode = core.ClassTable.ClassNodes[globalClassIndex].GetMemberFunction(t.Name, null, globalClassIndex, out isAccessibleFp, out realType);
+                        if (procNode != null && procNode.procId != Constants.kInvalidIndex && emitDebugInfo)
                         {
-                            procNode = core.ClassTable.ClassNodes[globalClassIndex].GetMemberFunction(t.Name, null, globalClassIndex, out isAccessibleFp, out realType);
-                        }
-                        if (procNode == null)
-                        {
-                            procNode = CoreUtils.GetFirstVisibleProcedure(t.Name, null, codeBlock);
-                        }
-                        if (procNode != null)
-                        {
-                            if (ProtoCore.DSASM.Constants.kInvalidIndex != procNode.procId && emitDebugInfo)
-                            {
-                                buildStatus.LogSemanticError(String.Format(Resources.FunctionAsVaribleError,t.Name), core.CurrentDSFileName, t.line, t.col);
-                            }
+                            buildStatus.LogSemanticError(String.Format(Resources.FunctionAsVaribleError, t.Name), core.CurrentDSFileName, t.line, t.col);
                         }
                     }
 

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -1039,7 +1039,7 @@ namespace ProtoImperative
             //bool allocatedExternally = isAllocated && core.runtimeTableIndex > localAllocBlock;
             //bool isVisible = isAllocated && core.runtimeTableIndex >= localAllocBlock;
             bool isAccessible = false;
-
+            bool isAllocated = VerifyAllocation(t.Value, globalClassIndex, globalProcIndex, out symbolnode, out isAccessible);
             if (null == t.ArrayDimensions)
             {
                 //check if it is a function instance
@@ -1067,7 +1067,6 @@ namespace ProtoImperative
                 }
             }
 
-            bool isAllocated = VerifyAllocation(t.Value, globalClassIndex, globalProcIndex, out symbolnode, out isAccessible);
             if (!isAllocated || !isAccessible)
             {
                 if (isAllocated)

--- a/test/Engine/ProtoTest/Associative/MethodResolution.cs
+++ b/test/Engine/ProtoTest/Associative/MethodResolution.cs
@@ -388,6 +388,30 @@ r3 = foo({1, 2.0}<1>);
             thisTest.Verify("r3", new object[] { true, false });
         }
 
+        [Test]
+        public void MAGN7807_ParameterNameSameAsFunctionName()
+        {
+            string code =
+@"
+def foo(foo : int)
+{
+    return = foo;
+}
 
+def bar(bar: int)
+{
+return = [Imperative]
+{
+    return = bar;
+}
+}
+
+x = foo({1,2,3});
+y = bar({4,5,6});
+";
+            thisTest.VerifyRunScriptSource(code, "");
+            thisTest.Verify("x", new object[] { 1, 2, 3 });
+            thisTest.Verify("y", new object[] { 4, 5, 6 });
+        }
     }
 }

--- a/test/Engine/ProtoTest/Associative/MethodResolution.cs
+++ b/test/Engine/ProtoTest/Associative/MethodResolution.cs
@@ -406,12 +406,30 @@ return = [Imperative]
 }
 }
 
+def qux1()
+{
+    qux1 = 21;
+    return = qux1 + 1;
+}
+
+def qux2()
+{
+    return = [Imperative] {
+       qux2 = 21;
+       return = qux2 + 1;
+    }
+}
+
 x = foo({1,2,3});
 y = bar({4,5,6});
+z1 = qux1();
+z2 = qux2();
 ";
             thisTest.VerifyRunScriptSource(code, "");
             thisTest.Verify("x", new object[] { 1, 2, 3 });
             thisTest.Verify("y", new object[] { 4, 5, 6 });
+            thisTest.Verify("z1", 22);
+            thisTest.Verify("z2", 22);
         }
     }
 }

--- a/test/Engine/ProtoTest/MultiLangTests/FunctionPointerTest.cs
+++ b/test/Engine/ProtoTest/MultiLangTests/FunctionPointerTest.cs
@@ -243,24 +243,19 @@ b = a();";
         [Test]
         public void T10_NegativeTest_UsingFunctionNameAsVarName_Global()
         {
-            Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
-            {
-                string code = @"
+            string code = @"
 def foo:int(x:int)
 {
 	return = x;
 }
 foo = 3;";
-                ExecutionMirror mirror = thisTest.RunScriptSource(code);
-            });
+            ExecutionMirror mirror = thisTest.RunScriptSource(code);
         }
 
         [Test]
         public void T11_NegativeTest_UsingFunctionNameAsVarName_Global_ImperBlk()
         {
-            Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
-            {
-                string code = @"
+            string code = @"
 [Imperative]
 {
 	def foo:int(x:int)
@@ -269,17 +264,14 @@ foo = 3;";
 	}
 	foo = 3;
 }";
-                ExecutionMirror mirror = thisTest.RunScriptSource(code);
-            });
+            ExecutionMirror mirror = thisTest.RunScriptSource(code);
         }
 
         [Test]
         [Category("DSDefinedClass")]
         public void T12_NegativeTest_UsingGlobalFunctionNameAsMemVarName_Class()
         {
-            Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
-            {
-                string code = @"
+            string code = @"
 def foo:int(x:int)
 {
 	return = x;
@@ -288,8 +280,7 @@ class A
 {
 	foo : var;
 }";
-                ExecutionMirror mirror = thisTest.RunScriptSource(code);
-            });
+            ExecutionMirror mirror = thisTest.RunScriptSource(code);
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/Associative/Function.cs
+++ b/test/Engine/ProtoTest/TD/Associative/Function.cs
@@ -315,9 +315,7 @@ result2;
         [Category("SmokeTest")]
         public void T014_Associative_Function_DuplicateVariableAndFunctionName_Negative()
         {
-            Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
-            {
-                string code = @"
+            string code = @"
 [Associative]
 {
 	def Foo : int ()
@@ -328,8 +326,7 @@ result2;
 	
 	
 }";
-                ExecutionMirror mirror = thisTest.RunScriptSource(code);
-            });
+            ExecutionMirror mirror = thisTest.RunScriptSource(code);
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
@@ -4732,7 +4732,7 @@ f1;f2;f3;f4;
 
         }
 
-        [Test] //Fuqiang: this is changed due to the implementation of function pointer
+        [Test] 
         [Category("SmokeTest")]
         public void TV57_Defect_1454932()
         {
@@ -4748,7 +4748,6 @@ f1;f2;f3;f4;
 	c = Foo;
 }";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
-            thisTest.Verify("c", 5, 0);
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
@@ -2040,11 +2040,7 @@ a;b;
         [Category("SmokeTest")]
         public void T69_Function_Name_Checking()
         {
-            Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
-            {
-                string code = @"
-[Imperative]
-{
+            string code = @"
 	def foo : int ( a : int )
 	{
 		foo = 3;
@@ -2054,24 +2050,18 @@ a;b;
 	a = 1;
 	foo = 2;
 	b = foo(a);           
-}
-	 
-	 
 ";
-                ExecutionMirror mirror = thisTest.RunScriptSource(code);
-                //thisTest.Verify("a", 1, 0);
-                //thisTest.Verify("a", 4, 0);
-                //thisTest.Verify("foo", 2, 0);
-            });
+            ExecutionMirror mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("a", 1, 0);
+            thisTest.Verify("foo", 2, 0);
+            thisTest.Verify("b", null, 0);
         }
 
         [Test] //Fuqiang: this is changed due to the implementation of function pointer
         [Category("SmokeTest")]
         public void T70_Function_Name_Checking()
         {
-            Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
-            {
-                string code = @"
+            string code = @"
 [Associative]
 {
 	def foo : int ( a : int )
@@ -2100,15 +2090,12 @@ a;b;
                 //thisTest.Verify("a", 1, 0);
                 //thisTest.Verify("b", 4, 0);
                 //thisTest.Verify("foo", 2, 0);
-            });
         }
 
         [Test] //Fuqiang: this is changed due to the implementation of function pointer
         [Category("SmokeTest")]
         public void T71_Function_Name_Checking()
         {
-            Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
-            {
                 string code = @"
 [Associative]
 {
@@ -2135,7 +2122,6 @@ a;b;
                 //thisTest.Verify("foo", 2, 0);
                 //thisTest.Verify("c", 3, 0);
                 //thisTest.Verify("b", 4, 0);
-            });
         }
 
         [Test]
@@ -4750,9 +4736,7 @@ f1;f2;f3;f4;
         [Category("SmokeTest")]
         public void TV57_Defect_1454932()
         {
-            Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
-            {
-                string code = @"
+            string code = @"
 [Associative]
 {
 	def Foo : int ()
@@ -4763,10 +4747,8 @@ f1;f2;f3;f4;
 	b = Foo();
 	c = Foo;
 }";
-                ExecutionMirror mirror = thisTest.RunScriptSource(code);
-                //thisTest.Verify("b", 4, 0);
-                //thisTest.Verify("c", 5, 0);
-            });
+            ExecutionMirror mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("c", 5, 0);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

This is to fix defect [MAGN 7807 When typing DS code in CBN if the function name and argument passed to the function are same it does not throw error](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7807).

Basically this fix extends variable shadowing to allows variables/parameters to mask function names. For example:
* Parameter name masks function name
```
def foo(foo)
{
    return = foo + 2;
}
x = foo(3);   // x is 5 after execution
```
* Variable name masks function name
```
def foo()
{
    foo = 21;
    return = foo;
}
x = foo();     // x is 21 after execution
```

```
def foo()
{
    return = 21;
}
foo = 2;
x = foo;      // x is 2
```

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers
@aparajit-pratap  PTAL.