### PR TITLE
Cleanup Node Layout: fix on groups and remove left alignment

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1058,45 +1058,45 @@ namespace Dynamo.ViewModels
             var graph = new GraphLayout.Graph();
             var models = new Dictionary<ModelBase, UndoRedoRecorder.UserAction>();
 
-            foreach (AnnotationModel n in Model.Annotations)
+            foreach (AnnotationModel group in Model.Annotations)
             {
                 // Treat a group as a graph layout node/vertex
-                graph.AddNode(n.GUID, n.Width, n.Height, n.Y);
-                models.Add(n, UndoRedoRecorder.UserAction.Modification);
+                graph.AddNode(group.GUID, group.Width, group.Height, group.Y);
+                models.Add(group, UndoRedoRecorder.UserAction.Modification);
             }
 
-            foreach (NodeModel n in Model.Nodes)
+            foreach (NodeModel node in Model.Nodes)
             {
                 AnnotationModel group = Model.Annotations.Where(
-                    s => s.SelectedModels.Contains(n)).ToList().FirstOrDefault();
+                    g => g.SelectedModels.Contains(node)).ToList().FirstOrDefault();
 
                 // Do not process nodes within groups
                 if (group == null)
                 {
-                    graph.AddNode(n.GUID, n.Width, n.Height, n.Y, n.InPorts.Count);
-                    models.Add(n, UndoRedoRecorder.UserAction.Modification);
+                    graph.AddNode(node.GUID, node.Width, node.Height, node.Y, node.InPorts.Count);
+                    models.Add(node, UndoRedoRecorder.UserAction.Modification);
                 }
             }
 
-            foreach (ConnectorModel x in Model.Connectors)
+            foreach (ConnectorModel edge in Model.Connectors)
             {
                 AnnotationModel startGroup = null, endGroup = null;
                 startGroup = Model.Annotations.Where(
-                    s => s.SelectedModels.Contains(x.Start.Owner)).ToList().FirstOrDefault();
+                    g => g.SelectedModels.Contains(edge.Start.Owner)).ToList().FirstOrDefault();
                 endGroup = Model.Annotations.Where(
-                    s => s.SelectedModels.Contains(x.End.Owner)).ToList().FirstOrDefault();
+                    g => g.SelectedModels.Contains(edge.End.Owner)).ToList().FirstOrDefault();
 
                 // Treat a group as a node, but do not process edges within a group
                 if (startGroup == null || endGroup == null || startGroup != endGroup)
                 {
                     graph.AddEdge(
-                        startGroup == null ? x.Start.Owner.GUID : startGroup.GUID,
-                        endGroup == null ? x.End.Owner.GUID : endGroup.GUID,
-                        x.Start.Center.Y,
-                        x.End.Center.Y);
+                        startGroup == null ? edge.Start.Owner.GUID : startGroup.GUID,
+                        endGroup == null ? edge.End.Owner.GUID : endGroup.GUID,
+                        edge.Start.Center.Y,
+                        edge.End.Center.Y);
                 }
 
-                models.Add(x, UndoRedoRecorder.UserAction.Modification);
+                models.Add(edge, UndoRedoRecorder.UserAction.Modification);
             }
 
             // Support undo for graph layout command
@@ -1110,28 +1110,28 @@ namespace Dynamo.ViewModels
             graph.NormalizeGraphPosition();
 
             // Assign coordinates to nodes inside groups
-            foreach (var x in Model.Annotations)
+            foreach (var group in Model.Annotations)
             {
-                var id = x.GUID;
-                double deltaX = graph.FindNode(id).X - x.X;
-                double deltaY = graph.FindNode(id).Y - x.Y;
-                foreach (var n in x.SelectedModels)
+                var g = graph.FindNode(group.GUID);
+                double deltaX = g.X - group.X;
+                double deltaY = g.Y - group.Y;
+                foreach (var node in group.SelectedModels)
                 {
-                    n.X += deltaX;
-                    n.Y += deltaY;
-                    n.ReportPosition();
+                    node.X += deltaX;
+                    node.Y += deltaY;
+                    node.ReportPosition();
                 }
             }
 
             // Assign coordinates to nodes outside groups
-            foreach (var x in Model.Nodes)
+            foreach (var node in Model.Nodes)
             {
-                var n = graph.FindNode(x.GUID);
+                var n = graph.FindNode(node.GUID);
                 if (n != null)
                 {
-                    x.X = n.X;
-                    x.Y = n.Y;
-                    x.ReportPosition();
+                    node.X = n.X;
+                    node.Y = n.Y;
+                    node.ReportPosition();
                 }
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1086,17 +1086,15 @@ namespace Dynamo.ViewModels
                 endGroup = Model.Annotations.Where(
                     s => s.SelectedModels.Contains(x.End.Owner)).ToList().FirstOrDefault();
 
-                // Connector does not belong to any group
-                if ((startGroup == null) && (endGroup == null))
-                    graph.AddEdge(x.Start.Owner.GUID, x.End.Owner.GUID, x.Start.Center.Y, x.End.Center.Y);
-
-                // Connector starts from a node within a group
-                else if ((startGroup != null) && (endGroup == null))
-                    graph.AddEdge(startGroup.GUID, x.End.Owner.GUID, x.Start.Center.Y, x.End.Center.Y);
-
-                // Connector ends at a node within a group
-                else if ((startGroup == null) && (endGroup != null))
-                    graph.AddEdge(x.Start.Owner.GUID, endGroup.GUID, x.Start.Center.Y, x.End.Center.Y);
+                // Treat a group as a node, but do not process edges within a group
+                if (startGroup == null || endGroup == null || startGroup != endGroup)
+                {
+                    graph.AddEdge(
+                        startGroup == null ? x.Start.Owner.GUID : startGroup.GUID,
+                        endGroup == null ? x.End.Owner.GUID : endGroup.GUID,
+                        x.Start.Center.Y,
+                        x.End.Center.Y);
+                }
 
                 models.Add(x, UndoRedoRecorder.UserAction.Modification);
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1073,7 +1073,7 @@ namespace Dynamo.ViewModels
                 // Do not process nodes within groups
                 if (group == null)
                 {
-                    graph.AddNode(node.GUID, node.Width, node.Height, node.Y, node.InPorts.Count);
+                    graph.AddNode(node.GUID, node.Width, node.Height, node.Y);
                     models.Add(node, UndoRedoRecorder.UserAction.Modification);
                 }
             }

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -31,10 +31,9 @@ namespace GraphLayout
         /// <param name="height">The height of the node view.</param>
         /// <param name="y">The y coordinate of the node view.</param>
         /// <param name="inPortCount">The number of input ports of the node.</param>
-        public void AddNode(Guid guid, double width, double height, double y, int inPortCount = 0)
+        public void AddNode(Guid guid, double width, double height, double y)
         {
             var node = new Node(guid, width, height, y, this);
-            node.InPortCount = inPortCount;
             Nodes.Add(node);
         }
 
@@ -337,13 +336,12 @@ namespace GraphLayout
                 }
             }
 
-            // Put all input nodes and isolated nodes on the leftmost layer
+            // Put all isolated nodes on the leftmost layer
             AddToLayer(Nodes.Where(x =>
-                (x.LeftEdges.Count == 0 && !x.HasUnconnectedInPort) ||
                 (x.LeftEdges.Count == 0 && x.RightEdges.Count == 0)).ToList(), Layers.Count);
 
             // Assign nodes with unconnected input ports right behind its next layer
-            foreach (Node n in Nodes.Where(x => x.LeftEdges.Count == 0 && x.RightEdges.Count > 0 && x.HasUnconnectedInPort))
+            foreach (Node n in Nodes.Where(x => x.LeftEdges.Count == 0 && x.RightEdges.Count > 0))
                 AddToLayer(n, n.RightEdges.Max(x => x.EndNode.Layer) + 1);
 
         }
@@ -566,11 +564,6 @@ namespace GraphLayout
         public int Layer = -1;
 
         /// <summary>
-        /// The number of input ports of the node.
-        /// </summary>
-        public int InPortCount;
-
-        /// <summary>
         /// The set of edges connected to the input ports the node.
         /// </summary>
         public HashSet<Edge> LeftEdges = new HashSet<Edge>();
@@ -579,15 +572,6 @@ namespace GraphLayout
         /// The set of edges connected to the output ports of the node.
         /// </summary>
         public HashSet<Edge> RightEdges = new HashSet<Edge>();
-
-        /// <summary>
-        /// Gets a Boolean value of whether the node has any unconnected input ports.
-        /// </summary>
-        /// <value>True if the node has at least one unconnected input port, otherwise false.</value>
-        public bool HasUnconnectedInPort
-        {
-            get { return LeftEdges.Count < InPortCount; }
-        }
 
         public Node(Guid guid, double width, double height, double y, Graph ownerGraph)
         {

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -337,8 +337,8 @@ namespace GraphLayout
             }
 
             // Put all isolated nodes on the leftmost layer
-            AddToLayer(Nodes.Where(x =>
-                (x.LeftEdges.Count == 0 && x.RightEdges.Count == 0)).ToList(), Layers.Count);
+            AddToLayer(Nodes.Where(x => (x.Layer < 0 &&
+                x.LeftEdges.Count == 0 && x.RightEdges.Count == 0)).ToList(), Layers.Count);
 
             // Assign nodes with unconnected input ports right behind its next layer
             foreach (Node n in Nodes.Where(x => x.LeftEdges.Count == 0 && x.RightEdges.Count > 0))

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -68,16 +68,16 @@ namespace GraphLayout
         }
 
         /// <summary>
-        /// Finds an edge between two nodes.
+        /// Finds an active edge between two nodes.
         /// </summary>
         /// <param name="start">Start node.</param>
         /// <param name="end">End node.</param>
         /// <returns>The edge object.</returns>
         public Edge FindEdge(Node start, Node end)
         {
-            foreach (Edge edge in Edges.Where(x => x.Active))
+            foreach (Edge edge in Edges)
             {
-                if (start.Equals(edge.StartNode) && end.Equals(edge.EndNode))
+                if (edge.Active && start.Equals(edge.StartNode) && end.Equals(edge.EndNode))
                 {
                     return edge;
                 }


### PR DESCRIPTION
### Purpose

This PR is to resolve the following two issues:

##### [MAGN-8271](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8271) Groups should be horizontally aligned when they all are from same graph
![image](https://cloud.githubusercontent.com/assets/6386550/9597656/9874f802-50b6-11e5-975d-2aba2e8bbbbd.png)
This is to fix a bug from the previous pull request where groups became laid out vertically if nodes from a group were connected to nodes in a different group.


##### [MAGN-8299](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8299) Input nodes should not be aligned to the left
![image](https://cloud.githubusercontent.com/assets/6386550/9597587/f01769ce-50b5-11e5-9bbd-cd12a7f818b4.png)
This is done in order to minimize the overall connector length and the number of crossings.


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 

### FYIs

@riteshchandawar 