### PR TITLE
MAGN-8303 Preview Setting Control should not be displayed once user switched to Node View.

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.3.2425")]
+[assembly: AssemblyVersion("0.8.3.2445")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.3.2425")]
+[assembly: AssemblyFileVersion("0.8.3.2445")]

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -76,7 +76,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private double nearPlaneDistanceFactor = 0.01;
         private Vector3 directionalLightDirection = new Vector3(-0.5f, -1.0f, 0.0f);
         private DirectionalLight3D directionalLight;
-        private bool showWatchSettingsControl = false;
 
         private readonly Color4 directionalLightColor = new Color4(0.9f, 0.9f, 0.9f, 1.0f);
         private readonly Color4 defaultSelectionColor = new Color4(new Color3(0, 158.0f / 255.0f, 1.0f));
@@ -272,16 +271,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         }
 
         public bool IsResizable { get; protected set; }
-
-        public bool ShowWatchSettingsControl
-        {
-            get { return showWatchSettingsControl; }
-            set
-            {
-                showWatchSettingsControl = value;
-                RaisePropertyChanged("ShowWatchSettingsControl");
-            }
-        }
 
         public IEnumerable<Model3D> SceneItems
         {

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml
@@ -77,13 +77,6 @@
 
                 <MenuItem Header="{x:Static p:Resources.Watch3DViewContextMenuZoomToFit}"
                           Click="OnZoomToFitClickedHandler" />
-
-                <MenuItem Header="Show Preview Settings Control" Focusable="False" IsCheckable="True">
-                    <MenuItem.IsChecked>
-                        <Binding Path="ShowWatchSettingsControl"
-                                 Mode="TwoWay"/>
-                    </MenuItem.IsChecked>
-                </MenuItem>
                 
             </ContextMenu>
         </Grid.ContextMenu>
@@ -118,12 +111,6 @@
                 <MouseBinding Command="{Binding LeftClickCommand}" Gesture="LeftClick"/>
             </hx:Viewport3DX.InputBindings>            
         </hx:Viewport3DX>
-
-        <Grid Visibility="{Binding ShowWatchSettingsControl, Converter={StaticResource BoolToVisibilityConverter}}">
-            <preview:Watch3DSettingsControl x:Name="WatchSettingsControl"  
-                                            HorizontalAlignment="Left" 
-                                            VerticalAlignment="Top" Margin="10,30" />
-        </Grid>
         
         <Thumb Name ="resizeThumb" 
                Width="10" Height="10" 


### PR DESCRIPTION
### Purpose

This PR addresses [MAGN-8303](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8303). The watch settings control should not be accessible to users until we have time to refine the design. This PR removes it.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
  - No new documentation required. Removal of code only.
- [ ] The level of testing this PR includes is appropriate
  - No new tests required. This functionality was view-level only and did not have tests.
- [ ] User facing strings, if any, are extracted into `*.resx` files
  - No new strings added/removed.

### Reviewers

@ramramps 