### PR TITLE
MAGN-8242 'Add to Group' option remains even though node is not selected.

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.3.2445")]
+[assembly: AssemblyVersion("0.8.3.2446")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.3.2445")]
+[assembly: AssemblyFileVersion("0.8.3.2446")]

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -971,9 +971,9 @@ namespace Dynamo.ViewModels
         private bool CanAddToGroup(object parameters)
         {          
             var groups = WorkspaceViewModel.Model.Annotations;
-            if (groups.Any(x => x.IsSelected))
+            if (groups.Any(x => x.IsSelected) && NodeLogic.IsSelected)
             {
-                return !(groups.ContainsModel(NodeLogic.GUID));
+                return !(groups.ContainsModel(NodeLogic.GUID)); 
             }
             return false;
         }


### PR DESCRIPTION
### Purpose

This PR addresses [MAGN-8242](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8242).  
AddToGroup in context menu should not be visible when a node is unselected.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR 
- [ ] The level of testing this PR includes is appropriate
  - No new tests required. This is on the View Layer.
- [ ] User facing strings, if any, are extracted into `*.resx` files
  - No new strings added/removed.

### Reviewers

@mjkkirschner 