### PR TITLE
Fix erroneous graph execution caused by the code change in CBN

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -9,6 +9,7 @@ using ProtoScript.Runners;
 
 using BuildWarning = ProtoCore.BuildData.WarningEntry;
 using RuntimeWarning = ProtoCore.Runtime.WarningEntry;
+using System.Diagnostics;
 
 namespace Dynamo.Core.Threading
 {
@@ -60,7 +61,23 @@ namespace Dynamo.Core.Threading
 
                 ModifiedNodes = ComputeModifiedNodes(workspace);
                 graphSyncData = engineController.ComputeSyncData(workspace.Nodes, ModifiedNodes, verboseLogging);
-                return graphSyncData != null;
+
+                Debug.Assert(graphSyncData != null);
+                // We clear dirty flags before executing the task. If we clear
+                // flags after the execution of task, for example in
+                // AsyncTask.Completed or in HandleTaskCompletionCore(), as both
+                // are executed in the other thread, although some nodes are
+                // modified and we request graph execution, but just before
+                // computing sync data, the task completion handler jumps in
+                // and clear dirty flags. Now graph sync data will be null and
+                // graph is in wrong state.
+                foreach (var nodeGuid in graphSyncData.NodeIDs)
+                {
+                    var node = workspace.Nodes.FirstOrDefault(n => n.GUID.Equals(nodeGuid));
+                    node.ClearDirtyFlag();
+                }
+
+                return true;
             }
             catch (Exception e)
             {
@@ -103,37 +120,37 @@ namespace Dynamo.Core.Threading
             }
         }
 
+        /// <summary>
+        /// Return if this task's graph sync data is a super set of the other
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        private bool Contains(UpdateGraphAsyncTask other)
+        {
+            // Be more conservative here. Not only check ModifiedNodes, but
+            // also check *all* nodes in graph sync data. For example, consider
+            // a CBN outputs to a node, the node is a downstream node of cbn.
+            //
+            // Now if node is modified and request a run, task's ModifiedNodes
+            // will cotain this node; then CBN is modified and request a run,
+            // ModifiedNodes would contain both CBN and the node, and previous
+            // task will be thrown away.
+            return other.graphSyncData.NodeIDs.All(graphSyncData.NodeIDs.Contains) && 
+                   other.ModifiedNodes.All(ModifiedNodes.Contains); 
+        }
+
         protected override AsyncTask.TaskMergeInstruction CanMergeWithCore(AsyncTask otherTask)
         {
             var theOtherTask = otherTask as UpdateGraphAsyncTask;
             if (theOtherTask == null)
                 return base.CanMergeWithCore(otherTask);
 
-            // Comparing to another UpdateGraphAsyncTask, verify 
-            // that they are updating a similar set of nodes.
-
-            if ((graphSyncData != null && 
-                graphSyncData.DeletedSubtrees != null && 
-                graphSyncData.DeletedSubtrees.Any()) ||
-                (theOtherTask.graphSyncData != null &&
-                 theOtherTask.graphSyncData.DeletedSubtrees != null && 
-                 theOtherTask.graphSyncData.DeletedSubtrees.Any()))
-                return TaskMergeInstruction.KeepBoth;
-
-            // Other node is either equal or a superset of this task
-            if (ModifiedNodes.All(x => theOtherTask.ModifiedNodes.Contains(x)))
-            {
+            if (theOtherTask.Contains(this))
                 return TaskMergeInstruction.KeepOther;
-            }
-
-            // This node is a superset of the other
-            if (theOtherTask.ModifiedNodes.All(x => ModifiedNodes.Contains(x)))
-            {
+            else if (this.Contains(theOtherTask)) 
                 return TaskMergeInstruction.KeepThis;
-            }
-
-            // They're different, keep both
-            return TaskMergeInstruction.KeepBoth;
+            else
+                return TaskMergeInstruction.KeepBoth;
         }
 
         #endregion

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -414,11 +414,6 @@ namespace Dynamo.Models
                 node.Warning(message.Value); // Update node warning message.
             }
 
-            foreach (var node in Nodes)
-            {
-                node.ClearDirtyFlag();
-            }
-
             // Notify listeners (optional) of completion.
             RunSettings.RunEnabled = true; // Re-enable 'Run' button.
 

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -81,12 +81,24 @@ namespace ProtoScript.Runners
             private set;
         }
 
+        public IEnumerable<Guid> NodeIDs
+        {
+            get;
+            private set;
+        }
+
         public GraphSyncData(List<Subtree> deleted, List<Subtree> added, List<Subtree> modified)
         {
             DeletedSubtrees = deleted;
             AddedSubtrees = added;
             ModifiedSubtrees = modified;
+
+            NodeIDs = Enumerable.Empty<Guid>()
+                                .Concat(deleted == null ? Enumerable.Empty<Guid>() : deleted.Select(t => t.GUID))
+                                .Concat(added == null ? Enumerable.Empty<Guid>() : added.Select(t => t.GUID))
+                                .Concat(modified == null ? Enumerable.Empty<Guid>() : modified.Select(t => t.GUID));
         }
+
 
         public override string ToString()
         {


### PR DESCRIPTION
### Purpose

This PR is to fix defect [MAGN 8300 Updating CBN affects non related changes in other node which is connected to same CBN](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8300). In short, it is because some graph execution tasks are thrown away, but there are two causes. 

**The first issue is some graph execution tasks are thrown away.** All graph executions are wrapped `UpdateGraphAsyncTask` tasks which are asynchronous tasks, and the scheduler may throw a `UpdateGraphAsyncTask` task away if the other one is a super set of this one. This super set checking is done by collecting all modified nodes and their downstream nodes in `UpdateGraphAsyncTask` initialization and check if this `ModifiedNodes` is the super set of other task's `ModifiedNodes`. Let's consider the following case: a code block node outputs to a function node foo:

```
  cbn                 foo          task queue
+------+           +--------+      <empty>
|  21  | --------> | foo(x) |
+------+           +--------+
```
Now we update the code in this code block node. The code block node will delete all connectors which triggers a graph execution (from `foo.OnModified()`):
```
  cbn                 foo          task queue
+------+           +--------+      UpdateGraphAsyncTask: {ModifiedNodes: {foo}, Code: {foo(null)}}
|  42  | ---X----> | foo()  |
+------+           +--------+
```
and this task gets executed immediately. Now after updating code, code block node will restore all previous connectors which triggers the other graph execution (from `foo.OnModified()`)
```
  cbn                 foo          task queue
+------+           +--------+      UpdateGraphAsyncTask: {ModifiedNodes: {foo}, Code: {foo(x)}}
|  42  | --------> | foo(x) |
+------+           +--------+
```
Suppose this task won't get executed immediately. Now the code block node itself requests a graph execution. Note as the second task's `ModifiedNodes` contains all `ModifiedNodes` in the first task, the first task is thrown away, so `foo` node is in error state.
```
  cbn                 foo          task queue
+------+           +--------+      UpdateGraphAsyncTask: {ModifiedNodes: {foo}, Code: {foo(x)}}
|  42  | --------> | foo(x) |      UpdateGraphAsyncTask: {ModifiedNodes: {cbn, foo}, Code: {t = 42}}
+------+           +--------+
```
To fix this issue, the superset testing will include **all nodes** in the graph sync data, instead of just testing downstream nodes. 

**The second issue is, some graph sync data can't generate.** That is because after the execution of `UpdateGraphAsyncTask`, all nodes' dirty flag will be cleared. Previously, it is done in `HomeWorkspace.OnUpdateGraphCompleted()` which is called from `AsyncTask.HandleTaskCompletionCore()`. As it is invoked in the other thread, it may jump in in the middle of the other graph execution event. 

For example, suppose we modify node1 and trigger graph execution:
```
  node1            node2        task queue
+------+         +-------+      UpdateGraphAsyncTask: {ModifiedNodes: {node1}, ...}
|      |         |       |      U
+------+         +-------+
  modified
```
and we modify node2 and trigger graph execution, but before computing graph sync data for node2, the execution of node1 is done and we clear all dirty flags for node1 and node2. Now as node2 is clean, graph sync data is null, node2 will be in error state.

To fix this issue, we have to move dirty flag clearing work to main UI thread to avoid race condition.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 

### FYIs

@riteshchandawar 
