### PR TITLE
Fix for FullCategoryNameToMarginConverterTest

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.3.2454")]
+[assembly: AssemblyVersion("0.8.3.2455")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.3.2454")]
+[assembly: AssemblyFileVersion("0.8.3.2455")]

--- a/test/DynamoCoreWpfTests/ConverterTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterTests.cs
@@ -355,32 +355,24 @@ namespace Dynamo.Tests
             string name = "";
             var thickness = new Thickness(5, 0, 0, 0);
             object result;
-
-            //1. Name is null.
-            //2. Name is empty.
-            //3. Name is "Category".
-            //4. Name is "Category.NestedClass1".
-            //5. Name is "Category.NestedClass1.NestedClass2".
-
-            // 1 case            
-            Assert.Throws<ArgumentException>(() => converter.Convert(null, null, null, null));
-
-            // 2 case            
-            Assert.Throws<ArgumentException>(() => converter.Convert(name, null, null, null));
-
-            // 3 case
+            
+            //1. Name is "Category".
+            //2. Name is "Category.NestedClass1".
+            //3. Name is "Category.NestedClass1.NestedClass2".
+           
+            // 1 case
             name = "Category";
             thickness = new Thickness(5, 0, 0, 0);
             result = converter.Convert(name, null, null, null);
             Assert.AreEqual(thickness, result);
 
-            // 4 case
+            // 2 case
             name = "Category.NestedClass1";
             thickness = new Thickness(25, 0, 20, 0);
             result = converter.Convert(name, null, null, null);
             Assert.AreEqual(thickness, result);
 
-            // 5 case
+            // 3 case
             name = "Category.NestedClass1.NestedClass2";
             thickness = new Thickness(45, 0, 20, 0);
             result = converter.Convert(name, null, null, null);


### PR DESCRIPTION
### Purpose

This PR addresses the issue with the test FullCategoryNameToMarginConverterTest. 
Before the TreeView, if the incoming name is null or empty, then an execption is thrown. After the tree view, if the name is null or empty then a default thickness is returned.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR 
- [x] The level of testing this PR includes is appropriate
  - Updated the test
- [ ] User facing strings, if any, are extracted into `*.resx` files
  - No new strings added/removed.

### Reviewers

@pboyer 