### PR TITLE
Move Background Preview + Node View to top of window

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -321,8 +321,39 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top">
 
+            <StackPanel Name="statusBarPanel"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Height="Auto">
+                <ui:ImageCheckBox Width="56"
+                              Height="30"
+                              Margin="4,4,0,4"
+                              StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-geom-states.png"
+                              CheckImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-geom-check.png"
+                              ToolTip="{x:Static p:Resources.InCanvasGeomButtonToolTip}">
+                    <ui:ImageCheckBox.IsChecked>
+                        <Binding Path="DataContext.BackgroundPreviewViewModel.CanNavigateBackground"
+                             RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
+                    </ui:ImageCheckBox.IsChecked>
+                </ui:ImageCheckBox>
+                <ui:ImageCheckBox Width="55"
+                              Height="30"
+                              Margin="0,4,0,4"
+                              StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-node-states.png"
+                              CheckImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-node-check.png"
+                              ToolTip="{x:Static p:Resources.InCanvasNodeButtonToolTip}">
+                    <ui:ImageCheckBox.IsChecked>
+                        <Binding Path="DataContext.BackgroundPreviewViewModel.CanNavigateBackground"
+                             RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}"
+                             Converter="{StaticResource InverseBooleanConverter}" />
+                    </ui:ImageCheckBox.IsChecked>
+                </ui:ImageCheckBox>
+            </StackPanel>
+
             <ui:ImageButton Width="30"
                             Height="28"
+                            HorizontalAlignment="Right"
                             StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-fit-view-states.png">
                 <ui:ImageButton.Command>
                     <Binding Path="DataContext.FitViewCommand"
@@ -332,6 +363,7 @@
 
             <ui:ImageRepeatButton Width="30"
                                   Height="24"
+                                  HorizontalAlignment="Right"
                                   StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-zoom-in-states.png">
                 <ui:ImageRepeatButton.Command>
                     <Binding Path="DataContext.ZoomInCommand"
@@ -341,6 +373,7 @@
 
             <ui:ImageRepeatButton Width="30"
                                   Height="28"
+                                  HorizontalAlignment="Right"
                                   StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-zoom-out-states.png">
                 <ui:ImageRepeatButton.Command>
                     <Binding Path="DataContext.ZoomOutCommand"
@@ -350,6 +383,7 @@
 
             <ui:ImageCheckBox Width="30"
                               Height="30"
+                              HorizontalAlignment="Right"
                               StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-pan-states.png"
                               CheckImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-pan-check.png">
                 <ui:ImageCheckBox.Command>
@@ -365,6 +399,7 @@
 
             <ui:ImageCheckBox Width="30"
                               Height="30"
+                              HorizontalAlignment="Right"
                               StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-orbit-states.png"
                               CheckImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-orbit-check.png">
                 <ui:ImageCheckBox.Command>
@@ -385,35 +420,7 @@
 
         </StackPanel>
 
-        <StackPanel Name="statusBarPanel"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Bottom"
-                    Height="Auto">
-            <ui:ImageCheckBox Width="56"
-                              Height="30"
-                              Margin="4,4,0,4"
-                              StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-geom-states.png"
-                              CheckImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-geom-check.png"
-                              ToolTip="{x:Static p:Resources.InCanvasGeomButtonToolTip}">
-                <ui:ImageCheckBox.IsChecked>
-                    <Binding Path="DataContext.BackgroundPreviewViewModel.CanNavigateBackground"
-                             RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
-                </ui:ImageCheckBox.IsChecked>
-            </ui:ImageCheckBox>
-            <ui:ImageCheckBox Width="55"
-                              Height="30"
-                              Margin="0,4,4,4"
-                              StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-node-states.png"
-                              CheckImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-node-check.png"
-                              ToolTip="{x:Static p:Resources.InCanvasNodeButtonToolTip}">
-                <ui:ImageCheckBox.IsChecked>
-                    <Binding Path="DataContext.BackgroundPreviewViewModel.CanNavigateBackground"
-                             RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}"
-                             Converter="{StaticResource InverseBooleanConverter}" />
-                </ui:ImageCheckBox.IsChecked>
-            </ui:ImageCheckBox>
-        </StackPanel>
+     
 
         <Popup Name="InCanvasSearchBar"
                StaysOpen="True"


### PR DESCRIPTION
### Purpose

This PR moves the toggle buttons for background preview and node view to the top of the UI.

The stack panel containing these controls was embedded into the stack panel that contained the other view navigation buttons, and the margins and alignments were slightly adjusted.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate

![screen shot 2015-09-03 at 3 43 55 pm](https://cloud.githubusercontent.com/assets/508936/9669076/094197a0-5253-11e5-8eeb-52183914a803.png)


### Reviewers

@ramramps 

### FYIs

@mccrone @riteshchandawar @Racel 