### PR TITLE
Generate type dependent variable name in node to code

### DIFF
--- a/src/DynamoCore/Core/CustomNodeDefinition.cs
+++ b/src/DynamoCore/Core/CustomNodeDefinition.cs
@@ -129,6 +129,7 @@ namespace Dynamo
                 .Select(node => node.Definition)
                 .Where(def => def.FunctionId != functionId)
                 .Distinct();
+            ReturnType = ProtoCore.TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar);
         }
 
         public static CustomNodeDefinition MakeProxy(Guid functionId, string displayName)
@@ -187,6 +188,11 @@ namespace Dynamo
         ///     User friendly name on UI.
         /// </summary>
         public string DisplayName { get; private set; }
+
+        /// <summary>
+        ///     Return type.
+        /// </summary>
+        public ProtoCore.Type ReturnType { get; private set; }
         
         #region Dependencies
 

--- a/src/DynamoCore/Engine/NodeToCode.cs
+++ b/src/DynamoCore/Engine/NodeToCode.cs
@@ -520,15 +520,9 @@ namespace Dynamo.Engine
                 this.core = core;
             }
 
-            public string GenerateNextDefaultName()
+            public string GetName(ProtoCore.Type? typeHint)
             {
-                defaultNS.BumpID();
-                return defaultNS.NumberedVariable;
-            }
-
-            public string GenerateNextNameForType(ProtoCore.Type type)
-            {
-                var ns = GetNumberingStateForType(type);
+                var ns = typeHint.HasValue ? GetNumberingStateForType(typeHint.Value) : defaultNS;
                 ns.BumpID();
                 return ns.NumberedVariable;
             }
@@ -997,15 +991,14 @@ namespace Dynamo.Engine
             HashSet<string> mappedVariables,
             string varName)
         {
-            ProtoCore.Type typeHint;
-            bool hasHint = typeHints.TryGetValue(varName, out typeHint);
+            ProtoCore.Type? type = null;
+            ProtoCore.Type t;
+            if (typeHints.TryGetValue(varName, out t))
+                type = t;
 
-            var shortName = hasHint ? generator.GenerateNextNameForType(typeHint) 
-                                    : generator.GenerateNextDefaultName();
-
+            var shortName = generator.GetName(type);
             while (mappedVariables.Contains(shortName))
-                shortName = hasHint ? generator.GenerateNextNameForType(typeHint) 
-                                    : generator.GenerateNextDefaultName();
+                shortName = generator.GetName(type);
 
             return shortName;
         }

--- a/src/DynamoCore/Engine/NodeToCode.cs
+++ b/src/DynamoCore/Engine/NodeToCode.cs
@@ -340,6 +340,7 @@ namespace Dynamo.Engine
                 // Rewrite the AST using the shortest name
                 var newIdentList = CoreUtils.CreateNodeFromString(shortName);
                 return newIdentList;
+
             }
         }
 
@@ -506,7 +507,7 @@ namespace Dynamo.Engine
         }
 
         /// <summary>
-        /// Generate short variable name.
+        /// Generate type-dependent short variable name in format: type+ID.
         /// </summary>
         private class ShortNameGenerator
         {
@@ -545,6 +546,17 @@ namespace Dynamo.Engine
                     var preferredShortName = String.Empty;
                     if (classNode.ClassAttributes != null)
                         preferredShortName = classNode.ClassAttributes.PreferredShortName;
+
+                    // Otherwise check if its base class provides a short name.
+                    var baseClass = classNode;
+                    while (String.IsNullOrEmpty(preferredShortName) && baseClass.baseList.Any())
+                    {
+                        var baseIndex = baseClass.baseList[0];
+                        baseClass = core.ClassTable.ClassNodes[baseIndex];
+
+                        if (baseClass.ClassAttributes != null)
+                            preferredShortName = baseClass.ClassAttributes.PreferredShortName;
+                    }
 
                     // Otherwise change class name to its lower case
                     if (String.IsNullOrEmpty(preferredShortName) && (type.UID > (int)ProtoCore.PrimitiveType.kMaxPrimitives))

--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -42,6 +42,11 @@ namespace Dynamo.Engine
         ///     Function name.
         /// </summary>
         string FunctionName { get; }
+
+        /// <summary>
+        ///     Return Type
+        /// </summary>
+        ProtoCore.Type ReturnType { get; }
     }
 
     public class FunctionDescriptorParams
@@ -110,12 +115,7 @@ namespace Dynamo.Engine
             }
 
             InputParameters = inputParameters;
-            
-            //Not sure why returnType for constructors are var[]..[], use UnqualifiedClassName
-            ReturnType = (type == FunctionType.Constructor) ?
-                UnqualifedClassName :
-                funcDescParams.ReturnType.ToShortString();
-
+            ReturnType =  funcDescParams.ReturnType;
             Type = type;
             ReturnKeys = funcDescParams.ReturnKeys;
             IsVarArg = funcDescParams.IsVarArg;
@@ -151,7 +151,7 @@ namespace Dynamo.Engine
         /// <summary>
         ///     Function return type.
         /// </summary>
-        public string ReturnType { get; private set; }
+        public ProtoCore.Type ReturnType { get; private set; }
 
         /// <summary>
         ///     If the function returns a dictionary, ReturnKeys is the key collection
@@ -285,8 +285,9 @@ namespace Dynamo.Engine
                 else if (FunctionType.InstanceProperty != Type && FunctionType.StaticProperty != Type)
                     descBuf.Append(" ( )");
 
-                if (!string.IsNullOrEmpty(ReturnType))
-                    descBuf.Append(": " + ReturnType);
+                var typeName = ReturnType.ToShortString();
+                if (!string.IsNullOrEmpty(typeName))
+                    descBuf.Append(": " + typeName);
 
                 return descBuf.ToString();
             }

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -603,6 +603,17 @@ namespace Dynamo.Models
             }
         }
 
+        /// <summary>
+        ///      The type of node's output 
+        /// </summary>
+        /// <returns></returns>
+        public virtual ProtoCore.Type OutputType
+        {
+            get 
+            {
+                return ProtoCore.TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.kTypeVar);
+            }
+        }
         #endregion
 
         protected NodeModel()

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -604,15 +604,13 @@ namespace Dynamo.Models
         }
 
         /// <summary>
-        ///      The type of node's output 
+        ///      The possible type of output at specified port. This 
+        ///      type information is not necessary to be accurate.
         /// </summary>
         /// <returns></returns>
-        public virtual ProtoCore.Type OutputType
+        public virtual ProtoCore.Type GetTypeHintForOutput(int index)
         {
-            get 
-            {
-                return ProtoCore.TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.kTypeVar);
-            }
+             return ProtoCore.TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.kTypeVar);
         }
         #endregion
 

--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -430,7 +430,8 @@ namespace Dynamo.Nodes
             if (functionCallNode != null)
             {
                 ProtoCore.FunctionGroup funcGroup;
-                if (core.FunctionTable.FunctionList.TryGetValue(functionCallNode.Name, out funcGroup))
+                var funcTable = core.FunctionTable.GlobalFuncTable[0];
+                if (funcTable.TryGetValue(functionCallNode.Function.Name, out funcGroup))
                 {
                     var func = funcGroup.FunctionEndPoints.FirstOrDefault();
                     if (func != null)

--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -394,7 +394,7 @@ namespace Dynamo.Nodes
         /// <returns></returns>
         public override ProtoCore.Type GetTypeHintForOutput(int index)
         {
-            ProtoCore.Type type = new ProtoCore.Type();
+            ProtoCore.Type type = ProtoCore.TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.kTypeVar);
             var statement = GetStatementForOutput(index);
             if (statement == null)
                 return type;
@@ -421,7 +421,7 @@ namespace Dynamo.Nodes
                     return type;
 
                 var targetClass = core.ClassTable.ClassNodes[classIndex];
-                var func = targetClass.GetFirstMemberFunctionBy(funcNode.Name);
+                var func = targetClass.GetFirstMemberFunctionBy(funcNode.Function.Name);
                 type = func.returntype;
                 return type;
             }

--- a/src/DynamoCore/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Nodes/CodeBlockNode.cs
@@ -17,6 +17,7 @@ using Node = ProtoCore.AST.Node;
 using Operator = ProtoCore.DSASM.Operator;
 using ProtoCore.Utils;
 using Dynamo.UI;
+using ProtoCore;
 
 namespace Dynamo.Nodes
 {
@@ -394,7 +395,7 @@ namespace Dynamo.Nodes
         /// <returns></returns>
         public override ProtoCore.Type GetTypeHintForOutput(int index)
         {
-            ProtoCore.Type type = ProtoCore.TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.kTypeVar);
+            ProtoCore.Type type = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar);
             var statement = GetStatementForOutput(index);
             if (statement == null)
                 return type;
@@ -405,9 +406,9 @@ namespace Dynamo.Nodes
             
             var core = libraryServices.LibraryManagementCore;
 
-            var identListNode = expr.RightNode as IdentifierListNode;
-            if (identListNode != null)
+            if (expr.RightNode is IdentifierListNode) 
             {
+                var identListNode = expr.RightNode as IdentifierListNode;
                 var funcNode = identListNode.RightNode as FunctionCallNode;
                 if (funcNode == null)
                     return type;
@@ -425,10 +426,9 @@ namespace Dynamo.Nodes
                 type = func.returntype;
                 return type;
             }
-
-            var functionCallNode = expr.RightNode as FunctionCallNode;
-            if (functionCallNode != null)
+            else if (expr.RightNode is FunctionCallNode)
             {
+                var functionCallNode = expr.RightNode as FunctionCallNode;
                 ProtoCore.FunctionGroup funcGroup;
                 var funcTable = core.FunctionTable.GlobalFuncTable[0];
                 if (funcTable.TryGetValue(functionCallNode.Function.Name, out funcGroup))
@@ -438,6 +438,14 @@ namespace Dynamo.Nodes
                         return func.procedureNode.returntype;
                 }
             }
+            else if (expr.RightNode is IntNode)
+                return TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeInt);
+            else if (expr.RightNode is StringNode)
+                return TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeString);
+            else if (expr.RightNode is DoubleNode)
+                return TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeDouble);
+            else if (expr.RightNode is StringNode)
+                return TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeString);
 
             return type;
         }

--- a/src/DynamoCore/Nodes/ZeroTouch/DSFunctionBase.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSFunctionBase.cs
@@ -67,6 +67,14 @@ namespace Dynamo.Nodes
         {
             return Controller.BuildAst(this, inputAstNodes);
         }
+
+        public override ProtoCore.Type OutputType
+        {
+            get
+            {
+                return Controller.Definition.ReturnType;
+            }
+        }
     }
     
 
@@ -170,9 +178,7 @@ namespace Dynamo.Nodes
             }
             else
             {
-                string displayReturnType = IsConstructor()
-                    ? Definition.UnqualifedClassName
-                    : Definition.ReturnType;
+                string displayReturnType = Definition.ReturnType.ToShortString();
 
                 var returns = Definition.Returns;
 

--- a/src/DynamoCore/Nodes/ZeroTouch/DSFunctionBase.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSFunctionBase.cs
@@ -68,13 +68,10 @@ namespace Dynamo.Nodes
             return Controller.BuildAst(this, inputAstNodes);
         }
 
-        public override ProtoCore.Type OutputType
+        public override ProtoCore.Type GetTypeHintForOutput(int index)
         {
-            get
-            {
-                return Controller.Definition.ReturnType;
-            }
-        }
+            return Controller.Definition.ReturnType;
+        } 
     }
     
 

--- a/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
@@ -44,7 +44,7 @@ namespace Dynamo.Search.SearchElements
                 ElementType |= ElementTypes.Packaged;
 
             inputParameters = new List<Tuple<string, string>>(functionDescriptor.InputParameters);
-            outputParameters = new List<string>() { functionDescriptor.ReturnType };
+            outputParameters = new List<string>() { functionDescriptor.ReturnType.ToShortString() };
 
             foreach (var tag in functionDescriptor.GetSearchTags())
                 SearchKeywords.Add(tag);

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -5751,7 +5751,7 @@ namespace ProtoAssociative
                 if (globalClassIndex != -1)
                     localProcedure.returntype.Name = core.ClassTable.ClassNodes[globalClassIndex].name;
                 localProcedure.returntype.UID = globalClassIndex;
-                localProcedure.returntype.rank = Constants.kArbitraryRank;
+                localProcedure.returntype.rank = 0;
                 localProcedure.isConstructor = true;
                 localProcedure.runtimeIndex = 0;
                 localProcedure.isExternal = funcDef.IsExternLib;

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -5748,6 +5748,8 @@ namespace ProtoAssociative
                 localProcedure.name = funcDef.Name;
                 localProcedure.pc = ProtoCore.DSASM.Constants.kInvalidIndex;
                 localProcedure.localCount = 0;// Defer till all locals are allocated
+                if (globalClassIndex != -1)
+                    localProcedure.returntype.Name = core.ClassTable.ClassNodes[globalClassIndex].name;
                 localProcedure.returntype.UID = globalClassIndex;
                 localProcedure.returntype.rank = Constants.kArbitraryRank;
                 localProcedure.isConstructor = true;

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -1223,11 +1223,6 @@ namespace ProtoFFI
             get { return attributes; }
         }
 
-        public string PreferredShortName
-        {
-            get; private set;
-        }
-
         public FFIClassAttributes(Type type)
         {
             if (type == null)

--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -195,12 +195,14 @@ namespace ProtoCore
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeArray);
 
             cnode = new ClassNode { name = DSDefinitions.Keyword.Double, rank = 4, typeSystem = this };
+            cnode.ClassAttributes = new AST.AssociativeAST.ClassAttributes("", "num");
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceDoubleToIntScore);
             cnode.classId = (int)PrimitiveType.kTypeDouble;
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeDouble);
 
             cnode = new ClassNode { name = DSDefinitions.Keyword.Int, rank = 3, typeSystem = this };
+            cnode.ClassAttributes = new AST.AssociativeAST.ClassAttributes("", "num");
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeDouble, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceIntToDoubleScore);
             cnode.classId = (int)PrimitiveType.kTypeInt;
@@ -208,6 +210,7 @@ namespace ProtoCore
 
             cnode = new ClassNode { name = DSDefinitions.Keyword.Bool, rank = 2, typeSystem = this };
             cnode.classId = (int)PrimitiveType.kTypeBool;
+            cnode.ClassAttributes = new AST.AssociativeAST.ClassAttributes("", "bool");
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeBool);
 
             cnode = new ClassNode { name = DSDefinitions.Keyword.Char, rank = 1, typeSystem = this };
@@ -248,7 +251,7 @@ namespace ProtoCore
             cnode = new ClassNode { name = DSDefinitions.Keyword.FunctionPointer, rank = 0,typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypeFunctionPointer;
-            cnode.ClassAttributes = new AST.AssociativeAST.ClassAttributes("", "fptr");
+            cnode.ClassAttributes = new AST.AssociativeAST.ClassAttributes("", "func");
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeFunctionPointer);
 
             cnode = new ClassNode { name = "return_reserved", rank = 0, typeSystem = this };

--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -220,6 +220,7 @@ namespace ProtoCore
             cnode = new ClassNode { name = DSDefinitions.Keyword.String, rank = 0, typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeBool, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypeString;
+            cnode.ClassAttributes = new AST.AssociativeAST.ClassAttributes("", "str");
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeString);
 
             cnode = new ClassNode { name = DSDefinitions.Keyword.Var, rank = 0, typeSystem = this };
@@ -247,6 +248,7 @@ namespace ProtoCore
             cnode = new ClassNode { name = DSDefinitions.Keyword.FunctionPointer, rank = 0,typeSystem = this };
             cnode.coerceTypes.Add((int)PrimitiveType.kTypeInt, (int)ProtoCore.DSASM.ProcedureDistance.kCoerceScore);
             cnode.classId = (int)PrimitiveType.kTypeFunctionPointer;
+            cnode.ClassAttributes = new AST.AssociativeAST.ClassAttributes("", "fptr");
             classTable.SetClassNodeAt(cnode, (int)PrimitiveType.kTypeFunctionPointer);
 
             cnode = new ClassNode { name = "return_reserved", rank = 0, typeSystem = this };

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -1357,10 +1357,11 @@ namespace ProtoCore.AST.AssociativeAST
         public bool HiddenInLibrary { get; protected set; }
         public string ObsoleteMessage { get; protected set; }
         public bool IsObsolete { get { return !string.IsNullOrEmpty(ObsoleteMessage); } }
-        public ClassAttributes(string msg = "")
+        public ClassAttributes(string msg = "", string preferredShortName = "")
         {
             ObsoleteMessage = msg;
             HiddenInLibrary = IsObsolete;
+            PreferredShortName = preferredShortName;
         }
     }
 

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -1353,6 +1353,7 @@ namespace ProtoCore.AST.AssociativeAST
 
     public class ClassAttributes 
     {
+        public string PreferredShortName { get; protected set; }
         public bool HiddenInLibrary { get; protected set; }
         public string ObsoleteMessage { get; protected set; }
         public bool IsObsolete { get { return !string.IsNullOrEmpty(ObsoleteMessage); } }

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1161,7 +1161,6 @@ namespace Dynamo.Tests
 
             var command = new DynamoModel.ConvertNodesToCodeCommand();
             CurrentDynamoModel.ExecuteCommand(command);
-            CurrentDynamoModel.ForceRun();
 
             var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
             Assert.IsNotNull(cbn);
@@ -1178,7 +1177,6 @@ namespace Dynamo.Tests
 
             var command = new DynamoModel.ConvertNodesToCodeCommand();
             CurrentDynamoModel.ExecuteCommand(command);
-            CurrentDynamoModel.ForceRun();
 
             var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
             Assert.IsNotNull(cbn);

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -23,6 +23,7 @@ namespace Dynamo.Tests
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
             libraries.Add("ProtoGeometry.dll");
+            libraries.Add("DSCoreNodes.dll");
             base.GetLibrariesToPreload(libraries);
         }
 
@@ -332,15 +333,15 @@ namespace Dynamo.Tests
             Assert.AreEqual(4, result.AstNodes.Count());
             Assert.True(result.AstNodes.All(n => n is BinaryExpressionNode));
 
-            var exprs = String.Concat(result.AstNodes
-                                            .Cast<BinaryExpressionNode>()
-                                            .Select(e => e.ToString().Replace(" ", String.Empty)));
+            var lhs = result.AstNodes.Cast<BinaryExpressionNode>()
+                                     .Select(expr => expr.LeftNode as IdentifierNode);
 
             // It totally depends on which code block node is compiled firstly.
             // Variables in the first one won't be renamed.
-            Assert.IsTrue(
-               (exprs.Contains("t3=1") && exprs.Contains("t1=2") && exprs.Contains("t4=3") && exprs.Contains("t2=4"))
-             || (exprs.Contains("t3=3") && exprs.Contains("t2=4") && exprs.Contains("t4=1") && exprs.Contains("t1=2")));
+            Assert.IsNotNull(lhs.FirstOrDefault(x => x.Value.Equals("t1")));
+            Assert.IsNotNull(lhs.FirstOrDefault(x => x.Value.Equals("t2")));
+            Assert.IsNotNull(lhs.FirstOrDefault(x => x.Value.Equals("num1")));
+            Assert.IsNotNull(lhs.FirstOrDefault(x => x.Value.Equals("num2")));
         }
 
         [Test]
@@ -363,13 +364,16 @@ namespace Dynamo.Tests
             Assert.IsNotNull(result.AstNodes);
             Assert.True(result.AstNodes.All(n => n is BinaryExpressionNode));
 
-            var exprs = String.Concat(result.AstNodes
-                                            .Cast<BinaryExpressionNode>()
-                                            .Select(e => e.ToString().Replace(" ", String.Empty)));
+            var lhs = result.AstNodes.Cast<BinaryExpressionNode>()
+                                     .Select(expr => expr.LeftNode as IdentifierNode);
 
             // It totally depends on which code block node is compiled firstly.
             // Variables in the first one won't be renamed.
-            Assert.IsTrue(exprs.Contains("b=t2") && exprs.Contains("t2=2"));
+            Assert.IsNotNull(lhs.FirstOrDefault(x => x.Value.Equals("b")));
+            Assert.IsNotNull(lhs.FirstOrDefault(x => x.Value.Equals("a")));
+            Assert.IsNotNull(lhs.FirstOrDefault(x => x.Value.Equals("num1")));
+            Assert.IsNotNull(lhs.FirstOrDefault(x => x.Value.Equals("num3")));
+            Assert.IsNotNull(lhs.FirstOrDefault(x => x.Value.Equals("num4")));
         }
 
         [Test]
@@ -571,7 +575,7 @@ namespace Dynamo.Tests
 
             var expr = result.AstNodes.Last() as BinaryExpressionNode;
             Assert.IsNotNull(expr);
-            Assert.AreEqual("t1.DistanceTo(t2)", expr.RightNode.ToString());
+            Assert.AreEqual("point1.DistanceTo(point2)", expr.RightNode.ToString());
         }
 
         [Test]
@@ -1145,6 +1149,40 @@ namespace Dynamo.Tests
 
             Thread.CurrentThread.CurrentCulture = currentCulture;
             Thread.CurrentThread.CurrentUICulture = currentUICulture;
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void TestUsingTypeDependentVariableName01()
+        {
+            OpenModel(@"core\node2code\string.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+            SelectAll(nodes);
+
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+            CurrentDynamoModel.ForceRun();
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+            Assert.IsTrue(cbn.GetAstIdentifierForOutputIndex(0).Value.StartsWith("str"));
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void TestUsingTypeDependentVariableName02()
+        {
+            OpenModel(@"core\node2code\num.dyn");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes;
+            SelectAll(nodes);
+
+            var command = new DynamoModel.ConvertNodesToCodeCommand();
+            CurrentDynamoModel.ExecuteCommand(command);
+            CurrentDynamoModel.ForceRun();
+
+            var cbn = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<CodeBlockNodeModel>().FirstOrDefault();
+            Assert.IsNotNull(cbn);
+            Assert.IsTrue(cbn.GetAstIdentifierForOutputIndex(0).Value.StartsWith("num"));
         }
     }
 

--- a/test/core/node2code/num.dyn
+++ b/test/core/node2code/num.dyn
@@ -1,0 +1,18 @@
+<Workspace Version="0.8.3.2501" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Math" resolvedName="DSCore.Math" assemblyName="DSCoreNodes.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="7a43565a-9914-4739-9523-1dedf394b035" type="Dynamo.Nodes.DSFunction" nickname="Math.Sin" x="489.5" y="269" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="DSCoreNodes.dll" function="DSCore.Math.Sin@double" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="2bae3fbd-a9f7-44c5-8f8b-2b0ffa8b3295" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="282" y="233" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="3;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="2bae3fbd-a9f7-44c5-8f8b-2b0ffa8b3295" start_index="0" end="7a43565a-9914-4739-9523-1dedf394b035" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>

--- a/test/core/node2code/string.dyn
+++ b/test/core/node2code/string.dyn
@@ -1,0 +1,18 @@
+<Workspace Version="0.8.3.2501" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="String" resolvedName="DSCore.String" assemblyName="DSCoreNodes.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="0fa964a1-304d-4924-a409-8169febcd946" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="427" y="310" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="&quot;foo&quot;;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="270b90dc-9636-48b5-8996-0c036de67647" type="Dynamo.Nodes.DSFunction" nickname="String.ToLower" x="613.5" y="318" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="DSCoreNodes.dll" function="DSCore.String.ToLower@string" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="0fa964a1-304d-4924-a409-8169febcd946" start_index="0" end="270b90dc-9636-48b5-8996-0c036de67647" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR supports to [generate type dependent variable name in node to code](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2506).

During node to code, we try to collect the type information comes from two sources: one is provided by node itself, typically from a zero touch node; the other source is directly from analyzing binary AST expression to figure out the possible type. Note the type information would be inaccurate, but that is acceptable. 

Once we get the type candidate, we query `PreferredShortName` attribute on the class and use that short name as variable prefix; otherwise we use class name in lower case as variable prefix, e.g., `point1`, `arc2` and so on.

Sample result:
![untitled](https://cloud.githubusercontent.com/assets/2600379/9727697/2ed300c8-5634-11e5-827c-110a9d73afc5.png)
And after n2c:
![2](https://cloud.githubusercontent.com/assets/2600379/9727698/32c8ba92-5634-11e5-813d-efb125b59d29.png)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin PTAL

### FYIs

@monikaprabhu 