### PR TITLE
Fix regressed test case TestTaskQueuePreProcessing00

### DIFF
--- a/test/DynamoCoreTests/SchedulerTests.cs
+++ b/test/DynamoCoreTests/SchedulerTests.cs
@@ -381,6 +381,15 @@ namespace Dynamo.Tests
         {
             // Avoid base method which access EngineController.
         }
+
+        protected override AsyncTask.TaskMergeInstruction CanMergeWithCore(AsyncTask otherTask)
+        {
+            var theOtherTask = otherTask as UpdateGraphAsyncTask;
+            if (theOtherTask == null)
+                return TaskMergeInstruction.KeepBoth;
+
+            return TaskMergeInstruction.KeepOther;
+        }
     }
 
     internal class FakeUpdateRenderPackageAsyncTask : UpdateRenderPackageAsyncTask


### PR DESCRIPTION
### Purpose

This is because of PR #5225 which doesn't allow `UpdateGraphAsyncTask.graphSyncData` be null, but the test case creates a derived class from `UpdateGraphAsyncTask` and its `graphSyncData` is null. 

Override `CanMergeWithCore()` to fix the regression.