### PR TITLE
Fix regression Defect_MAGN_904

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -61,6 +61,8 @@ namespace Dynamo.Core.Threading
 
                 ModifiedNodes = ComputeModifiedNodes(workspace);
                 graphSyncData = engineController.ComputeSyncData(workspace.Nodes, ModifiedNodes, verboseLogging);
+                if (graphSyncData == null)
+                    return false;
 
                 // We clear dirty flags before executing the task. If we clear
                 // flags after the execution of task, for example in
@@ -73,10 +75,11 @@ namespace Dynamo.Core.Threading
                 foreach (var nodeGuid in graphSyncData.NodeIDs)
                 {
                     var node = workspace.Nodes.FirstOrDefault(n => n.GUID.Equals(nodeGuid));
-                    node.ClearDirtyFlag();
+                    if (node != null)
+                        node.ClearDirtyFlag();
                 }
 
-                return graphSyncData != null;
+                return true;
             }
             catch (Exception e)
             {

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1994,10 +1994,10 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(2, cbn.InPorts.Count);
 
             //Check the position of ports
-            Assert.AreEqual("t3", cbn.OutPorts[0].ToolTipContent);
+            Assert.AreEqual("vector1", cbn.OutPorts[0].ToolTipContent);
             Assert.AreEqual(0, cbn.OutPorts[0].MarginThickness.Top);
 
-            Assert.AreEqual("t4", cbn.OutPorts[1].ToolTipContent);
+            Assert.AreEqual("vector2", cbn.OutPorts[1].ToolTipContent);
             Assert.AreEqual(0, cbn.OutPorts[1].MarginThickness.Top);
         }
 


### PR DESCRIPTION
### Purpose

This PR is to fix undo crash that introduced by PR #5225 which removed null check in `UpdateGraphAsyncTask.Initialize()` for `graphSyncData`. Restore null check and fix regression. 
