### PR TITLE
Fix to support AST rewrite for associative language blocks

### DIFF
--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -965,7 +965,11 @@ namespace ProtoCore
                         else
                         {
                             string message = String.Format(Resources.kUnboundIdentifierMsg, identnode.Value);
-                            buildStatus.LogWarning(ProtoCore.BuildData.WarningID.kIdUnboundIdentifier, message, core.CurrentDSFileName, identnode.line, identnode.col, graphNode);
+                            var unboundSymbol = new SymbolNode
+                            {
+                                name = identnode.Value
+                            };
+                            buildStatus.LogUnboundVariableWarning(unboundSymbol, message, core.CurrentDSFileName, identnode.line, identnode.col, graphNode);
                         }
 
                         if (depth == 0)

--- a/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
@@ -477,6 +477,19 @@ namespace ProtoCore.SyntaxAnalysis
             return node;
         }
 
+        public override AssociativeNode VisitLanguageBlockNode(LanguageBlockNode node)
+        {
+            var cbn = node.CodeBlockNode as CodeBlockNode;
+            if (cbn == null)
+            {
+                return base.VisitLanguageBlockNode(node);
+            }
+
+            var nodeList = cbn.Body.Select(astNode => astNode.Accept(this)).ToList();
+            cbn.Body = nodeList;
+            return node;
+        }
+
         public override AssociativeNode VisitFunctionDefinitionNode(FunctionDefinitionNode node)
         {
             var nodeList = node.FunctionBody.Body.Select(astNode => astNode.Accept(this)).ToList();

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -1080,7 +1080,11 @@ namespace ProtoImperative
                 else
                 {
                     string message = String.Format(ProtoCore.Properties.Resources.kUnboundIdentifierMsg, t.Value);
-                    buildStatus.LogWarning(WarningID.kIdUnboundIdentifier, message, core.CurrentDSFileName, t.line, t.col, graphNode);
+                    var unboundSymbol = new SymbolNode
+                    {
+                        name = t.Value
+                    };
+                    buildStatus.LogUnboundVariableWarning(unboundSymbol, message, core.CurrentDSFileName, t.line, t.col, graphNode);
                 }
 
                 inferedType.UID = (int)ProtoCore.PrimitiveType.kTypeNull;


### PR DESCRIPTION
### Purpose

This PR fixes issues with some `AssociativeNode` expressions in CBN for which ...

1.[Input/output ports were not being computed correctly] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8381):
![image](https://cloud.githubusercontent.com/assets/5710686/9785125/80f124ca-57e2-11e5-89f8-12dc844520a9.png)
2. [Errors in namespace resolution of classes used inside associative language blocks] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8382):
![image](https://cloud.githubusercontent.com/assets/5710686/9785140/9e584e58-57e2-11e5-9fd5-f37bc9e85a78.png)

### Declarations

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@junmendoza Reviewer 1 

There needs to be a separate fix for namespace resolution of statements inside `Imperative` language blocks. This is tracked [here] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8046).