### PR TITLE
REACH-338 Publish Customizer correct status message

### DIFF
--- a/src/DynamoPublish/Properties/Resources.Designer.cs
+++ b/src/DynamoPublish/Properties/Resources.Designer.cs
@@ -475,6 +475,15 @@ namespace Dynamo.Publish.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your workspace has been successfully published!.
+        /// </summary>
+        public static string UploadedMessage {
+            get {
+                return ResourceManager.GetString("UploadedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Uploading....
         /// </summary>
         public static string UploadingMessage {

--- a/src/DynamoPublish/Properties/Resources.resx
+++ b/src/DynamoPublish/Properties/Resources.resx
@@ -261,4 +261,7 @@
   <data name="RequestOnPendingState" xml:space="preserve">
     <value>Request pending...</value>
   </data>
+  <data name="UploadedMessage" xml:space="preserve">
+    <value>Your workspace has been successfully published!</value>
+  </data>
 </root>

--- a/src/DynamoPublish/ViewModels/PublishViewModel.cs
+++ b/src/DynamoPublish/ViewModels/PublishViewModel.cs
@@ -224,7 +224,7 @@ namespace Dynamo.Publish.ViewModels
                 }
             }
 
-            UploadStateMessage = Resources.ReadyForPublishMessage;
+            UploadStateMessage = (model.State == PublishModel.UploadState.Succeeded) ? Resources.UploadedMessage : Resources.ReadyForPublishMessage;
             IsReadyToUpload = true;
             return true;
         }


### PR DESCRIPTION
### Purpose

This PR fixes incorrect status displaying when publishing customizer.
Link to Youtrack: http://adsk-oss.myjetbrains.com/youtrack/issue/REACH-338#

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers
@pboyer 

### FYIs
@jnealb 