### PR TITLE
Package search jumps: fix with .NET 4.5

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/InstalledPackagesView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/InstalledPackagesView.xaml
@@ -39,7 +39,8 @@
                  Background="Black"
                  HorizontalContentAlignment="Stretch"
                  ScrollViewer.VerticalScrollBarVisibility="Auto"
-                 ScrollViewer.HorizontalScrollBarVisibility="Hidden">
+                 ScrollViewer.HorizontalScrollBarVisibility="Hidden"
+                 VirtualizingPanel.ScrollUnit="Pixel">
 
             <ListBox.ItemContainerStyle>
                 <Style TargetType="ListBoxItem">
@@ -165,32 +166,21 @@
                                             <Label Content="{x:Static p:Resources.InstalledPackageViewCustomNodesLabel}"
                                                    FontWeight="Bold"
                                                    Foreground="Gray"></Label>
-                                            <ListBox Name="LoadedCustomNodes"
+                                            <ItemsControl Name="LoadedCustomNodes"
                                                      ItemsSource="{Binding Path=Model.LoadedCustomNodes}"
                                                      BorderThickness="0"
                                                      Padding="0"
                                                      Margin="10,0,0,0"
                                                      Background="Transparent">
 
-                                                <ListBox.ItemContainerStyle>
-                                                    <Style TargetType="ListBoxItem">
-                                                        <Style.Resources>
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}"
-                                                                             Color="#000" />
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}"
-                                                                             Color="#000" />
-                                                        </Style.Resources>
-                                                    </Style>
-                                                </ListBox.ItemContainerStyle>
-
-                                                <ListBox.ItemTemplate>
+                                                <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
                                                         <TextBlock Text="{Binding Path=Name}"
                                                                    Foreground="White" />
                                                     </DataTemplate>
-                                                </ListBox.ItemTemplate>
+                                                </ItemsControl.ItemTemplate>
 
-                                            </ListBox>
+                                            </ItemsControl>
 
                                         </StackPanel>
 
@@ -199,25 +189,14 @@
                                             <Label Content="{x:Static p:Resources.InstalledPackageViewNodeLibrariesLabel}"
                                                    FontWeight="Bold"
                                                    Foreground="Gray"></Label>
-                                            <ListBox Name="NodeLibraries"
+                                            <ItemsControl Name="NodeLibraries"
                                                      ItemsSource="{Binding Path=Model.LoadedAssemblies}"
                                                      BorderThickness="0"
                                                      Padding="0"
                                                      Margin="10,0,0,0"
                                                      Background="Transparent">
 
-                                                <ListBox.ItemContainerStyle>
-                                                    <Style TargetType="ListBoxItem">
-                                                        <Style.Resources>
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}"
-                                                                             Color="#000" />
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}"
-                                                                             Color="#000" />
-                                                        </Style.Resources>
-                                                    </Style>
-                                                </ListBox.ItemContainerStyle>
-
-                                                <ListBox.ItemTemplate>
+                                                <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
                                                         <TextBlock Name="Label"
                                                                    Text="{Binding Path=Name}"
@@ -232,9 +211,9 @@
                                                             </DataTrigger>
                                                         </DataTemplate.Triggers>
                                                     </DataTemplate>
-                                                </ListBox.ItemTemplate>
+                                                </ItemsControl.ItemTemplate>
 
-                                            </ListBox>
+                                            </ItemsControl>
                                         </StackPanel>
 
                                         <StackPanel Visibility="{Binding Path=HasAdditionalAssemblies, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
@@ -242,25 +221,14 @@
                                             <Label Content="{x:Static p:Resources.InstalledPackageViewAdditionalLabel}"
                                                    FontWeight="Bold"
                                                    Foreground="Gray"></Label>
-                                            <ListBox Name="AddAssemblies"
+                                            <ItemsControl Name="AddAssemblies"
                                                      ItemsSource="{Binding Path=Model.LoadedAssemblies}"
                                                      BorderThickness="0"
                                                      Padding="0"
                                                      Margin="10,0,0,0"
                                                      Background="Transparent">
 
-                                                <ListBox.ItemContainerStyle>
-                                                    <Style TargetType="ListBoxItem">
-                                                        <Style.Resources>
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}"
-                                                                             Color="#000" />
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}"
-                                                                             Color="#000" />
-                                                        </Style.Resources>
-                                                    </Style>
-                                                </ListBox.ItemContainerStyle>
-
-                                                <ListBox.ItemTemplate>
+                                                <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
                                                         <TextBlock Name="Label"
                                                                    Text="{Binding Path=Name}"
@@ -275,9 +243,9 @@
                                                             </DataTrigger>
                                                         </DataTemplate.Triggers>
                                                     </DataTemplate>
-                                                </ListBox.ItemTemplate>
+                                                </ItemsControl.ItemTemplate>
 
-                                            </ListBox>
+                                            </ItemsControl>
 
                                         </StackPanel>
 
@@ -286,32 +254,21 @@
                                             <Label Content="{x:Static p:Resources.InstalledPackageViewAdditionalFileLabel}"
                                                    FontWeight="Bold"
                                                    Foreground="Gray"></Label>
-                                            <ListBox Name="AdditionalFiles"
+                                            <ItemsControl Name="AdditionalFiles"
                                                      ItemsSource="{Binding Path=Model.AdditionalFiles}"
                                                      BorderThickness="0"
                                                      Padding="0"
                                                      Margin="10,0,0,0"
                                                      Background="Transparent">
 
-                                                <ListBox.ItemContainerStyle>
-                                                    <Style TargetType="ListBoxItem">
-                                                        <Style.Resources>
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}"
-                                                                             Color="#000" />
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}"
-                                                                             Color="#000" />
-                                                        </Style.Resources>
-                                                    </Style>
-                                                </ListBox.ItemContainerStyle>
-
-                                                <ListBox.ItemTemplate>
+                                                <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
                                                         <TextBlock Text="{Binding Path=RelativePath}"
                                                                    Foreground="White" />
                                                     </DataTemplate>
-                                                </ListBox.ItemTemplate>
+                                                </ItemsControl.ItemTemplate>
 
-                                            </ListBox>
+                                            </ItemsControl>
                                         </StackPanel>
                                     </StackPanel>
                                 </Border>

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -175,7 +175,16 @@
 
             </Grid>
 
-            <ListBox Name="SearchResultsListBox" ItemsSource="{Binding Path=SearchResults}" ScrollViewer.VerticalScrollBarVisibility="Visible" BorderThickness="0" Padding="0" Background="Black" Grid.Column="0" Grid.Row="1" SelectedIndex="{Binding Path=SelectedIndex}">
+            <ListBox Name="SearchResultsListBox"
+                     ItemsSource="{Binding Path=SearchResults}"
+                     ScrollViewer.VerticalScrollBarVisibility="Visible"
+                     BorderThickness="0"
+                     Padding="0"
+                     Background="Black"
+                     Grid.Column="0"
+                     Grid.Row="1"
+                     SelectedIndex="{Binding Path=SelectedIndex}"
+                     VirtualizingPanel.ScrollUnit="Pixel">
 
                 <ListBox.Resources>
                     <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Transparent" />
@@ -324,18 +333,8 @@
 
                                     <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
                                         <TextBlock FontSize="11" FontWeight="Bold" Text="{x:Static p:Resources.PackageSearchViewVersions}" Foreground="WhiteSmoke"  Padding="0,0,5,0"/>
-                                        <ListBox Name="Versions" ItemsSource="{Binding Path=Versions}" BorderThickness="0" Padding="0" Margin="10,0,0,0" Background="Transparent" >
-
-                                            <ListBox.ItemContainerStyle>
-                                                <Style TargetType="ListBoxItem">
-                                                    <Style.Resources>
-                                                        <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#000"/>
-                                                        <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="#000" />
-                                                    </Style.Resources>
-                                                </Style>
-                                            </ListBox.ItemContainerStyle>
-
-                                            <ListBox.ItemTemplate >
+                                        <ItemsControl Name="Versions" ItemsSource="{Binding Path=Versions}" BorderThickness="0" Padding="0" Margin="10,0,0,0" Background="Transparent" >
+                                            <ItemsControl.ItemTemplate >
                                                 <DataTemplate>
                                                     <StackPanel Orientation="Horizontal">
                                                         <TextBlock Text="{Binding Path=Item1.version}" MinWidth="50" Margin="5"  Foreground="WhiteSmoke" />
@@ -370,9 +369,9 @@
 
                                                     </StackPanel>
                                                 </DataTemplate>
-                                            </ListBox.ItemTemplate>
+                                            </ItemsControl.ItemTemplate>
 
-                                        </ListBox>
+                                        </ItemsControl>
                                     </StackPanel>
 
                                     <Button Name="SiteButton" Content="{x:Static p:Resources.PackageSearchViewVisitWebSiteButton}" Visibility="{Binding Path=Model.SiteUrl, Converter={StaticResource EmptyStringToCollapsedConverter}}" Command="{Binding Path=VisitSiteCommand}" Style="{StaticResource SBadgeButton}" />


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7274](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7274) Package search "jumps" when a package is expanded
[MAGN-8221](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8221) Manage Packages' Show Contents scroll bar is unresponsive

This PR fixes 2 issues:
- scroll jump;
- scroll unresponsive;

Reasons of these bugs:
- `ListBox` in .NET 4.0 didn't support scrolling by pixels (for more info look https://github.com/DynamoDS/Dynamo/pull/5191)
- `ListBox` by default contains `ScrollViewer`. So, if we put `ListBox` inside of another `ListBox`, then inner `ScrollViewer` handles all scroll events. I.e. we try scrolling inner `ListBox` instead of outer `ListBox`.

Fixes, that were used:
- Add `VirtualizingPanel.ScrollUnit="Pixel"`to enable pixel scrolling;
- Use `ItemsControl` instead of inner `ListBox`. It removes blue highlight. But @Racel is ok with it. (for more info look https://github.com/DynamoDS/Dynamo/pull/5191)

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough 
@Benglin 

### FYIs

@Racel 