### PR TITLE
MAGN-8378 Not able to place nodes after searching from Geometry library.

### DIFF
--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
+using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Threading;
 using Dynamo.Search;
@@ -128,11 +129,24 @@ namespace Dynamo.UI.Views
             var senderButton = e.OriginalSource as FrameworkElement;
             if (senderButton != null)
             {
-                var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
+                HelperHandleMouseDown(e.GetPosition(null), senderButton.DataContext);
+            }
+            else
+            {
+                var senderRunButton = e.OriginalSource as Run;
+                if (senderRunButton != null)
+                {
+                    HelperHandleMouseDown(e.GetPosition(null), senderRunButton.DataContext);
+                }
+            }
+        }
 
-                if (searchElementVM != null)
-                    dragDropHelper.HandleMouseDown(e.GetPosition(null), searchElementVM);
-            }          
+        private void HelperHandleMouseDown(Point position, object dataContext)
+        {
+            var searchElementVM = dataContext as NodeSearchElementViewModel;
+
+            if (searchElementVM != null)
+                dragDropHelper.HandleMouseDown(position, searchElementVM);
         }
 
         private void OnButtonPreviewMouseMove(object sender, MouseEventArgs e)

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -146,7 +146,9 @@ namespace Dynamo.UI.Views
             var searchElementVM = dataContext as NodeSearchElementViewModel;
 
             if (searchElementVM != null)
+            {
                 dragDropHelper.HandleMouseDown(position, searchElementVM);
+            }
         }
 
         private void OnButtonPreviewMouseMove(object sender, MouseEventArgs e)


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8378](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8378) Not able to place nodes after searching from Geometry library.

Reason of bug:
In https://github.com/DynamoDS/Dynamo/pull/5245 we added grey incoming parameters for overloads. I did it with `Run` element, because it works faster, then 2 `TextBox`es.
And now `OriginalSource` can be `Run` or `FrameworkElement`. So, we have to check them both.

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@mjkkirschner 

### FYIs

@riteshchandawar 
