### PR TITLE
Enable Customizer publish capabilities in Dynamo

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.3.2514")]
+[assembly: AssemblyVersion("0.8.3.2534")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.3.2514")]
+[assembly: AssemblyFileVersion("0.8.3.2534")]

--- a/src/DynamoPublish/DynamoPublish.csproj
+++ b/src/DynamoPublish/DynamoPublish.csproj
@@ -142,6 +142,6 @@
     <ItemGroup>
       <ExtensionDefinition Include="DynamoPublishExtension_ViewExtensionDefinition.xml" />
     </ItemGroup>
-    <!--<Copy SourceFiles="@(ExtensionDefinition)" DestinationFolder="$(OutputPath)\viewExtensions\" />-->
+    <Copy SourceFiles="@(ExtensionDefinition)" DestinationFolder="$(OutputPath)\viewExtensions\" />
   </Target>
 </Project>

--- a/src/DynamoPublish/DynamoPublish.dll.config
+++ b/src/DynamoPublish/DynamoPublish.dll.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="ServerUrl" value="http://10.39.165.198:3000" />
+    <add key="ServerUrl" value="https://www.dynamoreach.com" />
     <add key="Page" value="ws" />
     <add key="Invite" value="invite" />
-    <add key="ManagerPage" value="http://10.39.165.198:3000/manager.html" />
+    <add key="ManagerPage" value="https://www.dynamoreach.com/manager.html" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
### Purpose

This enables the ability to publish customizers in Dynamo. This is only possible if the user has authentication capabilities.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough 

### FYIs

@RodRecker 