### PR TITLE
Graph Layout updates

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1132,6 +1132,7 @@ namespace Dynamo.ViewModels
                     node.X = n.X;
                     node.Y = n.Y;
                     node.ReportPosition();
+                    node.OnNodeModified();
                 }
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1062,7 +1062,7 @@ namespace Dynamo.ViewModels
             foreach (AnnotationModel group in Model.Annotations)
             {
                 // Treat a group as a graph layout node/vertex
-                graph.AddNode(group.GUID, group.Width, group.Height, group.Y);
+                graph.AddNode(group.GUID, group.Width, group.Height, group.X, group.Y);
                 models.Add(group, UndoRedoRecorder.UserAction.Modification);
             }
 
@@ -1074,7 +1074,7 @@ namespace Dynamo.ViewModels
                 // Do not process nodes within groups
                 if (group == null)
                 {
-                    graph.AddNode(node.GUID, node.Width, node.Height, node.Y);
+                    graph.AddNode(node.GUID, node.Width, node.Height, node.X, node.Y);
                     models.Add(node, UndoRedoRecorder.UserAction.Modification);
                 }
             }
@@ -1101,13 +1101,16 @@ namespace Dynamo.ViewModels
 
             // Support undo for graph layout command
             WorkspaceModel.RecordModelsForModification(new List<ModelBase>(Model.Nodes), Model.UndoRecorder);
+            graph.RecordInitialPosition();
 
             // Sugiyama algorithm steps
             graph.RemoveCycles();
             graph.AssignLayers();
             graph.OrderNodes();
 
-            graph.NormalizeGraphPosition();
+            // Node and graph positioning
+            graph.DistributeNodePosition();
+            graph.SetGraphPosition();
 
             // Assign coordinates to nodes inside groups
             foreach (var group in Model.Annotations)

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -31,9 +31,9 @@ namespace GraphLayout
         /// <param name="height">The height of the node view.</param>
         /// <param name="y">The y coordinate of the node view.</param>
         /// <param name="inPortCount">The number of input ports of the node.</param>
-        public void AddNode(Guid guid, double width, double height, double y)
+        public void AddNode(Guid guid, double width, double height, double x, double y)
         {
-            var node = new Node(guid, width, height, y, this);
+            var node = new Node(guid, width, height, x, y, this);
             Nodes.Add(node);
         }
 
@@ -481,10 +481,21 @@ namespace GraphLayout
 
         #endregion
 
+        #region Graph positioning methods
+
+        private double CenterX;
+        private double CenterY;
+
+        public void RecordInitialPosition()
+        {
+            CenterX = (Nodes.Min(n => n.X) + Nodes.Max(n => n.X + n.Width)) / 2;
+            CenterY = (Nodes.Min(n => n.Y) + Nodes.Max(n => n.Y + n.Height)) / 2;
+        }
+
         /// <summary>
-        /// To align the top and left bound of the graph at x = 0 and y = 0.
+        /// To set spaces between the nodes based on the default node distance.
         /// </summary>
-        public void NormalizeGraphPosition()
+        public void DistributeNodePosition()
         {
             double previousLayerX = 0;
             double offsetY = -Nodes.OrderBy(x => x.Y).First().Y;
@@ -517,6 +528,23 @@ namespace GraphLayout
                 }
             }
         }
+
+        /// <summary>
+        /// To shift the whole graph back to its original position.
+        /// </summary>
+        public void SetGraphPosition()
+        {
+            double moveX = CenterX - (Nodes.Max(n => n.X + n.Width) - Nodes.Min(n => n.X)) / 2;
+            double moveY = CenterY - (Nodes.Max(n => n.Y + n.Height) - Nodes.Min(n => n.Y)) / 2;
+
+            foreach (Node n in Nodes)
+            {
+                n.X += moveX;
+                n.Y += moveY;
+            }
+        }
+
+        #endregion
 
     }
 
@@ -570,11 +598,12 @@ namespace GraphLayout
         /// </summary>
         public HashSet<Edge> RightEdges = new HashSet<Edge>();
 
-        public Node(Guid guid, double width, double height, double y, Graph ownerGraph)
+        public Node(Guid guid, double width, double height, double x, double y, Graph ownerGraph)
         {
             Id = guid;
             Width = width;
             Height = height;
+            X = x;
             Y = y;
             OwnerGraph = ownerGraph;
         }

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -598,6 +598,11 @@ namespace GraphLayout
         /// </summary>
         public HashSet<Edge> RightEdges = new HashSet<Edge>();
 
+        /// <summary>
+        /// A list of note models which has this node as the closest node.
+        /// </summary>
+        public List<Object> LinkedNotes = new List<Object>();
+
         public Node(Guid guid, double width, double height, double x, double y, Graph ownerGraph)
         {
             Id = guid;

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -29,6 +29,7 @@ namespace GraphLayout
         /// <param name="guid">The guid as a unique identifier of the node.</param>
         /// <param name="width">The width of the node view.</param>
         /// <param name="height">The height of the node view.</param>
+        /// <param name="x">The x coordinate of the node view.</param>
         /// <param name="y">The y coordinate of the node view.</param>
         /// <param name="inPortCount">The number of input ports of the node.</param>
         public void AddNode(Guid guid, double width, double height, double x, double y)
@@ -483,13 +484,26 @@ namespace GraphLayout
 
         #region Graph positioning methods
 
-        private double CenterX;
-        private double CenterY;
+        private double InitialGraphCenterX;
+        private double InitialGraphCenterY;
 
+        public double GraphCenterX
+        {
+            get { return (Nodes.Min(n => n.X) + Nodes.Max(n => n.X + n.Width)) / 2; }
+        }
+
+        public double GraphCenterY
+        {
+            get { return (Nodes.Min(n => n.Y) + Nodes.Max(n => n.Y + n.Height)) / 2; }
+        }
+
+        /// <summary>
+        /// To save the initial center position of the graph.
+        /// </summary>
         public void RecordInitialPosition()
         {
-            CenterX = (Nodes.Min(n => n.X) + Nodes.Max(n => n.X + n.Width)) / 2;
-            CenterY = (Nodes.Min(n => n.Y) + Nodes.Max(n => n.Y + n.Height)) / 2;
+            InitialGraphCenterX = GraphCenterX;
+            InitialGraphCenterY = GraphCenterY;
         }
 
         /// <summary>
@@ -534,8 +548,8 @@ namespace GraphLayout
         /// </summary>
         public void SetGraphPosition()
         {
-            double moveX = CenterX - (Nodes.Max(n => n.X + n.Width) - Nodes.Min(n => n.X)) / 2;
-            double moveY = CenterY - (Nodes.Max(n => n.Y + n.Height) - Nodes.Min(n => n.Y)) / 2;
+            double moveX = InitialGraphCenterX - GraphCenterX;
+            double moveY = InitialGraphCenterY - GraphCenterY;
 
             foreach (Node n in Nodes)
             {

--- a/test/DynamoCoreWpfTests/GraphLayoutTests.cs
+++ b/test/DynamoCoreWpfTests/GraphLayoutTests.cs
@@ -51,14 +51,17 @@ namespace Dynamo.Tests
             var y = ViewModel.CurrentSpace.Y;
             var zoom = ViewModel.CurrentSpace.Zoom;
 
+            var prevX = nodes.ElementAt(0).X;
+            var prevY = nodes.ElementAt(0).Y;
+
             ViewModel.DoGraphAutoLayout(null);
 
             Assert.AreEqual(ViewModel.CurrentSpace.Nodes.Count(), 1);
             Assert.AreEqual(ViewModel.CurrentSpace.Connectors.Count(), 0);
             AssertGraphLayoutLayers(new List<int> { 1 });
 
-            Assert.AreEqual(nodes.ElementAt(0).X, 0);
-            Assert.AreEqual(nodes.ElementAt(0).Y, 0);
+            Assert.AreEqual(nodes.ElementAt(0).X, prevX);
+            Assert.AreEqual(nodes.ElementAt(0).Y, prevY);
 
             Assert.Inconclusive("RequestZoomToFitView is null");
 
@@ -80,9 +83,6 @@ namespace Dynamo.Tests
             Assert.AreEqual(ViewModel.CurrentSpace.Connectors.Count(), 1);
             AssertGraphLayoutLayers(new List<int> { 1, 1 });
 
-            Assert.AreEqual(nodes.ElementAt(0).Y, 0);
-            Assert.AreEqual(nodes.ElementAt(1).X, 0);
-
             Assert.Greater(nodes.ElementAt(0).X, nodes.ElementAt(1).X);
             Assert.Less(nodes.ElementAt(0).Y, nodes.ElementAt(1).Y);
 
@@ -100,11 +100,6 @@ namespace Dynamo.Tests
             Assert.AreEqual(ViewModel.CurrentSpace.Connectors.Count(), 0);
             AssertGraphLayoutLayers(new List<int> { 3 });
 
-            Assert.AreEqual(nodes.ElementAt(0).X, 0);
-            Assert.AreEqual(nodes.ElementAt(1).X, 0);
-            Assert.AreEqual(nodes.ElementAt(2).X, 0);
-
-            Assert.AreEqual(nodes.ElementAt(0).Y, 0);
             Assert.Greater(nodes.ElementAt(2).Y, nodes.ElementAt(0).Y);
             Assert.Greater(nodes.ElementAt(1).Y, nodes.ElementAt(2).Y);
 
@@ -121,13 +116,6 @@ namespace Dynamo.Tests
             Assert.AreEqual(ViewModel.CurrentSpace.Nodes.Count(), 15);
             Assert.AreEqual(ViewModel.CurrentSpace.Connectors.Count(), 17);
             AssertGraphLayoutLayers(new List<int> { 1, 1, 2, 1, 1, 2, 2, 2, 1, 2 });
-
-            Assert.AreEqual(nodes.ElementAt(5).X, 0);  // "put"
-
-            Assert.AreEqual(nodes.ElementAt(8).X, 0);  // "come"
-            Assert.Greater(nodes.ElementAt(8).Y, 0);
-
-            Assert.Greater(nodes.ElementAt(3).X, 0);   // rightmost Watch node
 
             AssertNoOverlap();
             AssertMaxCrossings(2);
@@ -271,7 +259,7 @@ namespace Dynamo.Tests
                 9, 9, 9, 4, 3, 5, 4, 3, 1, 2, 3, 1, 3, 7, 7, 1, 1, 2, 4, 3, 2, 3 });
 
             AssertNoOverlap();
-            AssertMaxCrossings(198);
+            AssertMaxCrossings(200);
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/GraphLayoutTests.cs
+++ b/test/DynamoCoreWpfTests/GraphLayoutTests.cs
@@ -117,8 +117,14 @@ namespace Dynamo.Tests
             Assert.AreEqual(ViewModel.CurrentSpace.Connectors.Count(), 17);
             AssertGraphLayoutLayers(new List<int> { 1, 1, 2, 1, 1, 2, 2, 2, 1, 2 });
 
+            var prevX = (nodes.Min(n => n.X) + nodes.Max(n => n.X + n.Width)) / 2;
+            var prevY = (nodes.Min(n => n.Y) + nodes.Max(n => n.Y + n.Height)) / 2;
+
             AssertNoOverlap();
             AssertMaxCrossings(2);
+
+            Assert.Less(Math.Abs((nodes.Min(n => n.X) + nodes.Max(n => n.X + n.Width)) / 2 - prevX), 10);
+            Assert.Less(Math.Abs((nodes.Min(n => n.Y) + nodes.Max(n => n.Y + n.Height)) / 2 - prevY), 10);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

- [MAGN-8302](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8302) Node Layout command should make file dirty so that it will ask for save.

- [MAGN-8355](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8355) After undoing Node Layout command, nodes are disappear from the view, user has to run Fit View to get the nodes back in position.

- [MAGN-8356](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8356) Node Layout should take care of Notes which are near to nodes.
![image](https://cloud.githubusercontent.com/assets/6386550/9870091/9ea500e0-5bbb-11e5-8f1f-e8237a1072db.png)

These three tasks are parts of Cleanup Node Layout improvements ([MAGN-8380](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8380)).


### Declarations

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@aparajit-pratap 

### FYIs

@riteshchandawar 