### PR TITLE
Fix issue that graph not executed if Show Run Preview turned on

### DIFF
--- a/src/DynamoCore/Engine/AstBuilder.cs
+++ b/src/DynamoCore/Engine/AstBuilder.cs
@@ -40,6 +40,7 @@ namespace Dynamo.Engine
             None,
             DeltaExecution,
             NodeToCode,
+            PreviewGraph,
         }
 
         private readonly IAstNodeContainer nodeContainer;

--- a/src/DynamoCore/Engine/AstBuilder.cs
+++ b/src/DynamoCore/Engine/AstBuilder.cs
@@ -221,7 +221,7 @@ namespace Dynamo.Engine
             if (node.State == ElementState.Error)
                 Log("Error in Node. Not sent for building and compiling");
 
-            if (context == CompilationContext.DeltaExecution)
+            if (context == CompilationContext.DeltaExecution || context == CompilationContext.PreviewGraph)
                 OnAstNodeBuilding(node.GUID);
 
 #if DEBUG
@@ -245,7 +245,7 @@ namespace Dynamo.Engine
 
             if(null == astNodes)
                 resultList.AddRange(new AssociativeNode[0]);
-            else if (context == CompilationContext.DeltaExecution)
+            else if (context == CompilationContext.DeltaExecution || context == CompilationContext.PreviewGraph)
             {
                 OnAstNodeBuilt(node.GUID, astNodes);
                 resultList.AddRange(astNodes);

--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -45,7 +45,7 @@ namespace Dynamo.Engine
         private readonly LibraryServices libraryServices;
         private CodeCompletionServices codeCompletionServices;
         private readonly AstBuilder astBuilder;
-        private readonly SyncDataManager syncDataManager;
+        private SyncDataManager syncDataManager;
         private readonly Queue<GraphSyncData> graphSyncDataQueue = new Queue<GraphSyncData>();
         private readonly Queue<List<Guid>> previewGraphQueue = new Queue<List<Guid>>();
         public bool VerboseLogging;
@@ -257,6 +257,7 @@ namespace Dynamo.Engine
             if (updatedNodes == null)
                 return null;
 
+            var tempSyncDataManager = syncDataManager.Clone();
             var activeNodes = updatedNodes.Where(n => n.State != ElementState.Error);
             if (activeNodes.Any())
             {
@@ -265,6 +266,7 @@ namespace Dynamo.Engine
 
             GraphSyncData graphSyncdata = syncDataManager.GetSyncData();
             List<Guid> previewGraphData = this.liveRunnerServices.PreviewGraph(graphSyncdata, verboseLogging);
+            syncDataManager = tempSyncDataManager;
 
              lock (previewGraphQueue)
              {

--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -260,7 +260,7 @@ namespace Dynamo.Engine
             var activeNodes = updatedNodes.Where(n => n.State != ElementState.Error);
             if (activeNodes.Any())
             {
-                astBuilder.CompileToAstNodes(activeNodes, AstBuilder.CompilationContext.DeltaExecution, verboseLogging);
+                astBuilder.CompileToAstNodes(activeNodes, AstBuilder.CompilationContext.PreviewGraph, verboseLogging);
             }
 
             GraphSyncData graphSyncdata = syncDataManager.GetSyncData();

--- a/src/DynamoCore/Engine/SyncDataManager.cs
+++ b/src/DynamoCore/Engine/SyncDataManager.cs
@@ -36,6 +36,30 @@ namespace Dynamo.Engine
         }
 
         /// <summary>
+        ///     Return a clone of current SyncDataManager.
+        /// </summary>
+        /// <returns></returns>
+        public SyncDataManager Clone()
+        {
+            SyncDataManager clone = new SyncDataManager();
+            foreach (var key in states.Keys)
+            {
+                clone.states.Add(key, states[key]);
+            }
+
+            foreach (var key in nodes.GetKeys())
+            {
+                var asts = nodes.GetItems(key);
+                foreach (var ast in asts)
+                {
+                    clone.nodes.AddItem(key, ast);
+                }
+            }
+            
+            return clone;
+        }
+
+        /// <summary>
         ///     Reset states of all nodes to State.NoChange. It should be called
         ///     before each running.
         /// </summary>

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -332,6 +332,34 @@ namespace ProtoScript.Runners
         }
 
         /// <summary>
+        /// Deep clone the change set computer
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public ChangeSetComputer Clone()
+        {
+            ChangeSetComputer comp = new ChangeSetComputer(this.core, this.runtimeCore);
+
+            comp.currentSubTreeList = new Dictionary<Guid, Subtree>();
+            foreach (var subTreePairs in currentSubTreeList)
+            {
+                comp.currentSubTreeList.Add(subTreePairs.Key, subTreePairs.Value); 
+            }
+
+            comp.csData = new ChangeSetData();
+            comp.csData.ContainsDeltaAST = csData.ContainsDeltaAST;
+            comp.csData.DeletedBinaryExprASTNodes = new List<AssociativeNode>(csData.DeletedBinaryExprASTNodes);
+            comp.csData.DeletedFunctionDefASTNodes = new List<AssociativeNode>(csData.DeletedFunctionDefASTNodes);
+            comp.csData.RemovedBinaryNodesFromModification = new List<AssociativeNode>(csData.RemovedBinaryNodesFromModification);
+            comp.csData.ModifiedNodesForRuntimeSetValue = new List<AssociativeNode>(csData.ModifiedNodesForRuntimeSetValue);
+            comp.csData.RemovedFunctionDefNodesFromModification = new List<AssociativeNode>(csData.RemovedFunctionDefNodesFromModification);
+            comp.csData.ForceExecuteASTList = new List<AssociativeNode>(csData.ForceExecuteASTList);
+            comp.csData.ModifiedFunctions = new List<AssociativeNode>(csData.ModifiedFunctions);
+            comp.csData.ModifiedNestedLangBlock = new List<AssociativeNode>(csData.ModifiedNestedLangBlock);
+            return comp;
+        }
+
+        /// <summary>
         /// Given deltaGraphNodes, estimate the reachable graphnodes from the live core
         /// </summary>
         /// <param name="liveCore"></param>
@@ -1804,11 +1832,12 @@ namespace ProtoScript.Runners
 
         private List<Guid> PreviewInternal(GraphSyncData syncData)
         {
+            var previewChangeSetComputer = changeSetComputer.Clone();
             // Get the list of ASTs that will be affected by syncData
-            var previewAstList = changeSetComputer.GetDeltaASTList(syncData);
+            var previewAstList = previewChangeSetComputer.GetDeltaASTList(syncData);
 
             // Get the list of guid's affected by the astlist
-            List<Guid> cbnGuidList = changeSetComputer.EstimateNodesAffectedByASTList(previewAstList);
+            List<Guid> cbnGuidList = previewChangeSetComputer.EstimateNodesAffectedByASTList(previewAstList);
             return cbnGuidList;
         }
 


### PR DESCRIPTION
### Purpose

This PR is to fix defect [MAGN-8357 Newly created CBN not executed if Show Run Preview turned on](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8357).

The root cause is previewing graph changes both the state of `SyncDataManager` in `EngineController` and the state of `ChangeSetComputer` in `LiveRunner`. 

There are two steps to preview graph:
  1. Calculating graph sync data. Graph sync data has state, that is, if a node is compiled for the first time, its state is `SyncDataManager.State.Added`, otherwise its state is changed to  `SyncDataManager.State.Modified`. So calculating graph sync data would potentially change current graph sync data state even graph hasn't run yet.
  2. Sending graph sync data to live runner. Live runner internally uses `ChangeSetComputer` to calculate the delta between this graph sync data and the latest one that it executes. As computation result is cached, previewing graph changes its cache. 

So both these two steps change global states. We have to make a copy of `SyncDataManager` as well as `ChangeSetComputer` for previewing graph. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@junmendoza 
