### PR TITLE
Fix graph execution error in node to code

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -142,8 +142,12 @@ namespace Dynamo.Core.Threading
 
             if (graphSyncData == null)
                 return other.graphSyncData == null;
-            else
-                return other.graphSyncData == null ? true : other.graphSyncData.NodeIDs.All(graphSyncData.NodeIDs.Contains);
+            else if (other.graphSyncData == null)
+                return true;
+
+            return other.graphSyncData.AddedNodeIDs.All(graphSyncData.AddedNodeIDs.Contains) &&
+                   other.graphSyncData.ModifiedNodeIDs.All(graphSyncData.ModifiedNodeIDs.Contains) &&
+                   other.graphSyncData.DeletedNodeIDs.All(graphSyncData.DeletedNodeIDs.Contains);
         }
 
         protected override AsyncTask.TaskMergeInstruction CanMergeWithCore(AsyncTask otherTask)

--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -381,7 +381,7 @@ namespace Dynamo.Engine
                 nodes.Where(n => n.NeedsForceExecution)
                      .Select(n => n.GUID));
 
-            if (reExecuteNodesIds.Any() && graphSyncdata.ModifiedSubtrees != null)
+            if (reExecuteNodesIds.Any())
             {
                 for (int i = 0; i < graphSyncdata.ModifiedSubtrees.Count; ++i)
                 {
@@ -395,9 +395,7 @@ namespace Dynamo.Engine
                 }
             }
 
-            if ((graphSyncdata.AddedSubtrees != null && graphSyncdata.AddedSubtrees.Count > 0) ||
-                (graphSyncdata.ModifiedSubtrees != null && graphSyncdata.ModifiedSubtrees.Count > 0) ||
-                (graphSyncdata.DeletedSubtrees != null && graphSyncdata.DeletedSubtrees.Count > 0))
+            if (graphSyncdata.AddedSubtrees.Any() || graphSyncdata.ModifiedSubtrees.Any() || graphSyncdata.DeletedSubtrees.Any())
             {
                 lock (graphSyncDataQueue)
                 {

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -97,7 +97,7 @@ namespace ProtoScript.Runners
         {
             get
             {
-                return AddedSubtrees == null ? Enumerable.Empty<Guid>() : AddedSubtrees.Select(ts => ts.GUID);
+                return AddedSubtrees.Select(ts => ts.GUID);
             }
         }
 
@@ -108,7 +108,7 @@ namespace ProtoScript.Runners
         {
             get
             {
-                return ModifiedSubtrees == null ? Enumerable.Empty<Guid>() : ModifiedSubtrees.Select(ts => ts.GUID);
+                return ModifiedSubtrees.Select(ts => ts.GUID);
             }
         }
 
@@ -119,7 +119,7 @@ namespace ProtoScript.Runners
         {
             get
             {
-                return DeletedSubtrees == null ? Enumerable.Empty<Guid>() : DeletedSubtrees.Select(ts => ts.GUID);
+                return DeletedSubtrees.Select(ts => ts.GUID);
             }
         }
 
@@ -136,9 +136,9 @@ namespace ProtoScript.Runners
 
         public GraphSyncData(List<Subtree> deleted, List<Subtree> added, List<Subtree> modified)
         {
-            DeletedSubtrees = deleted;
-            AddedSubtrees = added;
-            ModifiedSubtrees = modified;
+            DeletedSubtrees = deleted ?? new List<Subtree>();
+            AddedSubtrees = added ?? new List<Subtree>();
+            ModifiedSubtrees = modified ?? new List<Subtree>();
         }
 
         public override string ToString()

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -63,28 +63,75 @@ namespace ProtoScript.Runners
     /// </summary>
     public class GraphSyncData
     {
+        /// <summary>
+        /// Deleted sub trees.
+        /// </summary>
         public List<Subtree> DeletedSubtrees
         {
             get;
             private set;
         }
 
+        /// <summary>
+        /// Added sub trees.
+        /// </summary>
         public List<Subtree> AddedSubtrees
         {
             get;
             private set;
         }
 
+        /// <summary>
+        /// Modified sub trees.
+        /// </summary>
         public List<Subtree> ModifiedSubtrees
         {
             get;
             private set;
         }
 
+        /// <summary>
+        /// Newly added nodes' IDs.
+        /// </summary>
+        public IEnumerable<Guid> AddedNodeIDs
+        {
+            get
+            {
+                return AddedSubtrees == null ? Enumerable.Empty<Guid>() : AddedSubtrees.Select(ts => ts.GUID);
+            }
+        }
+
+        /// <summary>
+        /// Modified nodes' IDs.
+        /// </summary>
+        public IEnumerable<Guid> ModifiedNodeIDs
+        {
+            get
+            {
+                return ModifiedSubtrees == null ? Enumerable.Empty<Guid>() : ModifiedSubtrees.Select(ts => ts.GUID);
+            }
+        }
+
+        /// <summary>
+        /// Deleted nodes' IDs.
+        /// </summary>
+        public IEnumerable<Guid> DeletedNodeIDs 
+        {
+            get
+            {
+                return DeletedSubtrees == null ? Enumerable.Empty<Guid>() : DeletedSubtrees.Select(ts => ts.GUID);
+            }
+        }
+
+        /// <summary>
+        /// All node IDs in this graph sync data.
+        /// </summary>
         public IEnumerable<Guid> NodeIDs
         {
-            get;
-            private set;
+            get
+            {
+                return AddedNodeIDs.Concat(ModifiedNodeIDs).Concat(DeletedNodeIDs);
+            }
         }
 
         public GraphSyncData(List<Subtree> deleted, List<Subtree> added, List<Subtree> modified)
@@ -92,13 +139,7 @@ namespace ProtoScript.Runners
             DeletedSubtrees = deleted;
             AddedSubtrees = added;
             ModifiedSubtrees = modified;
-
-            NodeIDs = Enumerable.Empty<Guid>()
-                                .Concat(deleted == null ? Enumerable.Empty<Guid>() : deleted.Select(t => t.GUID))
-                                .Concat(added == null ? Enumerable.Empty<Guid>() : added.Select(t => t.GUID))
-                                .Concat(modified == null ? Enumerable.Empty<Guid>() : modified.Select(t => t.GUID));
         }
-
 
         public override string ToString()
         {


### PR DESCRIPTION
### Purpose

This PR is to fix defect [MAGN-8403 that graph doesn't execute properly in node to code](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8403#).

Again, it is because some `UpdateGraphAsyncTask` are discarded. Related fix and explanation for erroneous graph execution is PR #5225. We have to check more strictly about if a graph sync data contains the other one; otherwise it would fail for the following case:
  * Graph sync data 1 contains a newly added node "foo", and a deleted node "bar".
  * Graph sync data 2 contains a modified node "foo".

Based on current rule, the first one contains the second one because all nodes that changed in the first graph sync data is a super set of all nodes changed in the second graph sync data. But throwing the second graph sync data away is wrong because the second one contains the latest change for node "foo". We have to check added/modified/deleted nodes in graph sync data separately. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 