### PR TITLE
Add build.xml to store build configuration

### DIFF
--- a/src/build.xml
+++ b/src/build.xml
@@ -1,0 +1,17 @@
+<Project
+    xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
+    ToolsVersion="4.0"
+    DefaultTargets="Build">
+	
+	
+<ItemGroup>
+    <ProjectToBuild Include="Dynamo.All.2013.sln" >
+        <Properties>Configuration=Release;Platform=Any CPU</Properties>
+    </ProjectToBuild>
+</ItemGroup>
+
+<Target Name="Build">
+    <MSBuild Projects="@(ProjectToBuild)"/>
+</Target>
+
+</Project>


### PR DESCRIPTION
__Purpose__

Implementing build.xml to store all build configurations for msbuild. This allows EngOps to have a single build command for all the dynamo projects. 

__Reviewers__
@aparajit-pratap 