### PR TITLE
Fix regression that all nodes' preview values become null when switch workspace

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -646,7 +646,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     OnClear();
                     foreach (var node in model.CurrentWorkspace.Nodes)
                     {
-                        node.IsUpdated = true;
                         node.RequestVisualUpdateAsync(scheduler, engineManager.EngineController, renderPackageFactory);
                     }
                     break;


### PR DESCRIPTION
### Purpose

This PR tries to fix regression [MAGN-8358 Custom Node shows preview as null after editing](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8358). Actually the defect is not only reproducible on custom node instance, but on all nodes: switch to custom workspace and switch back to home workspace, all nodes' preview values are null.

That's because when switching workspace, `HelixWatch3DViewModel.OnModelPropertyChanged()` will be triggered and all nodes' `IsUpdated` are set to true, and consequently all nodes' cached mirror data is cleaned up.  

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough  could you please take a look? Which case we need to set `NodeModel.IsUpdated`? The other way is to call `NodeModel.RequestValueUpdateAsync()` to get a new mirror data. 

### FYIs

@monikaprabhu