### PR TITLE
No search results crash.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -735,7 +735,10 @@ namespace Dynamo.ViewModels
             }
 
             if (nodes.Count() == 0)
+            {
+                selectionNavigator.UpdateRootCategories(SearchRootCategories);
                 return;
+            }
 
             // Clone top node.
             NodeSearchElementViewModel topNode;


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8394](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8394) hitting enter when there are no results in search crashes Dynamo

Fix is extremely easy: just update `SelectionNavigator` with empty category list.

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough 
@Benglin 
