### PR TITLE
Remove whitespace between delimiter and data for CSV.WriteToFile

### DIFF
--- a/src/Libraries/CoreNodes/Files.cs
+++ b/src/Libraries/CoreNodes/Files.cs
@@ -439,7 +439,7 @@ namespace DSCore.IO
                     {
                         writer.Write(entry);
                         if (++count < line.Length)
-                            writer.Write(", ");
+                            writer.Write(",");
                     }
                     writer.WriteLine();
                 }


### PR DESCRIPTION
### Purpose

I have observed that the CSV.WriteToFile node adds a whitespace in front of every string. The effect is that Dynamo adds another whitespace each time data from an existing CSV file is added to a new CSV file, like so (whitespace replaced by underscores for readability):
Original: ```item1,item2,item3```
Iteration 1: ```item1,_item2,_item3```
Iteration 2: ```item1,__item2,__item3```
Iteration 3: ```item1,___item2,___item3```
and so on.

You can easily test the current deficiency by running this simple graph on any CSV file multiple times (careful - set graph to manual mode):
![csvloop](https://cloud.githubusercontent.com/assets/3014437/9979271/7f3f41b4-5f64-11e5-9353-0749906c37fd.PNG)


This PR removes the whitespace between the delimiter and the data.
I have **not** built and tested this but it really is a trivial change.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough

FYI - This is related to DynamoAutomation

### FYIs

---