### PR TITLE
Correctly set owner, location of customizer Publish views

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.3.2534")]
+[assembly: AssemblyVersion("0.8.3.2634")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.3.2534")]
+[assembly: AssemblyFileVersion("0.8.3.2634")]

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Dynamo.Controls;
@@ -21,6 +22,14 @@ namespace Dynamo.Wpf.Extensions
         private readonly DynamoView dynamoView;
         private readonly DynamoViewModel dynamoViewModel;
         public readonly Menu dynamoMenu;
+
+        public Window DynamoWindow
+        {
+            get
+            {
+                return dynamoView;
+            }
+        }
 
         internal ViewLoadedParams(DynamoView dynamoV, DynamoViewModel dynamoVM) :
             base(dynamoVM.Model)

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -23,6 +23,10 @@ namespace Dynamo.Wpf.Extensions
         private readonly DynamoViewModel dynamoViewModel;
         public readonly Menu dynamoMenu;
 
+        /// <summary>
+        /// A reference to the Dynamo Window object. Useful for correctly setting the parent of a 
+        /// newly created window.
+        /// </summary>
         public Window DynamoWindow
         {
             get

--- a/src/DynamoPublish/DynamoPublishExtension.cs
+++ b/src/DynamoPublish/DynamoPublishExtension.cs
@@ -6,6 +6,7 @@ using Dynamo.Wpf.Extensions;
 using System;
 using System.Windows.Controls;
 using System.Linq;
+using System.Windows;
 using Dynamo.Models;
 using Dynamo.Publish.Properties;
 
@@ -17,6 +18,7 @@ namespace Dynamo.Publish
         private PublishModel publishModel;
         private InviteViewModel inviteViewModel;
         private InviteModel inviteModel;
+        private Window dynamoWindow;
         private Menu dynamoMenu;
         private MenuItem extensionMenuItem; 
         private MenuItem inviteMenuItem; 
@@ -49,6 +51,8 @@ namespace Dynamo.Publish
         {
             if (publishViewModel == null || inviteViewModel == null)
                 return;
+
+            this.dynamoWindow = p.DynamoWindow;
 
             publishViewModel.Workspaces = p.WorkspaceModels;
             publishViewModel.CurrentWorkspaceModel = p.CurrentWorkspaceModel;
@@ -113,10 +117,15 @@ namespace Dynamo.Publish
             item.IsEnabled = isEnabled;
 
             item.Click += (sender, args) =>
+            {
+                var publishWindow = new PublishView(publishViewModel)
                 {
-                    PublishView publishWindow = new PublishView(publishViewModel);
-                    publishWindow.ShowDialog();                    
+                    Owner = this.dynamoWindow,
+                    WindowStartupLocation = WindowStartupLocation.CenterOwner
                 };
+
+                publishWindow.ShowDialog();                    
+            };
 
             return item;
         }
@@ -136,7 +145,12 @@ namespace Dynamo.Publish
 
             item.Click += (sender, args) =>
             {
-                InviteView inviteWindow = new InviteView(inviteViewModel);
+                var inviteWindow = new InviteView(inviteViewModel)
+                {
+                    Owner = this.dynamoWindow,
+                    WindowStartupLocation = WindowStartupLocation.CenterOwner
+                };
+
                 inviteWindow.ShowDialog();
             };
 


### PR DESCRIPTION
### Purpose

The Customizer windows were getting lost behind Dynamo. This is fixed in this PR.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ramramps 
