### PR TITLE
Adding error checking on iscc.exe command

### DIFF
--- a/tools/install/CreateInstallers.bat
+++ b/tools/install/CreateInstallers.bat
@@ -46,4 +46,10 @@ robocopy %cwd%\Extra\DirectX %cwd%\temp\DirectX
 robocopy %cwd%\..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%\gallery %cwd%\temp\gallery /s
 
 "C:\Program Files (x86)\Inno Setup 5\iscc.exe" %cwd%\DynamoInstaller.iss
+
+if not errorlevel 0 (
+   echo "C:\Program Files (x86)\Inno Setup 5\iscc.exe %cwd%\DynamoInstaller.iss return error, exiting"
+   rmdir /Q /S %cwd%\temp & exit /b %errorlevel%
+)
+
 rmdir /Q /S %cwd%\temp


### PR DESCRIPTION
__Purpose__

Currently if there is an error in iscc.exe, it went undetected in Electric Commander as CreateInstallers.bat return no error since the last command "rmdir /Q /S %cwd%\temp" run successfully. This changes add additional error checking on command iscc.exe %cwd%\DynamoInstaller.iss

__Reviewers__

@aparajit-pratap @sharadkjaiswal 