### PR TITLE
Fix code completion tests.

### DIFF
--- a/test/Libraries/DynamoPythonTests/CodeCompletionTests.cs
+++ b/test/Libraries/DynamoPythonTests/CodeCompletionTests.cs
@@ -259,7 +259,7 @@ namespace DynamoPythonTests
 
             var completionData = completionProvider.GetCompletionData(str);
 
-            Assert.AreEqual(224, completionData.Length);
+            Assert.AreEqual(226, completionData.Length);
             Assert.AreEqual(1, completionProvider.ImportedTypes.Count);
             Assert.IsTrue(completionProvider.ImportedTypes.ContainsKey("System"));
 


### PR DESCRIPTION
This PR fixes erring tests by updating one code completion length assertion. The length of the code completion data returned here is longer in 4.5 than in 4.0.

FYI:
@aparajit-pratap (We might run into more of these)