### PR TITLE
Fix two recorded tests which use python.

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.3.2644")]
+[assembly: AssemblyVersion("0.8.3.2647")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.3.2644")]
+[assembly: AssemblyFileVersion("0.8.3.2647")]

--- a/test/core/recorded/Defect_MAGN_2247.xml
+++ b/test/core/recorded/Defect_MAGN_2247.xml
@@ -1,5 +1,5 @@
 <Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
-  <CreateNodeCommand NodeId="308100d3-a47f-431c-b99b-d53b9f8aa01a" NodeName="DSIronPythonNode.PythonNode" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
+  <CreateNodeCommand NodeId="308100d3-a47f-431c-b99b-d53b9f8aa01a" NodeName="PythonNodeModels.PythonNode" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
   <UpdateModelValueCommand ModelGuid="308100d3-a47f-431c-b99b-d53b9f8aa01a" Name="ScriptContent" Value="import clr&#xA;clr.AddReference('ProtoGeometry')&#xA;from Autodesk.DesignScript.Geometry import *&#xA;#The inputs to this node will be stored as a list in the IN variable.&#xA;dataEnteringNode = IN&#xA;sum=0;&#xA;&#xA;    &#xA;for item in IN:&#xA;	sum=sum+item&#xA;#Assign your output to the OUT variable&#xA;OUT = sum" />
   <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
   <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />

--- a/test/core/recorded/MAGN_7348_Core_Python.xml
+++ b/test/core/recorded/MAGN_7348_Core_Python.xml
@@ -15,7 +15,7 @@
     <ModelGuid>38c0a969-27ff-41b1-86a4-a9b9fe2f1205</ModelGuid>
   </UpdateModelValueCommand>
   <CreateNodeCommand X="0" Y="0" DefaultPosition="true" TransformCoordinates="true">
-    <DSIronPythonNode.PythonNode guid="30c44e0a-dae2-4cb2-b871-ca13954fc41b" type="DSIronPythonNode.PythonNode" nickname="Python Script" x="182.5" y="89.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2">
+    <PythonNodeModels.PythonNode guid="30c44e0a-dae2-4cb2-b871-ca13954fc41b" type="PythonNodeModels.PythonNode" nickname="Python Script" x="182.5" y="89.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2">
       <Script>import clr
 clr.AddReference('ProtoGeometry')
 from Autodesk.DesignScript.Geometry import *
@@ -24,7 +24,7 @@ dataEnteringNode = IN
 
 #Assign your output to the OUT variable
 OUT = 0</Script>
-    </DSIronPythonNode.PythonNode>
+    </PythonNodeModels.PythonNode>
   </CreateNodeCommand>
   <ModelEventCommand ModelGuid="30c44e0a-dae2-4cb2-b871-ca13954fc41b" EventName="AddInPort" />
   <SelectModelCommand ModelGuid="30c44e0a-dae2-4cb2-b871-ca13954fc41b" Modifiers="0" />
@@ -69,7 +69,7 @@ OUT = 0</Script>
   <DragSelectionCommand X="224.742712880193" Y="108.57555010845" DragOperation="0" />
   <DragSelectionCommand X="224.742712880193" Y="108.57555010845" DragOperation="1" />
   <CreateNodeCommand X="0" Y="0" DefaultPosition="true" TransformCoordinates="true">
-    <DSIronPythonNode.PythonNode guid="3617330e-a33d-4fd6-b13d-b3eee9da5f18" type="DSIronPythonNode.PythonNode" nickname="Python Script" x="131.718372443533" y="396.529539669599" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2">
+    <PythonNodeModels.PythonNode guid="3617330e-a33d-4fd6-b13d-b3eee9da5f18" type="PythonNodeModels.PythonNode" nickname="Python Script" x="131.718372443533" y="396.529539669599" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2">
       <Script># Python script to find add or subtract a series of numbers. 
 
 # Boiler-plate import statments included out-of-the-box
@@ -101,7 +101,7 @@ for index in range(len(nums)):
 OUT = []
 OUT.append(result)
 OUT.append(partials)</Script>
-    </DSIronPythonNode.PythonNode>
+    </PythonNodeModels.PythonNode>
   </CreateNodeCommand>
   <SelectModelCommand ModelGuid="3617330e-a33d-4fd6-b13d-b3eee9da5f18" Modifiers="0" />
   <DragSelectionCommand X="195.766896232472" Y="296.381769121454" DragOperation="0" />


### PR DESCRIPTION
This PR fixes the namespaces in two recorded tests. Without this fix, the python nodes cannot be found, and the recorded tests fail to run.

FYI:
@pbidenko 