### PR TITLE
MAGN-8328 Pressing Esc key flickering a nodes and try to go to background view without continuous press.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -322,7 +322,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         {
             get { return navigationKeyIsDown; }
             set 
-            { 
+            {
+                if (navigationKeyIsDown == value) return;
+
                 navigationKeyIsDown = value;
                 RaisePropertyChanged("NavigationKeyIsDown");
                 RaisePropertyChanged("CanNavigateBackground");

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -30,7 +30,6 @@
         AllowsTransparency="False"
         KeyDown="DynamoView_KeyDown"
         KeyUp="DynamoView_KeyUp"
-        LostFocus="DynamoView_LostFocus"
         Background="#FF353535"
         SnapsToDevicePixels="True"
         ResizeMode="CanResizeWithGrip"

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1011,30 +1011,19 @@ namespace Dynamo.Controls
         // passes it to thecurrent workspace
         void DynamoView_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Escape && this.IsMouseOver)
-            {
-                dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown = true;
-                e.Handled = true;
-            }
+            if (e.Key != Key.Escape || !IsMouseOver || !e.IsRepeat) return;
+
+            dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown = true;
+            e.Handled = true;
         }
 
         void DynamoView_KeyUp(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Escape && dynamoViewModel.BackgroundPreviewViewModel.CanNavigateBackground)
-            {
-                dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown = false;
-                dynamoViewModel.EscapeCommand.Execute(null);
-                e.Handled = true;
-            }
-        }
+            if (e.Key != Key.Escape || !dynamoViewModel.BackgroundPreviewViewModel.CanNavigateBackground) return;
 
-        void DynamoView_LostFocus(object sender, EventArgs e)
-        {
-            if (dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown)
-            {
-                dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown = false;
-                dynamoViewModel.EscapeCommand.Execute(null);
-            }
+            dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown = false;
+            dynamoViewModel.EscapeCommand.Execute(null);
+            e.Handled = true;
         }
 
         private void WorkspaceTabs_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
### Purpose

Pressing the `ESC` key in Dynamo should <strong>not</strong> cause Dynamo to enter 3D navigation mode. Holding the `ESC` key <strong>should</strong> cause Dynamo to enter 3D navigation mode. This PR uses the `KeyEventArgs.IsRepeat` property to check if the key press is a repeat (i.e. a continuous press) before entering background navigation mode. This prevents the behavior described by [MAGN-8238](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8328), where simply pressing the `ESC` key causes the nodes to "flash" as their transparency is tied to the `CanNavigateBackground` property on `Watch3DViewModel`.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
  - No new documentation required.
- [ ] The level of testing this PR includes is appropriate
  - No new tests added.
- [ ] User facing strings, if any, are extracted into `*.resx` files
  - No new user-facing strings added.

### Reviewers

@mjkkirschner 

### FYIs

@Randy-Ma (Might cause partial regression of MAGN-5055)