### PR TITLE
Copy paste nodes

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1567,9 +1567,6 @@ namespace Dynamo.Models
             var notes = ClipBoard.OfType<NoteModel>();
             var annotations = ClipBoard.OfType<AnnotationModel>();
 
-            var minX = Double.MaxValue;
-            var minY = Double.MaxValue;
-
             // Create the new NoteModel's
             var newNoteModels = new List<NoteModel>();
             foreach (var note in notes)
@@ -1578,9 +1575,6 @@ namespace Dynamo.Models
                 //Store the old note as Key and newnote as value.
                 modelLookup.Add(note.GUID,noteModel);
                 newNoteModels.Add(noteModel);
-
-                minX = Math.Min(note.X, minX);
-                minY = Math.Min(note.Y, minY);
             }
 
             var xmlDoc = new XmlDocument();
@@ -1613,26 +1607,15 @@ namespace Dynamo.Models
                 modelLookup.Add(node.GUID, newNode);
 
                 newNodeModels.Add( newNode );
-
-                minX = Math.Min(node.X, minX);
-                minY = Math.Min(node.Y, minY);
             }
-
-            // Move all of the notes and nodes such that they are aligned with
-            // the top left of the workspace
-            var workspaceX = -CurrentWorkspace.X / CurrentWorkspace.Zoom;
-            var workspaceY = -CurrentWorkspace.Y / CurrentWorkspace.Zoom;
 
             // Provide a small offset when pasting so duplicate pastes aren't directly on top of each other
             CurrentWorkspace.IncrementPasteOffset();
 
-            var shiftX = workspaceX - minX + CurrentWorkspace.CurrentPasteOffset;
-            var shiftY = workspaceY - minY + CurrentWorkspace.CurrentPasteOffset;
-
             foreach (var model in newNodeModels.Concat<ModelBase>(newNoteModels))
             {
-                model.X = model.X + shiftX;
-                model.Y = model.Y + shiftY;
+                model.X = model.X + (model.Width + CurrentWorkspace.CurrentPasteOffset) / CurrentWorkspace.Zoom;
+                model.Y = model.Y + (model.Height + CurrentWorkspace.CurrentPasteOffset) / CurrentWorkspace.Zoom;
             }
 
             // Add the new NodeModel's to the Workspace

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1579,8 +1579,8 @@ namespace Dynamo.Models
                 modelLookup.Add(note.GUID,noteModel);
                 newNoteModels.Add(noteModel);
 
-                minXY = Math.Min(note.CenterX + note.CenterY, minXY);
-                maxXY = Math.Max(note.CenterX + note.CenterY, maxXY);
+                minXY = Math.Round(Math.Min(note.CenterX + note.CenterY, minXY), 3);
+                maxXY = Math.Round(Math.Max(note.CenterX + note.CenterY, maxXY), 3);
             }
 
             var xmlDoc = new XmlDocument();
@@ -1615,10 +1615,10 @@ namespace Dynamo.Models
 
                 modelLookup.Add(node.GUID, newNode);
 
-                newNodeModels.Add( newNode );
+                newNodeModels.Add(newNode);
 
-                minXY = Math.Min(node.CenterX + node.CenterY, minXY);
-                maxXY = Math.Max(node.CenterX + node.CenterY, maxXY);
+                minXY = Math.Round(Math.Min(node.CenterX + node.CenterY, minXY), 3);
+                maxXY = Math.Round(Math.Max(node.CenterX + node.CenterY, maxXY), 3);
             }
 
             // Provide a small offset when pasting so duplicate pastes aren't directly on top of each other
@@ -1627,10 +1627,10 @@ namespace Dynamo.Models
             var newItems = newNodeModels.Concat<ModelBase>(newNoteModels);
 
             // Search for the rightmost item. It's item with the biggest X, Y coordinates of center.
-            var rightMostItem = newItems.FirstOrDefault(item => (item.CenterX + item.CenterY) == maxXY);
+            var rightMostItem = newItems.FirstOrDefault(item => Math.Round((item.CenterX + item.CenterY), 3) == maxXY);
 
             // Search for the leftmost item. It's item with the smallest X, Y coordinates of center.
-            var leftMostItem = newItems.FirstOrDefault(item => (item.CenterX + item.CenterY) == minXY);
+            var leftMostItem = newItems.FirstOrDefault(item => Math.Round((item.CenterX + item.CenterY), 3) == minXY);
 
             var oldCoordinateX = leftMostItem.X;
             var oldCoordinateY = leftMostItem.Y;

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -41,7 +41,10 @@ namespace Dynamo.Models
         private int currentPasteOffset = 0;
         internal int CurrentPasteOffset
         {
-            get { return currentPasteOffset; }
+            get
+            {
+                return currentPasteOffset == 0 ? PASTE_OFFSET_STEP : currentPasteOffset;
+            }
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -43,19 +43,19 @@ namespace Dynamo.Models
         {
             get
             {
-                return currentPasteOffset == 0 ? PASTE_OFFSET_STEP : currentPasteOffset;
+                return currentPasteOffset == 0 ? PasteOffsetStep : currentPasteOffset;
             }
         }
 
         /// <summary>
         ///     The step to offset elements between subsequent paste operations
         /// </summary>
-        internal static readonly int PASTE_OFFSET_STEP = 10;
+        internal static readonly int PasteOffsetStep = 10;
 
         /// <summary>
         ///     The maximum paste offset before reset
         /// </summary>
-        internal static readonly int PASTE_OFFSET_MAX = 60;
+        internal static readonly int PasteOffsetMax = 60;
 
         private string fileName;
         private string name;
@@ -1017,7 +1017,7 @@ namespace Dynamo.Models
         /// </summary>
         internal void IncrementPasteOffset()
         {
-            this.currentPasteOffset = (this.currentPasteOffset + PASTE_OFFSET_STEP) % PASTE_OFFSET_MAX;
+            this.currentPasteOffset = (this.currentPasteOffset + PasteOffsetStep) % PasteOffsetMax;
         }
         
         #endregion

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -240,6 +240,67 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
+        public void CanCopydAndPasteNodeWithRightOffset()
+        {
+            var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
+            addNode.Height = 2;
+            addNode.Width = 2;
+            addNode.CenterX = 3;
+            addNode.CenterY = 2;
+
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            CurrentDynamoModel.AddToSelection(addNode);
+            Assert.AreEqual(1, DynamoSelection.Instance.Selection.Count);
+
+            CurrentDynamoModel.Copy();
+            Assert.AreEqual(1, CurrentDynamoModel.ClipBoard.Count);
+
+            CurrentDynamoModel.Paste();
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            Assert.AreEqual(14, CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(1).X);
+            Assert.AreEqual(11, CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(1).Y);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void CanCopydAndPaste2NodesWithRightOffset()
+        {
+            var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
+            addNode.Height = 2;
+            addNode.Width = 2;
+            addNode.CenterX = 3;
+            addNode.CenterY = 2;
+
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
+            CurrentDynamoModel.AddToSelection(addNode);
+
+            addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
+            addNode.Height = 2;
+            addNode.Width = 2;
+            addNode.CenterX = 6;
+            addNode.CenterY = 8;
+
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
+            CurrentDynamoModel.AddToSelection(addNode);
+
+            CurrentDynamoModel.Copy();
+            Assert.AreEqual(2, CurrentDynamoModel.ClipBoard.Count);
+
+            CurrentDynamoModel.Paste();
+            Assert.AreEqual(4, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            Assert.AreEqual(17, CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(2).X);
+            Assert.AreEqual(17, CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(2).Y);
+
+            Assert.AreEqual(20, CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(3).X);
+            Assert.AreEqual(23, CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(3).Y);
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void CanAdd100NodesToClipboardAndPaste3Times()
         {
             int numNodes = 100;


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8386](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8386) As a user, when I copy and paste nodes, I want the pasted nodes to appear in their original location with a slight offset, so I can easily find them.

Results:
![image](https://cloud.githubusercontent.com/assets/8158404/10096670/09778cc2-637c-11e5-87e8-2a3d6b0cd8aa.png)

![image](https://cloud.githubusercontent.com/assets/8158404/10096688/2f7dff6e-637c-11e5-8184-6b928e1c8341.png)

![image](https://cloud.githubusercontent.com/assets/8158404/10096712/602681ae-637c-11e5-806c-2c8b7c4f6190.png)

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

?

### FYIs

@Racel 
@lillismith 