### PR TITLE
Port class tests 10

### DIFF
--- a/test/Engine/ProtoTest/TD/MultiLangTests/RangeExpressions.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/RangeExpressions.cs
@@ -410,7 +410,7 @@ o = {0.800000,0.810000}
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T11_RangeExpressionUsingClasses()
         {
@@ -529,7 +529,7 @@ a1;a2;a3;a4;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T14_RangeExpressionUsingClassMethods()
         {
@@ -853,7 +853,7 @@ b;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T22_RangeExpressionsUsingClassMethods_2()
         {
@@ -884,7 +884,7 @@ d;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T23_RangeExpressionsUsingClassMethods_3()
         {
             //string err = "1467069 - Sprint 23: rev 2634: 328588 An array cannot be used to index into an array, must throw warning";
@@ -1277,40 +1277,32 @@ num = length(arr);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TA21_Defect_1454692_3()
         {
             string code = @"
-class A
+
+def length (pts : double[] )
 {
-	Pts : var[];
-	constructor A ( pts : double[] )
+	numPts = [Imperative]
 	{
-	    Pts = pts;
-	}
-	def length ()
-	{
-		numPts = [Imperative]
+		counter = 0;
+		for(pt in pts)
 		{
-			counter = 0;
-			for(pt in Pts)
-			{
-				counter = counter + 1;
-			}
-			
-			return = counter;
+			counter = counter + 1;
 		}
-		return = numPts;
+			
+		return = counter;
 	}
+	return = numPts;
 }
     
-arr = 0.0..3.0;//{0.0,1.0,2.0,3.0};
-a1 = A.A(arr);
-num = a1.length();
+arr = 0.0..3.0;
+len = length(arr);
 	";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
-            thisTest.Verify("num", 4, 0);
+            thisTest.Verify("len", 4, 0);
         }
 
 
@@ -1612,7 +1604,7 @@ c=twice(4);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T27_RangeExpression_class_return_1463472_2()
         {
             string code = @"
@@ -1773,21 +1765,14 @@ c = 5;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void IndexingIntoClassInstanceByRangeExpr()
         {
             string code = @"
-class A
-{
-    x;
-    constructor A(i)
-    {
-        x = i;
-    }
-}
-x = (A.A(1..3))[0];
-z = x.x;
+import(""FFITarget.dll"");
+x = (ClassFunctionality.ClassFunctionality(1..3))[0];
+z = x.IntVal;
 ";
             thisTest.VerifyRunScriptSource(code, "DNL-1467618 Regression : Use of the array index after replicated constructor yields complier error now");
             thisTest.Verify("z", 1);

--- a/test/Engine/ProtoTest/TD/MultiLangTests/RecursionTest.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/RecursionTest.cs
@@ -242,7 +242,7 @@ c = 3.0..5.0;//3.0,4.0,5.0
 
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void TestCallingConstructor()
         {
             // Tracked by http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4134

--- a/test/Engine/ProtoTest/TD/MultiLangTests/StringTest.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/StringTest.cs
@@ -175,7 +175,7 @@ result =
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T03_Defect_UndefinedType()
         {
@@ -185,29 +185,10 @@ def foo(x:S)
 	return = x;
 }
 b = foo(1);
-class C 
-{
-	fx:M;
-	constructor C(x :N)
-	{
-		fx = x;
-	}
-	
-	def foo(fy : M)
-	{
-		fx = fy;
-		return = fx;
-	}
-	
-}
-c = C.C(1);
-r1 = c.fx;
-r2 = c.foo(2);";
+";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             object v1 = null;
-            TestFrameWork.Verify(mirror, "r1", v1, 0);
-            TestFrameWork.Verify(mirror, "r2", v1, 0);
-            TestFrameWork.Verify(mirror, "c", v1, 0);
+            TestFrameWork.Verify(mirror, "b", v1, 0);
         }
 
         [Test]
@@ -275,7 +256,7 @@ r =
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T06_String_Class()
         {
@@ -606,18 +587,19 @@ m = m+n;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("ConcatenationString")]
         public void TV_ADD_StringPointer_1()
         {
             String code =
-                @"                class A {}                a  = A.A();                b = ""a"" + a;                    ";
+                @"
+import(""FFITarget.dll"");                a  = ClassFunctionality.ClassFunctionality();                b = ""a"" + a;                    ";
             thisTest.RunScriptSource(code);
-            thisTest.Verify("b", "aA{}");
+            thisTest.Verify("b", "aFFITarget.ClassFunctionality");
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("ConcatenationString")]
         public void TV_ADD_StringPointer_2()
         {
@@ -628,16 +610,17 @@ m = m+n;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("ConcatenationString")]
         public void TV_ADD_StringArr()
         {
             String code =
-                @"                class A {                    fx:int = 1;                }                a  = A.A();                arr1 = {1,2};                arr2 = {1,a};                b1 = ""a"" + __ToStringFromArray(arr1);                b2 = ""a"" + __ToStringFromArray(arr2);                ";
+                @"
+import(""FFITarget.dll"");                a  = ClassFunctionality.ClassFunctionality(1);                arr1 = {1,2};                arr2 = {1,a};                b1 = ""a"" + __ToStringFromArray(arr1);                b2 = ""a"" + __ToStringFromArray(arr2);                ";
             thisTest.RunScriptSource(code);
             thisTest.SetErrorMessage("1467263 - Concatenating a string with an integer throws method resolution error");
             thisTest.Verify("b1", "a{1,2}");
-            thisTest.Verify("b2", "a{1,A{fx = 1}}");
+            thisTest.Verify("b2", "a{1,FFITarget.ClassFunctionality}");
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestClass.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestClass.cs
@@ -6,95 +6,76 @@ namespace ProtoTest.TD.MultiLangTests
 {
     class TestClass : ProtoTestBase
     {
-        [Test][Category("DSDefinedClass")]
-        [Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T01_Class_In_Various_Scopes()
         {
             string code = @"
-class Dummy
-{ 
-	x : var;  
-	constructor Dummy () 
-	{	
-		x = 2;	 
-	}
-}
+import(""FFITarget.dll"");
 obj1 = [Imperative]
 {
-	a = Dummy.Dummy();
-	a1 = a.x;
+	a = ClassFunctionality.ClassFunctionality(2);
+	a1 = a.IntVal;
 	return = a;
 }
-getX1 = obj1.x;	
+getX1 = obj1.IntVal;	
 obj2 = [Associative]
 {
-	b = Dummy.Dummy();
-	b1 = b.x;
+	b = ClassFunctionality.ClassFunctionality(2);
+	b1 = b.IntVal;
 	return = b1;
 }
-getX2 = obj2.x;	";
+getX2 = obj2.IntVal;	";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
 
         }
 
-        [Test][Category("DSDefinedClass")][Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T02_Class_In_Various_Nested_Scopes()
         {
             string code = @"
-class Dummy
-{ 
-	x : var;  
-	constructor Dummy () 
-	{	
-		x = 2;	 
-	}
-}
+import(""FFITarget.dll"");
 c1 = [Imperative]
 {
-	a = Dummy.Dummy();
+	a = ClassFunctionality.ClassFunctionality(2);
 	b = [Associative]
 	{
-	    return = Dummy.Dummy();
+	    return = ClassFunctionality.ClassFunctionality(2);
 	}
-	c = a.x + b.x;
+	c = a.IntVal + b.IntVal;
 	return = c;
 }
 c2 = [Associative]
 {
-	a = Dummy.Dummy();
+	a = ClassFunctionality.ClassFunctionality(2);
 	b = [Imperative]
 	{
-	    return = Dummy.Dummy();
+	    return = ClassFunctionality.ClassFunctionality(2);
 	}
-	c = a.x + b.x;
+	c = a.IntVal + b.IntVal;
 	return = c;
 }";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T03_Class_In_Various_Scopes()
         {
             string code = @"
-class Dummy
-{ 
-	x : var;  
-	constructor Dummy () 
-	{	
-		x = 2;	 
-	}
-}
-a = Dummy.Dummy();
+import(""FFITarget.dll"");
+a = ClassFunctionality.ClassFunctionality(2);
 c1 = [Imperative]
 {
 	b = [Associative]
 	{
 	    return = a;
 	}
-	c = a.x + b.x;
+	c = a.IntVal + b.IntVal;
 	return = c;
 }
 c2 = [Associative]
@@ -103,13 +84,14 @@ c2 = [Associative]
 	{
 	    return = a;
 	}
-	c = a.x + b.x;
+	c = a.IntVal + b.IntVal;
 	return = c;
 }";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T04_Class_Properties()
         {
@@ -156,7 +138,8 @@ t6 = t5[0].y;
             thisTest.Verify("t6", t6, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T05_Class_Properties()
         {
@@ -205,7 +188,8 @@ t6 = t5[0].y;
             thisTest.Verify("t6", 1, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T06_Class_Properties()
         {
@@ -225,7 +209,7 @@ t1 = a.x1;
             thisTest.Verify("t1", 5, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T07_Class_Properties()
         {
@@ -244,7 +228,8 @@ t1 = a.x1;
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T08_Class_Properties()
         {
@@ -276,7 +261,8 @@ t2 = a.x2[1].x1;
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T09_Class_Inheritance()
         {
@@ -312,7 +298,8 @@ b3 = a1.x3;
             thisTest.Verify("b3", 2, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T10_Class_Inheritance()
         {
@@ -348,7 +335,8 @@ b3 = a1.x3;
             thisTest.Verify("b3", 2);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T11_Class_Inheritance()
         {
@@ -399,24 +387,17 @@ b2 = a1.foo2(1);
             thisTest.Verify("b2", 1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T12_Class_CheckPropertyWhenCreatedInImperativeCode()
         {
             String code =
-            @"class Dummy
-{
- x : var;
- 
- constructor Dummy ()
- {
-	x = 2;	
- }
-}
+            @"
+import(""FFITarget.dll"");
 obj = [Imperative]{
-return = Dummy.Dummy();
+return = ClassFunctionality.ClassFunctionality(2);
 }
-getX = obj.x;;
+getX = obj.IntVal;
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             //Verification
@@ -424,7 +405,8 @@ getX = obj.x;;
             thisTest.Verify("getX", getX, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T13_Class_Default_Constructors()
         {
@@ -460,7 +442,8 @@ p1 = a1.p;
             thisTest.Verify("w1", null);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T14_Class_Named_Constructors()
         {
@@ -503,7 +486,7 @@ x3 = xx[2].x;
             thisTest.Verify("x3", 3, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T15_Class_Constructor_Negative()
         {
@@ -534,7 +517,7 @@ x2 = 3;
             thisTest.Verify("x2", 3);
         }
 
-        [Test][Category("DSDefinedClass")] 
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")] 
         [Category("SmokeTest")]
         public void T15_Class_Constructor_Negative_1467598()
         {
@@ -565,7 +548,7 @@ x2 = 3;
             thisTest.Verify("x2", 3);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T16_Class_Constructor_Negative()
         {
@@ -590,7 +573,7 @@ a1 = A.A(1);
             });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T17_Class_Constructor_Negative()
         {
@@ -623,7 +606,7 @@ a1 = A.A(b1);
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T18_Class_Constructor_Empty()
         {
@@ -649,7 +632,7 @@ x3 = a1.y;
             Assert.IsTrue(mirror.GetValue("x3").DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T19_Class_Constructor_Test_Default_Property_Values()
         {
@@ -695,7 +678,7 @@ x9 = a1.w4;
             thisTest.Verify("x9", null);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T20_Class_Constructor_Fails()
         {
@@ -716,7 +699,7 @@ b1 = a1.x;
             Assert.IsTrue(mirror.GetValue("b1").DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T21_Class_Constructor_Calling_Base_Constructor()
         {
@@ -759,7 +742,7 @@ c3 = c.z;
             thisTest.Verify("c3", 3, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T22_Class_Constructor_Not_Calling_Base_Constructor()
         {
@@ -792,7 +775,7 @@ c2 = c.y;
             thisTest.Verify("c2", 2, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T23_Class_Constructor_Base_Constructor_Same_Name()
         {
@@ -858,7 +841,7 @@ d2 = d.y;
             thisTest.Verify("d2", 2, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T24_Class_Constructor_Calling_Base_Methods()
         {
@@ -897,7 +880,7 @@ c2 = c.y;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T25_Class_Properties_Modifiers()
         {
@@ -938,7 +921,7 @@ a4 = a.y;
             thisTest.Verify("a3", 4, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T26_Class_Properties_Access()
         {
@@ -1000,7 +983,7 @@ a11;a12;a2;a3;a4;a5;
             thisTest.Verify("a5", 1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T27_Class_Properties_Access()
         {
@@ -1064,7 +1047,7 @@ aa;a2;
             thisTest.Verify("a2", 15);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Method Resolution")]
         public void T28_Class_Properties_Access()
         {
@@ -1155,7 +1138,7 @@ f2 = foo(a2,b2);
             thisTest.Verify("f2", 4);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T29_Class_Method_Chaining()
         {
             //Assert.Fail("1454966 - Sprint15: Rev 720 : [Geometry Porting] Assignment operation where the right had side is Class.Constructor.Property is not working ");
@@ -1207,7 +1190,7 @@ t1 = b1[0].x.x[1];
 
 
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T30_Class_Property_Update_Negative()
         {
@@ -1236,7 +1219,7 @@ x3 = 3;
             TestFrameWork.Verify(mirror, "x2", null);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T31_Class_By_Composition()
         {
@@ -1296,7 +1279,7 @@ x1 = testP.X;
             thisTest.Verify("x1", 7.5, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T32_Class_ReDeclaration()
         {
@@ -1370,7 +1353,7 @@ x1 = testP.X;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T33_Class_Methods()
         {
@@ -1418,7 +1401,7 @@ x6 = p1.X;
             thisTest.Verify("x6", 1.0, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T34_Class_Static_Methods()
         {
@@ -1464,7 +1447,7 @@ x5 = 1;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T35_Class_Method_Overloading()
         {
@@ -1517,7 +1500,7 @@ a2 = p2.add1();
             thisTest.Verify("a2", 35.0, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T36_Class_Method_Calling_Constructor()
         {
@@ -1583,7 +1566,7 @@ b5 = b1.b;
             thisTest.Verify("b5", 40.0, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T37_Class_Method_Using_This()
         {
@@ -1621,7 +1604,7 @@ a3 = p1.Y;
             });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T38_Class_Method_Using_This()
         {
@@ -1656,7 +1639,7 @@ a3 = p1.Y;
             thisTest.Verify("a3", 14.0, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T39_Class_Method_Returning_Collection()
         {
@@ -1689,7 +1672,7 @@ a3 = a1[1];
             thisTest.Verify("a3", 14.0, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T40_Class_Property_Initialization_With_Another_Class()
         {
@@ -1715,7 +1698,7 @@ t1 = p1.inner.X;
             thisTest.Verify("t1", 3.0, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T41_Test_Static_Properties()
         {
@@ -1735,7 +1718,7 @@ t2 = A.x;
             thisTest.Verify("t2", 3, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T41_Test_Static_Properties_2()
         {
@@ -1761,7 +1744,7 @@ b = [Imperative]
         }
 
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T42_Defect_1461717()
         {
@@ -1791,7 +1774,7 @@ A = B.B();
         }
 
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T43_Defect_1461479()
         {
@@ -1806,7 +1789,7 @@ x2 = A.x;
             thisTest.Verify("x2", 1, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T43_Defect_1461479_2()
         {
@@ -1826,7 +1809,7 @@ t1 = a.x1;
             thisTest.Verify("t1", 5, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Update")]
         [Category("Failure")]
         public void T43_Defect_1461479_3()
@@ -1880,7 +1863,7 @@ t6 = x3.foo2();
             thisTest.Verify("t6", v1, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T43_Defect_1461479_4()
         {
@@ -1913,7 +1896,7 @@ d = a.foo();
             thisTest.Verify("d", 4, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T44_Defect_1461860()
         {
@@ -1938,7 +1921,7 @@ b;
             thisTest.Verify("b", 4);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T44_Defect_1461860_2()
         {
@@ -1971,7 +1954,7 @@ c = y.x;
         }
 
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T46_Defect_1461716()
         {
@@ -1994,7 +1977,7 @@ c1 = b1.a;";
             thisTest.Verify("c1", v1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T46_Defect_1461716_2()
         {
@@ -2030,7 +2013,7 @@ b1;c1;
             thisTest.Verify("x", v2);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T47_Calling_Imperative_Code_From_Conctructor()
         {
@@ -2056,7 +2039,7 @@ a1 = A1.a;";
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T48_Defect_1460027()
         {
@@ -2081,7 +2064,7 @@ b1=a1[1][0];";
             thisTest.Verify("b1", 4);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T48_Defect_1460027_2()
         {
@@ -2106,7 +2089,7 @@ b1=a1[1][0];
             thisTest.Verify("b1", 4);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T48_Defect_1460027_3()
         {
@@ -2136,7 +2119,7 @@ class A
             thisTest.Verify("c", 4, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T48_Defect_1460027_4()
         {
@@ -2167,7 +2150,7 @@ class A
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kCyclicDependency);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T49_Defect_1460505()
         {
@@ -2206,7 +2189,7 @@ derivedPoint2 = modify( derivedpoint );";
             thisTest.Verify("derivedPoint2", true, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T49_Defect_1460505_2()
         {
@@ -2246,7 +2229,7 @@ derivedPoint2 = modify( derivedpoint );";
             thisTest.Verify("derivedPoint2", true, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T50_Defect_1460510()
         {
@@ -2286,7 +2269,7 @@ class derived extends TestPoint
                 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T50_Defect_1460510_2()
         {
@@ -2322,7 +2305,7 @@ class Derived extends Base
             });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T51_Defect_1461399()
         {
@@ -2352,7 +2335,7 @@ test = CurveProperties(null);";
             thisTest.Verify("test", ExpectedResult);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T51_Defect_1461399_2()
         {
@@ -2389,7 +2372,7 @@ class Arc
             thisTest.Verify("test", ExpectedResult);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T51_Defect_1461399_3()
         {
@@ -2430,7 +2413,7 @@ test;
         }
 
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T52_Defect_1461479()
         {
@@ -2450,7 +2433,7 @@ a = A.foo();
             Assert.IsTrue(mirror.GetValue("a", 0).DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T52_Defect_1461479_2()
         {
@@ -2470,7 +2453,7 @@ test1 = Sample.ret_a();
             Assert.IsTrue(mirror.GetValue("test1", 0).DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T52_Defect_1461479_3()
         {
@@ -2498,7 +2481,7 @@ class Sample
             thisTest.Verify("test2", 2, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T52_Defect_1461479_4()
         {
@@ -2535,7 +2518,7 @@ test6 = S2.ret_a();";
             Object v1 = null;
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T52_Defect_1461479_5()
         {
@@ -2582,7 +2565,7 @@ test1;test2;test7;test8;
             thisTest.Verify("test8", v2, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter()
         {
@@ -2629,7 +2612,7 @@ x2 = derivedpoint.B;
             Assert.IsTrue(mirror.GetValue("derivedPoint2", 0).DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738()
         {
@@ -2675,7 +2658,7 @@ x2=derivedpoint.B; ";
             Assert.IsTrue(mirror.GetValue("derivedPoint2", 0).DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738_2()
         {
@@ -2722,7 +2705,7 @@ x2 = derivedpoint.B;
             Assert.IsTrue(mirror.GetValue("derivedPoint2", 0).DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738_3()
         {
@@ -2768,7 +2751,7 @@ x2 = derivedpoint.B;";
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738_4()
         {
@@ -2816,7 +2799,7 @@ x2 = derivedpoint.B;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738_6()
         {
@@ -2871,7 +2854,7 @@ x2 = derivedpoint.B;
             thisTest.Verify("x2", 9);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T53_Undefined_Class_As_Parameter_1463738_7()
         {
             string code = @"
@@ -2927,7 +2910,7 @@ x2 = derivedpoint.B; // expected 8; received : 9
             thisTest.Verify("x2", 9);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738_8()
         {
@@ -2982,7 +2965,7 @@ x2 = derivedpoint.B;
             thisTest.Verify("x2", 9);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_imperative_1463738_9()
         {
@@ -3031,7 +3014,7 @@ x2 = derivedpoint.B;
             thisTest.Verify("x2", 8);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_negative_1467107_10()
         {
@@ -3049,7 +3032,7 @@ y2 = m.foo(2);
             thisTest.Verify("y2", a);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_negative_imperative_1467107_11()
         {
@@ -3071,7 +3054,7 @@ y2;
             thisTest.Verify("y2", a);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_negative_imperative_1467091_12()
         {
@@ -3091,7 +3074,7 @@ y;
             thisTest.Verify("y", a);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_negative_associative_1467091_13()
         {
@@ -3109,7 +3092,7 @@ y = test.foo (1);
 
         // Jun: To address on dot op defect
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T55_Defect_1460616()
         {
             string code = @"
@@ -3157,7 +3140,7 @@ x3 = a3.x;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Failure")]
         public void TV55_Defect_1460616_1()
         {
@@ -3207,7 +3190,7 @@ x3 = a3.x;
             thisTest.Verify("x3", v1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T55_Defect_1460616_2()
         {
@@ -3230,7 +3213,7 @@ x3 = a3.x;
         }
 
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T56_Local_Class_method_Same_Name_As_Global_Function()
         {
@@ -3265,7 +3248,7 @@ x = b.ding();  // expect 100 but got 1000
             thisTest.Verify("x", 100);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Method Resolution")]
         public void T58_Defect_1462445()
         {
@@ -3301,7 +3284,7 @@ class A
             thisTest.Verify("w", 2);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T59_Defect_1466572()
         {
@@ -3331,7 +3314,7 @@ zz = p1.Z;// expected -1, received -1
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T60_Defect_1467004()
         {
@@ -3356,7 +3339,7 @@ s = test.foo(arr); //Expected output should be -123
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T59_Defect_1466572_2()
         {
@@ -3386,7 +3369,7 @@ zz = p1.Z;
             thisTest.Verify("zz", 1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T59_Defect_1466572_3()
         {
@@ -3419,7 +3402,7 @@ p2 = foo ( -x1, -(x1+x2), -x1*x2+0.5 );
             thisTest.Verify("p2", 0.5);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T61_Defect_1459171()
         {
@@ -3451,7 +3434,7 @@ a3 = a1.Y;
             thisTest.Verify("a3", 10.000000);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T62_class_assignment_inside_imperative()
         {
             string code = @"class point{
@@ -3505,7 +3488,7 @@ return=controlPoly;
             // thisTest.VerifyBuildWarning(ProtoCore.BuildData.WarningID.kFunctionNotFound);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T63_Array_inClass_Imperative_1465637()
         {
@@ -3548,7 +3531,7 @@ b2 = {0,0,0,0,0};
         }
 
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T68_Inherit_Base_Constructor_1467153()
         {
             string code = @"
@@ -3586,7 +3569,7 @@ d=n.Fixity;
             thisTest.Verify("d", false);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T68_Inherit_Base_Constructor_1467153_negative()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
@@ -3625,7 +3608,7 @@ d=n.Fixity;
         }
 
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T63_Class_methodresolution_1457172()
         {
             string code = @"
@@ -3686,7 +3669,7 @@ p8 = y[2][2];
             thisTest.Verify("p8", a);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T63_Class_methodresolution_1457172_2()
         {
             string code = @"
@@ -3747,7 +3730,7 @@ p4 = y[0][1][1];
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T63_Class_methodresolution_1457172_3()
         {
             string code = @"
@@ -3768,7 +3751,7 @@ y = x.foo ();
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T69_Redefine_property_inherited_1467141()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
@@ -3800,7 +3783,7 @@ r2 = a.fy;
             });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T70_Defect_1467112_Method_Overloading_Issue()
         {
             string code = @"
@@ -3830,7 +3813,7 @@ b1 = b.foo1(1);";
             thisTest.Verify("b1", 2);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T71_class_inherit_arg_var_1467157()
         {
             // Assert.Fail("1467157 - Sprint 25 - rev 3047 class inheritance if the argument is var and the same declared both in base calss and inherited class it throws error ");
@@ -3864,7 +3847,7 @@ b=a.CreateNew(1);
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T72_class_inherit_1467097_1()
         {
             //Assert.Fail("1467097 Sprint 24 - Rev 2761 - if var is used as a argument to function and call function with defined class it goes into a loop and hangs DS ");
@@ -3911,7 +3894,7 @@ c=oldPoint.C;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T72_class_inherit_1467097_2()
         {
             //Assert.Fail("1467097 Sprint 24 - Rev 2761 - if var is used as a argument to function and call function with defined class it goes into a loop and hangs DS ");
@@ -3959,7 +3942,7 @@ c=derivedpoint.C;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void TV_1467097_class_inherit()
         {
             String code =
@@ -3992,7 +3975,7 @@ rb = oldPoint.B;
         }
 
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T73_Defect_1467210_Expected_Warning()
         {
@@ -4016,7 +3999,7 @@ a = Test.DoSomething(); //wrong warning is thrown:
             thisTest.Verify("a", n1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T74_Defect_1469099_Access_Property()
         {
@@ -4049,7 +4032,7 @@ t2 = b1.ang;";
             thisTest.Verify("t2", 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T74_Defect_1469099_Access_Property_2()
         {
@@ -4092,7 +4075,7 @@ t1;t2;
             thisTest.Verify("t2", 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T75_Defect_1467188_Class_Instantiation()
         {
@@ -4120,7 +4103,7 @@ RY = ty.foo(t);";
             thisTest.Verify("RY", 1.0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T75_Defect_1467188_Class_Instantiation_2()
         {
@@ -4158,7 +4141,7 @@ RY = ty.foo( t );";
             thisTest.Verify("RY", 9.0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T76_Defect_1467186_Class_Update()
         {
@@ -4181,7 +4164,7 @@ x = 5;";
 
     
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T77_Defect_1460274_Class_Update_2()
         {
             string code = @"
@@ -4224,7 +4207,7 @@ test3 = pointGroup3.X;
             thisTest.Verify("test3", new Object[] { 4, 2 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T77_Defect_1460274_Class_Update_3()
         {
@@ -4252,7 +4235,7 @@ test = pointGroup.X;";
             thisTest.Verify("test", new Object[] { 4, 2 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T77_Defect_1460274_Class_Update_5()
         {
             string code = @"
@@ -4277,7 +4260,7 @@ test = geometry;";
             thisTest.Verify("test", new Object[] { 5, 10, 15, null, 11 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T78_Defect_1467146_Class_Update_With_Replication()
         {
@@ -4297,7 +4280,7 @@ val = v[0];";
             thisTest.Verify("val", 100);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T78_Defect_1467146_Class_Update_With_Replication_2()
         {
@@ -4317,7 +4300,7 @@ val = v[0];";
             thisTest.Verify("val", n1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Failure")]
         public void T78_Defect_1467146_Class_Update_With_Replication_3()
         {
@@ -4339,7 +4322,7 @@ v = A.execute(arr);
             thisTest.Verify("v", new Object[] { 100, 100, n1 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         [Category("Failure")]
         public void T78_Defect_1467146_Class_Update_With_Replication_4()
@@ -4361,7 +4344,7 @@ v = A.execute(arr);
             thisTest.Verify("v", new Object[] { 100, n1, n1 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T78_Defect_1467146_Class_Update_With_Replication_5()
         {
             string code = @"
@@ -4400,7 +4383,7 @@ p2 = B.execute2(arr2);";
             thisTest.Verify("p2", 200);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T79_Defect_1458581_Unnamed_Constructor()
         {
             string code = @"
@@ -4423,7 +4406,7 @@ b2 = a1.x2;";
             thisTest.Verify("b2", 1.5);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Replication")]
         public void T80_Defect_1444246_Replication()
         {
@@ -4447,7 +4430,7 @@ xs;
             thisTest.Verify("xs", new Object[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Replication")]
         public void T80_Defect_1444246_Replication_2()
         {
@@ -4467,7 +4450,7 @@ p2 = MyPoint.CreateXY(-20.0,-30.0).X;";
             thisTest.Verify("p2", -20.0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T81_Defect_1467246_derived_class_setter()
         {
             string code = @"
@@ -4498,7 +4481,7 @@ z1 = a1.z;
             thisTest.Verify("z1", 6);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T82_Defect_1467174()
         {
             string code = @"
@@ -4534,7 +4517,7 @@ t1 = l1.StartPoint.X;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Replication")]
         public void T83_Defect_1463232()
         {
@@ -4552,7 +4535,7 @@ t = a.x;
             thisTest.Verify("t", n1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Replication")]
         public void T83_Defect_1463232_2()
         {
@@ -4574,7 +4557,7 @@ t = a.x;
             thisTest.Verify("t", n1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Replication")]
         [Category("Failure")]
         public void T83_Defect_1463232_3()
@@ -4597,7 +4580,7 @@ t = a.x;
             thisTest.Verify("t", new Object[] { n1, n1 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T84_ClassNameAsPropertyName_01()
         {
             string code = @"
@@ -4638,7 +4621,7 @@ x2 = b.getx();
             thisTest.VerifyBuildWarningCount(0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T85_Defect_1467247()
         {
             string code = @"
@@ -4680,7 +4663,7 @@ t2 = a.y;
         }
 
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T85_Defect_1467247_2()
         {
             string code = @"
@@ -4721,7 +4704,7 @@ a.y = 5;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Failure")]
         public void T85_Defect_1467247_3()
         {
@@ -4749,7 +4732,7 @@ a.x = 4;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T86_Defect_1467216()
         {
             string code = @"
@@ -4776,7 +4759,7 @@ test = p.x;
             thisTest.Verify("test", 10);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T86_Defect_1467216_2()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
@@ -4794,7 +4777,7 @@ test = Plane.x;
             });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T86_Defect_1467216_3()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
@@ -4811,7 +4794,7 @@ test = Plane;
             });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T86_Defect_1467216_4()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
@@ -4832,7 +4815,7 @@ test = foo();
             });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T87_Defect_1467243()
         {
             string code = @"
@@ -4854,7 +4837,7 @@ r2 = fa.fx[0];
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T87_Defect_1467243_2()
         {
             string code = @"
@@ -4875,7 +4858,7 @@ r2 = fa.fx[0][0];
             thisTest.Verify("r1", new Object[] { true });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T88_Runtime_MemberFunction01()
         {
             string code = @"
@@ -4905,7 +4888,7 @@ r = x.foo();
             thisTest.Verify("r", null);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T89_Runtime_MemberFunction02()
         {
             string code = @"
@@ -4935,7 +4918,7 @@ r = b.foo();
             thisTest.Verify("r", 200);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T89_1467344_02()
         {
             string code = @"
@@ -4970,7 +4953,7 @@ r;
             thisTest.Verify("r", 200);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T90_Runtime_MemberFunction03()
         {
             string code = @"
@@ -5007,7 +4990,7 @@ r = x.foo();
             thisTest.Verify("r", 300);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T91_stackoverflow()
         {
             string code = @"
@@ -5042,7 +5025,7 @@ r = x.foo();
             thisTest.VerifyBuildWarningCount(0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         [Category("Failure")]
         public void T92_default_argument_1467384()
@@ -5064,7 +5047,7 @@ r = x.foo();
             thisTest.Verify("a", 4, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T92_default_argument_1467402()
         {
@@ -5084,7 +5067,7 @@ r = x.foo();
             thisTest.Verify("d", 1, 0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T93_Defect_1467349_update_static_properties()
         {
@@ -5101,7 +5084,7 @@ Base.x = { 5.2, 3.9 };
             thisTest.Verify("t", new Object[] { 5, 4 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T93_Defect_1467349_update_static_properties_2()
         {
@@ -5121,7 +5104,7 @@ b2 = b1;
             thisTest.Verify("b2", 3);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T93_Defect_1467349_update_static_properties_3()
         {
@@ -5145,7 +5128,7 @@ b2 = b1;
             thisTest.Verify("b2", 3);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T93_Defect_1467349_update_static_properties_4()
         {
@@ -5169,7 +5152,7 @@ b2 = b1;
             thisTest.Verify("b2", new Object[] { 3, 4 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T93_Defect_1467349_update_static_properties_5()
         {
@@ -5194,7 +5177,7 @@ b2 = b1;
             thisTest.Verify("b2", new Object[] { 3, 4 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467343()
         {
@@ -5227,7 +5210,7 @@ r = x.foo();
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467343_2()
         {
@@ -5263,7 +5246,7 @@ r;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467344_3()
         {
@@ -5296,7 +5279,7 @@ r = b.foo();
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467344_4()
         {
@@ -5332,7 +5315,7 @@ r = b.foo();
             thisTest.Verify("r", 200);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467443()
         {
@@ -5351,7 +5334,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94__imperative_1467443_7()
         {
@@ -5373,7 +5356,7 @@ a = test.test();
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467443_2()
         {
@@ -5388,7 +5371,7 @@ a.b = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_imperative_1467443_8()
         {
@@ -5407,7 +5390,7 @@ a.b = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467443_3()
         {
@@ -5430,7 +5413,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_iperative_1467443_9()
         {
@@ -5457,7 +5440,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467443_4()
         {
@@ -5480,7 +5463,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_imperative_1467443_10()
         {
@@ -5507,7 +5490,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467443_6()
         {
@@ -5534,7 +5517,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_imperative_1467443_11()
         {
@@ -5565,7 +5548,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_1()
         {
@@ -5587,7 +5570,7 @@ a.foo = 1;
             thisTest.Verify("y", 1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_2()
         {
@@ -5609,7 +5592,7 @@ a.foo = 1;
             thisTest.Verify("y", new object[] { 1, 2, 3 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_3()
         {
@@ -5635,7 +5618,7 @@ y = x.a;
             thisTest.Verify("y", 1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_4()
         {
@@ -5661,7 +5644,7 @@ y = x.a;
             thisTest.Verify("y", new object[] { 1, 2, 3 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_5()
         {
@@ -5687,7 +5670,7 @@ y = x.a;
             thisTest.Verify("y", 1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_6()
         {
@@ -5713,7 +5696,7 @@ y = x.a;
             thisTest.Verify("y", new object[] { 1, 2, 3 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_7()
         {
@@ -5739,7 +5722,7 @@ y = x.a;
             thisTest.Verify("y", new object[] { 2, 3 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467464_1()
         {
@@ -5770,7 +5753,7 @@ y = x.a;
             thisTest.Verify("b", null);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T97_1467440_Class_Not_Defined_1()
         {
@@ -5788,7 +5771,7 @@ z = foo({ 1, 2 });
             thisTest.Verify("z", n1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T97_1467440_Class_Not_Defined_2()
         {
@@ -5810,7 +5793,7 @@ z;
             thisTest.Verify("z", n1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T97_1467440_Class_Not_Defined_3
             ()
@@ -5833,7 +5816,7 @@ z;
             thisTest.Verify("z", n1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T98_1467450_Class_Not_Defined_1
             ()
@@ -5854,7 +5837,7 @@ a4 = A.A({1,2}, c..d, 0..1, 5..f);
             thisTest.Verify("a4", n1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T98_1467450_Class_Not_Defined_2
             ()
@@ -5879,7 +5862,7 @@ a1;a2;a3;a4;
             thisTest.Verify("a4", n1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T98_1467450_Class_Not_Defined_3
             ()
@@ -5907,7 +5890,7 @@ a4 : int;
             thisTest.Verify("a4", n1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T98_1467450_Class_Not_Defined_4
             ()
@@ -5939,7 +5922,7 @@ test = A.foo();
             thisTest.Verify("a4", n1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T99_UnnamedConstructor01()
         {
@@ -5958,7 +5941,7 @@ r = a.x;
             thisTest.Verify("r", 41);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T99_1467469
             ()
@@ -5979,7 +5962,7 @@ d = a == b;
             thisTest.Verify("c", false);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467421()
         {
@@ -6003,7 +5986,7 @@ r = a1.count;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467421_2()
         {
@@ -6027,7 +6010,7 @@ r = a1.count;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467421_3()
         {
@@ -6055,7 +6038,7 @@ r2 = b1.count;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467421_4()
         {
@@ -6083,7 +6066,7 @@ r2 = b1.count;
             thisTest.Verify("r2", new object[] { 4, 5, 6 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467421_5()
         {
@@ -6110,7 +6093,7 @@ r = a1.count;
             thisTest.Verify("r", 1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467472()
         {
@@ -6136,7 +6119,7 @@ r2=a1.pt;
             thisTest.Verify("r2", 1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467472_2()
         {
@@ -6169,7 +6152,7 @@ r2=b1.pt;
             thisTest.Verify("r2", 2);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467472_3()
         {
@@ -6200,7 +6183,7 @@ r2=a1.pt;
             thisTest.Verify("r2", 1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467472_4()
         {
@@ -6237,7 +6220,7 @@ r2=b1.pt;
             thisTest.Verify("r2", 2);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467078_unnamed_constructor_1()
         {
@@ -6263,7 +6246,7 @@ test = t.i;
             thisTest.Verify("test", 41);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467078_unnamed_constructor_2()
         {
@@ -6295,7 +6278,7 @@ test2 = t.j;
             thisTest.Verify("test2", 4);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467078_unnamed_constructor_3()
         {
@@ -6326,7 +6309,7 @@ test1 = t.j.i;
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467078_unnamed_constructor_4()
         {
@@ -6361,7 +6344,7 @@ test1;
             thisTest.Verify("test1", 4);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467078_unnamed_constructor_5()
         {
@@ -6396,7 +6379,7 @@ test1 = foo();
             thisTest.Verify("test1", 4);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T97_1467522_Indexing_Class_Properties_1()
         {
@@ -6435,7 +6418,7 @@ test2 = walls[0].Start.x; // received 1
             thisTest.Verify("test", 1.0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T97_1467522_Indexing_Class_Properties_2()
         {
@@ -6470,7 +6453,7 @@ test2 = wall[0].func(wall[1]);  // 3; expected test1=test2
             thisTest.Verify("test1", 3);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Failure")]
         public void T98_Class_Static_Property_Using_Global_Variable()
         {
@@ -6489,7 +6472,7 @@ test1 = A.a;
             thisTest.Verify("test1", 3);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T98_Class_Static_Property_Using_Other_Properties()
         {
             String code =
@@ -6507,7 +6490,7 @@ test1 = A.a;
             thisTest.VerifyBuildWarningCount(1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T98_1467571_static_nonstatic_issue()
         {
             String code =
@@ -6530,7 +6513,7 @@ test2 = aa.a2();
             thisTest.VerifyBuildWarningCount(1);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T99_1467578_this_imperative()
         {
             String code =
@@ -6564,7 +6547,7 @@ val=seed.someOperation().IntValue;
             thisTest.VerifyBuildWarningCount(0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T100_1467578_this_imperative()
         {
             String code =
@@ -6604,7 +6587,7 @@ startArray = MyInt.Default(1..5);
             thisTest.VerifyBuildWarningCount(0);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T110_IDE_884_Testing_Bang_Inside_Imperative()
         {
             String code =
@@ -6683,7 +6666,7 @@ test4 = t.foo4();
             thisTest.Verify("test4", false);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T110_IDE_884_Testing_Bang_Inside_Imperative_2()
         {
             String code =
@@ -6726,7 +6709,7 @@ test3 = foo(a);
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T111_Class_Constructor_Negative_1467598()
         {
@@ -6749,7 +6732,7 @@ a = test.sum();
 
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T112_1467578_this_imperative()
         {
@@ -6795,7 +6778,7 @@ test = seed.someOperation(startArray).IntValue;
             thisTest.Verify("test", new Object[] { 2, 0, 0, 0, 0 });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T113_1467599_Type_Conversion()
         {
@@ -6845,7 +6828,7 @@ b = MyInt.MyInt().foo();
             thisTest.Verify("b", null);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T114_1467599_Type_Conversion()
         {
@@ -6896,7 +6879,7 @@ b = MyInt.MyInt().foo();
             thisTest.Verify("b", new Object[] { null, null });
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T115_1467599_Type_Conversion()
         {
@@ -6931,7 +6914,7 @@ b = MyInt.MyInt().foo().IntValue;
             thisTest.Verify("b", null);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T116_1467599_Type_Conversion()
         {
             String code =
@@ -6951,7 +6934,7 @@ x = 1;
             thisTest.Verify("x", 1.5);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T117_1467599_Type_Conversion()
         {
@@ -6981,7 +6964,7 @@ c = a.x;
             thisTest.Verify("c", 1.5);
         }
 
-        [Test][Category("DSDefinedClass")]
+        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T118_1467695_setter_inlinecondition()
         {


### PR DESCRIPTION
### Purpose

Porting/Rewriting DS defined classes to remove the DS class and only focus on the specific test.
This is submission 10/14

Refer to this top level task:
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8349

See the guidlines:
A test that uses a DS defined class should be re-written such that the DS defined class is removed.
This means doing one or a combination of the following:
1 Write an FFI class to replace the DS defined class
2 Remove the DS class if it is not necessary
3 Remove verification that is unncecessary
4 Rename the test appropriately if needed
5 If a test is ported, modify the category from DSDefinedClass to DSDefinedClass_Ported
6 If a test is NOT ported, modify the category from DSDefinedClass to DSDefinedClass_Ignored_SomeDecriptionHere
7 At the end of the class porting task, the only categories left should be DSDefinedClass_Ported and DSDefinedClass_Ignored. 
8 There should be no regressions is these tasks. Tests that must be removed completely will be done at the end of the porting /rewriting task

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

This has been reviewed by @lukechurch 