### PR TITLE
Port class tests 11

### DIFF
--- a/test/Engine/ProtoTest/TD/MultiLangTests/UseCaseTesting.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/UseCaseTesting.cs
@@ -194,7 +194,7 @@ b  = b2 + 2;    // 5";
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_ModifierBlock")]
         [Category("ModifierBlock")] 
         public void T007_surface_trimmed_with_modifier_and_named_states_Robert()
         {
@@ -247,7 +247,7 @@ test = mySurface.x; //expected : 4
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_ComplexUseCase")]
         [Category("SmokeTest")]
         public void T008_long_hand_surface_trim_Robert()
         {
@@ -334,7 +334,7 @@ x;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_ComplexUseCase")]
         public void T011_Cyclic_Dependency_From_Geometry()
         {
             string code = @"
@@ -357,7 +357,7 @@ projectVector = Vector.ByCoordinates(5.0,0,-1);";
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_ComplexUseCase")]
         public void T012_property_test_on_collections_2_Robert()
         {
             string code = @"
@@ -376,7 +376,7 @@ t2= line2.Color;";
 
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_ComplexUseCase")]
         public void T013_nested_programming_blocks_1_Robert()
         {
             string errmsg = "";

--- a/test/Engine/ProtoTest/TD/OtherMiscTests/MiscTest.cs
+++ b/test/Engine/ProtoTest/TD/OtherMiscTests/MiscTest.cs
@@ -413,7 +413,7 @@ inputBool = true;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         [Category("Failure")]
         public void DynamicReferenceResolving_Complex_Case()
@@ -493,7 +493,7 @@ testInFunction2 = foo2(b2); //testInFunction2 = 7;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void DynamicReference_Variable()
         {
@@ -522,7 +522,7 @@ kk = t.k;";
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void DynamicReference_FunctionCall()
         {
@@ -550,7 +550,7 @@ testFoo1 = t.foo1(6); // foo1 does not exist in A, function not found warning; t
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         [Category("Failure")]
         public void DynamicReference_FunctionCall_With_Default_Arg()
@@ -746,7 +746,7 @@ a=1;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void GarbageCollection_1467148()
         {
             string code = @"

--- a/test/Engine/ProtoTest/UtilsTests/ClassUtilsTest.cs
+++ b/test/Engine/ProtoTest/UtilsTests/ClassUtilsTest.cs
@@ -12,7 +12,7 @@ namespace ProtoTest.UtilsTests
     class ClassUtilsTest : ProtoTestBase
     {
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         public void GetUpcastChainTest()
         {
             String code =

--- a/test/Engine/ProtoTest/UtilsTests/CoreDump.cs
+++ b/test/Engine/ProtoTest/UtilsTests/CoreDump.cs
@@ -17,7 +17,7 @@ namespace ProtoTest.UtilsTests
             coreRunner = new ProtoScript.Runners.ProtoScriptTestRunner();
         }
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_CoreDumpNeedsToSupportFFIClass")]
         public void TestArrayCoreDump01()
         {
             string sourceCode = @"                class A                {                    c : int = 0;                        constructor B(v : int)                    {                        c = v;                    }                }                values = A.B(1..20..1);";
@@ -28,7 +28,7 @@ namespace ProtoTest.UtilsTests
             Assert.AreEqual("values = { A(c = 1), A(c = 2), A(c = 3), ..., A(c = 18), A(c = 19), A(c = 20) }", globalVariables[0]);
         }
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_CoreDumpNeedsToSupportFFIClass")]
         public void TestArrayCoreDump02() // Test array truncation size being an even number.
         {
             string sourceCode = @"                class A                {                    c : int = 0;                        constructor B(v : int)                    {                        c = v;                    }                }                under = A.B(1..7..1);                match = A.B(1..8..1);                over = A.B(1..9..1);";
@@ -41,7 +41,7 @@ namespace ProtoTest.UtilsTests
             Assert.AreEqual("over = { A(c = 1), A(c = 2), A(c = 3), A(c = 4), ..., A(c = 6), A(c = 7), A(c = 8), A(c = 9) }", globalVariables[2]);
         }
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_CoreDumpNeedsToSupportFFIClass")]
         public void TestArrayCoreDump03() // Test array truncation size being an odd number.
         {
             string sourceCode = @"                class A                {                    c : int = 0;                        constructor B(v : int)                    {                        c = v;                    }                }                under = A.B(1..6..1);                match = A.B(1..7..1);                over = A.B(1..8..1);";
@@ -54,7 +54,7 @@ namespace ProtoTest.UtilsTests
             Assert.AreEqual("over = { A(c = 1), A(c = 2), A(c = 3), ..., A(c = 6), A(c = 7), A(c = 8) }", globalVariables[2]);
         }
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_CoreDumpNeedsToSupportFFIClass")]
         public void TestRecursiveCoreDump()
         {
             string sourceCode = @"                class A                {                    x;                }                a = A.A();                x = a.x;                a.x = a;";


### PR DESCRIPTION
### Purpose

Porting/Rewriting DS defined classes to remove the DS class and only focus on the specific test.
This is submission 11/14

Refer to this top level task:
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8350

See the guidlines:
A test that uses a DS defined class should be re-written such that the DS defined class is removed.
This means doing one or a combination of the following:
1 Write an FFI class to replace the DS defined class
2 Remove the DS class if it is not necessary
3 Remove verification that is unncecessary
4 Rename the test appropriately if needed
5 If a test is ported, modify the category from DSDefinedClass to DSDefinedClass_Ported
6 If a test is NOT ported, modify the category from DSDefinedClass to DSDefinedClass_Ignored_SomeDecriptionHere
7 At the end of the class porting task, the only categories left should be DSDefinedClass_Ported and DSDefinedClass_Ignored. 
8 There should be no regressions is these tasks. Tests that must be removed completely will be done at the end of the porting /rewriting task

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

This has been reviewed by @lukechurch 