### PR TITLE
Fix components checkbox index in installer

### DIFF
--- a/tools/install/DynamoInstaller.iss
+++ b/tools/install/DynamoInstaller.iss
@@ -250,13 +250,13 @@ begin
   if CurPageID = wpSelectComponents then
   if not RevitInstallationExists('Revit2015') then
     begin
-      WizardForm.ComponentsList.Checked[2] := False;
-      WizardForm.ComponentsList.ItemEnabled[2] := False;
+      WizardForm.ComponentsList.Checked[1] := False;
+      WizardForm.ComponentsList.ItemEnabled[1] := False;
     end;
   if not RevitInstallationExists('Revit2016') then
     begin
-      WizardForm.ComponentsList.Checked[3] := False;
-      WizardForm.ComponentsList.ItemEnabled[3] := False;
+      WizardForm.ComponentsList.Checked[2] := False;
+      WizardForm.ComponentsList.ItemEnabled[2] := False;
     end;
 end;
 


### PR DESCRIPTION
### Purpose
- Fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8474

### Analysis
While removing support for Revit2014, we removed the components for Revit2014 which changed the index for compoents. Hence the code for updating check box of installed components should be updated accordingly.

### Reviewers
- [ ] @ikeough 