### PR TITLE
Remove render tier check.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -590,12 +590,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         {
             recentlyAddedNodes.Clear();
 
-            // Don't render if the user's system is incapable.
-            if (renderingTier == 0)
-            {
-                return;
-            }
-
 #if DEBUG
             renderTimer.Start();
 #endif

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/Watch3DViewModelBase.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/Watch3DViewModelBase.cs
@@ -65,7 +65,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         protected readonly IDynamoViewModel viewModel;
         protected readonly INotifyPropertyChanged renderPackageFactoryViewModel;
 
-        protected int renderingTier;
         protected List<NodeModel> recentlyAddedNodes = new List<NodeModel>();
         protected bool active;
         private readonly List<IRenderPackage> currentTaggedPackages = new List<IRenderPackage>();
@@ -190,7 +189,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         private void LogVisualizationCapabilities()
         {
-            renderingTier = (RenderCapability.Tier >> 16);
+            var renderingTier = (RenderCapability.Tier >> 16);
             var pixelShader3Supported = RenderCapability.IsPixelShaderVersionSupported(3, 0);
             var pixelShader4Supported = RenderCapability.IsPixelShaderVersionSupported(4, 0);
             var softwareEffectSupported = RenderCapability.IsShaderEffectSoftwareRenderingSupported;

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -1,46 +1,17 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Media.Media3D;
 using System.Windows.Threading;
-using System.Xml;
 using Autodesk.DesignScript.Interfaces;
-using Dynamo.Core;
-using Dynamo.Core.Threading;
-using Dynamo.Interfaces;
-using Dynamo.Models;
-using Dynamo.Selection;
-using Dynamo.UI;
-using Dynamo.ViewModels;
-using Dynamo.Wpf;
-using Dynamo.Wpf.Rendering;
-using Dynamo.Wpf.ViewModels;
 using Dynamo.Wpf.ViewModels.Watch3D;
 using Dynamo.Wpf.Views.Preview;
-using DynamoUtilities;
 using HelixToolkit.Wpf.SharpDX;
-using HelixToolkit.Wpf.SharpDX.Core;
-using SharpDX;
-using Color = System.Windows.Media.Color;
-using ColorConverter = System.Windows.Media.ColorConverter;
 using GeometryModel3D = HelixToolkit.Wpf.SharpDX.GeometryModel3D;
-using MeshGeometry3D = HelixToolkit.Wpf.SharpDX.MeshGeometry3D;
 using Model3D = HelixToolkit.Wpf.SharpDX.Model3D;
-using PerspectiveCamera = HelixToolkit.Wpf.SharpDX.PerspectiveCamera;
 using Point = System.Windows.Point;
-using Quaternion = SharpDX.Quaternion;
-using TextInfo = HelixToolkit.Wpf.SharpDX.TextInfo;
 
 namespace Dynamo.Controls
 {


### PR DESCRIPTION
This PR fixes an unrecognized bug with the render tier check refusing to render on systems that don't support hardware rendering (RDP). When we tested this on remote desktop, which now supports software rendering with WARP, no geometry would render because the render tier check prevented it.