### PR TITLE
Fix issues when updated graph is not run again

### DIFF
--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -600,30 +600,28 @@ namespace ProtoScript.Runners
                         // Get the cached AST and append it to the changeSet
                         csData.ForceExecuteASTList.AddRange(GetUnmodifiedASTList(oldSubTree.AstNodes, st.AstNodes));
                     }
-                    else
-                    {
-                        // Only update the cached ASTs if it is not ForceExecution
 
-                        List<AssociativeNode> newCachedASTList = new List<AssociativeNode>();
+                    // Update the cached AST to reflect the change
 
-                        // Get all the unomodified ASTs and append them to the cached ast list 
-                        newCachedASTList.AddRange(GetUnmodifiedASTList(oldSubTree.AstNodes, st.AstNodes));
+                    List<AssociativeNode> newCachedASTList = new List<AssociativeNode>();
 
-                        // Append all the modified ASTs to the cached ast list 
-                        newCachedASTList.AddRange(modifiedASTList);
+                    // Get all the unomodified ASTs and append them to the cached ast list 
+                    newCachedASTList.AddRange(GetUnmodifiedASTList(oldSubTree.AstNodes, st.AstNodes));
 
-                        // ================================================================================
-                        // Get a list of functions that were removed
-                        // This is the list of functions that exist in oldSubTree.AstNodes and no longer exist in st.AstNodes
-                        // This will passed to the changeset applier to handle removed functions in the VM
-                        // ================================================================================
-                        IEnumerable<AssociativeNode> removedFunctions = oldSubTree.AstNodes.Where(f => f is FunctionDefinitionNode && !st.AstNodes.Contains(f));
-                        csData.RemovedFunctionDefNodesFromModification.AddRange(removedFunctions);
+                    // Append all the modified ASTs to the cached ast list 
+                    newCachedASTList.AddRange(modifiedASTList);
 
-                        st.AstNodes.Clear();
-                        st.AstNodes.AddRange(newCachedASTList);
-                        currentSubTreeList[st.GUID] = st;
-                    }
+                    // ================================================================================
+                    // Get a list of functions that were removed
+                    // This is the list of functions that exist in oldSubTree.AstNodes and no longer exist in st.AstNodes
+                    // This will passed to the changeset applier to handle removed functions in the VM
+                    // ================================================================================
+                    IEnumerable<AssociativeNode> removedFunctions = oldSubTree.AstNodes.Where(f => f is FunctionDefinitionNode && !st.AstNodes.Contains(f));
+                    csData.RemovedFunctionDefNodesFromModification.AddRange(removedFunctions);
+
+                    st.AstNodes.Clear();
+                    st.AstNodes.AddRange(newCachedASTList);
+                    currentSubTreeList[st.GUID] = st;
                 }
             }
         }


### PR DESCRIPTION
### Purpose

This pull request is to fix MAGN-8367. When an updated graph data is sent to the live runner, somehow some part of the updated graph is not run again. Thus strange behaviors occur.

When the live runner receives the updated graph data, it will try to get the delta AST nodes which include deleted AST nodes, added AST nodes and modified AST nodes. These AST nodes will be sent to the engine to compile again. The way that these nodes are figured out is by comparing cached AST nodes with the AST nodes in the updated graph data. But somehow for the issues to be fixed, the cached AST nodes already contain one AST node which is contained in the updated graph data. As a result, one change in one node is not considered when running the graph.

It looks weird that the cached AST nodes already contain the updated AST node. The reason is that when updating the cached AST nodes, old AST nodes are not removed in some situations.

For the following graph, when it changed from:
```
              +----------+
              |  "abc"   |-----------------|            +-----------------+
              +----------+                 |----------->|                 |
                                                        |   xyz node      |
              +----------+                         |--->|                 |
              |  1       |-------------------------|    +-----------------+
              +----------+
```
to:
```
              +----------+
              |  "ab"    |-----------------|            +-----------------+
              +----------+                 |----------->|                 |
                                                        |   xyz node      |
              +----------+                         |--->|                 |
              |  2       |-------------------------|    +-----------------+
              +----------+
```
and then to:
```
              +----------+
              |  "abc"   |-----------------|            +-----------------+
              +----------+                 |----------->|                 |
                                                        |   xyz node      |
              +----------+                         |--->|                 |
              |  3       |-------------------------|    +-----------------+
              +----------+
```


So for the upper left node, the value changed from "abc" to "ab" and then back to "abc". If for some reason, the cached AST nodes related to "abc" are not removed when changing from "abc" to "ab", the change will not considered as a change when "ab" is changed to "abc" because the cached AST nodes already contain the nodes related to "abc.

The reason that cached AST nodes are not removed is the related sub-tree is marked as force execution. But logically the cached AST nodes still need to be updated in such cases. This submission makes the fix to update the cached AST nodes for such cases as well.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@junmendoza 
