### PR TITLE
Fix crash when starting with usage reporting dialogue.

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.8.3.2712")]
+[assembly: AssemblyVersion("0.9.0.2717")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.8.3.2712")]
+[assembly: AssemblyFileVersion("0.9.0.2717")]

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -823,11 +823,7 @@
                 </Canvas.Background>
             </Canvas>
 
-            <controls:Watch3DView x:Name="BackgroundPreview" 
-                                  DataContext="{Binding BackgroundPreviewViewModel}"
-                                  Margin="0,20,0,0"
-                                  Visibility="{Binding Active, Mode=TwoWay, Converter={StaticResource BooleanToVisibilityConverter}}">
-            </controls:Watch3DView>
+            <!-- The BackgroundPreview is now created in the DynamoView_Loaded method.-->
             
         </Grid>
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -64,6 +64,8 @@ namespace Dynamo.Controls
 
         private readonly DispatcherTimer _workspaceResizeTimer = new DispatcherTimer { Interval = new TimeSpan(0, 0, 0, 0, 500), IsEnabled = false };
 
+        internal Watch3DView BackgroundPreview { get; private set; }
+
         public DynamoView(DynamoViewModel dynamoViewModel)
         {
             // The user's choice to enable hardware acceleration is now saved in
@@ -466,6 +468,23 @@ namespace Dynamo.Controls
                 }
             }
 
+            // For everything but a small number of tests,
+            // we do not want to create the 3D view when we
+            // are in test mode.
+            if (DynamoModel.IsTestMode) return;
+
+            BackgroundPreview = new Watch3DView();
+            background_grid.Children.Add(BackgroundPreview);
+            BackgroundPreview.DataContext = dynamoViewModel.BackgroundPreviewViewModel;
+            BackgroundPreview.Margin = new System.Windows.Thickness(0,20,0,0);
+            var vizBinding = new Binding
+            {
+                Source = dynamoViewModel.BackgroundPreviewViewModel,
+                Path = new PropertyPath("Active"),
+                Mode = BindingMode.TwoWay,
+                Converter = new BooleanToVisibilityConverter()
+            };
+            BackgroundPreview.SetBinding(VisibilityProperty, vizBinding);
         }
 
         /// <summary>

--- a/test/DynamoCoreWpfTests/HelixWatch3DViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/HelixWatch3DViewModelTests.cs
@@ -25,7 +25,7 @@ using Model3D = HelixToolkit.Wpf.SharpDX.Model3D;
 
 namespace DynamoCoreWpfTests
 {
-    [TestFixture]
+    [TestFixture, Category("Failure")]
     public class HelixWatch3DViewModelTests : SystemTestBase
     {
         protected override void GetLibrariesToPreload(List<string> libraries)


### PR DESCRIPTION
### Purpose

This PR fixes [MAGN-8512](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8512). Dynamo failed to start successfully on "first run" due to a initialization defect in the Helix Toolkit library. This was solved by moving the initialization of the `Watch3DView` into the `DynamoView_Loaded` handler.

Additionally, the initialization of the `Watch3DView` is NOT done if the `Dynamo.IsTestMode` is `true`. This solves issues on some CI systems which do not have GPUs, by not loading the 3D view during testing. This is a regression from the previous behavior as many of the internals of the `Watch3D` were lazily initialized previously, and this was done behind a check on the rendering tier that we have since removed. That check, checked whether the system 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
  - No new documentation required. Inline comments are added where appropriate.
- [x] The level of testing this PR includes is appropriate
  - This fixes the behavior of existing tests.
- [ ] User facing strings, if any, are extracted into `*.resx` files - n/a

### Reviewers

@pboyer - Please review after the fact. I am merging this now in order to get the build going again.

### FYIs

@jnealb 