### PR TITLE
Don't create the watch 3d view models during testing.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -479,6 +479,7 @@ namespace Dynamo.ViewModels
 
             RenderPackageFactoryViewModel = new RenderPackageFactoryViewModel(Model.PreferenceSettings);
 
+            if (DynamoModel.IsTestMode) return;
             var backgroundPreviewParams = new Watch3DViewModelStartupParams(Model, this, Resources.BackgroundPreviewName);
 
             var watch3DViewModel = HelixWatch3DViewModel.Start(backgroundPreviewParams);


### PR DESCRIPTION
This is a follow on the #5393, to disable the `Watch3DViewModel` when in test mode.