### PR TITLE
Port ds class test14

### DIFF
--- a/test/Engine/ProtoTest/ProtoAST/RoundTripTests.cs
+++ b/test/Engine/ProtoTest/ProtoAST/RoundTripTests.cs
@@ -527,7 +527,6 @@ namespace ProtoTest.ProtoAST
 
         [Test]
         [Category("DSDefinedClass_Ported")]
-        [Category("Failure")]
         public void TestAstToCode()
         {
             // Tracked in: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4393

--- a/test/Engine/ProtoTest/ProtoAST/RoundTripTests.cs
+++ b/test/Engine/ProtoTest/ProtoAST/RoundTripTests.cs
@@ -285,7 +285,7 @@ namespace ProtoTest.ProtoAST
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void TestRoundTrip_ClassDecl_PropertyAccess_01()
         {
             int result1 = 10;
@@ -389,7 +389,7 @@ namespace ProtoTest.ProtoAST
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void TestRoundTrip_ClassDecl_MemFunctionCall_01()
         {
             int result1 = 20;
@@ -526,7 +526,7 @@ namespace ProtoTest.ProtoAST
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("Failure")]
         public void TestAstToCode()
         {
@@ -549,7 +549,6 @@ namespace ProtoTest.ProtoAST
                 "return = {1, 2, 3};",
                 "return = Math.PI;",
                 "return = Math.Cos(1.2);", 
-                "class Foo { f0; f1 = 1; f2 = 2 + 3; f3: int = 3 + 4; f4: int[] = 5; f5: int[]..[] = {1,2,3} ; x:var; y:int[][][]; z:double[]..[]; constructor Foo(p:int[]) { x = p; } def foo:var[](p:int[]..[]) { return = 0; }  static def bar() { return = null; }}",
                 "x[0][1] = {};",
                 
             };

--- a/test/Engine/ProtoTest/TD/ArrayUtilsTest.cs
+++ b/test/Engine/ProtoTest/TD/ArrayUtilsTest.cs
@@ -29,22 +29,15 @@ namespace ProtoTest.UtilsTests
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void StackValueDiffTestUserDefined()
         {
             String code =
 @"
-class A
-{
-    x : var;
-    constructor A()
-    {
-        x = 20;
-    }
-}
+import(""FFITarget.dll"");
 [Imperative]
 {
-	a = A.A();
+	a = ClassFunctionality.ClassFunctionality(20);
     b = 1.0;
 }
 ";
@@ -57,22 +50,15 @@ class A
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void StackValueDiffTestProperty01()
         {
             String code =
 @"
-class A
-{
-    x : var;
-    constructor A()
-    {
-        x = 20;
-    }
-}
+import(""FFITarget.dll"");
 [Imperative]
 {
-	a = A.A();
+	a = ClassFunctionality.ClassFunctionality(20);
     b = 1.0;
 }
 ";
@@ -85,23 +71,16 @@ class A
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void StackValueDiffTestProperty02()
         {
             String code =
 @"
-class A
-{
-    x : var;
-    constructor A()
-    {
-        x = 20;
-    }
-}
+import(""FFITarget.dll"");
 [Imperative]
 {
-	a = A.A();
-    b = a.x;
+	a = ClassFunctionality.ClassFunctionality(20);
+    b = a.IntVal;
     c = 1.0;
 }
 ";
@@ -215,7 +194,7 @@ a;b;c;d;e;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         public void TestArrayGetCommonSuperType()
         {
             String code =
@@ -342,7 +321,7 @@ tCCC = {C.C(), C.C(), C.C()};
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         public void Defect_TestArrayGetCommonSuperType()
         {
             String code =
@@ -351,7 +330,7 @@ class A{};
 class B extends A{};
 class C extends A{};
 class D extends C{};
-a = A.A();
+a =A.A();
 b = B.B();
 c = C.C();
 d = D.D();
@@ -402,7 +381,7 @@ tCD = { c, d };
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         [Category("Method Resolution")]
         public void Defect_TestArrayGetCommonSuperType_2_EmptyArray()
         {
@@ -448,7 +427,7 @@ tE = {};//empty array
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         [Category("Method Resolution")]
         public void Defect_TestArrayGetCommonSuperType_3()
         {

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
@@ -218,7 +218,7 @@ a;b;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T08_Function_From_Inside_Class_Constructor()
         {
@@ -263,7 +263,7 @@ a;b;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T09_Function_From_Inside_Class_Constructor()
         {
@@ -307,7 +307,7 @@ a;b;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T10_Function_From_Inside_Class_Method()
         {
@@ -355,7 +355,7 @@ a;b;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T11_Function_From_Inside_Class_Method()
         {
@@ -770,26 +770,13 @@ x;y;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T22_Function_Call_As_Instance_Arguments()
         {
             string code = @"
-A1;A2;
-class A
-{
-	a : var;
-	constructor CreateA ( a1 : int )
-	{
-		a = a1;
-	}
-	
-	constructor CreateB ( a1 : double )
-	{
-		a = a1;
-	}
-}
-[Associative]
+import(""FFITarget.dll"");
+A1 = [Associative]
 {
 	def foo : int( n : int )
 	{
@@ -801,12 +788,10 @@ class A
 		return = n ;	
 	}
 	
-	A1 = A.CreateA(foo(foo(1))).a;	
-	A2 = A.CreateB(foo2(foo(1))).a;
+	return = ClassFunctionality.ClassFunctionality(foo(foo(1))).IntVal;	
 }";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("A1", 1);
-            thisTest.Verify("A2", 1.0);
         }
 
         [Test]
@@ -1115,34 +1100,23 @@ b2;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T33_Function_With_Mismatching_Return_Type()
         {
-            //Assert.Throws(typeof(ProtoCore.Exceptions.RuntimeException), () =>
-            //{
-            //Assert.Fail("1467156 - Sprint 25 - Rev 3026 type checking of return types at run time ");
             string code = @"
-class A
-{
-    a : int;
-	constructor A1(a1 : int)
-	{
-	    a = a1;
-	}
-}
-b2;
-[Imperative]
+import(""FFITarget.dll"");
+b2 = [Imperative]
 { 
 	 def foo3 : int ( a : double )
 	 {
-	    temp = A.A1(1);
+	    temp = ClassFunctionality.ClassFunctionality(1);
 		return = temp;
 	 }
 	 
 	dummyArg = 1.5;
 	
-	b2 = foo3 ( dummyArg );	
+	return = foo3 ( dummyArg );	
 }
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
@@ -1226,7 +1200,7 @@ b2;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T37_Function_With_Mismatching_Return_Type()
         {
@@ -1235,26 +1209,18 @@ b2;
             //{
             //Assert.Fail("1467156 - Sprint 25 - Rev 3026 type checking of return types at run time ");
             string code = @"
-class A
-{
-    a : int;
-	constructor A1(a1 : int)
-	{
-	    a = a1;
-	}
-}
-b2;
-[Associative]
+import(""FFITarget.dll"");
+b2 = [Associative]
 { 
 	 def foo3 : int ( a : double )
 	 {
-	    temp = A.A1(1);
+	    temp = ClassFunctionality.ClassFunctionality(1);
 		return = temp;
 	 }
 	 
 	dummyArg = 1.5;
 	
-	b2 = foo3 ( dummyArg );	
+	return = foo3 ( dummyArg );	
 }
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
@@ -1480,7 +1446,7 @@ c;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T48_Function_With_Mismatching_Argument_Type()
         {
@@ -1510,29 +1476,21 @@ class A
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T49_Function_With_Matching_Return_Type()
         {
             string code = @"
-c;
-class A
-{
-    a : int;
-	constructor A1(a1 : int)
-	{
-	    a = a1;
-	}
-}
-[Associative]
+import(""FFITarget.dll"");
+c = [Associative]
 { 
-	 def foo : A ( x : A )
+	 def foo : ClassFunctionality ( x : ClassFunctionality )
 	 {
 	    return = x;
      }
-	 aa = A.A1(1);
-	 b2 = foo ( aa).a;
-	 c = 3;	
+	 aa = ClassFunctionality.ClassFunctionality(1);
+	 b2 = foo ( aa).IntVal;
+	 return = 3;	
 	 
 }
 ";
@@ -2125,21 +2083,14 @@ a;b;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T72_Function_Name_Checking()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
             {
                 string code = @"
-class foo
-{
-    a : int;
-	constructor foo ( b : int )
-	{
-	    a = b;
-	}
-}
+import(""FFITarget.dll"");
 [Associative]
 {
     def foo : int ( a : int )
@@ -2149,8 +2100,8 @@ class foo
 	}
 	foo = 1;
 	x = foo(foo);
-	y = foo.foo(foo);
-	z = y.a;
+	y = ClassFunctionality.ClassFunctionality(foo);
+	z = y.IntVal;
 }
 	 
 	 
@@ -2518,28 +2469,21 @@ def foo:int ( a : int )
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T84_Function_With_User_Defined_Class()
         {
             string code = @"
-class A
+import(""FFITarget.dll"");
+def foo : ClassFunctionality ( a : ClassFunctionality )
 {
-    i : int;
-	constructor A ( x : int )
-	{
-	    i = x;
-	}
-}
-def foo : A ( a : A )
-{
-    a1 = a.i;
-	b1 = A.A(a1+1);
+    a1 = a.IntVal;
+	b1 = ClassFunctionality.ClassFunctionality(a1+1);
 	return = b1;
 }
-x = A.A(1);
+x = ClassFunctionality.ClassFunctionality(1);
 y = foo (x);
-z = y.i;";
+z = y.IntVal;";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("z", 2, 0);
         }
@@ -2690,36 +2634,21 @@ t2 = two[1];
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T90_Function_PassingNullToUserDefinedType()
         {
             string code = @"
-class Point
+import(""FFITarget.dll"");
+def GetVal : int(p:ClassFunctionality)
 {
-	length : int;
-	constructor Create(l:int)
-	{
-		length = l;
-	}
-	def GetLength : int()
-	{
-		return = length;
-	}
+	return = p.IntVal;
 }
-def GetPointLength : int(p:Point)
-{
-	return = p.GetLength();
-}
-p = Point.Create(2);
-testP = GetPointLength(p);
 p2 = null;
 testNull = GetPointLength(p2);";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             //Verification
-            object testP = 2;
             object testNull = null;
-            thisTest.Verify("testP", testP, 0);
             thisTest.Verify("testNull", testNull, 0);
         }
 
@@ -2792,7 +2721,7 @@ e = foo(1, 2.0, 3); // not found, null
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T93_Function_With_Default_Arg_In_Class()
         {
             string str = "";
@@ -3133,31 +3062,20 @@ i;j;k;a;b;c;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV10_Function_With_Class_Instances()
         {
-            string src = @"b;
-class A
+            string src = @"
+import(""FFITarget.dll"");
+def foo:int( a : int )
 {
-	a : var;
-	constructor CreateA ( a1 : int )
-	{
-		a = a1;
-	}
-	def add1 : int(  )
-    {
-	    return = a + 1;
-    }
+	A1 = ClassFunctionality.ClassFunctionality( a );
+	return = A1.IntVal + a;
 }
-	def foo:int( a : int )
-	{
-		A1 = A.CreateA( a );
-		return = A1.add1();
-	}
-[Imperative]
+b = [Imperative]
 {
-	b = foo(1);
+	return = foo(1);
 }
 	
 ";
@@ -3399,30 +3317,19 @@ e;f;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV22_Function_With_Class_Object_As_Argument()
         {
-            string src = @"b;
-class A
-{
-	a : var;
-	constructor CreateA ( a1 : int )
-	{
-		a = a1;
-	}
-	def add1 : int(  )
-    {
-	    return = a + 1;
-    }
-}
-def foo:int ( A_Inst : A )
+            string src = @"
+import(""FFITarget.dll"");
+def foo:int ( A_Inst : ClassFunctionality )
 {	
-	return = A_Inst.add1();
+	return = A_Inst.IntVal + 1;
 }
-[Associative]
+b = [Associative]
 {
-	b = foo( A.CreateA( 1 ) );
+	return = foo( ClassFunctionality.ClassFunctionality( 1 ) );
 }
 	";
             ExecutionMirror mirror = thisTest.RunScriptSource(src);
@@ -3481,7 +3388,7 @@ b;c;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_InvalidTest_NoVerification")]
         [Category("SmokeTest")]
         public void TV25_Defect_1454923()
         {
@@ -4177,35 +4084,28 @@ b1;b2;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TV46_Defect_1455278()
         {
             string code = @"
-class A
+import(""FFITarget.dll"");
+def foo : int ( a1 : int, a: int)
 {
-    a : var;
-    constructor A ( i )
+	c = [Imperative]
 	{
-	    a = i;
-	}
-	def foo : int ( a1 : int )
-	{
-		c = [Imperative]
+		d = 0;
+		if( a1 > 1 )
 		{
-		    d = 0;
-			if( a1 > 1 )
-			{
-				d = 1;
-			}
-			return = d;	
+			d = 1;
 		}
-		return  = a + c;
+		return = d;	
 	}
+	return  = a + c;
 }
 	
-a1 = A.A(1);
-b1 = a1.foo(2);
-b2 = a1.foo(0);
+a = 1;
+b1 = foo(2, a);
+b2 = foo(0, a);
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("b1", 2, 0);
@@ -4357,58 +4257,46 @@ c;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV51_Defect_1456108_3()
         {
-            // object[] expectedResult1 = { 2.0, 3, 4 };
-            object expectedResult2 = null;
 
             string code = @"
-class A
+import(""FFITarget.dll"");
+def add_1:double[](a: double[] )
 {
-    b : double[];
-	
-	constructor A (x : double[])
+	j = 0;
+	return = [Imperative]
 	{
-		b = x;
-	}
-	def add_1:double[](a: double[] )
-	{
-		j = 0;
-		a = [Imperative]
+		for ( i in a )
 		{
-			for ( i in a )
-			{
-				a[j] = a[j] + 1;
-				j = j + 1;
-			}
-			return = a;
+			a[j] = a[j] + 1;
+			j = j + 1;
 		}
-		
 		return = a;
 	}
+}
 	
-	def add_2:double[]( )
+def add_2:double[](b : double[] )
+{
+	j = 0;
+	return = [Imperative]
 	{
-		j = 0;
-		x = [Imperative]
+		for ( i in b )
 		{
-			for ( i in b )
-			{
-				b[j] = b[j] + 1;
-				j = j + 1;
-			}
-			return = b;
+			b[j] = b[j] + 1;
+			j = j + 1;
 		}
-		
-		return = x;
+		return = b;
 	}
 }
-c = { 1.0, 2.0, 3.0 };
-a1 = A.A( c );
-c = a1.add_1( c );
-b2 = a1.add_2( );";
+
+b = { 1.0, 2.0, 3.0 };
+c = add_1(b);
+b2 = add_2( b );
+";
+            object[] expectedResult2 = { 2.0, 3.0, 4.0 };
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             // b1 is updated as well. 
             thisTest.Verify("a1", expectedResult2, 0);
@@ -4416,38 +4304,15 @@ b2 = a1.add_2( );";
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV51_Defect_1456108_4()
         {
             object[] expectedResult1 = { 1.0, 2.0, 3.0 };
             object[] expectedResult2 = { 2.0, 3.0, 4.0 };
             string code = @"
-class A
-{
-    b : double[];
-	
-	constructor A (x : double[])
-	{
-		b = x;
-	}
-	def add_1:double[](a: double[] )
-	{
-		j = 0;
-		a = [Imperative]
-		{
-			for ( i in a )
-			{
-				a[j] = a[j] + 1;
-				j = j + 1;
-			}
-			return = a;
-		}
-		
-		return = a;
-	}
-	
-	def add_2:double[]( )
+import(""FFITarget.dll"");
+	def add_2:double[]( b : double[] )
 	{
 		j = 0;
 		x = [Imperative]
@@ -4462,35 +4327,22 @@ class A
 		
 		return = x;
 	}
-}
-c = { 1.0, 2.0, 3.0 };
-a1 = A.A( c );
-t1 = a1.b;
-t2 = a1.add_2();
-t=c;
+
+b= { 1.0, 2.0, 3.0 };
+t2 = add_2(b);
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
-
-            thisTest.Verify("t", expectedResult1, 0);
             thisTest.Verify("t2", expectedResult2, 0);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV51_Defect_1456108_5()
         {
-            object[] expectedResult1 = { 0.0, 0.0, 0.0 };
             string code = @"
-class A
-{
-    b : double[];
-	
-	constructor A (x : double[])
-	{
-		b = x;
-	}
-	def add_1:double[](a: double[] )
+import(""FFITarget.dll"");
+	def add_1:double[](a: double[],  b : double[])
 	{
 		j = 0;
 		a = [Imperative]
@@ -4506,7 +4358,7 @@ class A
 		return = a;
 	}
 	
-	def add_2:double[]( )
+	def add_2:double[]( b : double[])
 	{
 		j = 0;
 		x = [Imperative]
@@ -4521,36 +4373,25 @@ class A
 		
 		return = x;
 	}
-}
 c = { 1.0, 2.0, 3.0 };
-a1 = A.A( c );
-b1 = a1.add_1( c );
-b2 = a1.add_2( );
-t = a1.b;
+b1 = add_1( c, c );
+b2 = add_2(c);
 c = { -1, -1, -1 };";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             //Assert.Fail("1467238 - Sprint25: rev 3420 : REGRESSION : Update issue when class collection property is updated");
-            thisTest.Verify("t", expectedResult1, 0);
+            object[] expectedResult1 = { 0.0, 0.0, 0.0 };
             thisTest.Verify("b2", expectedResult1, 0);
             thisTest.Verify("b1", expectedResult1, 0);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV52_Defect_1456397()
         {
             string code = @"
-class A
-{
-	a : var;
-	
-	constructor CreateA ( a1 : int )
-	{	
-		a = a1 ;
-	}		
-	
-	def CreateNewVal ( )
+import(""FFITarget.dll"");
+	def CreateNewVal ( a )
 	{
 		y = [Imperative]
 		{
@@ -4562,47 +4403,36 @@ class A
  		}
 		return = y + a;
 	}
-}
-b1;
-[Associative]
+
+b1 = [Associative]
 {
-    a1 = A.CreateA(1);
-	b1 = a1.CreateNewVal();
-}";
+	return = CreateNewVal(1);
+}
+";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("b1", 12);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV53_Defect_1456397_2()
         {
             string code = @"
-class A
+import(""FFITarget.dll"");
+def CreateNewVal (a )
 {
-	a : var;
-	
-	constructor CreateA ( a1 : int )
-	{	
-		a = a1 ;
-	}		
-	
-	def CreateNewVal ( )
+	y = [Associative]
 	{
-		y = [Associative]
-		{
-			return = a;
- 		}
-		return = y + a;
-	}
+		return = a;
+ 	}
+	return = y + a;
 }
-b1;
-[Imperative]
+b1 = [Imperative]
 {
-    a1 = A.CreateA(1);
-	b1 = a1.CreateNewVal();
-}";
+	return = CreateNewVal(1);
+}
+";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("b1", 2);
         }
@@ -4676,7 +4506,7 @@ x;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void TV56_Defect_1456571_3()
         {
@@ -4751,36 +4581,30 @@ f1;f2;f3;f4;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV58_Defect_1455278()
         {
             string code = @"
-class A
-{
-    a : var;
-    constructor A ( i )
-	{
-		a = i;
-	}
-	
-	def foo : int ( a1 : int )
+import(""FFITarget.dll"");
+	def foo : int ( a1 : int, a )
 	{
 		c = [Imperative]
 		{
 			d = 0;
 			if( a1 > 1 )
-		{
-			d = 1;
+		    {
+			    d = 1;
+		    }
+		    return = d;	
 		}
-		return = d;	
-		}
-	return  = a + c;
+	    return = a + c;
 	}
-}
-	a1 = A.A(1);
-	b1 = a1.foo(2); 
-	b2 = a1.foo(0); ";
+
+	a = 1;
+	b1 = foo(2, a); 
+	b2 = foo(0, a); 
+";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("b1", 2, 0);
             thisTest.Verify("b2", 1, 0);
@@ -4961,73 +4785,45 @@ c;d;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV65_Defect_1455090_4()
         {
             string code = @"
-class A
+import(""FFITarget.dll"");
+def foo: int(a : int[]..[])
 {
-	a : var[]..[];
-	
-	constructor Create( a1 : int[]..[])
-	{
-		a = a1;
-	}
-	
-	def foo: int( )
-	{
-		return = a[0][0];
-	}	
-		
-}
-	
-	b = {{1,2},{3,4}};
-	A1 = A.Create( b );
-	a = A1.foo();
-	
-		
+	return = a[0][0];
+}	
+b = {{1,2},{3,4}};
+a = foo( b );
 	";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("a", 1, 0);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV66_Defect_1455090_5()
         {
             string code = @"
-class A
-{
-	a : var;
-	
-	constructor Create( a1 :int)
-	{
-		a = a1;
-	}
-	
-	def foo: int( )
-	{
-		return = a;
-	}	
-		
-}
-	def objarray:A ( arr : A[]..[] )
+import(""FFITarget.dll"");
+	def objarray:ClassFunctionality ( arr : ClassFunctionality[]..[] )
 	{
 		return = arr[1][0];
 	}
 	
-	A1 = A.Create( 1 );
-	A2 = A.Create( 3 );
-	A3 = A.Create( 5 );
-	A4 = A.Create( 7 );
+	A1 = ClassFunctionality.ClassFunctionality( 1 );
+	A2 = ClassFunctionality.ClassFunctionality( 3 );
+	A3 = ClassFunctionality.ClassFunctionality( 5 );
+	A4 = ClassFunctionality.ClassFunctionality( 7 );
 	
 	B = { { A1,A2 },{ A3,A4} };
 	
 	b = objarray( B );
 	
-	c = b.foo();
+	c = b.IntVal;
 	
 	
 	
@@ -5037,92 +4833,76 @@ class A
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV67_Defect_1455090_6()
         {
             string code = @"
-class A
+import(""FFITarget.dll"");
+c = [Imperative]
 {
-	a : var;
-	
-	constructor Create( a1 :int)
+	def objarray:ClassFunctionality ( arr : ClassFunctionality[]..[] )
 	{
-		a = a1;
+		return = arr[1][0];
 	}
 	
-	def foo: int( )
-	{
-		return = a;
-	}	
+	A1 = ClassFunctionality.ClassFunctionality( 1 );
+	A2 = ClassFunctionality.ClassFunctionality( 3 );
+	A3 = ClassFunctionality.ClassFunctionality( 5 );
+	A4 = ClassFunctionality.ClassFunctionality( 7 );
+	
+	B = { { A1,A2 },{ A3,A4} };
 		
+	b = objarray( B );
+	
+	return = b.IntVal;
 }
-c;
-	[Imperative]
-	{
-		def objarray:A ( arr : A[]..[] )
-		{
-			return = arr[1][0];
-		}
-	
-		A1 = A.Create( 1 );
-		A2 = A.Create( 3 );
-		A3 = A.Create( 5 );
-		A4 = A.Create( 7 );
-	
-		B = { { A1,A2 },{ A3,A4} };
-		
-		b = objarray( B );
-	
-		c = b.foo();
-	}";
+";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("c", 5);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV68_Defect_1455090_7()
         {
             //Assert.Fail("1463372 - Sprint 20 : Rev 2088 : Imperative code is not allowed in class constructor ");
 
             string code = @"
-class A
+import(""FFITarget.dll"");
+def create(i:int)
 {
-	a : var;
-	
-	constructor create(i:int)
+	return = [Imperative]
 	{
-		[Imperative]
+	    a = null;
+		if( i == 1 )
 		{
-			if( i == 1 )
-			{
-				a = { { 1,2,3 } , { 4,5,6 } };
-			}
-			else
-			{
-			    a = { { 1,2,3 } , { 1,2,3 } };
-			}
+			a = { { 1,2,3 } , { 4,5,6 } };
 		}
-	
-	}
-	
-	def compare:int ( b : int[]..[], i : int, j : int )
-	{
-		temp = [Imperative]
+		else
 		{
-		    if( b[i][j] == a[i][j] )
-		        return = 1;
-			return = 0;
+			a = { { 1,2,3 } , { 1,2,3 } };
 		}
-		return = temp ;
+	    return = a;
 	}
 }
+	
+def compare:int ( b : int[]..[], a : int[]..[], i : int, j : int )
+{
+	temp = [Imperative]
+	{
+		if( b[i][j] == a[i][j] )
+		    return = 1;
+		return = 0;
+	}
+	return = temp ;
+}
+
 b1 = { {1, 2, 3},{ 1, 2, 3} };
-A1 = A.create(1);
-a1 = A1.compare( b1, 0, 0 );
-a2 = A1.compare( b1, 1, 1 );
+a = create(1);
+a1 = compare( b1, a, 0, 0 );
+a2 = compare( b1, a, 1, 1 );
 	";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("a1", 1);
@@ -5130,7 +4910,7 @@ a2 = A1.compare( b1, 1, 1 );
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_Redundant")]
         [Category("SmokeTest")]
         public void TV69_Defect_1456799()
         {
@@ -5166,7 +4946,7 @@ bcurvePtX = bcurvePt.X;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_Redundant")]
         [Category("SmokeTest")]
         public void TV69_Defect_1456799_2()
         {
@@ -5201,7 +4981,7 @@ bcurvePtX = bcurve.P[1].X;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_Redundant")]
         [Category("SmokeTest")]
         public void TV69_Defect_1456799_3()
         {
@@ -5240,40 +5020,19 @@ bcurvePtX;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV70_Defect_1456798()
         {
             string code = @"
-class Point
-{
-    X : var;
-    Y : var;
-    Z : var;
-    constructor ByCoordinates(x : double, y : double, z : double)
-    {
-        X = x;
-        Y = y;
-        Z = z;
-    }
-}
-class BSplineCurve
-{
-    Pts : var[];
-	
-	constructor ByPoints(ptsOnCurve : Point[])
-    {
-	    Pts = ptsOnCurve;
-    }
-}
-pt1 = Point.ByCoordinates(0,0,0);
-pt2 = Point.ByCoordinates(5,0,0);
-pt3 = Point.ByCoordinates(10,0,0);
-pt4 = Point.ByCoordinates(15,0,0);
-pt5 = Point.ByCoordinates(20,0,0);
+import(""FFITarget.dll"");
+pt1 = DummyPoint.ByCoordinates(0,0,0);
+pt2 = DummyPoint.ByCoordinates(5,0,0);
+pt3 = DummyPoint.ByCoordinates(10,0,0);
+pt4 = DummyPoint.ByCoordinates(15,0,0);
+pt5 = DummyPoint.ByCoordinates(20,0,0);
 pts = {pt1, pt2, pt3, pt4, pt5};
-bcurve = BSplineCurve.ByPoints(pts);
-p = bcurve.Pts[2];
+p = pts[2];
 X = p.X;
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
@@ -5594,7 +5353,7 @@ sum1;sum2;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("Method Resolution")]
         public void TV77_Defect_1455259()
         {
@@ -5607,22 +5366,8 @@ def foo2 : int ( a : int )
 {
 	return  = a + 1;
 }
-class A
-{
-    a1: var;
-	constructor A ( a)
-	{
-	    a1 = a;
-	}
-	def foo2  ( a : int )
-	{
-	    return  = a + a1;
-	}
-    
-}
 x1;y11;y21;
 x2;y12;y22;
-b;
 [Associative]
 {
     def foo : int ( a : int )
@@ -5655,9 +5400,6 @@ b;
 	x2 = 1;	
 	y12 = foo(x2);
 	y22 = foo1(x2);
-	a = A.A(1);
-	b = a.a1;
-	c = a.foo2(1);	
 	
 }
 ";
@@ -5668,11 +5410,10 @@ b;
             thisTest.Verify("x2", 1);
             thisTest.Verify("y12", 2);
             thisTest.Verify("y22", 2);
-            thisTest.Verify("b", 1);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void TV77_Defect_1455259_2()
         {
@@ -5763,7 +5504,7 @@ z2 = [Imperative]
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void TV78_Defect_1460866_2()
         {
@@ -5805,24 +5546,17 @@ z2 = x2.foo();
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV79_Defect_1462300()
         {
             string code = @"
-def testcall(a:test) 
+import(""FFITarget.dll"");
+def testcall(a:ClassFunctionality) 
 { 
 return ={a.ImNotDefined(),a.ImNotDefined()}; 
 } 
-class test 
-{ 
-p1 : var; 
-constructor test() 
-{ 
-p1=1; 
-} 
-}; 
-a= test.test(); 
+a= ClassFunctionality.ClassFunctionality(); 
 b=testcall(a); 
 aa = b[0]; 
 bb = b[1]; 
@@ -5836,23 +5570,16 @@ bb = b[1];
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV79_Defect_1462300_2()
         {
             string code = @"
-def testcall(a:test) 
+import(""FFITarget.dll"");
+def testcall(a:ClassFunctionality) 
 { 
 return ={a.ImNotDefined(),a.ImNotDefined()}; 
 } 
-class test 
-{ 
-p1 : var; 
-constructor test() 
-{ 
-p1=1; 
-} 
-}; 
 a= null; 
 b=testcall(a); 
 ";
@@ -5862,35 +5589,29 @@ b=testcall(a);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV79_Defect_1462300_3()
         {
             //Assert.Fail("1462300 - sprint 19 - rev 1948-316037 - if return an array of functions as properties then it does not return all of them");
 
             string code = @"
-def testcall2 :test[] () 
+import(""FFITarget.dll"");
+def testcall2 :ClassFunctionality[] () 
 { 	
-	return ={test.test(), test.test()}; 
+	return ={ClassFunctionality.ClassFunctionality(), ClassFunctionality.ClassFunctionality()}; 
 } 
 def testcall3 :int[] () 
 { 	
-	return ={test.test().x, test.test().y}; 
+	return ={ClassFunctionality.ClassFunctionality(), ClassFunctionality.ClassFunctionality()}; 
 } 
-def testcall4 :test[] () 
+def testcall4 :ClassFunctionality[] () 
 { 	
 	return ={null, null}; 
 } 
-class test 
-{ 
-	x : var;
-	y : var;
-}; 
 b = testcall2(); 
-//c = b.x; // expected : { null, null }
-d = testcall3(); // expected : { null, null }
-e1 = testcall4(); // expected : { null, null }
-//f = e1.y; // expected : { null, null }
+d = testcall3(); 
+e1 = testcall4(); 
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             Object[] v2 = new Object[] { null, null };
@@ -6249,25 +5970,22 @@ a;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV85_Function_Return_Type_Var_User_Defined_Type_Conversion()
         {
             string code = @"
-class A
-{
-    x : int;
-}
+import(""FFITarget.dll"");
 def goo : var()
 {
-    return = A.A();
+    return = ClassFunctionality.ClassFunctionality();
 }
-def foo : A ()
+def foo : ClassFunctionality ()
 {
     return = goo();
 }
 a = foo();
-b = a.x;";
+b = a.IntVal;";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
 
             thisTest.Verify("b", 0);
@@ -6297,7 +6015,7 @@ b = f2( { null, null } );
 
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void TV87_Defect_1464027()
         {
@@ -6355,7 +6073,7 @@ t11;t12;t13;t14;t15;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void TV87_Defect_1464027_2()
         {
@@ -6412,7 +6130,7 @@ t11;t12;t13;t14;t15;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void TV87_Defect_1464027_3()
         {
@@ -6470,7 +6188,7 @@ t11;t12;t13;t14;t15;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void TV87_Defect_1464027_4()
         {
@@ -6528,7 +6246,7 @@ t11;t12;t13;t14;t15;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void TV87_Defect_1464027_5()
         {
@@ -6663,44 +6381,45 @@ d1 = [Imperative]
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV89_Implicit_Type_Conversion_1()
         {
             string code = @"
-class A
+def bar ( x : bool )
 {
-    y : bool;
-	constructor A ( x : bool )
-	{
-	    y = x && true;
-	}
-	def foo: bool ( x : bool )
-	{
-		[Imperative]
-		{
-		    if( x == false )
-			    y = true;
-			else
-			    y = false;
-		}		
-		return = y;
-	}
+	return = x && true;
 }
-c = A.A ( 6 );
-y1 = c.foo( 6 );
-c1 = A.A ( 0 );
-y2 = c1.foo( 0 ); 
+def foo: bool ( x : bool, y : bool )
+{
+	[Imperative]
+	{
+		if( x == false )
+        {
+			y = true;
+        }
+		else
+        {
+			y = false;
+        }
+	}		
+	return = y;
+}
+
+c = bar ( 6 );
+y1 = foo( 6, c);
+c1 = bar( 0 );
+y2 = foo( 0, c1 ); 
 d = [Imperative]
 {
-    return = A.A ( -3 );
+    return = bar ( -3 );
 }
-y3 = d.foo ( -3 );
+y3 = foo ( -3, d );
 d1 = [Imperative]
 {
-    return = A.A ( 0 );
+    return = bar ( 0 );
 }
-y4 = d1.foo ( 0 );
+y4 = foo ( 0, d1 );
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("y1", false);
@@ -6776,70 +6495,52 @@ b1 = a;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV90_Defect_1463474_4()
         {
             string code = @"
-class A
+def foo : void  ( )
 {
-    a :int = 3;
-	def foo : void  ( )
-	{
-		a = 2;		
-	}
+	a = 2;		
 }
-c1 = A.A();
-b1 = c1.foo();
-d1 = c1.a;	
+b1 = foo();
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             Object v1 = null;
             thisTest.Verify("b1", v1);
-            thisTest.Verify("d1", 2);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV91_Defect_1463703()
         {
             string code = @"
-def foo2 : int ( a : int )
+def Create : var ( a)
 {
-	return  = a + 1;
+	return = a;
 }
-class A
+def foo2  ( a : int, a1: var)
 {
-    a1: var;
-	constructor A ( a)
-	{
-	    a1 = a;
-	}
-	def foo2  ( a : int )
-	{
-	    return  = a + a1;
-	}
+	return  = a + a1;
+}
     
-}
 b;c;d;
 [Imperative]
 {
-	a = A.A(1);
-	b = a.a1;
-	c = a.foo2(1);
-	d = foo2(1);	
+	b = Create(1);
+	c = foo2(1, b);
 }
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
 
-            thisTest.Verify("c", 2);
-            thisTest.Verify("d", 2);
             thisTest.Verify("b", 1);
+            thisTest.Verify("c", 2);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_Redundant")]
         public void TV91_Defect_1463703_2()
         {
             //This failure is no longer related to this defect. Back to TD.
@@ -6909,7 +6610,7 @@ y1;y2;y3;y4;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_Failing")]
         [Category("Method Resolution")]
         [Category("Failure")]
         public void TV91_Defect_1463703_3()
@@ -6988,29 +6689,22 @@ x2 =
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV92_Accessing_Variables_Declared_Inside_Function_Body()
         {
             string code = @"
-class A
-{
-    a : var;
-    constructor A ( y )
-    {
-        a = y;
-    }
-}
+import(""FFITarget.dll"");
 def foo ( )
 {
     a = { 1, 2, 3};
-    b = A.A(10);
+    b = ClassFunctionality.ClassFunctionality(10);
     return = {a,b};
 }
 x = foo ();
 a = x[0][0]; // expected 1, received 1
 b = x[1];
-c = b.a; // expected 10, received 10";
+c = b.IntVal; // expected 10, received 10";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
 
             thisTest.Verify("a", 1);
@@ -7018,33 +6712,23 @@ c = b.a; // expected 10, received 10";
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TV93_Modifying_Global_Var_In_Func_Call()
         {
             string code = @"
-class Point
+import(""FFITarget.dll"");
+def foo ( p: DummyPoint)
 {
-    X : var;
-	Y: var;
-	Z: var;
-	constructor Point ( x, y, z )
-	{
-	    X = x;
-		Y = y;
-		Z = z;
-	}
-	def foo ( p: Point)
-	{
-	    return = Point.Point( (p.X), (p.Y), (p.Z) );
-	}
+	return = DummyPoint.ByCoordinates( (p.X), (p.Y), (p.Z) );
 }
-def func1(pts : Point[]) 
+
+def func1(pts : DummyPoint[]) 
 {
   pts[1] = pts[0];
   return = null;
 }
-p1 = Point.Point ( 0,0,0);
-p2 = Point.Point ( 1, 1, 1 );
+p1 = DummyPoint.ByCoordinates( 0,0,0);
+p2 = DummyPoint.ByCoordinates( 1, 1, 1 );
 p = { p1, p2 }; 
 xx = p[1].X;
 yy = p[1].Y;
@@ -7059,27 +6743,16 @@ dummy = func1(p);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TV93_Modifying_Global_Var_In_Func_Call_2()
         {
             string code = @"
-class Point
+import(""FFITarget.dll"");
+def foo ( p: DummyPoint)
 {
-    X : var;
-	Y: var;
-	Z: var;
-	constructor Point ( x, y, z )
-	{
-	    X = x;
-		Y = y;
-		Z = z;
-	}
-	def foo ( p: Point)
-	{
-	    return = Point.Point( (p.X), (p.Y), (p.Z) );
-	}
+	return = DummyPoint.ByCoordinates( (p.X), (p.Y), (p.Z) );
 }
-def func1(pts : Point[]) 
+def func1(pts : DummyPoint[]) 
 {
   pts[1] = pts[0];
   return = null;
@@ -7102,33 +6775,23 @@ dummy = func1(p);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TV93_Modifying_Global_Var_In_Func_Call_3()
         {
             string code = @"
-class Point
+import(""FFITarget.dll"");
+def foo ( p: DummyPoint)
 {
-    X : var;
-	Y: var;
-	Z: var;
-	constructor Point ( x, y, z )
-	{
-	    X = x;
-		Y = y;
-		Z = z;
-	}
-	def foo ( p: Point)
-	{
-	    return = Point.Point( (p.X), (p.Y), (p.Z) );
-	}
+	return = DummyPoint.ByCoordinates( (p.X), (p.Y), (p.Z) );
 }
-def func1(p1 : Point, p2 : Point) 
+
+def func1(p1 : DummyPoint, p2 : DummyPoint) 
 {
   p1 = p1.foo(p2);
   return = null;
 }
-p1 = Point.Point ( 0,0,0);
-p2 = Point.Point ( 1, 1, 1 );
+p1 = DummyPoint.ByCoordinates( 0,0,0);
+p2 = DummyPoint.ByCoordinates( 1, 1, 1 );
 dummy = func1(p1, p2);
 xx = p1.X; 
 yy = p1.Y; 
@@ -7142,26 +6805,16 @@ zz = p1.Z;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TV93_Modifying_Global_Var_In_Func_Call_4()
         {
             string code = @"
-class Point
+import(""FFITarget.dll"");
+def foo ( p: DummyPoint)
 {
-    X : var;
-	Y: var;
-	Z: var;
-	constructor Point ( x, y, z )
-	{
-	    X = x;
-		Y = y;
-		Z = z;
-	}
-	def foo ( p: Point)
-	{
-	    return = Point.Point( (p.X+X), (p.Y+Y), (p.Z+Z) );
-	}
+	return = DummyPoint.ByCoordinates( (p.X+X), (p.Y+Y), (p.Z+Z) );
 }
+
 def UnionBox(combined : Point, arr : Point[], index : int) {
   
   // Nothing changed for combined outside Unionbox()
@@ -7175,7 +6828,7 @@ def UnionBox(combined : Point, arr : Point[], index : int) {
   }
   return = null;
 }
-points = { Point.Point ( 0,0,0), Point.Point ( 1, 1, 1 ), Point.Point ( 2, 2, 2 ), Point.Point ( 3, 3, 3 ) };
+points = { DummyPoint.ByCoordinates( 0,0,0), DummyPoint.ByCoordinates( 1, 1, 1 ), DummyPoint.ByCoordinates( 2, 2, 2 ), DummyPoint.ByCoordinates( 3, 3, 3 ) };
 top_index = Count( points ) - 2;
 base_index = Count ( points ) -1;
 s = points[base_index];
@@ -7192,7 +6845,7 @@ s1 = UnionBox(s, points, top_index);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void TV95_Method_Resolution_Derived_Class_Arguments()
         {
@@ -7307,15 +6960,13 @@ x = [Imperative]
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV97_Heterogenous_Objects_As_Function_Arguments_No_Replication()
         {
             string code = @"
-class A
-{
-}
-a1 = A.A();
+import(""FFITarget.dll"");
+a1 = ClassFunctionality.ClassFunctionality();
 def foo ( x : double[])
 {
     return = x;
@@ -7338,20 +6989,13 @@ b3 = foo ( a3 );
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV97_Heterogenous_Objects_As_Function_Arguments_No_Replication_2()
         {
             string code = @"
-class A
-{
-    t1 : var;
-    constructor A ( t2 :  var )
-    {
-        t1 = t2;
-    }
-}
-a = A.A(1);
+import(""FFITarget.dll"");
+a = ClassFunctionality.ClassFunctionality(1);
 def foo ( x : var[])
 {
     return = 1;
@@ -7391,15 +7035,13 @@ b3 = foo ( a3 );
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV97_Heterogenous_Objects_As_Function_Arguments_With_Replication_2()
         {
             string code = @"
-class A
-{
-}
-a1 = A.A();
+import(""FFITarget.dll"");
+a1 = ClassFunctionality.ClassFunctionality();
 def foo ( x : var)
 {
     return = 1;
@@ -7604,18 +7246,16 @@ b1 = foo ( a1 );";
 
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TV99_Defect_1463456_Array_By_Reference_Issue()
         {
             string errmsg = " 1467318 -  Cannot return an array from a function whose return type is var with undefined rank (-2)  ";
-            string code = @"class A
-{
-a = {1,2,3};
-}
-a = A.A();
-val = a.a;
+            string code = @"
+import(""FFITarget.dll"");
+a = ArrayMember.Ctor({1,2,3});
+val = a.X;
 val[0] = 100;
-t = a.a[0]; //expected 100; received 1";
+t = a.X[0]; //expected 100; received 1";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("val", new object[] { 100, 2, 3 });
             thisTest.Verify("t", 1);
@@ -7638,7 +7278,7 @@ t = val[0]; //expected 100, received 1";
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         public void T100_Class_inheritance_replication()
         {
             string code = @"
@@ -7664,7 +7304,7 @@ b = c.Test(c);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         public void T100_Class_inheritance_replication_2()
         {
             // Assert.Fail("1467131- Sprint 24 - Rev 2910 method overload with replication , throws error WARNING: Multiple type+pattern match parameters found, non-deterministic dispatch" );
@@ -7691,7 +7331,7 @@ result = c.Test(c);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         [Category("Method Resolution")]
         public void T100_Defect_Class_inheritance_dispatch()
         {
@@ -7722,7 +7362,7 @@ r2 = b.Test(b);//1
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         [Category("Method Resolution")]
         public void T100_Defect_Class_inheritance_dispatch_a()
         {
@@ -7749,7 +7389,7 @@ r2 = b.Test(b);//1
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         public void T100_Defect_Class_inheritance_replication_1()
         {
             String code =
@@ -7895,81 +7535,58 @@ t = foo()[0];";
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TV101_Indexing_Into_classCall_1463234_6()
         {
             // Assert.Fail("1467131- Sprint 24 - Rev 2910 method overload with replication , throws error WARNING: Multiple type+pattern match parameters found, non-deterministic dispatch" );
             string code = @"
-class test{
-	constructor test()
-	{
-	}
-	def foo()
-	{
-		return = {1,2};
-	}
+def foo()
+{
+	return = {1,2};
 }
-a=test.test();
-t = a.foo()[0];";
+t = foo()[0];";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
 
             thisTest.Verify("t", 1);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TV101_Indexing_Into_classCall_1463234_7()
         {
             // Assert.Fail("1467131- Sprint 24 - Rev 2910 method overload with replication , throws error WARNING: Multiple type+pattern match parameters found, non-deterministic dispatch" );
             string code = @"
-class test{
-	constructor test()
-	{
-	}
-	def foo()
-	{
-		return = {1,2};
-	}
-}
-t;
-[Imperative]
+def foo()
 {
-a=test.test();
-t = a.foo()[0];
-}";
+	return = {1,2};
+}
+t = [Imperative]
+{
+    return = foo()[0];
+}
+";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("t", 1);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TV102_GlobalVariable_Function_1466768()
         {
             // Assert.Fail("1467131- Sprint 24 - Rev 2910 method overload with replication , throws error WARNING: Multiple type+pattern match parameters found, non-deterministic dispatch" );
             string code = @"
-class Point
+import(""FFITarget.dll"");
+def foo ( p: DummyPoint)
 {
-X : var;
-Y: var;
-Z: var;
-	constructor Point ( x, y, z )
-	{
-		X = x;
-		Y = y;
-		Z = z;
-	}
-	def foo ( p: Point)
-	{
-		return = Point.Point( (p.X), (p.Y), (p.Z) );
-	}
+	return = DummyPoint.ByCoordinates( (p.X), (p.Y), (p.Z) );
 }
-def func1(p1 : Point, p2 : Point)
+def func1(p1 : DummyPoint, p2 : DummyPoint)
 {
-	p1 = p1.foo(p2);
+	p1 = foo(p2);
 	return = null;
 }
-p1 = Point.Point ( 0,0,0);
-p2 = Point.Point ( 1, 1, 1 );
+p1 = DummyPoint.ByCoordinates( 0,0,0);
+p2 = DummyPoint.ByCoordinates( 1, 1, 1 );
 dummy = func1(p1, p2);
 xx = p1.X; // expected 0, received 0
 yy = p1.Y; // expected 0, received 0
@@ -7983,34 +7600,23 @@ zz = p1.Z; // expected 0, received 0
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TV102_GlobalVariable_Function_1466768_1()
         {
             // Assert.Fail("1467131- Sprint 24 - Rev 2910 method overload with replication , throws error WARNING: Multiple type+pattern match parameters found, non-deterministic dispatch" );
             string code = @"
-class Point
+import(""FFITarget.dll"");
+def foo ( p: DummyPoint)
 {
-X : var;
-Y: var;
-Z: var;
-	constructor Point ( x, y, z )
-	{
-		X = x;
-		Y = y;
-		Z = z;
-	}
-	def foo ( p: Point)
-	{
-		return = Point.Point( (p.X), (p.Y), (p.Z) );
-	}
+	return = DummyPoint.ByCoordinates( (p.X), (p.Y), (p.Z) );
 }
-def func1()
+def func1(p1 : DummyPoint, p2 : DummyPoint)
 {
-	p1 = p1.foo(p2);
+	p1 = foo(p2);
 	return = null;
 }
-p1 = Point.Point ( 0,0,0);
-p2 = Point.Point ( 1, 1, 1 );
+p1 =  DummyPoint.ByCoordinates( 0,0,0);
+p2 =  DummyPoint.ByCoordinates( 1, 1, 1 );
 dummy = func1();
 xx = p1.X; // expected 0, received 0
 yy = p1.Y; // expected 0, received 0
@@ -8024,34 +7630,28 @@ zz = p1.Z; // expected 0, received 0
 
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TV102_GlobalVariable_Function_1466768_2()
         {
             // Assert.Fail("1467131- Sprint 24 - Rev 2910 method overload with replication , throws error WARNING: Multiple type+pattern match parameters found, non-deterministic dispatch" );
             string code = @"
-class Point
+import(""FFITarget.dll"");
+def foo ( p: DummyPoint)
 {
-X : var;
-Y: var;
-Z: var;
-constructor Point ( x, y, z )
+	return = DummyPoint.ByCoordinates( (p.X), (p.Y), (p.Z) );
+}
+def func1(p1 : DummyPoint, p2 : DummyPoint)
 {
-X = x;
-Y = y;
-Z = z;
+	p1 = foo(p2);
+	return = null;
 }
-def foo ( p: Point)
-{
-return = Point.Point( (p.X), (p.Y), (p.Z) );
-}
-}
-def func1(pts : Point[])
+def func1(pts : DummyPoint[])
 {
 pts[1] = pts[0];
 return = null;
 }
-p1 = Point.Point ( 0,0,0);
-p2 = Point.Point ( 1, 1, 1 );
+p1 = DummyPoint.ByCoordinates( 0,0,0);
+p2 = DummyPoint.ByCoordinates( 1, 1, 1 );
 p = { p1, p2 };
 xx = p[1].X;
 yy = p[1].Y;
@@ -8064,29 +7664,22 @@ zz = p[1].Z;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV103_Defect_1467149()
         {
             string code = @"
-class surf
+import(""FFITarget.dll"");
+convert={ClassFunctionality.ClassFunctionality(1..2), ClassFunctionality.ClassFunctionality(3)};
+def prop(test:ClassFunctionality)
 {
-	a:double;
-	constructor surf(c:double)
-	{
-		a=1;
-	}
-}
-convert={surf.surf(1..2), surf.surf(3)};
-def prop(test:surf)
-{
-	return= test.a;
+	return= test.IntVal;
 }
 b=prop(convert);
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             //Assert.Fail("1467183 - Sprint24: rev 3163 : replication on nested array is outputting extra brackets in some cases");
-            thisTest.Verify("b", new Object[] { new Object[] { 1.0, 1.0 }, 1.0 });
+            thisTest.Verify("b", new Object[] { new Object[] { 1.0, 2.0 }, 3.0 });
 
         }
 
@@ -8113,33 +7706,25 @@ b = foo ( a );
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV103_Defect_1455090_Rank_Of_Arg_2()
         {
             String code =
-@"class A
+@"
+def foo : var[][][] (X : var[][][])
 {
-    X : var[][][];
-    constructor A ( b : double[]..[] )
-    {
-        X = b;
-    }
-    def foo : var[][][] (  )
-    {
-        return = X ; 
-    }
+    return = X ; 
 }
 a = { { { 0, 1} }, { {2, 3} } };
-b = A.A ( a );
-c = b.foo();";
+c = foo(a);";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("c", new Object[] { new Object[] { new Object[] { 0.0, 1.0 } }, new Object[] { new Object[] { 2.0, 3.0 } } });
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_Redundant")]
         [Category("SmokeTest")]
         public void TV103_Defect_1455090_Rank_Of_Arg_3()
         {
@@ -8167,26 +7752,25 @@ c = b.foo();";
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV103_Defect_1455090_Rank_Of_Arg_4()
         {
             String code =
-@"  class A
+@" 
+def Create : var[][]( b : double[][] )
 {
-    X : var[][];
-    constructor A ( b : double[][] )
-    {
-        X = b;
-    }
-    def foo : var[][][] (  )
-    {
-        return = X ; 
-    }
+    return = b;
 }
+def foo : var[][][] (  X : var[][])
+{
+    return = X ; 
+}
+
 a = { { 0, 1} ,  2  };
-b = A.A ( a );
-c = b.foo();";
+b = Create( a );
+c = foo(b);
+";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             //Assert.Fail("1467183 - Sprint24: rev 3163 : replication on nested array is outputting extra brackets in some cases");
@@ -8230,26 +7814,23 @@ c = foo();";
 
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV103_Defect_1455090_Rank_Of_Arg_5()
         {
             String code =
-                @"class A
-                {
-                    X : var[][];
-                    constructor A ( b : double[][] )
-                    {
-                        X = b;
-                    }
-                    def foo : var[][][] (  )
-                    {
-                        return = X ; 
-                    }
-                }
+                @"
+def Create : var[][]( b : double[][] )
+{
+    return = b;
+}
+def foo : var[][][] (  X : var[][])
+{
+    return = X; 
+}
                 a = { 3, { 0, 1} ,  2  };
-                b = A.A ( a );
-                c = b.foo();";
+                b = A.A ( a);
+                c = foo(b);";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             //Assert.Fail("1467183 - Sprint24: rev 3163 : replication on nested array is outputting extra brackets in some cases");
@@ -8277,7 +7858,7 @@ b = foo ( a );";
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void TV104_Defect_1467112()
         {
@@ -8443,25 +8024,22 @@ d = foo({1.5,2.5});";
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV107_Defect_1467273_Function_Resolution_Over_Argument_Rank_4()
         {
             String code =
 @"
-class A
+def foo(x:int[]..[])
 {
-    def foo(x:int[]..[])
-    {
-        return = 2;
-    }
-    def foo(x:int[])
-    {
-        return = 1;
-    }
+    return = 2;
 }
-a = A.A();
-d = a.foo({1,2});";
+def foo(x:int[])
+{
+    return = 1;
+}
+
+d = foo({1,2});";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
             string errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -8469,25 +8047,22 @@ d = a.foo({1,2});";
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV107_Defect_1467273_Function_Resolution_Over_Argument_Rank_4a()
         {
             String code =
 @"
-class A
+def foo(x:int[]..[])
 {
-    def foo(x:int[]..[])
-    {
-        return = 2;
-    }
-    def foo(x:int[])
-    {
-        return = 1;
-    }
+    return = 2;
 }
-a = A.A();
-d = a.foo({1.0,2.2});";
+def foo(x:int[])
+{
+    return = 1;
+}
+
+d = foo({1.0,2.2});";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
             string errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -8514,34 +8089,34 @@ b = 1;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void TV105_Defect_1467409()
         {
             String code =
 @"
+import(""FFITarget.dll"");
 def foo ( x1: int, y1 : int )
 {
     return = x1;
 }
-class A {}
-a=A.A();
+a=ClassFunctionality.ClassFunctionality();
 r=a.foo(); // calling a non-exist function shouldn't get a warning at complie time
 b = foo1();
-d = foo(2, A.A() );
+d = foo(2, ClassFunctionality.ClassFunctionality() );
 f = foo3();
 r1;b1;d1;
 [Imperative]
 {
     r1=a.foo(); 
     b1 = foo1();
-    d1 = foo(2, A.A() );
+    d1 = foo(2, ClassFunctionality.ClassFunctionality() );
 }
 def foo3()
 {
     r2=a.foo(); 
     b2 = foo1();
-    d2 = foo(2, A.A() );
+    d2 = foo(2, ClassFunctionality.ClassFunctionality() );
     return = { r2, b2, d2 };
 }
 ";
@@ -8762,30 +8337,24 @@ p = foo(x);
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         public void TestMultiOverLoadWithDefaultArg()
         {
             string code = @"
-class Bar
+import(""FFITarget.dll"");
+def foo(x = 0, y = 0, z = 0)
 {
+    return = 41;
 }
-
-class Foo
-{
-    def foo(x = 0, y = 0, z = 0)
-    {
-        return = 41;
-    }
     
-    def foo(x : Bar)
-    {
-        return = 42;
-    }
+def foo(x : ClassFunctionality)
+{
+    return = 42;
 }
 
-b = Bar();
-f = Foo();
-r = f.foo(b); // shoudn't be resolved to foo(x = 0, y = 0, z = 0)
+
+b = ClassFunctionality.ClassFunctionality();
+r = foo(b); // shoudn't be resolved to foo(x = 0, y = 0, z = 0)
 ";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, "");
             thisTest.Verify("r", 42);

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
@@ -2083,14 +2083,21 @@ a;b;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ported")]
+        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T72_Function_Name_Checking()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
             {
                 string code = @"
-import(""FFITarget.dll"");
+class foo
+{
+    a : int;
+	constructor foo ( b : int )
+	{
+	    a = b;
+	}
+}
 [Associative]
 {
     def foo : int ( a : int )
@@ -2100,11 +2107,9 @@ import(""FFITarget.dll"");
 	}
 	foo = 1;
 	x = foo(foo);
-	y = ClassFunctionality.ClassFunctionality(foo);
-	z = y.IntVal;
-}
-	 
-	 
+	y = foo.foo(foo);
+	z = y.a;
+} 
 ";
                 ExecutionMirror mirror = thisTest.RunScriptSource(code);
             });
@@ -4299,7 +4304,7 @@ b2 = add_2( b );
             object[] expectedResult2 = { 2.0, 3.0, 4.0 };
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             // b1 is updated as well. 
-            thisTest.Verify("a1", expectedResult2, 0);
+            thisTest.Verify("c", expectedResult2, 0);
             thisTest.Verify("b2", expectedResult2, 0);
         }
 
@@ -7610,7 +7615,7 @@ def foo ( p: DummyPoint)
 {
 	return = DummyPoint.ByCoordinates( (p.X), (p.Y), (p.Z) );
 }
-def func1(p1 : DummyPoint, p2 : DummyPoint)
+def func1()
 {
 	p1 = foo(p2);
 	return = null;
@@ -7618,9 +7623,9 @@ def func1(p1 : DummyPoint, p2 : DummyPoint)
 p1 =  DummyPoint.ByCoordinates( 0,0,0);
 p2 =  DummyPoint.ByCoordinates( 1, 1, 1 );
 dummy = func1();
-xx = p1.X; // expected 0, received 0
-yy = p1.Y; // expected 0, received 0
-zz = p1.Z; // expected 0, received 0
+xx = p1.X; 
+yy = p1.Y; 
+zz = p1.Z; 
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("xx", 1);

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
@@ -7829,8 +7829,9 @@ def foo : var[][][] (  X : var[][])
     return = X; 
 }
                 a = { 3, { 0, 1} ,  2  };
-                b = A.A ( a);
-                c = foo(b);";
+                b = Create ( a);
+                c = foo(b);
+";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             //Assert.Fail("1467183 - Sprint24: rev 3163 : replication on nested array is outputting extra brackets in some cases");

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestScope.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestScope.cs
@@ -1807,28 +1807,22 @@ a = 10;
         }
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T051_Test_Identifier_Scope_01()
         {
             String code =
-  @"class A
-{
-  @a : var;
-  constructor A(@b:var)
-    {
-        @a = @b;
-    }
+  @"
+
   def foo(@c:var)
   {
     @a = @c;
     return = @a;
   }
-}
+
   @a = 1;
-  p = A.A(2);
   @t = 3;
-  @a = p.foo(@t);
+  @a = foo(@t);
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             Assert.IsTrue((Int64)mirror.GetValue("@a").Payload == 3);
@@ -1959,31 +1953,29 @@ def foo(@a:var)
 
 
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T052_DNL_1467464()
         {
             string code = @"
-class test
+def test()
 {
     f;
-    constructor test()
-    {
     [Associative]
+    {
+        i;
+        [Imperative]
         {
-            [Imperative]
-            {
-                i = 3;
-            }
-            f = i;
+            i = 3;
         }
+        f = i;
     }
+    return = f;
 }
-a = test.test();
-b = a.f;
+b = test();
 ";
             thisTest.RunScriptSource(code);
-            thisTest.Verify("b", null);
+            thisTest.Verify("b", 3);
         }
     }
 }

--- a/test/Engine/ProtoTest/UtilsTests/TextFxTests.cs
+++ b/test/Engine/ProtoTest/UtilsTests/TextFxTests.cs
@@ -11,12 +11,12 @@ namespace ProtoTest.UtilsTests
     class TextFxTests : ProtoTestBase
     {
         [Test]
-        [Category("DSDefinedClass")]
+        [Category("DSDefinedClass_Ported")]
         [Category("TextFx Tests")]
         public void BasicRunAndVerify()
         {
             String code =
-@"	class f	{		fx : var;		fy : var;		constructor f()		{			fx = 123;			fy = 345;		}	}// Construct class 'f'	cf = f.f();	x = cf.fx;	y = cf.fy;";
+@"	fx = 123;	fy = 345;	x = fx;	y = fy;";
             thisTest.RunScriptSource(code);
             thisTest.Verify("x", 123);
             thisTest.Verify("y", 345);


### PR DESCRIPTION
### Purpose

Porting/Rewriting DS defined classes to remove the DS class and only focus on the specific test.
This is submission 14/14

Refer to this top level task:
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8353

See the guidlines:
A test that uses a DS defined class should be re-written such that the DS defined class is removed.
This means doing one or a combination of the following:
1 Write an FFI class to replace the DS defined class
2 Remove the DS class if it is not necessary
3 Remove verification that is unncecessary
4 Rename the test appropriately if needed
5 If a test is ported, modify the category from DSDefinedClass to DSDefinedClass_Ported
6 If a test is NOT ported, modify the category from DSDefinedClass to DSDefinedClass_Ignored_SomeDecriptionHere
7 At the end of the class porting task, the only categories left should be DSDefinedClass_Ported and DSDefinedClass_Ignored. 
8 There should be no regressions is these tasks. Tests that must be removed completely will be done at the end of the porting /rewriting task

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate

### Reviewers

This has been reviewed by @lukechurch 