### PR TITLE
Fix for migration of custom package folder locations

### DIFF
--- a/src/DynamoCore/Core/DynamoMigrator.cs
+++ b/src/DynamoCore/Core/DynamoMigrator.cs
@@ -166,21 +166,22 @@ namespace Dynamo.Core
         /// /// <returns>new migrator instance after migration</returns>
         protected virtual DynamoMigratorBase MigrateFrom(DynamoMigratorBase sourceMigrator)
         {
-            Copy(sourceMigrator.PackagesDirectory, this.PackagesDirectory);
-            Copy(sourceMigrator.DefinitionsDirectory, this.DefinitionsDirectory);
+            Copy(sourceMigrator.PackagesDirectory, PackagesDirectory);
+            Copy(sourceMigrator.DefinitionsDirectory, DefinitionsDirectory);
 
-            this.PreferenceSettings = sourceMigrator.PreferenceSettings;
-            if (this.PreferenceSettings == null) return this;
+            PreferenceSettings = sourceMigrator.PreferenceSettings;
+            if (PreferenceSettings == null) return this;
 
             // All preference settings are copied over including custom package folders
             // However if one of the custom folder locations points to the user data directory
             // of the previous version, it needs to be replaced with that of the current version
-            var indexToreplace = this.PreferenceSettings.CustomPackageFolders.FindIndex(f => f.Contains(sourceMigrator.UserDataDirectory));
+            var folders = PreferenceSettings.CustomPackageFolders;
+            var indexToReplace = folders.FindIndex(f => f.Contains(sourceMigrator.UserDataDirectory));
             
-            if (indexToreplace <= -1) return this;
-            
-            this.PreferenceSettings.CustomPackageFolders.RemoveAt(indexToreplace);
-            this.PreferenceSettings.CustomPackageFolders.Insert(indexToreplace, this.UserDataDirectory);
+            if (indexToReplace <= -1) return this;
+
+            folders.RemoveAt(indexToReplace);
+            folders.Insert(indexToReplace, UserDataDirectory);
             
             return this;
         }

--- a/src/DynamoCore/Core/DynamoMigrator.cs
+++ b/src/DynamoCore/Core/DynamoMigrator.cs
@@ -197,11 +197,6 @@ namespace Dynamo.Core
         /// <returns>new migrator instance after migration</returns>
         public static DynamoMigratorBase MigrateBetweenDynamoVersions(IPathManager pathManager, IPathResolver pathResolver)
         {
-            // No migration required if the current version is <= version 0.7
-            if (pathManager.MajorFileVersion == 0 &&
-                pathManager.MinorFileVersion <= 7)
-                return null;
-
             var userDataDir = Path.GetDirectoryName(pathManager.UserDataDirectory);
             var versions = GetInstalledVersions(userDataDir).ToList();
             if (versions.Count() < 2)
@@ -209,8 +204,6 @@ namespace Dynamo.Core
 
             var previousVersion = versions[1];
             var currentVersion = versions[0];
-            Debug.Assert(currentVersion.MajorPart == pathManager.MajorFileVersion
-                && currentVersion.MinorPart == pathManager.MinorFileVersion);
 
             return Migrate(pathResolver, previousVersion, currentVersion);
         }

--- a/test/DynamoCoreTests/UserDataMigrationTests.cs
+++ b/test/DynamoCoreTests/UserDataMigrationTests.cs
@@ -200,14 +200,14 @@ namespace Dynamo
             if (!Directory.Exists(tempFolder))
                 Directory.CreateDirectory(tempFolder);
 
-            File.Create(Path.Combine(tempFolder, "package1.dll"));
+            using(File.Create(Path.Combine(tempFolder, "package1.dll"))) { }
 
             tempFolder = Path.Combine(userDataDir, "0.8", "definitions");
 
             if (!Directory.Exists(tempFolder))
                 Directory.CreateDirectory(tempFolder);
 
-            File.Create(Path.Combine(tempFolder, "definition1.dyn"));
+            using(File.Create(Path.Combine(tempFolder, "definition1.dyn"))) { }
 
             tempFolder = Path.Combine(userDataDir, "0.9");
 
@@ -249,7 +249,7 @@ namespace Dynamo
             mockPathResolver.Setup(x => x.UserDataRootFolder).Returns(() => userDataDir);
             mockPathManager.Setup(x => x.UserDataDirectory).Returns(() => currentVersionDir);
 
-            try
+            //try
             {
                 // Test MigrateBetweenDynamoVersions
                 var targetMigrator = DynamoMigratorBase.MigrateBetweenDynamoVersions(
@@ -275,11 +275,11 @@ namespace Dynamo
                 Assert.AreEqual(currentVersionDir,
                     targetMigrator.PreferenceSettings.CustomPackageFolders[0]);
             }
-            finally
-            {
-                // Delete folders from Temp dir
-                Directory.Delete(userDataDir, recursive: true);
-            }
+            //finally
+            //{
+            //    // Delete folders from Temp dir
+            //    Directory.Delete(userDataDir, recursive: true);
+            //}
         }
     }
 }

--- a/test/DynamoCoreTests/UserDataMigrationTests.cs
+++ b/test/DynamoCoreTests/UserDataMigrationTests.cs
@@ -186,11 +186,9 @@ namespace Dynamo
         /// Create empty packages and definitions dir in 0.9 folder
         /// </summary>
         /// <param name="userDataDir">return root folder</param>
-        private static void CreateMockDirectoriesAndFiles(out string userDataDir)
+        private void CreateMockDirectoriesAndFiles(out string userDataDir)
         {
-            
-            string tempPath = Path.GetTempPath();
-            userDataDir = Path.Combine(tempPath, "DynamoMigration");
+            userDataDir = Path.Combine(TempFolder, "DynamoMigration");
 
             var tempFolder = Path.Combine(userDataDir, "0.8");
 

--- a/test/DynamoCoreTests/UserDataMigrationTests.cs
+++ b/test/DynamoCoreTests/UserDataMigrationTests.cs
@@ -249,37 +249,29 @@ namespace Dynamo
             mockPathResolver.Setup(x => x.UserDataRootFolder).Returns(() => userDataDir);
             mockPathManager.Setup(x => x.UserDataDirectory).Returns(() => currentVersionDir);
 
-            //try
-            {
-                // Test MigrateBetweenDynamoVersions
-                var targetMigrator = DynamoMigratorBase.MigrateBetweenDynamoVersions(
-                    mockPathManager.Object, mockPathResolver.Object);
+            // Test MigrateBetweenDynamoVersions
+            var targetMigrator = DynamoMigratorBase.MigrateBetweenDynamoVersions(
+                mockPathManager.Object, mockPathResolver.Object);
 
-                // Assert that both 0.8 and 0.9 dirs are the same after migration
-                var sourcePackageDir = Path.Combine(sourceVersionDir, "packages");
-                var currentPackageDir = Path.Combine(currentVersionDir, "packages");
+            // Assert that both 0.8 and 0.9 dirs are the same after migration
+            var sourcePackageDir = Path.Combine(sourceVersionDir, "packages");
+            var currentPackageDir = Path.Combine(currentVersionDir, "packages");
 
-                bool areDirectoriesEqual = Directory.EnumerateFiles(sourcePackageDir).Select(Path.GetFileName).
-                    SequenceEqual(Directory.EnumerateFiles(currentPackageDir).Select(Path.GetFileName));
-                Assert.IsTrue(areDirectoriesEqual);
+            bool areDirectoriesEqual = Directory.EnumerateFiles(sourcePackageDir).Select(Path.GetFileName).
+                SequenceEqual(Directory.EnumerateFiles(currentPackageDir).Select(Path.GetFileName));
+            Assert.IsTrue(areDirectoriesEqual);
 
-                var sourceDefinitionDir = Path.Combine(sourceVersionDir, "definitions");
-                var currentDefinitionDir = Path.Combine(currentVersionDir, "definitions");
+            var sourceDefinitionDir = Path.Combine(sourceVersionDir, "definitions");
+            var currentDefinitionDir = Path.Combine(currentVersionDir, "definitions");
 
-                areDirectoriesEqual = Directory.EnumerateFiles(sourceDefinitionDir).Select(Path.GetFileName).
-                    SequenceEqual(Directory.EnumerateFiles(currentDefinitionDir).Select(Path.GetFileName));
-                Assert.IsTrue(areDirectoriesEqual);
+            areDirectoriesEqual = Directory.EnumerateFiles(sourceDefinitionDir).Select(Path.GetFileName).
+                SequenceEqual(Directory.EnumerateFiles(currentDefinitionDir).Select(Path.GetFileName));
+            Assert.IsTrue(areDirectoriesEqual);
 
-                // Assert that new CustomePackageFolders in preference settings
-                // for 0.9 version points to user data dir for 0.9
-                Assert.AreEqual(currentVersionDir,
-                    targetMigrator.PreferenceSettings.CustomPackageFolders[0]);
-            }
-            //finally
-            //{
-            //    // Delete folders from Temp dir
-            //    Directory.Delete(userDataDir, recursive: true);
-            //}
+            // Assert that new CustomePackageFolders in preference settings
+            // for 0.9 version points to user data dir for 0.9
+            Assert.AreEqual(currentVersionDir,
+                targetMigrator.PreferenceSettings.CustomPackageFolders[0]);
         }
     }
 }

--- a/test/DynamoCoreTests/UserDataMigrationTests.cs
+++ b/test/DynamoCoreTests/UserDataMigrationTests.cs
@@ -2,8 +2,12 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Dynamo.Core;
+using Dynamo.Interfaces;
+using Dynamo.Tests;
+using Moq;
 using NUnit.Framework;
 
 namespace Dynamo
@@ -165,6 +169,119 @@ namespace Dynamo
                 Assert.IsTrue(e.ParamName == "rootFolder");                
             }
             
+        }
+
+        private static void CreateMockPreferenceSettingsFile(string filePath, string packageDir)
+        {
+            var settings = new PreferenceSettings
+            {
+                CustomPackageFolders = new List<string>{packageDir}
+            };
+            settings.Save(filePath);
+        }
+
+        /// <summary>
+        /// Create 0.8, and 0.9 version directories in Temp dir
+        /// Create dummy package and definitions files in 0.8 dir
+        /// Create empty packages and definitions dir in 0.9 folder
+        /// </summary>
+        /// <param name="userDataDir">return root folder</param>
+        private static void CreateMockDirectoriesAndFiles(out string userDataDir)
+        {
+            
+            string tempPath = Path.GetTempPath();
+            userDataDir = Path.Combine(tempPath, "DynamoMigration");
+
+            var tempFolder = Path.Combine(userDataDir, "0.8");
+
+            if (!Directory.Exists(tempFolder))
+                Directory.CreateDirectory(tempFolder);
+
+            tempFolder = Path.Combine(userDataDir, "0.8", "packages");
+
+            if (!Directory.Exists(tempFolder))
+                Directory.CreateDirectory(tempFolder);
+
+            File.Create(Path.Combine(tempFolder, "package1.dll"));
+
+            tempFolder = Path.Combine(userDataDir, "0.8", "definitions");
+
+            if (!Directory.Exists(tempFolder))
+                Directory.CreateDirectory(tempFolder);
+
+            File.Create(Path.Combine(tempFolder, "definition1.dyn"));
+
+            tempFolder = Path.Combine(userDataDir, "0.9");
+
+            if (!Directory.Exists(tempFolder))
+                Directory.CreateDirectory(tempFolder);
+
+            tempFolder = Path.Combine(userDataDir, "0.9", "packages");
+
+            if (!Directory.Exists(tempFolder))
+                Directory.CreateDirectory(tempFolder);
+
+            tempFolder = Path.Combine(userDataDir, "0.9", "definitions");
+
+            if (!Directory.Exists(tempFolder))
+                Directory.CreateDirectory(tempFolder);
+
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void TestMigration()
+        {
+            // Create 0.8, and 0.9 version user data directories in Temp folder
+            string userDataDir;
+            CreateMockDirectoriesAndFiles(out userDataDir);
+
+            var sourceVersionDir = Path.Combine(userDataDir, "0.8");
+            var settingsFilePath = Path.Combine(sourceVersionDir, "DynamoSettings.xml");
+
+            // Create PreferenceSettings.xml file in 0.8 
+            CreateMockPreferenceSettingsFile(settingsFilePath, sourceVersionDir);
+
+            // Create mock objects for IPathManager and IPathResolver
+            var mockPathManager = new Mock<IPathManager>();
+            var mockPathResolver = new Mock<IPathResolver>();
+
+            var currentVersionDir = Path.Combine(userDataDir, "0.9");
+
+            mockPathResolver.Setup(x => x.UserDataRootFolder).Returns(() => userDataDir);
+            mockPathManager.Setup(x => x.UserDataDirectory).Returns(() => currentVersionDir);
+
+            try
+            {
+                // Test MigrateBetweenDynamoVersions
+                var targetMigrator = DynamoMigratorBase.MigrateBetweenDynamoVersions(
+                    mockPathManager.Object, mockPathResolver.Object);
+
+                // Assert that both 0.8 and 0.9 dirs are the same after migration
+                var sourcePackageDir = Path.Combine(sourceVersionDir, "packages");
+                var currentPackageDir = Path.Combine(currentVersionDir, "packages");
+
+                bool areDirectoriesEqual = Directory.EnumerateFiles(sourcePackageDir).Select(Path.GetFileName).
+                    SequenceEqual(Directory.EnumerateFiles(currentPackageDir).Select(Path.GetFileName));
+                Assert.IsTrue(areDirectoriesEqual);
+
+                var sourceDefinitionDir = Path.Combine(sourceVersionDir, "definitions");
+                var currentDefinitionDir = Path.Combine(currentVersionDir, "definitions");
+
+                areDirectoriesEqual = Directory.EnumerateFiles(sourceDefinitionDir).Select(Path.GetFileName).
+                    SequenceEqual(Directory.EnumerateFiles(currentDefinitionDir).Select(Path.GetFileName));
+                Assert.IsTrue(areDirectoriesEqual);
+
+                // Assert that new CustomePackageFolders in preference settings
+                // for 0.9 version points to user data dir for 0.9
+                Assert.AreEqual(currentVersionDir,
+                    targetMigrator.PreferenceSettings.CustomPackageFolders[0]);
+            }
+            finally
+            {
+                // Delete folders from Temp dir
+                Directory.Delete(userDataDir, recursive: true);
+            }
         }
     }
 }


### PR DESCRIPTION
### Purpose

This fixes a [defect] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8739) with migration of preference settings between Dynamo versions.

There is a new `CustomPackagesFolder` entry in the preference settings file `DynamoSettings.xml`. When this file is migrated from the older to the newer version, the “CustomPackagesFolder” setting is copied over as well. As a result the new “DynamoSettings.xml” file for `09` version for example, is also pointing its `CustomPackagesFolder` to the `08` directory. As a result when Dynamo `09` is loaded, packages are loaded up from the `08` directory, which is ... a bug!

### Declarations

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin Reviewer 1 

