### PR TITLE
Make OnActiveStateChanged virtual.

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.0.2727")]
+[assembly: AssemblyVersion("0.9.0.2734")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.0.2727")]
+[assembly: AssemblyFileVersion("0.9.0.2734")]

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -116,6 +116,16 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
         }
 
+        protected override void OnActiveStateChanged()
+        {
+            preferences.IsBackgroundPreviewActive = active;
+
+            if (active == false && CanNavigateBackground)
+            {
+                CanNavigateBackground = false;
+            }
+        }
+
         public event Action<Model3D> RequestAttachToScene;
         protected void OnRequestAttachToScene(Model3D model3D)
         {

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/Watch3DViewModelBase.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/Watch3DViewModelBase.cs
@@ -212,15 +212,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             // Override in inherited classes.
         }
 
-        private void OnActiveStateChanged()
+        protected virtual void OnActiveStateChanged()
         {
-            preferences.IsBackgroundPreviewActive = active;
-
-            if (active == false && CanNavigateBackground)
-            {
-                CanNavigateBackground = false;
-            }
-
             UnregisterEventHandlers();
             OnClear();
         }


### PR DESCRIPTION
This method needs to be virtual so that it can be overidden in consumers like Revit.

FYI:
@RodRecker This will get the build going again.
@pboyer Don't worry about the build.