### PR TITLE
Set preview in base watch view model as well.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/Watch3DViewModelBase.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/Watch3DViewModelBase.cs
@@ -214,6 +214,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         protected virtual void OnActiveStateChanged()
         {
+            preferences.IsBackgroundPreviewActive = active;
+
             UnregisterEventHandlers();
             OnClear();
         }


### PR DESCRIPTION
The preference setting for background active needs to be synchronized in the base view model as well, for situations where the Helix-based view model cannot be created.

This fixes one broken test on the CI.