### PR TITLE
Graph layout inside groups

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -925,7 +925,7 @@ namespace Dynamo.Models
         /// This function wraps a few methods on the workspace model layer
         /// to set up and run the graph layout algorithm.
         /// </summary>
-        public void DoGraphAutoLayout()
+        internal void DoGraphAutoLayout()
         {
             if (Nodes.Count() < 2) return;
 

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2164,6 +2164,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cleanup Node Layout.
+        /// </summary>
+        public static string GroupContextMenuGraphLayout {
+            get {
+                return ResourceManager.GetString("GroupContextMenuGraphLayout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ungroup.
         /// </summary>
         public static string GroupContextMenuUngroup {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1607,6 +1607,9 @@ Do you want to install the latest Dynamo update?</value>
   <data name="GroupContextMenuUngroup" xml:space="preserve">
     <value>Ungroup</value>
   </data>
+  <data name="GroupContextMenuGraphLayout" xml:space="preserve">
+    <value>Cleanup Node Layout</value>
+  </data>
   <data name="PackageDuplicateAssemblyWarning" xml:space="preserve">
     <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while {0} is not running and try again.</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1607,6 +1607,9 @@ Do you want to install the latest Dynamo update?</value>
   <data name="GroupContextMenuUngroup" xml:space="preserve">
     <value>Ungroup</value>
   </data>
+  <data name="GroupContextMenuGraphLayout" xml:space="preserve">
+    <value>Cleanup Node Layout</value>
+  </data>
   <data name="PackageDuplicateAssemblyWarning" xml:space="preserve">
     <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while {0} is not running and try again.</value>
   </data>

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -142,7 +142,10 @@
                            Click="OnDeleteAnnotation"/>
                 <MenuItem  Header="{x:Static p:Resources.GroupContextMenuUngroup}"
                                Name="UngroupAnnotation"
-                           Click="OnUngroupAnnotation"/>               
+                           Click="OnUngroupAnnotation"/>
+                <MenuItem  Header="{x:Static p:Resources.GroupContextMenuGraphLayout}"
+                               Name="GraphLayoutAnnotation"
+                           Click="OnGraphLayoutAnnotation"/>
                 <MenuItem  Header="{x:Static p:Resources.GroupContextMenuFont}"
                                Name="ChangeSize">                   
                     <MenuItem Header ="14" Name="FontSize0" Command="{Binding ChangeFontSize}" CommandParameter="14"

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -227,5 +227,20 @@ namespace Dynamo.Nodes
                 ViewModel.WorkspaceViewModel.DynamoViewModel.DeleteCommand.Execute(null);
             }
         }
+
+        /// <summary>
+        /// This function will run graph layout algorithm to the nodes inside the selected group.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
+        private void OnGraphLayoutAnnotation(object sender, RoutedEventArgs e)
+        {
+            if (ViewModel != null)
+            {
+                ViewModel.Select();
+                ViewModel.WorkspaceViewModel.DynamoViewModel.GraphAutoLayoutCommand.Execute(null);
+            }
+        }
+
     }
 }

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -567,13 +567,13 @@ namespace GraphLayout
         /// <summary>
         /// To shift the whole graph back to its original position.
         /// </summary>
-        public void SetGraphPosition()
+        public void SetGraphPosition(bool isGroupLayout)
         {
             double moveX = 0;
             double moveY = 0;
 
-            // If this is a separate subgraph then retain original position
-            if (AnchorLeftEdges.Count + AnchorRightEdges.Count == 0)
+            // If this is a group or a separate subgraph then retain original position
+            if (isGroupLayout || AnchorLeftEdges.Count + AnchorRightEdges.Count == 0)
             {
                 moveX = InitialGraphCenterX - GraphCenterX;
                 moveY = InitialGraphCenterY - GraphCenterY;

--- a/test/DynamoCoreWpfTests/GraphLayoutTests.cs
+++ b/test/DynamoCoreWpfTests/GraphLayoutTests.cs
@@ -48,9 +48,6 @@ namespace Dynamo.Tests
 
             Assert.AreEqual(ViewModel.CurrentSpace.Nodes.Count(), 1);
             Assert.AreEqual(ViewModel.CurrentSpace.Connectors.Count(), 0);
-            AssertGraphLayoutLayers(new object[] {
-                new int[] { 0, 1 }
-            });
 
             Assert.AreEqual(nodes.ElementAt(0).X, prevX);
             Assert.AreEqual(nodes.ElementAt(0).Y, prevY);


### PR DESCRIPTION
### Purpose

#### References
- [MAGN-8487](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8487) Implement group node layout and its context menu
- https://github.com/ellensi/Dynamo/pull/2 Graph layout inside groups (previous PR on my branch for code review)

#### Description
This pull request addresses several improvements on Graph Layout algorithm to handle nodes inside groups. This layout algorithm for nodes inside a group uses the same implementation as the one for selection of nodes (#5376). In addition, a group should retain its initial center position after layout.

\# | Command | Workspace state | Result | Status
:---: | :---: | --- | --- | ---
1 | Ctrl + L | Unselected graph | All nodes are laid out. Groups are treated as wholes and their contents are unchanged. | Implemented (#5127)
2 | Ctrl + L | Some nodes (and groups) are selected | Selected nodes are laid out. Selected groups are treated as wholes and their contents are unchanged. | Implemented (#5376)
3 | Ctrl + L | One or several groups are selected | Nodes inside each group are laid out. | This PR
4 | Right click on a group | One group is selected | Select ***Cleanup Node Layout*** context menu → nodes inside the group are laid out. | This PR

#### Screenshots

- **Scenario 2**: Some nodes (and groups) are selected → Ctrl + L
![image](https://cloud.githubusercontent.com/assets/6386550/10239267/a931155e-68fd-11e5-8dac-ca44cec36ec4.png)

- **Scenario 3**: One or several groups are selected → Ctrl + L
![image](https://cloud.githubusercontent.com/assets/6386550/10239268/af5c9f34-68fd-11e5-9f6c-536e5119d933.png)

- **Scenario 4**: Right click on a group → Cleanup Node Layout
![image](https://cloud.githubusercontent.com/assets/6386550/10239097/df6fb45c-68fa-11e5-9ce7-6ba6332d6111.png)

### Declarations

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] Testing: separated to another task [MAGN-8452](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8452)

### Reviewers

@aparajit-pratap

### FYIs

@Racel @lillismith @riteshchandawar @sharadkjaiswal 