### PR TITLE
MAGN-8734 Startup crash with Dynamo/Revit2016 points to SharpDX

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.0.2734")]
+[assembly: AssemblyVersion("0.9.0.2741")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.0.2734")]
+[assembly: AssemblyFileVersion("0.9.0.2741")]

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -486,6 +486,7 @@ namespace Dynamo.ViewModels
                 Model.Logger.Log("Failed to create Watch3DViewModel. Creating base view model.");
 
                 watch3DViewModel = Watch3DViewModelBase.Start(backgroundPreviewParams);
+                watch3DViewModel.Active = false;
             }
 
             BackgroundPreviewViewModel = watch3DViewModel;

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -302,6 +302,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         public void SerializeCamera(XmlElement camerasElement)
         {
+            if (camera == null) return;
+
             try
             {
                 var node = XmlHelper.AddNode(camerasElement, "Camera");
@@ -926,11 +928,13 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         public void SetCameraData(CameraData data)
         {
-            Camera.LookDirection = data.LookDirection;
-            Camera.Position = data.EyePosition;
-            Camera.UpDirection = data.UpDirection;
-            Camera.NearPlaneDistance = data.NearPlaneDistance;
-            Camera.FarPlaneDistance = data.FarPlaneDistance;
+            if (camera == null) return;
+
+            camera.LookDirection = data.LookDirection;
+            camera.Position = data.EyePosition;
+            camera.UpDirection = data.UpDirection;
+            camera.NearPlaneDistance = data.NearPlaneDistance;
+            camera.FarPlaneDistance = data.FarPlaneDistance;
         }
 
         private double CalculateNearClipPlane(double maxDim)


### PR DESCRIPTION
### Purpose

This PR adds two null checks that prevent crashes during serialization and deserialization of `Camera` objects. This prevents a crash when the `Camera` has not been set.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
  - n/a No new documentation required.
- [x] The level of testing this PR includes is appropriate
  - Existing cameral serialization/deserialization tests cover this.
- [ ] User facing strings, if any, are extracted into `*.resx` files
  - No new user-facing strings added.

### Reviewers

@mjkkirschner 

### FYIs

@jnealb 