### PR TITLE
8473 packagepublisherror

### DIFF
--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -146,13 +146,15 @@ namespace Dynamo.PackageManager
                 if (ret == null)
                 {
                     packageUploadHandle.Error("Failed to submit.  Try again later.");
+                    return;
                 }
 
                 if (ret != null && !ret.success)
                 {
                     packageUploadHandle.Error(ret.message);
+                    return;
                 }
-
+               
                 packageUploadHandle.Done(null);
             }
             catch (Exception e)

--- a/test/Libraries/PackageManagerTests/PackageManagerClientTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageManagerClientTests.cs
@@ -362,6 +362,25 @@ namespace Dynamo.PackageManager.Tests
             Assert.AreEqual(PackageUploadHandle.State.Error, handle.UploadState);
         }
 
+        [Test]
+        public void Publish_SetsErrorStatusWhenResponseIsNull()
+        {
+            var gc = new Mock<IGregClient>();
+            var rb = new ResponseBody();
+            rb.success = false;
+           
+            gc.Setup(x => x.ExecuteAndDeserialize(It.IsAny<PackageUpload>())).Returns(rb);
+
+            var pc = new PackageManagerClient(gc.Object, MockMaker.Empty<IPackageUploadBuilder>(), "");
+
+            var pkg = new Package("", "Package", "0.1.0", "MIT");
+
+            var handle = new PackageUploadHandle(PackageUploadBuilder.NewRequestBody(pkg));
+            pc.Publish(pkg, Enumerable.Empty<string>(), true, handle);
+
+            Assert.AreEqual(PackageUploadHandle.State.Error, handle.UploadState);
+        }
+
         #endregion
 
         #region Deprecate


### PR DESCRIPTION
### Purpose

This PR fixes an issue where null or non success responses from the package manager would still close the window confusing the user and not displaying the error message.

If we encounter a null or non success response we return from the publish method - the publish window will stay open and the error message will be displayed correctly.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ramramps 

##### FYI

@jnealb - for a new test