### PR TITLE
MAGN-8515 Change appearance of geometry lines in background preview so that users can distinguish them more easily from the grid.

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.0.2776")]
+[assembly: AssemblyVersion("0.9.0.2777")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.0.2776")]
+[assembly: AssemblyFileVersion("0.9.0.2777")]

--- a/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
@@ -38,9 +38,9 @@ namespace Dynamo.Core.Threading
     /// 
     class UpdateRenderPackageAsyncTask : AsyncTask
     {
-        private const byte DefR = 101;
-        private const byte DefG = 86;
-        private const byte DefB = 130;
+        private const byte DefR = 0;
+        private const byte DefG = 0;
+        private const byte DefB = 0;
         private const byte DefA = 255;
         private const byte MidTone = 180;
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1023,7 +1023,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                         }
                         else
                         {
-                            lineGeometry3D = CreateLineGeometryModel3D(rp);
+                            // If the package contains mesh vertices, then the lines represent the 
+                            // edges of meshes. Draw them with a different thickness.
+                            lineGeometry3D = CreateLineGeometryModel3D(rp, rp.MeshVertices.Any()?0.5:1.0);
                             Model3DDictionary.Add(id, lineGeometry3D);
                         }
 
@@ -1153,19 +1155,18 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     Console.WriteLine(ex.StackTrace);
                 }
             }
-            //((MaterialGeometryModel3D)meshGeometry3D).SelectionColor = defaultSelectionColor;
 
             return meshGeometry3D;
         }
 
-        private DynamoLineGeometryModel3D CreateLineGeometryModel3D(HelixRenderPackage rp)
+        private DynamoLineGeometryModel3D CreateLineGeometryModel3D(HelixRenderPackage rp, double thickness = 1.0)
         {
             var lineGeometry3D = new DynamoLineGeometryModel3D()
             {
                 Geometry = HelixRenderPackage.InitLineGeometry(),
                 Transform = Model1Transform,
                 Color = Color.White,
-                Thickness = 0.5,
+                Thickness = thickness,
                 IsHitTestVisible = false,
                 IsSelected = rp.IsSelected
             };

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -80,7 +80,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private readonly Color4 directionalLightColor = new Color4(0.9f, 0.9f, 0.9f, 1.0f);
         private readonly Color4 defaultSelectionColor = new Color4(new Color3(0, 158.0f / 255.0f, 1.0f));
         private readonly Color4 defaultMaterialColor = new Color4(new Color3(1.0f, 1.0f, 1.0f));
-        private readonly Size defaultPointSize = new Size(8, 8);
+        private readonly Size defaultPointSize = new Size(4, 4);
         private readonly Color4 defaultLineColor = new Color4(new Color3(0, 0, 0));
         private readonly Color4 defaultPointColor = new Color4(new Color3(0, 0, 0));
 


### PR DESCRIPTION
This PR addresses [MAGN-8515](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8515). 

- The default color for points and lines is set to black.
- The line thickness for curves is increased from 0.5 to 1.0.
- The line thickness for edges remains at 0.5.
- The size of points is decreased from 8px to 4px. 

![image](https://cloud.githubusercontent.com/assets/1139788/10293006/14155d10-6b67-11e5-8d4c-c5023d080c3f.png)

Curves with a thickness of 1.0 with mesh edges with a thickness of 0.5:
![image](https://cloud.githubusercontent.com/assets/1139788/10294830/82fe243c-6b71-11e5-841a-8a190aa3fbcd.png)

Points at 4x4px:
![image](https://cloud.githubusercontent.com/assets/1139788/10294969/404187f0-6b72-11e5-94cc-fdcf30786337.png)


### Reviewers:
@ramramps 
@Racel
@lillismith 