### PR TITLE
MAGN-8750 Pan is getting stuck even after pressing Esc, it doesn't get rest to normal selection.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/Watch3DViewModelBase.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/Watch3DViewModelBase.cs
@@ -458,6 +458,12 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             // Override in derived classes
         }
 
+        internal void CancelNavigationState()
+        {
+            if(IsPanning) TogglePan(null);
+            if(IsOrbiting) ToggleOrbit(null);
+        }
+
         #region command methods
 
         internal void TogglePan(object parameter)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1030,9 +1030,19 @@ namespace Dynamo.Controls
         // passes it to thecurrent workspace
         void DynamoView_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key != Key.Escape || !IsMouseOver || !e.IsRepeat) return;
+            if (e.Key != Key.Escape || !IsMouseOver) return;
 
-            dynamoViewModel.BackgroundPreviewViewModel.NavigationKeyIsDown = true;
+            var vm = dynamoViewModel.BackgroundPreviewViewModel;
+
+            if (e.IsRepeat)
+            {
+                vm.NavigationKeyIsDown = true;
+            }
+            else
+            {
+                vm.CancelNavigationState();
+            }
+            
             e.Handled = true;
         }
 


### PR DESCRIPTION
This PR addresses [MAGN-8750](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8750). A new method `CancelNavigationState()` is added to cancel the navigation state when the `Esc` key is pressed (but not held). Now, when the user selects either the pan or orbit modes, while navigating 3D, then they hit escape, their current navigation mode will be deselected. If they are in pan mode, their current mode will stay set when they switch back to 2D navigation, until they press the `Esc` key, or they toggle the button.

### Reviewer:
@mjkkirschner 

