### PR TITLE
Fix magn-8575: exception in node to code for unknown types

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -5895,8 +5895,8 @@ namespace ProtoAssociative
                 if (returnType.UID == (int)PrimitiveType.kInvalidType)
                 {
                     string message = String.Format(ProtoCore.Properties.Resources.kReturnTypeUndefined, funcDef.ReturnType.Name, funcDef.Name);
-                    buildStatus.LogWarning(ProtoCore.BuildData.WarningID.kTypeUndefined, message, core.CurrentDSFileName, funcDef.line, funcDef.col, graphNode);
-                    returnType.UID = (int)PrimitiveType.kTypeVar;
+                    buildStatus.LogWarning(WarningID.kTypeUndefined, message, core.CurrentDSFileName, funcDef.line, funcDef.col, graphNode);
+                    returnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, rank);
                 }
                 localProcedure.ReturnType = returnType;
                 localProcedure.IsConstructor = false;

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -1253,13 +1253,13 @@ namespace ProtoImperative
                 localProcedure.LocalCount = funcDef.localVars;
                 var returnType = new ProtoCore.Type();
                 returnType.UID = core.TypeSystem.GetType(funcDef.ReturnType.Name);
+                returnType.rank = funcDef.ReturnType.rank;
                 if (returnType.UID == (int)PrimitiveType.kInvalidType)
                 {
                     string message = String.Format(ProtoCore.Properties.Resources.kReturnTypeUndefined, funcDef.ReturnType.Name, funcDef.Name);
                     buildStatus.LogWarning(ProtoCore.BuildData.WarningID.kTypeUndefined, message, null, funcDef.line, funcDef.col, firstSSAGraphNode);
-                    returnType.UID = (int)PrimitiveType.kTypeVar;
+                    returnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeVar, funcDef.ReturnType.rank);
                 }
-                returnType.rank = funcDef.ReturnType.rank;
                 localProcedure.ReturnType = returnType;
                 localProcedure.RuntimeIndex = codeBlock.codeBlockId;
                 globalProcIndex = codeBlock.procedureTable.Append(localProcedure);


### PR DESCRIPTION
### Purpose

This PR is to fix [MAGN-8757 Convert SunSettings.CurrentDateTime to N2C and it throws exception](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8757). It is because for unknown type, we internally replace it with `var`, but we only assign `Type` object `UID`, not setting its `Name` property, therefore it causes null access exception.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewer
@junmendoza PTAL
