### PR TITLE
Fix for MAGN-8332: Dynamo taking a long time to launch, when there are custom path for network locations.

### DIFF
--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -73,6 +73,7 @@ namespace Dynamo.Engine
         public IPathManager PathManager { get; set; }
         public bool IsVarArg { get; set; }
         public bool IsBuiltIn { get; set; }
+        public bool IsPackageMember { get; set; }
     }
 
     /// <summary>
@@ -127,6 +128,7 @@ namespace Dynamo.Engine
             ObsoleteMessage = funcDescParams.ObsoleteMsg;
             CanUpdatePeriodically = funcDescParams.CanUpdatePeriodically;
             IsBuiltIn = funcDescParams.IsBuiltIn;
+            IsPackageMember = funcDescParams.IsPackageMember;
         }
 
         public bool IsOverloaded { get; set; }
@@ -169,6 +171,7 @@ namespace Dynamo.Engine
         public bool IsVarArg { get; private set; }
 
         public bool IsBuiltIn { get; private set; }
+        public bool IsPackageMember { get; private set; }
 
         public string ObsoleteMessage { get; protected set; }
         public bool IsObsolete { get { return !string.IsNullOrEmpty(ObsoleteMessage); } }

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -34,8 +34,10 @@ namespace Dynamo.Engine
         private readonly Dictionary<string, Dictionary<string, FunctionGroup>> importedFunctionGroups =
             new Dictionary<string, Dictionary<string, FunctionGroup>>(new LibraryPathComparer());
 
+        // This list includes all preloaded libraries, packaged libraries, and zero-touch imported libraries
         private readonly List<string> importedLibraries = new List<string>();
 
+        // This list includes all libraries loaded from package folders
         private readonly List<string> packagedLibraries = new List<string>();
 
         private readonly IPathManager pathManager;

--- a/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/ZeroTouchSearchElement.cs
@@ -45,9 +45,7 @@ namespace Dynamo.Search.SearchElements
             if (functionDescriptor.IsBuiltIn)
                 ElementType |= ElementTypes.BuiltIn;
 
-            // Assembly, that is located in package directory, considered as part of package.
-            var packageDirectories = functionDescriptor.PathManager.PackagesDirectories;
-            if (packageDirectories.Any(directory => Assembly.StartsWith(directory)))
+            if (functionDescriptor.IsPackageMember)
                 ElementType |= ElementTypes.Packaged;
 
             inputParameters = new List<Tuple<string, string>>(functionDescriptor.InputParameters);

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -45,7 +45,7 @@ namespace Dynamo.PackageManager
 
         public PackageLoader(IEnumerable<string> packagesDirectories)
         {
-            if (packagesDirectories == null || (!packagesDirectories.Any()))
+            if (packagesDirectories == null)
                 throw new ArgumentNullException("packagesDirectories");
 
             this.packagesDirectories.AddRange(packagesDirectories);


### PR DESCRIPTION
### Purpose

Reference: [MAGN-8332](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8332) Dynamo taking a long time to launch, when there are custom path for network locations.

This submission is a fix for the abovementioned defect. The lengthy loading is caused by Dynamo checking for the existence of a folder every time a function group (a node in the library) is loaded, and Dynamo preloads hundreds of nodes. After the fix, this checking is only done once for each custom library.

The following table shows the average running times of the commands for loading a downloaded package *LunchBox for Dynamo* from various folder locations specified in the `CustomPackageFolders` field in the preferences file:

Package location | Example path | Before change | After change | Improvement
--- | --- | :---: | :---: | :---:
Package is not downloaded | - | 00:00.900 | 00:00.867 | 3.67%
Default package folder | `%AppData%\Dynamo\0.9 \packages\LunchBox` | 00:01.625 | 00:00.598 | 63.20%
A folder in local machine | `C:\MyFolder\LunchBox` | 00:01.649 | 00:00.583 | 64.65%
An *offline* folder on local network | `\\xxx\MyFolder\LunchBox` | **04:03.380** | 00:02.438 | 99.00%
An available folder via VPN | `\\yyy\MyFolder\LunchBox` | 00:14.744 | 00:08.884 | 39.74%

* These numbers are as a reference only.
* Elapsed times are shown in the form of *(minutes):(seconds).(milliseconds)*

### Reviewers

@Benglin 

### FYIs

@riteshchandawar 