### PR TITLE
MAGN 8214 package manager does not show error message that files are not saved

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -976,6 +976,8 @@ namespace Dynamo.PackageManager
             var files = BuildPackage();
             try
             {
+                //if buildPackage() returns no files then the package
+                //is empty so we should return
                 if (files == null || files.Count() < 1)
                 {
                     return;
@@ -990,6 +992,7 @@ namespace Dynamo.PackageManager
             }
             catch (Exception e)
             {
+                UploadState = PackageUploadHandle.State.Error;
                 ErrorString = e.Message;
                 dynamoViewModel.Model.Logger.Log(e);
             }
@@ -1007,6 +1010,8 @@ namespace Dynamo.PackageManager
 
             try
             {
+                //if buildPackage() returns no files then the package
+                //is empty so we should return
                 if (files == null || files.Count() < 1)
                 {
                     return;
@@ -1068,6 +1073,7 @@ namespace Dynamo.PackageManager
             }
             catch (Exception e)
             {
+                UploadState = PackageUploadHandle.State.Error;
                 ErrorString = e.Message;
                 dynamoViewModel.Model.Logger.Log(e);
             }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -976,6 +976,10 @@ namespace Dynamo.PackageManager
             var files = BuildPackage();
             try
             {
+                if (files == null || files.Count() < 1)
+                {
+                    return;
+                }
                 // begin submission
                 var pmExtension = dynamoViewModel.Model.GetPackageManagerExtension();
                 var handle = pmExtension.PackageManagerClient.PublishAsync(Package, files, IsNewVersion);
@@ -1003,6 +1007,10 @@ namespace Dynamo.PackageManager
 
             try
             {
+                if (files == null || files.Count() < 1)
+                {
+                    return;
+                }
                 UploadState = PackageUploadHandle.State.Copying;
                 Uploading = true;
                 // begin publishing to local directory

--- a/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
@@ -40,11 +40,11 @@ namespace DynamoCoreWpfTests
 
         }
 
-        [Test, ]
+        [Test]
         public void SetsErrorState()
         {
            
-            //open a dyf file and modify if
+            //open a dyf file and modify it
             string packagedirectory = Path.Combine(TestDirectory, "pkgs");
             var packages = Directory.EnumerateDirectories(packagedirectory);
             var first = Path.GetFullPath(packages.First());

--- a/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
@@ -4,6 +4,8 @@ using Dynamo.PackageManager;
 using System.IO;
 using Dynamo.Tests;
 using System;
+using Moq;
+using System.Collections.Generic;
 
 namespace DynamoCoreWpfTests
 {
@@ -35,6 +37,40 @@ namespace DynamoCoreWpfTests
 
             //assert that canExecute changed was fired one time 
             Assert.AreEqual(canExecuteChangedFired, 1);
+
+        }
+
+        [Test, ]
+        public void SetsErrorState()
+        {
+           
+            //open a dyf file and modify if
+            string packagedirectory = Path.Combine(TestDirectory, "pkgs");
+            var packages = Directory.EnumerateDirectories(packagedirectory);
+            var first = Path.GetFullPath(packages.First());
+            string dyfpath = Path.Combine(first, "dyf");
+            var customnodes = Directory.GetFiles(dyfpath);
+            var firstnode = customnodes.First();
+            
+            OpenModel(firstnode);
+
+            //add a preset so that customnode has changes that are unsaved
+            GetModel().CurrentWorkspace.AddPreset("a useless preset", "some thing that will modify the definition",
+                new List<Guid>(){GetModel().CurrentWorkspace.Nodes.First().GUID});
+
+            Assert.IsTrue(GetModel().CurrentWorkspace.HasUnsavedChanges);
+
+            //now try to upload this file
+            var vm = new PublishPackageViewModel(this.ViewModel);
+            ViewModel.OnRequestPackagePublishDialog(vm);
+            //now add a customnode to the package
+            vm.AddFile(firstnode);
+            Console.WriteLine("add node at" + firstnode + "to package");
+
+            vm.PublishLocallyCommand.Execute();
+            //assert that we have not uploaded the file or indicated that we have
+            Assert.AreNotEqual(vm.UploadState,PackageUploadHandle.State.Uploaded);
+            Console.WriteLine(vm.ErrorString);
 
         }
 


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8214

This PR addresses the defect that that package manager does not show an error when attempting to upload or publish locally a package with unsaved files.

The package manager currently attempts to build a package and return all files, if any of the workspaces are unsaved it bails and throws an exception - the package is published incorrectly, potentially missing files. It also creates empty package folders if attempting to publish locally.

The window is then closed so it appears that everything has gone ok.

To fix this I have added checks in ``submit()`` and ``PublishLocally()`` that the files returned from ``BuildPackage()`` have some files.  If an exception is caught during getting files, build package returns 0 files. If this condition is true, the we return from ``submit()`` or ``PublishLocally()`` and the window will stay open as upload state has not been set to ``uploaded`` so the error will be visible to the user.

I also made the catch blocks for ``submit()`` and ``PublishLocally()`` match as the error state should be set correctly in either case.

finally, inside ``build package`` method I set the upload state to error even though we have not started uploading I think it is appropriate that if we check the Upload state at this time we should see the state in error.


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@pboyer 

### FYIs

@jnealb 