### PR TITLE
Remove the Test created for SearchUI

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.0.2777")]
+[assembly: AssemblyVersion("0.9.0.2787")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.0.2777")]
+[assembly: AssemblyFileVersion("0.9.0.2787")]

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2719,10 +2719,7 @@ namespace Dynamo.Controls
                 }
 
                 var type = (SearchElementGroup)value;
-
-                // It's just for tests.
-                if (!UriParser.IsKnownScheme("pack")) new Application();
-
+               
                 var resourceDictionary = SharedDictionaryManager.DynamoColorsAndBrushesDictionary;
 
                 switch (type)

--- a/test/DynamoCoreWpfTests/ConverterTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterTests.cs
@@ -619,29 +619,6 @@ namespace Dynamo.Tests
             Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath(@"\\psf\\Home\somedyn.dyn"));
             Assert.DoesNotThrow(() => FilePathDisplayConverter.ShortenNestedFilePath(@"\\psf\somedyn.dyn"));
             Assert.AreEqual(@"\\psf\Home\Desktop\somedyn.dyn", FilePathDisplayConverter.ShortenNestedFilePath(@"\\psf\Home\Desktop\somedyn.dyn"));
-        }
-
-        [Test]
-        [Category("UnitTests")]
-        public void ElementGroupToColorConverterTest()
-        {
-            var converter = new ElementGroupToColorConverter();
-
-            object result = converter.Convert("DummyValue", null, null, null);
-            SolidColorBrush expected = null;
-            Assert.AreEqual(expected, result);            
-
-            result = converter.Convert(SearchElementGroup.Create, null, null, null);
-            expected = (SolidColorBrush)new BrushConverter().ConvertFromString("#7B9F2D");
-            Assert.AreEqual(expected.ToString(), result.ToString());
-
-            result = converter.Convert(SearchElementGroup.Action, null, null, null);
-            expected = (SolidColorBrush)new BrushConverter().ConvertFromString("#D56867");
-            Assert.AreEqual(expected.ToString(), result.ToString());
-
-            result = converter.Convert(SearchElementGroup.Query, null, null, null);
-            expected = (SolidColorBrush)new BrushConverter().ConvertFromString("#65999A");
-            Assert.AreEqual(expected.ToString(), result.ToString());
-        }
+        }        
     }
 }


### PR DESCRIPTION
## Purpose

The purpose of this PR is to remove the test ElementGroupToColorConverterTest, becuase this test is trying to access the xaml before it is created. We cannot test something against XAML.  This was erroneous,and yes, the test will pass if it runs separately. 