### PR TITLE
Use CachedValue property, rather than IsUpdated to trigger UI updates

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.0.2795")]
+[assembly: AssemblyVersion("0.9.0.2806")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.0.2795")]
+[assembly: AssemblyFileVersion("0.9.0.2806")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.0.2787")]
+[assembly: AssemblyVersion("0.9.0.2795")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.0.2787")]
+[assembly: AssemblyFileVersion("0.9.0.2795")]

--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -1,5 +1,5 @@
-using System.Linq;
-﻿using System;
+﻿using System.Linq;
+ using System;
 using System.Collections.Generic;
 
 using Dynamo.Engine;
@@ -116,7 +116,7 @@ namespace Dynamo.Core.Threading
             // 
             foreach (var modifiedNode in ModifiedNodes)
             {
-                modifiedNode.IsUpdated = true;
+                modifiedNode.WasInvolvedInExecution = true;
                 if (modifiedNode.State == ElementState.Warning)
                     modifiedNode.ClearRuntimeError();
             }

--- a/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateRenderPackageAsyncTask.cs
@@ -89,7 +89,7 @@ namespace Dynamo.Core.Threading
                 throw new ArgumentNullException("initParams.DrawableIds");
 
             var nodeModel = initParams.Node;
-            if (!nodeModel.IsUpdated && !initParams.ForceUpdate)
+            if (!nodeModel.WasInvolvedInExecution && !initParams.ForceUpdate)
                 return false; // Not has not been updated at all.
 
             // If a node is in either of the following states, then it will not 

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -527,7 +527,7 @@ namespace Dynamo.Models
                 // Reset node states
                 foreach (var node in Nodes)
                 {
-                    node.IsUpdated = false;
+                    node.WasInvolvedInExecution = false;
                 }
 
                 // The workspace has been built for the first time

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -1617,8 +1617,10 @@ namespace Dynamo.Models
 
         private void QueryMirrorDataAsyncTaskCompleted(AsyncTask asyncTask)
         {
+            asyncTask.Completed -= QueryMirrorDataAsyncTaskCompleted;
+
             var task = asyncTask as QueryMirrorDataAsyncTask;
-            if (asyncTask != null)
+            if (task != null)
             {
                 this.CachedValue = task.MirrorData;
             }

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -1620,10 +1620,13 @@ namespace Dynamo.Models
             asyncTask.Completed -= QueryMirrorDataAsyncTaskCompleted;
 
             var task = asyncTask as QueryMirrorDataAsyncTask;
-            if (task != null)
+            if (task == null)
             {
-                this.CachedValue = task.MirrorData;
+                throw new InvalidOperationException("Expected a " + typeof(QueryMirrorDataAsyncTask).Name 
+                    + ", but got a " + asyncTask.GetType().Name );
             }
+
+            this.CachedValue = task.MirrorData;
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -463,16 +463,6 @@ namespace Dynamo.Models
             set
             {
                 isUpdated = value;
-                if (isUpdated)
-                {
-                    // When a NodeModel is updated, its
-                    // cached data should be invalidated.
-                    lock (cachedMirrorDataMutex)
-                    {
-                        cachedMirrorData = null;
-                    }
-                }
-
                 RaisePropertyChanged("IsUpdated");
             }
         }

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -42,15 +42,15 @@ namespace Dynamo.Models
         private string description;
         private string persistentWarning = "";
 
-        // Data caching related class members. There are multiple parties at
-        // play when it comes to caching MirrorData for a NodeModel, this value
-        // is accessed from UI thread for display (e.g. preview bubble) and it's
-        // updated by QueryMirrorDataAsyncTask on ISchedulerThread's context. 
-        // Access to the cached data is guarded by cachedMirrorDataMutex object.
-        // 
-        private bool isUpdated;
-        private MirrorData cachedMirrorData;
-        private readonly object cachedMirrorDataMutex = new object();
+        /// <summary>
+        /// The cached value of this node. The cachedValue object is protected by the cachedValueMutex
+        /// as it may be accessed from multiple threads concurrently. 
+        /// 
+        /// However, generally access to the cachedValue property should be protected by usage
+        /// of the Scheduler. 
+        /// </summary>
+        private MirrorData cachedValue;
+        private readonly object cachedValueMutex = new object();
 
         // Input and output port related data members.
         private ObservableCollection<PortModel> inPorts = new ObservableCollection<PortModel>();
@@ -401,20 +401,27 @@ namespace Dynamo.Models
             return elCatAttrib.ElementCategory;
         }
 
+        /// <summary>
+        /// The value of this node after the most recent computation
+        /// 
+        /// As this property could be modified by the virtual machine, it's dangerous 
+        /// to access this value without using the active Scheduler. Use the Scheduler to 
+        /// remove the possibility of race conditions.
+        /// </summary>
         public MirrorData CachedValue
         {
             get
             {
-                lock (cachedMirrorDataMutex)
+                lock (cachedValueMutex)
                 {
-                    return cachedMirrorData;
+                    return cachedValue;
                 }
             }
             private set
             {
-                lock (cachedMirrorDataMutex)
+                lock (cachedValueMutex)
                 {
-                    cachedMirrorData = value;
+                    cachedValue = value;
                 }
 
                 RaisePropertyChanged("CachedValue");
@@ -436,36 +443,28 @@ namespace Dynamo.Models
         /// 
         internal MirrorData GetCachedValueFromEngine(EngineController engine)
         {
-            if (cachedMirrorData != null)
-                return cachedMirrorData;
+            if (cachedValue != null)
+                return cachedValue;
 
             // Do not have an identifier for preview right now. For an example,
             // this can be happening at the beginning of a code block node creation.
             if (AstIdentifierForPreview.Value == null)
                 return null;
 
-            cachedMirrorData = null;
+            cachedValue = null;
 
             var runtimeMirror = engine.GetMirror(AstIdentifierForPreview.Value);
 
             if (runtimeMirror != null)
-                cachedMirrorData = runtimeMirror.GetData();
+                cachedValue = runtimeMirror.GetData();
 
-            return cachedMirrorData;
+            return cachedValue;
         }
 
         /// <summary>
-        ///     If the node is updated in LiveRunner's execution
+        /// Use to indicated if a node was involved in the most recent graph evaluation.
         /// </summary>
-        public bool IsUpdated
-        {
-            get { return isUpdated; }
-            set
-            {
-                isUpdated = value;
-                RaisePropertyChanged("IsUpdated");
-            }
-        }
+        internal bool WasInvolvedInExecution { get; set; }
 
         /// <summary>
         ///     Search tags for this Node.
@@ -1610,9 +1609,9 @@ namespace Dynamo.Models
             // requested to update its value. When the QueryMirrorDataAsyncTask 
             // returns, it will update cachedMirrorData with the latest value.
             // 
-            lock (cachedMirrorDataMutex)
+            lock (cachedValueMutex)
             {
-                cachedMirrorData = null;
+                cachedValue = null;
             }
 
             // Do not have an identifier for preview right now. For an example,

--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -410,6 +410,15 @@ namespace Dynamo.Models
                     return cachedMirrorData;
                 }
             }
+            private set
+            {
+                lock (cachedMirrorDataMutex)
+                {
+                    cachedMirrorData = value;
+                }
+
+                RaisePropertyChanged("CachedValue");
+            }
         }
 
         /// <summary>
@@ -1612,19 +1621,17 @@ namespace Dynamo.Models
                 VariableName = variableName
             });
 
-            task.Completed += OnNodeValueQueried;
+            task.Completed += QueryMirrorDataAsyncTaskCompleted;
             scheduler.ScheduleForExecution(task);
         }
 
-        private void OnNodeValueQueried(AsyncTask asyncTask)
+        private void QueryMirrorDataAsyncTaskCompleted(AsyncTask asyncTask)
         {
-            lock (cachedMirrorDataMutex)
+            var task = asyncTask as QueryMirrorDataAsyncTask;
+            if (asyncTask != null)
             {
-                var task = asyncTask as QueryMirrorDataAsyncTask;
-                cachedMirrorData = task.MirrorData;
+                this.CachedValue = task.MirrorData;
             }
-
-            RaisePropertyChanged("IsUpdated");
         }
 
         /// <summary>

--- a/src/DynamoCore/Properties/AssemblyInfo.cs
+++ b/src/DynamoCore/Properties/AssemblyInfo.cs
@@ -21,3 +21,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("DynamoCLI")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")] // Dynamic assembly created by Moq
 [assembly: InternalsVisibleTo("DynamoStudio")]
+[assembly: InternalsVisibleTo("Reach")]

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -501,7 +501,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
             switch (e.PropertyName)
             {
-                case "IsUpdated":
+                case "CachedValue":
                     // Only request updates when this is true. All nodes are marked IsUpdated=false
                     // before an evaluation occurs.
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -502,13 +502,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             switch (e.PropertyName)
             {
                 case "CachedValue":
-                    // Only request updates when this is true. All nodes are marked IsUpdated=false
-                    // before an evaluation occurs.
-
-                    if (node.IsUpdated)
-                    {
-                        node.RequestVisualUpdateAsync(scheduler, engineManager.EngineController, renderPackageFactory);
-                    }
+                    node.RequestVisualUpdateAsync(scheduler, engineManager.EngineController, renderPackageFactory);
                     break;
 
                 case "DisplayLabels":

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -155,19 +155,16 @@ namespace Dynamo.Controls
                     ViewModel.SetLacingTypeCommand.RaiseCanExecuteChanged();
                     break;
 
-                case "IsUpdated":
-                    HandleCacheValueUpdated();
+                case "CachedValue":
+                    CachedValueChanged();
                     break;
             }
         }
 
         /// <summary>
-        /// Whenever property "NodeModel.IsUpdated" is set to true, this method 
-        /// is invoked. It will result in preview control updated, if the control 
-        /// is currently visible. Otherwise this call will be ignored.
+        /// Called when the NodeModel's CachedValue property is updated
         /// </summary>
-        /// 
-        private void HandleCacheValueUpdated()
+        private void CachedValueChanged()
         {
             Dispatcher.BeginInvoke(new Action(delegate
             {

--- a/src/Libraries/CoreNodeModels/ColorRange.cs
+++ b/src/Libraries/CoreNodeModels/ColorRange.cs
@@ -59,7 +59,7 @@ namespace DSCoreNodesUI
 
         void ColorRange_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName != "IsUpdated")
+            if (e.PropertyName != "CachedValue")
                 return;
 
             if (InPorts.Any(x => x.Connectors.Count == 0))

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/WatchImage.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/WatchImage.cs
@@ -41,7 +41,7 @@ namespace Dynamo.Wpf.Nodes
 
         private void NodeModelOnPropertyChanged(object sender, PropertyChangedEventArgs args)
         {
-            if (args.PropertyName != "IsUpdated") 
+            if (args.PropertyName != "CachedValue") 
                 return;
 
             var data = nodeModel.CachedValue;

--- a/src/Libraries/DynamoWatch3D/HelixWatch3DNodeViewModel.cs
+++ b/src/Libraries/DynamoWatch3D/HelixWatch3DNodeViewModel.cs
@@ -57,7 +57,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var gathered = new List<NodeModel>();
             watchNode.VisibleUpstreamNodes(gathered);
 
-            gathered.ForEach(n => n.IsUpdated = true);
+            gathered.ForEach(n => n.WasInvolvedInExecution = true);
             gathered.ForEach(n => n.RequestVisualUpdateAsync(scheduler, engineManager.EngineController, renderPackageFactory));
         }
 


### PR DESCRIPTION
### Purpose

**`NodeModel.IsUpdated`, `NodeModel.cachedMirrorData`, and `NodeModel.CachedValue` are all used in slightly different ways and overlap in their meaning.** `IsUpdated` is meant primarily to indicate if a `NodeModel` was involved in a run, but it is also used to indicate if a `NodeModel` has had it's `cachedMirrorData` updated. These were the cause of many duplicate UI updates as `NodeView` used this property to determine if the `PreviewControl` should be updated. Furthermore, `CachedValue` is quite useful, but confusingly addressed throughout the code base. In this PR, I attempted to consolidate `CachedValue` and clarify some of the naming throughout the code base. 

Note, **I've removed the way that the `IsUpdated` setter mutates the `cachedMirrorData` field on `NodeModel`.** Consider the following code:

```
nodeModel.CachedValue = foo;
nodeModel.IsUpdated = true;
```

This code would result in `NodeModel.CachedValue` returning `null`. That is baffling behavior, and the cause of many recent defects. Perhaps there is some other purpose in mind here?

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough 

### FYI

@Benglin @ke-yu I've made a few subtle changes here. Maybe you can take a look to ensure that I've not done something dumb. ;)