### PR TITLE
MAGN-8485 "Input" node does not disappear, is duped in search when switching workspaces

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.0.2787")]
+[assembly: AssemblyVersion("0.9.0.2796")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.0.2787")]
+[assembly: AssemblyFileVersion("0.9.0.2796")]

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -99,7 +99,10 @@
             <!-- Remove default listbox blue highlight. Disable item selection -->
             <Style x:Key="SearchItemStyle"
                    TargetType="ListBoxItem">
-
+                <Setter Property="IsSelected"
+                        Value="{Binding IsSelected, Mode=OneWay}" />
+                <Setter Property="Visibility"
+                        Value="{Binding Visibility, Mode=OneWay, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="ListBoxItem">


### PR DESCRIPTION
### Purpose

There is a change from Treeview to ListView (during search), and Visibility property was not carried over. This PR is to add the visibility property to Search item.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@pboyer 

 

 