### PR TITLE
Restore deleted function RuntimeData.GetCallsitesForNode()

### DIFF
--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -113,6 +113,57 @@ namespace ProtoCore
             return csInstance;
         }
 
+        public Dictionary<Guid, List<CallSite>>
+        GetCallsitesForNodes(IEnumerable<Guid> nodeGuids, Executable executable)
+        {
+            if (nodeGuids == null)
+                throw new ArgumentNullException("nodeGuids");
+
+            var nodeMap = new Dictionary<Guid, List<CallSite>>();
+
+            if (!nodeGuids.Any()) // Nothing to persist now.
+                return nodeMap;
+
+            // Attempt to get the list of graph node if one exists.
+            IEnumerable<GraphNode> graphNodes = null;
+            {
+                if (executable != null)
+                {
+                    var stream = executable.instrStreamList;
+                    if (stream != null && (stream.Length > 0))
+                    {
+                        var graph = stream[0].dependencyGraph;
+                        if (graph != null)
+                            graphNodes = graph.GraphList;
+                    }
+                }
+
+
+                if (graphNodes == null) // No execution has taken place.
+                    return nodeMap;
+            }
+
+            foreach (Guid nodeGuid in nodeGuids)
+            {
+                // Get a list of GraphNode objects that correspond to this node.
+                var matchingGraphNodes = graphNodes.
+                        Where(gn => gn.guid == nodeGuid);
+
+                if (!matchingGraphNodes.Any())
+                    continue;
+
+                // Get all callsites that match the graph node ids.
+                var matchingCallSites = (from cs in CallsiteCache
+                                         from gn in matchingGraphNodes
+                                         where string.Equals(cs.Key, gn.CallsiteIdentifier)
+                                         select cs.Value);
+
+                // Append each callsite element under node element.
+                nodeMap[nodeGuid] = matchingCallSites.ToList();
+            }
+
+            return nodeMap;
+        }
 
         #region Trace Data Serialization Methods/Members
 


### PR DESCRIPTION
### Purpose

`RuntimeData.GetCAllsitesForNode()` was removed in PR #5449. This function is not used in `Dynamo`, but used in `DynamoRevit`, so restore this function. 

### FYIs
@junmendoza 