### PR TITLE
Make the scheduler mode dependent on the configuration

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -474,7 +474,7 @@ namespace Dynamo.Models
             MigrationManager.MigrationTargets.Add(typeof(WorkspaceMigrations));
 
             var thread = config.SchedulerThread ?? new DynamoSchedulerThread();
-            Scheduler = new DynamoScheduler(thread, IsTestMode ? TaskProcessMode.Synchronous : TaskProcessMode.Asynchronous);
+            Scheduler = new DynamoScheduler(thread, config.ProcessMode);
             Scheduler.TaskStateChanged += OnAsyncTaskStateChanged;
 
             geometryFactoryPath = config.GeometryFactoryPath;


### PR DESCRIPTION
### Purpose

This is to set the process mode for the scheduler based on the process mode in the configuration. I think this is reasonable, because there are multiple places which is trying to set the process mode through the configuration. If this is always overriden to Syncronous, it will limit the possibility to run test cases in asyncronous mode.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers
@Benglin 