### PR TITLE
MAGN-8513 Ctrl + drag to duplicate nodes, groups, and notes

### DIFF
--- a/src/DynamoCore/Core/DynamoSelection.cs
+++ b/src/DynamoCore/Core/DynamoSelection.cs
@@ -53,6 +53,8 @@ namespace Dynamo.Selection
             }
         }
 
+        public bool ClearSelectionDisabled { get; set; }
+
         private DynamoSelection()
         {
             Selection.CollectionChanged += selection_CollectionChanged;
@@ -91,6 +93,8 @@ namespace Dynamo.Selection
         /// </summary>
         public void ClearSelection()
         {
+            if (ClearSelectionDisabled) return;
+            
             Instance.Selection.ToList().ForEach(x=>x.Deselect());
             Instance.Selection.Reset(new List<ISelectable>());
         }

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Rendering\RenderPackageExtensions.cs" />
     <Compile Include="Services\IconServices.cs" />
     <Compile Include="UI\ClassObjectTemplateSelector.cs" />
+    <Compile Include="UI\DraggedAdorner.cs" />
     <Compile Include="UI\HeaderTemplateSelector.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/DynamoCoreWpf/UI/DraggedAdorner.cs
+++ b/src/DynamoCoreWpf/UI/DraggedAdorner.cs
@@ -1,0 +1,92 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace Dynamo.Wpf.UI
+{
+    /// <summary>
+    /// Adorner to visualize dragged content
+    /// </summary>
+    class DraggedAdorner: Adorner
+    {
+        // single visual child of the adorner
+        private readonly ContentPresenter contentPresenter;
+        private readonly AdornerLayer adornerLayer;
+        private double left;
+        private double top;
+
+        /// <summary>
+        /// Initializes a new instance of the DraggedAdorner class.
+        /// </summary>
+        /// <param name="dragDropData">Dragged content data</param>
+        /// <param name="dragDropTemplate">Template to visualize dragged content</param>
+        /// <param name="adornedElement">The element to bind the adorner to</param>
+        /// <param name="layer">AdornerLayer element to attach the adorner</param>
+        public DraggedAdorner(object dragDropData, DataTemplate dragDropTemplate, 
+            UIElement adornedElement, AdornerLayer layer)
+            : base(adornedElement)
+        {
+            adornerLayer = layer;
+            contentPresenter = new ContentPresenter
+            {
+                Content = dragDropData,
+                ContentTemplate = dragDropTemplate,
+                Opacity = 0.7
+            };
+
+            adornerLayer.Add(this);
+        }
+
+        /// <summary>
+        /// Set position of the dragged data
+        /// </summary>
+        /// <param name="left">X coordinate</param>
+        /// <param name="top">Y coordianate</param>
+        public void SetPosition(double left, double top)
+        {
+            this.left = left;
+            this.top = top;
+            if (adornerLayer != null)
+            {
+                adornerLayer.Update(AdornedElement);
+            }
+        }
+
+        protected override Size MeasureOverride(Size constraint)
+        {
+            contentPresenter.Measure(constraint);
+            return contentPresenter.DesiredSize;
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            contentPresenter.Arrange(new Rect(finalSize));
+            return finalSize;
+        }
+
+        protected override Visual GetVisualChild(int index)
+        {
+            return contentPresenter;
+        }
+
+        protected override int VisualChildrenCount
+        {
+            get { return 1; }
+        }
+
+        public override GeneralTransform GetDesiredTransform(GeneralTransform transform)
+        {
+            var result = new GeneralTransformGroup();
+            result.Children.Add(base.GetDesiredTransform(transform));
+            result.Children.Add(new TranslateTransform(left, top));
+
+            return result;
+        }
+
+        public void Detach()
+        {
+            adornerLayer.Remove(this);
+        }
+    }
+}

--- a/src/DynamoCoreWpf/UI/DraggedAdorner.cs
+++ b/src/DynamoCoreWpf/UI/DraggedAdorner.cs
@@ -43,10 +43,12 @@ namespace Dynamo.Wpf.UI
         /// </summary>
         /// <param name="left">X coordinate</param>
         /// <param name="top">Y coordianate</param>
-        public void SetPosition(double left, double top)
+        /// <param name="bounds">Visible rectangle of dragged content</param>
+        public void SetPosition(double left, double top, Rect bounds)
         {
             this.left = left;
             this.top = top;
+            contentPresenter.Clip = new RectangleGeometry(bounds);
             if (adornerLayer != null)
             {
                 adornerLayer.Update(AdornedElement);

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -132,6 +132,11 @@ namespace Dynamo.ViewModels
             draggedNodes.Clear(); // We are no longer dragging anything.
         }
 
+        internal void PasteSelection(Point2D targetPoint)
+        {
+            stateMachine.PasteSelection(targetPoint);
+        }
+
         internal void BeginConnection(Guid nodeId, int portIndex, PortType portType)
         {
             bool isInPort = portType == PortType.Input;
@@ -638,13 +643,20 @@ namespace Dynamo.ViewModels
                         return false;
                     }
 
-                    // Record and begin the drag operation for selected nodes.
-                    var operation = DynCmd.DragSelectionCommand.Operation.BeginDrag;
-                    var command = new DynCmd.DragSelectionCommand(mouseCursor.AsDynamoType(), operation);
-                    owningWorkspace.DynamoViewModel.ExecuteCommand(command);
+                    if (Keyboard.Modifiers != ModifierKeys.Control)
+                    {
 
-                    SetCurrentState(State.NodeReposition);
-                    return true;
+                        // Record and begin the drag operation for selected nodes.
+                        var operation = DynCmd.DragSelectionCommand.Operation.BeginDrag;
+                        var command = new DynCmd.DragSelectionCommand(
+                            mouseCursor.AsDynamoType(),
+                            operation);
+                        owningWorkspace.DynamoViewModel.ExecuteCommand(command);
+
+                        SetCurrentState(State.NodeReposition);
+                        return true;
+                    }
+
                 }
                 else if (this.currentState == State.NodeReposition)
                 {
@@ -715,6 +727,22 @@ namespace Dynamo.ViewModels
                 }
 
                 return true;
+            }
+
+            internal void PasteSelection(Point2D targetPoint)
+            {
+                var model = owningWorkspace.DynamoViewModel.Model;
+                var oldClipboardData = model.ClipBoard.ToList();
+
+                model.Copy();
+                if (model.ClipBoard.Any())
+                {
+                    model.Paste(targetPoint);
+                }
+
+                model.ClipBoard.Clear();
+                model.ClipBoard.AddRange(oldClipboardData);
+                SetCurrentState(State.None);
             }
 
             #endregion

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -645,7 +645,6 @@ namespace Dynamo.ViewModels
 
                     if (Keyboard.Modifiers != ModifierKeys.Control)
                     {
-
                         // Record and begin the drag operation for selected nodes.
                         var operation = DynCmd.DragSelectionCommand.Operation.BeginDrag;
                         var command = new DynCmd.DragSelectionCommand(

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -738,6 +738,8 @@ namespace Dynamo.ViewModels
                 if (model.ClipBoard.Any())
                 {
                     model.Paste(targetPoint);
+                    owningWorkspace.DynamoViewModel.UndoCommand.RaiseCanExecuteChanged();
+                    owningWorkspace.DynamoViewModel.RedoCommand.RaiseCanExecuteChanged();
                 }
 
                 model.ClipBoard.Clear();

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -87,6 +87,21 @@
             <EventSetter Event="PreviewMouseDown"
                          Handler="OnInCanvasSearchContextMenuMouseDown" />
         </Style>
+        <DataTemplate x:Key="DraggedSelectionTemplate">
+            <ItemsControl ItemsSource="{Binding}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <Canvas/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="Canvas.Left" Value="{Binding Left}"/>
+                        <Setter Property="Canvas.Top" Value="{Binding Top}"/>
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
+            </ItemsControl>
+        </DataTemplate>
     </UserControl.Resources>
 
     <Grid  Name="outerCanvas"
@@ -284,8 +299,7 @@
                                              HorizontalAlignment="Left"
                                              VerticalAlignment="Top"
                                              Visibility="Visible"
-                                             ContextMenuOpening="WorkBench_ContextMenuOpening"
-                                             Loaded="WorkBench_OnLoaded"
+                                             Loaded="workBench_OnLoaded"
                                              IsItemsHost="True">
                             <Canvas.Background>
                                 <SolidColorBrush Color="Transparent" />

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -512,7 +512,7 @@ namespace Dynamo.Views
                 var annotations = selection.OfType<AnnotationModel>();
                 
                 var connectors = nodes.SelectMany(n => 
-                    n.InPorts.Concat(n.OutPorts).SelectMany(port => port.Connectors)
+                    n.OutPorts.SelectMany(port => port.Connectors)
                         .Where(c => c.End != null && c.End.Owner.IsSelected)).Distinct();
 
                 // set list of selected viewmodels
@@ -611,11 +611,21 @@ namespace Dynamo.Views
                     draggedSelectionTemplate, WorkspaceElements, adornerLayer);
             }
 
+            var zoom = ViewModel.Zoom;
+            var xOffset = currentPosition.X - initialMousePosition.X;
+            var yOffset = currentPosition.Y - initialMousePosition.Y;
             // compute (x; y) so that dragged selection has mouse cursor 
             // in the same place as origin selection does
-            var x = (currentPosition.X - initialMousePosition.X) * ViewModel.Zoom;
-            var y = (currentPosition.Y - initialMousePosition.Y) * ViewModel.Zoom;
-            draggedAdorner.SetPosition(x, y);
+            var x = xOffset * zoom;
+            var y = yOffset * zoom;
+
+            // compute bounds of dragged content so that it does not go outside dragged canvas
+            var x1 = -ViewModel.Model.X/zoom - xOffset;
+            var y1 = -ViewModel.Model.Y/zoom - yOffset;
+            var x2 = WorkspaceElements.RenderSize.Width / zoom;
+            var y2 = WorkspaceElements.RenderSize.Height / zoom;
+            var bounds = new Rect(x1, y1, x2, y2);
+            draggedAdorner.SetPosition(x, y, bounds);
         }
 
         private PortViewModel GetSnappedPort(Point mouseCursor)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -11,11 +11,16 @@ using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.UI;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Threading;
+using System.Windows.Documents;
 
 using Dynamo.Wpf.Utilities;
 using Dynamo.Search.SearchElements;
 using Dynamo.UI.Controls;
+using Dynamo.Wpf.UI;
+
+using ModifierKeys = System.Windows.Input.ModifierKeys;
 
 
 namespace Dynamo.Views
@@ -45,9 +50,12 @@ namespace Dynamo.Views
             ResizeHorizontal
         }
 
-        private Dynamo.Controls.DragCanvas WorkBench = null;
-
-        private PortViewModel snappedPort = null;
+        private Controls.DragCanvas workBench;
+        private readonly DataTemplate draggedSelectionTemplate;
+        private DraggedAdorner draggedAdorner;
+        private object draggedData;
+        private Point initialMousePosition;
+        private PortViewModel snappedPort;
         private List<DependencyObject> hitResultsList = new List<DependencyObject>();
         Dictionary<CursorState, String> cursorSet = new Dictionary<CursorState, string>();
 
@@ -84,6 +92,14 @@ namespace Dynamo.Views
 
             Loaded += OnWorkspaceViewLoaded;
             Unloaded += OnWorkspaceViewUnloaded;
+
+            // view of items to drag
+            draggedSelectionTemplate = (DataTemplate)FindResource("DraggedSelectionTemplate");
+            var dictionaries = draggedSelectionTemplate.Resources.MergedDictionaries;
+
+            // let draggedSelectionTemplate know about views of node, note, annotation, connector
+            dictionaries.Add(SharedDictionaryManager.ConnectorsDictionary);
+            dictionaries.Add(SharedDictionaryManager.DataTemplatesDictionary);
         }
 
         void OnWorkspaceViewLoaded(object sender, RoutedEventArgs e)
@@ -230,7 +246,7 @@ namespace Dynamo.Views
         private void VmOnRequestSelectionBoxUpdate(object sender, SelectionBoxUpdateArgs e)
         {
             var originalLt = new Point(e.X, e.Y);
-            var translatedLt = WorkBench.TranslatePoint(originalLt, outerCanvas);
+            var translatedLt = workBench.TranslatePoint(originalLt, outerCanvas);
 
             if (e.UpdatedProps.HasFlag(SelectionBoxUpdateArgs.UpdateFlags.Position))
             {
@@ -241,7 +257,7 @@ namespace Dynamo.Views
             if (e.UpdatedProps.HasFlag(SelectionBoxUpdateArgs.UpdateFlags.Dimension))
             {
                 var originalRb = new Point(e.X + e.Width, e.Y + e.Height);
-                var translatedRb = WorkBench.TranslatePoint(originalRb, outerCanvas);
+                var translatedRb = workBench.TranslatePoint(originalRb, outerCanvas);
 
                 selectionBox.Width = translatedRb.X - translatedLt.X;
                 selectionBox.Height = translatedRb.Y - translatedLt.Y;
@@ -307,9 +323,9 @@ namespace Dynamo.Views
             // Transform dropPt from outerCanvas space into zoomCanvas space
             if (args.TransformCoordinates)
             {
-                if (WorkBench != null)
+                if (workBench != null)
                 {
-                    var a = outerCanvas.TransformToDescendant(WorkBench);
+                    var a = outerCanvas.TransformToDescendant(workBench);
                     dropPt = a.Transform(dropPt);
                 }
             }
@@ -479,7 +495,51 @@ namespace Dynamo.Views
                 wvm.HandlePortClicked(this.snappedPort);
             else
             {
-                wvm.HandleLeftButtonDown(this.WorkBench, e);
+                wvm.HandleLeftButtonDown(workBench, e);
+            }
+
+            // if selection is going to be dragged and ctrl is pressed
+            if (wvm.IsDragging && Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                initialMousePosition = e.GetPosition(WorkspaceElements);
+                
+                // disable clearing selection while dragged data is being generated
+                // new AnnotationViewModel unnecessarily clears selection 
+                DynamoSelection.Instance.ClearSelectionDisabled = true;
+                var selection = DynamoSelection.Instance.Selection;
+                var nodes = selection.OfType<NodeModel>();
+                var notes = selection.OfType<NoteModel>();
+                var annotations = selection.OfType<AnnotationModel>();
+                
+                var connectors = nodes.SelectMany(n => 
+                    n.InPorts.Concat(n.OutPorts).SelectMany(port => port.Connectors)
+                        .Where(c => c.End != null && c.End.Owner.IsSelected)).Distinct();
+
+                // set list of selected viewmodels
+                draggedData = nodes.Select(n => (ViewModelBase)new NodeViewModel(ViewModel, n))
+                    .Concat(notes.Select(n => new NoteViewModel(ViewModel, n)))
+                    .Concat(annotations.Select(a => new AnnotationViewModel(ViewModel, a)))
+                    .Concat(connectors.Select(c => new ConnectorViewModel(ViewModel, c))).ToList();
+                
+                var mouse = e.GetPosition(WorkspaceElements);
+                var locatableModels = nodes.Concat<ModelBase>(notes);
+                var minX = locatableModels.Any() ? locatableModels.Min(mb => mb.X) : 0;
+                var minY = locatableModels.Any() ? locatableModels.Min(mb => mb.Y) : 0;
+                // comput offset to correctly place selected items rigth under mouse cursor 
+                var mouseOffset = new Point2D(mouse.X - minX, mouse.Y - minY);
+
+                DynamoSelection.Instance.ClearSelectionDisabled = false;
+                DragDrop.DoDragDrop(this, mouseOffset, DragDropEffects.Copy);
+
+                // end dragging operation by setting State from DragSetup to None
+                ViewModel.HandleMouseRelease(workBench, e);
+                // remove dragged selection view 
+                if (draggedAdorner != null)
+                {
+                    draggedData = null;
+                    draggedAdorner.Detach();
+                    draggedAdorner = null;
+                }
             }
 
             InCanvasSearchBar.IsOpen = false;
@@ -493,7 +553,7 @@ namespace Dynamo.Views
 
             var wvm = (DataContext as WorkspaceViewModel);
             if (wvm == null) return;
-            wvm.HandleMouseRelease(this.WorkBench, e);
+            wvm.HandleMouseRelease(workBench, e);
         }
 
        
@@ -513,7 +573,7 @@ namespace Dynamo.Views
                     if (wvm.CheckActiveConnectorCompatibility(wvm.portViewModel))
                     {
                         mouseMessageHandled = true;
-                        wvm.HandleMouseMove(this.WorkBench, wvm.portViewModel.Center);
+                        wvm.HandleMouseMove(workBench, wvm.portViewModel.Center);
                     }
                 }
                 else
@@ -537,7 +597,25 @@ namespace Dynamo.Views
             }
 
             if (false == mouseMessageHandled)
-                wvm.HandleMouseMove(this.WorkBench, e);
+                wvm.HandleMouseMove(workBench, e);
+        }
+
+        protected override void OnDragOver(DragEventArgs e)
+        {
+            var currentPosition = e.GetPosition(WorkspaceElements);
+            // create adorner if it is necessary
+            if (draggedAdorner == null)
+            {
+                var adornerLayer = AdornerLayer.GetAdornerLayer(WorkspaceElements);
+                draggedAdorner = new DraggedAdorner(draggedData,
+                    draggedSelectionTemplate, WorkspaceElements, adornerLayer);
+            }
+
+            // compute (x; y) so that dragged selection has mouse cursor 
+            // in the same place as origin selection does
+            var x = (currentPosition.X - initialMousePosition.X) * ViewModel.Zoom;
+            var y = (currentPosition.Y - initialMousePosition.Y) * ViewModel.Zoom;
+            draggedAdorner.SetPosition(x, y);
         }
 
         private PortViewModel GetSnappedPort(Point mouseCursor)
@@ -579,10 +657,6 @@ namespace Dynamo.Views
             return Math.Sqrt(Math.Pow(mouse.X - point.X, 2) + Math.Pow(mouse.Y - point.Y, 2));
         }
 
-        private void WorkBench_ContextMenuOpening(object sender, ContextMenuEventArgs e)
-        {
-        }
-
         /// <summary>
         /// Centers the view on a node by changing the workspace's CurrentOffset.
         /// </summary>
@@ -597,9 +671,9 @@ namespace Dynamo.Views
 
                     var n = (e as ModelEventArgs).Model;
 
-                    if (WorkBench != null)
+                    if (workBench != null)
                     {
-                        var b = WorkBench.TransformToAncestor(outerCanvas);
+                        var b = workBench.TransformToAncestor(outerCanvas);
 
                         Point outerCenter = new Point(outerCanvas.ActualWidth / 2, outerCanvas.ActualHeight / 2);
                         Point nodeCenterInCanvas = new Point(n.X + n.Width / 2, n.Y + n.Height / 2);
@@ -617,10 +691,10 @@ namespace Dynamo.Views
                 });
         }
 
-        private void WorkBench_OnLoaded(object sender, RoutedEventArgs e)
+        private void workBench_OnLoaded(object sender, RoutedEventArgs e)
         {
-            WorkBench = sender as Dynamo.Controls.DragCanvas;
-            WorkBench.owningWorkspace = this;
+            workBench = sender as Controls.DragCanvas;
+            workBench.owningWorkspace = this;
         }
 
         private PortViewModel PortFromHitTestResult(DependencyObject depObject)
@@ -716,12 +790,27 @@ namespace Dynamo.Views
         
         private void OnWorkspaceDrop(object sender, DragEventArgs e)
         {
+            var mousePosition = e.GetPosition(WorkspaceElements);
+            var pointObj = e.Data.GetData(typeof(Point2D));
+            if (pointObj is Point2D)
+            {
+                var offset = (Point2D)pointObj;
+                // compute a point where (minX, minY) will be pasted -
+                // location of selection top left corner
+                var targetX = mousePosition.X - offset.X;
+                var targetY = mousePosition.Y - offset.Y;
+                var targetPoint = new Point2D(targetX, targetY);
+
+                ViewModel.PasteSelection(targetPoint);
+
+                return;
+            }
+
             var nodeInfo = e.Data.GetData(typeof(DragDropNodeSearchElementInfo)) as DragDropNodeSearchElementInfo;
             if (nodeInfo == null)
                 return;
 
             var nodeModel = nodeInfo.SearchElement.CreateNode();
-            var mousePosition = e.GetPosition(this.WorkspaceElements);
             ViewModel.DynamoViewModel.ExecuteCommand(new DynamoModel.CreateNodeCommand(
                 nodeModel, mousePosition.X, mousePosition.Y, false, true));
         }


### PR DESCRIPTION
### Purpose

When some nodes, groups, and notes are selected, they can be dragged by mouse with CTRL button pressed. 
During dragging semitransparant image of selection goes with mouse and becames real nodes, groups, notes when mouse is relesed. 
This operation can be undone by ctrl+z as any other operation in Dynamo.
Also it does not override Dynamo clipboard, i.e. is something was copied before, after dragging selection that copied content still is able to be pasted.

### Screenshot

Created by Windows Steps recorder to show mouse cursor.
![drag](https://cloud.githubusercontent.com/assets/7658189/10424268/728827c8-70d6-11e5-8f83-73eed789d6e0.png)

### Reviewers

@ikeough 