### PR TITLE
MAGN-8514 Add Copy/Paste to the context menu

### DIFF
--- a/src/DynamoCore/Core/DynamoSelection.cs
+++ b/src/DynamoCore/Core/DynamoSelection.cs
@@ -125,6 +125,18 @@ namespace Dynamo.Selection
         {
         }
 
+        /// <summary>
+        /// Adds an item only if the sequence does not have it yet
+        /// </summary>
+        /// <param name="item">Item to add</param>
+        public void AddUnique(T item)
+        {
+            if (!Contains(item))
+            {
+                Add(item);
+            }
+        }
+
         public void AddRange(IEnumerable<T> range)
         {
             foreach (var item in range)

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1556,8 +1556,8 @@ namespace Dynamo.Models
             // Provide a small offset when pasting so duplicate pastes aren't directly on top of each other
             CurrentWorkspace.IncrementPasteOffset();
 
-            var locatebleModels = ClipBoard.Where(model => model is NoteModel || model is NodeModel);
-            var orderedItems = locatebleModels.OrderBy(item => item.CenterX + item.CenterY);
+            var locatableModels = ClipBoard.Where(model => model is NoteModel || model is NodeModel);
+            var orderedItems = locatableModels.OrderBy(item => item.CenterX + item.CenterY);
 
             // Search for the rightmost item. It's item with the biggest X, Y coordinates of center.
             var rightMostItem = orderedItems.Last();
@@ -1570,8 +1570,8 @@ namespace Dynamo.Models
             var shiftY = rightMostItem.Y + CurrentWorkspace.CurrentPasteOffset - leftMostItem.Y;
 
 
-            var x = shiftX + locatebleModels.Min(m => m.X);
-            var y = shiftY + locatebleModels.Min(m => m.Y);
+            var x = shiftX + locatableModels.Min(m => m.X);
+            var y = shiftY + locatableModels.Min(m => m.Y);
             var targetPoint = new Point2D(x, y);
             
             Paste(targetPoint);
@@ -1661,7 +1661,6 @@ namespace Dynamo.Models
             {
                 CurrentWorkspace.AddAndRegisterNode(newNode, false);
                 createdModels.Add(newNode);
-                AddToSelection(newNode);
             }
 
             // TODO: is this required?
@@ -1672,7 +1671,6 @@ namespace Dynamo.Models
             {
                 CurrentWorkspace.AddNote(newNote, false);
                 createdModels.Add(newNote);
-                AddToSelection(newNote);
             }
 
             ModelBase start;
@@ -1740,6 +1738,12 @@ namespace Dynamo.Models
                 AddToSelection(newAnnotation);
             }
 
+            // adding an annotation overrides selection, so add nodes and notes after
+            foreach (var item in newItems)
+            {
+                AddToSelection(item);
+            }
+
             // Record models that are created as part of the command.
             CurrentWorkspace.RecordCreatedModels(createdModels);
         }
@@ -1751,10 +1755,9 @@ namespace Dynamo.Models
         public void AddToSelection(object parameters)
         {
             var selectable = parameters as ISelectable;
-            if ((selectable != null) && !selectable.IsSelected)
+            if (selectable != null)
             {
-                if (!DynamoSelection.Instance.Selection.Contains(selectable))
-                    DynamoSelection.Instance.Selection.Add(selectable);
+                DynamoSelection.Instance.Selection.AddUnique(selectable);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -569,10 +569,9 @@ namespace Dynamo.ViewModels
                 {
                     selection.AddUnique(n);
                 }
-                else
+                else if (n.IsSelected)
                 {
-                    if (n.IsSelected)
-                        selection.Remove(n);
+                    selection.Remove(n);
                 }
             }
 
@@ -587,10 +586,9 @@ namespace Dynamo.ViewModels
                         selection.AddUnique(m);
                     }
                 }
-                else
+                else if (n.IsSelected)
                 {
-                    if (n.IsSelected)
-                        selection.Remove(n);
+                    selection.Remove(n);
                 }
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -559,56 +559,38 @@ namespace Dynamo.ViewModels
 
         internal void SelectInRegion(Rect2D region, bool isCrossSelect)
         {
-            bool fullyEnclosed = !isCrossSelect;
+            var fullyEnclosed = !isCrossSelect;
+            var selection = DynamoSelection.Instance.Selection;
+            var childlessModels = Model.Nodes.Concat<ModelBase>(Model.Notes);
 
-            foreach (NodeModel n in Model.Nodes)
+            foreach (var n in childlessModels)
             {
-                double x0 = n.X;
-                double y0 = n.Y;
-
                 if (IsInRegion(region, n, fullyEnclosed))
                 {
-                    if (!DynamoSelection.Instance.Selection.Contains(n))
-                        DynamoSelection.Instance.Selection.Add(n);
+                    selection.AddUnique(n);
                 }
                 else
                 {
                     if (n.IsSelected)
-                        DynamoSelection.Instance.Selection.Remove(n);
-                }
-            }
-
-            foreach (var n in Model.Notes)
-            {
-                double x0 = n.X;
-                double y0 = n.Y;
-
-                if (IsInRegion(region, n, fullyEnclosed))
-                {
-                    if (!DynamoSelection.Instance.Selection.Contains(n))
-                        DynamoSelection.Instance.Selection.Add(n);
-                }
-                else
-                {
-                    if (n.IsSelected)
-                        DynamoSelection.Instance.Selection.Remove(n);
+                        selection.Remove(n);
                 }
             }
 
             foreach (var n in Model.Annotations)
             {
-                double x0 = n.X;
-                double y0 = n.Y;
-
                 if (IsInRegion(region, n, fullyEnclosed))
                 {
-                    if (!DynamoSelection.Instance.Selection.Contains(n))
-                        DynamoSelection.Instance.Selection.Add(n);
+                    selection.AddUnique(n);
+                    // if annotation is selected its children should be added to selection too
+                    foreach (var m in n.SelectedModels)
+                    {
+                        selection.AddUnique(m);
+                    }
                 }
                 else
                 {
                     if (n.IsSelected)
-                        DynamoSelection.Instance.Selection.Remove(n);
+                        selection.Remove(n);
                 }
             }
         }

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -205,8 +205,7 @@ namespace Dynamo.Controls
                     DynamoSelection.Instance.ClearSelection();
                 }
 
-                if (!DynamoSelection.Instance.Selection.Contains(ViewModel.NodeLogic))
-                    DynamoSelection.Instance.Selection.Add(ViewModel.NodeLogic);
+                DynamoSelection.Instance.Selection.AddUnique(ViewModel.NodeLogic);
             }
             else
             {

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
@@ -60,10 +60,7 @@ namespace Dynamo.Nodes
                     DynamoSelection.Instance.ClearSelection();
                 }
 
-                if (!DynamoSelection.Instance.Selection.Contains(ViewModel.Model))
-                {
-                    DynamoSelection.Instance.Selection.Add(ViewModel.Model);
-                }
+                DynamoSelection.Instance.Selection.AddUnique(ViewModel.Model);
 
             }
             else


### PR DESCRIPTION
### Purpose

If a pasted selection has groups it has an issue with copy/paste:
- create a node, then a group from the node and select the group, then copy and paste the selection anywhere => pasted group and node inside it visually are selected, but `Selection` contains only the group.

Also the PR contains some code improvement.

### Reviewers

@mjkkirschner 