### PR TITLE
Update Default Edge and Point Colors

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.0.2816")]
+[assembly: AssemblyVersion("0.9.0.2845")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.0.2816")]
+[assembly: AssemblyFileVersion("0.9.0.2845")]

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -63,8 +63,8 @@
     <SolidColorBrush x:Key="UpdateManagerUpToDateBrush" Color="Green"/>
     
     <!--3D-->
-    <Color x:Key="EdgeColor">#655682</Color>
-    <Color x:Key="PointColor">#655682</Color>
+    <Color x:Key="EdgeColor">#000000</Color>
+    <Color x:Key="PointColor">#000000</Color>
     <Color x:Key="SelectionColor">#009EFF</Color>
     <Color x:Key="MaterialColor">#efede4</Color>
 


### PR DESCRIPTION
This PR fixes one broken test, `Display_ModelCurveDrawnInBackground_HasCorrectColor`. The edge color had not yet been updated to match core.

This is required for https://github.com/DynamoDS/DynamoRevit/pull/700.