### PR TITLE
MAGN-8774 DynamoAPI documentation page for NotifyPropertyChangedInvocatorAttribute has formatting errors

### DIFF
--- a/tools/XmlDocToMarkdown/DocumentationTestLibrary/TestDocumentation.cs
+++ b/tools/XmlDocToMarkdown/DocumentationTestLibrary/TestDocumentation.cs
@@ -15,7 +15,9 @@ using System.IO;
 
 namespace Dynamo.DocumentationTestLibrary
 {
+
     #region Interface
+
     /// <summary>
     /// Interface with generics
     /// </summary>
@@ -46,7 +48,7 @@ namespace Dynamo.DocumentationTestLibrary
         public enum TaskPriority
         {
             Critical,
-            Highest,          
+            Highest,
         }
 
         #region properties
@@ -75,6 +77,7 @@ namespace Dynamo.DocumentationTestLibrary
         #endregion
 
         #region events
+
         /// <summary>
         /// Delegate
         /// </summary>
@@ -154,7 +157,7 @@ namespace Dynamo.DocumentationTestLibrary
         /// <param name="test3">The test3.</param>
         public void TestWithMultipleParameters(int test1, int test2, int test3)
         {
-            
+
         }
 
         /// <summary>
@@ -167,7 +170,7 @@ namespace Dynamo.DocumentationTestLibrary
         /// </summary>
         public virtual void TestingVirtualMethod()
         {
-            
+
         }
 
         /// <summary>
@@ -223,7 +226,7 @@ namespace Dynamo.DocumentationTestLibrary
         /// </value>
         public virtual int VirtualProperty { get; set; }
 
-    
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Person"/> class.
         /// </summary>
@@ -233,5 +236,56 @@ namespace Dynamo.DocumentationTestLibrary
 
         }
 
-    }    
+    }
+
+    /// <summary>
+    /// Indicates that the method is contained in a type that implements
+    /// <see cref="System.ComponentModel.INotifyPropertyChanged"/> interface
+    /// and this method is used to notify that some property value changed
+    /// </summary>
+    /// <remarks>
+    /// The method should be non-static and conform to one of the supported signatures:
+    /// <list>
+    /// <item><c>NotifyChanged(string)</c></item>
+    /// <item><c>NotifyChanged(params string[])</c></item>
+    /// <item><c>NotifyChanged{T}(Expression{Func{T}})</c></item>
+    /// <item><c>NotifyChanged{T,U}(Expression{Func{T,U}})</c></item>
+    /// <item><c>SetProperty{T}(ref T, T, string)</c></item>
+    /// </list>
+    /// </remarks>
+    /// <example><code>
+    /// public class Foo : INotifyPropertyChanged {
+    ///   public event PropertyChangedEventHandler PropertyChanged;
+    ///   [NotifyPropertyChangedInvocator]
+    ///   protected virtual void NotifyChanged(string propertyName) { ... }
+    ///
+    ///   private string _name;
+    ///   public string Name {
+    ///     get { return _name; }
+    ///     set { _name = value; NotifyChanged("LastName"); /* Warning */ }
+    ///   }
+    /// }
+    /// </code>
+    /// Examples of generated notifications:
+    /// <list>
+    /// <item><c>NotifyChanged("Property")</c></item>
+    /// <item><c>NotifyChanged(() =&gt; Property)</c></item>
+    /// <item><c>NotifyChanged((VM x) =&gt; x.Property)</c></item>
+    /// <item><c>SetProperty(ref myField, value, "Property")</c></item>
+    /// </list>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public sealed class NotifyPropertyChangedInvocatorAttribute : Attribute
+    {
+        public NotifyPropertyChangedInvocatorAttribute() { }
+        public NotifyPropertyChangedInvocatorAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; private set; }
+    }
+
 }
+
+

--- a/tools/XmlDocToMarkdown/XmlDocToMarkdown/XmlMarkDown.cs
+++ b/tools/XmlDocToMarkdown/XmlDocToMarkdown/XmlMarkDown.cs
@@ -68,7 +68,7 @@ namespace XmlDocToMarkdown
                     {"event", "|{0}  \n| ------------- | :--------------- \n{1}\n"},
                     {"summary", "| {0}\n"},
                     {"remarks", "| {0}\n"},
-                    {"example", "| **Example:** | _C# code_\n\n```c#\n{0}\n```\n"},
+                    {"example", "| \n**Example:** | _C# code_\n\n```\nc#\n{0}\n```\n"},
                     {"seePage", "[[{1}|{0}]]"},
                     {"seeAnchor", "[{1}]({0})"},
                     {"param", "| **{0}**\n|{1}\n" },

--- a/tools/XmlDocToMarkdown/XmlDocToMarkdown/XmlMarkDown.cs
+++ b/tools/XmlDocToMarkdown/XmlDocToMarkdown/XmlMarkDown.cs
@@ -68,7 +68,7 @@ namespace XmlDocToMarkdown
                     {"event", "|{0}  \n| ------------- | :--------------- \n{1}\n"},
                     {"summary", "| {0}\n"},
                     {"remarks", "| {0}\n"},
-                    {"example", "| \n**Example:** | _C# code_\n\n```\nc#\n{0}\n```\n"},
+                    {"example", "| \n**Example:** | _C# code_\n\n```\n{0}\n```\n"},
                     {"seePage", "[[{1}|{0}]]"},
                     {"seeAnchor", "[{1}]({0})"},
                     {"param", "| **{0}**\n|{1}\n" },

--- a/tools/XmlDocToMarkdown/XmlDocToMarkdown/XmlMarkDown.cs
+++ b/tools/XmlDocToMarkdown/XmlDocToMarkdown/XmlMarkDown.cs
@@ -69,8 +69,8 @@ namespace XmlDocToMarkdown
                     {"summary", "| {0}\n"},
                     {"remarks", "| {0}\n"},
                     {"example", "| \n**Example:** | _C# code_\n\n```\n{0}\n```\n"},
-                    {"seePage", "[[{1}|{0}]]"},
-                    {"seeAnchor", "[{1}]({0})"},
+                    {"seePage", "*{0}*"},
+                    {"seeAnchor", "[**{1}**](**{0}**)"},
                     {"param", "| **{0}**\n|{1}\n" },
                     {"exception", "| **[[{0}|{0}]]:** | {1}\n" },
                     {"returns", "| **Return Value:** {0}\n"},
@@ -83,7 +83,7 @@ namespace XmlDocToMarkdown
         private static Func<string, XElement, string[]> d =
             new Func<string, XElement, string[]>((att, node) => new[]
                 {
-                    node.Attribute(att).Value, 
+                    node.Attribute(att).Value.ToClassString(), 
                     node.Nodes().NodeMarkDown()
                 });
 
@@ -359,6 +359,24 @@ namespace XmlDocToMarkdown
             var lines = s.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
             var blank = lines[0].TakeWhile(x => x == ' ').Count() - 4;
             return string.Join("\n", lines.Select(x => new string(x.SkipWhile((y, i) => i < blank).ToArray())));
+        }
+
+        static string ToClassString(this string s)
+        {
+            if (s.Contains("T:"))
+            {
+                var className = s.Replace("T:", "");
+                var methodName = className.Split('.').Last();
+                if (className.Contains("Dynamo"))
+                {
+                    var url = className.ConstructUrl(methodName);
+                    return url;
+                }
+
+                return methodName;
+            }
+
+            return s;
         }
     }
 }


### PR DESCRIPTION
### Purpose

This  PR fixes the issue around Example in Dynamo Documentation. Removed the extra characters and placed the C# code under the right markdown.

Link : http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8774
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough 

 

 