### PR TITLE
Ignore DS Defined class tests

### DIFF
--- a/test/Engine/ProtoTest/Associative/Inheritance.cs
+++ b/test/Engine/ProtoTest/Associative/Inheritance.cs
@@ -8,7 +8,7 @@ namespace ProtoTest.Associative
     class InheritaceTest : ProtoTestBase
     {
         [Test]
-        [Category("DSDefinedClass_Ignored_DoNotTestInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignored_DoNotTestInheritance")]
         public void InheritanceTest01()
         {
             String code =
@@ -20,7 +20,7 @@ namespace ProtoTest.Associative
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DoNotTestInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignored_DoNotTestInheritance")]
         public void InheritanceTest02()
         {
             String code =
@@ -30,7 +30,7 @@ namespace ProtoTest.Associative
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DoNotTestInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignored_DoNotTestInheritance")]
         public void InheritanceTest03()
         {
             String code =
@@ -40,7 +40,7 @@ namespace ProtoTest.Associative
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DoNotTestInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignored_DoNotTestInheritance")]
         public void InheritanceTest04()
         {
             String code =
@@ -51,7 +51,7 @@ namespace ProtoTest.Associative
 
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DoNotTestInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignored_DoNotTestInheritance")]
         public void InheritanceTest05()
         {
             String code =

--- a/test/Engine/ProtoTest/TD/Associative/Class.cs
+++ b/test/Engine/ProtoTest/TD/Associative/Class.cs
@@ -64,7 +64,7 @@ import(""FFITarget.dll"");
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T004_Associative_Class_Property_DefaultInitialization()
         {
@@ -96,7 +96,7 @@ import(""FFITarget.dll"");
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T005_Associative_Class_Property_Get_InternalClassFunction()
         {
@@ -144,7 +144,7 @@ import(""FFITarget.dll"");
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T006_Associative_Class_Property_UseInsideInternalClassFunction()
         {
@@ -195,7 +195,7 @@ import(""FFITarget.dll"");
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T008_Associative_Class_Property_CallFromAnotherExternalClass()
         {
@@ -238,7 +238,7 @@ zPosition = myPoint.Z;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T009_Associative_Class_Property_AssignInDifferentNamedConstructors()
         {
@@ -324,7 +324,7 @@ import(""FFITarget.dll"");
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T011_Associative_Class_Property_ExtendedClass()
         {
@@ -372,7 +372,7 @@ zPt1;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T012_Associative_Class_Property_Var()
         {
@@ -404,7 +404,7 @@ zPt1;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T013_Associative_Class_Property_GetFromAnotherConstructorInSameClass()
         {
@@ -485,7 +485,7 @@ testY1 = pt1.Y;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_Redundant")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_Redundant")]
         [Category("SmokeTest")]
         public void T016_Associative_Class_Property_SetInClassMethod()
         {
@@ -524,7 +524,7 @@ testY1 = pt1.Y;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_Redundant")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_Redundant")]
         [Category("SmokeTest")]
         public void T017_Associative_Class_Property_SetInExternalClassMethod()
         {
@@ -584,7 +584,7 @@ testY1 = pt1.Y;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_InvalidTest_NoVerification")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_InvalidTest_NoVerification")]
         [Category("SmokeTest")]
         public void T018_Associative_Class_Constructor_WithSameNameAndArgument_Negative()
         {
@@ -633,7 +633,7 @@ import(""FFITarget.dll"");
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T020_Associative_Class_Constructor_Overloads_WithSameNameAndDifferentArgumenType()
         {
@@ -670,7 +670,7 @@ class TestClass
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T021_Associative_Class_Constructor_UsingUserDefinedClassAsArgument()
         {
@@ -709,7 +709,7 @@ class TestClass
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T022_Associative_Class_Constructor_AssignUserDefineProperties()
         {
@@ -752,7 +752,7 @@ class MyLine
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T023_Associative_Class_Constructor_CallingAFunction()
         {
@@ -783,7 +783,7 @@ class MyPoint
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T024_Associative_Class_Constructor_CallingAnImperativeFunction()
         {
@@ -826,7 +826,7 @@ p2Y = p2.Y;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T025_Associative_Class_Constructor_CallingAnotherConstructor()
         {
@@ -869,7 +869,7 @@ class MyLine
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T026_Associative_Class_Constructor_BaseConstructorAssignProperties()
         {
@@ -914,7 +914,7 @@ z = test.Z;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T027_Associative_Class_Constructor_BaseConstructorWithSameName()
         {
@@ -955,7 +955,7 @@ z = test.Z;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T028_Associative_Class_Property_DefaultAssignment()
         {
@@ -989,7 +989,7 @@ z = test.Z;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T029_Associative_Class_Property_AccessModifier()
         {
@@ -1011,7 +1011,7 @@ t = a.x;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T030_Associative_Class_Property_AccessModifier()
         {
@@ -1037,7 +1037,7 @@ class B extends A
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T031_Associative_Class_Property_AccessModifier()
         {
@@ -1068,7 +1068,7 @@ x = b.foo();
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T051_Inherit_defaultconstructor()
         {
@@ -1096,7 +1096,7 @@ result3 = instance.val1;//2";
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T052_Inherit_defaultproperty()
         {
@@ -1148,7 +1148,7 @@ x9 = a1.w4;//null
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T053_Inherit_changevalue()
         {
@@ -1214,7 +1214,7 @@ x9 = a1.w4;//{null,null}";
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T056_Inherit_private()
         {
@@ -1270,7 +1270,7 @@ a5 = a.y;";
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("Method Resolution")]
         public void T057_Inherit_private_modify()
         {
@@ -1336,7 +1336,7 @@ b6 = b.y;";
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("Method Resolution")]
         public void T058_Inherit_private_notmodify()
         {
@@ -1397,7 +1397,7 @@ a6 = a.y;";
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("Method Resolution")]
         public void T059_Inherit_access_privatemember()
         {
@@ -1464,7 +1464,7 @@ a6 = a.y;";
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T061_Inherit_Property()
         {
@@ -1521,7 +1521,7 @@ xPoint3 = derivedpoint.D;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T062_Inherit_classAsArgument()
         {
@@ -1593,7 +1593,7 @@ class derived extends TestPoint
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T063_Inherit_classAsArgument_callinfunction()
         {
@@ -1656,7 +1656,7 @@ def modify(oldPoint : TestPoint)
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T064_Inherit_classAsArgument_callinfunction()
         {
@@ -1723,7 +1723,7 @@ def modify(oldPoint : TestPoint)
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T065_Inherit_constructor_withoutbase()
         {
@@ -1775,7 +1775,7 @@ xPoint3 = derivedpoint.D;//7";
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T066_Inherit_constructor_failing_witbase()
         {
@@ -1813,7 +1813,7 @@ b2 = b1.y;//10
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T067_Inherit_propertynotassignedinbase()
         {
@@ -1851,7 +1851,7 @@ b2 = b1.y;//10
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T068_Inherit_propertyassignedinherited()
         {
@@ -1889,7 +1889,7 @@ b3 = b1.x;//10
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T069_Inherit_constructor_failing_both()
         {
@@ -1926,7 +1926,7 @@ b2 = b1.y;//null
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T070_Inherit_constructor_failing_inherited()
         {
@@ -1965,7 +1965,7 @@ b3=b1.x;
 
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T071_Inherit_constructor_failing_inherited_sameproperty()
         {
@@ -2003,7 +2003,7 @@ b3=b1.x;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("Type System")]
         public void T072_inherit_Class_Constructor_CallingAFunction()
         {
@@ -2046,7 +2046,7 @@ pY = p.Y;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T073inherit_Constructor_WithSameNameAndDifferentArgumenType()
         {
@@ -2096,7 +2096,7 @@ test2 = myClass.Create (true, false);
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T074_Inherit_property_array()
         {
@@ -2129,7 +2129,7 @@ x1 = a1.y;//null
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T075_Inherit_property_array_modify()
         {
@@ -2161,7 +2161,7 @@ x1 = a1.y;//null
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T076_Inherit_property_array_modifyanitem()
         {
@@ -2194,7 +2194,7 @@ x1 = a1.y;//null
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T077_Inherit_property_thatdoesnotexist()
         {
@@ -2227,7 +2227,7 @@ x1 = a1.z;//null
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void T078_Inherit_property_singletonconvertedtoarray()
         {
@@ -2279,7 +2279,7 @@ sp_x = [Associative]
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_Redundant")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_Redundant")]
         [Category("SmokeTest")]
         public void Z002_Associative_Class_Property_Regress_1454056()
         {
@@ -2310,7 +2310,7 @@ val;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_InvalidTest")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_InvalidTest")]
         [Category("SmokeTest")]
         public void Z003_Associative_Class_Property_Regress_1454164()
         {
@@ -2332,7 +2332,7 @@ class Sample
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_Redundant")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_Redundant")]
         [Category("SmokeTest")]
         public void Z004_Associative_Class_Property_Regress_1454138()
         {
@@ -2405,7 +2405,7 @@ sum = [Associative]
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_Redundant")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_Redundant")]
         [Category("SmokeTest")]
         public void Z006_Associative_Class_Property_Regress_1453886()
         {
@@ -2510,7 +2510,7 @@ l_startPoint_X = l.Start.X;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_Redundant")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_Redundant")]
         [Category("SmokeTest")]
         public void Z010_Associative_Class_Property_Regress_1454658()
         {
@@ -2599,7 +2599,7 @@ import(""FFITarget.dll"");
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z012_Access_Class_Property_From_If_Block_In_Class_Method_Regress_1456397()
         {
@@ -2640,7 +2640,7 @@ b1;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z013_Defect_1457038()
         {
@@ -2686,7 +2686,7 @@ d;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z014_Defect_1457057()
         {
@@ -2801,7 +2801,7 @@ x = c.X;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void Z016_Defect_1456771()
         {
@@ -2848,7 +2848,7 @@ t2 = b1.foo1(1);
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z017_Defect_1456898()
         {
@@ -2943,7 +2943,7 @@ b2 = a1.Add();
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z018_Defect_1456798_2()
         {
@@ -2981,7 +2981,7 @@ a2;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z018_Defect_1456798_3()
         {
@@ -3013,7 +3013,7 @@ a2;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_Redundant")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_Redundant")]
         [Category("SmokeTest")]
         public void Z019_Defect_1457053()
         {
@@ -3063,7 +3063,7 @@ b6 = a3.add();
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z020_Defect_1457290()
         {
@@ -3093,7 +3093,7 @@ a2 = a1.foo();";
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z020_Defect_1457290_2()
         {
@@ -3126,7 +3126,7 @@ a2;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_Redundant")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_Redundant")]
         [Category("SmokeTest")]
         public void Z021_Defect_1458785()
         {
@@ -3220,7 +3220,7 @@ a6 = 3;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z021_Defect_1458785_4()
         {
@@ -3265,7 +3265,7 @@ test5= test1.testmethod();
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void Z021_Defect_1458785_5()
         {
@@ -3314,7 +3314,7 @@ a4 = a.y;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_Redundant")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_Redundant")]
         [Category("SmokeTest")]
         public void Z021_Defect_1458785_6()
         {
@@ -3345,7 +3345,7 @@ a2 = a1.x;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void Z022_Defect_1455292()
         {
@@ -3393,7 +3393,7 @@ dummy = intpt.x;    // i was expecting 100 here
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void Z022_Defect_1455292_2()
         {
@@ -3431,7 +3431,7 @@ yy = p.y;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void Z022_Defect_1455292_3()
         {
@@ -3491,7 +3491,7 @@ t = [Imperative]
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_Redundant")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_Redundant")]
         [Category("SmokeTest")]
         public void Z023_Defect_1455131()
         {
@@ -3553,7 +3553,7 @@ class TestClass
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z023_Defect_1455131_2()
         {
@@ -3628,7 +3628,7 @@ t = [Imperative]
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z024_Defect_1461133()
         {
@@ -3655,7 +3655,7 @@ a = 2;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z024_Defect_1461133_2()
         {
@@ -3683,7 +3683,7 @@ test = a1.foo( a2 );
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z025_Defect_1459626()
         {
@@ -3742,7 +3742,7 @@ t2 = t.X;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z026_Defect_1458563()
         {
@@ -3767,7 +3767,7 @@ t1 = a.x1;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("Update")]
         public void Z026_Defect_1458563_2()
         {
@@ -3838,7 +3838,7 @@ p7 = t7;//a.x7;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassInheritance")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassInheritance")]
         [Category("SmokeTest")]
         public void Z027_Defect_1461365()
         {
@@ -3860,7 +3860,7 @@ b1 = B.B();
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignoreed_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void Z028_Same_Name_Constructor_And_Method_Negative()
         {

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestClass.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestClass.cs
@@ -91,7 +91,7 @@ c2 = [Associative]
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T04_Class_Properties()
         {
@@ -139,7 +139,7 @@ t6 = t5[0].y;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T05_Class_Properties()
         {
@@ -189,7 +189,7 @@ t6 = t5[0].y;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T06_Class_Properties()
         {
@@ -209,7 +209,7 @@ t1 = a.x1;
             thisTest.Verify("t1", 5, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T07_Class_Properties()
         {
@@ -229,7 +229,7 @@ t1 = a.x1;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T08_Class_Properties()
         {
@@ -262,7 +262,7 @@ t2 = a.x2[1].x1;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T09_Class_Inheritance()
         {
@@ -299,7 +299,7 @@ b3 = a1.x3;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T10_Class_Inheritance()
         {
@@ -336,7 +336,7 @@ b3 = a1.x3;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T11_Class_Inheritance()
         {
@@ -406,7 +406,7 @@ getX = obj.IntVal;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T13_Class_Default_Constructors()
         {
@@ -443,7 +443,7 @@ p1 = a1.p;
         }
 
         [Test]
-        [Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T14_Class_Named_Constructors()
         {
@@ -486,7 +486,7 @@ x3 = xx[2].x;
             thisTest.Verify("x3", 3, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T15_Class_Constructor_Negative()
         {
@@ -517,7 +517,7 @@ x2 = 3;
             thisTest.Verify("x2", 3);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")] 
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")] 
         [Category("SmokeTest")]
         public void T15_Class_Constructor_Negative_1467598()
         {
@@ -548,7 +548,7 @@ x2 = 3;
             thisTest.Verify("x2", 3);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T16_Class_Constructor_Negative()
         {
@@ -573,7 +573,7 @@ a1 = A.A(1);
             });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T17_Class_Constructor_Negative()
         {
@@ -606,7 +606,7 @@ a1 = A.A(b1);
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T18_Class_Constructor_Empty()
         {
@@ -632,7 +632,7 @@ x3 = a1.y;
             Assert.IsTrue(mirror.GetValue("x3").DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T19_Class_Constructor_Test_Default_Property_Values()
         {
@@ -678,7 +678,7 @@ x9 = a1.w4;
             thisTest.Verify("x9", null);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T20_Class_Constructor_Fails()
         {
@@ -699,7 +699,7 @@ b1 = a1.x;
             Assert.IsTrue(mirror.GetValue("b1").DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T21_Class_Constructor_Calling_Base_Constructor()
         {
@@ -742,7 +742,7 @@ c3 = c.z;
             thisTest.Verify("c3", 3, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T22_Class_Constructor_Not_Calling_Base_Constructor()
         {
@@ -775,7 +775,7 @@ c2 = c.y;
             thisTest.Verify("c2", 2, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T23_Class_Constructor_Base_Constructor_Same_Name()
         {
@@ -841,7 +841,7 @@ d2 = d.y;
             thisTest.Verify("d2", 2, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T24_Class_Constructor_Calling_Base_Methods()
         {
@@ -880,7 +880,7 @@ c2 = c.y;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T25_Class_Properties_Modifiers()
         {
@@ -921,7 +921,7 @@ a4 = a.y;
             thisTest.Verify("a3", 4, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T26_Class_Properties_Access()
         {
@@ -983,7 +983,7 @@ a11;a12;a2;a3;a4;a5;
             thisTest.Verify("a5", 1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T27_Class_Properties_Access()
         {
@@ -1047,7 +1047,7 @@ aa;a2;
             thisTest.Verify("a2", 15);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Method Resolution")]
         public void T28_Class_Properties_Access()
         {
@@ -1138,7 +1138,7 @@ f2 = foo(a2,b2);
             thisTest.Verify("f2", 4);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T29_Class_Method_Chaining()
         {
             //Assert.Fail("1454966 - Sprint15: Rev 720 : [Geometry Porting] Assignment operation where the right had side is Class.Constructor.Property is not working ");
@@ -1190,7 +1190,7 @@ t1 = b1[0].x.x[1];
 
 
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T30_Class_Property_Update_Negative()
         {
@@ -1219,7 +1219,7 @@ x3 = 3;
             TestFrameWork.Verify(mirror, "x2", null);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T31_Class_By_Composition()
         {
@@ -1279,7 +1279,7 @@ x1 = testP.X;
             thisTest.Verify("x1", 7.5, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T32_Class_ReDeclaration()
         {
@@ -1353,7 +1353,7 @@ x1 = testP.X;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T33_Class_Methods()
         {
@@ -1401,7 +1401,7 @@ x6 = p1.X;
             thisTest.Verify("x6", 1.0, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T34_Class_Static_Methods()
         {
@@ -1447,7 +1447,7 @@ x5 = 1;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T35_Class_Method_Overloading()
         {
@@ -1500,7 +1500,7 @@ a2 = p2.add1();
             thisTest.Verify("a2", 35.0, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T36_Class_Method_Calling_Constructor()
         {
@@ -1566,7 +1566,7 @@ b5 = b1.b;
             thisTest.Verify("b5", 40.0, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T37_Class_Method_Using_This()
         {
@@ -1604,7 +1604,7 @@ a3 = p1.Y;
             });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T38_Class_Method_Using_This()
         {
@@ -1639,7 +1639,7 @@ a3 = p1.Y;
             thisTest.Verify("a3", 14.0, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T39_Class_Method_Returning_Collection()
         {
@@ -1672,7 +1672,7 @@ a3 = a1[1];
             thisTest.Verify("a3", 14.0, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T40_Class_Property_Initialization_With_Another_Class()
         {
@@ -1698,7 +1698,7 @@ t1 = p1.inner.X;
             thisTest.Verify("t1", 3.0, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T41_Test_Static_Properties()
         {
@@ -1718,7 +1718,7 @@ t2 = A.x;
             thisTest.Verify("t2", 3, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T41_Test_Static_Properties_2()
         {
@@ -1744,7 +1744,7 @@ b = [Imperative]
         }
 
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T42_Defect_1461717()
         {
@@ -1774,7 +1774,7 @@ A = B.B();
         }
 
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T43_Defect_1461479()
         {
@@ -1789,7 +1789,7 @@ x2 = A.x;
             thisTest.Verify("x2", 1, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T43_Defect_1461479_2()
         {
@@ -1809,7 +1809,7 @@ t1 = a.x1;
             thisTest.Verify("t1", 5, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Update")]
         [Category("Failure")]
         public void T43_Defect_1461479_3()
@@ -1863,7 +1863,7 @@ t6 = x3.foo2();
             thisTest.Verify("t6", v1, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T43_Defect_1461479_4()
         {
@@ -1896,7 +1896,7 @@ d = a.foo();
             thisTest.Verify("d", 4, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T44_Defect_1461860()
         {
@@ -1921,7 +1921,7 @@ b;
             thisTest.Verify("b", 4);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T44_Defect_1461860_2()
         {
@@ -1954,7 +1954,7 @@ c = y.x;
         }
 
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T46_Defect_1461716()
         {
@@ -1977,7 +1977,7 @@ c1 = b1.a;";
             thisTest.Verify("c1", v1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T46_Defect_1461716_2()
         {
@@ -2013,7 +2013,7 @@ b1;c1;
             thisTest.Verify("x", v2);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T47_Calling_Imperative_Code_From_Conctructor()
         {
@@ -2039,7 +2039,7 @@ a1 = A1.a;";
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T48_Defect_1460027()
         {
@@ -2064,7 +2064,7 @@ b1=a1[1][0];";
             thisTest.Verify("b1", 4);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T48_Defect_1460027_2()
         {
@@ -2089,7 +2089,7 @@ b1=a1[1][0];
             thisTest.Verify("b1", 4);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T48_Defect_1460027_3()
         {
@@ -2119,7 +2119,7 @@ class A
             thisTest.Verify("c", 4, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T48_Defect_1460027_4()
         {
@@ -2150,7 +2150,7 @@ class A
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kCyclicDependency);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T49_Defect_1460505()
         {
@@ -2189,7 +2189,7 @@ derivedPoint2 = modify( derivedpoint );";
             thisTest.Verify("derivedPoint2", true, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T49_Defect_1460505_2()
         {
@@ -2229,7 +2229,7 @@ derivedPoint2 = modify( derivedpoint );";
             thisTest.Verify("derivedPoint2", true, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T50_Defect_1460510()
         {
@@ -2269,7 +2269,7 @@ class derived extends TestPoint
                 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T50_Defect_1460510_2()
         {
@@ -2305,7 +2305,7 @@ class Derived extends Base
             });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T51_Defect_1461399()
         {
@@ -2335,7 +2335,7 @@ test = CurveProperties(null);";
             thisTest.Verify("test", ExpectedResult);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T51_Defect_1461399_2()
         {
@@ -2372,7 +2372,7 @@ class Arc
             thisTest.Verify("test", ExpectedResult);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T51_Defect_1461399_3()
         {
@@ -2413,7 +2413,7 @@ test;
         }
 
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T52_Defect_1461479()
         {
@@ -2433,7 +2433,7 @@ a = A.foo();
             Assert.IsTrue(mirror.GetValue("a", 0).DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T52_Defect_1461479_2()
         {
@@ -2453,7 +2453,7 @@ test1 = Sample.ret_a();
             Assert.IsTrue(mirror.GetValue("test1", 0).DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T52_Defect_1461479_3()
         {
@@ -2481,7 +2481,7 @@ class Sample
             thisTest.Verify("test2", 2, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T52_Defect_1461479_4()
         {
@@ -2518,7 +2518,7 @@ test6 = S2.ret_a();";
             Object v1 = null;
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T52_Defect_1461479_5()
         {
@@ -2565,7 +2565,7 @@ test1;test2;test7;test8;
             thisTest.Verify("test8", v2, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter()
         {
@@ -2612,7 +2612,7 @@ x2 = derivedpoint.B;
             Assert.IsTrue(mirror.GetValue("derivedPoint2", 0).DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738()
         {
@@ -2658,7 +2658,7 @@ x2=derivedpoint.B; ";
             Assert.IsTrue(mirror.GetValue("derivedPoint2", 0).DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738_2()
         {
@@ -2705,7 +2705,7 @@ x2 = derivedpoint.B;
             Assert.IsTrue(mirror.GetValue("derivedPoint2", 0).DsasmValue.IsNull);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738_3()
         {
@@ -2751,7 +2751,7 @@ x2 = derivedpoint.B;";
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738_4()
         {
@@ -2799,7 +2799,7 @@ x2 = derivedpoint.B;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738_6()
         {
@@ -2854,7 +2854,7 @@ x2 = derivedpoint.B;
             thisTest.Verify("x2", 9);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T53_Undefined_Class_As_Parameter_1463738_7()
         {
             string code = @"
@@ -2910,7 +2910,7 @@ x2 = derivedpoint.B; // expected 8; received : 9
             thisTest.Verify("x2", 9);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_1463738_8()
         {
@@ -2965,7 +2965,7 @@ x2 = derivedpoint.B;
             thisTest.Verify("x2", 9);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_As_Parameter_imperative_1463738_9()
         {
@@ -3014,7 +3014,7 @@ x2 = derivedpoint.B;
             thisTest.Verify("x2", 8);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_negative_1467107_10()
         {
@@ -3032,7 +3032,7 @@ y2 = m.foo(2);
             thisTest.Verify("y2", a);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_negative_imperative_1467107_11()
         {
@@ -3054,7 +3054,7 @@ y2;
             thisTest.Verify("y2", a);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_negative_imperative_1467091_12()
         {
@@ -3074,7 +3074,7 @@ y;
             thisTest.Verify("y", a);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T53_Undefined_Class_negative_associative_1467091_13()
         {
@@ -3092,7 +3092,7 @@ y = test.foo (1);
 
         // Jun: To address on dot op defect
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T55_Defect_1460616()
         {
             string code = @"
@@ -3140,7 +3140,7 @@ x3 = a3.x;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Failure")]
         public void TV55_Defect_1460616_1()
         {
@@ -3190,7 +3190,7 @@ x3 = a3.x;
             thisTest.Verify("x3", v1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T55_Defect_1460616_2()
         {
@@ -3213,7 +3213,7 @@ x3 = a3.x;
         }
 
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T56_Local_Class_method_Same_Name_As_Global_Function()
         {
@@ -3248,7 +3248,7 @@ x = b.ding();  // expect 100 but got 1000
             thisTest.Verify("x", 100);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Method Resolution")]
         public void T58_Defect_1462445()
         {
@@ -3284,7 +3284,7 @@ class A
             thisTest.Verify("w", 2);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T59_Defect_1466572()
         {
@@ -3314,7 +3314,7 @@ zz = p1.Z;// expected -1, received -1
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T60_Defect_1467004()
         {
@@ -3339,7 +3339,7 @@ s = test.foo(arr); //Expected output should be -123
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T59_Defect_1466572_2()
         {
@@ -3369,7 +3369,7 @@ zz = p1.Z;
             thisTest.Verify("zz", 1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T59_Defect_1466572_3()
         {
@@ -3402,7 +3402,7 @@ p2 = foo ( -x1, -(x1+x2), -x1*x2+0.5 );
             thisTest.Verify("p2", 0.5);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T61_Defect_1459171()
         {
@@ -3434,7 +3434,7 @@ a3 = a1.Y;
             thisTest.Verify("a3", 10.000000);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T62_class_assignment_inside_imperative()
         {
             string code = @"class point{
@@ -3488,7 +3488,7 @@ return=controlPoly;
             // thisTest.VerifyBuildWarning(ProtoCore.BuildData.WarningID.kFunctionNotFound);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T63_Array_inClass_Imperative_1465637()
         {
@@ -3531,7 +3531,7 @@ b2 = {0,0,0,0,0};
         }
 
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T68_Inherit_Base_Constructor_1467153()
         {
             string code = @"
@@ -3569,7 +3569,7 @@ d=n.Fixity;
             thisTest.Verify("d", false);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T68_Inherit_Base_Constructor_1467153_negative()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
@@ -3608,7 +3608,7 @@ d=n.Fixity;
         }
 
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T63_Class_methodresolution_1457172()
         {
             string code = @"
@@ -3669,7 +3669,7 @@ p8 = y[2][2];
             thisTest.Verify("p8", a);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T63_Class_methodresolution_1457172_2()
         {
             string code = @"
@@ -3730,7 +3730,7 @@ p4 = y[0][1][1];
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T63_Class_methodresolution_1457172_3()
         {
             string code = @"
@@ -3751,7 +3751,7 @@ y = x.foo ();
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T69_Redefine_property_inherited_1467141()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
@@ -3783,7 +3783,7 @@ r2 = a.fy;
             });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T70_Defect_1467112_Method_Overloading_Issue()
         {
             string code = @"
@@ -3813,7 +3813,7 @@ b1 = b.foo1(1);";
             thisTest.Verify("b1", 2);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T71_class_inherit_arg_var_1467157()
         {
             // Assert.Fail("1467157 - Sprint 25 - rev 3047 class inheritance if the argument is var and the same declared both in base calss and inherited class it throws error ");
@@ -3847,7 +3847,7 @@ b=a.CreateNew(1);
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T72_class_inherit_1467097_1()
         {
             //Assert.Fail("1467097 Sprint 24 - Rev 2761 - if var is used as a argument to function and call function with defined class it goes into a loop and hangs DS ");
@@ -3894,7 +3894,7 @@ c=oldPoint.C;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T72_class_inherit_1467097_2()
         {
             //Assert.Fail("1467097 Sprint 24 - Rev 2761 - if var is used as a argument to function and call function with defined class it goes into a loop and hangs DS ");
@@ -3942,7 +3942,7 @@ c=derivedpoint.C;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void TV_1467097_class_inherit()
         {
             String code =
@@ -3975,7 +3975,7 @@ rb = oldPoint.B;
         }
 
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T73_Defect_1467210_Expected_Warning()
         {
@@ -3999,7 +3999,7 @@ a = Test.DoSomething(); //wrong warning is thrown:
             thisTest.Verify("a", n1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T74_Defect_1469099_Access_Property()
         {
@@ -4032,7 +4032,7 @@ t2 = b1.ang;";
             thisTest.Verify("t2", 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T74_Defect_1469099_Access_Property_2()
         {
@@ -4075,7 +4075,7 @@ t1;t2;
             thisTest.Verify("t2", 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T75_Defect_1467188_Class_Instantiation()
         {
@@ -4103,7 +4103,7 @@ RY = ty.foo(t);";
             thisTest.Verify("RY", 1.0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T75_Defect_1467188_Class_Instantiation_2()
         {
@@ -4141,7 +4141,7 @@ RY = ty.foo( t );";
             thisTest.Verify("RY", 9.0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T76_Defect_1467186_Class_Update()
         {
@@ -4164,7 +4164,7 @@ x = 5;";
 
     
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T77_Defect_1460274_Class_Update_2()
         {
             string code = @"
@@ -4207,7 +4207,7 @@ test3 = pointGroup3.X;
             thisTest.Verify("test3", new Object[] { 4, 2 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T77_Defect_1460274_Class_Update_3()
         {
@@ -4235,7 +4235,7 @@ test = pointGroup.X;";
             thisTest.Verify("test", new Object[] { 4, 2 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T77_Defect_1460274_Class_Update_5()
         {
             string code = @"
@@ -4260,7 +4260,7 @@ test = geometry;";
             thisTest.Verify("test", new Object[] { 5, 10, 15, null, 11 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T78_Defect_1467146_Class_Update_With_Replication()
         {
@@ -4280,7 +4280,7 @@ val = v[0];";
             thisTest.Verify("val", 100);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T78_Defect_1467146_Class_Update_With_Replication_2()
         {
@@ -4300,7 +4300,7 @@ val = v[0];";
             thisTest.Verify("val", n1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Failure")]
         public void T78_Defect_1467146_Class_Update_With_Replication_3()
         {
@@ -4322,7 +4322,7 @@ v = A.execute(arr);
             thisTest.Verify("v", new Object[] { 100, 100, n1 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         [Category("Failure")]
         public void T78_Defect_1467146_Class_Update_With_Replication_4()
@@ -4344,7 +4344,7 @@ v = A.execute(arr);
             thisTest.Verify("v", new Object[] { 100, n1, n1 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T78_Defect_1467146_Class_Update_With_Replication_5()
         {
             string code = @"
@@ -4383,7 +4383,7 @@ p2 = B.execute2(arr2);";
             thisTest.Verify("p2", 200);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T79_Defect_1458581_Unnamed_Constructor()
         {
             string code = @"
@@ -4406,7 +4406,7 @@ b2 = a1.x2;";
             thisTest.Verify("b2", 1.5);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Replication")]
         public void T80_Defect_1444246_Replication()
         {
@@ -4430,7 +4430,7 @@ xs;
             thisTest.Verify("xs", new Object[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Replication")]
         public void T80_Defect_1444246_Replication_2()
         {
@@ -4450,7 +4450,7 @@ p2 = MyPoint.CreateXY(-20.0,-30.0).X;";
             thisTest.Verify("p2", -20.0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T81_Defect_1467246_derived_class_setter()
         {
             string code = @"
@@ -4481,7 +4481,7 @@ z1 = a1.z;
             thisTest.Verify("z1", 6);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T82_Defect_1467174()
         {
             string code = @"
@@ -4517,7 +4517,7 @@ t1 = l1.StartPoint.X;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Replication")]
         public void T83_Defect_1463232()
         {
@@ -4535,7 +4535,7 @@ t = a.x;
             thisTest.Verify("t", n1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Replication")]
         public void T83_Defect_1463232_2()
         {
@@ -4557,7 +4557,7 @@ t = a.x;
             thisTest.Verify("t", n1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Replication")]
         [Category("Failure")]
         public void T83_Defect_1463232_3()
@@ -4580,7 +4580,7 @@ t = a.x;
             thisTest.Verify("t", new Object[] { n1, n1 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T84_ClassNameAsPropertyName_01()
         {
             string code = @"
@@ -4621,7 +4621,7 @@ x2 = b.getx();
             thisTest.VerifyBuildWarningCount(0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T85_Defect_1467247()
         {
             string code = @"
@@ -4663,7 +4663,7 @@ t2 = a.y;
         }
 
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T85_Defect_1467247_2()
         {
             string code = @"
@@ -4704,7 +4704,7 @@ a.y = 5;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Failure")]
         public void T85_Defect_1467247_3()
         {
@@ -4732,7 +4732,7 @@ a.x = 4;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T86_Defect_1467216()
         {
             string code = @"
@@ -4759,7 +4759,7 @@ test = p.x;
             thisTest.Verify("test", 10);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T86_Defect_1467216_2()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
@@ -4777,7 +4777,7 @@ test = Plane.x;
             });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T86_Defect_1467216_3()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
@@ -4794,7 +4794,7 @@ test = Plane;
             });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T86_Defect_1467216_4()
         {
             Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
@@ -4815,7 +4815,7 @@ test = foo();
             });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T87_Defect_1467243()
         {
             string code = @"
@@ -4837,7 +4837,7 @@ r2 = fa.fx[0];
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T87_Defect_1467243_2()
         {
             string code = @"
@@ -4858,7 +4858,7 @@ r2 = fa.fx[0][0];
             thisTest.Verify("r1", new Object[] { true });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T88_Runtime_MemberFunction01()
         {
             string code = @"
@@ -4888,7 +4888,7 @@ r = x.foo();
             thisTest.Verify("r", null);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T89_Runtime_MemberFunction02()
         {
             string code = @"
@@ -4918,7 +4918,7 @@ r = b.foo();
             thisTest.Verify("r", 200);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T89_1467344_02()
         {
             string code = @"
@@ -4953,7 +4953,7 @@ r;
             thisTest.Verify("r", 200);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T90_Runtime_MemberFunction03()
         {
             string code = @"
@@ -4990,7 +4990,7 @@ r = x.foo();
             thisTest.Verify("r", 300);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T91_stackoverflow()
         {
             string code = @"
@@ -5025,7 +5025,7 @@ r = x.foo();
             thisTest.VerifyBuildWarningCount(0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         [Category("Failure")]
         public void T92_default_argument_1467384()
@@ -5047,7 +5047,7 @@ r = x.foo();
             thisTest.Verify("a", 4, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T92_default_argument_1467402()
         {
@@ -5067,7 +5067,7 @@ r = x.foo();
             thisTest.Verify("d", 1, 0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T93_Defect_1467349_update_static_properties()
         {
@@ -5084,7 +5084,7 @@ Base.x = { 5.2, 3.9 };
             thisTest.Verify("t", new Object[] { 5, 4 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T93_Defect_1467349_update_static_properties_2()
         {
@@ -5104,7 +5104,7 @@ b2 = b1;
             thisTest.Verify("b2", 3);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T93_Defect_1467349_update_static_properties_3()
         {
@@ -5128,7 +5128,7 @@ b2 = b1;
             thisTest.Verify("b2", 3);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T93_Defect_1467349_update_static_properties_4()
         {
@@ -5152,7 +5152,7 @@ b2 = b1;
             thisTest.Verify("b2", new Object[] { 3, 4 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T93_Defect_1467349_update_static_properties_5()
         {
@@ -5177,7 +5177,7 @@ b2 = b1;
             thisTest.Verify("b2", new Object[] { 3, 4 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467343()
         {
@@ -5210,7 +5210,7 @@ r = x.foo();
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467343_2()
         {
@@ -5246,7 +5246,7 @@ r;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467344_3()
         {
@@ -5279,7 +5279,7 @@ r = b.foo();
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467344_4()
         {
@@ -5315,7 +5315,7 @@ r = b.foo();
             thisTest.Verify("r", 200);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467443()
         {
@@ -5334,7 +5334,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94__imperative_1467443_7()
         {
@@ -5356,7 +5356,7 @@ a = test.test();
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467443_2()
         {
@@ -5371,7 +5371,7 @@ a.b = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_imperative_1467443_8()
         {
@@ -5390,7 +5390,7 @@ a.b = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467443_3()
         {
@@ -5413,7 +5413,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_iperative_1467443_9()
         {
@@ -5440,7 +5440,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467443_4()
         {
@@ -5463,7 +5463,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_imperative_1467443_10()
         {
@@ -5490,7 +5490,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_1467443_6()
         {
@@ -5517,7 +5517,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T94_imperative_1467443_11()
         {
@@ -5548,7 +5548,7 @@ a.foo = 1;
             TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.kMethodResolutionFailure);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_1()
         {
@@ -5570,7 +5570,7 @@ a.foo = 1;
             thisTest.Verify("y", 1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_2()
         {
@@ -5592,7 +5592,7 @@ a.foo = 1;
             thisTest.Verify("y", new object[] { 1, 2, 3 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_3()
         {
@@ -5618,7 +5618,7 @@ y = x.a;
             thisTest.Verify("y", 1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_4()
         {
@@ -5644,7 +5644,7 @@ y = x.a;
             thisTest.Verify("y", new object[] { 1, 2, 3 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_5()
         {
@@ -5670,7 +5670,7 @@ y = x.a;
             thisTest.Verify("y", 1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_6()
         {
@@ -5696,7 +5696,7 @@ y = x.a;
             thisTest.Verify("y", new object[] { 1, 2, 3 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467437_7()
         {
@@ -5722,7 +5722,7 @@ y = x.a;
             thisTest.Verify("y", new object[] { 2, 3 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467464_1()
         {
@@ -5753,7 +5753,7 @@ y = x.a;
             thisTest.Verify("b", null);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T97_1467440_Class_Not_Defined_1()
         {
@@ -5771,7 +5771,7 @@ z = foo({ 1, 2 });
             thisTest.Verify("z", n1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T97_1467440_Class_Not_Defined_2()
         {
@@ -5793,7 +5793,7 @@ z;
             thisTest.Verify("z", n1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T97_1467440_Class_Not_Defined_3
             ()
@@ -5816,7 +5816,7 @@ z;
             thisTest.Verify("z", n1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T98_1467450_Class_Not_Defined_1
             ()
@@ -5837,7 +5837,7 @@ a4 = A.A({1,2}, c..d, 0..1, 5..f);
             thisTest.Verify("a4", n1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T98_1467450_Class_Not_Defined_2
             ()
@@ -5862,7 +5862,7 @@ a1;a2;a3;a4;
             thisTest.Verify("a4", n1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T98_1467450_Class_Not_Defined_3
             ()
@@ -5890,7 +5890,7 @@ a4 : int;
             thisTest.Verify("a4", n1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T98_1467450_Class_Not_Defined_4
             ()
@@ -5922,7 +5922,7 @@ test = A.foo();
             thisTest.Verify("a4", n1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T99_UnnamedConstructor01()
         {
@@ -5941,7 +5941,7 @@ r = a.x;
             thisTest.Verify("r", 41);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T99_1467469
             ()
@@ -5962,7 +5962,7 @@ d = a == b;
             thisTest.Verify("c", false);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467421()
         {
@@ -5986,7 +5986,7 @@ r = a1.count;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467421_2()
         {
@@ -6010,7 +6010,7 @@ r = a1.count;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467421_3()
         {
@@ -6038,7 +6038,7 @@ r2 = b1.count;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467421_4()
         {
@@ -6066,7 +6066,7 @@ r2 = b1.count;
             thisTest.Verify("r2", new object[] { 4, 5, 6 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467421_5()
         {
@@ -6093,7 +6093,7 @@ r = a1.count;
             thisTest.Verify("r", 1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467472()
         {
@@ -6119,7 +6119,7 @@ r2=a1.pt;
             thisTest.Verify("r2", 1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467472_2()
         {
@@ -6152,7 +6152,7 @@ r2=b1.pt;
             thisTest.Verify("r2", 2);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467472_3()
         {
@@ -6183,7 +6183,7 @@ r2=a1.pt;
             thisTest.Verify("r2", 1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T95_1467472_4()
         {
@@ -6220,7 +6220,7 @@ r2=b1.pt;
             thisTest.Verify("r2", 2);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467078_unnamed_constructor_1()
         {
@@ -6246,7 +6246,7 @@ test = t.i;
             thisTest.Verify("test", 41);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467078_unnamed_constructor_2()
         {
@@ -6278,7 +6278,7 @@ test2 = t.j;
             thisTest.Verify("test2", 4);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467078_unnamed_constructor_3()
         {
@@ -6309,7 +6309,7 @@ test1 = t.j.i;
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467078_unnamed_constructor_4()
         {
@@ -6344,7 +6344,7 @@ test1;
             thisTest.Verify("test1", 4);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T96_1467078_unnamed_constructor_5()
         {
@@ -6379,7 +6379,7 @@ test1 = foo();
             thisTest.Verify("test1", 4);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T97_1467522_Indexing_Class_Properties_1()
         {
@@ -6418,7 +6418,7 @@ test2 = walls[0].Start.x; // received 1
             thisTest.Verify("test", 1.0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T97_1467522_Indexing_Class_Properties_2()
         {
@@ -6453,7 +6453,7 @@ test2 = wall[0].func(wall[1]);  // 3; expected test1=test2
             thisTest.Verify("test1", 3);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("Failure")]
         public void T98_Class_Static_Property_Using_Global_Variable()
         {
@@ -6472,7 +6472,7 @@ test1 = A.a;
             thisTest.Verify("test1", 3);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T98_Class_Static_Property_Using_Other_Properties()
         {
             String code =
@@ -6490,7 +6490,7 @@ test1 = A.a;
             thisTest.VerifyBuildWarningCount(1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T98_1467571_static_nonstatic_issue()
         {
             String code =
@@ -6513,7 +6513,7 @@ test2 = aa.a2();
             thisTest.VerifyBuildWarningCount(1);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T99_1467578_this_imperative()
         {
             String code =
@@ -6547,7 +6547,7 @@ val=seed.someOperation().IntValue;
             thisTest.VerifyBuildWarningCount(0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T100_1467578_this_imperative()
         {
             String code =
@@ -6587,7 +6587,7 @@ startArray = MyInt.Default(1..5);
             thisTest.VerifyBuildWarningCount(0);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T110_IDE_884_Testing_Bang_Inside_Imperative()
         {
             String code =
@@ -6666,7 +6666,7 @@ test4 = t.foo4();
             thisTest.Verify("test4", false);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T110_IDE_884_Testing_Bang_Inside_Imperative_2()
         {
             String code =
@@ -6709,7 +6709,7 @@ test3 = foo(a);
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T111_Class_Constructor_Negative_1467598()
         {
@@ -6732,7 +6732,7 @@ a = test.sum();
 
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T112_1467578_this_imperative()
         {
@@ -6778,7 +6778,7 @@ test = seed.someOperation(startArray).IntValue;
             thisTest.Verify("test", new Object[] { 2, 0, 0, 0, 0 });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T113_1467599_Type_Conversion()
         {
@@ -6828,7 +6828,7 @@ b = MyInt.MyInt().foo();
             thisTest.Verify("b", null);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T114_1467599_Type_Conversion()
         {
@@ -6879,7 +6879,7 @@ b = MyInt.MyInt().foo();
             thisTest.Verify("b", new Object[] { null, null });
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T115_1467599_Type_Conversion()
         {
@@ -6914,7 +6914,7 @@ b = MyInt.MyInt().foo().IntValue;
             thisTest.Verify("b", null);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         public void T116_1467599_Type_Conversion()
         {
             String code =
@@ -6934,7 +6934,7 @@ x = 1;
             thisTest.Verify("x", 1.5);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T117_1467599_Type_Conversion()
         {
@@ -6964,7 +6964,7 @@ c = a.x;
             thisTest.Verify("c", 1.5);
         }
 
-        [Test][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
+        [Test][Ignore][Category("DSDefinedClass_Ignored_DSDefinedClassSemantics")]
         [Category("SmokeTest")]
         public void T118_1467695_setter_inlinecondition()
         {


### PR DESCRIPTION
### Purpose
This PR ignores all DS defined class tests that test the DS class semantics.
As such, a majority of the ignored tests are in this PR

diffs are in: 
https://drive.google.com/drive/u/1/folders/0B27Qm0olhNl9SFNFVmVwNmRGcUE?ths=true

### Reviewers
@lukechurch 
