### PR TITLE
Key navigation is back.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -153,19 +153,7 @@ namespace Dynamo.ViewModels
             }
             set
             {
-                // Unselect all.
-                foreach (NodeSearchElementViewModel res in value)
-                {
-                    res.IsSelected = false;
-                }
-
-                // Select first.
-                if (value.Any())
-                {
-                    value.First().IsSelected = true;
-                }
-
-                filteredResults = value;
+                filteredResults = ToggleSelect(value);
                 RaisePropertyChanged("FilteredResults");
             }
         }
@@ -179,6 +167,24 @@ namespace Dynamo.ViewModels
             FilteredResults = searchResults.Where(x => allowedCategories
                                                                        .Select(cat => cat.Name)
                                                                        .Contains(x.Category));
+        }
+
+        /// <summary>
+        /// Unselects all items and selectes the first one.
+        /// </summary>
+        private IEnumerable<NodeSearchElementViewModel> ToggleSelect(IEnumerable<NodeSearchElementViewModel> items)
+        {
+            if (!items.Any())
+            {
+                return items;
+            }
+
+            // Unselect all.
+            items.Skip(1).ToList().ForEach(x => x.IsSelected = false);
+            // Select first.
+            items.First().IsSelected = true;
+
+            return items;
         }
 
         /// <summary>
@@ -857,9 +863,9 @@ namespace Dynamo.ViewModels
 
         #region Key navigation
 
-        public enum MovementDirection
+        public enum Direction
         {
-            Forward, Back
+            Down, Up
         }
 
         /// <summary>
@@ -879,14 +885,15 @@ namespace Dynamo.ViewModels
         /// When down key is pressed, selected element should move forward.
         /// When up key is pressed, selected element should move back.
         /// </summary>
-        public void MoveSelection(MovementDirection direction)
+        public void MoveSelection(Direction direction)
         {
             var oldItem = FilteredResults.FirstOrDefault(item => item.IsSelected);
             if (oldItem == null) return;
 
             int newItemIndex = FilteredResults.IndexOf(oldItem);
+            if (newItemIndex < 0 || newItemIndex >= FilteredResults.Count()) return;
 
-            if (direction == MovementDirection.Forward)
+            if (direction == Direction.Down)
             {
                 newItemIndex++;
             }
@@ -903,7 +910,6 @@ namespace Dynamo.ViewModels
         }
 
         #endregion
-
 
         #region Search field manipulation
 

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -172,7 +172,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Unselects all items and selectes the first one.
         /// </summary>
-        private IEnumerable<NodeSearchElementViewModel> ToggleSelect(IEnumerable<NodeSearchElementViewModel> items)
+        internal IEnumerable<NodeSearchElementViewModel> ToggleSelect(IEnumerable<NodeSearchElementViewModel> items)
         {
             if (!items.Any())
             {

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -891,7 +891,8 @@ namespace Dynamo.ViewModels
             if (oldItem == null) return;
 
             int newItemIndex = FilteredResults.IndexOf(oldItem);
-            if (newItemIndex < 0 || newItemIndex >= FilteredResults.Count()) return;
+            if ((newItemIndex <= 0 && direction == Direction.Up) ||
+                (newItemIndex >= FilteredResults.Count() - 1 && direction == Direction.Down)) return;
 
             if (direction == Direction.Down)
             {
@@ -901,8 +902,6 @@ namespace Dynamo.ViewModels
             {
                 newItemIndex--;
             }
-
-            if (newItemIndex < 0 || newItemIndex >= FilteredResults.Count()) return;
 
             oldItem.IsSelected = false;
             var newItem = FilteredResults.ElementAt(newItemIndex);

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -153,6 +153,18 @@ namespace Dynamo.ViewModels
             }
             set
             {
+                // Unselect all.
+                foreach (NodeSearchElementViewModel res in value)
+                {
+                    res.IsSelected = false;
+                }
+
+                // Select first.
+                if (value.Any())
+                {
+                    value.First().IsSelected = true;
+                }
+
                 filteredResults = value;
                 RaisePropertyChanged("FilteredResults");
             }
@@ -710,7 +722,7 @@ namespace Dynamo.ViewModels
             var foundNodes = Search(query);
             searchResults = new List<NodeSearchElementViewModel>(foundNodes);
 
-            filteredResults = searchResults;
+            FilteredResults = searchResults;
             UpdateSearchCategories();
 
             RaisePropertyChanged("FilteredResults");
@@ -842,6 +854,56 @@ namespace Dynamo.ViewModels
         }
 
         #endregion
+
+        #region Key navigation
+
+        public enum MovementDirection
+        {
+            Forward, Back
+        }
+
+        /// <summary>
+        /// Executes selected item in search UI.
+        /// </summary>
+        public void ExecuteSelectedItem()
+        {
+            var selected = FilteredResults.FirstOrDefault(item => item.IsSelected);
+
+            if (selected != null)
+            {
+                selected.ClickedCommand.Execute(null);
+            }
+        }
+
+        /// <summary>
+        /// When down key is pressed, selected element should move forward.
+        /// When up key is pressed, selected element should move back.
+        /// </summary>
+        public void MoveSelection(MovementDirection direction)
+        {
+            var oldItem = FilteredResults.FirstOrDefault(item => item.IsSelected);
+            if (oldItem == null) return;
+
+            int newItemIndex = FilteredResults.IndexOf(oldItem);
+
+            if (direction == MovementDirection.Forward)
+            {
+                newItemIndex++;
+            }
+            else
+            {
+                newItemIndex--;
+            }
+
+            if (newItemIndex < 0 || newItemIndex >= FilteredResults.Count()) return;
+
+            oldItem.IsSelected = false;
+            var newItem = FilteredResults.ElementAt(newItemIndex);
+            newItem.IsSelected = true;
+        }
+
+        #endregion
+
 
         #region Search field manipulation
 

--- a/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
@@ -203,7 +203,7 @@ namespace Dynamo.Search
                             break;
                         }
 
-                        viewModel.MoveSelection(SearchViewModel.MovementDirection.Forward);
+                        viewModel.MoveSelection(SearchViewModel.Direction.Down);
                         break;
                     }
 
@@ -215,7 +215,7 @@ namespace Dynamo.Search
                             break;
                         }
 
-                        viewModel.MoveSelection(SearchViewModel.MovementDirection.Back);
+                        viewModel.MoveSelection(SearchViewModel.Direction.Up);
                         break;
                     }
             }

--- a/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
@@ -183,6 +183,41 @@ namespace Dynamo.Search
                         }
                     }
                     break;
+                case Key.Enter:
+                    {
+                        if (viewModel.CurrentMode != SearchViewModel.ViewMode.LibrarySearchView
+                            || !viewModel.IsAnySearchResult)
+                        {
+                            break;
+                        }
+
+                        viewModel.ExecuteSelectedItem();
+                        break;
+                    }
+
+                case Key.Down:
+                    {
+                        if (viewModel.CurrentMode != SearchViewModel.ViewMode.LibrarySearchView
+                            || !viewModel.IsAnySearchResult)
+                        {
+                            break;
+                        }
+
+                        viewModel.MoveSelection(SearchViewModel.MovementDirection.Forward);
+                        break;
+                    }
+
+                case Key.Up:
+                    {
+                        if (viewModel.CurrentMode != SearchViewModel.ViewMode.LibrarySearchView
+                            || !viewModel.IsAnySearchResult)
+                        {
+                            break;
+                        }
+
+                        viewModel.MoveSelection(SearchViewModel.MovementDirection.Back);
+                        break;
+                    }
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -134,7 +134,11 @@
                         <Setter Property="Background"
                                 Value="{StaticResource LibraryMemberOnHover}" />
                     </Trigger>
-
+                    <Trigger Property="IsSelected"
+                             Value="True">
+                        <Setter Property="Background"
+                                Value="{StaticResource LibraryMemberOnHover}" />
+                    </Trigger>
                 </Style.Triggers>
             </Style>
 

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -631,6 +631,26 @@ namespace Dynamo.Tests
         #region Key navigation
 
         [Test, Category("UnitTests")]
+        public void ToggleSelectionTest()
+        {
+            var elementVM = CreateCustomNodeViewModel(CreateCustomNode("AMember", "Category"));
+            elementVM.IsSelected = false;
+
+            var items = new List<NodeSearchElementViewModel>();
+            items.Add(elementVM);
+
+            elementVM = CreateCustomNodeViewModel(CreateCustomNode("BMember", "Category"));
+            elementVM.IsSelected = true;
+
+            items.Add(elementVM);
+
+            var result = viewModel.ToggleSelect(items);
+
+            Assert.IsTrue(result.First().IsSelected);
+            Assert.IsFalse(result.Last().IsSelected);
+        }
+
+        [Test, Category("UnitTests")]
         public void FirstItemIsSelectedAfterSearch()
         {
             var element = CreateCustomNode("AMember", "Category");
@@ -645,6 +665,15 @@ namespace Dynamo.Tests
             Assert.AreEqual(2, viewModel.FilteredResults.Count());
             Assert.IsTrue(viewModel.FilteredResults.ElementAt(0).IsSelected);
             Assert.IsFalse(viewModel.FilteredResults.ElementAt(1).IsSelected);
+        }
+
+        [Test, Category("UnitTests")]
+        public void NoItemsAfterSearch()
+        {
+            viewModel.Visible = true;
+            viewModel.SearchAndUpdateResults("member");
+
+            Assert.DoesNotThrow(() => viewModel.MoveSelection(SearchViewModel.Direction.Down));
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -674,6 +674,7 @@ namespace Dynamo.Tests
             viewModel.SearchAndUpdateResults("member");
 
             Assert.DoesNotThrow(() => viewModel.MoveSelection(SearchViewModel.Direction.Down));
+            Assert.IsFalse(viewModel.FilteredResults.Any());
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -668,7 +668,7 @@ namespace Dynamo.Tests
         }
 
         [Test, Category("UnitTests")]
-        public void NoItemsAfterSearch()
+        public void NoItemsIsSelectedAfterSearch()
         {
             viewModel.Visible = true;
             viewModel.SearchAndUpdateResults("member");

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -630,6 +630,23 @@ namespace Dynamo.Tests
 
         #region Key navigation
 
+        [Test, Category("UnitTests")]
+        public void FirstItemIsSelectedAfterSearch()
+        {
+            var element = CreateCustomNode("AMember", "Category");
+            model.Add(element);
+
+            element = CreateCustomNode("BMember", "Category");
+            model.Add(element);
+
+            viewModel.Visible = true;
+            viewModel.SearchAndUpdateResults("member");
+
+            Assert.AreEqual(2, viewModel.FilteredResults.Count());
+            Assert.IsTrue(viewModel.FilteredResults.ElementAt(0).IsSelected);
+            Assert.IsFalse(viewModel.FilteredResults.ElementAt(1).IsSelected);
+        }
+
         [Test]
         [Category("UnitTests")]
         public void MoveForward()
@@ -646,10 +663,10 @@ namespace Dynamo.Tests
             Assert.AreEqual(2, viewModel.FilteredResults.Count());
             Assert.IsTrue(viewModel.FilteredResults.ElementAt(0).IsSelected);
 
-            viewModel.MoveSelection(SearchViewModel.MovementDirection.Forward);
+            viewModel.MoveSelection(SearchViewModel.Direction.Down);
             Assert.IsTrue(viewModel.FilteredResults.ElementAt(1).IsSelected);
 
-            viewModel.MoveSelection(SearchViewModel.MovementDirection.Forward);
+            viewModel.MoveSelection(SearchViewModel.Direction.Down);
             Assert.IsTrue(viewModel.FilteredResults.ElementAt(1).IsSelected);
         }
 
@@ -669,13 +686,13 @@ namespace Dynamo.Tests
             Assert.AreEqual(2, viewModel.FilteredResults.Count());
             Assert.IsTrue(viewModel.FilteredResults.ElementAt(0).IsSelected);
 
-            viewModel.MoveSelection(SearchViewModel.MovementDirection.Back);
+            viewModel.MoveSelection(SearchViewModel.Direction.Up);
             Assert.IsTrue(viewModel.FilteredResults.ElementAt(0).IsSelected);
 
-            viewModel.MoveSelection(SearchViewModel.MovementDirection.Forward);
+            viewModel.MoveSelection(SearchViewModel.Direction.Down);
             Assert.IsTrue(viewModel.FilteredResults.ElementAt(1).IsSelected);
 
-            viewModel.MoveSelection(SearchViewModel.MovementDirection.Back);
+            viewModel.MoveSelection(SearchViewModel.Direction.Up);
             Assert.IsTrue(viewModel.FilteredResults.ElementAt(0).IsSelected);
         }
 

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -628,6 +628,59 @@ namespace Dynamo.Tests
 
         #endregion
 
+        #region Key navigation
+
+        [Test]
+        [Category("UnitTests")]
+        public void MoveForward()
+        {
+            var element = CreateCustomNode("AMember", "Category");
+            model.Add(element);
+
+            element = CreateCustomNode("BMember", "Category");
+            model.Add(element);
+
+            viewModel.Visible = true;
+            viewModel.SearchAndUpdateResults("member");
+
+            Assert.AreEqual(2, viewModel.FilteredResults.Count());
+            Assert.IsTrue(viewModel.FilteredResults.ElementAt(0).IsSelected);
+
+            viewModel.MoveSelection(SearchViewModel.MovementDirection.Forward);
+            Assert.IsTrue(viewModel.FilteredResults.ElementAt(1).IsSelected);
+
+            viewModel.MoveSelection(SearchViewModel.MovementDirection.Forward);
+            Assert.IsTrue(viewModel.FilteredResults.ElementAt(1).IsSelected);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void MoveBack()
+        {
+            var element = CreateCustomNode("AMember", "Category");
+            model.Add(element);
+
+            element = CreateCustomNode("BMember", "Category");
+            model.Add(element);
+
+            viewModel.Visible = true;
+            viewModel.SearchAndUpdateResults("member");
+
+            Assert.AreEqual(2, viewModel.FilteredResults.Count());
+            Assert.IsTrue(viewModel.FilteredResults.ElementAt(0).IsSelected);
+
+            viewModel.MoveSelection(SearchViewModel.MovementDirection.Back);
+            Assert.IsTrue(viewModel.FilteredResults.ElementAt(0).IsSelected);
+
+            viewModel.MoveSelection(SearchViewModel.MovementDirection.Forward);
+            Assert.IsTrue(viewModel.FilteredResults.ElementAt(1).IsSelected);
+
+            viewModel.MoveSelection(SearchViewModel.MovementDirection.Back);
+            Assert.IsTrue(viewModel.FilteredResults.ElementAt(0).IsSelected);
+        }
+
+        #endregion
+
         #region Helpers
 
         private static NodeSearchElement CreateCustomNode(string name, string category,


### PR DESCRIPTION
### Purpose

[MAGN-8796](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8796) Arrow Keys and Enter key in search do nothing

During https://github.com/DynamoDS/Dynamo/pull/5417 I had to remove key navigation, because the whole Search view changed and navigation changed too.

Now I returned it back. 

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ramramps 

### FYIs

@Racel 