### PR TITLE
Fix MAGN-8465 For some node, type dependent name in N2C include square bracket

### DIFF
--- a/src/DynamoCore/Engine/NodeToCode.cs
+++ b/src/DynamoCore/Engine/NodeToCode.cs
@@ -57,9 +57,13 @@ namespace Dynamo.Engine.NodeToCode
                 // Otherwise change class name to its lower case
                 if (String.IsNullOrEmpty(prefix) && (type.UID > (int)ProtoCore.PrimitiveType.kMaxPrimitives))
                 {
-                    prefix = type.ToShortString();
-                    if (!String.IsNullOrEmpty(prefix))
+                    prefix = type.Name;
+                    if (!string.IsNullOrEmpty(prefix))
+                    {
+                        if (prefix.Contains("."))
+                            prefix = prefix.Split('.').Last();
                         prefix = prefix.ToLower();
+                    }
                 }
             }
 


### PR DESCRIPTION
### Purpose

Fix [MAGN-8465 For some node, type dependent name in N2C include square bracket](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8465#).

We shouldn't use `Type.ToShortString()`, which includes rank string like `[]`. Instead, using `Type.Name` directly.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@junmendoza 