### PR TITLE
fix sample tests after changing samples to use 90 file path for datasets

### DIFF
--- a/test/Libraries/WorkflowTests/DynamoSamples.cs
+++ b/test/Libraries/WorkflowTests/DynamoSamples.cs
@@ -508,10 +508,10 @@ namespace Dynamo.Tests
             var filename = CurrentDynamoModel.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
             string resultPath = SampleDirectory + "Data\\helix.csv";
-            // Although old path is a hard coded but that is not going to change 
-            // because it is saved in DYN which we have added in Samples folder.
-            filename.Value = filename.Value.Replace
-                ("C:\\ProgramData\\Dynamo\\0.8\\samples\\Data\\helix.csv", resultPath);
+          
+            //we cannot count on this path never changing as the samples path
+            //must be updated to match dynamo version number
+            filename.Value = resultPath;
 
             RunCurrentModel();
 
@@ -534,10 +534,10 @@ namespace Dynamo.Tests
             var filename = CurrentDynamoModel.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
             string resultPath = Path.Combine(TempFolder, "icosohedron_points.csv");
-            // Although old path is a hard coded but that is not going to change 
-            // because it is saved in DYN which we have added in Samples folder.
-            filename.Value = filename.Value.Replace
-                ("C:\\ProgramData\\Dynamo\\0.8\\samples\\Data\\icosohedron_points.csv", resultPath);
+
+            //we cannot count on this path never changing as the samples path
+            //must be updated to match dynamo version number
+            filename.Value = resultPath;
 
             RunCurrentModel();
 
@@ -562,10 +562,10 @@ namespace Dynamo.Tests
             var filename = CurrentDynamoModel.CurrentWorkspace.FirstNodeFromWorkspace<DSCore.File.Filename>();
 
             string resultPath = SampleDirectory + "Data\\helix.xlsx";
-            // Although old path is a hard coded but that is not going to change 
-            // because it is saved in DYN which we have added in Samples folder.
-            filename.Value = filename.Value.Replace
-                ("C:\\ProgramData\\Dynamo\\0.8\\samples\\Data\\helix.xlsx", resultPath);
+
+            //we cannot count on this path never changing as the samples path
+            //must be updated to match dynamo version number
+            filename.Value = resultPath;
 
             //RunCurrentModel();
 


### PR DESCRIPTION
get rid of replace call using hardcoded value which was stopping the …value from actually being replaced causing failures.

instead just replace string with the correct path.

@ikeough could you take a look at this, I'm unclear if the smoke tests are currently failing on the CI for master, but there was a failure on RC90 branch.

once this is LGTM I will cherry pick to .90RC - 