### PR TITLE
 MAGN 5185 Undo crashes after deleting an input for a custom node, again

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -1138,8 +1138,6 @@ namespace Dynamo.Core
                 var collapsedNode = CreateCustomNodeInstance(newId, isTestMode: isTestMode);
                 collapsedNode.X = avgX;
                 collapsedNode.Y = avgY;
-                collapsedNode.Controller.SyncWithDefinitionStart += currentWorkspace.OnSyncWithDefintionStart;
-                collapsedNode.Controller.SyncWithDefinitionEnd += currentWorkspace.OnSyncWithDefinitionEnd;
                 currentWorkspace.AddAndRegisterNode(collapsedNode, centered: false);
                 undoRecorder.RecordCreationForUndo(collapsedNode);
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -800,6 +800,13 @@ namespace Dynamo.Models
         {
             node.Modified += NodeModified;
             node.ConnectorAdded += OnConnectorAdded;
+
+            var functionNode = node as Function;
+            if (functionNode != null)
+            {
+                functionNode.Controller.SyncWithDefinitionStart += OnSyncWithDefintionStart;
+                functionNode.Controller.SyncWithDefinitionEnd += OnSyncWithDefinitionEnd;
+            }
         }
 
         protected virtual void RequestRun()
@@ -833,6 +840,12 @@ namespace Dynamo.Models
 
         protected virtual void DisposeNode(NodeModel model)
         {
+            var functionNode = model as Function;
+            if (functionNode != null)
+            {
+                functionNode.Controller.SyncWithDefinitionStart -= OnSyncWithDefintionStart;
+                functionNode.Controller.SyncWithDefinitionEnd -= OnSyncWithDefinitionEnd;
+            }
             model.ConnectorAdded -= OnConnectorAdded;
             model.Modified -= NodeModified;
             model.Dispose();


### PR DESCRIPTION
### Purpose

Continue the fix for [MAGN 5185: Crash after deleting an input for a custom node + undoing from main canvas](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5185). The major issue already fixed in PR #5518 - in that PR the controller of `Function` node will notify workspace once the node starts syncing with its definition so that workspace could record all those off-track models. 

But the problem is the event handler is registered in collapsing selection node to custom node. When the instance is deleted and then restored, its event handler is gone. We should register that in `Workspace.RegisterNode()`.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin ;;
