### PR TITLE
Corss merge the fix for MAGN 5185 Undo crashes after deleting an input for a custom node

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -1138,8 +1138,6 @@ namespace Dynamo.Core
                 var collapsedNode = CreateCustomNodeInstance(newId, isTestMode: isTestMode);
                 collapsedNode.X = avgX;
                 collapsedNode.Y = avgY;
-                collapsedNode.Controller.SyncWithDefinitionStart += currentWorkspace.OnSyncWithDefintionStart;
-                collapsedNode.Controller.SyncWithDefinitionEnd += currentWorkspace.OnSyncWithDefinitionEnd;
                 currentWorkspace.AddAndRegisterNode(collapsedNode, centered: false);
                 undoRecorder.RecordCreationForUndo(collapsedNode);
 

--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -794,6 +794,13 @@ namespace Dynamo.Models
         {
             node.Modified += NodeModified;
             node.ConnectorAdded += OnConnectorAdded;
+
+            var functionNode = node as Function;
+            if (functionNode != null)
+            {
+                functionNode.Controller.SyncWithDefinitionStart += OnSyncWithDefintionStart;
+                functionNode.Controller.SyncWithDefinitionEnd += OnSyncWithDefinitionEnd;
+            }
         }
 
         protected virtual void RequestRun()
@@ -827,6 +834,12 @@ namespace Dynamo.Models
 
         protected virtual void DisposeNode(NodeModel model)
         {
+            var functionNode = model as Function;
+            if (functionNode != null)
+            {
+                functionNode.Controller.SyncWithDefinitionStart -= OnSyncWithDefintionStart;
+                functionNode.Controller.SyncWithDefinitionEnd -= OnSyncWithDefinitionEnd;
+            }
             model.ConnectorAdded -= OnConnectorAdded;
             model.Modified -= NodeModified;
             model.Dispose();


### PR DESCRIPTION
### Purpose

Cross merge the fix #5553  for [MAGN 5185: Crash after deleting an input for a custom node + undoing from main canvas](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5185) to RC branch.