### PR TITLE
Magn 8758 view extensions localized loading

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Extensions\IViewExtension.cs" />
     <Compile Include="Extensions\IViewExtensionLoader.cs" />
     <Compile Include="Extensions\IViewExtensionManager.cs" />
+    <Compile Include="Extensions\MenuBarTypeExtensions.cs" />
     <Compile Include="Extensions\ViewExtensionLoader.cs" />
     <Compile Include="Extensions\ViewExtensionManager.cs" />
     <Compile Include="Extensions\ViewLoadedParams.cs" />

--- a/src/DynamoCoreWpf/Extensions/MenuBarTypeExtensions.cs
+++ b/src/DynamoCoreWpf/Extensions/MenuBarTypeExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Dynamo.Wpf.Extensions
+{
+    /// <summary>
+    /// A class of extensions for the MenuBarType Enum.
+    /// </summary>
+    internal static class MenuBarTypeExtensions
+    {
+        /// <summary>
+        /// A method to extract the appropriate localized string 
+        /// representing the header name of this menu type
+        /// i.e. file -> "_File"
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns>A localized string used as the menu header</returns>
+        internal static string ToDisplayString(this MenuBarType type)
+        {
+            switch (type)
+            {
+                case MenuBarType.File: return Properties.Resources.DynamoViewFileMenu;
+                case MenuBarType.Edit: return Properties.Resources.DynamoViewEditMenu;
+                case MenuBarType.View: return Properties.Resources.DynamoViewViewMenu;
+                case MenuBarType.Help: return Properties.Resources.DynamoViewHelpMenu;
+
+                default: throw new ArgumentOutOfRangeException("type");
+            }
+        }
+    }
+}

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -111,8 +111,8 @@ namespace Dynamo.Wpf.Extensions
 
     }
     /// <summary>
-    /// an enum that represets the different possible 
-    /// MenuBrs which view extensions may add items to.
+    /// An enum that represents the different possible 
+    /// MenuBars which ViewExtensions may add items to.
     /// </summary>
     public enum MenuBarType
     {
@@ -123,17 +123,17 @@ namespace Dynamo.Wpf.Extensions
     }
 
     /// <summary>
-    /// a class of extensins to the MenuBarEnum
+    /// A class of extensions for the MenuBarType Enum.
     /// </summary>
     public static class MenuBarTypeExtensions
     {
         /// <summary>
-        /// a method to extract the appropriate localized string 
+        /// A method to extract the appropriate localized string 
         /// representing the header name of this menu type
-        /// i.e. file -> _File
+        /// i.e. file -> "_File"
         /// </summary>
         /// <param name="type"></param>
-        /// <returns>a localized string used as the menu header</returns>
+        /// <returns>A localized string used as the menu header</returns>
         public static string ToDisplayString(this MenuBarType type)
         {
             switch (type)

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -122,30 +122,4 @@ namespace Dynamo.Wpf.Extensions
         Help
     }
 
-    /// <summary>
-    /// A class of extensions for the MenuBarType Enum.
-    /// </summary>
-    public static class MenuBarTypeExtensions
-    {
-        /// <summary>
-        /// A method to extract the appropriate localized string 
-        /// representing the header name of this menu type
-        /// i.e. file -> "_File"
-        /// </summary>
-        /// <param name="type"></param>
-        /// <returns>A localized string used as the menu header</returns>
-        public static string ToDisplayString(this MenuBarType type)
-        {
-            switch (type)
-            {
-                case MenuBarType.File: return Properties.Resources.DynamoViewFileMenu;
-                case MenuBarType.Edit: return Properties.Resources.DynamoViewEditMenu;
-                case MenuBarType.View: return Properties.Resources.DynamoViewViewMenu;
-                case MenuBarType.Help: return Properties.Resources.DynamoViewHelpMenu;
-
-                default: throw new ArgumentOutOfRangeException("type");
-            }
-        }
-    }
-
 }

--- a/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
+++ b/src/DynamoCoreWpf/Extensions/ViewLoadedParams.cs
@@ -106,11 +106,14 @@ namespace Dynamo.Wpf.Extensions
         private MenuItem SearchForMenuItem(MenuBarType type)
         {
             var dynamoMenuItems = dynamoMenu.Items.OfType<MenuItem>();
-            return dynamoMenuItems.First(item => item.Header.ToString() == "_" + type);
+            return dynamoMenuItems.First(item => item.Header.ToString() == type.ToDisplayString());
         }
 
     }
-
+    /// <summary>
+    /// an enum that represets the different possible 
+    /// MenuBrs which view extensions may add items to.
+    /// </summary>
     public enum MenuBarType
     {
         File,
@@ -118,4 +121,31 @@ namespace Dynamo.Wpf.Extensions
         View,
         Help
     }
+
+    /// <summary>
+    /// a class of extensins to the MenuBarEnum
+    /// </summary>
+    public static class MenuBarTypeExtensions
+    {
+        /// <summary>
+        /// a method to extract the appropriate localized string 
+        /// representing the header name of this menu type
+        /// i.e. file -> _File
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns>a localized string used as the menu header</returns>
+        public static string ToDisplayString(this MenuBarType type)
+        {
+            switch (type)
+            {
+                case MenuBarType.File: return Properties.Resources.DynamoViewFileMenu;
+                case MenuBarType.Edit: return Properties.Resources.DynamoViewEditMenu;
+                case MenuBarType.View: return Properties.Resources.DynamoViewViewMenu;
+                case MenuBarType.Help: return Properties.Resources.DynamoViewHelpMenu;
+
+                default: throw new ArgumentOutOfRangeException("type");
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
### Purpose

PR for:

MAGN-8758 Publish Customizer application menu items absent in French Windows
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8758

This PR addresses the issue that view extensions were not loaded in localized environments. This was due to a search for the file menu using the string ```"_file"```. Instead we extract the localized header of the file menu from the properties.resources dictionary and compare against this.

This is done for other menus that view extensions might add items to by creating an extension method that extracts the appropriate localized string depending on menu type.


loading now works on EN-US and FR

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ramramps 

### FYIs

@jnealb 
