### PR TITLE
Expose DefaultNumInputs in DsVarArgFunction

### DIFF
--- a/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
+++ b/src/DynamoCore/Nodes/ZeroTouch/DSVarArgFunction.cs
@@ -25,7 +25,14 @@ namespace Dynamo.Nodes
             : base(new ZeroTouchVarArgNodeController<FunctionDescriptor>(descriptor))
         {
             VarInputController = new ZeroTouchVarInputController(this);
+            defaultNumInputs = descriptor.Parameters.Count();
         }
+
+        /// <summary>
+        /// Returns the default number of inputs for the node
+        /// </summary>
+        private readonly int defaultNumInputs;
+        internal int DefaultNumInputs { get { return defaultNumInputs; } }
 
         protected override void SerializeCore(XmlElement element, SaveContext context)
         {


### PR DESCRIPTION
### Purpose

This is necessary for proper conversion of nodes for Reach.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@mjkkirschner 