### PR TITLE
MAGN-8874 Zoom tools throw exception and crash dynamo in Geometry view on a fresh VM

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.1.2882")]
+[assembly: AssemblyVersion("0.9.1.2916")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.1.2882")]
+[assembly: AssemblyFileVersion("0.9.1.2916")]

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -564,7 +564,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         private bool CanToggleCanNavigateBackground(object parameter)
         {
-            return true;
+            return false;
         }
 
         private static bool CanZoomToFit(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -562,7 +562,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             InstrumentationLogger.LogAnonymousScreen(CanNavigateBackground ? "Geometry" : "Nodes");
         }
 
-        private bool CanToggleCanNavigateBackground(object parameter)
+        protected virtual bool CanToggleCanNavigateBackground(object parameter)
         {
             return false;
         }

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -655,6 +655,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             OnRequestZoomToFit(selectionBounds);
         }
 
+        protected override bool CanToggleCanNavigateBackground(object parameter)
+        {
+            return true;
+        }
+
         #region internal methods
 
         internal void ComputeFrameUpdate()

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -350,6 +350,10 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"
                     Height="Auto">
+                <StackPanel.IsEnabled>
+                    <Binding Path="DataContext.BackgroundPreviewViewModel.Active"
+                             RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
+                </StackPanel.IsEnabled>
                 <ui:ImageCheckBox Width="56"
                               Height="30"
                               Margin="4,4,0,4"
@@ -443,8 +447,6 @@
             </ui:ImageCheckBox>
 
         </StackPanel>
-
-     
 
         <Popup Name="InCanvasSearchBar"
                StaysOpen="True"


### PR DESCRIPTION


### Purpose

This PR addresses [MAGN-8874](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8874)

When the background preview cannot be activated, disable the background 3D preview toggle to avoid the user entering the background preview state and attempting to zoom or pan.
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@pboyer 

### FYIs

@monikaprabhu 