### PR TITLE
MAGN 8879 Opening .dyf after opening .dyn crashes Dynamo

### DIFF
--- a/src/DynamoCore/Core/Threading/CompileCustomNodeAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/CompileCustomNodeAsyncTask.cs
@@ -77,6 +77,9 @@ namespace Dynamo.Core.Threading
         protected override void HandleTaskExecutionCore()
         {
             // Updating graph in the context of ISchedulerThread.
+
+            // EngineController might be disposed and become invalid.
+            // After MAGN-5167 is done, we could remove this checking.
             if (!engineController.IsDisposed)
                 engineController.UpdateGraphImmediate(graphSyncData);
         }

--- a/src/DynamoCore/Core/Threading/CompileCustomNodeAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/CompileCustomNodeAsyncTask.cs
@@ -77,7 +77,8 @@ namespace Dynamo.Core.Threading
         protected override void HandleTaskExecutionCore()
         {
             // Updating graph in the context of ISchedulerThread.
-            engineController.UpdateGraphImmediate(graphSyncData);
+            if (!engineController.IsDisposed)
+                engineController.UpdateGraphImmediate(graphSyncData);
         }
 
         protected override void HandleTaskCompletionCore()

--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -95,11 +95,15 @@ namespace Dynamo.Core.Threading
         protected override void HandleTaskExecutionCore()
         {
             // Updating graph in the context of ISchedulerThread.
-            engineController.UpdateGraphImmediate(graphSyncData);
+            if (!engineController.IsDisposed)
+                engineController.UpdateGraphImmediate(graphSyncData);
         }
 
         protected override void HandleTaskCompletionCore()
         {
+            if (engineController.IsDisposed)
+                return;
+
             // Retrieve warnings in the context of ISchedulerThread.
             BuildWarnings = engineController.GetBuildWarnings();
             RuntimeWarnings = engineController.GetRuntimeWarnings();

--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -95,6 +95,9 @@ namespace Dynamo.Core.Threading
         protected override void HandleTaskExecutionCore()
         {
             // Updating graph in the context of ISchedulerThread.
+
+            // EngineController might be disposed and become invalid.
+            // After MAGN-5167 is done, we could remove this checking.
             if (!engineController.IsDisposed)
                 engineController.UpdateGraphImmediate(graphSyncData);
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1082,12 +1082,24 @@ namespace Dynamo.Models
         /// Call this method to reset the virtual machine, avoiding a race 
         /// condition by using a thread join inside the vm executive.
         /// TODO(Luke): Push this into a resync call with the engine controller
+        ///
+        /// Tracked in MAGN-5167.
+        /// As some async tasks use engine controller, for example 
+        /// CompileCustomNodeAsyncTask and UpdateGraphAsyncTask, it is possible
+        /// that engine controller is reset *before* tasks get executed. For
+        /// example, opening custom node will schedule a CompileCustomNodeAsyncTask
+        /// firstly and then reset engine controller. 
+        /// 
+        /// We should make sure engine controller is reset after all tasks that
+        /// depend on it get executed, or those tasks are thrown away if safe to 
+        /// do that. 
         /// </summary>
         /// <param name="markNodesAsDirty">Set this parameter to true to force 
         ///     reset of the execution substrait. Note that setting this parameter 
         ///     to true will have a negative performance impact.</param>
         public virtual void ResetEngine(bool markNodesAsDirty = false)
         {
+            
             ResetEngineInternal();
             foreach (var workspaceModel in Workspaces.OfType<HomeWorkspaceModel>())
             {


### PR DESCRIPTION
### Purpose

This PR provides a workaround for [MAGN 8879 Opening .dyf after opening .dyn crashes Dynamo](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8879). 

Some async task, for example, `CompileCustomNodeAsyncTask` and `UpdateGraphAsyncTask` use `EngineController`, but `EngineController` could become invalid *before* these async tasks get executed. For example, when opening a .dyf file,
  1. A `CompileCustomNodeAsyncTask` will be scheduled
  2. `EngineController` will be reset, so the previous one become invalid
  3. Scheduled `CompileCustomNodeAsyncTask` gets executed, and accesses invalid `EngineController`.

Ideally, resetting `EngineController` should be wrapped as an async task and executed by `DynamoScheduler`. This is already tracked by [MAGN-5167](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5167). But in this PR we just discard the task if `EngineController` has been disposed. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 