### PR TITLE
Package manager: Dynamo Tutorial 

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/InstalledPackagesView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/InstalledPackagesView.xaml
@@ -60,6 +60,10 @@
 
                 <DataTemplate>
 
+                    <!--This border shouldn't be wider then installed packages window.
+                    That's why bind its' width to ItemsPresenter's width. 
+                    ItemsPresenter is UI container for ListBox items.
+                    ItemsPresenter can't be wider then visible part of the window.-->
                     <Border BorderBrush="#222"
                             BorderThickness="0,0,0,1"
                             Background="#333"

--- a/src/DynamoCoreWpf/Views/PackageManager/InstalledPackagesView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/InstalledPackagesView.xaml
@@ -25,8 +25,7 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Grid Background="Black"
-          Margin="0">
+    <Grid Background="Black">
 
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
@@ -40,7 +39,8 @@
                  HorizontalContentAlignment="Stretch"
                  ScrollViewer.VerticalScrollBarVisibility="Auto"
                  ScrollViewer.HorizontalScrollBarVisibility="Hidden"
-                 VirtualizingPanel.ScrollUnit="Pixel">
+                 VirtualizingPanel.ScrollUnit="Pixel"
+                 Padding="0">
 
             <ListBox.ItemContainerStyle>
                 <Style TargetType="ListBoxItem">
@@ -50,6 +50,8 @@
                         <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}"
                                          Color="#000" />
                     </Style.Resources>
+                    <Setter Property="Padding"
+                            Value="0,0,0,0" />
                 </Style>
 
             </ListBox.ItemContainerStyle>
@@ -60,7 +62,9 @@
 
                     <Border BorderBrush="#222"
                             BorderThickness="0,0,0,1"
-                            Background="#333">
+                            Background="#333"
+                            Width="{Binding Path=ActualWidth, RelativeSource={RelativeSource FindAncestor, 
+                                                                        AncestorType={x:Type ItemsPresenter}}}">
                         <Border BorderBrush="#444"
                                 BorderThickness="0,1,0,0">
 
@@ -167,16 +171,17 @@
                                                    FontWeight="Bold"
                                                    Foreground="Gray"></Label>
                                             <ItemsControl Name="LoadedCustomNodes"
-                                                     ItemsSource="{Binding Path=Model.LoadedCustomNodes}"
-                                                     BorderThickness="0"
-                                                     Padding="0"
-                                                     Margin="10,0,0,0"
-                                                     Background="Transparent">
+                                                          ItemsSource="{Binding Path=Model.LoadedCustomNodes}"
+                                                          BorderThickness="0"
+                                                          Padding="0"
+                                                          Margin="10,0,0,0"
+                                                          Background="Transparent">
 
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
                                                         <TextBlock Text="{Binding Path=Name}"
-                                                                   Foreground="White" />
+                                                                   Foreground="White"
+                                                                   TextTrimming="CharacterEllipsis" />
                                                     </DataTemplate>
                                                 </ItemsControl.ItemTemplate>
 
@@ -190,17 +195,18 @@
                                                    FontWeight="Bold"
                                                    Foreground="Gray"></Label>
                                             <ItemsControl Name="NodeLibraries"
-                                                     ItemsSource="{Binding Path=Model.LoadedAssemblies}"
-                                                     BorderThickness="0"
-                                                     Padding="0"
-                                                     Margin="10,0,0,0"
-                                                     Background="Transparent">
+                                                          ItemsSource="{Binding Path=Model.LoadedAssemblies}"
+                                                          BorderThickness="0"
+                                                          Padding="0"
+                                                          Margin="10,0,0,0"
+                                                          Background="Transparent">
 
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
                                                         <TextBlock Name="Label"
                                                                    Text="{Binding Path=Name}"
-                                                                   Foreground="White" />
+                                                                   Foreground="White"
+                                                                   TextTrimming="CharacterEllipsis" />
 
                                                         <DataTemplate.Triggers>
                                                             <DataTrigger Binding="{Binding Path=IsNodeLibrary}"
@@ -222,17 +228,18 @@
                                                    FontWeight="Bold"
                                                    Foreground="Gray"></Label>
                                             <ItemsControl Name="AddAssemblies"
-                                                     ItemsSource="{Binding Path=Model.LoadedAssemblies}"
-                                                     BorderThickness="0"
-                                                     Padding="0"
-                                                     Margin="10,0,0,0"
-                                                     Background="Transparent">
+                                                          ItemsSource="{Binding Path=Model.LoadedAssemblies}"
+                                                          BorderThickness="0"
+                                                          Padding="0"
+                                                          Margin="10,0,0,0"
+                                                          Background="Transparent">
 
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
                                                         <TextBlock Name="Label"
                                                                    Text="{Binding Path=Name}"
-                                                                   Foreground="White" />
+                                                                   Foreground="White"
+                                                                   TextTrimming="CharacterEllipsis" />
 
                                                         <DataTemplate.Triggers>
                                                             <DataTrigger Binding="{Binding Path=IsNodeLibrary}"
@@ -255,16 +262,17 @@
                                                    FontWeight="Bold"
                                                    Foreground="Gray"></Label>
                                             <ItemsControl Name="AdditionalFiles"
-                                                     ItemsSource="{Binding Path=Model.AdditionalFiles}"
-                                                     BorderThickness="0"
-                                                     Padding="0"
-                                                     Margin="10,0,0,0"
-                                                     Background="Transparent">
+                                                          ItemsSource="{Binding Path=Model.AdditionalFiles}"
+                                                          BorderThickness="0"
+                                                          Padding="0"
+                                                          Margin="10,0,0,0"
+                                                          Background="Transparent">
 
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
                                                         <TextBlock Text="{Binding Path=RelativePath}"
-                                                                   Foreground="White" />
+                                                                   Foreground="White"
+                                                                   TextTrimming="CharacterEllipsis" />
                                                     </DataTemplate>
                                                 </ItemsControl.ItemTemplate>
 


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8203](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8203) Manage Packages... ui control is lost after expanding the Dynamo Tutorial package

@ikeough was right. The problem is too long textblock.

Bad side of `Border`, that it can get infinite width or height. It doesn't pay attention, that its' width is bigger then windows' width. I added additional binding. Now border width is the same as width of parent control.
I added Padding = 0. That fixes little jump, that I noticed during testing.
Also I added text trimming, so now if textblock is too long, it truncates with "...".

Results:
![image](https://cloud.githubusercontent.com/assets/8158404/10604647/6b9933c2-772e-11e5-8f37-def881aaaa77.png)
![image](https://cloud.githubusercontent.com/assets/8158404/10604675/9b964fe2-772e-11e5-8034-347fc9916c57.png)
![image](https://cloud.githubusercontent.com/assets/8158404/10604658/7e79397e-772e-11e5-9a76-c1a2e210da92.png)


### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@mjkkirschner 

### FYIs

@Racel 