### PR TITLE
Added new command to create and connect node in single step

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1510,13 +1510,16 @@ namespace Dynamo.Models
         /// </summary>
         /// <param name="node"></param>
         /// <param name="centered"></param>
-        public void AddNodeToCurrentWorkspace(NodeModel node, bool centered)
+        public void AddNodeToCurrentWorkspace(NodeModel node, bool centered, bool addToSelection = true)
         {
             CurrentWorkspace.AddAndRegisterNode(node, centered);
 
             //TODO(Steve): This should be moved to WorkspaceModel.AddNode when all workspaces have their own selection -- MAGN-5707
-            DynamoSelection.Instance.ClearSelection();
-            DynamoSelection.Instance.Selection.Add(node);
+            if (addToSelection)
+            {
+                DynamoSelection.Instance.ClearSelection();
+                DynamoSelection.Instance.Selection.Add(node);
+            }
 
             //TODO(Steve): Make sure we're not missing something with TransformCoordinates. -- MAGN-5708
         }

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -70,7 +70,7 @@ namespace Dynamo.Models
         {
             using (CurrentWorkspace.UndoRecorder.BeginActionGroup())
             {
-                var newNode = CurrentWorkspace.GetModelInternal(command.ModelGuid) as NodeModel;
+                var newNode = command.NewNode;
                 var existingNode = CurrentWorkspace.GetModelInternal(command.ModelGuids.ElementAt(1)) as NodeModel;
                 
                 if(newNode == null || existingNode == null) return;

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.Design;
 using System.Linq;
 using Dynamo.Core;
 using Dynamo.Nodes;
@@ -63,6 +64,15 @@ namespace Dynamo.Models
 
             AddNodeToCurrentWorkspace(node, centered: command.DefaultPosition);
             CurrentWorkspace.RecordCreatedModel(node);
+        }
+
+        void CreateAndConnectNodeImpl(CreateAndConnectNodeCommand command)
+        {
+            AddNodeToCurrentWorkspace(command.NewNode, false, command.AddNewNodeToSelection);
+            CurrentWorkspace.RecordCreatedModel(command.NewNode);
+
+            ExecuteCommand(command.MakeConnectionCommandBegin);
+            ExecuteCommand(command.MakeConnectionCommandEnd);
         }
 
         NodeModel GetNodeFromCommand(CreateNodeCommand command)

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -762,9 +762,12 @@ namespace Dynamo.Models
             {
                 base.SerializeCore(element);
 
-                SerializeCreateNodeCommand(element);
-
                 var helper = new XmlElementHelper(element);
+                helper.SetAttribute("X", X);
+                helper.SetAttribute("Y", Y);
+                helper.SetAttribute("CreateAsDownstreamNode", CreateAsDownstreamNode);
+                helper.SetAttribute("AddNewNodeToSelection", AddNewNodeToSelection);
+
                 helper.SetAttribute("OutPortIndex", OutputPortIndex);
                 helper.SetAttribute("InPortIndex", InputPortIndex);
             }
@@ -788,14 +791,6 @@ namespace Dynamo.Models
                     createAsDownstreamNode, addNewNodeToSelection);
             }
 
-            private void SerializeCreateNodeCommand(XmlElement element)
-            {
-                var helper = new XmlElementHelper(element);
-                helper.SetAttribute("X", X);
-                helper.SetAttribute("Y", Y);
-                helper.SetAttribute("CreateAsDownstreamNode", CreateAsDownstreamNode);
-                helper.SetAttribute("AddNewNodeToSelection", AddNewNodeToSelection);
-            }
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -701,7 +701,7 @@ namespace Dynamo.Models
             #region Public Class Methods
 
             /// <summary>
-            /// 
+            /// Creates a new CreateAndConnectNodeCommand with the given inputs
             /// </summary>
             /// <param name="newNode">new node to create in the command</param>
             /// <param name="existingNode">Existing node to connect from/to</param>
@@ -786,10 +786,45 @@ namespace Dynamo.Models
 
             protected override void SerializeCore(XmlElement element)
             {
-                var command = new CreateNodeCommand(NewNode, X, Y, true, true);
-                command.Serialize();
-                MakeConnectionCommandBegin.Serialize();
-                MakeConnectionCommandEnd.Serialize();
+                SerializeCreateNodeCommand(element);
+
+                SerializeMakeConnectionCommand(element, OutputPortIndex, PortType.Output, 
+                MakeConnectionCommand.Mode.Begin);
+
+                SerializeMakeConnectionCommand(element, InputPortIndex, PortType.Input, 
+                MakeConnectionCommand.Mode.End);
+            }
+
+            private void SerializeCreateNodeCommand(XmlElement element)
+            {
+                base.SerializeCore(element);
+                var helper = new XmlElementHelper(element);
+                helper.SetAttribute("X", X);
+                helper.SetAttribute("Y", Y);
+
+                if (NewNode != null)
+                {
+                    var nodeElement = NewNode.Serialize(element.OwnerDocument, SaveContext.File);
+                    element.AppendChild(nodeElement);
+                }
+                //else if (NodeXml != null)
+                //{
+                //    element.AppendChild(NodeXml);
+                //}
+                //else
+                //{
+                //    helper.SetAttribute("NodeName", Name);
+                //}
+            }
+
+            private void SerializeMakeConnectionCommand(XmlElement element, int portIndex, PortType type, 
+                MakeConnectionCommand.Mode mode)
+            {
+                base.SerializeCore(element);
+                var helper = new XmlElementHelper(element);
+                helper.SetAttribute("PortIndex", portIndex);
+                helper.SetAttribute("Type", ((int)type));
+                helper.SetAttribute("ConnectionMode", ((int)mode));
             }
 
             #endregion

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -699,8 +699,41 @@ namespace Dynamo.Models
         [DataContract]
         public class CreateAndConnectNodeCommand : ModelBasedRecordableCommand
         {
-            
+            private void SetProperties(double x, double y, int outPortIndex, int inPortIndex,
+                bool createAsDownstreamNode, bool addNewNodeToSelection)
+            {
+                OutputPortIndex = outPortIndex;
+                InputPortIndex = inPortIndex;
+                X = x;
+                Y = y;
+
+                CreateAsDownstreamNode = createAsDownstreamNode;
+                AddNewNodeToSelection = addNewNodeToSelection;
+            }
+
             #region Public Class Methods
+
+            /// <summary>
+            /// Creates a new CreateAndConnectNodeCommand given a new node and an existing node to connect to
+            /// </summary>
+            /// <param name="newNode"></param>
+            /// <param name="existingNode"></param>
+            /// <param name="outPortIndex"></param>
+            /// <param name="inPortIndex"></param>
+            /// <param name="x"></param>
+            /// <param name="y"></param>
+            /// <param name="createAsDownstreamNode">
+            /// new node to be created as downstream or upstream node wrt the existing node
+            /// </param>
+            /// <param name="addNewNodeToSelection">select the new node after it is created by default</param>
+            public CreateAndConnectNodeCommand(NodeModel newNode, NodeModel existingNode, int outPortIndex, int inPortIndex,
+                double x, double y, bool createAsDownstreamNode, bool addNewNodeToSelection)
+                : base(newNode != null && existingNode != null ? new[] { newNode.GUID, existingNode.GUID } : new[] { Guid.Empty })
+            {
+                NewNode = newNode;
+
+                SetProperties(x, y, outPortIndex, inPortIndex, createAsDownstreamNode, addNewNodeToSelection);
+            }
 
             /// <summary>
             /// Creates a new CreateAndConnectNodeCommand with the given inputs
@@ -714,22 +747,18 @@ namespace Dynamo.Models
             /// new node to be created as downstream or upstream node wrt the existing node
             /// </param>
             /// <param name="addNewNodeToSelection">select the new node after it is created by default</param>
-            public CreateAndConnectNodeCommand(IEnumerable<Guid> nodeGuids, int outPortIndex, int inPortIndex, 
+            internal CreateAndConnectNodeCommand(IEnumerable<Guid> nodeGuids, int outPortIndex, int inPortIndex, 
                 double x, double y, bool createAsDownstreamNode, bool addNewNodeToSelection)
                 : base(nodeGuids)
             {
-                OutputPortIndex = outPortIndex;
-                InputPortIndex = inPortIndex;
-                X = x;
-                Y = y;
-
-                CreateAsDownstreamNode = createAsDownstreamNode;
-                AddNewNodeToSelection = addNewNodeToSelection;
+                SetProperties(x, y, outPortIndex, inPortIndex, createAsDownstreamNode, addNewNodeToSelection);
             }
 
             #endregion
 
             #region Public Command Properties
+
+            internal NodeModel NewNode { get; private set; }
 
             [DataMember]
             internal int OutputPortIndex { get; private set; }

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -121,7 +121,7 @@ namespace Dynamo.ViewModels
                 case "ConvertNodesToCodeCommand":
                 case "UngroupModelCommand":
                 case "AddModelToGroupCommand":
-                case "AutoCreateNodeCommand":
+                case "CreateAndConnectNodeCommand":
                     RaiseCanExecuteUndoRedo();
                     break;
 
@@ -177,7 +177,7 @@ namespace Dynamo.ViewModels
                 case "AddModelToGroupCommand":
                 case "AddPresetCommand":
                 case "ApplyPresetCommand":
-                case "AutoCreateNodeCommand":
+                case "CreateAndConnectNodeCommand":
                     // for this commands there is no need
                     // to do anything before execution
                     break;

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -121,6 +121,7 @@ namespace Dynamo.ViewModels
                 case "ConvertNodesToCodeCommand":
                 case "UngroupModelCommand":
                 case "AddModelToGroupCommand":
+                case "AutoCreateNodeCommand":
                     RaiseCanExecuteUndoRedo();
                     break;
 
@@ -176,6 +177,7 @@ namespace Dynamo.ViewModels
                 case "AddModelToGroupCommand":
                 case "AddPresetCommand":
                 case "ApplyPresetCommand":
+                case "AutoCreateNodeCommand":
                     // for this commands there is no need
                     // to do anything before execution
                     break;

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -354,6 +354,37 @@ namespace DynamoCoreWpfTests
         }
 
         [Test, RequiresSTA]
+        public void TestCreateAndConnectNodeCommand()
+        {
+            // Create the command in completely unpredictable states. These 
+            // states should properly be serialized and deserialized across 
+            // two instances of the same command.
+            // 
+            Guid newNodeGuid = Guid.NewGuid();
+            Guid existingNodeGuid = Guid.NewGuid();
+            double x = randomizer.NextDouble() * 1000;
+            double y = randomizer.NextDouble() * 1000;
+
+            var cmdOne = new DynamoModel.CreateAndConnectNodeCommand(newNodeGuid, existingNodeGuid, 
+                0, 0, x, y, false, false);
+
+            var cmdTwo = DuplicateAndCompare(cmdOne);
+            Assert.AreEqual(cmdOne.X, cmdTwo.X, 0.000001);
+            Assert.AreEqual(cmdOne.Y, cmdTwo.Y, 0.000001);
+            Assert.AreEqual(cmdOne.InputPortIndex, cmdTwo.InputPortIndex);
+            Assert.AreEqual(cmdOne.OutputPortIndex, cmdTwo.OutputPortIndex);
+            Assert.AreEqual(cmdOne.CreateAsDownstreamNode, cmdTwo.CreateAsDownstreamNode);
+            Assert.AreEqual(cmdOne.AddNewNodeToSelection, cmdTwo.AddNewNodeToSelection);
+            Assert.AreEqual(cmdOne.NewNodeGuid, cmdTwo.NewNodeGuid);
+            Assert.AreEqual(cmdOne.ExistingNodeGuid, cmdTwo.ExistingNodeGuid);
+
+            // A RecordableCommand should be created in "recording mode" by default, 
+            // and only deserialized commands should be marked as "in playback mode".
+            Assert.AreEqual(false, cmdOne.IsInPlaybackMode);
+            Assert.AreEqual(true, cmdTwo.IsInPlaybackMode);
+        }
+
+        [Test, RequiresSTA]
         public void TestCreateNoteCommand()
         {
             // Create the command in completely unpredictable states. These 

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -365,7 +365,7 @@ namespace DynamoCoreWpfTests
             double x = randomizer.NextDouble() * 1000;
             double y = randomizer.NextDouble() * 1000;
 
-            var cmdOne = new DynamoModel.CreateAndConnectNodeCommand(newNodeGuid, existingNodeGuid, 
+            var cmdOne = new DynamoModel.CreateAndConnectNodeCommand(new [] {newNodeGuid, existingNodeGuid},
                 0, 0, x, y, false, false);
 
             var cmdTwo = DuplicateAndCompare(cmdOne);
@@ -375,8 +375,8 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(cmdOne.OutputPortIndex, cmdTwo.OutputPortIndex);
             Assert.AreEqual(cmdOne.CreateAsDownstreamNode, cmdTwo.CreateAsDownstreamNode);
             Assert.AreEqual(cmdOne.AddNewNodeToSelection, cmdTwo.AddNewNodeToSelection);
-            Assert.AreEqual(cmdOne.NewNodeGuid, cmdTwo.NewNodeGuid);
-            Assert.AreEqual(cmdOne.ExistingNodeGuid, cmdTwo.ExistingNodeGuid);
+            Assert.AreEqual(cmdOne.ModelGuid, cmdTwo.ModelGuid);
+            Assert.AreEqual(cmdOne.ModelGuids.ElementAt(1), cmdTwo.ModelGuids.ElementAt(1));
 
             // A RecordableCommand should be created in "recording mode" by default, 
             // and only deserialized commands should be marked as "in playback mode".

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -362,13 +362,15 @@ namespace DynamoCoreWpfTests
             // 
             Guid newNodeGuid = Guid.NewGuid();
             Guid existingNodeGuid = Guid.NewGuid();
+
             double x = randomizer.NextDouble() * 1000;
             double y = randomizer.NextDouble() * 1000;
 
             var cmdOne = new DynamoModel.CreateAndConnectNodeCommand(new [] {newNodeGuid, existingNodeGuid},
-                0, 0, x, y, false, false);
+                0, 1, x, y, false, false);
 
             var cmdTwo = DuplicateAndCompare(cmdOne);
+
             Assert.AreEqual(cmdOne.X, cmdTwo.X, 0.000001);
             Assert.AreEqual(cmdOne.Y, cmdTwo.Y, 0.000001);
             Assert.AreEqual(cmdOne.InputPortIndex, cmdTwo.InputPortIndex);

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -366,11 +366,12 @@ namespace DynamoCoreWpfTests
             double x = randomizer.NextDouble() * 1000;
             double y = randomizer.NextDouble() * 1000;
 
-            var cmdOne = new DynamoModel.CreateAndConnectNodeCommand(new [] {newNodeGuid, existingNodeGuid},
-                0, 1, x, y, false, false);
+            var cmdOne = new DynamoModel.CreateAndConnectNodeCommand(newNodeGuid, existingNodeGuid, 
+                "dummyNode", 0, 1, x, y, false, false);
 
             var cmdTwo = DuplicateAndCompare(cmdOne);
 
+            Assert.AreEqual(cmdOne.NewNodeName, cmdTwo.NewNodeName);
             Assert.AreEqual(cmdOne.X, cmdTwo.X, 0.000001);
             Assert.AreEqual(cmdOne.Y, cmdTwo.Y, 0.000001);
             Assert.AreEqual(cmdOne.InputPortIndex, cmdTwo.InputPortIndex);


### PR DESCRIPTION
### Purpose

This PR adds a new `Recordable` command called `CreateAndConnectNodeCommand`. This command is required by the DM extension as well as upcoming features in Dynamo where there is a need to automatically generate a new node and connect it to the given node by specifying the new node, the given node to which the new node needs to be connected, and the output and input port indices.

### Declarations


- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)

### Reviewers

@Benglin Reviewer 1  


### FYIs

@pboyer 