### PR TITLE
Fix MAGN-8827 Revit and Dynamo have crashes after connecting two identical nodes

### DIFF
--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -435,9 +435,11 @@ namespace Dynamo.Models
                 // But for cyclic dependency warnings, it is
                 // easier to understand to report a build warning.
                 string message = string.Empty;
-                if (messages.ContainsKey(warning.Key) &&
-                    warning.Value.Any(w => w.ID == ProtoCore.BuildData.WarningID.kInvalidStaticCyclicDependency))
+                if (messages.ContainsKey(warning.Key))
                 {
+                    if (!warning.Value.Any(w => w.ID == ProtoCore.BuildData.WarningID.kInvalidStaticCyclicDependency))
+                        continue;
+
                     messages.Remove(warning.Key);
                     message = string.Join("\n", warning.Value.
                         Where(w => w.ID == ProtoCore.BuildData.WarningID.kInvalidStaticCyclicDependency).

--- a/src/DynamoCore/Models/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Models/HomeWorkspaceModel.cs
@@ -432,11 +432,26 @@ namespace Dynamo.Models
             {
                 // If there is already runtime warnings for 
                 // this node, then ignore the build warnings.
-                if (messages.ContainsKey(warning.Key))
-                    continue;
+                // But for cyclic dependency warnings, it is
+                // easier to understand to report a build warning.
+                string message = string.Empty;
+                if (messages.ContainsKey(warning.Key) &&
+                    warning.Value.Any(w => w.ID == ProtoCore.BuildData.WarningID.kInvalidStaticCyclicDependency))
+                {
+                    messages.Remove(warning.Key);
+                    message = string.Join("\n", warning.Value.
+                        Where(w => w.ID == ProtoCore.BuildData.WarningID.kInvalidStaticCyclicDependency).
+                        Select(w => w.Message));
+                }
+                else
+                {
+                    message = string.Join("\n", warning.Value.Select(w => w.Message));
+                }
 
-                var message = string.Join("\n", warning.Value.Select(w => w.Message));
-                messages.Add(warning.Key, message);
+                if (!string.IsNullOrEmpty(message))
+                {
+                    messages.Add(warning.Key, message);
+                }
             }
 
             var workspace = updateTask.TargetedWorkspace;

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -385,9 +385,12 @@ namespace ProtoAssociative
 
                 string symbol1 = firstNode.updateNodeRefList[0].nodeList[0].symbol.name;
                 string symbol2 = lastNode.updateNodeRefList[0].nodeList[0].symbol.name;
-                string message = String.Format(ProtoCore.Properties.Resources.kInvalidStaticCyclicDependency, symbol1, symbol2);
 
-                core.BuildStatus.LogWarning(ProtoCore.BuildData.WarningID.kInvalidStaticCyclicDependency, message, core.CurrentDSFileName);
+                foreach (var n in dependencyList.GroupBy(x => x.guid).Select(y => y.First()))
+                {
+                    core.BuildStatus.LogWarning(ProtoCore.BuildData.WarningID.kInvalidStaticCyclicDependency,
+                        ProtoCore.Properties.Resources.kInvalidStaticCyclicDependency, core.CurrentDSFileName, graphNode: n);
+                }
                 firstNode.isCyclic = true;
 
                 cyclicSymbol1 = firstNode.updateNodeRefList[0].nodeList[0].symbol;

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -1277,7 +1277,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A cyclic dependency exists between &apos;{0}&apos; and &apos;{1}&apos;.
+        ///   Looks up a localized string similar to A cyclic dependency exists between two variables.
         /// </summary>
         public static string kInvalidStaticCyclicDependency {
             get {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -295,7 +295,7 @@
     <value>Internal error, please report: Statement continue cause function to abnormally return null. (fd67aaee)</value>
   </data>
   <data name="kInvalidStaticCyclicDependency" xml:space="preserve">
-    <value>A cyclic dependency exists between '{0}' and '{1}'</value>
+    <value>A cyclic dependency exists between two variables</value>
   </data>
   <data name="kInvalidThis" xml:space="preserve">
     <value>'this' can only be used in methods that are members of a class</value>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -298,7 +298,7 @@
     <value>Internal error, please report: Statement continue cause function to abnormally return null. (fd67aaee)</value>
   </data>
   <data name="kInvalidStaticCyclicDependency" xml:space="preserve">
-    <value>A cyclic dependency exists between '{0}' and '{1}'</value>
+    <value>A cyclic dependency exists between two variables</value>
   </data>
   <data name="kInvalidThis" xml:space="preserve">
     <value>'this' can only be used in methods that are members of a class</value>

--- a/test/DynamoCoreTests/DynamoDefects.cs
+++ b/test/DynamoCoreTests/DynamoDefects.cs
@@ -472,5 +472,24 @@ namespace Dynamo.Tests
             // Same Stinrg input
             AssertPreviewValue("56f3c0fd-d39c-46cb-a4ea-4f266f7a9fce", true);
         }
+
+        [Test, Category("RegressionTests")]
+        public void CyclicDependency_Defect8827()
+        {
+            string openPath = Path.Combine(TestDirectory,
+                                        @"core\DynamoDefects\Defect_MAGN_8827.dyn");
+            RunModel(openPath);
+            // check for number of Nodes and Connectors
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
+
+            var node1 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace
+                ("385281c8-3177-4359-a348-a3084e16a41a");
+            var node2 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace
+                ("1ad8632e-7ddc-4cc7-bfa5-58cb899a5ddf");
+
+            Assert.IsTrue(node1.ToolTipText.Contains("cyclic"));
+            Assert.IsTrue(node2.ToolTipText.Contains("cyclic"));
+        }
     }
 }

--- a/test/DynamoCoreTests/DynamoDefects.cs
+++ b/test/DynamoCoreTests/DynamoDefects.cs
@@ -488,8 +488,8 @@ namespace Dynamo.Tests
             var node2 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace
                 ("1ad8632e-7ddc-4cc7-bfa5-58cb899a5ddf");
 
-            Assert.IsTrue(node1.ToolTipText.Contains("cyclic"));
-            Assert.IsTrue(node2.ToolTipText.Contains("cyclic"));
+            Assert.IsTrue(node1.ToolTipText.Equals(ProtoCore.Properties.Resources.kInvalidStaticCyclicDependency));
+            Assert.IsTrue(node2.ToolTipText.Equals(ProtoCore.Properties.Resources.kInvalidStaticCyclicDependency));
         }
     }
 }

--- a/test/core/DynamoDefects/Defect_MAGN_8827.dyn
+++ b/test/core/DynamoDefects/Defect_MAGN_8827.dyn
@@ -1,0 +1,17 @@
+<Workspace Version="0.9.1.2860" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="False">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="385281c8-3177-4359-a348-a3084e16a41a" type="Dynamo.Nodes.DSFunction" nickname="AnalysisExtensions.IsAlmostEqualTo" x="384.5" y="125" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="Analysis.dll" function="Analysis.AnalysisExtensions.IsAlmostEqualTo@Autodesk.DesignScript.Geometry.UV,Autodesk.DesignScript.Geometry.UV" />
+    <Dynamo.Nodes.DSFunction guid="1ad8632e-7ddc-4cc7-bfa5-58cb899a5ddf" type="Dynamo.Nodes.DSFunction" nickname="AnalysisExtensions.IsAlmostEqualTo" x="383.5" y="268" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="Analysis.dll" function="Analysis.AnalysisExtensions.IsAlmostEqualTo@Autodesk.DesignScript.Geometry.UV,Autodesk.DesignScript.Geometry.UV" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="385281c8-3177-4359-a348-a3084e16a41a" start_index="0" end="1ad8632e-7ddc-4cc7-bfa5-58cb899a5ddf" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="1ad8632e-7ddc-4cc7-bfa5-58cb899a5ddf" start_index="0" end="385281c8-3177-4359-a348-a3084e16a41a" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This is to address MAGN-8827. Originally for the involved graph, on each node, there is a warning message: "Warning: Converting objects to a function pointer is not allowed". The warning message is not easy to understand.

Basically for graphs like this, there is a cyclic dependency which is causing errors. The warning message as mentioned is a kind of run-time warning. But for this case, the compile time warning is easier to understand.

In the warning reporting implementation, currently all run-time warnings take precedence over compile-time warnings. Also for compile time warnings, only warnings which are related to nodes will be reported. That is why the compile time warning is ignored and not reported.

The fix here is to add a warning of cyclic dependency to each node in the cyclic graph. Later cyclic dependency warnings which are produced in compile time, are modified to take precedence over run time warnnings.

![image](https://cloud.githubusercontent.com/assets/5584246/10630404/cbf64324-7808-11e5-98ad-aef9d2ff9e25.png)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@aparajit-pratap 

### FYIs

@monikaprabhu 
