### PR TITLE
MAGN-8513 Ctrl + drag to duplicate nodes, groups, and notes

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -174,8 +174,7 @@ namespace Dynamo.Models
                     if (!command.Modifiers.HasFlag(ModifierKeys.Shift) && command.ModelGuids.Count() == 1)
                         DynamoSelection.Instance.ClearSelection();
 
-                    if (!DynamoSelection.Instance.Selection.Contains(model))
-                        DynamoSelection.Instance.Selection.Add(model);
+                    DynamoSelection.Instance.Selection.AddUnique(model);
                 }
                 else
                 {

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -52,8 +52,9 @@
     <Color x:Key="HeaderTopColor">#FFC5CBF9</Color>
     <Color x:Key="DatagridCurrentCellBorderColor">Black</Color>
     <Color x:Key="SliderTrackDarkColor">#FFC5CBF9</Color>
-
     <Color x:Key="NavButtonFrameColor">#FF3843C4</Color>
+
+    <clr:Double x:Key="NodeNickNameHeight">27</clr:Double>
 
     <!--InfoBubble colors-->
     <SolidColorBrush x:Key="InfoBubbleBackNormalBrush"

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -47,6 +47,7 @@ namespace Dynamo.ViewModels
 
         public readonly DynamoViewModel DynamoViewModel;
         public readonly WorkspaceViewModel WorkspaceViewModel;
+        public readonly Size? PreferredSize;
 
         public NodeModel NodeModel { get { return nodeLogic; } private set { nodeLogic = value; } }
 
@@ -362,20 +363,20 @@ namespace Dynamo.ViewModels
 
         public NodeViewModel(WorkspaceViewModel workspaceViewModel, NodeModel logic)
         {
-            this.WorkspaceViewModel = workspaceViewModel;
-            this.DynamoViewModel = workspaceViewModel.DynamoViewModel;
+            WorkspaceViewModel = workspaceViewModel;
+            DynamoViewModel = workspaceViewModel.DynamoViewModel;
            
             nodeLogic = logic;
             
-            //respond to collection changed events to sadd
+            //respond to collection changed events to add
             //and remove port model views
             logic.InPorts.CollectionChanged += inports_collectionChanged;
             logic.OutPorts.CollectionChanged += outports_collectionChanged;
 
             logic.PropertyChanged += logic_PropertyChanged;
 
-            this.DynamoViewModel.Model.PropertyChanged += Model_PropertyChanged;
-            this.DynamoViewModel.Model.DebugSettings.PropertyChanged += DebugSettings_PropertyChanged;
+            DynamoViewModel.Model.PropertyChanged += Model_PropertyChanged;
+            DynamoViewModel.Model.DebugSettings.PropertyChanged += DebugSettings_PropertyChanged;
 
             ErrorBubble = new InfoBubbleViewModel(DynamoViewModel);
             UpdateBubbleContent();
@@ -390,9 +391,17 @@ namespace Dynamo.ViewModels
             {
                 DynamoViewModel.EngineController.AstBuilt += EngineController_AstBuilt;
             }
+
             ShowExecutionPreview = workspaceViewModel.DynamoViewModel.ShowRunPreview;
             IsNodeAddedRecently = true;
             DynamoSelection.Instance.Selection.CollectionChanged += SelectionOnCollectionChanged;
+        }
+
+        public NodeViewModel(WorkspaceViewModel workspaceViewModel, NodeModel logic, Size preferredSize)
+            :this(workspaceViewModel, logic)
+        {
+            // preferredSize is set when a node needs to have a fixed size
+            PreferredSize = preferredSize;
         }
 
         private void SelectionOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -24,7 +24,7 @@
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
-            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto" MaxHeight="{StaticResource NodeNickNameHeight}"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -214,7 +214,7 @@
                    TextAlignment="Center"
                    IsHitTestVisible="False"
                    Canvas.ZIndex="12"
-                   Height="27"
+                   Height="{StaticResource NodeNickNameHeight}"
                    Background="{x:Null}"
                    Style="{StaticResource SZoomFadeText}">
             <TextBlock.Foreground>

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -14,11 +14,12 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading;
 using System.Windows.Documents;
-
+using Dynamo.Controls;
 using Dynamo.Wpf.Utilities;
 using Dynamo.Search.SearchElements;
 using Dynamo.UI.Controls;
 using Dynamo.Wpf.UI;
+using Dynamo.Utilities;
 
 using ModifierKeys = System.Windows.Input.ModifierKeys;
 
@@ -516,16 +517,24 @@ namespace Dynamo.Views
                         .Where(c => c.End != null && c.End.Owner.IsSelected)).Distinct();
 
                 // set list of selected viewmodels
-                draggedData = nodes.Select(n => (ViewModelBase)new NodeViewModel(ViewModel, n))
+                draggedData = connectors.Select(c => (ViewModelBase)new ConnectorViewModel(ViewModel, c))
                     .Concat(notes.Select(n => new NoteViewModel(ViewModel, n)))
                     .Concat(annotations.Select(a => new AnnotationViewModel(ViewModel, a)))
-                    .Concat(connectors.Select(c => new ConnectorViewModel(ViewModel, c))).ToList();
+                    .Concat(nodes.Select(n =>
+                    {
+                        var nodeRect = this.ChildrenOfType<NodeView>()
+                            .First(view => view.ViewModel.NodeModel == n).nodeBorder;
+                        var size = new Size(nodeRect.ActualWidth, nodeRect.ActualHeight);
+                        // set fixed size for dragged nodes, 
+                        // so that they will correspond to origin nodes
+                        return new NodeViewModel(ViewModel, n, size);
+                    })).ToList();
                 
                 var mouse = e.GetPosition(WorkspaceElements);
                 var locatableModels = nodes.Concat<ModelBase>(notes);
                 var minX = locatableModels.Any() ? locatableModels.Min(mb => mb.X) : 0;
                 var minY = locatableModels.Any() ? locatableModels.Min(mb => mb.Y) : 0;
-                // comput offset to correctly place selected items rigth under mouse cursor 
+                // compute offset to correctly place selected items right under mouse cursor 
                 var mouseOffset = new Point2D(mouse.X - minX, mouse.Y - minY);
 
                 DynamoSelection.Instance.ClearSelectionDisabled = false;


### PR DESCRIPTION
### Purpose

Issue: When dragging nodes with pressed CTRL, for simplicity nodes are dragged without their custom content and therefore ghost nodes have different size that erroneously notify listeners of source nodes. 

Fix: set size of ghosted hodes to source nodes size.

Also, small issue with drawing ghosted connectors (start and end circle of connector are placed in front of its node) is fixed in this PR 

### Screenshot

![ctrl_drag](https://cloud.githubusercontent.com/assets/7658189/10637908/d134c038-7810-11e5-8dd1-786e55315727.png)

### Reviewers

@ikeough 