### PR TITLE
Cannot open file after opening .dyf on Revit

### DIFF
--- a/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Core/Threading/UpdateGraphAsyncTask.cs
@@ -105,27 +105,32 @@ namespace Dynamo.Core.Threading
         protected override void HandleTaskCompletionCore()
         {
             if (engineController.IsDisposed)
-                return;
-
-            // Retrieve warnings in the context of ISchedulerThread.
-            BuildWarnings = engineController.GetBuildWarnings();
-            RuntimeWarnings = engineController.GetRuntimeWarnings();
-
-            // Mark all modified nodes as being updated (if the task has been 
-            // successfully scheduled, executed and completed, it is expected 
-            // for "modifiedNodes" to be both non-null and non-empty.
-            // 
-            // In addition to marking modified nodes as being updated, their 
-            // warning states are cleared (which include the tool-tip). Any node
-            // that has build/runtime warnings assigned to it will properly be 
-            // restored to warning state when task completion handler sets the 
-            // corresponding build/runtime warning on it.
-            // 
-            foreach (var modifiedNode in ModifiedNodes)
             {
-                modifiedNode.WasInvolvedInExecution = true;
-                if (modifiedNode.State == ElementState.Warning)
-                    modifiedNode.ClearRuntimeError();
+                BuildWarnings = new Dictionary<Guid, List<BuildWarning>>();
+                RuntimeWarnings = new Dictionary<Guid, List<RuntimeWarning>>();
+            }
+            else
+            {
+                // Retrieve warnings in the context of ISchedulerThread.
+                BuildWarnings = engineController.GetBuildWarnings();
+                RuntimeWarnings = engineController.GetRuntimeWarnings();
+
+                // Mark all modified nodes as being updated (if the task has been 
+                // successfully scheduled, executed and completed, it is expected 
+                // for "modifiedNodes" to be both non-null and non-empty.
+                // 
+                // In addition to marking modified nodes as being updated, their 
+                // warning states are cleared (which include the tool-tip). Any node
+                // that has build/runtime warnings assigned to it will properly be 
+                // restored to warning state when task completion handler sets the 
+                // corresponding build/runtime warning on it.
+                // 
+                foreach (var modifiedNode in ModifiedNodes)
+                {
+                    modifiedNode.WasInvolvedInExecution = true;
+                    if (modifiedNode.State == ElementState.Warning)
+                        modifiedNode.ClearRuntimeError();
+                }
             }
         }
 


### PR DESCRIPTION
### Purpose

This PR continues the fix for [MAGN 8879 Opening .dyf after opening .dyn crashes Dynamo](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8879). 

In PR #5565 `HandleTaskCompletionCore()` returns if engine controller has been disposed, but remains `BuildWarnings` and `RuntimeWarnings` uninitialized, which cause null reference exceptions. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Benglin 