### PR TITLE
List.Create: update port names

### DIFF
--- a/src/Libraries/CoreNodeModels/CreateList.cs
+++ b/src/Libraries/CoreNodeModels/CreateList.cs
@@ -16,7 +16,7 @@ namespace DSCoreNodesUI
     {
         public CreateList()
         {
-            InPortData.Add(new PortData("index0", Resources.CreateListPortDataIndex0ToolTip));
+            InPortData.Add(new PortData("item0", Resources.CreateListPortDataIndex0ToolTip));
             OutPortData.Add(new PortData("list", Resources.CreateListPortDataResultToolTip));
 
             RegisterAllPorts();
@@ -26,7 +26,7 @@ namespace DSCoreNodesUI
 
         protected override string GetInputName(int index)
         {
-            return "index" + index;
+            return "item" + index;
         }
 
         protected override string GetInputTooltip(int index)


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8440](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8440) Update tooltips, port names for List.Create

Original Acceptance Criteria was:
- rename input ports from "index0" to "item0"
- update tooltips with new attribute tooltip styling.

But that was too complicated task, because `CreateList` is class, that is inherited from `VariableInputNode`. To accomplish this task I had to updated all nodes inherited from `VariableInputNode`, like Python node, Fucntion.Apply node, List.Reduce node and many many other. As we decided during daily meeting it takes too many time for this from the first side easy task. So Acceptance Criteria was reduced, and now it's just needed to rename incomming ports.

Nevertheless, when I'll have free time, I want to return to this task and finally complete the whole Acceptance Criteria.
Link to old PR: https://github.com/DynamoDS/Dynamo/pull/5483

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@pboyer 

### FYIs

@Racel 