### PR TITLE
MAGN-8911 Custom node returns null after opening the .dyf file

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1188,18 +1188,21 @@ namespace Dynamo.Models
                         OnWorkspaceOpening(xmlDoc);
 
                         // TODO: #4258
-                        // Remove this ResetEngine call when multiple home workspaces is supported.
-                        // This call formerly lived in DynamoViewModel
-                        ResetEngine();
-
-                        // TODO: #4258
                         // The following logic to start periodic evaluation will need to be moved
                         // inside of the HomeWorkspaceModel's constructor.  It cannot be there today
                         // as it causes an immediate crash due to the above ResetEngine call.
                         var hws = ws as HomeWorkspaceModel;
-                        if (hws != null && hws.RunSettings.RunType == RunType.Periodic)
+                        if (hws != null)
                         {
-                            hws.StartPeriodicEvaluation();
+                            // TODO: #4258
+                            // Remove this ResetEngine call when multiple home workspaces is supported.
+                            // This call formerly lived in DynamoViewModel
+                            ResetEngine();
+
+                            if (hws.RunSettings.RunType == RunType.Periodic)
+                            {
+                                hws.StartPeriodicEvaluation();
+                            }
                         }
 
                         CurrentWorkspace = ws;


### PR DESCRIPTION
### Purpose

This PR tries to fix defect [MAGN 8911: Custom node returns null after opening the .dyf file](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8911).

The root cause is async tasks `UpdateGraphAsyncTask` and `CompileCustomNodeAsyncTask` reference to global `EngineController` which may be disposed (done by `ResetEngine()`) *before* they are executed. If engine controller has been disposed, these tasks will be discarded, but the state of nodes have been changed. 

First possible fix is to defer the dirty flag cleaning after the task is executed, but it is problematic: before `UpdateGraphAsyncTask` 1 is executed, nodes are modified. When returning from `UpdateAsyncTask` 1, these nodes are marked as clean, so no graph sync data will be generated for `UpdateAsyncTask` 2 and new modifications won't be executed.
```
     UpdateGraphAsyncTask 1         UI
            |                       |
            v                       |
     Computate Graph Sync Data      |
            |                       |
            |                       v
            |                  Modify nodes ------------+
            |                                           |
            v                                           v  
        Execute                                 UpdateGraphAsyncTask 2
            |                                           |
            V                                           |
    Mark nodes as clean ----------------------------->  |
            |                                           v
            v                                 Compuate Graph Sync Data = null

```

The second approach is to wrap `ResetEngine()` operation in an async task to make sure `UpdateGraphAsyncTask` and `CompileCustomNodeAsyncTask` will be executed before resetting engine. The problem is, the application will access engine controller from main thread right after resetting it, so reset engine async task has be synchronous. It is a deadlock on Revit because the scheduler thread is main thread. 

Or, we could put all remaining code as continuation of reset engine async task, but the scope of remaining code is hard to define. 

This PR doesn't really fix the problem, but the other workaround: don't reset engine controller when opening a custom node definition (and it shouldn't actually) so that scheduled `CompileCustomNodeAsyncTask` and `UpdateGraphAsyncTask` will always have valid engine controller object. It is fine to reset engine controller when opening a home workspace -- in that case, it is safe to discard these tasks.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.

### Reviewers

@Benglin 