### PR TITLE
Rounding off slider values for display as text

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/SliderBase.cs
+++ b/src/Libraries/CoreNodeModels/Input/SliderBase.cs
@@ -88,6 +88,13 @@ namespace DSCoreNodesUI.Input
         
         public static string ConvertNumberToString(T value)
         {
+            if (value.GetType() == typeof(double))
+            {
+                var obj = (object)value;
+                var val = (double)obj;
+                val = Math.Round(val, 1);
+                return Convert.ToString(val, CultureInfo.InvariantCulture);
+            }
             return Convert.ToString(value, CultureInfo.InvariantCulture);
         }
 


### PR DESCRIPTION
### Purpose ###
If `double` values are sent to the slider node with large number of decimal places, they are converted to `string` as is, which leads to the value text to become very long in the slider textbox. This fix is an attempt to round off those values in the conversion method before it is displayed in the UI.

@sharadkjaiswal 