### PR TITLE
MAGN-8389 As a user, I don't want to have the option to toggle to geometry preview if 'Background Preview' is off so that I don't get a blank screen

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -245,7 +245,9 @@
                 <Separator />
 
                 <MenuItem Header="{x:Static p:Resources.ContextMenuGeometryView}"
-                          Command="{Binding DynamoViewModel.BackgroundPreviewViewModel.ToggleCanNavigateBackgroundCommand}" />
+                          Command="{Binding DynamoViewModel.BackgroundPreviewViewModel.ToggleCanNavigateBackgroundCommand}"
+                          Visibility="{Binding DynamoViewModel.BackgroundPreviewViewModel.Active, 
+                          Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"/>
                 <MenuItem Header="{x:Static p:Resources.ContextMenuPan}"
                           Command="{Binding DynamoViewModel.BackgroundPreviewViewModel.TogglePanCommand}">
                     <MenuItem.IsChecked>
@@ -350,10 +352,11 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"
                     Height="Auto">
-                <StackPanel.IsEnabled>
+                <StackPanel.Visibility>
                     <Binding Path="DataContext.BackgroundPreviewViewModel.Active"
-                             RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
-                </StackPanel.IsEnabled>
+                             RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}"
+                             Converter="{StaticResource BooleanToVisibilityConverter}"/>
+                </StackPanel.Visibility>
                 <ui:ImageCheckBox Width="56"
                               Height="30"
                               Margin="4,4,0,4"

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml
@@ -43,7 +43,7 @@
                 <MenuItem Header="{x:Static p:Resources.Watch3DViewContextMenuSwitchView}" 
                           Command="{Binding Path=ToggleCanNavigateBackgroundCommand}">
                     <MenuItem.Visibility>
-                        <Binding Path="IsBackgroundPreview"
+                        <Binding Path="Active"
                                  Mode="OneWay"
                                  Converter="{StaticResource BoolToVisibilityCollapsedConverter}"/>
                     </MenuItem.Visibility>

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -24,6 +24,7 @@ using SharpDX;
 using TestServices;
 using Color = System.Windows.Media.Color;
 using Model3D = HelixToolkit.Wpf.SharpDX.Model3D;
+using Dynamo.Views;
 using GeometryModel3D = HelixToolkit.Wpf.SharpDX.GeometryModel3D;
 
 namespace WpfVisualizationTests
@@ -633,6 +634,24 @@ namespace WpfVisualizationTests
             Assert.IsTrue(bPreviewVm.IsGridVisible, "Background grid has not appeared");
             Assert.IsTrue(bPreviewVm.Model3DDictionary
                 .ContainsKey(HelixWatch3DViewModel.DefaultGridName), "Background grid has not appeared");
+        }
+
+        [Test]
+        public void HelixWatch3DViewModel_ChangeBackgroundVisibility_CanNavigateButtonsAreCorrect()
+        {
+            var bPreviewVm = ViewModel.BackgroundPreviewViewModel as HelixWatch3DViewModel;
+            Assert.IsNotNull(bPreviewVm, "HelixWatch3D has not been loaded");
+            bPreviewVm.Active = false;
+
+            Assert.IsFalse(bPreviewVm.Active, "Background has not been turned off");
+            var currentWorkspace = View.WorkspaceTabs.ChildrenOfType<WorkspaceView>().First();
+            Assert.AreEqual(Visibility.Hidden, currentWorkspace.statusBarPanel.Visibility, "Navigation buttons were not hidden");
+
+            // turn on background
+            ViewModel.ToggleFullscreenWatchShowingCommand.Execute(null);
+
+            Assert.IsTrue(bPreviewVm.Active, "Background has not been turned on");
+            Assert.AreEqual(Visibility.Visible, currentWorkspace.statusBarPanel.Visibility, "Navigation buttons did not appear");
         }
 
         #endregion


### PR DESCRIPTION
### Purpose

Hide switch buttons when 3D background is turned off + test case for this

### Screenshots

3D background is turned on:
![3d_on](https://cloud.githubusercontent.com/assets/7658189/10760640/321c488a-7cc6-11e5-8096-fded44cca52e.png)

3D background is turned off:
![3d_off](https://cloud.githubusercontent.com/assets/7658189/10760647/39d7d6c0-7cc6-11e5-995f-72e7ab1c7a38.png)

### Reviewers

@ikeough 