### PR TITLE
Xml Cleanup

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.1.3055")]
+[assembly: AssemblyVersion("0.9.1.3067")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.1.3055")]
+[assembly: AssemblyFileVersion("0.9.1.3067")]

--- a/src/Config/DynamoWpf.targets
+++ b/src/Config/DynamoWpf.targets
@@ -2,13 +2,22 @@
   <!--The SharpDX NuGet package will automatically install certain
   dlls in the output directory. This task is used to remove those files
   from the nodes directory, as they will be available in the main directory.-->
-  <Target Name="SharpDXCleanup" AfterTargets="AfterBuild">
+  <Target Name="SharpDXCleanupNodes" AfterTargets="AfterBuild">
     <Message Text="Removing SharpDX assemblies from nodes folder..." Importance="high"/>
     <ItemGroup>
       <FilesToDelete Include="$(OutputPath)\nodes\Assimp*"/>
       <FilesToDelete Include="$(OutputPath)\nodes\SharpDX*"/>
       <FilesToDelete Include="$(OutputPath)\nodes\HelixToolkit*"/>
       <FilesToDelete Include="$(OutputPath)\nodes\Cyotek*"/>
+    </ItemGroup> 
+    <Delete Files="@(FilesToDelete)"/>
+  </Target>
+  <Target Name="SharpDXCleanupMain" AfterTargets="AfterBuild">
+    <Message Text="Removing Helix xmls from main folder..." Importance="high"/>
+    <ItemGroup>
+      <FilesToDelete Include="$(OutputPath)\Assimp*.xml"/>
+      <FilesToDelete Include="$(OutputPath)\Helix*.xml"/>
+      <FilesToDelete Include="$(OutputPath)\Sharpdx*.xml"/>
     </ItemGroup> 
     <Delete Files="@(FilesToDelete)"/>
   </Target>

--- a/src/VisualizationTests/WpfVisualizationTests.csproj
+++ b/src/VisualizationTests/WpfVisualizationTests.csproj
@@ -3,6 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)Config/CS.props" />
+    <Import Project="$(SolutionDir)Config/DynamoWpf.targets" />
     <Import Project="..\packages\SharpDX.2.6.3\build\SharpDX.targets" Condition="Exists('..\packages\SharpDX.2.6.3\build\SharpDX.targets')" />
     <Import Project="..\packages\SharpDX.Toolkit.2.6.3\build\SharpDX.Toolkit.targets" Condition="Exists('..\packages\SharpDX.Toolkit.2.6.3\build\SharpDX.Toolkit.targets')" />
   </ImportGroup>


### PR DESCRIPTION
This PR adds an additional cleanup target which removes xml files installed by NuGet packages. These xml files are not required for the running of the application, and will be deleted at build time.

FYI: @riteshchandawar 

### Cherry Picks
- [ ] RC0.9.0_master