### PR TITLE
Fix for GraphLayout on note models inside groups

### DIFF
--- a/src/DynamoCore/Models/WorkspaceModel.cs
+++ b/src/DynamoCore/Models/WorkspaceModel.cs
@@ -1075,11 +1075,33 @@ namespace Dynamo.Models
 
             foreach (NoteModel note in Notes)
             {
-                // Link a note to the nearest node
-                GraphLayout.Node nd = combinedGraph.Nodes.OrderBy(node =>
-                    Math.Pow(node.X + node.Width / 2 - note.X - note.Width / 2, 2) +
-                    Math.Pow(node.Y + node.Height / 2 - note.Y - note.Height / 2, 2)).FirstOrDefault();
+                AnnotationModel group = Annotations.Where(
+                    g => g.SelectedModels.Contains(note)).ToList().FirstOrDefault();
 
+                GraphLayout.Node nd = null;
+
+                if (!isGroupLayout || group == null)
+                {
+                    // If note is not part of a group, link to the nearest node in the graph
+                    nd = combinedGraph.Nodes.OrderBy(node =>
+                        Math.Pow(node.X + node.Width / 2 - note.X - note.Width / 2, 2) +
+                        Math.Pow(node.Y + node.Height / 2 - note.Y - note.Height / 2, 2)).FirstOrDefault();
+                }
+                else
+                {
+                    // If note is part of a group, link to the nearest node in the group
+                    NodeModel ndm = group.SelectedModels.OfType<NodeModel>().OrderBy(node =>
+                        Math.Pow(node.X + node.Width / 2 - note.X - note.Width / 2, 2) +
+                        Math.Pow(node.Y + node.Height / 2 - note.Y - note.Height / 2, 2)).FirstOrDefault();
+
+                    // If the nearest point is a node model
+                    nd = combinedGraph.FindNode(ndm.GUID);
+
+                    // If the nearest point is a group model
+                    nd = nd ?? combinedGraph.FindNode(group.GUID);
+                }
+
+                // Otherwise, leave the note unchanged
                 if (nd != null)
                 {
                     nd.LinkNote(note, note.Width, note.Height);
@@ -1099,7 +1121,7 @@ namespace Dynamo.Models
                 foreach (AnnotationModel group in DynamoSelection.Instance.Selection.OfType<AnnotationModel>())
                 {
                     List<GraphLayout.Node> cluster = new List<GraphLayout.Node>();
-                    cluster.AddRange(group.SelectedModels.Select(x => combinedGraph.FindNode(x.GUID)));
+                    cluster.AddRange(group.SelectedModels.OfType<NodeModel>().Select(x => combinedGraph.FindNode(x.GUID)));
                     SubgraphClusters.Add(cluster);
                 }
             }
@@ -1131,7 +1153,7 @@ namespace Dynamo.Models
                 {
                     if (group.IsSelected)
                     {
-                        group.Deselect();
+                        group.SelectedModels.OfType<NodeModel>().ToList().ForEach(x => x.IsSelected = false);
                         undoItems.AddRange(group.SelectedModels);
                     }
                 }

--- a/test/core/GraphLayout/GraphLayoutConnectedGroups.dyn
+++ b/test/core/GraphLayout/GraphLayoutConnectedGroups.dyn
@@ -1,7 +1,7 @@
 <Workspace Version="0.8.3.2432" X="256.878110992409" Y="292.047324687886" zoom="0.643383330581561" Name="Home" Description="" RunType="Manual" RunPeriod="100" HasRunWithoutCrash="False">
   <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="cb7a2190-3551-4a0a-b484-b546a7387e46" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="946.187475560775" y="-10.7082360552373" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="0..9;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="cb7a2190-3551-4a0a-b484-b546a7387e46" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1078.18765303155" y="-98.3438501886553" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="0..9;" ShouldFocus="false" />
     <Dynamo.Nodes.CodeBlockNodeModel guid="166ba32d-ff51-4992-9f3f-d45c16ee7a7c" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="942.59515237349" y="150.291763944763" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="0..5;" ShouldFocus="false" />
     <Dynamo.Nodes.DSFunction guid="aafc2def-647b-4891-8f7a-6d0eb5bbbdd0" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="1195.91609832766" y="146.771015062701" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
       <PortInfo index="0" default="True" />
@@ -71,12 +71,12 @@
     <Dynamo.Models.ConnectorModel start="b4ad9290-2703-4530-ab37-f241310a4616" start_index="0" end="d1846005-5570-4aff-af03-b4c510c6b285" end_index="0" portType="0" />
   </Connectors>
   <Notes>
-    <Dynamo.Models.NoteModel guid="458cec10-5a60-4acf-93f0-76f933f463ca" text="This is a note" x="706.085368327469" y="-254.72474954846" />
+    <Dynamo.Models.NoteModel guid="458cec10-5a60-4acf-93f0-76f933f463ca" text="This is a note" x="706.085368327469" y="-354.72474954846" />
     <Dynamo.Models.NoteModel guid="f1bf1119-6610-4432-bc77-49ff9025c415" text="This is a note" x="323.931828936944" y="-18.6793635507272" />
-    <Dynamo.Models.NoteModel guid="96838ac9-4384-44da-9252-11b7ed9bc98d" text="This is another note." x="609.719800472365" y="273.731590302109" />
+    <Dynamo.Models.NoteModel guid="96838ac9-4384-44da-9252-11b7ed9bc98d" text="This is another note." x="609.719800472365" y="173.731590302109" />
   </Notes>
   <Annotations>
-    <Dynamo.Models.AnnotationModel guid="508fe6d8-c560-44a4-b0fc-0aff8af79323" annotationText="&lt;Click here to edit the group title&gt;" left="201.365465710663" top="-316.881933664516" width="656.642249826003" height="371.575992390672" fontSize="14" InitialTop="-286.881933664516" InitialHeight="371.575992390672" TextblockHeight="20" backgrouund="#FFBB87C6">
+    <Dynamo.Models.AnnotationModel guid="508fe6d8-c560-44a4-b0fc-0aff8af79323" annotationText="&lt;Click here to edit the group title&gt;" left="201.365465710663" top="-384.72474954846" width="656.642249826003" height="439.418808274616" fontSize="14" InitialTop="-354.72474954846" InitialHeight="371.575992390672" TextblockHeight="20" backgrouund="#FFBB87C6">
       <Models ModelGuid="7d03321c-aa1b-48c9-810c-d0b63e199f22" />
       <Models ModelGuid="e93fee37-1901-4162-8f73-6b5e98c1167f" />
       <Models ModelGuid="5ddd5fde-9281-4e2e-95f3-b965eebf59b2" />
@@ -86,7 +86,7 @@
       <Models ModelGuid="458cec10-5a60-4acf-93f0-76f933f463ca" />
       <Models ModelGuid="f1bf1119-6610-4432-bc77-49ff9025c415" />
     </Dynamo.Models.AnnotationModel>
-    <Dynamo.Models.AnnotationModel guid="4745884a-8db2-42d7-b470-64e8c9063089" annotationText="&lt;Click here to edit the group title&gt;" left="932.59515237349" top="-79.8049773279723" width="656.642249826" height="371.575992390673" fontSize="14" InitialTop="-49.8049773279723" InitialHeight="371.575992390673" TextblockHeight="20" backgrouund="#FFFF7BAC">
+    <Dynamo.Models.AnnotationModel guid="4745884a-8db2-42d7-b470-64e8c9063089" annotationText="&lt;Click here to edit the group title&gt;" left="932.59515237349" top="-108.343850188655" width="656.642249826" height="400.114865251356" fontSize="14" InitialTop="-78.3438501886553" InitialHeight="371.575992390673" TextblockHeight="20" backgrouund="#FFFF7BAC">
       <Models ModelGuid="cb7a2190-3551-4a0a-b484-b546a7387e46" />
       <Models ModelGuid="166ba32d-ff51-4992-9f3f-d45c16ee7a7c" />
       <Models ModelGuid="aafc2def-647b-4891-8f7a-6d0eb5bbbdd0" />

--- a/test/core/GraphLayout/GraphLayoutConnectedGroups.dyn
+++ b/test/core/GraphLayout/GraphLayoutConnectedGroups.dyn
@@ -73,6 +73,7 @@
   <Notes>
     <Dynamo.Models.NoteModel guid="458cec10-5a60-4acf-93f0-76f933f463ca" text="This is a note" x="706.085368327469" y="-254.72474954846" />
     <Dynamo.Models.NoteModel guid="f1bf1119-6610-4432-bc77-49ff9025c415" text="This is a note" x="323.931828936944" y="-18.6793635507272" />
+    <Dynamo.Models.NoteModel guid="96838ac9-4384-44da-9252-11b7ed9bc98d" text="This is another note." x="609.719800472365" y="273.731590302109" />
   </Notes>
   <Annotations>
     <Dynamo.Models.AnnotationModel guid="508fe6d8-c560-44a4-b0fc-0aff8af79323" annotationText="&lt;Click here to edit the group title&gt;" left="201.365465710663" top="-316.881933664516" width="656.642249826003" height="371.575992390672" fontSize="14" InitialTop="-286.881933664516" InitialHeight="371.575992390672" TextblockHeight="20" backgrouund="#FFBB87C6">

--- a/test/core/GraphLayout/GraphLayoutConnectedGroups.dyn
+++ b/test/core/GraphLayout/GraphLayoutConnectedGroups.dyn
@@ -70,7 +70,10 @@
     <Dynamo.Models.ConnectorModel start="da57af46-b231-4206-a0c4-5704695acfd9" start_index="0" end="ce17d82e-d510-4e5e-bcf3-46faa1672d98" end_index="0" portType="0" />
     <Dynamo.Models.ConnectorModel start="b4ad9290-2703-4530-ab37-f241310a4616" start_index="0" end="d1846005-5570-4aff-af03-b4c510c6b285" end_index="0" portType="0" />
   </Connectors>
-  <Notes />
+  <Notes>
+    <Dynamo.Models.NoteModel guid="458cec10-5a60-4acf-93f0-76f933f463ca" text="This is a note" x="706.085368327469" y="-254.72474954846" />
+    <Dynamo.Models.NoteModel guid="f1bf1119-6610-4432-bc77-49ff9025c415" text="This is a note" x="323.931828936944" y="-18.6793635507272" />
+  </Notes>
   <Annotations>
     <Dynamo.Models.AnnotationModel guid="508fe6d8-c560-44a4-b0fc-0aff8af79323" annotationText="&lt;Click here to edit the group title&gt;" left="201.365465710663" top="-316.881933664516" width="656.642249826003" height="371.575992390672" fontSize="14" InitialTop="-286.881933664516" InitialHeight="371.575992390672" TextblockHeight="20" backgrouund="#FFBB87C6">
       <Models ModelGuid="7d03321c-aa1b-48c9-810c-d0b63e199f22" />
@@ -79,6 +82,8 @@
       <Models ModelGuid="97fdff50-38a7-47f8-9167-441db4c59c22" />
       <Models ModelGuid="942ecaa8-7557-469e-8f1d-fea057446cad" />
       <Models ModelGuid="2e504b57-8c99-4f52-9442-7a2bcfd63c8d" />
+      <Models ModelGuid="458cec10-5a60-4acf-93f0-76f933f463ca" />
+      <Models ModelGuid="f1bf1119-6610-4432-bc77-49ff9025c415" />
     </Dynamo.Models.AnnotationModel>
     <Dynamo.Models.AnnotationModel guid="4745884a-8db2-42d7-b470-64e8c9063089" annotationText="&lt;Click here to edit the group title&gt;" left="932.59515237349" top="-79.8049773279723" width="656.642249826" height="371.575992390673" fontSize="14" InitialTop="-49.8049773279723" InitialHeight="371.575992390673" TextblockHeight="20" backgrouund="#FFFF7BAC">
       <Models ModelGuid="cb7a2190-3551-4a0a-b484-b546a7387e46" />

--- a/test/core/GraphLayout/GraphLayoutTree.dyn
+++ b/test/core/GraphLayout/GraphLayoutTree.dyn
@@ -40,7 +40,10 @@
     <Dynamo.Models.ConnectorModel start="15feece7-b122-4514-a00e-f031136e336f" start_index="0" end="6a34a52a-a23f-4962-bb0a-971ffd5cd6be" end_index="2" portType="0" />
     <Dynamo.Models.ConnectorModel start="28b87b8c-b25a-4f4e-8954-e2452bb0588f" start_index="0" end="a93dc4ad-9f2a-4158-b994-363ce737a070" end_index="0" portType="0" />
   </Connectors>
-  <Notes />
+  <Notes>
+    <Dynamo.Models.NoteModel guid="84796624-0188-444f-8053-20d636a7ccaf" text="This is a note." x="-3540.14554067101" y="-3670.53429668482" />
+    <Dynamo.Models.NoteModel guid="e8939575-e8c8-4786-864e-3083ba267611" text="This is another note." x="-2412.23413237467" y="-3693.4991720698" />
+  </Notes>
   <Annotations />
   <Presets />
   <Cameras>


### PR DESCRIPTION
### Purpose

Reference: [MAGN-8890](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8890)

This PR fixes the crash which happened when doing Cleanup Node Layout command on a group containing one or more note models. A test case has been modified to test this.

### Declarations

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] All tests pass using the self-service CI.

### Reviewers

@Randy-Ma 

### FYIs

@riteshchandawar 