### PR TITLE
Code clean up for CoreUtils and VarDeclNode

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -4673,7 +4673,6 @@ namespace ProtoAssociative
         {
             var argument = new ProtoCore.AST.AssociativeAST.VarDeclNode()
             {
-                memregion = ProtoCore.DSASM.MemoryRegion.kMemStack,
                 access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic,
                 NameNode =AstFactory.BuildIdentifier(Constants.kTempArg),
                 ArgumentType = argType
@@ -6984,7 +6983,6 @@ namespace ProtoAssociative
 
             VarDeclNode thisPtrArg = new ProtoCore.AST.AssociativeAST.VarDeclNode()
             {
-                memregion = ProtoCore.DSASM.MemoryRegion.kMemStack,
                 access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic,
                 NameNode = ident,
                 ArgumentType = new ProtoCore.Type { Name = className, UID = procOverload.classIndex, rank = 0 }

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -5163,8 +5163,6 @@ namespace ProtoAssociative
                                 currentClassScope = globalClassIndex;
                                 ix = 0;
                             }
-                            ProtoCore.AST.AssociativeAST.VarDeclNode varnode = classDecl.varlist[ix++] as ProtoCore.AST.AssociativeAST.VarDeclNode;
-                            sn.Attributes = PopulateAttributes((varnode).Attributes);
                         }
                     }
                 }

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -4673,7 +4673,7 @@ namespace ProtoAssociative
         {
             var argument = new ProtoCore.AST.AssociativeAST.VarDeclNode()
             {
-                access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic,
+                Access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic,
                 NameNode =AstFactory.BuildIdentifier(Constants.kTempArg),
                 ArgumentType = argType
             };
@@ -4849,7 +4849,7 @@ namespace ProtoAssociative
                 // It is possible that fail to allocate variable. In that 
                 // case we should remove initializing expression from 
                 // cnode's defaultArgExprList
-                int symbolIndex = AllocateMemberVariable(thisClassIndex, thisClassIndex, varIdent.Value, vardecl.ArgumentType.rank, vardecl.access, vardecl.IsStatic);
+                int symbolIndex = AllocateMemberVariable(thisClassIndex, thisClassIndex, varIdent.Value, vardecl.ArgumentType.rank, vardecl.Access, vardecl.IsStatic);
                 if (symbolIndex == ProtoCore.DSASM.Constants.kInvalidIndex)
                 {
                     Validity.Assert(thisClass.DefaultArgExprList.Count > 0);
@@ -6983,7 +6983,7 @@ namespace ProtoAssociative
 
             VarDeclNode thisPtrArg = new ProtoCore.AST.AssociativeAST.VarDeclNode()
             {
-                access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic,
+                Access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic,
                 NameNode = ident,
                 ArgumentType = new ProtoCore.Type { Name = className, UID = procOverload.classIndex, rank = 0 }
             };

--- a/src/Engine/ProtoAssociative/Compiler.cs
+++ b/src/Engine/ProtoAssociative/Compiler.cs
@@ -77,7 +77,7 @@ namespace ProtoAssociative
                         if (!core.builtInsLoaded)
                         {
                             // Load the built-in methods manually
-                            ProtoCore.Utils.CoreUtils.InsertPredefinedAndBuiltinMethods(core, codeBlockNode, false);
+                            CoreUtils.InsertPredefinedAndBuiltinMethods(core, codeBlockNode as ProtoCore.AST.AssociativeAST.CodeBlockNode);
                             core.builtInsLoaded = true;
                         }
                     }

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -844,7 +844,6 @@ namespace ProtoFFI
         private ProtoCore.AST.AssociativeAST.VarDeclNode ParseArgumentDeclaration(string parameterName, Type parameterType)
         {
             ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = new ProtoCore.AST.AssociativeAST.VarDeclNode();
-            varDeclNode.memregion = ProtoCore.DSASM.MemoryRegion.kMemStack;
             varDeclNode.access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic;
 
             ProtoCore.AST.AssociativeAST.IdentifierNode identifierNode = 

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -844,7 +844,7 @@ namespace ProtoFFI
         private ProtoCore.AST.AssociativeAST.VarDeclNode ParseArgumentDeclaration(string parameterName, Type parameterType)
         {
             ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = new ProtoCore.AST.AssociativeAST.VarDeclNode();
-            varDeclNode.access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic;
+            varDeclNode.Access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic;
 
             ProtoCore.AST.AssociativeAST.IdentifierNode identifierNode = 
                 new ProtoCore.AST.AssociativeAST.IdentifierNode

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -1031,7 +1031,7 @@ namespace ProtoCore.AST.AssociativeAST
                 Name = rhs.ArgumentType.Name
             };
             NameNode = NodeUtils.Clone(rhs.NameNode);
-            access = rhs.access;
+            Access = rhs.Access;
             IsStatic = rhs.IsStatic;
             ExternalAttributes = rhs.ExternalAttributes;
         }
@@ -1039,7 +1039,7 @@ namespace ProtoCore.AST.AssociativeAST
         public List<AssociativeNode> Attributes { get; set; }
         public Type ArgumentType { get; set; }
         public AssociativeNode NameNode { get; set; }
-        public ProtoCore.CompilerDefinitions.AccessModifier access { get; set; }
+        public CompilerDefinitions.AccessModifier Access { get; set; }
         public bool IsStatic { get; set; }
         public ExternalAttributes ExternalAttributes { get; set; }
 

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -1017,13 +1017,11 @@ namespace ProtoCore.AST.AssociativeAST
     {
         public VarDeclNode()
         {
-            Attributes = new List<AssociativeNode>();
         }
 
         public VarDeclNode(VarDeclNode rhs)
             : base(rhs)
         {
-            Attributes = rhs.Attributes.Select(NodeUtils.Clone).ToList();
             ArgumentType = new Type
             {
                 UID = rhs.ArgumentType.UID,
@@ -1036,7 +1034,6 @@ namespace ProtoCore.AST.AssociativeAST
             ExternalAttributes = rhs.ExternalAttributes;
         }
 
-        public List<AssociativeNode> Attributes { get; set; }
         public Type ArgumentType { get; set; }
         public AssociativeNode NameNode { get; set; }
         public CompilerDefinitions.AccessModifier Access { get; set; }
@@ -1074,9 +1071,8 @@ namespace ProtoCore.AST.AssociativeAST
                 return false;
 
             return ArgumentType.Equals(otherNode.ArgumentType) &&
-                   EqualityComparer<AssociativeNode>.Default.Equals(NameNode, otherNode.NameNode) && 
-                   IsStatic == otherNode.IsStatic && 
-                   Attributes.SequenceEqual(otherNode.Attributes);
+                   EqualityComparer<AssociativeNode>.Default.Equals(NameNode, otherNode.NameNode) &&
+                   IsStatic == otherNode.IsStatic;
         }
 
         public override int GetHashCode()
@@ -1085,10 +1081,8 @@ namespace ProtoCore.AST.AssociativeAST
             var nameNodeHashCode =
                 (NameNode == null ? base.GetHashCode() : NameNode.GetHashCode());
             var isStaticHashCode = IsStatic? 1 : 0;
-            var attributesHashCode =
-                (Attributes == null ? base.GetHashCode() : Attributes.GetHashCode());
 
-            return argumentTypeHashCode ^ nameNodeHashCode ^ isStaticHashCode ^ attributesHashCode;
+            return argumentTypeHashCode ^ nameNodeHashCode ^ isStaticHashCode;
         }
 
         public override void Accept(AssociativeAstVisitor visitor)

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -1017,7 +1017,6 @@ namespace ProtoCore.AST.AssociativeAST
     {
         public VarDeclNode()
         {
-            memregion = MemoryRegion.kInvalidRegion;
             Attributes = new List<AssociativeNode>();
         }
 
@@ -1025,7 +1024,6 @@ namespace ProtoCore.AST.AssociativeAST
             : base(rhs)
         {
             Attributes = rhs.Attributes.Select(NodeUtils.Clone).ToList();
-            memregion = rhs.memregion;
             ArgumentType = new Type
             {
                 UID = rhs.ArgumentType.UID,
@@ -1039,7 +1037,6 @@ namespace ProtoCore.AST.AssociativeAST
         }
 
         public List<AssociativeNode> Attributes { get; set; }
-        public MemoryRegion memregion { get; set; }
         public Type ArgumentType { get; set; }
         public AssociativeNode NameNode { get; set; }
         public ProtoCore.CompilerDefinitions.AccessModifier access { get; set; }
@@ -1076,8 +1073,7 @@ namespace ProtoCore.AST.AssociativeAST
             if (null == otherNode)
                 return false;
 
-            return memregion == otherNode.memregion  &&
-                   ArgumentType.Equals(otherNode.ArgumentType) &&
+            return ArgumentType.Equals(otherNode.ArgumentType) &&
                    EqualityComparer<AssociativeNode>.Default.Equals(NameNode, otherNode.NameNode) && 
                    IsStatic == otherNode.IsStatic && 
                    Attributes.SequenceEqual(otherNode.Attributes);
@@ -1085,7 +1081,6 @@ namespace ProtoCore.AST.AssociativeAST
 
         public override int GetHashCode()
         {
-            var memregionHashCode = memregion.GetHashCode();
             var argumentTypeHashCode = ArgumentType.GetHashCode();
             var nameNodeHashCode =
                 (NameNode == null ? base.GetHashCode() : NameNode.GetHashCode());
@@ -1093,8 +1088,7 @@ namespace ProtoCore.AST.AssociativeAST
             var attributesHashCode =
                 (Attributes == null ? base.GetHashCode() : Attributes.GetHashCode());
 
-            return memregionHashCode ^ argumentTypeHashCode ^ 
-                nameNodeHashCode ^ isStaticHashCode ^ attributesHashCode;
+            return argumentTypeHashCode ^ nameNodeHashCode ^ isStaticHashCode ^ attributesHashCode;
         }
 
         public override void Accept(AssociativeAstVisitor visitor)
@@ -3392,7 +3386,6 @@ namespace ProtoCore.AST.AssociativeAST
             var result = new ImperativeAST.VarDeclNode
             {
                 ArgumentType = aNode.ArgumentType,
-                memregion = aNode.memregion,
                 NameNode = aNode.NameNode.ToImperativeAST()
             };
             CopyProps(aNode, result);

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -1537,7 +1537,6 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		ProtoCore.AST.AssociativeAST.IdentifierNode tNode = null; 
 		ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = new ProtoCore.AST.AssociativeAST.VarDeclNode(); 
 		varDeclNode.Access = access;
-		varDeclNode.Attributes = attrs;
 		varDeclNode.IsStatic = isStatic;
 		
 		Expect(1);

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -1545,7 +1545,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		   errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
 		}
 		NodeUtils.SetNodeLocation(varDeclNode, t);
-		tNode = ProtoCore.Utils.CoreUtils.BuildAssocIdentifier(core, t.val);
+		tNode = AstFactory.BuildIdentifier(t.val);
 		NodeUtils.SetNodeLocation(tNode, t);
 		varDeclNode.NameNode = tNode;
 		
@@ -1720,7 +1720,9 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		    SynErr(String.Format(Resources.InvalidReturnStatement, la.val));
 		}
 		
-		node = ProtoCore.Utils.CoreUtils.BuildAssocIdentifier(core, t.val, (ProtoCore.PrimitiveType)ltype);
+		var identNode = AstFactory.BuildIdentifier(t.val);
+		identNode.datatype = TypeSystem.BuildPrimitiveTypeObject((ProtoCore.PrimitiveType)ltype, 0);
+		node = identNode;
 		NodeUtils.SetNodeLocation(node, t);
 		
 	}
@@ -1780,7 +1782,9 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		ProtoCore.AST.AssociativeAST.CodeBlockNode functionBody = new ProtoCore.AST.AssociativeAST.CodeBlockNode(); 
 		
 		ProtoCore.AST.AssociativeAST.BinaryExpressionNode binaryExpr = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
-		binaryExpr.LeftNode = ProtoCore.Utils.CoreUtils.BuildAssocIdentifier(core, "return", ProtoCore.PrimitiveType.kTypeReturn);
+		IdentifierNode returnNode = AstFactory.BuildIdentifier("return");
+		returnNode.datatype = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeReturn, 0);
+		binaryExpr.LeftNode = returnNode;
 		ProtoCore.AST.AssociativeAST.AssociativeNode expr;
 		
 		Associative_Expression(out expr);
@@ -1875,7 +1879,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 		{
 		   errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
 		}
-		tNode = ProtoCore.Utils.CoreUtils.BuildAssocIdentifier(core, t.val);
+		tNode = AstFactory.BuildIdentifier(t.val);
 		NodeUtils.SetNodeLocation(tNode, t);
 		varDeclNode.NameNode = tNode;
 		NodeUtils.CopyNodeLocation(varDeclNode, tNode);

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -1536,7 +1536,6 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 	void Associative_vardecl(out ProtoCore.AST.AssociativeAST.AssociativeNode node, ProtoCore.CompilerDefinitions.AccessModifier access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic, bool isStatic = false, List<ProtoCore.AST.AssociativeAST.AssociativeNode> attrs = null) {
 		ProtoCore.AST.AssociativeAST.IdentifierNode tNode = null; 
 		ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = new ProtoCore.AST.AssociativeAST.VarDeclNode(); 
-		varDeclNode.memregion = ProtoCore.DSASM.MemoryRegion.kMemStack;
 		varDeclNode.access = access;
 		varDeclNode.Attributes = attrs;
 		varDeclNode.IsStatic = isStatic;
@@ -1870,7 +1869,6 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 	void Associative_ArgDecl(out ProtoCore.AST.AssociativeAST.AssociativeNode node, ProtoCore.CompilerDefinitions.AccessModifier access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic) {
 		ProtoCore.AST.AssociativeAST.IdentifierNode tNode = null; 
 		ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = new ProtoCore.AST.AssociativeAST.VarDeclNode(); 
-		varDeclNode.memregion = ProtoCore.DSASM.MemoryRegion.kMemStack;
 		varDeclNode.access = access;
 		
 		Expect(1);

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -784,9 +784,9 @@ public Node root { get; set; }
 	void DesignScriptParser() {
 		Node node = null; 
 		Hydrogen(out node);
-		if (!core.IsParsingPreloadedAssembly && !core.IsParsingCodeBlockNode)
+		if (!core.IsParsingPreloadedAssembly && !core.IsParsingCodeBlockNode && !builtinMethodsLoaded)
 		{
-		   ProtoCore.Utils.CoreUtils.InsertPredefinedAndBuiltinMethods(core, node, builtinMethodsLoaded);
+		   CoreUtils.InsertPredefinedAndBuiltinMethods(core, node as CodeBlockNode);
 		   root = node;
 		}
 		else
@@ -838,9 +838,9 @@ public Node root { get; set; }
 		if (rootImport && null != imh && imh.RootImportNode.CodeNode.Body.Count != 0)
 		   (codeblock as ProtoCore.AST.AssociativeAST.CodeBlockNode).Body.Add(imh.RootImportNode);
 		
-		if (rootImport && core.IsParsingPreloadedAssembly)
+		if (rootImport && core.IsParsingPreloadedAssembly && !builtinMethodsLoaded)
 		{
-		ProtoCore.Utils.CoreUtils.InsertPredefinedAndBuiltinMethods(core, codeblock, builtinMethodsLoaded);
+		CoreUtils.InsertPredefinedAndBuiltinMethods(core, codeblock);
 		core.ImportNodes = codeblock;
 		}
 		
@@ -1536,7 +1536,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 	void Associative_vardecl(out ProtoCore.AST.AssociativeAST.AssociativeNode node, ProtoCore.CompilerDefinitions.AccessModifier access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic, bool isStatic = false, List<ProtoCore.AST.AssociativeAST.AssociativeNode> attrs = null) {
 		ProtoCore.AST.AssociativeAST.IdentifierNode tNode = null; 
 		ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = new ProtoCore.AST.AssociativeAST.VarDeclNode(); 
-		varDeclNode.access = access;
+		varDeclNode.Access = access;
 		varDeclNode.Attributes = attrs;
 		varDeclNode.IsStatic = isStatic;
 		
@@ -1869,7 +1869,7 @@ langblock.codeblock.language == ProtoCore.Language.kInvalid) {
 	void Associative_ArgDecl(out ProtoCore.AST.AssociativeAST.AssociativeNode node, ProtoCore.CompilerDefinitions.AccessModifier access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic) {
 		ProtoCore.AST.AssociativeAST.IdentifierNode tNode = null; 
 		ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = new ProtoCore.AST.AssociativeAST.VarDeclNode(); 
-		varDeclNode.access = access;
+		varDeclNode.Access = access;
 		
 		Expect(1);
 		if (IsKeyWord(t.val, true))

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -604,7 +604,7 @@ Associative_vardecl<.out ProtoCore.AST.AssociativeAST.AssociativeNode node, Prot
                                             errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
                                         }
                                         NodeUtils.SetNodeLocation(varDeclNode, t);
-                                        tNode = ProtoCore.Utils.CoreUtils.BuildAssocIdentifier(core, t.val);
+                                        tNode = AstFactory.BuildIdentifier(t.val);
                                         NodeUtils.SetNodeLocation(tNode, t);
                                         varDeclNode.NameNode = tNode;
                                     .)  
@@ -682,7 +682,7 @@ Associative_ArgDecl<out ProtoCore.AST.AssociativeAST.AssociativeNode node, Proto
                                         {
                                             errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
                                         }
-                                        tNode = ProtoCore.Utils.CoreUtils.BuildAssocIdentifier(core, t.val);
+                                        tNode = AstFactory.BuildIdentifier(t.val);
                                         NodeUtils.SetNodeLocation(tNode, t);
                                         varDeclNode.NameNode = tNode;
                                         NodeUtils.CopyNodeLocation(varDeclNode, tNode);
@@ -798,7 +798,9 @@ Associative_FunctionalMethodBodySingleLine<out ProtoCore.AST.AssociativeAST.Asso
                                             ProtoCore.AST.AssociativeAST.CodeBlockNode functionBody = new ProtoCore.AST.AssociativeAST.CodeBlockNode(); 
 
                                             ProtoCore.AST.AssociativeAST.BinaryExpressionNode binaryExpr = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
-                                            binaryExpr.LeftNode = ProtoCore.Utils.CoreUtils.BuildAssocIdentifier(core, "return", ProtoCore.PrimitiveType.kTypeReturn);
+                                            IdentifierNode returnNode = AstFactory.BuildIdentifier("return");
+                                            returnNode.datatype = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.kTypeReturn, 0);
+                                            binaryExpr.LeftNode = returnNode;
                                             ProtoCore.AST.AssociativeAST.AssociativeNode expr;
                                         .)
     Associative_Expression<out expr>
@@ -1945,7 +1947,9 @@ Associative_Ident<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
                      SynErr(String.Format(Resources.InvalidReturnStatement, la.val));
                 }
                 
-                node = ProtoCore.Utils.CoreUtils.BuildAssocIdentifier(core, t.val, (ProtoCore.PrimitiveType)ltype);
+                var identNode = AstFactory.BuildIdentifier(t.val);
+                identNode.datatype = TypeSystem.BuildPrimitiveTypeObject((ProtoCore.PrimitiveType)ltype, 0);
+                node = identNode;
                 NodeUtils.SetNodeLocation(node, t);
             .)
 .

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -593,15 +593,10 @@ Associative_vardecl<.out ProtoCore.AST.AssociativeAST.AssociativeNode node, Prot
                                     (.
                                         ProtoCore.AST.AssociativeAST.IdentifierNode tNode = null; 
                                         ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = new ProtoCore.AST.AssociativeAST.VarDeclNode(); 
-                                        varDeclNode.memregion = ProtoCore.DSASM.MemoryRegion.kMemStack;
                                         varDeclNode.access = access;
                                         varDeclNode.Attributes = attrs;
                                         varDeclNode.IsStatic = isStatic;
                                     .)
-
-//    [
-//        kw_heap_alloc               (. varDeclNode.memregion = ProtoCore.DSASM.MemoryRegion.kMemHeap; .)
-//    ]
 
     (
         ident                       (. 
@@ -679,7 +674,6 @@ Associative_ArgDecl<out ProtoCore.AST.AssociativeAST.AssociativeNode node, Proto
                                     (.
                                         ProtoCore.AST.AssociativeAST.IdentifierNode tNode = null; 
                                         ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = new ProtoCore.AST.AssociativeAST.VarDeclNode(); 
-                                        varDeclNode.memregion = ProtoCore.DSASM.MemoryRegion.kMemStack;
                                         varDeclNode.access = access;
                                     .)
 

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -44,9 +44,9 @@ Hydrogen<out Node codeBlockNode>
                                if (rootImport && null != imh && imh.RootImportNode.CodeNode.Body.Count != 0)
                                    (codeblock as ProtoCore.AST.AssociativeAST.CodeBlockNode).Body.Add(imh.RootImportNode);
                             .)
-                            (. if (rootImport && core.IsParsingPreloadedAssembly)
+                            (. if (rootImport && core.IsParsingPreloadedAssembly && !builtinMethodsLoaded)
         {
-                ProtoCore.Utils.CoreUtils.InsertPredefinedAndBuiltinMethods(core, codeblock, builtinMethodsLoaded);
+            CoreUtils.InsertPredefinedAndBuiltinMethods(core, codeblock);
             core.ImportNodes = codeblock;
         }
 .)

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -593,8 +593,7 @@ Associative_vardecl<.out ProtoCore.AST.AssociativeAST.AssociativeNode node, Prot
                                     (.
                                         ProtoCore.AST.AssociativeAST.IdentifierNode tNode = null; 
                                         ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = new ProtoCore.AST.AssociativeAST.VarDeclNode(); 
-                                        varDeclNode.access = access;
-                                        varDeclNode.Attributes = attrs;
+                                        varDeclNode.Access = access;
                                         varDeclNode.IsStatic = isStatic;
                                     .)
 
@@ -674,7 +673,7 @@ Associative_ArgDecl<out ProtoCore.AST.AssociativeAST.AssociativeNode node, Proto
                                     (.
                                         ProtoCore.AST.AssociativeAST.IdentifierNode tNode = null; 
                                         ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = new ProtoCore.AST.AssociativeAST.VarDeclNode(); 
-                                        varDeclNode.access = access;
+                                        varDeclNode.Access = access;
                                     .)
 
     (

--- a/src/Engine/ProtoCore/Parser/atg/Start.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Start.atg
@@ -721,9 +721,9 @@ DesignScriptParser
 =                           (. Node node = null; .)
     Hydrogen<out node>       
         (. 
-            if (!core.IsParsingPreloadedAssembly && !core.IsParsingCodeBlockNode)
+            if (!core.IsParsingPreloadedAssembly && !core.IsParsingCodeBlockNode && !builtinMethodsLoaded)
             {
-                ProtoCore.Utils.CoreUtils.InsertPredefinedAndBuiltinMethods(core, node, builtinMethodsLoaded);
+                CoreUtils.InsertPredefinedAndBuiltinMethods(core, node as CodeBlockNode);
                 root = node;
             }
             else

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -17,15 +17,6 @@ namespace ProtoCore.Utils
                 InsertBuiltInMethods(core, root);
             }
         }
-
-        public static IdentifierNode BuildAssocIdentifier(Core core, string name, PrimitiveType type = PrimitiveType.kTypeVar)
-        {
-            var ident = new IdentifierNode();
-            ident.Name = ident.Value = name;
-            ident.datatype = TypeSystem.BuildPrimitiveTypeObject(type, 0);
-            return ident;
-        }
-
         private static FunctionDefinitionNode GenerateBuiltInMethodSignatureNode(Lang.BuiltInMethods.BuiltInMethod method)
         {
             FunctionDefinitionNode fDef = new FunctionDefinitionNode();
@@ -48,12 +39,12 @@ namespace ProtoCore.Utils
             return fDef;
         }
 
-        private static void InsertBuiltInMethods(Core core, AST.Node root)
+        private static void InsertBuiltInMethods(Core core, CodeBlockNode root)
         {
             Lang.BuiltInMethods builtInMethods = new Lang.BuiltInMethods(core);
             foreach (Lang.BuiltInMethods.BuiltInMethod method in builtInMethods.Methods)
             {
-                (root as CodeBlockNode).Body.Add(GenerateBuiltInMethodSignatureNode(method));
+                root.Body.Add(GenerateBuiltInMethodSignatureNode(method));
             }
         }
 
@@ -69,23 +60,24 @@ namespace ProtoCore.Utils
             args.AddArgument(new VarDeclNode()
             {
                 Access = CompilerDefinitions.AccessModifier.kPublic,
-                NameNode = BuildAssocIdentifier(core, DSASM.Constants.kLHS),
+                NameNode = AstFactory.BuildIdentifier(DSASM.Constants.kLHS),
                 ArgumentType = new Type { Name = core.TypeSystem.GetType((int)op1), UID = (int)op1, rank = op1rank }
             });
             args.AddArgument(new VarDeclNode()
             {
                 Access = CompilerDefinitions.AccessModifier.kPublic,
-                NameNode = BuildAssocIdentifier(core, DSASM.Constants.kRHS),
+                NameNode = AstFactory.BuildIdentifier(DSASM.Constants.kRHS),
                 ArgumentType = new Type { Name = core.TypeSystem.GetType((int)op2), UID = (int)op2, rank = op2rank }
             });
             funcDefNode.Signature = args;
 
             CodeBlockNode body = new CodeBlockNode();
-            IdentifierNode _return = BuildAssocIdentifier(core, DSDefinitions.Keyword.Return, PrimitiveType.kTypeReturn);
 
-            IdentifierNode lhs = BuildAssocIdentifier(core, DSASM.Constants.kLHS);
-            IdentifierNode rhs = BuildAssocIdentifier(core, DSASM.Constants.kRHS);
-            body.Body.Add(new BinaryExpressionNode() { LeftNode = _return, Optr = DSASM.Operator.assign, RightNode = new BinaryExpressionNode() { LeftNode = lhs, RightNode = rhs, Optr = op } });
+            var lhs = AstFactory.BuildIdentifier(DSASM.Constants.kLHS);
+            var rhs = AstFactory.BuildIdentifier(DSASM.Constants.kRHS);
+            var binaryExpr = AstFactory.BuildBinaryExpression(lhs, rhs, op);
+            body.Body.Add(AstFactory.BuildReturnStatement(binaryExpr));
+
             funcDefNode.FunctionBody = body;
             root.Body.Add(funcDefNode);
         }
@@ -104,15 +96,14 @@ namespace ProtoCore.Utils
             args.AddArgument(new VarDeclNode()
             {
                 Access = CompilerDefinitions.AccessModifier.kPublic,
-                NameNode = BuildAssocIdentifier(core, "%param"),
+                NameNode = AstFactory.BuildIdentifier("%param"),
                 ArgumentType = new Type { Name = core.TypeSystem.GetType((int)operand), UID = (int)operand }
             });
             funcDefNode.Signature = args;
 
             CodeBlockNode body = new CodeBlockNode();
-            IdentifierNode _return = BuildAssocIdentifier(core, DSDefinitions.Keyword.Return, PrimitiveType.kTypeReturn);
-            IdentifierNode param = BuildAssocIdentifier(core, "%param");
-            body.Body.Add(new BinaryExpressionNode() { LeftNode = _return, Optr = DSASM.Operator.assign, RightNode = new UnaryExpressionNode() { Expression = param, Operator = op } });
+            IdentifierNode param = AstFactory.BuildIdentifier("%param");
+            body.Body.Add(AstFactory.BuildReturnStatement(new UnaryExpressionNode() { Expression = param, Operator = op }));
             funcDefNode.FunctionBody = body;
             root.Body.Add(funcDefNode);
         }

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -72,14 +72,12 @@ namespace ProtoCore.Utils
         ArgumentSignatureNode args = new ArgumentSignatureNode();
         args.AddArgument(new VarDeclNode()
         {
-            memregion = DSASM.MemoryRegion.kMemStack,
             access = CompilerDefinitions.AccessModifier.kPublic,
             NameNode = BuildAssocIdentifier(core, DSASM.Constants.kLHS),
             ArgumentType = new Type { Name = core.TypeSystem.GetType((int)op1), UID = (int)op1, rank = op1rank}
         });
         args.AddArgument(new VarDeclNode()
         {
-            memregion = DSASM.MemoryRegion.kMemStack,
             access = CompilerDefinitions.AccessModifier.kPublic,
             NameNode = BuildAssocIdentifier(core, DSASM.Constants.kRHS),
             ArgumentType = new Type { Name = core.TypeSystem.GetType((int)op2), UID = (int)op2, rank = op2rank}
@@ -109,7 +107,6 @@ namespace ProtoCore.Utils
         ArgumentSignatureNode args = new ArgumentSignatureNode();
         args.AddArgument(new VarDeclNode()
         {
-            memregion = DSASM.MemoryRegion.kMemStack,
             access = CompilerDefinitions.AccessModifier.kPublic,
             NameNode = BuildAssocIdentifier(core, "%param"),
             ArgumentType = new Type { Name = core.TypeSystem.GetType((int)operand), UID = (int)operand }

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -1,47 +1,47 @@
-﻿using ProtoCore.DSASM;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using ProtoCore.DSASM;
 using ProtoCore.AST.AssociativeAST;
 
 namespace ProtoCore.Utils
 {
     public static class CoreUtils
     {
-        public static void InsertPredefinedAndBuiltinMethods(Core core, ProtoCore.AST.Node root, bool builtinMethodsLoaded)
+        public static void InsertPredefinedAndBuiltinMethods(Core core, AST.Node root, bool builtinMethodsLoaded)
         {
             if (DSASM.InterpreterMode.kNormal == core.Options.RunMode)
             {
                 if (core.Options.AssocOperatorAsMethod)
                 {
-                    ProtoCore.Utils.CoreUtils.InsertPredefinedMethod(core, root, builtinMethodsLoaded);
+                    CoreUtils.InsertPredefinedMethod(core, root, builtinMethodsLoaded);
                 }
-                ProtoCore.Utils.CoreUtils.InsertBuiltInMethods(core, root, builtinMethodsLoaded);
+                CoreUtils.InsertBuiltInMethods(core, root, builtinMethodsLoaded);
             }
         }
 
         
-    public static ProtoCore.AST.AssociativeAST.IdentifierNode BuildAssocIdentifier(Core core, string name, ProtoCore.PrimitiveType type = ProtoCore.PrimitiveType.kTypeVar)
+    public static IdentifierNode BuildAssocIdentifier(Core core, string name, PrimitiveType type = PrimitiveType.kTypeVar)
     {
-        var ident = new ProtoCore.AST.AssociativeAST.IdentifierNode();
+        var ident = new IdentifierNode();
         ident.Name = ident.Value = name;
         ident.datatype = TypeSystem.BuildPrimitiveTypeObject(type, 0);
         return ident;
     }
 
-    private static ProtoCore.AST.AssociativeAST.FunctionDefinitionNode GenerateBuiltInMethodSignatureNode(ProtoCore.Lang.BuiltInMethods.BuiltInMethod method)
+    private static FunctionDefinitionNode GenerateBuiltInMethodSignatureNode(Lang.BuiltInMethods.BuiltInMethod method)
     {
-        ProtoCore.AST.AssociativeAST.FunctionDefinitionNode fDef = new ProtoCore.AST.AssociativeAST.FunctionDefinitionNode();
-        fDef.Name = ProtoCore.Lang.BuiltInMethods.GetMethodName(method.ID);
+        FunctionDefinitionNode fDef = new FunctionDefinitionNode();
+        fDef.Name = Lang.BuiltInMethods.GetMethodName(method.ID);
         fDef.ReturnType = method.ReturnType;
         fDef.IsExternLib = true;
         fDef.IsBuiltIn = true;
         fDef.BuiltInMethodId = method.ID;
-        fDef.Signature = new ProtoCore.AST.AssociativeAST.ArgumentSignatureNode();
+        fDef.Signature = new ArgumentSignatureNode();
         fDef.MethodAttributes = method.MethodAttributes;
 
-        foreach (KeyValuePair<string, ProtoCore.Type> param in method.Parameters)
+        foreach (KeyValuePair<string, Type> param in method.Parameters)
         {
-            ProtoCore.AST.AssociativeAST.VarDeclNode arg = new ProtoCore.AST.AssociativeAST.VarDeclNode();
-            arg.NameNode = new ProtoCore.AST.AssociativeAST.IdentifierNode { Name = param.Key, Value = param.Key };
+            VarDeclNode arg = new VarDeclNode();
+            arg.NameNode = new IdentifierNode { Name = param.Key, Value = param.Key };
             arg.ArgumentType = param.Value;
             fDef.Signature.AddArgument(arg);
         }
@@ -49,82 +49,82 @@ namespace ProtoCore.Utils
         return fDef;
     }
         
-	private static void InsertBuiltInMethods(Core core, ProtoCore.AST.Node root, bool builtinMethodsLoaded)
+	private static void InsertBuiltInMethods(Core core, AST.Node root, bool builtinMethodsLoaded)
     {
         if (!builtinMethodsLoaded)
         {
-            ProtoCore.Lang.BuiltInMethods builtInMethods = new Lang.BuiltInMethods(core);
-            foreach (ProtoCore.Lang.BuiltInMethods.BuiltInMethod method in builtInMethods.Methods)
+            Lang.BuiltInMethods builtInMethods = new Lang.BuiltInMethods(core);
+            foreach (Lang.BuiltInMethods.BuiltInMethod method in builtInMethods.Methods)
 			{
-				(root as ProtoCore.AST.AssociativeAST.CodeBlockNode).Body.Add(GenerateBuiltInMethodSignatureNode(method));
+				(root as CodeBlockNode).Body.Add(GenerateBuiltInMethodSignatureNode(method));
 			}
 		}
     }
 
-    private static void InsertBinaryOperationMethod(Core core, ProtoCore.AST.Node root, Operator op, PrimitiveType r, PrimitiveType op1, PrimitiveType op2, int retRank = 0, int op1rank = 0, int op2rank = 0)
+    private static void InsertBinaryOperationMethod(Core core, AST.Node root, Operator op, PrimitiveType r, PrimitiveType op1, PrimitiveType op2, int retRank = 0, int op1rank = 0, int op2rank = 0)
     {
-        ProtoCore.AST.AssociativeAST.FunctionDefinitionNode funcDefNode = new ProtoCore.AST.AssociativeAST.FunctionDefinitionNode();
-        funcDefNode.access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic;
+        FunctionDefinitionNode funcDefNode = new FunctionDefinitionNode();
+        funcDefNode.access = CompilerDefinitions.AccessModifier.kPublic;
         funcDefNode.IsAssocOperator = true;
         funcDefNode.IsBuiltIn = true;
         funcDefNode.Name = Op.GetOpFunction(op);
-        funcDefNode.ReturnType = new ProtoCore.Type() { Name = core.TypeSystem.GetType((int)r), UID = (int)r, rank = retRank};
-        ProtoCore.AST.AssociativeAST.ArgumentSignatureNode args = new ProtoCore.AST.AssociativeAST.ArgumentSignatureNode();
-        args.AddArgument(new ProtoCore.AST.AssociativeAST.VarDeclNode()
+        funcDefNode.ReturnType = new Type() { Name = core.TypeSystem.GetType((int)r), UID = (int)r, rank = retRank};
+        ArgumentSignatureNode args = new ArgumentSignatureNode();
+        args.AddArgument(new VarDeclNode()
         {
-            memregion = ProtoCore.DSASM.MemoryRegion.kMemStack,
-            access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic,
-            NameNode = BuildAssocIdentifier(core, ProtoCore.DSASM.Constants.kLHS),
-            ArgumentType = new ProtoCore.Type { Name = core.TypeSystem.GetType((int)op1), UID = (int)op1, rank = op1rank}
+            memregion = DSASM.MemoryRegion.kMemStack,
+            access = CompilerDefinitions.AccessModifier.kPublic,
+            NameNode = BuildAssocIdentifier(core, DSASM.Constants.kLHS),
+            ArgumentType = new Type { Name = core.TypeSystem.GetType((int)op1), UID = (int)op1, rank = op1rank}
         });
-        args.AddArgument(new ProtoCore.AST.AssociativeAST.VarDeclNode()
+        args.AddArgument(new VarDeclNode()
         {
-            memregion = ProtoCore.DSASM.MemoryRegion.kMemStack,
-            access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic,
-            NameNode = BuildAssocIdentifier(core, ProtoCore.DSASM.Constants.kRHS),
-            ArgumentType = new ProtoCore.Type { Name = core.TypeSystem.GetType((int)op2), UID = (int)op2, rank = op2rank}
+            memregion = DSASM.MemoryRegion.kMemStack,
+            access = CompilerDefinitions.AccessModifier.kPublic,
+            NameNode = BuildAssocIdentifier(core, DSASM.Constants.kRHS),
+            ArgumentType = new Type { Name = core.TypeSystem.GetType((int)op2), UID = (int)op2, rank = op2rank}
         });
         funcDefNode.Signature = args;
 
-        ProtoCore.AST.AssociativeAST.CodeBlockNode body = new ProtoCore.AST.AssociativeAST.CodeBlockNode();
-        ProtoCore.AST.AssociativeAST.IdentifierNode _return = BuildAssocIdentifier(core, ProtoCore.DSDefinitions.Keyword.Return, ProtoCore.PrimitiveType.kTypeReturn);
+        CodeBlockNode body = new CodeBlockNode();
+        IdentifierNode _return = BuildAssocIdentifier(core, DSDefinitions.Keyword.Return, PrimitiveType.kTypeReturn);
 
-        ProtoCore.AST.AssociativeAST.IdentifierNode lhs = BuildAssocIdentifier(core, ProtoCore.DSASM.Constants.kLHS);
-        ProtoCore.AST.AssociativeAST.IdentifierNode rhs = BuildAssocIdentifier(core, ProtoCore.DSASM.Constants.kRHS);
-        body.Body.Add(new ProtoCore.AST.AssociativeAST.BinaryExpressionNode() { LeftNode = _return, Optr = ProtoCore.DSASM.Operator.assign, RightNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode() { LeftNode = lhs, RightNode = rhs, Optr = op } });
+        IdentifierNode lhs = BuildAssocIdentifier(core, DSASM.Constants.kLHS);
+        IdentifierNode rhs = BuildAssocIdentifier(core, DSASM.Constants.kRHS);
+        body.Body.Add(new BinaryExpressionNode() { LeftNode = _return, Optr = DSASM.Operator.assign, RightNode = new BinaryExpressionNode() { LeftNode = lhs, RightNode = rhs, Optr = op } });
         funcDefNode.FunctionBody = body;
-        (root as ProtoCore.AST.AssociativeAST.CodeBlockNode).Body.Add(funcDefNode);
+        (root as CodeBlockNode).Body.Add(funcDefNode);
     }
 
 	// The following methods are used to insert methods to the bottom of the AST and convert operator to these method calls 
 	// to support replication on operators 
-	private static void InsertUnaryOperationMethod(Core core, ProtoCore.AST.Node root, UnaryOperator op, PrimitiveType r, PrimitiveType operand)
+	private static void InsertUnaryOperationMethod(Core core, AST.Node root, UnaryOperator op, PrimitiveType r, PrimitiveType operand)
     {
-        ProtoCore.AST.AssociativeAST.FunctionDefinitionNode funcDefNode = new ProtoCore.AST.AssociativeAST.FunctionDefinitionNode();
-        funcDefNode.access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic;
+        FunctionDefinitionNode funcDefNode = new FunctionDefinitionNode();
+        funcDefNode.access = CompilerDefinitions.AccessModifier.kPublic;
         funcDefNode.IsAssocOperator = true;
         funcDefNode.IsBuiltIn = true;
         funcDefNode.Name = Op.GetUnaryOpFunction(op);
-        funcDefNode.ReturnType = new ProtoCore.Type() { Name = core.TypeSystem.GetType((int)r), UID = (int)r };
-        ProtoCore.AST.AssociativeAST.ArgumentSignatureNode args = new ProtoCore.AST.AssociativeAST.ArgumentSignatureNode();
-        args.AddArgument(new ProtoCore.AST.AssociativeAST.VarDeclNode()
+        funcDefNode.ReturnType = new Type() { Name = core.TypeSystem.GetType((int)r), UID = (int)r };
+        ArgumentSignatureNode args = new ArgumentSignatureNode();
+        args.AddArgument(new VarDeclNode()
         {
-            memregion = ProtoCore.DSASM.MemoryRegion.kMemStack,
-            access = ProtoCore.CompilerDefinitions.AccessModifier.kPublic,
+            memregion = DSASM.MemoryRegion.kMemStack,
+            access = CompilerDefinitions.AccessModifier.kPublic,
             NameNode = BuildAssocIdentifier(core, "%param"),
-            ArgumentType = new ProtoCore.Type { Name = core.TypeSystem.GetType((int)operand), UID = (int)operand }
+            ArgumentType = new Type { Name = core.TypeSystem.GetType((int)operand), UID = (int)operand }
         });
         funcDefNode.Signature = args;
 
-        ProtoCore.AST.AssociativeAST.CodeBlockNode body = new ProtoCore.AST.AssociativeAST.CodeBlockNode();
-        ProtoCore.AST.AssociativeAST.IdentifierNode _return = BuildAssocIdentifier(core, ProtoCore.DSDefinitions.Keyword.Return, ProtoCore.PrimitiveType.kTypeReturn);
-        ProtoCore.AST.AssociativeAST.IdentifierNode param = BuildAssocIdentifier(core, "%param");
-        body.Body.Add(new ProtoCore.AST.AssociativeAST.BinaryExpressionNode() { LeftNode = _return, Optr = ProtoCore.DSASM.Operator.assign, RightNode = new ProtoCore.AST.AssociativeAST.UnaryExpressionNode() { Expression = param, Operator = op } });
+        CodeBlockNode body = new CodeBlockNode();
+        IdentifierNode _return = BuildAssocIdentifier(core, DSDefinitions.Keyword.Return, PrimitiveType.kTypeReturn);
+        IdentifierNode param = BuildAssocIdentifier(core, "%param");
+        body.Body.Add(new BinaryExpressionNode() { LeftNode = _return, Optr = DSASM.Operator.assign, RightNode = new UnaryExpressionNode() { Expression = param, Operator = op } });
         funcDefNode.FunctionBody = body;
-        (root as ProtoCore.AST.AssociativeAST.CodeBlockNode).Body.Add(funcDefNode);
+        (root as CodeBlockNode).Body.Add(funcDefNode);
     }
 
-    private static void InsertPredefinedMethod(Core core, ProtoCore.AST.Node root, bool builtinMethodsLoaded)
+    private static void InsertPredefinedMethod(Core core, AST.Node root, bool builtinMethodsLoaded)
     {
         if (!builtinMethodsLoaded)
         {
@@ -152,33 +152,33 @@ namespace ProtoCore.Utils
             string languageString = string.Empty;
             if (Language.kAssociative == language)
             {
-                languageString = ProtoCore.DSASM.kw.associative;
+                languageString = DSASM.kw.associative;
             }
             else if (Language.kImperative == language)
             {
-                languageString = ProtoCore.DSASM.kw.imperative;
+                languageString = DSASM.kw.imperative;
             }
             else if (Language.kOptions == language)
             {
-                languageString = ProtoCore.DSASM.kw.options;
+                languageString = DSASM.kw.options;
             }
             return languageString;
         }
 
-        public static void LogWarning(this Interpreter dsi, ProtoCore.Runtime.WarningID id, string msg, string fileName = null, int line = -1, int col = -1)
+        public static void LogWarning(this Interpreter dsi, Runtime.WarningID id, string msg, string fileName = null, int line = -1, int col = -1)
         {
-            ProtoCore.RuntimeCore runtimeCore = dsi.runtime.RuntimeCore;
+            RuntimeCore runtimeCore = dsi.runtime.RuntimeCore;
             runtimeCore.RuntimeStatus.LogWarning(id, msg, fileName, line, col);
         }
 
         public static void LogSemanticError(this Interpreter dsi, string msg, string fileName = null, int line = -1, int col = -1)
         {
             // Consider renaming this function as there is no such thing as a semantic error at runtime
-            ProtoCore.RuntimeCore runtimeCore = dsi.runtime.RuntimeCore;
-            runtimeCore.RuntimeStatus.LogWarning(ProtoCore.Runtime.WarningID.kDefault, msg, fileName, line, col);
+            RuntimeCore runtimeCore = dsi.runtime.RuntimeCore;
+            runtimeCore.RuntimeStatus.LogWarning(Runtime.WarningID.kDefault, msg, fileName, line, col);
         }
 
-        public static void LogWarning(this Core core, ProtoCore.BuildData.WarningID id, string msg, string fileName = null, int line = -1, int col = -1)
+        public static void LogWarning(this Core core, BuildData.WarningID id, string msg, string fileName = null, int line = -1, int col = -1)
         {
             core.BuildStatus.LogWarning(id, msg, fileName, line, col);
         }
@@ -189,24 +189,24 @@ namespace ProtoCore.Utils
         }
 
 
-        public static string GenerateIdentListNameString(ProtoCore.AST.AssociativeAST.AssociativeNode node)
+        public static string GenerateIdentListNameString(AssociativeNode node)
         {
-            ProtoCore.AST.AssociativeAST.IdentifierListNode iNode;
-            ProtoCore.AST.AssociativeAST.AssociativeNode leftNode = node;
+            IdentifierListNode iNode;
+            AssociativeNode leftNode = node;
             List<string> stringList = new List<string>();
-            while (leftNode is ProtoCore.AST.AssociativeAST.IdentifierListNode)
+            while (leftNode is IdentifierListNode)
             {
-                iNode = leftNode as ProtoCore.AST.AssociativeAST.IdentifierListNode;
+                iNode = leftNode as IdentifierListNode;
                 leftNode = iNode.LeftNode;
-                if (iNode.RightNode is ProtoCore.AST.AssociativeAST.IdentifierNode)
+                if (iNode.RightNode is IdentifierNode)
                 {
-                    ProtoCore.AST.AssociativeAST.IdentifierNode currentNode = (iNode.RightNode as ProtoCore.AST.AssociativeAST.IdentifierNode);
+                    IdentifierNode currentNode = (iNode.RightNode as IdentifierNode);
                     stringList.Add(currentNode.ToString());
 
                 }
-                else if (iNode.RightNode is ProtoCore.AST.AssociativeAST.FunctionCallNode)
+                else if (iNode.RightNode is FunctionCallNode)
                 {
-                    ProtoCore.AST.AssociativeAST.FunctionCallNode fCall = iNode.RightNode as ProtoCore.AST.AssociativeAST.FunctionCallNode;
+                    FunctionCallNode fCall = iNode.RightNode as FunctionCallNode;
                     stringList.Add(fCall.Function.Name);
                 }
                 else
@@ -240,31 +240,31 @@ namespace ProtoCore.Utils
         public static bool IsGetter(string propertyName)
         {
             Validity.Assert(null != propertyName);
-            return propertyName.StartsWith(ProtoCore.DSASM.Constants.kGetterPrefix);
+            return propertyName.StartsWith(DSASM.Constants.kGetterPrefix);
         }
 
         public static bool IsSetter(string propertyName)
         {
             Validity.Assert(null != propertyName);
-            return propertyName.StartsWith(ProtoCore.DSASM.Constants.kSetterPrefix);
+            return propertyName.StartsWith(DSASM.Constants.kSetterPrefix);
         }
 
         public static bool StartsWithSingleUnderscore(string name)
         {
             Validity.Assert(null != name);
-            return name.StartsWith(ProtoCore.DSASM.Constants.kSingleUnderscore);
+            return name.StartsWith(DSASM.Constants.kSingleUnderscore);
         }
 
         public static bool StartsWithDoubleUnderscores(string name)
         {
             Validity.Assert(null != name);
-            return name.StartsWith(ProtoCore.DSASM.Constants.kDoubleUnderscores);
+            return name.StartsWith(DSASM.Constants.kDoubleUnderscores);
         }
 
         public static bool TryGetOperator(string methodName, out Operator op)
         {
             Validity.Assert(null != methodName);
-            if (!methodName.StartsWith(ProtoCore.DSASM.Constants.kInternalNamePrefix))
+            if (!methodName.StartsWith(DSASM.Constants.kInternalNamePrefix))
             {
                 op = Operator.none;
                 return false;
@@ -284,12 +284,12 @@ namespace ProtoCore.Utils
             Validity.Assert(null != methodName);
             if (IsGetter(methodName))
             {
-                propertyName = methodName.Substring(ProtoCore.DSASM.Constants.kGetterPrefix.Length);
+                propertyName = methodName.Substring(DSASM.Constants.kGetterPrefix.Length);
                 return true;
             }
             else if (IsSetter(methodName))
             {
-                propertyName = methodName.Substring(ProtoCore.DSASM.Constants.kSetterPrefix.Length);
+                propertyName = methodName.Substring(DSASM.Constants.kSetterPrefix.Length);
                 return true;
             }
 
@@ -315,7 +315,7 @@ namespace ProtoCore.Utils
             // This ensures that the variables is compiler generated as the '%' symbol cannot be used as an identifier and will fail compilation
             string sGUID = core.SSASubscript_GUID.ToString();
             sGUID = sGUID.Replace("-", string.Empty);
-            string SSATemp = ProtoCore.DSASM.Constants.kSSATempPrefix + core.SSASubscript.ToString() + "_" + sGUID;
+            string SSATemp = DSASM.Constants.kSSATempPrefix + core.SSASubscript.ToString() + "_" + sGUID;
             ++core.SSASubscript;
             return SSATemp;
         }
@@ -325,59 +325,59 @@ namespace ProtoCore.Utils
             // Jun Comment: The current convention for auto generated SSA variables begin with '%'
             // This ensures that the variables is compiler generated as the '%' symbol cannot be used as an identifier and will fail compilation
             Validity.Assert(!string.IsNullOrEmpty(ssaVar));
-            return ssaVar.StartsWith(ProtoCore.DSASM.Constants.kSSATempPrefix);
+            return ssaVar.StartsWith(DSASM.Constants.kSSATempPrefix);
         }
 
         public static bool IsTempVarProperty(string varname)
         {
             Validity.Assert(!string.IsNullOrEmpty(varname));
-            return varname.StartsWith(ProtoCore.DSASM.Constants.kTempPropertyVar);
+            return varname.StartsWith(DSASM.Constants.kTempPropertyVar);
         }
 
         public static bool IsCompilerGenerated(string varname)
         {
             Validity.Assert(!string.IsNullOrEmpty(varname));
-            return varname.StartsWith(ProtoCore.DSASM.Constants.kInternalNamePrefix);
+            return varname.StartsWith(DSASM.Constants.kInternalNamePrefix);
         }
 
         public static bool IsInternalFunction(string methodName)
         {
             Validity.Assert(!string.IsNullOrEmpty(methodName));
-            return methodName.StartsWith(ProtoCore.DSASM.Constants.kInternalNamePrefix) || methodName.StartsWith(ProtoCore.DSDefinitions.Keyword.Dispose);
+            return methodName.StartsWith(DSASM.Constants.kInternalNamePrefix) || methodName.StartsWith(DSDefinitions.Keyword.Dispose);
         }
 
         public static bool IsDisposeMethod(string methodName)
         {
             Validity.Assert(!string.IsNullOrEmpty(methodName));
-            return methodName.Equals(ProtoCore.DSDefinitions.Keyword.Dispose);
+            return methodName.Equals(DSDefinitions.Keyword.Dispose);
         }
 
         public static bool IsGetTypeMethod(string methodName)
         {
             Validity.Assert(!string.IsNullOrEmpty(methodName));
-            return methodName.Equals(ProtoCore.DSDefinitions.Keyword.GetType);
+            return methodName.Equals(DSDefinitions.Keyword.GetType);
         }
 
         public static bool IsPropertyTemp(string varname)
         {
             Validity.Assert(!string.IsNullOrEmpty(varname));
-            return varname.StartsWith(ProtoCore.DSASM.Constants.kTempPropertyVar);
+            return varname.StartsWith(DSASM.Constants.kTempPropertyVar);
         }
 
         public static bool IsDefaultArgTemp(string varname)
         {
             Validity.Assert(null != varname);
-            return varname.StartsWith(ProtoCore.DSASM.Constants.kTempDefaultArg);
+            return varname.StartsWith(DSASM.Constants.kTempDefaultArg);
         }
 
-        public static ProtoCore.AST.AssociativeAST.FunctionDotCallNode GenerateCallDotNode(ProtoCore.AST.AssociativeAST.AssociativeNode lhs, 
-            ProtoCore.AST.AssociativeAST.FunctionCallNode rhsCall, Core core = null)
+        public static FunctionDotCallNode GenerateCallDotNode(AssociativeNode lhs, 
+            FunctionCallNode rhsCall, Core core = null)
         {
             // The function name to call
             string rhsName = rhsCall.Function.Name;
             int argNum = rhsCall.FormalArguments.Count;
-            ProtoCore.AST.AssociativeAST.ExprListNode argList = new ProtoCore.AST.AssociativeAST.ExprListNode();
-            foreach (ProtoCore.AST.AssociativeAST.AssociativeNode arg in rhsCall.FormalArguments)
+            ExprListNode argList = new ExprListNode();
+            foreach (AssociativeNode arg in rhsCall.FormalArguments)
             {
                 // The function arguments
                 argList.list.Add(arg);
@@ -390,14 +390,14 @@ namespace ProtoCore.Utils
             funCallNode.Name = Constants.kDotArgMethodName;
 
             NodeUtils.CopyNodeLocation(funCallNode, lhs);
-            int rhsIdx = ProtoCore.DSASM.Constants.kInvalidIndex;
+            int rhsIdx = DSASM.Constants.kInvalidIndex;
             string lhsName = string.Empty;
-            if (lhs is ProtoCore.AST.AssociativeAST.IdentifierNode)
+            if (lhs is IdentifierNode)
             {
-                lhsName = (lhs as ProtoCore.AST.AssociativeAST.IdentifierNode).Name;
-                if (lhsName == ProtoCore.DSDefinitions.Keyword.This)
+                lhsName = (lhs as IdentifierNode).Name;
+                if (lhsName == DSDefinitions.Keyword.This)
                 {
-                    lhs = new ProtoCore.AST.AssociativeAST.ThisPointerNode();
+                    lhs = new ThisPointerNode();
                 }
             }
 
@@ -423,25 +423,25 @@ namespace ProtoCore.Utils
             funCallNode.FormalArguments.Add(rhs);
 
             // The array dimensions
-            ProtoCore.AST.AssociativeAST.ExprListNode arrayDimExperList = new ProtoCore.AST.AssociativeAST.ExprListNode();
+            ExprListNode arrayDimExperList = new ExprListNode();
             int dimCount = 0;
-            if (rhsCall.Function is ProtoCore.AST.AssociativeAST.IdentifierNode)
+            if (rhsCall.Function is IdentifierNode)
             {
                 // Number of dimensions
-                ProtoCore.AST.AssociativeAST.IdentifierNode fIdent = rhsCall.Function as ProtoCore.AST.AssociativeAST.IdentifierNode;
+                IdentifierNode fIdent = rhsCall.Function as IdentifierNode;
                 if (fIdent.ArrayDimensions != null)
                 {
-                    arrayDimExperList = ProtoCore.Utils.CoreUtils.BuildArrayExprList(fIdent.ArrayDimensions);
+                    arrayDimExperList = CoreUtils.BuildArrayExprList(fIdent.ArrayDimensions);
                     dimCount = arrayDimExperList.list.Count;
                 }
                 else if (rhsCall.ArrayDimensions != null)
                 {
-                    arrayDimExperList = ProtoCore.Utils.CoreUtils.BuildArrayExprList(rhsCall.ArrayDimensions);
+                    arrayDimExperList = CoreUtils.BuildArrayExprList(rhsCall.ArrayDimensions);
                     dimCount = arrayDimExperList.list.Count;
                 }
                 else
                 {
-                    arrayDimExperList = new ProtoCore.AST.AssociativeAST.ExprListNode();
+                    arrayDimExperList = new ExprListNode();
                 }
             }
 
@@ -475,19 +475,19 @@ namespace ProtoCore.Utils
         }
 
 
-        public static ProtoCore.AST.AssociativeAST.ExprListNode BuildArrayExprList(ProtoCore.AST.AssociativeAST.AssociativeNode arrayNode)
+        public static ExprListNode BuildArrayExprList(AssociativeNode arrayNode)
         {
-            ProtoCore.AST.AssociativeAST.ExprListNode exprlist = new ProtoCore.AST.AssociativeAST.ExprListNode();
-            while (arrayNode is ProtoCore.AST.AssociativeAST.ArrayNode)
+            ExprListNode exprlist = new ExprListNode();
+            while (arrayNode is ArrayNode)
             {
-                ProtoCore.AST.AssociativeAST.ArrayNode array = arrayNode as ProtoCore.AST.AssociativeAST.ArrayNode;
+                ArrayNode array = arrayNode as ArrayNode;
                 exprlist.list.Add(array.Expr);
                 arrayNode = array.Type;
             }
             return exprlist;
         }
 
-        public static void CopyDebugData(ProtoCore.AST.Node nodeTo, ProtoCore.AST.Node nodeFrom)
+        public static void CopyDebugData(AST.Node nodeTo, AST.Node nodeFrom)
         {
             if (null != nodeTo && null != nodeFrom)
             {
@@ -503,11 +503,11 @@ namespace ProtoCore.Utils
         /// </summary>
         /// <param name="functionDef"></param>
         /// <returns></returns>
-        public static int GetFunctionHash(ProtoCore.AST.AssociativeAST.FunctionDefinitionNode functionDef)
+        public static int GetFunctionHash(FunctionDefinitionNode functionDef)
         {
             Validity.Assert(null != functionDef);
             string functionDescription = functionDef.Name;
-            foreach (ProtoCore.AST.AssociativeAST.VarDeclNode argNode in functionDef.Signature.Arguments)
+            foreach (VarDeclNode argNode in functionDef.Signature.Arguments)
             {
                 functionDescription += argNode.ArgumentType.ToString();
             }
@@ -527,7 +527,7 @@ namespace ProtoCore.Utils
         /// </summary>
         /// <param name="identList"></param>
         /// <returns></returns>
-        public static string GetIdentifierStringUntilFirstParenthesis(ProtoCore.AST.AssociativeAST.IdentifierListNode identList)
+        public static string GetIdentifierStringUntilFirstParenthesis(IdentifierListNode identList)
         {
             Validity.Assert(null != identList);
             string identListString = identList.ToString();
@@ -645,7 +645,7 @@ namespace ProtoCore.Utils
             //throw new NotImplementedException();
             var ci = classTable.IndexOf(className);
 
-            if (ci == ProtoCore.DSASM.Constants.kInvalidIndex) 
+            if (ci == DSASM.Constants.kInvalidIndex) 
                 return string.Empty;
             
             var classNode = classTable.ClassNodes[ci];
@@ -725,11 +725,11 @@ namespace ProtoCore.Utils
         /// <param name="core"></param>
         /// <param name="code"></param>
         /// <returns></returns>
-        public static List<AssociativeNode> BuildASTList(ProtoCore.Core core, string code)
+        public static List<AssociativeNode> BuildASTList(Core core, string code)
         {
             Validity.Assert(null != core);
             List<AssociativeNode> astList = new List<AssociativeNode>();
-            var cbn = ProtoCore.Utils.ParserUtils.Parse(code) as CodeBlockNode;
+            var cbn = ParserUtils.Parse(code) as CodeBlockNode;
             astList.AddRange(cbn.Body);
             return astList;
         }
@@ -741,7 +741,7 @@ namespace ProtoCore.Utils
         /// <param name="core"></param>
         /// <param name="code"></param>
         /// <returns></returns>
-        public static List<AssociativeNode> BuildASTList(ProtoCore.Core core, List<string> codeList)
+        public static List<AssociativeNode> BuildASTList(Core core, List<string> codeList)
         {
             List<AssociativeNode> astList = new List<AssociativeNode>();
             foreach (string code in codeList)
@@ -809,9 +809,9 @@ namespace ProtoCore.Utils
         /// <returns></returns>
         public static bool IsPrimitiveASTNode(AssociativeNode node)
         {
-            if (node is ProtoCore.AST.AssociativeAST.IntNode
-            || node is ProtoCore.AST.AssociativeAST.DoubleNode
-            || node is ProtoCore.AST.AssociativeAST.BooleanNode)
+            if (node is IntNode
+            || node is DoubleNode
+            || node is BooleanNode)
             {
                 return true;
             }
@@ -823,15 +823,15 @@ namespace ProtoCore.Utils
         {
             Validity.Assert(IsPrimitiveASTNode(node) == true);
 
-            if (node is ProtoCore.AST.AssociativeAST.IntNode)
+            if (node is IntNode)
             {
                 return StackValue.BuildInt((node as IntNode).Value);
             }
-            else if (node is ProtoCore.AST.AssociativeAST.DoubleNode)
+            else if (node is DoubleNode)
             {
                 return StackValue.BuildDouble((node as DoubleNode).Value);
             }
-            else if (node is ProtoCore.AST.AssociativeAST.BooleanNode)
+            else if (node is BooleanNode)
             {
                 return StackValue.BuildBoolean((node as BooleanNode).Value);
             }


### PR DESCRIPTION
### Purpose

Remove unnecessary parameter for some functions in `ProtoCore.CoreUtils`: change 

``` 
public static void InsertPredefinedAndBuiltinMethods(Core core, ProtoCore.AST.Node root, bool builtinMethodsLoaded)
{
    InsertPredefinedMethod(core, root, builtinMethodsLoaded);
   ...
}
public static void InsertPredefinedMethod(Core core, ProtoCore.AST.Node root, bool builtinMethodsLoaded)
{
    if (!builtinMethodsLoaded) {
        ...
        (root as CodeBlockNode)...
    }
}
```
to
```
public static void InsertPredefinedAndBuiltinMethod(Core core, CodeBlockNode root)
{
    InsertPredefinedMethod(core, root);
}
public static void InsertPredefinedMethod(Core core, CodeBlockNode root)
{
    ...
}
```

Remove `VarDeclNode.Attrbiutes` and `VarDeclNode.memoryregion` properties; rename `VarDeclNode.access` to `VarDeclNode.Access`.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@sharadkjaiswal 