### PR TITLE
Update NuGet packages to 0.9.1-beta1

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.1.3096")]
+[assembly: AssemblyVersion("0.9.1.3111")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.1.3096")]
+[assembly: AssemblyFileVersion("0.9.1.3111")]

--- a/tools/NuGet/DynamoVisualProgramming.Core/Core.nuspec
+++ b/tools/NuGet/DynamoVisualProgramming.Core/Core.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>DynamoVisualProgramming.Core</id>
-    <version>0.9.0.0</version>
+    <version>0.9.1-beta1</version>
     <authors>Autodesk</authors>
     <owners>Autodesk</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>

--- a/tools/NuGet/DynamoVisualProgramming.Tests/Tests.nuspec
+++ b/tools/NuGet/DynamoVisualProgramming.Tests/Tests.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>DynamoVisualProgramming.Tests</id>
-    <version>0.9.0.0</version>
+    <version>0.9.1-beta1</version>
     <authors>Autodesk</authors>
     <owners>Autodesk</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>

--- a/tools/NuGet/DynamoVisualProgramming.WpfUILibrary/WpfUILibrary.nuspec
+++ b/tools/NuGet/DynamoVisualProgramming.WpfUILibrary/WpfUILibrary.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>DynamoVisualProgramming.WpfUILibrary</id>
-    <version>0.9.0.0</version>
+    <version>0.9.1-beta1</version>
     <authors>Autodesk</authors>
     <owners>Autodesk</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>

--- a/tools/NuGet/DynamoVisualProgramming.ZeroTouchLibrary/ZeroTouchLibrary.nuspec
+++ b/tools/NuGet/DynamoVisualProgramming.ZeroTouchLibrary/ZeroTouchLibrary.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>DynamoVisualProgramming.ZeroTouchLibrary</id>
-    <version>0.9.0.0</version>
+    <version>0.9.1-beta1</version>
     <authors>Autodesk</authors>
     <owners>Autodesk</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>


### PR DESCRIPTION
This PR updates the .nuspec files to 0.9.1-beta1. These packages will not be published on nuget until the first release candidate.