### PR TITLE
More color range fixes

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -744,7 +744,7 @@ namespace Dynamo.Core
                     new HashSet<Tuple<NodeModel, int, Tuple<int, NodeModel>>>(
                         selectedNodeSet.SelectMany(
                             node =>
-                                Enumerable.Range(0, node.InPortData.Count)
+                                Enumerable.Range(0, node.InPorts.Count)
                                 .Where(node.HasConnectedInput)
                                 .Select(data => Tuple.Create(node, data, node.InputNodes[data]))
                                 .Where(input => !selectedNodeSet.Contains(input.Item3.Item2))));
@@ -753,7 +753,7 @@ namespace Dynamo.Core
                     new HashSet<Tuple<NodeModel, int, Tuple<int, NodeModel>>>(
                         selectedNodeSet.SelectMany(
                             node =>
-                                Enumerable.Range(0, node.OutPortData.Count)
+                                Enumerable.Range(0, node.OutPorts.Count)
                                 .Where(node.HasOutput)
                                 .SelectMany(
                                     data =>
@@ -958,7 +958,7 @@ namespace Dynamo.Core
 
                         node = new Symbol
                         {
-                            InputSymbol = inputReceiverNode.InPortData[inputReceiverData].NickName,
+                            InputSymbol = inputReceiverNode.InPorts[inputReceiverData].PortName,
                             X = 0
                         };
 
@@ -1056,7 +1056,7 @@ namespace Dynamo.Core
                             //Create Symbol Node
                             var node = new Output
                             {
-                                Symbol = outputSenderNode.OutPortData[outputSenderData].NickName,
+                                Symbol = outputSenderNode.OutPorts[outputSenderData].PortName,
                                 X = rightMost + 75 - leftShift
                             };
 


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8990](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8990) Creating a custom node for the Color Range node disconnects its connectors

Problem occurs, because we don't set `InPortData` and `OutPortData` in ColorRange node, since they are deprecated.

So, I had to update `CustomNodeManager`, so that it used `InPorts` and `OutPorts`.
I run Self CI. All tests passed.

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.

### Reviewers

@ikeough 

### FYIs

@pboyer 
