### PR TITLE
Update migration to create custom node.

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.1.3131")]
+[assembly: AssemblyVersion("0.9.1.3136")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.1.3131")]
+[assembly: AssemblyFileVersion("0.9.1.3136")]

--- a/src/DynamoCore/Migration/Migration.cs
+++ b/src/DynamoCore/Migration/Migration.cs
@@ -726,12 +726,12 @@ namespace Dynamo.Migration
             if (srcElement == null)
                 throw new ArgumentNullException("srcElement");
 
-            XmlElement funcEl = document.CreateElement("Dynamo.Graph.Nodes.Function");
+            XmlElement funcEl = document.CreateElement("Dynamo.Graph.Nodes.CustomNodes.Function");
 
             foreach (XmlAttribute attribute in srcElement.Attributes)
                 funcEl.SetAttribute(attribute.Name, attribute.Value);
 
-            funcEl.SetAttribute("type", "Dynamo.Graph.Nodes.Function");
+            funcEl.SetAttribute("type", "Dynamo.Graph.Nodes.CustomNodes.Function");
 
             var idEl = document.CreateElement("ID");
             idEl.SetAttribute("value", id);


### PR DESCRIPTION
This PR fixes an error in the `Migration.CreateCustomNodeFrom(...)` method, which was attempting to construct a custom node using the wrong namespace.

See https://github.com/DynamoDS/Dynamo/pull/5631.