### PR TITLE
Fix MAGN-6873 Operations on empty list fails with warning

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -524,8 +524,15 @@ namespace ProtoCore.Lang
 
             if (!isValidThisPointer || (!thisObject.IsPointer && !thisObject.IsArray))
             {
-                runtimeCore.RuntimeStatus.LogWarning(WarningID.kDereferencingNonPointer, Resources.kDeferencingNonPointer);
-                return StackValue.Null;
+                if (ArrayUtils.IsEmpty(lhs, runtimeCore))
+                { 
+                    return lhs;
+                }
+                else
+                {
+                    runtimeCore.RuntimeStatus.LogWarning(WarningID.kDereferencingNonPointer, Resources.kDeferencingNonPointer);
+                    return StackValue.Null;
+                }
             }
 
             int stackPtr = rmem.Stack.Count - 1;

--- a/src/Engine/ProtoCore/Utils/ArrayUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ArrayUtils.cs
@@ -457,5 +457,20 @@ namespace ProtoCore.Utils
                 return zippedIndices;
             }
         }
+
+        /// <summary>
+        /// Return if an array is an empty list or all its elements are empty lists.
+        /// </summary>
+        /// <param name="arrayPointer"></param>
+        /// <param name="runtimeCore"></param>
+        /// <returns></returns>
+        public static bool IsEmpty(StackValue arrayPointer, RuntimeCore runtimeCore)
+        {
+            if (!arrayPointer.IsArray)
+                return false;
+
+            var array = runtimeCore.Heap.ToHeapObject<DSArray>(arrayPointer);
+            return array.Values.All(v => IsEmpty(v, runtimeCore));
+        }
    }
 }

--- a/test/Engine/ProtoTest/Associative/MethodsFocusTeam.cs
+++ b/test/Engine/ProtoTest/Associative/MethodsFocusTeam.cs
@@ -500,6 +500,13 @@ import(""FFITarget.dll"");p = DummyPoint.ByCoordinates(1..3, 20, 30);a = p.X[0
             thisTest.Verify("x", v);                    
         }
 
+        [Test]
+        public void DotCallOnEmptyList()
+        {
+            string code = @"x = {{}, {}}; y = x.foo();";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("x", new object [] { new object [] { }, new object [] { } });
+        }
 
         [Test]
         public void T020_Replication_Var()


### PR DESCRIPTION
### Purpose

This PR fixes defect [MAGN-6873 Operations on empty list fails with warning](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6873).

If the operation is on an empty list, return that empty list.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
