### PR TITLE
Don't add TestServices.dll.config to nuget.

### DIFF
--- a/tools/NuGet/BuildDynamoTestsPackage.bat
+++ b/tools/NuGet/BuildDynamoTestsPackage.bat
@@ -16,6 +16,4 @@ mkdir .\%test%\tools
 copy %base%\TestServices.dll .\%test%\lib\%framework%\TestServices.dll
 copy %base%\SystemTestServices.dll .\%test%\lib\%framework%\SystemTestServices.dll
 
-copy %base%\TestServices.dll.config .\%test%\content\TestServices.dll.config
-
 nuget pack .\%test%\Tests.nuspec


### PR DESCRIPTION
This is a minor PR which removes one config file from the NuGets.