### PR TITLE
Special render package implementation for Manipulators

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1328,13 +1328,14 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         }
 
         /// <summary>
-        /// Updates the Geometry model for special Render packages starting with
-        /// descriptions as defined in RenderDescriptions.
+        /// Updates or replaces the GeometryModel3D for special IRenderPackage. Special 
+        /// IRenderPackage has a Description field that starts with a string value defined 
+        /// in RenderDescriptions. See RenderDescriptions for details of possible values.
         /// </summary>
-        /// <param name="rp">Renderpackage</param>
-        /// <param name="id">id of the package</param>
-        /// <returns>True if input is special render package and successfully 
-        /// updated the geometry model.</returns>
+        /// <param name="rp">The target HelixRenderPackage object</param>
+        /// <param name="id">id of the HelixRenderPackage object</param>
+        /// <returns>Returns true if rp is a special render package, and its GeometryModel3D
+        /// is successfully updated.</returns>
         private bool UpdateGeometryModelForSpecialRenderPackage(HelixRenderPackage rp, string id)
         {
             int desclength = RenderDescriptions.ManipulatorAxis.Length;

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1158,13 +1158,19 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     // with `points`, `lines`, or `mesh`. For each RenderPackage, we check whether the geometry dictionary
                     // has entries for the points, lines, or mesh already. If so, we add the RenderPackage's geometry
                     // to those geometry objects.
-
+                    
                     var baseId = rp.Description;
                     if (baseId.IndexOf(":", StringComparison.Ordinal) > 0)
                     {
                         baseId = baseId.Split(':')[0];
                     }
                     var id = baseId;
+                    //If this render package belongs to special render package, then create
+                    //and update the corresponding GeometryModel. Sepcial renderpackage are
+                    //defined based on its description containing one of the constants from
+                    //RenderDescriptions struct.
+                    if (UpdateGeometryModelForSpecialRenderPackage(rp, id))
+                        continue;
 
                     var drawDead = InCustomNode() && !customNodeIdents.Contains(baseId);
 
@@ -1318,6 +1324,62 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 }
 
                 AttachAllGeometryModel3DToRenderHost();
+            }
+        }
+
+        /// <summary>
+        /// Updates the Geometry model for special Render packages starting with
+        /// descriptions as defined in RenderDescriptions.
+        /// </summary>
+        /// <param name="rp">Renderpackage</param>
+        /// <param name="id">id of the package</param>
+        /// <returns>True if input is special render package and successfully 
+        /// updated the geometry model.</returns>
+        private bool UpdateGeometryModelForSpecialRenderPackage(HelixRenderPackage rp, string id)
+        {
+            int desclength = RenderDescriptions.ManipulatorAxis.Length;
+            if (rp.Description.Length < desclength)
+                return false;
+
+            string description = rp.Description.Substring(0, desclength);
+            Model3D model = null;
+            Model3DDictionary.TryGetValue(id, out model);
+            switch(description)
+            {
+                case RenderDescriptions.ManipulatorAxis:
+                    var manipulator = model as DynamoGeometryModel3D;
+                    if (null == manipulator)
+                        manipulator = CreateDynamoGeometryModel3D(rp);
+                    
+                    var mb = new MeshBuilder();
+                    mb.AddArrow(rp.Lines.Positions[0], rp.Lines.Positions[1], 0.3, 2, 64);
+                    manipulator.Geometry = mb.ToMeshGeometry3D();
+                    
+                    if (rp.Lines.Colors[0].Red == 1)
+                        manipulator.Material = PhongMaterials.Red;
+                    else if (rp.Lines.Colors[0].Green == 1)
+                        manipulator.Material = PhongMaterials.Green;
+                    else if (rp.Lines.Colors[0].Blue == 1)
+                        manipulator.Material = PhongMaterials.Blue;
+
+                    Model3DDictionary[id] = manipulator;
+                    return true;
+                case RenderDescriptions.AxisLine:
+                    var centerline = model as DynamoLineGeometryModel3D;
+                    if (null == centerline)
+                        centerline = CreateLineGeometryModel3D(rp, 0.3);
+                    centerline.Geometry = rp.Lines;
+                    Model3DDictionary[id] = centerline;
+                    return true;
+                case RenderDescriptions.ManipulatorPlane:
+                    var plane = model as DynamoLineGeometryModel3D;
+                    if (null == plane)
+                        plane = CreateLineGeometryModel3D(rp, 0.7);
+                    plane.Geometry = rp.Lines;
+                    Model3DDictionary[id] = plane;
+                    return true;
+                default:
+                    return false;
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/IWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/IWatch3DViewModel.cs
@@ -18,6 +18,34 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     }
 
     /// <summary>
+    /// These constants are defined to specify special render packages, so that
+    /// they can be rendered differently.
+    /// 
+    /// If a render package description starts with any of the following constants
+    /// that will be rendered differently.
+    /// 
+    /// We need to ensure that all the strings are of same length and starts with 
+    /// an alphabet. Usually these are taken from the last part of a GUID.
+    /// </summary>
+    public struct RenderDescriptions
+    {
+        /// <summary>
+        /// Draws line strip segment as a 3D arrow.
+        /// </summary>
+        public const string ManipulatorAxis   = "B0C5DE5EB5CA";
+
+        /// <summary>
+        /// Draws line strip segment as thin(0.3) line to represent axis line.
+        /// </summary>
+        public const string AxisLine          = "C4F6AC80953B";
+
+        /// <summary>
+        /// Draws a line strip segment as little thinner(0.7) line to represent a plane.
+        /// </summary>
+        public const string ManipulatorPlane  = "E75B2B0E31F1";
+    }
+
+    /// <summary>
     /// An interface to expose API's on the Watch UI Viewmodel to extensions
     /// </summary>
     public interface IWatch3DViewModel


### PR DESCRIPTION
### Purpose

Defines RenderDescriptions for special type of render packages to support some special rendering of manipulators. For now three different render descriptions are supported as follows:

- ManipulatorAxis: Drawn as 3D arrow head.
- AxisLine: Drawn as thin line to represent axis lines.
- ManipulatorPlane: Drawn as rectangle, with slightly higher thickness.

### Reviewers
- [x] @Benglin 
- [ ] @ikeough 
- [ ] @aparajit-pratap 