### PR TITLE
Support highlight for block comment in code block node

### DIFF
--- a/src/DynamoCoreWpf/UI/Resources/DesignScript.Resources.SyntaxHighlighting.xshd
+++ b/src/DynamoCoreWpf/UI/Resources/DesignScript.Resources.SyntaxHighlighting.xshd
@@ -30,6 +30,10 @@
       <Span name="LineComment" stopateol="true" color="#309130">
         <Begin>//</Begin>
       </Span>
+      <Span name="MultiLineComment" stopateol="false" color="#309130">
+        <Begin>/*</Begin>
+        <End>*/</End>
+      </Span>
       <Span name="String" stopateol="true" color="#885D3B" escapecharacter="\">
         <Begin>"</Begin>
         <End>"</End>


### PR DESCRIPTION
### Purpose

Code block node now is able to highlight block line comments (in `/* */`)

![untitled](https://cloud.githubusercontent.com/assets/2600379/11201506/c4591a62-8d19-11e5-9e9a-f1f464a684e1.png)

### Reviewer

@aparajit-pratap (pending)
