### PR TITLE
Remove compile warning of input node

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -10,6 +10,7 @@ using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM;
 using ProtoCore.Namespace;
 using ProtoCore.Utils;
+using ProtoCore.BuildData;
 
 namespace Dynamo.Graph.Nodes.CustomNodes
 {
@@ -401,9 +402,17 @@ namespace Dynamo.Graph.Nodes.CustomNodes
                         defaultValue = node.RightNode;
 
                     if (parseParam.Errors.Any())
+                    {
                         this.Error(parseParam.Errors.First().Message);
+                    }
                     else if (parseParam.Warnings.Any())
-                        this.Warning(parseParam.Warnings.First().Message);
+                    {
+                        var warnings = parseParam.Warnings.Where(w => w.ID != WarningID.kIdUnboundIdentifier);
+                        if (warnings.Any())
+                        {
+                            this.Warning(parseParam.Warnings.First().Message);
+                        }
+                    }
 
                     return identifier != null;
                 }


### PR DESCRIPTION
### Purpose

Fix defect [MAGN 9083 Typed variable in custom workspace throws warning if there is not default argument](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9083).

If the expression in input node doesn't have any value, for example, `x : int`, there is a warning like `var %typeIdentifier not defined yet`. This warning should be ignored. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
