### PR TITLE
MAGN-8959 As a user, I want to SEE watch nodes in a frozen state so that I can tell that they are not being executed

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.1.3205")]
+[assembly: AssemblyVersion("0.9.1.3224")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.1.3205")]
+[assembly: AssemblyFileVersion("0.9.1.3224")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.1.3226")]
+[assembly: AssemblyVersion("0.9.1.3234")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.1.3226")]
+[assembly: AssemblyFileVersion("0.9.1.3234")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.1.3224")]
+[assembly: AssemblyVersion("0.9.1.3225")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.1.3224")]
+[assembly: AssemblyFileVersion("0.9.1.3225")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.1.3225")]
+[assembly: AssemblyVersion("0.9.1.3226")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.1.3225")]
+[assembly: AssemblyFileVersion("0.9.1.3226")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.1.3234")]
+[assembly: AssemblyVersion("0.9.1.3235")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.1.3234")]
+[assembly: AssemblyFileVersion("0.9.1.3235")]

--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -609,29 +609,15 @@ namespace Dynamo.Engine
         /// <param name="node">The node.</param>
         public void DeleteFrozenNodesFromAST(NodeModel node)
         {
-            List<NodeModel> gathered = new List<NodeModel>();
-            GetDownstreamNodes(node, gathered);
+            HashSet<NodeModel> gathered = new HashSet<NodeModel>();
+            node.GetDownstreamNodes(node, gathered);
             foreach (var iNode in gathered)
             {
                 syncDataManager.DeleteNodes(iNode.GUID);               
             }
         }
 
-        private static void GetDownstreamNodes(NodeModel node, ICollection<NodeModel> gathered)
-        {
-            if (gathered.Contains(node)) // Considered this node before, bail.pu
-                return;
-
-            gathered.Add(node);
-
-            var sets = node.OutputNodes.Values;
-            var outputNodes = sets.SelectMany(set => set.Select(t => t.Item2)).Distinct();
-            foreach (var outputNode in outputNodes)
-            {
-                // Recursively get all downstream nodes.
-                GetDownstreamNodes(outputNode, gathered);
-            }
-        }
+        
 
         #region Node2Code
 

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -645,9 +645,7 @@ namespace Dynamo.Graph.Nodes
                 else
                 {
                     OnToggleNodeFreeze();
-                }
-
-                RaisePropertyChanged("IsFrozen");     
+                }                   
             }
         }
        

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1251,7 +1251,7 @@ namespace Dynamo.Graph.Nodes
             areInputPortsRegistered = true;
 
             RaisesModificationEvents = true;
-            //OnNodeModified();
+            OnNodeModified();
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -647,6 +647,8 @@ namespace Dynamo.Graph.Nodes
                 {
                     OnToggleNodeFreeze();
                 }
+
+                RaisePropertyChanged("IsFrozen");
             }
         }
        

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -684,13 +684,32 @@ namespace Dynamo.Graph.Nodes
 
         private void MarkDownStreamNodesAsModified(NodeModel node)
         {                         
+            HashSet<NodeModel> gathered = new HashSet<NodeModel>();
+            GetDownstreamNodes(node,gathered);
+            foreach (var iNode in gathered)
+            {
+                iNode.executionHint = ExecutionHints.Modified;                
+            }
+        }
+
+        /// <summary>
+        /// Gets the downstream nodes for the given node.
+        /// </summary>
+        /// <param name="node">The node.</param>
+        /// <param name="gathered">The gathered.</param>
+        internal void GetDownstreamNodes(NodeModel node, HashSet<NodeModel> gathered)
+        {
+            if (gathered.Contains(node)) // Considered this node before, bail.pu
+                return;
+
+            gathered.Add(node);
+
             var sets = node.OutputNodes.Values;
-            var outputNodes = sets.SelectMany(set => set.Select(t => t.Item2)).Distinct();
+            var outputNodes = sets.SelectMany(set => set.Select(t => t.Item2));
             foreach (var outputNode in outputNodes)
             {
-                outputNode.executionHint = ExecutionHints.Modified;     
                 // Recursively get all downstream nodes.
-                MarkDownStreamNodesAsModified(outputNode);
+                GetDownstreamNodes(outputNode, gathered);
             }
         }
         #endregion  

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -764,7 +764,7 @@ namespace Dynamo.Graph.Nodes
         public event Action<NodeModel> Modified;
         public virtual void OnNodeModified(bool forceExecute = false)
         {
-            if (!RaisesModificationEvents)
+            if (!RaisesModificationEvents || IsFrozen)
                 return;
 
             MarkNodeAsModified(forceExecute);           
@@ -1706,7 +1706,7 @@ namespace Dynamo.Graph.Nodes
             isUpstreamVisible = helper.ReadBoolean("isUpstreamVisible", true);
             argumentLacing = helper.ReadEnum("lacing", LacingStrategy.Disabled);
             IsSelectedInput = helper.ReadBoolean("isSelectedInput", true);
-            isFrozenExplicitly = helper.ReadBoolean("IsFrozen", false);            
+            IsFrozen = helper.ReadBoolean("IsFrozen", false);            
            
             var portInfoProcessed = new HashSet<int>();
 
@@ -1747,7 +1747,7 @@ namespace Dynamo.Graph.Nodes
                 RaisePropertyChanged("ArgumentLacing");
                 RaisePropertyChanged("IsVisible");
                 RaisePropertyChanged("IsUpstreamVisible");
-
+               
                 // Notify listeners that the position of the node has changed,
                 // then all connected connectors will also redraw themselves.
                 ReportPosition();

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -633,8 +633,7 @@ namespace Dynamo.Graph.Nodes
             }
             set
             {
-                isFrozenExplicitly = value;    
-                RaisePropertyChanged("IsFrozen");      
+                isFrozenExplicitly = value;                    
                 //If the node is Unfreezed then Mark all the downstream nodes as
                 // modified. This is essential recompiling the AST.
                 if (!value)
@@ -648,7 +647,7 @@ namespace Dynamo.Graph.Nodes
                     OnToggleNodeFreeze();
                 }
 
-                RaisePropertyChanged("IsFrozen");
+                RaisePropertyChanged("IsFrozen");     
             }
         }
        

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -642,9 +642,10 @@ namespace Dynamo.Graph.Nodes
                     OnNodeModified();
                 }
                 //If the node is frozen, then do not execute the graph immediately.
+                // delete the node and its downstream nodes from AST.
                 else
                 {
-                    OnToggleNodeFreeze();
+                    OnUpdateASTCollection();
                 }                   
             }
         }
@@ -790,10 +791,14 @@ namespace Dynamo.Graph.Nodes
             if (handler != null) handler(this);
         }
 
-        public event Action<NodeModel> ToggleNodeFreeze;
-        public virtual void OnToggleNodeFreeze()
+        /// <summary>
+        /// Event fired when the node's DesignScript AST should be updated.
+        /// This event deletes the frozen nodes from AST collection.
+        /// </summary>
+        public event Action<NodeModel> UpdateASTCollection;
+        public virtual void OnUpdateASTCollection()
         {            
-            var handler = ToggleNodeFreeze;
+            var handler = UpdateASTCollection;
             if (handler != null) handler(this);
         }
 

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -794,10 +794,7 @@ namespace Dynamo.Graph.Nodes
 
         public event Action<NodeModel> ToggleNodeFreeze;
         public virtual void OnToggleNodeFreeze()
-        {
-            if (!RaisesModificationEvents)
-                return;
-
+        {            
             var handler = ToggleNodeFreeze;
             if (handler != null) handler(this);
         }

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -254,6 +254,16 @@ namespace Dynamo.Graph.Workspaces
         }
 
         /// <summary>
+        /// When a node is frozen, then the node and its dependencies should be 
+        /// deleted from the current AST
+        /// </summary>
+        /// <param name="node">The node.</param>
+        protected override void OnToggleNodeFreeze(NodeModel node)
+        {
+            EngineController.DeleteFrozenNodesFromAST(node);
+        }
+
+        /// <summary>
         /// Called when a node is added to the workspace and event handlers are to be added
         /// </summary>
         /// <param name="node">The node itself</param>

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -808,6 +808,7 @@ namespace Dynamo.Graph.Workspaces
         {
             node.Modified += NodeModified;
             node.ConnectorAdded += OnConnectorAdded;
+            node.ToggleNodeFreeze +=OnToggleNodeFreeze;
             
             var functionNode = node as Function;
             if (functionNode != null)
@@ -815,6 +816,11 @@ namespace Dynamo.Graph.Workspaces
                 functionNode.Controller.SyncWithDefinitionStart += OnSyncWithDefintionStart;
                 functionNode.Controller.SyncWithDefinitionEnd += OnSyncWithDefinitionEnd;
             }
+        }
+
+        protected virtual void OnToggleNodeFreeze(NodeModel obj)
+        {
+             
         }
        
         protected virtual void RequestRun()

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -808,7 +808,7 @@ namespace Dynamo.Graph.Workspaces
         {
             node.Modified += NodeModified;
             node.ConnectorAdded += OnConnectorAdded;
-            node.ToggleNodeFreeze +=OnToggleNodeFreeze;
+            node.UpdateASTCollection +=OnToggleNodeFreeze;
             
             var functionNode = node as Function;
             if (functionNode != null)

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -636,11 +636,7 @@ namespace Dynamo.ViewModels
                 case "CanUpdatePeriodically":
                     RaisePropertyChanged("EnablePeriodicUpdate");
                     RaisePropertyChanged("PeriodicUpdateVisibility");
-                    break;   
-                case "IsFrozen":
-                    RaisePropertyChanged("IsFrozenExplicitly");
-                    RaisePropertyChanged("CanToggleFrozen");
-                    break;
+                    break;                 
             }
         }
 
@@ -1054,7 +1050,11 @@ namespace Dynamo.ViewModels
             {
                 node = DynamoSelection.Instance.Selection.Cast<NodeModel>().First();
                 node.IsFrozen = !node.IsFrozen;
-            }   
+            }
+
+            RaisePropertyChanged("IsFrozenExplicitly");
+            RaisePropertyChanged("CanToggleFrozen");
+            RaisePropertyChanged("IsFrozen");
         }
 
         private bool CanToggleIsFrozen(object parameters)

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -636,7 +636,11 @@ namespace Dynamo.ViewModels
                 case "CanUpdatePeriodically":
                     RaisePropertyChanged("EnablePeriodicUpdate");
                     RaisePropertyChanged("PeriodicUpdateVisibility");
-                    break;                             
+                    break;   
+                case "IsFrozen":
+                    RaisePropertyChanged("IsFrozenExplicitly");
+                    RaisePropertyChanged("CanToggleFrozen");
+                    break;
             }
         }
 

--- a/test/DynamoCoreTests/NodeExecutionTest.cs
+++ b/test/DynamoCoreTests/NodeExecutionTest.cs
@@ -247,8 +247,13 @@ namespace Dynamo.Tests
             //to frozen and not executing state
             Assert.AreEqual(addNode.IsFrozen, true);
             
-            //check the value on add node. 
-            AssertPreviewValue(addNode.GUID.ToString(), 5);
+            //check the value on add node. Add node is not executed in the run,
+            // becuase the frozen nodes are removed from AST. So the value of add node
+            // should be 0. But the cached value should be 3, which is from the previous execution.
+            AssertPreviewValue(addNode.GUID.ToString(), 0);
+            Assert.IsNotNull(addNode.CachedValue.Data);
+            Assert.AreEqual(Convert.ToInt32(addNode.CachedValue.Data),3);
+
         }
 
         [Test]
@@ -310,10 +315,7 @@ namespace Dynamo.Tests
             
             //add node should still be in frozen and can execute state
             Assert.AreEqual(addNode.IsFrozen, true);
-            
-            //addnode should change the value.
-            AssertPreviewValue(addNode.GUID.ToString(), 5);
-
+                      
             //now unfreeze the other node.
             numberNode2.IsFrozen = false;
             

--- a/test/DynamoCoreTests/NodeExecutionTest.cs
+++ b/test/DynamoCoreTests/NodeExecutionTest.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
+using DSCoreNodesUI;
 using DSCoreNodesUI.Input;
+using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Models;
@@ -16,6 +18,13 @@ namespace Dynamo.Tests
 {
     internal class NodeExecutionTest : DynamoModelTestBase
     {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("VMDataBridge.dll");
+            libraries.Add("DSCoreNodes.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
         [Test]
         [Category("UnitTests")]
         public void Freeze_ANode_Test()
@@ -30,6 +39,47 @@ namespace Dynamo.Tests
             addNode.IsFrozen = true;          
             Assert.AreEqual(addNode.IsFrozen, true);
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void Freeze_Test_On_WatchNode()
+        {
+            var model = CurrentDynamoModel;
+            //create some numbers
+            var numberNode1 = new DoubleInput();
+            numberNode1.Value = "1";
+            var numberNode2 = new DoubleInput();
+            numberNode2.Value = "2";
+            var addNode = new DSFunction(model.LibraryServices.GetFunctionDescriptor("+"));
+           
+            model.ExecuteCommand(new DynamoModel.CreateNodeCommand(numberNode1, 0, 0, true, false));
+            model.ExecuteCommand(new DynamoModel.CreateNodeCommand(numberNode2, 0, 0, true, false));
+            model.ExecuteCommand(new DynamoModel.CreateNodeCommand(addNode, 0, 0, true, false));
+
+            //connect them up
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(numberNode1.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 0, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(numberNode2.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 1, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+
+            //add  a watch node
+            var watchNode = new Watch();
+            model.ExecuteCommand(new DynamoModel.CreateNodeCommand(watchNode, 0, 0, true, false));
+
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchNode.GUID, 0, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 4);
+            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 3);
+
+            //check the value
+            AssertPreviewValue(addNode.GUID.ToString(), 3);
+        
+            //check the watch node value
+            AssertPreviewValue(watchNode.GUID.ToString(), 3);
+        }
+
 
         [Test]
         [Category("UnitTests")]
@@ -54,8 +104,15 @@ namespace Dynamo.Tests
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(numberNode2.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 1, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
 
-            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 3);
-            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 2);
+            //add  a watch node
+            var watchNode = new Watch();
+            model.ExecuteCommand(new DynamoModel.CreateNodeCommand(watchNode, 0, 0, true, false));
+
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchNode.GUID, 0, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 4);
+            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 3);
 
             //Check the value
             AssertPreviewValue(addNode.GUID.ToString(), 3);
@@ -74,6 +131,9 @@ namespace Dynamo.Tests
             
             //Since the nodes are frozen, the value  of add node should not change.            
             AssertPreviewValue(addNode.GUID.ToString(), 3);
+
+            //check the watch node value
+            AssertPreviewValue(watchNode.GUID.ToString(), 3);
         }
 
         [Test]
@@ -99,8 +159,15 @@ namespace Dynamo.Tests
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(numberNode2.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 1, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
 
-            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 3);
-            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 2);
+            //add  a watch node
+            var watchNode = new Watch();
+            model.ExecuteCommand(new DynamoModel.CreateNodeCommand(watchNode, 0, 0, true, false));
+
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchNode.GUID, 0, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 4);
+            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 3);
 
             //Check the value
             AssertPreviewValue(addNode.GUID.ToString(), 3);
@@ -125,6 +192,9 @@ namespace Dynamo.Tests
             
             //Since the add node is frozen, the value should not change
             AssertPreviewValue(addNode.GUID.ToString(), 3);
+
+            //check the watch node value
+            AssertPreviewValue(watchNode.GUID.ToString(), 3);
         }
 
         [Test]
@@ -150,8 +220,17 @@ namespace Dynamo.Tests
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(numberNode2.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 1, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
 
-            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 3);
-            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 2);
+            //add  a watch node
+            var watchNode = new Watch();
+            model.ExecuteCommand(new DynamoModel.CreateNodeCommand(watchNode, 0, 0, true, false));
+
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchNode.GUID, 0, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 4);
+            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 3);
+
+            BeginRun();
 
             //check the value
             AssertPreviewValue(addNode.GUID.ToString(), 3);
@@ -169,6 +248,9 @@ namespace Dynamo.Tests
             //check the value
             AssertPreviewValue(addNode.GUID.ToString(), 3);
 
+            //check the watch node value
+            AssertPreviewValue(watchNode.GUID.ToString(), 3);
+
             //now the number node1 is frozen. change the value.
             numberNode1.Value = "3.0";
 
@@ -185,6 +267,9 @@ namespace Dynamo.Tests
 
             //Now the add node should get the value
             AssertPreviewValue(addNode.GUID.ToString(), 5);
+
+            //check the watch node value
+            AssertPreviewValue(watchNode.GUID.ToString(), 5);
         }
 
         [Test]
@@ -210,8 +295,15 @@ namespace Dynamo.Tests
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(numberNode2.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 1, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
 
-            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 3);
-            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 2);
+            //add  a watch node
+            var watchNode = new Watch() {X = 100, Y = 300};
+            model.ExecuteCommand(new DynamoModel.CreateNodeCommand(watchNode, 0, 0, true, false));
+            
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchNode.GUID, 0, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 4);
+            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 3);
 
             //check the value
             AssertPreviewValue(addNode.GUID.ToString(), 3);
@@ -253,7 +345,7 @@ namespace Dynamo.Tests
             AssertPreviewValue(addNode.GUID.ToString(), 0);
             Assert.IsNotNull(addNode.CachedValue.Data);
             Assert.AreEqual(Convert.ToInt32(addNode.CachedValue.Data),3);
-
+            Assert.AreEqual(Convert.ToInt32(watchNode.CachedValue), 3);
         }
 
         [Test]
@@ -279,8 +371,15 @@ namespace Dynamo.Tests
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(numberNode2.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 1, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
 
-            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 3);
-            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 2);
+            //add  a watch node
+            var watchNode = new Watch() { X = 100, Y = 300 };
+            model.ExecuteCommand(new DynamoModel.CreateNodeCommand(watchNode, 0, 0, true, false));
+
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchNode.GUID, 0, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 4);
+            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 3);
 
             //check the value.
             AssertPreviewValue(addNode.GUID.ToString(), 3);
@@ -304,6 +403,7 @@ namespace Dynamo.Tests
             
             //addnode should not change the value.
             AssertPreviewValue(addNode.GUID.ToString(), 3);
+            Assert.AreEqual(Convert.ToInt32(watchNode.CachedValue),3);
 
             //unfreeze one of the number node          
             numberNode1.IsFrozen = false;
@@ -326,6 +426,7 @@ namespace Dynamo.Tests
             
             //addnode should change the value now.
             AssertPreviewValue(addNode.GUID.ToString(), 6);
+            AssertPreviewValue(watchNode.GUID.ToString(), 6);
         }
 
         [Test]
@@ -350,9 +451,16 @@ namespace Dynamo.Tests
 
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(numberNode2.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
             model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 1, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+            
+            //add  a watch node
+            var watchNode = new Watch() { X = 100, Y = 300 };
+            model.ExecuteCommand(new DynamoModel.CreateNodeCommand(watchNode, 0, 0, true, false));
 
-            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 3);
-            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 2);
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(addNode.GUID, 0, PortType.Output, DynCmd.MakeConnectionCommand.Mode.Begin));
+            model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchNode.GUID, 0, PortType.Input, DynCmd.MakeConnectionCommand.Mode.End));
+
+            Assert.AreEqual(model.CurrentWorkspace.Nodes.Count(), 4);
+            Assert.AreEqual(model.CurrentWorkspace.Connectors.Count(), 3);
 
             //check the value
             AssertPreviewValue(addNode.GUID.ToString(), 3);
@@ -373,6 +481,7 @@ namespace Dynamo.Tests
             
             //check the value
             AssertPreviewValue(addNode.GUID.ToString(), 3);
+            Assert.AreEqual(Convert.ToInt32(watchNode.CachedValue), 3);
 
             //undo the freeze on numbernode1
             model.CurrentWorkspace.Undo();
@@ -388,8 +497,7 @@ namespace Dynamo.Tests
            
             //check the value
             AssertPreviewValue(addNode.GUID.ToString(), 5);
-
-        }
-
+            AssertPreviewValue(watchNode.GUID.ToString(), 5);
+        }        
     }
 }


### PR DESCRIPTION
## Purpose

The purpose of this PR is to freeze the watch node and the watch node does not get evaluated until it is unfreeze. 

This PR refers to the below tasks 
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8959
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9096
 
Here the task is to freeze the execution of watch node. 
Refer to  this PR  [https://github.com/DynamoDS/Dynamo/pull/5669] for the watch node UI changes.

In this PR, the following tasks are accompolished
 1.When a node is Freeze, the graph does not execute. Instead, the node and all its dependencies are deleted from AST. So, all the frozen nodes never participates in any of the execution.

 2.When a node is unfreeze, all its downstream nodes are set to modified, and the graph will be executed. 

3.Any time, when an input node is in freeze state, the value from the preview run is maintained. 

4.If the value of a freeze node is changed, the value will be changed in UI. The value will not get propagated to VM until the node is made unfreeze.

## Design Document
 https://docs.google.com/a/adsk-oss.com/presentation/d/1MUhSzoDo-QFPysDv1E6gRslpq2pnb6eoPjKSsJN6g-o/edit?usp=sharing  

## Declaration
Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

## Reviewers
@pboyer 

FYI @mjkkirschner 
