### PR TITLE
Temporarily mark test case CyclicDependency_Defect8827 as failure

### DIFF
--- a/test/DynamoCoreTests/DynamoDefects.cs
+++ b/test/DynamoCoreTests/DynamoDefects.cs
@@ -472,7 +472,7 @@ namespace Dynamo.Tests
             AssertPreviewValue("56f3c0fd-d39c-46cb-a4ea-4f266f7a9fce", true);
         }
 
-        [Test, Category("RegressionTests")]
+        [Test, Category("Failure")]
         public void CyclicDependency_Defect8827()
         {
             string openPath = Path.Combine(TestDirectory,


### PR DESCRIPTION
### Purpose

The graph in this test case contains two cyclic dependent nodes, therefore NodeModel.CheckIfAnyUpstreamNodeIsFrozen() goes in infinite recursive call. Temporarily mark it as Failure so that we could get the build.

### FYIs
@ramramps please remove it from Failure category once fix is submitted. 