### PR TITLE
Dynamo Manipulator implementation

### DIFF
--- a/src/Dynamo.All.sln
+++ b/src/Dynamo.All.sln
@@ -213,6 +213,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfVisualizationTests", "Vi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShapewaysClient", "ShapewaysClient\ShapewaysClient.csproj", "{756CEBA5-4E20-4403-8448-C3C47957975B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamoManipulation", "DynamoManipulation\DynamoManipulation.csproj", "{33F88E8C-CC3C-4237-8AA9-CC891EFCABFA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -483,6 +485,10 @@ Global
 		{756CEBA5-4E20-4403-8448-C3C47957975B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{756CEBA5-4E20-4403-8448-C3C47957975B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{756CEBA5-4E20-4403-8448-C3C47957975B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33F88E8C-CC3C-4237-8AA9-CC891EFCABFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33F88E8C-CC3C-4237-8AA9-CC891EFCABFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33F88E8C-CC3C-4237-8AA9-CC891EFCABFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33F88E8C-CC3C-4237-8AA9-CC891EFCABFA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/DynamoManipulation/DynamoManipulation.csproj
+++ b/src/DynamoManipulation/DynamoManipulation.csproj
@@ -1,0 +1,102 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(SolutionDir)Config/CS.props" />
+  </ImportGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{33F88E8C-CC3C-4237-8AA9-CC891EFCABFA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Dynamo.Manipulation</RootNamespace>
+    <AssemblyName>DynamoManipulation</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(DynamoExternPath)\ProtoGeometry\ProtoGeometry.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ProtoInterface">
+      <HintPath>$(DynamoExternPath)\ProtoGeometry\ProtoInterface.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="PointOnCurveManipulator.cs" />
+    <Compile Include="TranslationGizmo.cs" />
+    <Compile Include="..\AssemblySharedInfoGenerator\AssemblySharedInfo.cs">
+      <Link>Properties\AssemblySharedInfo.cs</Link>
+    </Compile>
+    <Compile Include="ZeroTouchManipulatorCreator.cs" />
+    <Compile Include="DynamoManipulationExtension.cs" />
+    <Compile Include="INodeManipulator.cs" />
+    <Compile Include="NodeManipulator.cs" />
+    <Compile Include="ManipulatorDaemon.cs" />
+    <Compile Include="NodeManipulatorFactoryLoader.cs" />
+    <Compile Include="MousePointManipulator.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DynamoCoreWpf\DynamoCoreWpf.csproj">
+      <Project>{51bb6014-43f7-4f31-b8d3-e3c37ebedaf4}</Project>
+      <Name>DynamoCoreWpf</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\DynamoCore\DynamoCore.csproj">
+      <Project>{7858fa8c-475f-4b8e-b468-1f8200778cf8}</Project>
+      <Name>DynamoCore</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Engine\ProtoCore\ProtoCore.csproj">
+      <Project>{7a9e0314-966f-4584-baa3-7339cbb849d1}</Project>
+      <Name>ProtoCore</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Libraries\CoreNodeModels\CoreNodeModels.csproj">
+      <Project>{d8262d40-4880-41e4-91e4-af8f480c8637}</Project>
+      <Name>CoreNodeModels</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <ExtensionDefinition Include="DynamoManipulationExtension_ViewExtensionDefinition.xml" />
+    </ItemGroup>
+    <Copy SourceFiles="@(ExtensionDefinition)" DestinationFolder="$(OutputPath)\viewExtensions\" />
+  </Target>
+</Project>

--- a/src/DynamoManipulation/DynamoManipulationExtension_ViewExtensionDefinition.xml
+++ b/src/DynamoManipulation/DynamoManipulationExtension_ViewExtensionDefinition.xml
@@ -1,0 +1,4 @@
+<ViewExtensionDefinition>
+  <AssemblyPath>..\DynamoManipulation.dll</AssemblyPath>
+  <TypeName>Dynamo.Manipulation.DynamoManipulationExtension</TypeName>
+</ViewExtensionDefinition>

--- a/src/DynamoManipulation/INodeManipulator.cs
+++ b/src/DynamoManipulation/INodeManipulator.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using Autodesk.DesignScript.Interfaces;
+using Dynamo.Graph.Nodes;
+
+namespace Dynamo.Manipulation
+{
+    /// <summary>
+    /// Initializes a list of manipulator factories
+    /// </summary>
+    public interface INodeManipulatorFactoryLoader
+    {
+        Dictionary<Type, IEnumerable<INodeManipulatorFactory>> Load();
+    }
+
+    /// <summary>
+    /// Creates a set of manipulators for the given node 
+    /// </summary>
+    public interface INodeManipulatorFactory
+    {
+        INodeManipulator Create(NodeModel node, DynamoManipulationExtension manipulatorContext);
+    }
+
+    /// <summary>
+    /// Represents a manipulator for a given Node type
+    /// </summary>
+    public interface INodeManipulator : IDisposable
+    {
+        IEnumerable<IRenderPackage> BuildRenderPackage();
+    }
+}

--- a/src/DynamoManipulation/ManipulatorDaemon.cs
+++ b/src/DynamoManipulation/ManipulatorDaemon.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dynamo.Graph.Nodes;
+
+namespace Dynamo.Manipulation
+{
+    internal class ManipulatorDaemon
+    {
+        private readonly Dictionary<Type, IEnumerable<INodeManipulatorFactory>> registeredManipulatorCreators;
+        private readonly Dictionary<Guid, IDisposable> activeManipulators = new Dictionary<Guid, IDisposable>();
+
+        public IEnumerable<string> NodeNames { get; private set; }
+
+        private ManipulatorDaemon(Dictionary<Type, IEnumerable<INodeManipulatorFactory>> creators, IEnumerable<string> nodeNames)
+        {
+            registeredManipulatorCreators = creators;
+            NodeNames = nodeNames;
+        }
+
+        internal static ManipulatorDaemon Create(INodeManipulatorFactoryLoader initializer)
+        {
+            var creators = initializer.Load();
+            var names = creators.SelectMany(pair => pair.Value.SelectMany(x =>
+            {
+                var factory = x as ZeroTouchManipulatorFactory;
+                return factory != null ? factory.NodeNames : null;
+            }
+            ));
+
+            return new ManipulatorDaemon(creators, names);
+        }
+
+        internal void CreateManipulator(NodeModel model, DynamoManipulationExtension manipulatorContext)
+        {
+            var creators = registeredManipulatorCreators.Where(pair => pair.Key.IsInstanceOfType(model)).SelectMany(pair => pair.Value);
+            activeManipulators[model.GUID] = new CompositeManipulator(
+                creators.Select(x => x.Create(model, manipulatorContext)).
+                Where(x => x != null).ToList());
+        }
+
+        internal void KillManipulators(NodeModel model)
+        {
+            IDisposable manipulator;
+            if (activeManipulators.TryGetValue(model.GUID, out manipulator))
+            {
+                manipulator.Dispose();
+                activeManipulators.Remove(model.GUID);
+            }
+        }
+
+        internal void KillAll()
+        {
+            foreach (var manipulator in activeManipulators)
+            {
+                manipulator.Value.Dispose();
+            }
+            activeManipulators.Clear();
+        }
+    }
+}

--- a/src/DynamoManipulation/MousePointManipulator.cs
+++ b/src/DynamoManipulation/MousePointManipulator.cs
@@ -1,0 +1,333 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
+using Autodesk.DesignScript.Geometry;
+using Autodesk.DesignScript.Interfaces;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.ZeroTouch;
+using Dynamo.Models;
+using DoubleSlider = DSCoreNodesUI.Input.DoubleSlider;
+using Point = Autodesk.DesignScript.Geometry.Point;
+using Dynamo.Wpf.ViewModels.Watch3D;
+
+namespace Dynamo.Manipulation
+{
+    public sealed class MousePointManipulatorFactory : INodeManipulatorFactory
+    {
+        public INodeManipulator Create(NodeModel node, DynamoManipulationExtension manipulatorContext)
+        {
+            return new MousePointManipulator(node as DSFunction, manipulatorContext);
+        }
+    }
+
+    public class MousePointManipulator : NodeManipulator
+    {
+        private Point origin;
+
+        private Point expectedPosition;
+
+        private TranslationGizmo gizmo;
+
+        private Dictionary<int, Tuple<Vector, NodeModel>> indexedAxisNodePairs;
+
+        internal MousePointManipulator(DSFunction node, DynamoManipulationExtension manipulatorContext)
+            : base(node, manipulatorContext)
+        {
+        }
+       
+        #region overridden methods
+
+        protected override void AssignInputNodes()
+        {
+            //Default axes
+            var axes = new Vector[] { Vector.XAxis(), Vector.YAxis(), Vector.ZAxis() };
+            //Holds manipulator axis and input node pair for each input port.
+            indexedAxisNodePairs = new Dictionary<int, Tuple<Vector, NodeModel>>(3);
+
+            for (int i = 0; i < 3; i++)
+            {
+                //First find out if the input can be manipulated.
+                NodeModel node = null;
+                if (!CanManipulateInputNode(i, out node))
+                {
+                    continue;
+                }
+
+                //Input can be manipulated but there is not input node yet.
+                if (node == null)
+                {
+                    indexedAxisNodePairs.Add(i, Tuple.Create(axes[i], node));
+                    continue;
+                }
+
+                //Now check if the input node is already connected to other
+                //input of this node, then update the manipulation direction.
+                Vector axis = null;
+                int idx = -1;
+                foreach (var item in indexedAxisNodePairs)
+                {
+                    //If same node is connected to more than one input port.
+                    if (item.Value.Item2 == node)
+                    {
+                        //Combine old axis with this axis
+                        axis = item.Value.Item1;
+                        axis = axis.Add(axes[i]).Normalized();
+                        idx = item.Key;
+                        break;
+                    }
+                }
+                if (axis == null) //Didn't find matching node.
+                {
+                    indexedAxisNodePairs.Add(i, Tuple.Create(axes[i], node));
+                }
+                else
+                {
+                    //update the new axis value in dictionary
+                    indexedAxisNodePairs[idx] = Tuple.Create(axis, node);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a new Gizmo or Updates existing Gizmo with new axes and origin.
+        /// This method is called every time Gizmo's are requested.
+        /// </summary>
+        private void UpdateGizmo()
+        {
+            var axes = new Vector[] { null, null, null };
+            //Extract axis information from the axis node pairs.
+            int index = 0;
+            foreach (var item in indexedAxisNodePairs)
+            {
+                axes[index++] = item.Value.Item1;
+            }
+
+            if (null == gizmo)
+            {
+                gizmo = new TranslationGizmo(origin, axes[0], axes[1], axes[2], 6);
+            }
+            else
+            {
+                gizmo.UpdateGeometry(origin, axes[0], axes[1], axes[2], 6);
+            }
+        }
+
+        /// <summary>
+        /// Returns all the gizmos supported by this manipulator
+        /// </summary>
+        /// <returns>List of Gizmo</returns>
+        protected override IEnumerable<IGizmo> GetGizmos()
+        {
+            UpdateGizmo();
+
+            yield return gizmo;
+        }
+
+        /// <summary>
+        /// Called when Gizmo is clicked. Creates new input nodes if the
+        /// specific input is selected for manipulation by the Gizmo.
+        /// </summary>
+        /// <param name="gizmo">Gizmo that is clicked</param>
+        /// <param name="hitObject">The axis or plane of the gizmo hit</param>
+        protected override IEnumerable<NodeModel> OnGizmoClick(IGizmo gizmo, object hitObject)
+        {
+            //If an axis is hit, only one node will be updated.
+            var axis1 = hitObject as Vector;
+            Vector axis2 = null;
+            if(axis1 == null)
+            {
+                //Hit object is a plane, two axes will be updated simultaneously.
+                var plane = hitObject as Plane;
+                if(plane != null)
+                {
+                    axis1 = plane.XAxis;
+                    axis2 = plane.YAxis;
+                }
+            }
+
+            int count = indexedAxisNodePairs.Count;
+            var nodes = new Dictionary<int, NodeModel>(2); //placeholder for new nodes.
+            foreach (var item in indexedAxisNodePairs)
+            {
+                var v = item.Value.Item1;
+                var node = item.Value.Item2;
+                if (v.Equals(axis1) || v.Equals(axis2))
+                {
+                    if (node == null)
+                    {
+                        node = CreateAndConnectInputNode(0, item.Key);
+                    }
+                    
+                    nodes.Add(item.Key, node);
+                }
+            }
+
+            //Update the axisNodePairs with affected nodes.
+            foreach (var n in nodes)
+            {
+                var axisIndex = n.Key;
+                var axisNodePair = indexedAxisNodePairs[axisIndex];
+                var axisVector = axisNodePair.Item1;
+                var upstreamNode = n.Value;
+                indexedAxisNodePairs[axisIndex] = Tuple.Create(axisVector, upstreamNode);
+            }
+
+            return nodes.Values;
+        }
+
+        /// <summary>
+        /// Callback method when gizmo is moved by user action.
+        /// </summary>
+        /// <param name="gizmo">Gizmo that moved.</param>
+        /// <param name="offset">Offset by which the gizmo has moved.</param>
+        /// <returns>New expected position of the Gizmo</returns>
+        protected override Point OnGizmoMoved(IGizmo gizmo, Vector offset)
+        {
+            expectedPosition = origin.Add(offset);
+
+            foreach (var item in indexedAxisNodePairs)
+            {
+                // When more than one input is connected to the same slider, this
+                // method will decompose the axis corresponding to each input.
+                var v = GetFirstAxisComponent(item.Value.Item1);
+                var amount = Math.Round(offset.Dot(v), 3);
+                if (Math.Abs(amount) > 0.001)
+                    ModifyInputNode(item.Value.Item2, amount);
+            }
+
+            return expectedPosition;
+        }
+
+        /// <summary>
+        /// Synchronize the origin with the node's value.
+        /// </summary>
+        protected override void UpdatePosition()
+        {
+            Active = false;
+            if (Node == null || !indexedAxisNodePairs.Any()) return;
+
+            if (origin == null)
+            {
+                origin = Point.Origin();
+            }
+
+            // hack: to prevent node mirror value lookup from throwing an exception
+            var previousOrigin = Point.ByCoordinates(origin.X, origin.Y, origin.Z);
+            try
+            {
+                //Node output could be a collection, consider the first item as origin.
+                Point pt = GetFirstValueFromNode(Node) as Point;
+                origin = pt != null ? Point.ByCoordinates(pt.X, pt.Y, pt.Z) : origin;
+            }
+            catch (Exception)
+            {
+                origin = previousOrigin;
+            }
+
+            if (origin == null)
+            {
+                origin = Point.Origin();
+                return;
+            }
+
+            Active = true;
+        }
+
+        #endregion
+
+        #region helpers
+
+        /// <summary>
+        /// Decomposes given vector in natural axes and returns first axis.
+        /// </summary>
+        /// <param name="vector"></param>
+        /// <returns></returns>
+        private Vector GetFirstAxisComponent(Vector vector)
+        {
+            var tol = 0.0001;
+            var v1 = Vector.ByCoordinates(vector.X, 0, 0);
+            if (v1.Length > tol)
+                return v1.Normalized();
+
+            var v2 = Vector.ByCoordinates(0, vector.Y, 0);
+            if (v2.Length > tol)
+                return v2.Normalized();
+
+            return vector.Normalized();
+        }
+        
+        private static void SetSliderInputParams(DoubleSlider inputNode, double min, double max)
+        {
+        }
+
+        /// <summary>
+        /// Updates input node by specified amount.
+        /// </summary>
+        /// <param name="inputNode">Input node</param>
+        /// <param name="amount">Amount by which it needs to be modified.</param>
+        private static void ModifyInputNode(NodeModel inputNode, double amount)
+        {
+            if (inputNode == null) return;
+
+            if (Math.Abs(amount) < 0.001) return;
+
+            dynamic uiNode = inputNode;
+
+            uiNode.Value += amount;
+        }
+
+        #endregion
+    }
+
+    internal static class PointExtensions
+    {
+        public static Point ToPoint(this Point3D point)
+        {
+            return Point.ByCoordinates(point.X, point.Y, point.Z);
+        }
+
+        public static Vector ToVector(this Vector3D vec)
+        {
+            return Vector.ByCoordinates(vec.X, vec.Y, vec.Z);
+        }
+    }
+
+    internal static class RayExtensions
+    {
+        private const double axisScaleFactor = 100;
+        private const double rayScaleFactor = 10000;
+
+        public static Line ToLine(this IRay ray)
+        {
+            var origin = ray.Origin.ToPoint();
+            var direction = ray.Direction.ToVector();
+            return Line.ByStartPointEndPoint(origin, origin.Add(direction.Scale(rayScaleFactor)));
+        }
+
+        public static Line ToOriginCenteredLine(this IRay ray)
+        {
+            var origin = ray.Origin.ToPoint();
+            var direction = ray.Direction.ToVector();
+            return ToOriginCenteredLine(origin, direction);
+        }
+
+        public static Line ToOriginCenteredLine(Point origin, Vector axis)
+        {
+            return Line.ByStartPointEndPoint(origin.Add(axis.Scale(-axisScaleFactor)),
+                origin.Add(axis.Scale(axisScaleFactor)));
+        }
+
+        public static Point GetOriginPoint(this IRay ray)
+        {
+            return ray.Origin.ToPoint();
+        }
+
+        public static Vector GetDirectionVector(this IRay ray)
+        {
+            return ray.Direction.ToVector();
+        }
+    }
+}

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -1,0 +1,465 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Input;
+using Autodesk.DesignScript.Geometry;
+using Autodesk.DesignScript.Interfaces;
+using DSCoreNodesUI.Input;
+using Dynamo.Extensions;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Workspaces;
+using Dynamo.Models;
+using Dynamo.Visualization;
+using Dynamo.Wpf.ViewModels.Watch3D;
+using ProtoCore.Mirror;
+
+namespace Dynamo.Manipulation
+{
+    
+    public abstract class NodeManipulatorFactory : INodeManipulatorFactory
+    {
+        /// <summary>
+        /// Create a set of manipulators for the given node by inspecting its numeric inputs
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="manipulatorContext"></param>
+        /// <returns></returns>
+        public abstract INodeManipulator Create(NodeModel node, DynamoManipulationExtension manipulatorContext);
+    }
+
+    /// <summary>
+    /// Base class of all Manipulator types
+    /// Authors of Manipulators must derive from this class
+    /// </summary>
+    public abstract class NodeManipulator : INodeManipulator
+    {
+        #region properties
+
+        private const double NewNodeOffsetX = 350;
+        private const double NewNodeOffsetY = 50;
+        private Point newPosition;
+
+        protected NodeModel Node { get; set; }
+
+        protected IWorkspaceModel WorkspaceModel { get; private set; }
+
+        protected IWatch3DViewModel BackgroundPreviewViewModel { get; private set; }
+
+        protected IRenderPackageFactory RenderPackageFactory { get; private set; }
+
+        protected ICommandExecutive CommandExecutive { get; private set; }
+
+        protected string UniqueId { get; private set; }
+
+        protected string ExtensionName { get; private set; }
+        
+        protected bool Active { get; set; }
+
+        protected IGizmo GizmoInAction { get; private set; }
+
+        #endregion
+
+        #region abstract methods
+
+        /// <summary>
+        /// Returns list of Gizmos used by this manipulator.
+        /// </summary>
+        /// <returns>List of Gizmos.</returns>
+        protected abstract IEnumerable<IGizmo> GetGizmos();
+
+        /// <summary>
+        /// Implement to analyze inputs to the manipulator node and initialize them
+        /// If inputs are numbers or sliders, they are candidates for being manipulator inputs
+        /// Responsibility of deciding which inputs are "manipulatable" must lie with the implementor
+        /// </summary>
+        protected abstract void AssignInputNodes();
+
+        /// <summary>
+        /// Implement to update the position(s) of all manipulator inputs when the node is updated
+        /// </summary>
+        protected abstract void UpdatePosition();
+
+        /// <summary>
+        /// This method is called when a gizmo provided by derived class is hit.
+        /// Derived class can create or update the input nodes.
+        /// </summary>
+        /// <param name="gizmo">The Gizmo that's hit.</param>
+        /// <param name="hitObject">The object of Gizmo that's hit.</param>
+        /// <returns>List of updated nodes</returns>
+        protected abstract IEnumerable<NodeModel> OnGizmoClick(IGizmo gizmo, object hitObject);
+
+        /// <summary>
+        /// This method is called when the Gizmo in action is moved during mouse
+        /// move event. Derived class can use this notification to update the 
+        /// input nodes.
+        /// </summary>
+        /// <param name="gizmo">The Gizmo in action.</param>
+        /// <param name="offset">Offset amount by which Gizmo has moved.</param>
+        /// <returns>New expected position of the Gizmo</returns>
+        protected abstract Point OnGizmoMoved(IGizmo gizmo, Vector offset);
+
+        #endregion
+
+        #region protected methods
+
+        /// <summary>
+        /// Implement to dispose any implementation specific manipulator handlers and/or properties
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            var gizmos = GetGizmos();
+            foreach (var item in gizmos)
+            {
+                BackgroundPreviewViewModel.DeleteGeometryForIdentifier(item.Name);
+            }
+        }
+
+        /// <summary>
+        /// This method is called when mouse is moved, to check if the
+        /// Gizmo in action can be moved successfully. If it returns true
+        /// then this manipulator will compute the movement and call
+        /// OnGizmoMoved.
+        /// </summary>
+        /// <param name="gizmo">Gizmo in action.</param>
+        /// <returns>True if Gizmo is ready to move.</returns>
+        protected virtual bool CanMoveGizmo(IGizmo gizmo)
+        {
+            //Wait until node has been evaluated and has got new origin
+            //as expected position.
+            return gizmo != null && newPosition.DistanceTo(gizmo.Origin) < 0.01;
+        }
+
+        /// <summary>
+        /// Implements the MouseDown event handler for the manipulator
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="mouseButtonEventArgs"></param>
+        protected virtual void MouseDown(object sender, MouseButtonEventArgs mouseButtonEventArgs)
+        {
+            UpdatePosition();
+            GizmoInAction = null; //Reset Drag.
+
+            var gizmos = GetGizmos();
+            if (!Active || null == gizmos || !gizmos.Any())
+                return;
+
+            var ray = BackgroundPreviewViewModel.GetClickRay(mouseButtonEventArgs);
+            if (ray == null) return;
+
+            object hitObject;
+            foreach (var item in gizmos)
+            {
+                if (item.HitTest(ray.GetOriginPoint(), ray.GetDirectionVector(), out hitObject))
+                {
+                    GizmoInAction = item;
+                    var nodes = OnGizmoClick(item, hitObject);
+                    if(null != nodes && nodes.Any())
+                    {
+                        WorkspaceModel.RecordModelsForModification(nodes);
+                    }
+                    newPosition = GizmoInAction.Origin;
+                    return;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Implements the MouseUp event handler for the manipulator
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected virtual void MouseUp(object sender, MouseButtonEventArgs e)
+        {
+            GizmoInAction = null;
+            //Delete all transient axis line geometry
+            BackgroundPreviewViewModel.DeleteGeometryForIdentifier(RenderDescriptions.AxisLine);
+        }
+
+        /// <summary>
+        /// Implements the MouseMove event handler for the manipulator
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="mouseEventArgs"></param>
+        protected virtual void MouseMove(object sender, MouseEventArgs mouseEventArgs)
+        {
+            if (!CanMoveGizmo(GizmoInAction))
+                return;
+
+            var clickRay = BackgroundPreviewViewModel.GetClickRay(mouseEventArgs);
+            if (clickRay == null) return;
+
+            var offset = GizmoInAction.GetOffset(clickRay.GetOriginPoint(), clickRay.GetDirectionVector());
+            if (offset.Length < 0.01)
+                return;
+
+            newPosition = OnGizmoMoved(GizmoInAction, offset);
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="node">Node for which manipulator is created.</param>
+        /// <param name="manipulatorContext">Context for manipulator</param>
+        protected NodeManipulator(NodeModel node, DynamoManipulationExtension manipulatorContext)
+        {
+            Node = node;
+            WorkspaceModel = manipulatorContext.WorkspaceModel;
+            BackgroundPreviewViewModel = manipulatorContext.BackgroundPreviewViewModel;
+            RenderPackageFactory = manipulatorContext.RenderPackageFactory;
+            CommandExecutive = manipulatorContext.CommandExecutive;
+            UniqueId = manipulatorContext.UniqueId;
+            ExtensionName = manipulatorContext.Name;
+                
+            AttachBaseHandlers();
+
+            DrawManipulator();
+        }
+
+        /// <summary>
+        /// Helper method to get the first item from the objects resulted from 
+        /// this node.
+        /// </summary>
+        /// <param name="node">Input Node</param>
+        /// <returns>Returns the first item of the node.</returns>
+        protected static object GetFirstValueFromNode(NodeModel node)
+        {
+            return GetElementsFromMirrorData(node.CachedValue).FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Helper method to get all items from mirror data as flat list recursively.
+        /// </summary>
+        /// <param name="data">Input data</param>
+        /// <returns>List of objects</returns>
+        protected static IEnumerable<object> GetElementsFromMirrorData(MirrorData data)
+        {
+            if (data == null || data.IsNull)
+                yield return null;
+
+            if (data.IsCollection)
+            {
+                var elems = data.GetElements();
+                foreach (var item in elems)
+                {
+                    var objs = GetElementsFromMirrorData(item);
+                    foreach (var obj in objs)
+                    {
+                        yield return obj;
+                    }
+                }
+            }
+
+            yield return data.Data;
+        }
+
+        /// <summary>
+        /// Find connected node based on the input index and returns if this
+        /// input port value can be manipulated.
+        /// </summary>
+        /// <param name="inputPortIndex">Input index of input port</param>
+        /// <param name="inputNode">node connected to inputport</param>
+        /// <returns>True if a manipulator can be used for the given input port.</returns>
+        protected bool CanManipulateInputNode(int inputPortIndex, out NodeModel inputNode)
+        {
+            bool manipulate = false;
+            inputNode = null;
+            Tuple<int, NodeModel> val;
+            if (Node.InputNodes.TryGetValue(inputPortIndex, out val))
+            {
+                if (val != null)
+                {
+                    inputNode = val.Item2;
+                    if (val.Item2 is DSCoreNodesUI.Input.DoubleSlider)
+                        manipulate = true;
+                }
+                else
+                {
+                    manipulate = true;
+                }
+            }
+            else if (inputPortIndex < Node.InPorts.Count)
+            {
+                manipulate = true;
+            }
+            return manipulate;
+        }
+
+        /// <summary>
+        /// Executes CreateAndConnectNodeCommand to create DoubleSlider and 
+        /// connect it's output port to the input port of the node.
+        /// </summary>
+        /// <param name="outputPortIndex">index of output port of slider</param>
+        /// <param name="inputPortIndex">index of input port of the node.</param>
+        /// <returns>New slider node</returns>
+        protected NodeModel CreateAndConnectInputNode(int outputPortIndex, int inputPortIndex)
+        {
+            var loc = ComputeInputNodeLocation(inputPortIndex);
+
+            // Create number slider node and connect to Point node
+            var inputNodeGuid = Guid.NewGuid();
+
+            var command = new DynamoModel.CreateAndConnectNodeCommand(inputNodeGuid, Node.GUID,
+                "DSCoreNodesUI.Input.DoubleSlider", outputPortIndex, inputPortIndex, loc.Item1, loc.Item2, false, false);
+
+            CommandExecutive.ExecuteCommand(command, UniqueId, ExtensionName);
+
+            var inputNode = WorkspaceModel.Nodes.FirstOrDefault(node => node.GUID == command.ModelGuid) as DoubleSlider;
+            return inputNode;
+        }
+
+        #endregion
+
+        #region private methods
+
+        /// <summary>
+        /// Computes location of the slider node to be connected to given input
+        /// port.
+        /// </summary>
+        /// <param name="inputPortIndex">Index of input port</param>
+        /// <returns>X, Y values of node location</returns>
+        private Tuple<double, double> ComputeInputNodeLocation(int inputPortIndex)
+        {
+            // node params (e.g. for slider node, specify range)
+            double y;
+            switch (inputPortIndex)
+            {
+                case 0:
+                    y = Node.Y - NewNodeOffsetY;
+                    break;
+                case 1:
+                    y = Node.Y;
+                    break;
+                default:
+                    y = Node.Y + NewNodeOffsetY;
+                    break;
+            }
+
+            // location (relative to Node)
+            double x = Node.X - NewNodeOffsetX;
+
+            return new Tuple<double, double>(x, y);
+        }
+
+        /// <summary>
+        /// Method to draw manipulator
+        /// </summary>
+        private void DrawManipulator()
+        {
+            var packages = GenerateRenderPackages();
+
+            BackgroundPreviewViewModel.AddGeometryForRenderPackages(packages);
+        }
+
+        /// <summary>
+        /// Subscribes various event handlers.
+        /// </summary>
+        private void AttachBaseHandlers()
+        {
+            BackgroundPreviewViewModel.ViewMouseMove += MouseMove;
+            BackgroundPreviewViewModel.ViewMouseDown += MouseDown;
+            BackgroundPreviewViewModel.ViewMouseUp += MouseUp;
+
+            Node.RequestRenderPackages += GenerateRenderPackages;
+        }
+
+        /// <summary>
+        /// Generates render packages for all the drawables of this manipulator.
+        /// Before actually generating the render packages it ensures that this
+        /// object is properly updated. This method is called when the output 
+        /// of the node is rendered.
+        /// </summary>
+        /// <returns>List of render packages</returns>
+        private IEnumerable<IRenderPackage> GenerateRenderPackages()
+        {
+            // Currently collections are not being supported
+            //if(Node.CachedValue.IsCollection) return new List<IRenderPackage>();
+
+            var packages = new List<IRenderPackage>();
+
+            AssignInputNodes();
+
+            if (!Node.IsSelected)
+            {
+                return packages;
+            }
+
+            UpdatePosition();
+
+            if (!Active)
+            {
+                return packages;
+            }
+
+            return BuildRenderPackage();
+        }
+
+        /// <summary>
+        /// Unsubscribes all the event handlers registered by this manipulator.
+        /// </summary>
+        private void DetachHandlers()
+        {
+            BackgroundPreviewViewModel.ViewMouseMove -= MouseMove;
+            BackgroundPreviewViewModel.ViewMouseDown -= MouseDown;
+            BackgroundPreviewViewModel.ViewMouseUp -= MouseUp;
+
+            Node.RequestRenderPackages -= GenerateRenderPackages;
+        }
+
+        #endregion
+
+        #region Interface methods
+
+        public void Dispose()
+        {
+            Dispose(true);
+
+            DetachHandlers();
+        }
+
+        /// <summary>
+        /// Builds render packages as required for rendering this manipulator.
+        /// </summary>
+        /// <returns>List of render packages</returns>
+        public IEnumerable<IRenderPackage> BuildRenderPackage()
+        {
+            var packages = new List<IRenderPackage>();
+            var gizmos = GetGizmos();
+            foreach (var item in gizmos)
+            {
+                packages.AddRange(item.GetDrawables(RenderPackageFactory));
+            }
+
+            return packages;
+        }
+        #endregion
+    }
+
+    public class CompositeManipulator : INodeManipulator
+    {
+        private readonly List<INodeManipulator> subManipulators;
+        public CompositeManipulator(IEnumerable<INodeManipulator> manipulators)
+        {
+            subManipulators = manipulators.ToList();
+        }
+
+        #region Interface methods
+
+        public void Dispose()
+        {
+            subManipulators.ForEach(x => x.Dispose());
+        }
+
+        public IEnumerable<IRenderPackage> BuildRenderPackage()
+        {
+            var packages = new List<IRenderPackage>();
+            foreach (var subManipulator in subManipulators)
+            {
+                packages.AddRange(subManipulator.BuildRenderPackage());
+            }
+            return packages;
+        }
+
+        #endregion
+    }
+}

--- a/src/DynamoManipulation/NodeManipulatorFactoryLoader.cs
+++ b/src/DynamoManipulation/NodeManipulatorFactoryLoader.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using Dynamo.Graph.Nodes.ZeroTouch;
+
+namespace Dynamo.Manipulation
+{
+    public class NodeManipulatorFactoryLoader : INodeManipulatorFactoryLoader
+    {
+        public Dictionary<Type, IEnumerable<INodeManipulatorFactory>> Load()
+        {
+            return new Dictionary<Type, IEnumerable<INodeManipulatorFactory>>
+            {
+                { typeof(DSFunction), new[] { new ZeroTouchManipulatorFactory() } }
+            };
+        }
+    }
+}

--- a/src/DynamoManipulation/PointOnCurveManipulator.cs
+++ b/src/DynamoManipulation/PointOnCurveManipulator.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Autodesk.DesignScript.Geometry;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.ZeroTouch;
+using Dynamo.Nodes;
+
+namespace Dynamo.Manipulation
+{
+    public sealed class PointOnCurveManipulatorFactory : INodeManipulatorFactory
+    {
+        public INodeManipulator Create(NodeModel node, DynamoManipulationExtension manipulatorContext)
+        {
+            return new PointOnCurveManipulator(node as DSFunction, manipulatorContext);
+        }
+    }
+
+    class PointOnCurveManipulator : NodeManipulator
+    {
+        private const double NewNodeOffsetX = 350;
+        private const double NewNodeOffsetY = 50;
+
+        private Point pointOnCurve;
+
+        private Curve curve;
+
+        private Vector tangent;
+
+        private NodeModel inputNode;
+
+        private TranslationGizmo gizmo;
+
+        internal PointOnCurveManipulator(DSFunction node, DynamoManipulationExtension manipulatorContext)
+            : base(node, manipulatorContext)
+        {
+        }
+
+        #region abstract method implementation
+
+        protected override IEnumerable<IGizmo> GetGizmos()
+        {
+            UpdateGizmo();
+
+            yield return gizmo;
+        }
+
+        private void UpdateGizmo()
+        {
+            if (null == gizmo)
+                gizmo = new TranslationGizmo(pointOnCurve, tangent, 6);
+            else
+                gizmo.UpdateGeometry(pointOnCurve, tangent, null, null, 6);
+        }
+
+        protected override void AssignInputNodes()
+        {
+            curve = null;
+            NodeModel curveNode;
+            CanManipulateInputNode(0, out curveNode);
+            if (null == curveNode)
+                return; //Not enough input to manipulate
+
+            if (!CanManipulateInputNode(1, out inputNode))
+                return;
+
+            try
+            {
+                curve = GetFirstValueFromNode(curveNode) as Curve;
+                if (null == curve)
+                    return;
+            }
+            catch (Exception ex) 
+            { 
+                return; 
+            }
+        }
+
+        protected override void UpdatePosition()
+        {
+            Active = false;
+            if (curve == null) //Curve is not initialized, can't be manipulated now.
+                return;
+
+            if (pointOnCurve == null)
+                pointOnCurve = curve.StartPoint;
+
+            var oldPoint = Point.ByCoordinates(pointOnCurve.X, pointOnCurve.Y, pointOnCurve.Z);
+            try
+            {
+                //Node output could be a collection, consider the first item as origin.
+                Point pt = GetFirstValueFromNode(Node) as Point;
+                if (pt != null)
+                {
+                    var param = curve.ParameterAtPoint(pt);
+                    tangent = curve.TangentAtParameter(param);
+                    pointOnCurve = Point.ByCoordinates(pt.X, pt.Y, pt.Z);
+                }
+            }
+            catch (Exception)
+            {
+                pointOnCurve = oldPoint;
+            }
+
+            Active = tangent != null;
+        }
+
+        protected override IEnumerable<NodeModel> OnGizmoClick(IGizmo gizmo, object hitObject)
+        {
+            var axis = hitObject as Vector;
+            if (null == axis) return null;
+            
+            if(null == inputNode)
+            {
+                inputNode = CreateAndConnectInputNode(0, 1);
+            }
+
+            return new[] { inputNode };
+        }
+
+        protected override Point OnGizmoMoved(IGizmo gizmo, Vector offset)
+        {
+            var newPosition = pointOnCurve.Add(offset);
+            newPosition = curve.ClosestPointTo(newPosition);
+            var param = curve.ParameterAtPoint(newPosition);
+            param = Math.Round(param, 3);
+            newPosition = curve.PointAtParameter(param);
+            if (inputNode != null)
+            {
+                dynamic uinode = inputNode;
+                uinode.Value = param;
+            }
+
+            return newPosition;
+        }
+
+        #endregion
+    }
+}

--- a/src/DynamoManipulation/Properties/AssemblyInfo.cs
+++ b/src/DynamoManipulation/Properties/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DirectManipulation")]
+[assembly: AssemblyCulture("")]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7d1c274e-66f1-412b-abf1-c8f98b7cf364")]

--- a/src/DynamoManipulation/TranslationGizmo.cs
+++ b/src/DynamoManipulation/TranslationGizmo.cs
@@ -1,0 +1,446 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using Autodesk.DesignScript.Geometry;
+using Autodesk.DesignScript.Interfaces;
+using Dynamo.Visualization;
+using Dynamo.Wpf.ViewModels.Watch3D;
+
+namespace Dynamo.Manipulation
+{
+    /// <summary>
+    /// Interface to define visuals of a manipulator, called Gizmo.
+    /// </summary>
+    public interface IGizmo
+    {
+        /// <summary>
+        /// Unique name of the Gizmo
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Base position of the Gizmo
+        /// </summary>
+        Point Origin { get; }
+
+        /// <summary>
+        /// Performs hit test based on view projection ray and returns the
+        /// object which is hit. The hit object could be an axis, plane or
+        /// rotational arc etc.
+        /// </summary>
+        /// <param name="source">Source of the view projection ray.</param>
+        /// <param name="direction">View projection direction.</param>
+        /// <param name="hitObject">The object hit by the input ray.</param>
+        /// <returns>True when an object is hit, else false.</returns>
+        bool HitTest(Point source, Vector direction, out object hitObject);
+
+        /// <summary>
+        /// Computes new offset based on the hit point.
+        /// </summary>
+        /// <param name="newPosition">New position of mouse click.</param>
+        /// <param name="viewDirection">view projection direction</param>
+        /// <returns>Offset vector of hit point wrt it's origin.</returns>
+        Vector GetOffset(Point newPosition, Vector viewDirection);
+
+        /// <summary>
+        /// Gets render package for all the drawables of this Gizmo.
+        /// </summary>
+        /// <param name="factory">Render package factory</param>
+        /// <returns>List of render packages.</returns>
+        IEnumerable<IRenderPackage> GetDrawables(IRenderPackageFactory factory);
+    }
+
+    /// <summary>
+    /// Translation Gizmo, that handles translation.
+    /// </summary>
+    class TranslationGizmo : IGizmo
+    {
+        /// <summary>
+        /// Describes an axis with it's name, direction and color.
+        /// </summary>
+        struct AxisDescriptor
+        {
+            public Vector Axis; //Axis direction
+            public string Name; //Name of the axis
+            public Color Color; //Color for axis
+        }
+
+        /// <summary>
+        /// Defines type of planes.
+        /// </summary>
+        enum Planes
+        {
+            xyPlane,
+            yzPlane,
+            zxPlane,
+        }
+
+        #region Private members
+
+        /// <summary>
+        /// Origin position.
+        /// </summary>
+        private Point position;
+
+        /// <summary>
+        /// List of axis available for manipulation
+        /// </summary>
+        private List<AxisDescriptor> axes = new List<AxisDescriptor>();
+
+        /// <summary>
+        /// List of planes available for manipulation
+        /// </summary>
+        private List<Plane> planes = new List<Plane>();
+
+        /// <summary>
+        /// Scale to draw the gizmo
+        /// </summary>
+        private double scale = 1.0;
+
+        /// <summary>
+        /// Hit Data
+        /// </summary>
+        private Vector hitAxis = null;
+        private Plane hitPlane = null;
+
+        /// <summary>
+        /// Name of the gizmo.
+        /// </summary>
+        private string name = "_gizmo";
+
+        #endregion
+
+        #region public methods and constructors
+
+        /// <summary>
+        /// Constructs a linear gizmo, can be moved in one direction only.
+        /// </summary>
+        /// <param name="origin">Position of the gizmo.</param>
+        /// <param name="axis1">Axis of freedom</param>
+        /// <param name="size">Visual size of the Gizmo</param>
+        public TranslationGizmo(Point origin, Vector axis1, double size)
+        {
+            UpdateGeometry(origin, axis1, null, null, size);
+        }
+
+        /// <summary>
+        /// Constructs planar gizmo, can be manipulated in two directions.
+        /// </summary>
+        /// <param name="origin">Position of the gizmo</param>
+        /// <param name="axis1">First axis of freedom</param>
+        /// <param name="axis2">Second axis of freedom</param>
+        /// <param name="size">Visual size of the Gizmo</param>
+        public TranslationGizmo(Point origin, Vector axis1, Vector axis2, double size)
+        {
+            UpdateGeometry(origin, axis1, axis2, null, size);
+        }
+
+        /// <summary>
+        /// Construcs a 3D gizmo, can be manipulated in all three directions.
+        /// </summary>
+        /// <param name="origin">Position of the gizmo</param>
+        /// <param name="axis1">First axis of freedom</param>
+        /// <param name="axis2">Second axis of freedom</param>
+        /// <param name="axis3">Third axis of freedom</param>
+        /// <param name="size">Visual size of the Gizmo</param>
+        public TranslationGizmo(Point origin, Vector axis1, Vector axis2, Vector axis3, double size)
+        {
+            UpdateGeometry(origin, axis1, axis2, axis3, size);
+        }
+
+        /// <summary>
+        /// Construcs a 3D gizmo, can be manipulated in all three directions.
+        /// </summary>
+        /// <param name="origin">Position of the gizmo</param>
+        /// <param name="axis1">First axis of freedom</param>
+        /// <param name="axis2">Second axis of freedom</param>
+        /// <param name="axis3">Third axis of freedom</param>
+        /// <param name="size">Visual size of the Gizmo</param>
+        public void UpdateGeometry(Point origin, Vector axis1, Vector axis2, Vector axis3, double size)
+        {
+            if (axis1 == null)
+                throw new ArgumentNullException("axis1");
+
+            //Reset the dataset, but don't reset the cached hitAxis or hitPlane.
+            //hitAxis and hitPlane are used to compute the offset for a move.
+            axes.Clear();
+            planes.Clear();
+            
+            scale = size;
+            position = origin;
+            var col = Convert.ToByte(255);
+            
+            axes.Add(new AxisDescriptor() { Axis = axis1, Color = Color.FromRgb(col, 0, 0), Name = "_xAxis" });
+            if (axis2 != null)
+            {
+                axes.Add(new AxisDescriptor() { Axis = axis2, Color = Color.FromRgb(0, col, 0), Name = "_yAxis" });
+                planes.Add(Plane.ByOriginXAxisYAxis(position, axis1, axis2));
+            }
+            if (axis3 != null)
+            {
+                axes.Add(new AxisDescriptor() { Axis = axis3, Color = Color.FromRgb(0, 0, col), Name = "_zAxis" });
+                if (axis2 != null)
+                    planes.Add(Plane.ByOriginXAxisYAxis(position, axis2, axis3));
+                planes.Add(Plane.ByOriginXAxisYAxis(position, axis3, axis1));
+            }
+
+            if (axes.Count == 1 && hitAxis != null)
+                hitAxis = axes.First().Axis;
+        }
+
+        #endregion
+
+        #region private methods
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="direction"></param>
+        /// <returns></returns>
+        private object HitTest(Point source, Vector direction)
+        {
+            double tolerance = 0.15; //Hit tolerance
+            
+            using (var ray = GetRayGeometry(source, direction))
+            {
+                //First hit test for position
+                if (ray.DistanceTo(position) < tolerance)
+                {
+                    if (planes.Any())
+                        return planes.First();//Xy or first available plane is hit
+                    
+                    return axes.First().Axis; //xAxis or first axis is hit
+                }
+
+                foreach (var plane in planes)
+                {
+                    var pt = plane.Intersect(ray).FirstOrDefault() as Point;
+                    if (pt != null)
+                    {
+                        var vec = Vector.ByTwoPoints(position, pt);
+                        var dot1 = plane.XAxis.Dot(vec);
+                        var dot2 = plane.YAxis.Dot(vec);
+                        if( dot1 > 0 && dot2 > 0 && dot1 < scale/2 && dot2 < scale/2)
+                            return plane; //specific plane is hit
+                    }
+                }
+
+                foreach (var a in axes)
+                {
+                    using (var line = Line.ByStartPointDirectionLength(position, a.Axis, scale))
+                    {
+                        if (line.DistanceTo(ray) < tolerance)
+                            return a.Axis; //specific axis is hit.
+                    }
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="direction"></param>
+        /// <returns></returns>
+        private Line GetRayGeometry(Point source, Vector direction)
+        {
+            double size = position.DistanceTo(source) * 100;
+            return Line.ByStartPointDirectionLength(source, direction, size);
+        }
+
+        #endregion
+
+        #region interface methods
+
+        /// <summary>
+        /// Name of the Gizmo
+        /// </summary>
+        public string Name 
+        {
+            get { return name; }
+            set { name = value; }
+        }
+
+        /// <summary>
+        /// Origin of the Gizmo
+        /// </summary>
+        public Point Origin
+        {
+            get { return position; }
+            set { position = value; }
+        }
+
+        /// <summary>
+        /// Performs hit test on Gizmo to find out hit object. The returned 
+        /// hitObject could be either axis vector or a plane.
+        /// </summary>
+        /// <param name="source">Mouse click source for hit test</param>
+        /// <param name="direction">View projection direction</param>
+        /// <param name="hitObject">object hit</param>
+        /// <returns>True if Gizmo was hit successfully</returns>
+        public bool HitTest(Point source, Vector direction, out object hitObject)
+        {
+            hitAxis = null;
+            hitPlane = null; //reset hit objects
+            hitObject = HitTest(source, direction);
+            hitAxis = hitObject as Vector;
+            if (hitAxis == null)
+                hitPlane = hitObject as Plane;
+
+            return hitObject != null;
+        }
+
+        /// <summary>
+        /// Computes move vector, based on new position of mouse and view direction.
+        /// </summary>
+        /// <param name="newPosition">New mouse position</param>
+        /// <param name="viewDirection">view direction</param>
+        /// <returns>Offset vector wrt Origin</returns>
+        public Vector GetOffset(Point newPosition, Vector viewDirection)
+        {
+            Point hitPoint = position;
+            using (var ray = GetRayGeometry(newPosition, viewDirection))
+            {
+                if (hitPlane != null)
+                    hitPoint = hitPlane.Intersect(ray).FirstOrDefault() as Point;
+                else if (hitAxis != null)
+                {
+                    var axis = hitAxis.Cross(viewDirection);
+                    var plane = Plane.ByOriginXAxisYAxis(position, hitAxis, axis);
+                    hitPoint = plane.Intersect(ray).FirstOrDefault() as Point;
+                    if (null != hitPoint)
+                    {
+                        var projection = hitAxis.Dot(Vector.ByTwoPoints(position, hitPoint));
+                        hitPoint = position.Add(hitAxis.Normalized().Scale(projection));
+                    }
+                    else
+                    {
+                        using (var axisLine = RayExtensions.ToOriginCenteredLine(position, hitAxis))
+                            hitPoint = axisLine.ClosestPointTo(ray);
+                    }
+                }
+            }
+            if (hitPoint == null)
+                return Vector.ByCoordinates(0, 0, 0);
+
+            return Vector.ByTwoPoints(position, hitPoint);
+        }
+
+        /// <summary>
+        /// Gets drawables to render this Gizmo
+        /// </summary>
+        /// <param name="factory">Render package factory</param>
+        /// <returns>List of render package</returns>
+        public IEnumerable<IRenderPackage> GetDrawables(IRenderPackageFactory factory)
+        {
+            List<IRenderPackage> drawables = new List<IRenderPackage>();
+            foreach (var axis in axes)
+            {
+                IRenderPackage package = factory.CreateRenderPackage();
+                DrawAxis(ref package, axis);
+                drawables.Add(package);
+            }
+
+            var p = Planes.xyPlane;
+            foreach (var plane in planes)
+            {
+                IRenderPackage package = factory.CreateRenderPackage();
+                DrawPlane(ref package, plane, p++);
+                drawables.Add(package);
+            }
+
+            if(null != hitAxis)
+            {
+                IRenderPackage package = factory.CreateRenderPackage();
+                DrawAxisLine(ref package, hitAxis, "_xAxisLine");
+                drawables.Add(package);
+            }
+            if(null != hitPlane)
+            {
+                IRenderPackage package = factory.CreateRenderPackage();
+                DrawAxisLine(ref package, hitPlane.XAxis, "_xAxisLine");
+                drawables.Add(package);
+                
+                package = factory.CreateRenderPackage();
+                DrawAxisLine(ref package, hitPlane.YAxis, "_yAxisLine");
+                drawables.Add(package);
+            }
+            return drawables;
+        }
+
+        #endregion
+
+        #region Helper methods to draw the gizmo
+
+        /// <summary>
+        /// Draws axis line
+        /// </summary>
+        /// <param name="package"></param>
+        /// <param name="axis"></param>
+        /// <param name="name"></param>
+        private void DrawAxisLine(ref IRenderPackage package, Vector axis, string name)
+        {
+            package.Description = RenderDescriptions.AxisLine + Name + name;
+            using (var line = RayExtensions.ToOriginCenteredLine(Origin, axis))
+            {
+                package.AddLineStripVertexCount(2);
+                package.AddLineStripVertexColor(100, 100, 100, 255);
+                package.AddLineStripVertex(line.StartPoint.X, line.StartPoint.Y, line.StartPoint.Z);
+                package.AddLineStripVertexColor(100, 100, 100, 255);
+                package.AddLineStripVertex(line.EndPoint.X, line.EndPoint.Y, line.EndPoint.Z);
+            }
+        }
+
+        /// <summary>
+        /// Draws plane at half the scale.
+        /// </summary>
+        /// <param name="package"></param>
+        /// <param name="plane"></param>
+        /// <param name="name"></param>
+        private void DrawPlane(ref IRenderPackage package, Plane plane, Planes name)
+        {
+            package.Description = RenderDescriptions.ManipulatorPlane + Name + name.ToString();
+            var p1 = Origin.Add(plane.XAxis.Scale(scale/2));
+            var p2 = p1.Add(plane.YAxis.Scale(scale/2));
+            var p3 = Origin.Add(plane.YAxis.Scale(scale/2));
+            
+            package.AddLineStripVertexCount(3);
+            package.AddLineStripVertexColor(0, 0, 255, 255);
+            package.AddLineStripVertex(p1.X, p1.Y, p1.Z);
+
+            package.AddLineStripVertexColor(0, 0, 255, 255);
+            package.AddLineStripVertex(p2.X, p2.Y, p2.Z);
+
+            package.AddLineStripVertexColor(0, 0, 255, 255);
+            package.AddLineStripVertex(p3.X, p3.Y, p3.Z);
+        }
+
+        /// <summary>
+        /// Draws axis as 3D arrow based on scale factor.
+        /// </summary>
+        /// <param name="package"></param>
+        /// <param name="axis"></param>
+        private void DrawAxis(ref IRenderPackage package, AxisDescriptor axis)
+        {
+            package.Description = RenderDescriptions.ManipulatorAxis + Name + axis.Name;
+
+            using (var axisEnd = Origin.Add(axis.Axis.Scale(scale)))
+            {
+                var color = axis.Color;
+                package.AddLineStripVertexCount(2);
+                package.AddLineStripVertexColor(color.R, color.G, color.B, color.A);
+                package.AddLineStripVertex(Origin.X, Origin.Y, Origin.Z);
+                package.AddLineStripVertexColor(color.R, color.G, color.B, color.A);
+                package.AddLineStripVertex(axisEnd.X, axisEnd.Y, axisEnd.Z);
+            }
+        }
+
+        #endregion
+
+    }
+}

--- a/src/DynamoManipulation/ZeroTouchManipulatorCreator.cs
+++ b/src/DynamoManipulation/ZeroTouchManipulatorCreator.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.ZeroTouch;
+
+namespace Dynamo.Manipulation
+{
+    internal class ZeroTouchManipulatorFactory : INodeManipulatorFactory
+    {
+        private readonly Dictionary<string, IEnumerable<INodeManipulatorFactory>> manipulatorCreators;
+
+
+        public IEnumerable<string> NodeNames
+        {
+            get { return manipulatorCreators.Select(pair => pair.Key); }
+        }
+
+        internal ZeroTouchManipulatorFactory()
+        {
+            manipulatorCreators = new Dictionary<string, IEnumerable<INodeManipulatorFactory>>
+            {
+                {
+                    "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+                    new INodeManipulatorFactory[] { new MousePointManipulatorFactory() }
+                },
+                {
+                    "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double",
+                    new INodeManipulatorFactory[] { new MousePointManipulatorFactory() }
+                },
+                {
+                    "Autodesk.DesignScript.Geometry.Point.ByCartesianCoordinates@Autodesk.DesignScript.Geometry.CoordinateSystem,double,double,double",
+                    new INodeManipulatorFactory[] { new MousePointManipulatorFactory() }
+                },
+                {
+                    "Autodesk.DesignScript.Geometry.Curve.PointAtParameter@double",
+                    new INodeManipulatorFactory[] { new PointOnCurveManipulatorFactory() }
+                }
+            };
+        }
+
+        public INodeManipulator Create(NodeModel node, DynamoManipulationExtension manipulatorContext)
+        {
+            var dsFunction = node as DSFunction;
+            if (dsFunction == null) return null;
+
+            var name = dsFunction.CreationName;
+
+            IEnumerable<INodeManipulatorFactory> creators;
+            if (manipulatorCreators.TryGetValue(name, out creators))
+            {
+                return new CompositeManipulator(creators.Select(x => x.Create(node, manipulatorContext)).ToList());
+            }
+            return null;
+        }
+
+    }
+}


### PR DESCRIPTION
### Purpose

This submission introduces Direct Manipulation feature in Dynamo. Using this feature users can now manipulate some of the geometry in 3D view and eventually update the graph automatically.

**Point Manipulators:**
- A point can be manipulated with the help of Gizmo created at the position of the point. 
![image](https://cloud.githubusercontent.com/assets/1754137/11319864/f0696dd2-90c0-11e5-8b8b-d77d5a3556e9.png)
- Based on the degree of freedom of the point axis of the Gizmo is shown. e.g. If `x` and `y` input are same for the point then point can be manipulated along `x=y` line only in the `xy plane` however, it can also be manipulated in `z` axis if it's unconstrained.
- The points that can be manipulated are shown in `red`. When such a point is selected, the appropriate gizmo is shown.
- The gizmo can be moved along an axis as well as along a plane.
- Points created using `Point.ByCoordinates` and `Curve.PointAtParameter` nodes can now be manipulated. 

**Direct Manipulation Framework:**

- `DynamoManipulationExtension` implements `IViewExtension` interface and provides the entry point of the Dynamo Manipulator framework. It receives view specific event notification and subsequently controls the lifetime of manipulators as well as delegates mouse event to the manipulators.
- The interface `INodeManipulatorFactoryLoader` is defined to initialize the list of manipulator factories based on node type.
- The interface `INodeManipulatorFactory` is defined to create a set of manipulators for the given node.
- The interface `INodeManipulator` represents a manipulator for a given node type.
- The interface `IGizmo` represents visuals of the manipulator and provide hit test as well as mouse move offset calculations.
- The abstract class `NodeManipulator` implements interface `INodeManipulator`. This class provides the basic framework for mouse event handling and updating the input nodes due to manipulation. The derived class implements logic for assigning and updating the input nodes, the creation of gizmos, handling gizmo click and move events, updating gizmo positions, etc.
- `MousePointManipulator` and `PointOnCurveManipulator` are two concrete implementation of `NodeManipulator` class.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

- [ ] @ikeough
- [ ] @aparajit-pratap  