### PR TITLE
Fix MAGN-8827 Revit and Dynamo have crashes after connecting two identical nodes

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -648,22 +648,31 @@ namespace Dynamo.Graph.Nodes
         internal bool IsAnyUpstreamFrozen()
         {
             bool ret = false;
-            return CheckIfAnyUpstreamNodeIsFrozen(this, ref ret);
+            List<NodeModel> nodes = new List<NodeModel>();
+            return CheckIfAnyUpstreamNodeIsFrozen(this, nodes, ref ret);
         }
 
-        private bool CheckIfAnyUpstreamNodeIsFrozen(NodeModel node, ref bool ret)
+        private bool CheckIfAnyUpstreamNodeIsFrozen(NodeModel node, List<NodeModel> nodes, ref bool ret)
         {             
             var sets = node.InputNodes.Values;
             var inpNodes = sets.Where(x => x != null).Select(z => z.Item2).Distinct();
             foreach (var inode in inpNodes)
             {
+                //If there is a cyclic-dependency, stop traversing this branch
+                if (nodes.Contains(inode))
+                {
+                    continue;
+                }
+
                 if (inode.isFrozenExplicitly)
                 {
                     ret = true;
                     break;
                 }
 
-                CheckIfAnyUpstreamNodeIsFrozen(inode, ref ret);
+                List<NodeModel> newNodes = new List<NodeModel>(nodes);
+                newNodes.Add(inode);
+                CheckIfAnyUpstreamNodeIsFrozen(inode, newNodes, ref ret);
             }
 
             return ret;

--- a/test/DynamoCoreTests/DynamoDefects.cs
+++ b/test/DynamoCoreTests/DynamoDefects.cs
@@ -472,7 +472,7 @@ namespace Dynamo.Tests
             AssertPreviewValue("56f3c0fd-d39c-46cb-a4ea-4f266f7a9fce", true);
         }
 
-        [Test, Category("Failure")]
+        [Test]
         public void CyclicDependency_Defect8827()
         {
             string openPath = Path.Combine(TestDirectory,


### PR DESCRIPTION
### Purpose

This is to fix MAGN-8827 which has regressed because a traverse of cyclic graph causes an infinite loop in NodeModel.CheckIfAnyUpstreamNodeIsFrozen.

The fix here is to break the circle if it is found the parent node has already been visited.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@aparajit-pratap 

### FYIs

@ramramps 