### PR TITLE
Fix MAGN-9129 Preview broken when creating family instances based on Revit References

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -553,12 +553,6 @@ namespace Dynamo.Graph.Workspaces
                 task.Completed += OnUpdateGraphCompleted;
                 RunSettings.RunEnabled = false; // Disable 'Run' button.
 
-                // Reset node states
-                foreach (var node in Nodes)
-                {
-                    node.WasInvolvedInExecution = false;
-                }
-
                 // The workspace has been built for the first time
                 silenceNodeModifications = false;
 

--- a/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
@@ -110,6 +110,7 @@ namespace Dynamo.Scheduler
             previewIdentifierName = initParams.PreviewIdentifierName;
 
             nodeGuid = nodeModel.GUID;
+            nodeModel.WasInvolvedInExecution = false;
             return true;
         }
 


### PR DESCRIPTION
### Purpose

This is to fix MAGN-9129 Preview broken when creating family instances based on Revit References.

Before scheduling a UpdateGraphAsyncTask task, all nodes will be set to indicate that they will not require to update their render packages. After the task is completed, those modified nodes will be set to indicate that they need to update their render packages. This usually works. But when two UpdateGraphAsyncTask tasks are scheduled immediately one after another, the status of those modified nodes in the first run will be reset before the second task run. As a result, some nodes may not update their render packages.

In the case of this defect, this is happening. When the model curve element is moved, it will trigger 5 nodes of the graph to run. When the task is completed, the family instance is modified and a new UpdateGraphAsynTask task will be scheduled before any other tasks are scheduled. The Element.Geometry node is not taken as a modified node in the second run and will not update its render package later.

The fix here is to reset the flag to false at the end of the initialization process for a rendering task related to it. The part to reset the flag before an UpdateGraphAsynTask task is removed. 

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@Benglin 

### FYIs

@ikeough @pboyer 