### PR TITLE
Package icons fix

### DIFF
--- a/src/DynamoCore/Library/LibraryCustomization.cs
+++ b/src/DynamoCore/Library/LibraryCustomization.cs
@@ -51,7 +51,7 @@ namespace Dynamo.Engine
 
             if (ResolveResourceAssembly(assemblyPath, pathManager, useAdditionalPaths, out resourceAssemblyPath))
             {
-                resAssembly = Assembly.LoadFrom(resourceAssemblyPath);
+                resAssembly = Assembly.LoadFile(resourceAssemblyPath);
             }
 
             // We need 'LibraryCustomization' if either one is not 'null'
@@ -107,6 +107,8 @@ namespace Dynamo.Engine
                 var fn = Path.GetFileNameWithoutExtension(assemblyLocation);
                 // First try side-by-side search for customization dll.
                 var dirName = Path.GetDirectoryName(assemblyLocation);
+                if (String.IsNullOrEmpty(dirName)) dirName = Directory.GetCurrentDirectory();
+
                 resourceAssemblyPath = Path.Combine(dirName, fn + Configurations.IconResourcesDLL);
 
                 if (File.Exists(resourceAssemblyPath))


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9057](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9057) Clockwork package Icons overwrite other package icons

Fix is pretty simple. Use `LoadFile` instead of `LoadFrom` and use absolute paths. Because `LoadFile` (I can't explain why) loads assembly from the first package.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@pboyer 
