### PR TITLE
Fix MAGN 5579 Variables inside a array index is unreliable

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -877,6 +877,7 @@ namespace Dynamo.Graph.Nodes
             {
                 var node = astNode as ArrayNode;
                 MapIdentifiers(node.Expr);
+                MapIdentifiers(node.Type);
             }
             else if (astNode is ExprListNode)
             {

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -980,6 +980,17 @@ var06 = g;
             Assert.AreEqual(0, CurrentDynamoModel.LibraryServices.LibraryManagementCore.BuildStatus.Warnings.Count());
         }
 
+
+        [Test]
+        [Category("RegressionTests")]
+        public void TestMultipleIndexingInCodeBlockNode()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\dsevaluation\TestVariableIndexingInCBN.dyn");
+            RunModel(openPath);
+
+            AssertPreviewValue("7cbc2d85-d837-4969-8eba-36f672c77d6f", 6);
+            AssertPreviewValue("ebb49227-2e2b-4861-b824-1574ba89b455", 6);
+        }
         #endregion
 
 

--- a/test/core/dsevaluation/TestVariableIndexingInCBN.dyn
+++ b/test/core/dsevaluation/TestVariableIndexingInCBN.dyn
@@ -1,0 +1,25 @@
+<Workspace Version="0.9.1.3293" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="cf93e9a4-04fa-4533-8284-3ccc8e559a6c" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="270" y="176" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" CodeText="{{{1,2,3}, {4, 5, 6}}, {{7, 8, 9}, {10, 11, 12}}, {{13, 14, 15}, {16, 17, 18}}};&#xA;1;&#xA;0;&#xA;1;&#xA;2;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="c1e3381e-3b5e-44b3-b6b2-ce1a2e8bd19f" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1051" y="174" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="i = 0;&#xA;k = 2;&#xA;a[i][j][k];&#xA;b[x][y][z];" ShouldFocus="false" />
+    <DSCoreNodesUI.Watch guid="7cbc2d85-d837-4969-8eba-36f672c77d6f" type="DSCoreNodesUI.Watch" nickname="Watch" x="1272.5" y="159.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" />
+    <DSCoreNodesUI.Watch guid="ebb49227-2e2b-4861-b824-1574ba89b455" type="DSCoreNodesUI.Watch" nickname="Watch" x="1279.5" y="278.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="cf93e9a4-04fa-4533-8284-3ccc8e559a6c" start_index="0" end="c1e3381e-3b5e-44b3-b6b2-ce1a2e8bd19f" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="cf93e9a4-04fa-4533-8284-3ccc8e559a6c" start_index="0" end="c1e3381e-3b5e-44b3-b6b2-ce1a2e8bd19f" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="cf93e9a4-04fa-4533-8284-3ccc8e559a6c" start_index="1" end="c1e3381e-3b5e-44b3-b6b2-ce1a2e8bd19f" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="cf93e9a4-04fa-4533-8284-3ccc8e559a6c" start_index="2" end="c1e3381e-3b5e-44b3-b6b2-ce1a2e8bd19f" end_index="3" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="cf93e9a4-04fa-4533-8284-3ccc8e559a6c" start_index="3" end="c1e3381e-3b5e-44b3-b6b2-ce1a2e8bd19f" end_index="4" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="cf93e9a4-04fa-4533-8284-3ccc8e559a6c" start_index="4" end="c1e3381e-3b5e-44b3-b6b2-ce1a2e8bd19f" end_index="5" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="c1e3381e-3b5e-44b3-b6b2-ce1a2e8bd19f" start_index="2" end="7cbc2d85-d837-4969-8eba-36f672c77d6f" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="c1e3381e-3b5e-44b3-b6b2-ce1a2e8bd19f" start_index="3" end="ebb49227-2e2b-4861-b824-1574ba89b455" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR is to fix [MAGN 5579 Variables inside a array index is unreliable](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5579). 

It is because of a bug in code block node renaming: only the first dimension indexing variable is renamed, but not the others. 