### PR TITLE
Manipulator state with RunSettings and Freeze

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/IWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/IWorkspaceModel.cs
@@ -7,12 +7,35 @@ namespace Dynamo.Graph.Workspaces
 {
     public interface IWorkspaceModel
     {
+        /// <summary>
+        /// Name of the workspace
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Gets description of the workspace
+        /// </summary>
         string Description { get; }
+
+        /// <summary>
+        /// Gets FileName of the workspace
+        /// </summary>
         string FileName { get; }
 
+        /// <summary>
+        /// Gets list of connectors in the workspace
+        /// </summary>
         IEnumerable<ConnectorModel> Connectors { get; }
+
+        /// <summary>
+        /// Gets list of nodes owned by this workspace.
+        /// </summary>
         IEnumerable<NodeModel> Nodes { get; }
+
+        /// <summary>
+        /// Gets list of selected nodes.
+        /// </summary>
+        IEnumerable<NodeModel> CurrentSelection { get; }
 
         double CenterX { get; }
         double CenterY { get; }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -410,6 +410,14 @@ namespace Dynamo.Graph.Workspaces
             } 
         }
 
+        public IEnumerable<NodeModel> CurrentSelection
+        {
+            get
+            {
+                return DynamoSelection.Instance.Selection.OfType<NodeModel>();
+            }
+        }
+
         /// <summary>
         /// List of subgraphs for graph layout algorithm.
         /// </summary>

--- a/src/DynamoManipulation/DynamoManipulationExtension.cs
+++ b/src/DynamoManipulation/DynamoManipulationExtension.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows.Input;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Models;
 using Dynamo.Visualization;
 using Dynamo.Wpf.Extensions;
 using Dynamo.Wpf.ViewModels.Watch3D;
@@ -19,10 +21,83 @@ namespace Dynamo.Manipulation
         private IEnumerable<NodeModel> manipulatorNodes;
         private ManipulatorDaemon manipulatorDaemon;
         private ViewLoadedParams viewLoadedParams;
+        private IWorkspaceModel workspaceModel;
 
         internal IWatch3DViewModel BackgroundPreviewViewModel { get; private set; }
         internal IRenderPackageFactory RenderPackageFactory { get; private set; }
-        internal IWorkspaceModel WorkspaceModel { get; private set; }
+        internal IWorkspaceModel WorkspaceModel 
+        {
+            get { return workspaceModel; }
+            private set { SetWorkSpaceModel(value); } 
+        }
+
+        /// <summary>
+        /// Sets the workspace model property and updates event handlers accordingly.
+        /// </summary>
+        /// <param name="wsm">Workspace Model to set</param>
+        private void SetWorkSpaceModel(IWorkspaceModel wsm)
+        {
+            var settings = GetRunSettings(workspaceModel);
+            if (settings != null)
+            {
+                //Remove RunSettings event handler from old run settings.
+                settings.PropertyChanged -= OnRunSettingsPropertyChanged;
+            }
+
+            workspaceModel = wsm;
+
+            settings = GetRunSettings(wsm);
+            if (settings != null)
+            {
+                //Register RunSettings event handler
+                settings.PropertyChanged += OnRunSettingsPropertyChanged;
+            }
+        }
+
+        /// <summary>
+        /// Event handler to monitor RunType property of RunSettings.
+        /// </summary>
+        private void OnRunSettingsPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != "RunType")
+                return;
+
+            var settings = sender as RunSettings;
+            if (settings == null) return;
+
+            if (settings.RunType != RunType.Automatic)
+            {
+                manipulatorDaemon.KillAll();//remove all manipulators
+            }
+            else if(settings.RunEnabled)
+            {
+                CreateManipulators(WorkspaceModel.CurrentSelection);
+            }
+        }
+
+        /// <summary>
+        /// Get RunSettings object for a given Workspace Model. 
+        /// </summary>
+        /// <param name="wsm">IWorkspaceModel object</param>
+        /// <returns>RunSettings</returns>
+        private RunSettings GetRunSettings(IWorkspaceModel wsm)
+        {
+            var homeWSM = wsm as HomeWorkspaceModel;
+            return homeWSM == null ? null : homeWSM.RunSettings;
+        }
+
+        /// <summary>
+        /// Checks if manipulators are allowed in current workspace or not.
+        /// </summary>
+        /// <returns></returns>
+        bool EnableManipulators()
+        {
+            //If we are not in Home workspace, or not in Automatic execution mode do nothing.
+            var settings = GetRunSettings(WorkspaceModel);
+            
+            return settings != null && settings.RunEnabled && settings.RunType == RunType.Automatic;
+        }
+
         internal ICommandExecutive CommandExecutive { get; private set; }
 
         public Dictionary<Type, IEnumerable<INodeManipulatorFactory>> ManipulatorCreators { get; set; }
@@ -192,10 +267,17 @@ namespace Dynamo.Manipulation
                 manipulatorDaemon.KillAll();
             }
 
-            if (e.NewItems == null) return;
+            if (e.NewItems == null || !EnableManipulators()) return;
 
-            foreach (var nm in e.NewItems.OfType<NodeModel>())
+            CreateManipulators(e.NewItems.OfType<NodeModel>());
+        }
+
+        private void CreateManipulators(IEnumerable<NodeModel> nodes)
+        {
+            foreach (var nm in nodes)
             {
+                if (nm.IsFrozen || !nm.IsSelected) continue;
+
                 manipulatorDaemon.CreateManipulator(nm, this);
             }
         }

--- a/src/DynamoManipulation/MousePointManipulator.cs
+++ b/src/DynamoManipulation/MousePointManipulator.cs
@@ -40,6 +40,11 @@ namespace Dynamo.Manipulation
        
         #region overridden methods
 
+        protected override bool CanMoveGizmo(IGizmo gizmo)
+        {
+            return base.CanMoveGizmo(gizmo);
+        }
+
         protected override void AssignInputNodes()
         {
             //Default axes
@@ -220,28 +225,17 @@ namespace Dynamo.Manipulation
 
             if (origin == null)
             {
-                origin = Point.Origin();
+                origin = Point.Origin(); //First time initialization
             }
 
-            // hack: to prevent node mirror value lookup from throwing an exception
-            var previousOrigin = Point.ByCoordinates(origin.X, origin.Y, origin.Z);
-            try
-            {
-                //Node output could be a collection, consider the first item as origin.
-                Point pt = GetFirstValueFromNode(Node) as Point;
-                origin = pt != null ? Point.ByCoordinates(pt.X, pt.Y, pt.Z) : origin;
-            }
-            catch (Exception)
-            {
-                origin = previousOrigin;
-            }
+            //Node output could be a collection, consider the first item as origin.
+            Point pt = GetFirstValueFromNode(Node) as Point;
+            if (null == pt) return; //The node output is not Point, could be a function object.
 
-            if (origin == null)
-            {
-                origin = Point.Origin();
-                return;
-            }
-
+            //Don't cache pt directly here, we need to create a copy, because 
+            //pt may be GC'ed by VM.
+            origin = Point.ByCoordinates(pt.X, pt.Y, pt.Z);
+            
             Active = true;
         }
 

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows.Input;
 using Autodesk.DesignScript.Geometry;
@@ -109,11 +110,7 @@ namespace Dynamo.Manipulation
         /// <param name="disposing"></param>
         protected virtual void Dispose(bool disposing)
         {
-            var gizmos = GetGizmos(false);
-            foreach (var item in gizmos)
-            {
-                BackgroundPreviewViewModel.DeleteGeometryForIdentifier(item.Name);
-            }
+            HideGizmos();
         }
 
         /// <summary>
@@ -142,7 +139,7 @@ namespace Dynamo.Manipulation
             GizmoInAction = null; //Reset Drag.
 
             var gizmos = GetGizmos(false);
-            if (!Active || null == gizmos || !gizmos.Any())
+            if (!Active || !IsEnabled() || null == gizmos || !gizmos.Any())
                 return;
 
             var ray = BackgroundPreviewViewModel.GetClickRay(mouseButtonEventArgs);
@@ -211,7 +208,7 @@ namespace Dynamo.Manipulation
             CommandExecutive = manipulatorContext.CommandExecutive;
             UniqueId = manipulatorContext.UniqueId;
             ExtensionName = manipulatorContext.Name;
-                
+            
             AttachBaseHandlers();
 
             DrawManipulator();
@@ -373,9 +370,6 @@ namespace Dynamo.Manipulation
         /// <returns>List of render packages</returns>
         private IEnumerable<IRenderPackage> GenerateRenderPackages()
         {
-            // Currently collections are not being supported
-            //if(Node.CachedValue.IsCollection) return new List<IRenderPackage>();
-
             var packages = new List<IRenderPackage>();
 
             AssignInputNodes();
@@ -387,7 +381,7 @@ namespace Dynamo.Manipulation
 
             UpdatePosition();
 
-            if (!Active)
+            if (!Active || !IsEnabled())
             {
                 return packages;
             }
@@ -405,6 +399,18 @@ namespace Dynamo.Manipulation
             BackgroundPreviewViewModel.ViewMouseUp -= MouseUp;
 
             Node.RequestRenderPackages -= GenerateRenderPackages;
+        }
+
+        /// <summary>
+        /// Removes Gizmos from background preview.
+        /// </summary>
+        private void HideGizmos()
+        {
+            var gizmos = GetGizmos(false);
+            foreach (var item in gizmos)
+            {
+                BackgroundPreviewViewModel.DeleteGeometryForIdentifier(item.Name);
+            }
         }
 
         #endregion
@@ -435,6 +441,21 @@ namespace Dynamo.Manipulation
             }
 
             return packages;
+        }
+
+        /// <summary>
+        /// Checks if manipulator is enabled or not. Manipulator is enabled 
+        /// only if node is not frozen or not setup as partially applied function 
+        /// or Run setting is set to Automatic.
+        /// </summary>
+        /// <returns>True if enabled and can be manipulated.</returns>
+        public bool IsEnabled()
+        {
+            if (Node.IsFrozen) return false;
+
+            if (Node.CachedValue.IsNull) return false;
+
+            return true;
         }
         #endregion
     }

--- a/src/DynamoManipulation/PointOnCurveManipulator.cs
+++ b/src/DynamoManipulation/PointOnCurveManipulator.cs
@@ -91,23 +91,17 @@ namespace Dynamo.Manipulation
             if (pointOnCurve == null)
                 pointOnCurve = curve.StartPoint;
 
-            var oldPoint = Point.ByCoordinates(pointOnCurve.X, pointOnCurve.Y, pointOnCurve.Z);
-            try
-            {
-                //Node output could be a collection, consider the first item as origin.
-                Point pt = GetFirstValueFromNode(Node) as Point;
-                if (pt != null)
-                {
-                    var param = curve.ParameterAtPoint(pt);
-                    tangent = curve.TangentAtParameter(param);
-                    pointOnCurve = Point.ByCoordinates(pt.X, pt.Y, pt.Z);
-                }
-            }
-            catch (Exception)
-            {
-                pointOnCurve = oldPoint;
-            }
+            //Node output could be a collection, consider the first item as origin.
+            Point pt = GetFirstValueFromNode(Node) as Point;
+            if (pt == null) return; //The node output is not Point, could be a function object.
 
+            var param = curve.ParameterAtPoint(pt);
+            tangent = curve.TangentAtParameter(param);
+            
+            //Don't cache pt directly here, need to create a copy, because 
+            //pt may be GC'ed by VM.
+            pointOnCurve = Point.ByCoordinates(pt.X, pt.Y, pt.Z); 
+        
             Active = tangent != null;
         }
 


### PR DESCRIPTION
### Purpose

This PR address few scenarios where manipulator needs to be disabled/enabled to address [MAGN-8814](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8814)

- Extended IWorkspaceModel interface to have a new property CurrentSelection, to provide list of selected nodes.
- DynamoManipulationExtension (IViewExtension) now registers event handlers for RunSetting property change notification.
- RunSettings is obtained from workspace model, this object is only available if the workspace model is of type HomeWorkspaceModel.
- When RunType is not set Automatic, the extension kills all the manipulators and when RunType is set back to Automatic, the extension creates manipulators for all nodes in selection.
- If the node manipulator Gizmos are shown and node is modified to Freeze (implicit or explicit), the manipulator is disabled so it has no effect of click and drag.
- If a node is Frozen, then upon selection we don't create manipulators for such node.

### Reviewer
- [ ] @aparajit-pratap 

### FYI
@monikaprabhu 