### PR TITLE
MAGN-9081 Publish Customizer gives crash for specific dyn metadata

### DIFF
--- a/src/DynamoPublish/ViewModels/PublishViewModel.cs
+++ b/src/DynamoPublish/ViewModels/PublishViewModel.cs
@@ -337,8 +337,12 @@ namespace Dynamo.Publish.ViewModels
                     UploadStateMessage = Resources.PublishUnauthorizedMessage;
                     break;
                 case PublishModel.UploadErrorType.InvalidNodes:
-                    var nodeList = String.Join(", ", model.InvalidNodeNames);
+                    var nodeList = string.Join(", ", model.InvalidNodeNames);
                     UploadStateMessage = Resources.InvalidNodeMessage + nodeList;
+                    break;
+                case PublishModel.UploadErrorType.CustomNodeNotFound:
+                    UploadStateMessage = string.Format(Resources.CustomNodeDefinitionNotFoundErrorMessage, 
+                        model.NotFoundCustomNodeName);
                     break;
                 case PublishModel.UploadErrorType.UnknownServerError:
                     UploadStateMessage = Resources.UnknownServerErrorMessage;

--- a/test/DynamoPublishTests/PublishModelTests.cs
+++ b/test/DynamoPublishTests/PublishModelTests.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Reach.Upload;
 using System.Net;
+using System.Threading;
 using Dynamo.Graph;
 using Dynamo.Graph.Workspaces;
 using Reach.Messages.Data;
@@ -78,6 +79,32 @@ namespace DynamoPublishTests
             OpenModel(openPath);
 
             AssertNumberOfDeps(1);
+        }
+
+        [Test]
+        public void WorkspaceDependencies_Collect_ShouldNotCrashForWorkspaceWithProxyNode()
+        {
+            var openPath = Path.Combine(TestDirectory, @"Libraries\DynamoPublishTests\CustCrash.dyn");
+            OpenModel(openPath);
+
+            var hws = CurrentDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
+            publishModel.SendAsync(hws);
+            
+            // wait for sending completion
+            PublishModel.UploadState state;
+            var timesOfSleep = 0;
+            do
+            {
+                Thread.Sleep(500);
+                timesOfSleep++;
+                state = publishModel.State;
+            } while ((state == PublishModel.UploadState.Uninitialized 
+                || state == PublishModel.UploadState.Uploading)
+            // do not wait indefinetely
+                && timesOfSleep < 10);
+
+            Assert.AreEqual(PublishModel.UploadState.Failed, publishModel.State);
+            Assert.IsNotNull(publishModel.NotFoundCustomNodeName);
         }
 
         [Test]

--- a/test/Libraries/DynamoPublishTests/CustCrash.dyn
+++ b/test/Libraries/DynamoPublishTests/CustCrash.dyn
@@ -1,0 +1,38 @@
+<Workspace Version="0.9.1.3264" X="-886.19966469962" Y="-204.177556976576" zoom="0.432968542147608" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="bad86e93-13f5-46a4-9252-33e51ae72943" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="2853.11670928591" y="898.125313855309" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <DSCoreNodesUI.Input.DoubleSlider guid="c77d8cb6-c11a-423b-b3b4-a43ea63a460d" type="DSCoreNodesUI.Input.DoubleSlider" nickname="Number Slider" x="2511.52074111123" y="923.981545806321" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
+      <System.Double>27.191</System.Double>
+      <Range min="10" max="40" step="0.1" />
+    </DSCoreNodesUI.Input.DoubleSlider>
+    <Dynamo.Graph.Nodes.CustomNodes.Function guid="743ff826-a557-4705-8c38-e2a7a5861acc" type="Dynamo.Graph.Nodes.CustomNodes.Function" nickname="MakeATruss" x="3287.14474416376" y="51.704330100282" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false">
+      <ID value="51ddd293-ef60-4227-a75c-1bedf7464198" />
+      <Name value="MakeATruss" />
+      <Description value="makes lines for a truss from a base curve" />
+      <Inputs>
+        <Input value="curve" />
+        <Input value="numberofcells" />
+      </Inputs>
+      <Outputs>
+        <Output value="truss lines" />
+      </Outputs>
+    </Dynamo.Graph.Nodes.CustomNodes.Function>
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="c77d8cb6-c11a-423b-b3b4-a43ea63a460d" start_index="0" end="bad86e93-13f5-46a4-9252-33e51ae72943" end_index="1" portType="0" />
+  </Connectors>
+  <Notes>
+    <Dynamo.Graph.Notes.NoteModel guid="968666e7-8e8a-4f05-952c-e77209e14dff" text="Break apart the polyCurves because we only want to send line segments to Revit." x="4384.32693150347" y="514.693060864088" />
+    <Dynamo.Graph.Notes.NoteModel guid="70224ca7-76b8-4f40-ae46-ca265b150214" text="Break apart the polyCurves because we only want to send line segments to Revit." x="4376.96131333028" y="825.338728820893" />
+  </Notes>
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

Crash occurs if there are proxy nodes (i.e. their definitions have not been loaded) and a corresponding exception is not handled.

It turned out that both `.dyn` files mentioned in the [MAGN-9081](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9081) are provided without all necessary `.dyf` files and actually `CustCrash.dyn` contains `MakeATruss` custom node and `Woven+Surface.dyn` contains `test` custom node besides `woven` one.

In this PR the exception is handled and a corresponding message is shown to a user:
![custcrash](https://cloud.githubusercontent.com/assets/7658189/11424611/3a01a6f0-9457-11e5-8795-6d495ec8532f.png)

### Reviewers

@pboyer 

### FYIs

@kronz, @jnealb 