### PR TITLE
Mouse over highlights on gizmo axes to visually indicate active axis

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -60,6 +60,8 @@ namespace Dynamo.Controls
 
             if (ViewModel == null) return;
 
+            UnRegisterViewEventHandlers();
+
             ViewModel.RequestAttachToScene -= ViewModelRequestAttachToSceneHandler;
             ViewModel.RequestCreateModels -= RequestCreateModelsHandler;
             ViewModel.RequestViewRefresh -= RequestViewRefreshHandler;
@@ -92,6 +94,13 @@ namespace Dynamo.Controls
                 ViewModel.OnViewMouseMove(sender, args);
             };
         }
+
+        private void UnRegisterViewEventHandlers()
+        {
+            watch_view.MouseDown -= ViewModel.OnViewMouseDown;
+            watch_view.MouseUp -= ViewModel.OnViewMouseUp;
+            watch_view.MouseMove -= ViewModel.OnViewMouseMove;
+         }		         
 
         private void UnregisterButtonHandlers()
         {

--- a/src/DynamoManipulation/MousePointManipulator.cs
+++ b/src/DynamoManipulation/MousePointManipulator.cs
@@ -99,7 +99,9 @@ namespace Dynamo.Manipulation
         /// <summary>
         /// Returns all the gizmos supported by this manipulator
         /// </summary>
-        /// <param name="createOrUpdate">Whether to create a new gizmo or update a gizmo if already present.</param>
+        /// <param name="createOrUpdate">
+        /// If true: Create a new gizmo or update a gizmo if already present.
+        /// If false: Query for existing gizmos</param>
         /// <returns>List of Gizmo</returns>
         protected override IEnumerable<IGizmo> GetGizmos(bool createOrUpdate)
         {

--- a/src/DynamoManipulation/MousePointManipulator.cs
+++ b/src/DynamoManipulation/MousePointManipulator.cs
@@ -92,30 +92,6 @@ namespace Dynamo.Manipulation
         }
 
         /// <summary>
-        /// Creates a new Gizmo or Updates existing Gizmo with new axes and origin.
-        /// This method is called every time Gizmo's are requested.
-        /// </summary>
-        private void UpdateGizmo()
-        {
-            var axes = new Vector[] { null, null, null };
-            //Extract axis information from the axis node pairs.
-            int index = 0;
-            foreach (var item in indexedAxisNodePairs)
-            {
-                axes[index++] = item.Value.Item1;
-            }
-
-            if (null == gizmo)
-            {
-                gizmo = new TranslationGizmo(origin, axes[0], axes[1], axes[2], 6);
-            }
-            else
-            {
-                gizmo.UpdateGeometry(origin, axes[0], axes[1], axes[2], 6);
-            }
-        }
-
-        /// <summary>
         /// Returns all the gizmos supported by this manipulator
         /// </summary>
         /// <param name="createIfNone">Whether to create new gizmo if not already present.</param>
@@ -157,7 +133,6 @@ namespace Dynamo.Manipulation
                 }
             }
 
-            int count = indexedAxisNodePairs.Count;
             var nodes = new Dictionary<int, NodeModel>(2); //placeholder for new nodes.
             foreach (var item in indexedAxisNodePairs)
             {
@@ -250,6 +225,31 @@ namespace Dynamo.Manipulation
         #region helpers
 
         /// <summary>
+        /// Creates a new Gizmo or Updates existing Gizmo with new axes and origin.
+        /// This method is called every time Gizmo's are requested.
+        /// </summary>
+        private void UpdateGizmo()
+        {
+            var axes = new Vector[] { null, null, null };
+            //Extract axis information from the axis node pairs.
+            int index = 0;
+            foreach (var item in indexedAxisNodePairs)
+            {
+                axes[index++] = item.Value.Item1;
+            }
+
+            if (null == gizmo)
+            {
+                gizmo = new TranslationGizmo(origin, axes[0], axes[1], axes[2], 6);
+            }
+            else
+            {
+                gizmo.UpdateGeometry(origin, axes[0], axes[1], axes[2], 6);
+            }
+        }
+
+
+        /// <summary>
         /// Decomposes given vector in natural axes and returns first axis.
         /// </summary>
         /// <param name="vector"></param>
@@ -289,54 +289,5 @@ namespace Dynamo.Manipulation
         }
 
         #endregion
-    }
-
-    internal static class PointExtensions
-    {
-        public static Point ToPoint(this Point3D point)
-        {
-            return Point.ByCoordinates(point.X, point.Y, point.Z);
-        }
-
-        public static Vector ToVector(this Vector3D vec)
-        {
-            return Vector.ByCoordinates(vec.X, vec.Y, vec.Z);
-        }
-    }
-
-    internal static class RayExtensions
-    {
-        private const double axisScaleFactor = 100;
-        private const double rayScaleFactor = 10000;
-
-        public static Line ToLine(this IRay ray)
-        {
-            var origin = ray.Origin.ToPoint();
-            var direction = ray.Direction.ToVector();
-            return Line.ByStartPointEndPoint(origin, origin.Add(direction.Scale(rayScaleFactor)));
-        }
-
-        public static Line ToOriginCenteredLine(this IRay ray)
-        {
-            var origin = ray.Origin.ToPoint();
-            var direction = ray.Direction.ToVector();
-            return ToOriginCenteredLine(origin, direction);
-        }
-
-        public static Line ToOriginCenteredLine(Point origin, Vector axis)
-        {
-            return Line.ByStartPointEndPoint(origin.Add(axis.Scale(-axisScaleFactor)),
-                origin.Add(axis.Scale(axisScaleFactor)));
-        }
-
-        public static Point GetOriginPoint(this IRay ray)
-        {
-            return ray.Origin.ToPoint();
-        }
-
-        public static Vector GetDirectionVector(this IRay ray)
-        {
-            return ray.Direction.ToVector();
-        }
     }
 }

--- a/src/DynamoManipulation/MousePointManipulator.cs
+++ b/src/DynamoManipulation/MousePointManipulator.cs
@@ -99,19 +99,22 @@ namespace Dynamo.Manipulation
         /// <summary>
         /// Returns all the gizmos supported by this manipulator
         /// </summary>
-        /// <param name="createIfNone">Whether to create new gizmo if not already present.</param>
+        /// <param name="createOrUpdate">Whether to create a new gizmo or update a gizmo if already present.</param>
         /// <returns>List of Gizmo</returns>
-        protected override IEnumerable<IGizmo> GetGizmos(bool createIfNone)
+        protected override IEnumerable<IGizmo> GetGizmos(bool createOrUpdate)
         {
             //Don't create a new gizmo if not requested
-            if (gizmo == null && !createIfNone)
+            if (gizmo == null && !createOrUpdate)
                 yield break;
 
             //No axis data, so no gizmo.
             if (!indexedAxisNodePairs.Any())
                 yield break;
 
-            UpdateGizmo();
+            if (createOrUpdate)
+            {
+                UpdateGizmo();
+            }
 
             yield return gizmo;
         }

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -66,9 +66,9 @@ namespace Dynamo.Manipulation
         /// <summary>
         /// Returns list of Gizmos used by this manipulator.
         /// </summary>
-        /// <param name="createIfNone">Whether to create new gizmo if not already present.</param>
+        /// <param name="createOrUpdate">Whether to create new gizmo or to update an existing one.</param>
         /// <returns>List of Gizmos.</returns>
-        protected abstract IEnumerable<IGizmo> GetGizmos(bool createIfNone);
+        protected abstract IEnumerable<IGizmo> GetGizmos(bool createOrUpdate);
 
         /// <summary>
         /// Implement to analyze inputs to the manipulator node and initialize them
@@ -140,8 +140,7 @@ namespace Dynamo.Manipulation
             GizmoInAction = null; //Reset Drag.
 
             var gizmos = GetGizmos(false);
-            if (!Active || !IsEnabled() || null == gizmos || !gizmos.Any())
-                return;
+            if (!Active || !IsEnabled() || null == gizmos || !gizmos.Any()) return;
 
             var ray = BackgroundPreviewViewModel.GetClickRay(mouseButtonEventArgs);
             if (ray == null) return;

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -194,12 +194,13 @@ namespace Dynamo.Manipulation
                 var gizmos = GetGizmos(false);
                 foreach (var item in gizmos)
                 {
-                    // Delete all transient axis line geometry
-                    BackgroundPreviewViewModel.DeleteGeometryForIdentifier(RenderDescriptions.AxisLine);
+                    // Delete all transient geometry used to highlight gizmo
+                    item.UnhighlightDrawablesForMouseOver(BackgroundPreviewViewModel);
 
                     object hitObject;
                     if (item.HitTest(clickRay.GetOriginPoint(), clickRay.GetDirectionVector(), out hitObject))
                     {
+                        // Draw transient drawables for gizmo during mouse over
                         var packages = item.GetDrawablesForMouseOverHighlight(RenderPackageFactory);
                         BackgroundPreviewViewModel.AddGeometryForRenderPackages(packages);
                     }

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -66,7 +66,9 @@ namespace Dynamo.Manipulation
         /// <summary>
         /// Returns list of Gizmos used by this manipulator.
         /// </summary>
-        /// <param name="createOrUpdate">Whether to create new gizmo or to update an existing one.</param>
+        /// <param name="createOrUpdate">
+        /// Create new gizmos or update existing ones gizmos if parameter is true
+        /// otherwise simply query for existing gizmos if false.</param>
         /// <returns>List of Gizmos.</returns>
         protected abstract IEnumerable<IGizmo> GetGizmos(bool createOrUpdate);
 
@@ -186,21 +188,7 @@ namespace Dynamo.Manipulation
 
             if (GizmoInAction == null)
             {
-                // Check for mouse over highlights on gizmo
-                var gizmos = GetGizmos(false);
-                foreach (var item in gizmos)
-                {
-                    // Delete all transient geometry used to highlight gizmo
-                    item.UnhighlightDrawablesForMouseOver(BackgroundPreviewViewModel);
-
-                    object hitObject;
-                    if (item.HitTest(clickRay.GetOriginPoint(), clickRay.GetDirectionVector(), out hitObject))
-                    {
-                        // Draw transient drawables for gizmo during mouse over
-                        var packages = item.GetDrawablesForMouseOverHighlight(RenderPackageFactory);
-                        BackgroundPreviewViewModel.AddGeometryForRenderPackages(packages);
-                    }
-                }
+                HighlightGizmoOnRollOver(clickRay);
                 return;
             }
 
@@ -428,6 +416,25 @@ namespace Dynamo.Manipulation
             foreach (var item in gizmos)
             {
                 BackgroundPreviewViewModel.DeleteGeometryForIdentifier(item.Name);
+            }
+        }
+
+        /// <summary>
+        /// Highlights/Unhighlights Gizmo drawables on mouse roll-over
+        /// </summary>
+        /// <param name="clickRay"></param>
+        private void HighlightGizmoOnRollOver(IRay clickRay)
+        {
+            var gizmos = GetGizmos(false);
+            foreach (var item in gizmos)
+            {
+                item.UnhighlightGizmo(BackgroundPreviewViewModel);
+
+                object hitObject;
+                if (item.HitTest(clickRay.GetOriginPoint(), clickRay.GetDirectionVector(), out hitObject))
+                {
+                    item.HighlightGizmo(BackgroundPreviewViewModel, RenderPackageFactory);
+                }
             }
         }
 

--- a/src/DynamoManipulation/PointOnCurveManipulator.cs
+++ b/src/DynamoManipulation/PointOnCurveManipulator.cs
@@ -41,12 +41,15 @@ namespace Dynamo.Manipulation
 
         #region abstract method implementation
 
-        protected override IEnumerable<IGizmo> GetGizmos(bool createIfNone)
+        protected override IEnumerable<IGizmo> GetGizmos(bool createOrUpdate)
         {
-            if (gizmo == null && !createIfNone)
+            if (gizmo == null && !createOrUpdate)
                 yield break;
 
-            UpdateGizmo();
+            if (createOrUpdate)
+            {
+                UpdateGizmo();
+            }
 
             yield return gizmo;
         }

--- a/src/DynamoManipulation/PointOnCurveManipulator.cs
+++ b/src/DynamoManipulation/PointOnCurveManipulator.cs
@@ -41,6 +41,13 @@ namespace Dynamo.Manipulation
 
         #region abstract method implementation
 
+        /// <summary>
+        /// Returns all the gizmos supported by this manipulator
+        /// </summary>
+        /// <param name="createOrUpdate">
+        /// If true: Create a new gizmo or update a gizmo if already present.
+        /// If false: Query for existing gizmos</param>
+        /// <returns></returns>
         protected override IEnumerable<IGizmo> GetGizmos(bool createOrUpdate)
         {
             if (gizmo == null && !createOrUpdate)

--- a/src/DynamoManipulation/TranslationGizmo.cs
+++ b/src/DynamoManipulation/TranslationGizmo.cs
@@ -51,6 +51,8 @@ namespace Dynamo.Manipulation
         /// <param name="factory">Render package factory</param>
         /// <returns>List of render packages.</returns>
         IEnumerable<IRenderPackage> GetDrawables(IRenderPackageFactory factory);
+
+        IEnumerable<IRenderPackage> GetDrawablesForMouseOverHighlight(IRenderPackageFactory factory);
     }
 
     /// <summary>
@@ -84,12 +86,12 @@ namespace Dynamo.Manipulation
         /// <summary>
         /// List of axis available for manipulation
         /// </summary>
-        private List<Vector> axes = new List<Vector>();
+        private readonly List<Vector> axes = new List<Vector>();
 
         /// <summary>
         /// List of planes available for manipulation
         /// </summary>
-        private List<Plane> planes = new List<Plane>();
+        private readonly List<Plane> planes = new List<Plane>();
 
         /// <summary>
         /// Scale to draw the gizmo
@@ -426,6 +428,28 @@ namespace Dynamo.Manipulation
             return drawables;
         }
 
+        public IEnumerable<IRenderPackage> GetDrawablesForMouseOverHighlight(IRenderPackageFactory factory)
+        {
+            var drawables = new List<IRenderPackage>();
+            if (null != hitAxis)
+            {
+                IRenderPackage package = factory.CreateRenderPackage();
+                DrawAxisLine(ref package, hitAxis, "xAxisLine");
+                drawables.Add(package);
+            }
+            if (null != hitPlane)
+            {
+                IRenderPackage package = factory.CreateRenderPackage();
+                DrawAxisLine(ref package, hitPlane.XAxis, "xAxisLine");
+                drawables.Add(package);
+
+                package = factory.CreateRenderPackage();
+                DrawAxisLine(ref package, hitPlane.YAxis, "yAxisLine");
+                drawables.Add(package);
+            }
+            return drawables;
+        }
+
         #endregion
 
         #region Helper methods to draw the gizmo
@@ -458,7 +482,7 @@ namespace Dynamo.Manipulation
         /// <param name="name"></param>
         private void DrawPlane(ref IRenderPackage package, Plane plane, Planes name)
         {
-            package.Description = string.Format("{0}_{1}_{2}", RenderDescriptions.ManipulatorPlane, Name, name.ToString()); 
+            package.Description = string.Format("{0}_{1}_{2}", RenderDescriptions.ManipulatorPlane, Name, name); 
             var p1 = Origin.Add(plane.XAxis.Scale(scale/2));
             var p2 = p1.Add(plane.YAxis.Scale(scale/2));
             var p3 = Origin.Add(plane.YAxis.Scale(scale/2));
@@ -482,7 +506,7 @@ namespace Dynamo.Manipulation
         private void DrawAxis(ref IRenderPackage package, Vector axis)
         {
             var axisType = GetAlignedAxis(axis);
-            package.Description = string.Format("{0}_{1}_{2}", RenderDescriptions.ManipulatorAxis, Name, axisType.ToString());
+            package.Description = string.Format("{0}_{1}_{2}", RenderDescriptions.ManipulatorAxis, Name, axisType);
 
             using (var axisEnd = Origin.Add(axis.Scale(scale)))
             {

--- a/src/DynamoManipulation/TranslationGizmo.cs
+++ b/src/DynamoManipulation/TranslationGizmo.cs
@@ -52,7 +52,18 @@ namespace Dynamo.Manipulation
         /// <returns>List of render packages.</returns>
         IEnumerable<IRenderPackage> GetDrawables(IRenderPackageFactory factory);
 
+        /// <summary>
+        /// Get packages for drawables to be highlighted on gizmo during mouse over
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <returns></returns>
         IEnumerable<IRenderPackage> GetDrawablesForMouseOverHighlight(IRenderPackageFactory factory);
+
+        /// <summary>
+        /// Delete all transient geometry used to highlight gizmo during mouse over 
+        /// </summary>
+        /// <param name="backgroundPreviewViewModel"></param>
+        void UnhighlightDrawablesForMouseOver(IWatch3DViewModel backgroundPreviewViewModel);
     }
 
     /// <summary>
@@ -448,6 +459,12 @@ namespace Dynamo.Manipulation
                 drawables.Add(package);
             }
             return drawables;
+        }
+
+        public void UnhighlightDrawablesForMouseOver(IWatch3DViewModel backgroundPreviewViewModel)
+        {
+            // Delete all transient geometry used to highlight gizmo
+            backgroundPreviewViewModel.DeleteGeometryForIdentifier(RenderDescriptions.AxisLine);
         }
 
         #endregion

--- a/src/DynamoManipulation/TranslationGizmo.cs
+++ b/src/DynamoManipulation/TranslationGizmo.cs
@@ -53,17 +53,18 @@ namespace Dynamo.Manipulation
         IEnumerable<IRenderPackage> GetDrawables(IRenderPackageFactory factory);
 
         /// <summary>
-        /// Get packages for drawables to be highlighted on gizmo during mouse over
-        /// </summary>
-        /// <param name="factory"></param>
-        /// <returns></returns>
-        IEnumerable<IRenderPackage> GetDrawablesForMouseOverHighlight(IRenderPackageFactory factory);
-
-        /// <summary>
-        /// Delete all transient geometry used to highlight gizmo during mouse over 
+        /// Highlight gizmo drawables or create transient geometry to highlight the gizmo during mouse over
         /// </summary>
         /// <param name="backgroundPreviewViewModel"></param>
-        void UnhighlightDrawablesForMouseOver(IWatch3DViewModel backgroundPreviewViewModel);
+        /// <param name="factory"></param>
+        /// <returns></returns>
+        void HighlightGizmo(IWatch3DViewModel backgroundPreviewViewModel, IRenderPackageFactory factory);
+
+        /// <summary>
+        /// Unhighlight gizmo drawables or delete all transient geometry used to highlight gizmo during mouse over 
+        /// </summary>
+        /// <param name="backgroundPreviewViewModel"></param>
+        void UnhighlightGizmo(IWatch3DViewModel backgroundPreviewViewModel);
     }
 
     /// <summary>
@@ -419,27 +420,34 @@ namespace Dynamo.Manipulation
                 DrawPlane(ref package, plane, p++);
                 drawables.Add(package);
             }
+            drawables.AddRange(GetDrawablesForTransientGeometry(factory));
 
-            if(null != hitAxis)
-            {
-                IRenderPackage package = factory.CreateRenderPackage();
-                DrawAxisLine(ref package, hitAxis, "xAxisLine");
-                drawables.Add(package);
-            }
-            if(null != hitPlane)
-            {
-                IRenderPackage package = factory.CreateRenderPackage();
-                DrawAxisLine(ref package, hitPlane.XAxis, "xAxisLine");
-                drawables.Add(package);
-                
-                package = factory.CreateRenderPackage();
-                DrawAxisLine(ref package, hitPlane.YAxis, "yAxisLine");
-                drawables.Add(package);
-            }
             return drawables;
         }
 
-        public IEnumerable<IRenderPackage> GetDrawablesForMouseOverHighlight(IRenderPackageFactory factory)
+        public void HighlightGizmo(IWatch3DViewModel backgroundPreviewViewModel, 
+            IRenderPackageFactory factory)
+        {
+            var drawables = GetDrawablesForTransientGeometry(factory);
+            backgroundPreviewViewModel.AddGeometryForRenderPackages(drawables);
+        }
+
+        public void UnhighlightGizmo(IWatch3DViewModel backgroundPreviewViewModel)
+        {
+            // Delete all transient geometry used to highlight gizmo
+            backgroundPreviewViewModel.DeleteGeometryForIdentifier(RenderDescriptions.AxisLine);
+        }
+
+        #endregion
+
+        #region Helper methods to draw the gizmo
+
+        /// <summary>
+        /// Returns drawables for transient geometry associated with Gizmo
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <returns></returns>
+        private List<IRenderPackage> GetDrawablesForTransientGeometry(IRenderPackageFactory factory)
         {
             var drawables = new List<IRenderPackage>();
             if (null != hitAxis)
@@ -460,16 +468,6 @@ namespace Dynamo.Manipulation
             }
             return drawables;
         }
-
-        public void UnhighlightDrawablesForMouseOver(IWatch3DViewModel backgroundPreviewViewModel)
-        {
-            // Delete all transient geometry used to highlight gizmo
-            backgroundPreviewViewModel.DeleteGeometryForIdentifier(RenderDescriptions.AxisLine);
-        }
-
-        #endregion
-
-        #region Helper methods to draw the gizmo
 
         /// <summary>
         /// Draws axis line


### PR DESCRIPTION
### Purpose

This PR is for [MAGN-8823] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8823) to highlight gizmo axes on mouse-over so that the user gets a visual indication of which gizmo axis he is about to manipulate.

For the `Translation Gizmo` the respective axis lines are drawn for whichever axis or plane is highlighted by the mouse. These are transient geometries and when the mouse is moved away from the gizmo, these axis lines are deleted leaving just the manipulator gizmo displayed.

![image](https://cloud.githubusercontent.com/assets/5710686/11462968/b6cf9406-9756-11e5-923d-bbe62034bab2.png)

### Declarations

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)

### Reviewers

@sharadkjaiswal  Reviewer 1 


