### PR TITLE
Removed Run button enabled check for creation of manipulator

### DIFF
--- a/src/DynamoManipulation/DynamoManipulationExtension.cs
+++ b/src/DynamoManipulation/DynamoManipulationExtension.cs
@@ -95,7 +95,7 @@ namespace Dynamo.Manipulation
             //If we are not in Home workspace, or not in Automatic execution mode do nothing.
             var settings = GetRunSettings(WorkspaceModel);
             
-            return settings != null && settings.RunEnabled && settings.RunType == RunType.Automatic;
+            return settings != null && settings.RunType == RunType.Automatic;
         }
 
         internal ICommandExecutive CommandExecutive { get; private set; }


### PR DESCRIPTION
### Purpose
The run button `RunEnabled` check precondition to create a manipulator is not accurate as there are cases such as dropping a new node onto the canvas in which case the manipulator needs to be created by default however the `RunEnabled` flag is still set to `false` at this moment. This check has therefore been removed.

### FYIs
@sharadkjaiswal 