### PR TITLE
Fix issue that replication guide doesn't work for inline conditional expression

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -3141,18 +3141,33 @@ namespace ProtoAssociative
                 DFSEmitSSA_AST(ilnode.ConditionExpression, ssaStack, ref inlineExpressionASTList);
                 AssociativeNode cexpr = ssaStack.Pop();
                 ilnode.ConditionExpression = cexpr is BinaryExpressionNode ? (cexpr as BinaryExpressionNode).LeftNode : cexpr;
+                var namenode = ilnode.ConditionExpression as ArrayNameNode;
+                if (namenode != null)
+                {
+                    namenode.ReplicationGuides = GetReplicationGuides(cexpr is BinaryExpressionNode ? (cexpr as BinaryExpressionNode).RightNode : cexpr);
+                }
                 astlist.AddRange(inlineExpressionASTList);
                 inlineExpressionASTList.Clear();
 
                 DFSEmitSSA_AST(ilnode.TrueExpression, ssaStack, ref inlineExpressionASTList);
                 cexpr = ssaStack.Pop();
                 ilnode.TrueExpression = cexpr is BinaryExpressionNode ? (cexpr as BinaryExpressionNode).LeftNode : cexpr;
+                namenode = ilnode.TrueExpression as ArrayNameNode;
+                if (namenode != null)
+                {
+                    namenode.ReplicationGuides = GetReplicationGuides(cexpr is BinaryExpressionNode ? (cexpr as BinaryExpressionNode).RightNode : cexpr);
+                }
                 astlist.AddRange(inlineExpressionASTList);
                 inlineExpressionASTList.Clear();
 
                 DFSEmitSSA_AST(ilnode.FalseExpression, ssaStack, ref inlineExpressionASTList);
                 cexpr = ssaStack.Pop();
                 ilnode.FalseExpression = cexpr is BinaryExpressionNode ? (cexpr as BinaryExpressionNode).LeftNode : cexpr;
+                namenode = ilnode.FalseExpression as ArrayNameNode;
+                if (namenode != null)
+                {
+                    namenode.ReplicationGuides = GetReplicationGuides(cexpr is BinaryExpressionNode ? (cexpr as BinaryExpressionNode).RightNode : cexpr);
+                }
                 astlist.AddRange(inlineExpressionASTList);
                 inlineExpressionASTList.Clear();
 

--- a/test/Engine/ProtoTest/TD/Associative/Replication.cs
+++ b/test/Engine/ProtoTest/TD/Associative/Replication.cs
@@ -6331,6 +6331,19 @@ o = foo(a, 1);
             thisTest.Verify("o", new Object[] {  });   
         }
     
+        [Test]
+        public void TestReplicationInInlineConditional()
+        {
+            string code =
+@"
+cond = {true, false};
+vs1 = {2, 4};
+vs2 = {3, 5, 7};
+r = cond<1L> ? vs1<1L> : vs2<1L>;";
+
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("r", new object[] { 2, 5, 7 });
+        }
     }
 
 }


### PR DESCRIPTION
### Purpose

Notice that replication guide doesn't work for inline conditional expression (see #3106). 

That's because replication guides are lost during converting the expression to SSA form. They should be restored.

Now the following expression should work:
```
cond = {true, false};
true_values = {2, 4};
false_values = {3, 5, 7};
r = cond<1L> ? true_values<1L> : false_values<1L>; // r = {2, 5, 7}
```