### PR TITLE
Node tooltips to be displayed longer

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -37,6 +37,7 @@
               IsHitTestVisible="True"
               Margin="{Binding Path=MarginThickness}"
               Height="{Binding Path=Height}"
+              ToolTipService.ShowDuration="60000"
              >
 
             <interactivity:Interaction.Triggers>

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -189,6 +189,7 @@
                    StrokeThickness="0,0,0,1"
                    IsHitTestVisible="True"
                    Canvas.ZIndex="11"
+                   ToolTipService.ShowDuration="60000"
                    MouseDown="NickNameBlock_OnMouseDown">
             <Rectangle.Stroke>
                 <Binding Path="State"


### PR DESCRIPTION
### Purpose

Node summary and input/output port description tooltips should be displayed virtually as long as the user's cursor is hovering over the respective regions, overriding the default tooltip duration of 5 seconds.

![image](https://cloud.githubusercontent.com/assets/6386550/11527565/bb7e92fa-991c-11e5-9138-ff43d5692518.png)

### Reviewers

@Benglin 
