### PR TITLE
Preview bubble: minor fix

### DIFF
--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/CodeBlockNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/CodeBlockNodeViewCustomization.cs
@@ -28,8 +28,9 @@ namespace Dynamo.Wpf
                     NotifyOnValidationError = false,
                     Source = model,
                 });
-            
 
+            cbe.GotFocus += (s, args) => nodeView.TogglePreviewControlAllowance();
+            cbe.LostFocus += (s, args) => nodeView.TogglePreviewControlAllowance();
             if (model.ShouldFocus)
             {
                 cbe.Focus();

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -1674,6 +1674,24 @@
         </Setter>
     </Style>
 
+    <Style TargetType="Path"
+           x:Key="TreeViewItemPath">
+        <Setter Property="Stroke">
+            <Setter.Value>
+                <SolidColorBrush Color="{DynamicResource GlyphColor}" />
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=IsMouseOver,
+                                                                       RelativeSource={RelativeSource
+                                                                       AncestorType={x:Type Grid}}}"
+                         Value="True">
+                <Setter Property="Stroke"
+                        Value="#FF1BBBFA" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="{x:Type dynui:ImageButton}"
            TargetType="{x:Type dynui:ImageButton}">
         <Setter Property="SnapsToDevicePixels"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -1683,8 +1683,8 @@
         </Setter>
         <Style.Triggers>
             <DataTrigger Binding="{Binding Path=IsMouseOver,
-                                                                       RelativeSource={RelativeSource
-                                                                       AncestorType={x:Type Grid}}}"
+                                           RelativeSource={RelativeSource
+                                           AncestorType={x:Type Grid}}}"
                          Value="True">
                 <Setter Property="Stroke"
                         Value="#FF1BBBFA" />

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -27,6 +27,12 @@ namespace Dynamo.Controls
         private NodeViewModel viewModel = null;
         private PreviewControl previewControl = null;
 
+        /// <summary>
+        /// If false - hides preview control until it will be explicitly shown.
+        /// If true -preview control is shown and hidden on mouse enter/leave events.
+        /// </summary>
+        private bool previewEnabled = true;
+
         public NodeView TopControl
         {
             get { return topControl; }
@@ -370,6 +376,8 @@ namespace Dynamo.Controls
 
         private void OnNodeViewMouseEnter(object sender, MouseEventArgs e)
         {
+            if (!previewEnabled) return; // Preview is hidden. There is no need run further.
+
             if (PreviewControl.IsInTransition) // In transition state, come back later.
                 return;
 
@@ -421,7 +429,7 @@ namespace Dynamo.Controls
             {
                 case PreviewControl.State.Hidden:
                 {
-                    if (IsMouseOver)
+                    if (IsMouseOver && previewEnabled)
                     {
                         preview.TransitionToState(PreviewControl.State.Condensed);
                     }
@@ -464,6 +472,14 @@ namespace Dynamo.Controls
             {
                 PreviewControl.TransitionToState(PreviewControl.State.Condensed);
             }
+        }
+
+        /// <summary>
+        /// Enables/disables preview control. 
+        /// </summary>
+        internal void TogglePreviewControlAllowance()
+        {
+            previewEnabled = !previewEnabled;
         }
 
         #endregion

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -384,19 +384,18 @@ namespace Dynamo.Controls
 
         private void OnNodeViewMouseLeave(object sender, MouseEventArgs e)
         {
-            // If mouse in not over node/preview control and preview control is not pined, we can hide preview control.
-            if (!IsMouseOver && !PreviewControl.IsMouseOver && !PreviewControl.StaysOpen)
+            // If mouse in over node/preview control or preview control is pined, we can not hide preview control.
+            if (IsMouseOver || PreviewControl.IsMouseOver || PreviewControl.StaysOpen) return;
+
+            // If it's expanded, then first condense it.
+            if (PreviewControl.IsExpanded)
             {
-                // If it's expanded, then first condense it.
-                if (PreviewControl.IsExpanded)
-                {
-                    PreviewControl.TransitionToState(PreviewControl.State.Condensed);
-                }
-                // If it's condensed, then try to hide it.
-                if (PreviewControl.IsCondensed)
-                {
-                    PreviewControl.TransitionToState(PreviewControl.State.Hidden);
-                }
+                PreviewControl.TransitionToState(PreviewControl.State.Condensed);
+            }
+            // If it's condensed, then try to hide it.
+            if (PreviewControl.IsCondensed)
+            {
+                PreviewControl.TransitionToState(PreviewControl.State.Hidden);
             }
         }
 
@@ -407,6 +406,7 @@ namespace Dynamo.Controls
         /// E.g. When mouse leaves preview control, it should be first condesed, after that hidden.
         /// </summary>
         /// <param name="sender">PreviewControl</param>
+        /// <param name="e">Event arguments</param>
         private void OnPreviewControlStateChanged(object sender, EventArgs e)
         {
             var preview = sender as PreviewControl;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -480,6 +480,11 @@ namespace Dynamo.Controls
         internal void TogglePreviewControlAllowance()
         {
             previewEnabled = !previewEnabled;
+
+            if (previewEnabled == false && !PreviewControl.StaysOpen)
+            {
+                PreviewControl.TransitionToState(PreviewControl.State.Hidden);
+            }
         }
 
         #endregion

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -51,6 +51,8 @@ namespace Dynamo.Controls
                 {
                     previewControl = new PreviewControl(ViewModel);
                     previewControl.StateChanged += OnPreviewControlStateChanged;
+                    previewControl.MouseEnter += OnPreviewControlMouseEnter;
+                    previewControl.MouseLeave += OnPreviewControlMouseLeave;
                     expansionBay.Children.Add(previewControl);
                 }
 
@@ -382,16 +384,29 @@ namespace Dynamo.Controls
 
         private void OnNodeViewMouseLeave(object sender, MouseEventArgs e)
         {
-            if (PreviewControl.IsInTransition) // In transition state, come back later.
-                return;
-
             // If mouse in not over node/preview control and preview control is not pined, we can hide preview control.
             if (!IsMouseOver && !PreviewControl.IsMouseOver && !PreviewControl.StaysOpen)
             {
-                PreviewControl.TransitionToState(PreviewControl.State.Hidden);
+                // If it's expanded, then first condense it.
+                if (PreviewControl.IsExpanded)
+                {
+                    PreviewControl.TransitionToState(PreviewControl.State.Condensed);
+                }
+                // If it's condensed, then try to hide it.
+                if (PreviewControl.IsCondensed)
+                {
+                    PreviewControl.TransitionToState(PreviewControl.State.Hidden);
+                }
             }
         }
 
+        /// <summary>
+        /// This event fires right after preview's state has been changed.
+        /// This event is necessary, it handles some preview's manipulations, 
+        /// that we can't handle in mouse enter/leave events.
+        /// E.g. When mouse leaves preview control, it should be first condesed, after that hidden.
+        /// </summary>
+        /// <param name="sender">PreviewControl</param>
         private void OnPreviewControlStateChanged(object sender, EventArgs e)
         {
             var preview = sender as PreviewControl;
@@ -402,24 +417,52 @@ namespace Dynamo.Controls
                 return;
             }
 
-            if (IsMouseOver)
+            switch (preview.CurrentState)
             {
-                // The mouse is currently over the node, so if the 
-                // preview control is hidden, bring it into condensed state.
-                if (preview.IsHidden)
+                case PreviewControl.State.Hidden:
                 {
-                    preview.TransitionToState(PreviewControl.State.Condensed);
+                    if (IsMouseOver)
+                    {
+                        preview.TransitionToState(PreviewControl.State.Condensed);
+                    }
+                    break;
                 }
-            }
-            else
-            {
-                // The mouse is no longer over the node, if the preview 
-                // control is currently in condensed state, hide it from view.
-                if (preview.IsCondensed)
+                case PreviewControl.State.Condensed:
                 {
-                    preview.TransitionToState(PreviewControl.State.Hidden);
+                    if (preview.IsMouseOver)
+                    {
+                        preview.TransitionToState(PreviewControl.State.Expanded);
+                    }
+                    if (!IsMouseOver)
+                    {
+                        preview.TransitionToState(PreviewControl.State.Hidden);
+                    }
+                    break;
                 }
+                case PreviewControl.State.Expanded:
+                {
+                    if (!IsMouseOver || !preview.IsMouseOver)
+                    {
+                        preview.TransitionToState(PreviewControl.State.Condensed);
+                    }
+                    break;
+                }
+            };
+        }
 
+        private void OnPreviewControlMouseEnter(object sender, MouseEventArgs e)
+        {
+            if (PreviewControl.IsCondensed)
+            {
+                PreviewControl.TransitionToState(PreviewControl.State.Expanded);
+            }
+        }
+
+        private void OnPreviewControlMouseLeave(object sender, MouseEventArgs e)
+        {
+            if (!PreviewControl.StaysOpen && !PreviewControl.IsInTransition)
+            {
+                PreviewControl.TransitionToState(PreviewControl.State.Condensed);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -151,7 +151,8 @@
               Name="centralizedGrid"
               Width="{StaticResource MinPreviewControlWidth}"
               Height="{StaticResource MinPreviewControlHeight}"
-              VerticalAlignment="Top">
+              VerticalAlignment="Top"
+              Visibility="Hidden">
             <Border Background="White"
                     BorderThickness="1"
                     BorderBrush="{StaticResource BubblePreviewBorderColor}" />
@@ -180,7 +181,7 @@
 
             </Grid>
 
-            <Grid Name="largeContentGrid"                 
+            <Grid Name="largeContentGrid"
                   MaxWidth="{StaticResource MaxContentGridWidth}"
                   MaxHeight="{StaticResource MaxContentGridHeight}"
                   MinWidth="{Binding RelativeSource={RelativeSource FindAncestor, 

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -160,6 +160,7 @@
             <Grid Name="smallContentGrid"
                   HorizontalAlignment="Left"
                   VerticalAlignment="Center"
+                  Margin="3,0,0,0"
                   MinWidth="{Binding RelativeSource={RelativeSource FindAncestor, 
                              AncestorType={x:Type controls:NodeView}}, 
                              Path=ActualWidth}">
@@ -168,7 +169,8 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <TextBlock Margin="{StaticResource PreviewContentMargin}"
-                           Grid.Column="0">null</TextBlock>
+                           Grid.Column="0"
+                           FontFamily="Consolas">null</TextBlock>
 
                 <Image x:Name="ExpandIcon"
                        Grid.Column="1"

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -217,7 +217,7 @@
                                                           Converter={StaticResource PinIconForegroundConverter}}"
                                      Height="16"
                                      Width="12"
-                                     Margin="7,7,7,7" />
+                                     Margin="6,6,6,6" />
                     <Border.Style>
                         <Style TargetType="Border">
                             <Style.Triggers>

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -11,9 +11,7 @@
              xmlns:ui="clr-namespace:Dynamo.UI"
              xmlns:fa="http://schemas.fontawesome.io/icons/"
              xmlns:uicontrols="clr-namespace:Dynamo.UI.Controls"
-             mc:Ignorable="d"
-             MouseEnter="OnPreviewMouseEnter"
-             MouseLeave="OnPreviewMouseLeave">
+             mc:Ignorable="d">
 
     <UserControl.Resources>
         <ResourceDictionary>
@@ -30,7 +28,7 @@
             <clr:Double x:Key="MaxContentGridWidth">488.0</clr:Double>
             <clr:Double x:Key="MaxContentGridHeight">288</clr:Double>
 
-            <clr:Double x:Key="PhasedOutPosition">-32.0</clr:Double>
+            <clr:Double x:Key="PhasedOutPosition">-52.0</clr:Double>
             <clr:Double x:Key="PhasedInPosition">-20.0</clr:Double>
             <clr:TimeSpan x:Key="ResizeBeginTime">0:0:0.2</clr:TimeSpan>
             <sys:Duration x:Key="AnimationDuration">0:0:0.2</sys:Duration>
@@ -159,7 +157,6 @@
                     BorderBrush="{StaticResource BubblePreviewBorderColor}" />
 
             <Grid Name="smallContentGrid"
-                  Visibility="Collapsed"
                   HorizontalAlignment="Left"
                   VerticalAlignment="Center"
                   MinWidth="{Binding RelativeSource={RelativeSource FindAncestor, 
@@ -180,6 +177,7 @@
                        Height="6"
                        Width="6"
                        Margin="0,5,5,5" />
+
             </Grid>
 
             <Grid Name="largeContentGrid"                 

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -166,7 +166,7 @@
                              Path=ActualWidth}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="15" />
                 </Grid.ColumnDefinitions>
                 <TextBlock Margin="{StaticResource PreviewContentMargin}"
                            Grid.Column="0"
@@ -175,7 +175,6 @@
                 <Image x:Name="ExpandIcon"
                        Grid.Column="1"
                        Source="/DynamoCoreWpf;component/UI/Images/bubble-arrow.png"
-                       HorizontalAlignment="Right"
                        VerticalAlignment="Bottom"
                        Height="6"
                        Width="6"
@@ -218,7 +217,7 @@
                                                           Converter={StaticResource PinIconForegroundConverter}}"
                                      Height="16"
                                      Width="12"
-                                     Margin="5,5,5,5" />
+                                     Margin="7,7,7,7" />
                     <Border.Style>
                         <Style TargetType="Border">
                             <Style.Triggers>

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -424,41 +424,11 @@ namespace Dynamo.UI.Controls
             smallContentGrid.Measure(maxSize);
             Size smallContentGridSize = smallContentGrid.DesiredSize;
 
-            // Condensed bubble should be the same width as node or wider.
-            if (smallContentGridSize.Width == 0)
-            {
-                var nodeView = WpfUtilities.FindUpVisualTree<NodeView>(this);
-                if (nodeView != null)
-                {
-                    smallContentGridSize.Width = nodeView.ActualWidth;
-                }
-            }
+            // Don't make it smaller then min width.
+            smallContentGridSize.Width = smallContentGridSize.Width < smallContentGrid.MinWidth
+                ? smallContentGrid.MinWidth
+                : smallContentGridSize.Width;
 
-            // Count children size.
-            var childrenSize = new Size() { Width = 0, Height = 0 };
-            foreach (UIElement child in smallContentGrid.Children)
-            {
-                child.Measure(maxSize);
-
-                childrenSize.Width += child.DesiredSize.Width;
-                if (child.DesiredSize.Height > childrenSize.Height)
-                {
-                    childrenSize.Height = child.DesiredSize.Height;
-                }
-            }
-
-            // If children are smaller, update smallContentGridSize.
-            if (childrenSize.Height < smallContentGridSize.Height)
-            {
-                smallContentGridSize.Height = childrenSize.Height;
-            }
-            if (childrenSize.Width < smallContentGridSize.Width)
-            {
-                // But don't make it smaller, then min width.
-                smallContentGridSize.Width = childrenSize.Width < smallContentGrid.MinWidth
-                    ? smallContentGrid.MinWidth
-                    : childrenSize.Width;
-            }
             // Add padding since we are sizing the centralizedGrid.
             return ContentToControlSize(smallContentGridSize);
         }

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -469,8 +469,15 @@ namespace Dynamo.UI.Controls
                 Height = Configurations.MaxExpandedPreviewHeight
             });
 
+            Size largeContentGridSize = largeContentGrid.DesiredSize;
+
+            // Don't make it smaller then min width.
+            largeContentGridSize.Width = largeContentGridSize.Width < largeContentGrid.MinWidth
+                ? largeContentGrid.MinWidth
+                : largeContentGridSize.Width;
+
             // Add padding since we are sizing the centralizedGrid.
-            return ContentToControlSize(this.largeContentGrid.DesiredSize);
+            return ContentToControlSize(largeContentGridSize);
         }
 
         private Size ContentToControlSize(Size size)

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -197,6 +197,8 @@ namespace Dynamo.UI.Controls
             }
         }
 
+        internal State CurrentState { get { return currentState; } }
+
         #endregion
 
         #region Private Class Methods - Generic Helpers
@@ -688,22 +690,6 @@ namespace Dynamo.UI.Controls
         {
             SetCurrentStateAndNotify(State.Condensed);
             BeginNextTransition(); // See if there's any more requests.
-        }
-
-        private void OnPreviewMouseEnter(object sender, MouseEventArgs e)
-        {
-            if (IsMouseOver && IsCondensed)
-            {
-                TransitionToState(State.Expanded);
-            }
-        }
-
-        private void OnPreviewMouseLeave(object sender, MouseEventArgs e)
-        {
-            if (!StaysOpen)
-            {
-                TransitionToState(State.Condensed);
-            }
         }
 
         private void OnMapPinMouseClick(object sender, MouseButtonEventArgs e)

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -63,7 +63,8 @@
                         <ControlTemplate TargetType="ToggleButton">
                             <Grid Width="15"
                                   Height="13"
-                                  Background="Transparent">
+                                  Background="Transparent"
+                                  Margin="0,0,4,0">
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CheckStates">
                                         <VisualState x:Name="Checked">
@@ -97,7 +98,7 @@
                                       HorizontalAlignment="Left"
                                       VerticalAlignment="Center"
                                       Margin="1,1,1,1"
-                                      Data="M 0 4 L 8 4 L 4 8 Z"
+                                      Data="M 0 8 L 8 8 L 8 0 Z"
                                       Visibility="Hidden">
                                     <Path.Fill>
                                         <SolidColorBrush Color="{DynamicResource GlyphColor}" />
@@ -115,7 +116,7 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type TreeViewItem}">
-                            <Grid>
+                            <Grid x:Name="TreeViewItem">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="Auto" />
@@ -144,7 +145,8 @@
                                 <ItemsPresenter x:Name="ItemsHost"
                                                 Grid.ColumnSpan="2"
                                                 Grid.Column="1"
-                                                Grid.Row="1" />
+                                                Grid.Row="1"
+                                                Margin="8,0,0,0"/>
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsExpanded"
@@ -158,7 +160,45 @@
                                     <Setter Property="Visibility"
                                             TargetName="Expander"
                                             Value="Collapsed" />
+                                    <Setter Property="Margin"
+                                            TargetName="TreeViewItem"
+                                            Value="19,0,0,0" />
                                 </Trigger>
+
+                                <!-- __________________MultiDataTriggers______________________ -->
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <!-- If treeview item is root item. -->
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TreeViewItem}}}"
+                                                   Value="{x:Null}" />
+                                        <!-- If root treeview item has child items. -->
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=HasItems}"
+                                                   Value="true" />
+                                    </MultiDataTrigger.Conditions>
+                                    <MultiDataTrigger.Setters>
+                                        <Setter Property="Margin"
+                                                TargetName="TreeViewItem"
+                                                Value="4,0,0,0" />
+                                    </MultiDataTrigger.Setters>
+                                </MultiDataTrigger>
+
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <!-- If treeview item is root item. -->
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TreeViewItem}}}"
+                                                   Value="{x:Null}" />
+                                        <!-- If root treeview item doesn't have child items. -->
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=HasItems}"
+                                                   Value="false" />
+                                    </MultiDataTrigger.Conditions>
+                                    <MultiDataTrigger.Setters>
+                                        <Setter Property="Margin"
+                                                TargetName="TreeViewItem"
+                                                Value="0,0,0,0" />
+                                    </MultiDataTrigger.Setters>
+                                </MultiDataTrigger>
+                                <!-- __________________________________________ -->
+
                                 <Trigger Property="IsSelected"
                                          Value="true">
                                     <Setter Property="Background"
@@ -207,15 +247,17 @@
                     <VirtualizingStackPanel Orientation="Horizontal"
                                             Width="Auto">
                         <TextBlock Text="{Binding Path=ViewPath}"
-                                   VerticalAlignment="Center"                                   
+                                   VerticalAlignment="Center"
                                    Visibility="{Binding Path=ViewPath, Converter={StaticResource EmptyStringToCollapsedConverter}}"
                                    Width="Auto"
-                                   FontFamily="Consolas" />
+                                   FontFamily="Consolas"
+                                   Margin="0,0,4,0" />
                         <TextBlock Text="{Binding Path=NodeLabel}"
-                                   VerticalAlignment="Center"                                  
+                                   VerticalAlignment="Center"
                                    Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}"
                                    Width="Auto"
-                                   FontFamily="Consolas" />
+                                   FontFamily="Consolas"
+                                   Margin="0,0,4,0" />
                         <Button Content="{Binding Path=Link}"
                                 RenderTransformOrigin="0.5,0.5"
                                 Margin="10,2,2,2"

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -162,13 +162,13 @@
                                         BorderBrush="{TemplateBinding BorderBrush}"
                                         BorderThickness="{TemplateBinding BorderThickness}"
                                         Background="{TemplateBinding Background}"
-                                        Grid.Column="1"                                       
+                                        Grid.Column="1"
                                         SnapsToDevicePixels="true"
                                         Padding="0,2,0,2">
                                     <ContentPresenter x:Name="PART_Header"
                                                       ContentSource="Header"
                                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />                                    
+                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                 </Border>
                                 <ItemsPresenter x:Name="ItemsHost"
                                                 Grid.ColumnSpan="2"

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -163,18 +163,19 @@
                                         BorderThickness="{TemplateBinding BorderThickness}"
                                         Background="{TemplateBinding Background}"
                                         Grid.Column="1"
-                                        SnapsToDevicePixels="true"
-                                        Padding="0,2,0,2">
+                                        SnapsToDevicePixels="true">
                                     <ContentPresenter x:Name="PART_Header"
                                                       ContentSource="Header"
                                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                 </Border>
-                                <ItemsPresenter x:Name="ItemsHost"
-                                                Grid.ColumnSpan="2"
-                                                Grid.Column="1"
-                                                Grid.Row="1"
-                                                Margin="1,0,0,0" />
+                                <Border  x:Name="ItemsHostBorder"
+                                         Grid.ColumnSpan="2"
+                                         Grid.Column="1"
+                                         Grid.Row="1">
+                                    <ItemsPresenter x:Name="ItemsHost"
+                                                    Margin="1,0,0,0" />
+                                </Border>
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsExpanded"
@@ -191,8 +192,17 @@
                                     <Setter Property="Margin"
                                             TargetName="TreeViewItem"
                                             Value="16,0,0,0" />
+                                    <Setter Property="Padding"
+                                            TargetName="ItemsHostBorder"
+                                            Value="0,1,0,1" />
                                 </Trigger>
 
+                                <Trigger Property="HasItems"
+                                         Value="true">
+                                    <Setter Property="Padding"
+                                            TargetName="ItemsHostBorder"
+                                            Value="0,2,0,0" />
+                                </Trigger>
                                 <!-- __________________MultiDataTriggers______________________ -->
                                 <MultiDataTrigger>
                                     <MultiDataTrigger.Conditions>
@@ -292,7 +302,7 @@
                                 Margin="10,2,2,2"
                                 VerticalAlignment="Center"
                                 Click="Button_Click"
-                                Padding="4,2,4,2"
+                                Padding="4,0,4,0"
                                 Visibility="{Binding Path=Link, Converter={StaticResource EmptyStringToCollapsedConverter}}"
                                 Style="{StaticResource BorderlessButton}" />
                     </VirtualizingStackPanel>

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -144,7 +144,7 @@
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type TreeViewItem}">
                             <Grid x:Name="TreeViewItem"
-                                  Margin="-3,2,0,2">
+                                  Margin="-3,0,0,0">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="Auto" />
@@ -162,13 +162,13 @@
                                         BorderBrush="{TemplateBinding BorderBrush}"
                                         BorderThickness="{TemplateBinding BorderThickness}"
                                         Background="{TemplateBinding Background}"
-                                        Grid.Column="1"
-                                        Padding="{TemplateBinding Padding}"
-                                        SnapsToDevicePixels="true">
+                                        Grid.Column="1"                                       
+                                        SnapsToDevicePixels="true"
+                                        Padding="0,2,0,2">
                                     <ContentPresenter x:Name="PART_Header"
                                                       ContentSource="Header"
                                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />                                    
                                 </Border>
                                 <ItemsPresenter x:Name="ItemsHost"
                                                 Grid.ColumnSpan="2"
@@ -190,7 +190,7 @@
                                             Value="Collapsed" />
                                     <Setter Property="Margin"
                                             TargetName="TreeViewItem"
-                                            Value="16,2,0,2" />
+                                            Value="16,0,0,0" />
                                 </Trigger>
 
                                 <!-- __________________MultiDataTriggers______________________ -->
@@ -206,7 +206,7 @@
                                     <MultiDataTrigger.Setters>
                                         <Setter Property="Margin"
                                                 TargetName="TreeViewItem"
-                                                Value="4,2,0,2" />
+                                                Value="4,0,0,0" />
                                     </MultiDataTrigger.Setters>
                                 </MultiDataTrigger>
 
@@ -222,7 +222,7 @@
                                     <MultiDataTrigger.Setters>
                                         <Setter Property="Margin"
                                                 TargetName="TreeViewItem"
-                                                Value="0,2,0,2" />
+                                                Value="0,0,0,0" />
                                     </MultiDataTrigger.Setters>
                                 </MultiDataTrigger>
                                 <!-- __________________________________________ -->

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -1,14 +1,15 @@
 ﻿<UserControl x:Class="Dynamo.Controls.WatchTree"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"              
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:viewModels="clr-namespace:Dynamo.ViewModels"
              xmlns:ui="clr-namespace:Dynamo.UI"
-             mc:Ignorable="d" 
-             d:DesignHeight="161" d:DesignWidth="410" 
-             HorizontalAlignment="Stretch" 
-             VerticalAlignment="Stretch" 
+             mc:Ignorable="d"
+             d:DesignHeight="161"
+             d:DesignWidth="410"
+             HorizontalAlignment="Stretch"
+             VerticalAlignment="Stretch"
              BorderBrush="Black"
              MaxHeight="300">
     <UserControl.Resources>
@@ -18,35 +19,47 @@
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
-            <Style x:Key="BorderlessButton" TargetType="{x:Type Button}">
-                <Setter Property="Padding" Value="1"/>
-                <Setter Property="Background" Value="PaleGreen" />
+            <Style x:Key="BorderlessButton"
+                   TargetType="{x:Type Button}">
+                <Setter Property="Padding"
+                        Value="1" />
+                <Setter Property="Background"
+                        Value="PaleGreen" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type Button}">
-                            <Border Name="border" Background="{TemplateBinding Background}">
-                                <ContentPresenter Name="content" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                      Margin="{TemplateBinding Padding}"
-                                      RecognizesAccessKey="True"
-                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                            <Border Name="border"
+                                    Background="{TemplateBinding Background}">
+                                <ContentPresenter Name="content"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  Margin="{TemplateBinding Padding}"
+                                                  RecognizesAccessKey="True"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                             </Border>
                             <ControlTemplate.Triggers>
-                                <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="content" Property="RenderTransform" >
+                                <Trigger Property="IsMouseOver"
+                                         Value="True">
+                                    <Setter TargetName="content"
+                                            Property="RenderTransform">
                                         <Setter.Value>
-                                            <ScaleTransform ScaleX="1.1" ScaleY="1.1" />
+                                            <ScaleTransform ScaleX="1.1"
+                                                            ScaleY="1.1" />
                                         </Setter.Value>
                                     </Setter>
                                 </Trigger>
-                                <Trigger Property="IsPressed" Value="True">
-                                    <Setter TargetName="content" Property="RenderTransform" >
+                                <Trigger Property="IsPressed"
+                                         Value="True">
+                                    <Setter TargetName="content"
+                                            Property="RenderTransform">
                                         <Setter.Value>
-                                            <ScaleTransform ScaleX=".95" ScaleY=".95" />
+                                            <ScaleTransform ScaleX=".95"
+                                                            ScaleY=".95" />
                                         </Setter.Value>
                                     </Setter>
                                 </Trigger>
-                                <Trigger Property="IsFocused" Value="True">
+                                <Trigger Property="IsFocused"
+                                         Value="True">
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -89,20 +102,34 @@
                                       HorizontalAlignment="Left"
                                       VerticalAlignment="Center"
                                       Margin="1,1,1,1"
-                                      Data="M 4 0 L 8 4 L 4 8 Z">
-                                    <Path.Fill>
-                                        <SolidColorBrush Color="{DynamicResource GlyphColor}" />
-                                    </Path.Fill>
-                                </Path>
+                                      Data="M 4 0 L 8 4 L 4 8 Z"
+                                      StrokeLineJoin="Miter"
+                                      Style="{StaticResource TreeViewItemPath}" />
                                 <Path x:Name="Expanded"
                                       HorizontalAlignment="Left"
                                       VerticalAlignment="Center"
                                       Margin="1,1,1,1"
-                                      Data="M 0 8 L 8 8 L 8 0 Z"
+                                      Data="M 0 5 L 5 5 L 5 0 Z"
                                       Visibility="Hidden">
-                                    <Path.Fill>
-                                        <SolidColorBrush Color="{DynamicResource GlyphColor}" />
-                                    </Path.Fill>
+                                    <Path.Style>
+                                        <Style BasedOn="{StaticResource TreeViewItemPath}"
+                                               TargetType="Path">
+                                            <Setter Property="Fill">
+                                                <Setter.Value>
+                                                    <SolidColorBrush Color="{DynamicResource GlyphColor}" />
+                                                </Setter.Value>
+                                            </Setter>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Path=IsMouseOver,
+                                                                       RelativeSource={RelativeSource
+                                                                       AncestorType={x:Type Grid}}}"
+                                                             Value="True">
+                                                    <Setter Property="Fill"
+                                                            Value="White" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Path.Style>
                                 </Path>
                             </Grid>
                         </ControlTemplate>
@@ -116,7 +143,8 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type TreeViewItem}">
-                            <Grid x:Name="TreeViewItem">
+                            <Grid x:Name="TreeViewItem"
+                                  Margin="-3,2,0,2">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="Auto" />
@@ -146,7 +174,7 @@
                                                 Grid.ColumnSpan="2"
                                                 Grid.Column="1"
                                                 Grid.Row="1"
-                                                Margin="8,0,0,0"/>
+                                                Margin="1,0,0,0" />
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsExpanded"
@@ -162,7 +190,7 @@
                                             Value="Collapsed" />
                                     <Setter Property="Margin"
                                             TargetName="TreeViewItem"
-                                            Value="12,0,0,0" />
+                                            Value="16,2,0,2" />
                                 </Trigger>
 
                                 <!-- __________________MultiDataTriggers______________________ -->
@@ -178,7 +206,7 @@
                                     <MultiDataTrigger.Setters>
                                         <Setter Property="Margin"
                                                 TargetName="TreeViewItem"
-                                                Value="4,0,0,0" />
+                                                Value="4,2,0,2" />
                                     </MultiDataTrigger.Setters>
                                 </MultiDataTrigger>
 
@@ -194,7 +222,7 @@
                                     <MultiDataTrigger.Setters>
                                         <Setter Property="Margin"
                                                 TargetName="TreeViewItem"
-                                                Value="0,0,0,0" />
+                                                Value="0,2,0,2" />
                                     </MultiDataTrigger.Setters>
                                 </MultiDataTrigger>
                                 <!-- __________________________________________ -->
@@ -236,7 +264,8 @@
     <Grid>
         <TreeView Name="treeView1"
                   ItemsSource="{Binding Children}"
-                  Background="White" Opacity=".5"
+                  Background="White"
+                  Opacity=".5"
                   BorderBrush="{x:Null}"
                   VirtualizingStackPanel.IsVirtualizing="True"
                   VirtualizingStackPanel.VirtualizationMode="Recycling"

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -162,7 +162,7 @@
                                             Value="Collapsed" />
                                     <Setter Property="Margin"
                                             TargetName="TreeViewItem"
-                                            Value="19,0,0,0" />
+                                            Value="12,0,0,0" />
                                 </Trigger>
 
                                 <!-- __________________MultiDataTriggers______________________ -->


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8941](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8941) Make Preview Bubbles more discoverable by removing the preview icon from the node and relying on hover interactions

This PR addresses next issues:
* Preview bubble stays condensed, when mouse is over it. 
* Expanded preview bubble is smaller then its' condensed state.
* Margin in preview bubble, when it's value is `List`
* Preview Bubble is shown, when user changes the value of the node.

Changes:
* Rewrote `OnPreviewControlStateChanged`. Now `NodeView` takes care of Preview Bubble states.
* Expanded preview bubble shouldn't be smaller then node width. So we need to check its width with `MinWidth`. I added it in `ComputeLargeContentSize`.
* List representation has another margins, because I was asked to left-align the single line detailed view text (see https://github.com/DynamoDS/Dynamo/pull/5692#issuecomment-159257220). I had to rewrite default tree view template. That's why we lost margin not only for single line text, but also for all tree view items. I added several `MultyDataTriggers` in new tree view item template.
* Added `TogglePreviewControlAllowance` to control show or not show preview bubble.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@ramramps 

### FYIs

@Racel 