### PR TITLE
Range/Sequence default values

### DIFF
--- a/src/Libraries/CoreNodeModels/Range.cs
+++ b/src/Libraries/CoreNodeModels/Range.cs
@@ -13,11 +13,15 @@ namespace DSCoreNodesUI
     [IsDesignScriptCompatible]
     public class Range : NodeModel
     {
+        private readonly IntNode startPortDefaultValue = new IntNode(0);
+        private readonly IntNode endPortDefaultValue = new IntNode(9);
+        private readonly IntNode stepPortDefaultValue = new IntNode(1);
+
         public Range()
         {
-            InPortData.Add(new PortData("start", Resources.RangePortDataStartToolTip));
-            InPortData.Add(new PortData("end", Resources.RangePortDataEndToolTip));
-            InPortData.Add(new PortData("step", Resources.RangePortDataStepToolTip));
+            InPortData.Add(new PortData("start", Resources.RangePortDataStartToolTip, startPortDefaultValue));
+            InPortData.Add(new PortData("end", Resources.RangePortDataEndToolTip, endPortDefaultValue));
+            InPortData.Add(new PortData("step", Resources.RangePortDataStepToolTip, stepPortDefaultValue));
             OutPortData.Add(new PortData("seq", Resources.RangePortDataSeqToolTip));
 
             RegisterAllPorts();
@@ -32,20 +36,6 @@ namespace DSCoreNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            // Set default values.
-            if (!HasConnectedInput(0))
-            {
-                inputAstNodes[0] = new IntNode(0);
-            }
-            if (!HasConnectedInput(1))
-            {
-                inputAstNodes[1] = new IntNode(9);
-            }
-            if (!HasConnectedInput(2))
-            {
-                inputAstNodes[2] = new IntNode(1);
-            }
-
             return new[]
             {
                 AstFactory.BuildAssignment(
@@ -69,11 +59,15 @@ namespace DSCoreNodesUI
     [IsDesignScriptCompatible]
     public class Sequence : NodeModel
     {
+        private readonly IntNode startPortDefaultValue = new IntNode(0);
+        private readonly IntNode amountPortDefaultValue = new IntNode(9);
+        private readonly IntNode stepPortDefaultValue = new IntNode(1);
+
         public Sequence()
         {
-            InPortData.Add(new PortData("start", Resources.RangePortDataStartToolTip));
-            InPortData.Add(new PortData("amount", Resources.RangePortDataAmountToolTip));
-            InPortData.Add(new PortData("step", Resources.RangePortDataStepToolTip));
+            InPortData.Add(new PortData("start", Resources.RangePortDataStartToolTip, startPortDefaultValue));
+            InPortData.Add(new PortData("amount", Resources.RangePortDataAmountToolTip, amountPortDefaultValue));
+            InPortData.Add(new PortData("step", Resources.RangePortDataStepToolTip, stepPortDefaultValue));
             OutPortData.Add(new PortData("seq", Resources.RangePortDataSeqToolTip));
 
             RegisterAllPorts();
@@ -88,20 +82,6 @@ namespace DSCoreNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            // Set default values.
-            if (!HasConnectedInput(0))
-            {
-                inputAstNodes[0] = new IntNode(0);
-            }
-            if (!HasConnectedInput(1))
-            {
-                inputAstNodes[1] = new IntNode(10);
-            }
-            if (!HasConnectedInput(2))
-            {
-                inputAstNodes[2] = new IntNode(1);
-            }
-
             return new[]
             {
                 AstFactory.BuildAssignment(

--- a/src/Libraries/CoreNodeModels/Range.cs
+++ b/src/Libraries/CoreNodeModels/Range.cs
@@ -60,7 +60,7 @@ namespace DSCoreNodesUI
     public class Sequence : NodeModel
     {
         private readonly IntNode startPortDefaultValue = new IntNode(0);
-        private readonly IntNode amountPortDefaultValue = new IntNode(9);
+        private readonly IntNode amountPortDefaultValue = new IntNode(10);
         private readonly IntNode stepPortDefaultValue = new IntNode(1);
 
         public Sequence()


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9104](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9104) Default values for Range and Sequence nodes

Added default values in context menu:
![image](https://cloud.githubusercontent.com/assets/8158404/11533740/eee0a2ea-9913-11e5-9c65-0ebaa41bf260.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### FYIs

@marimano 
@Racel 
