### PR TITLE
Large File Does not Load

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -695,7 +695,8 @@ namespace Dynamo.Graph.Nodes
             //gather downstream nodes and bail if we see an already visited node
             HashSet<NodeModel> downStreamNodes = new HashSet<NodeModel>(visitedNodes);
             this.GetDownstreamNodes(this, downStreamNodes);
-            //then get the difference of the already visisted and new nodes, we are left with the
+            //then get the difference of the already visisted and new nodes,
+            //we are left with the new nodes discovered during traversal
 
             downStreamNodes.ExceptWith(visitedNodes);
            
@@ -719,6 +720,7 @@ namespace Dynamo.Graph.Nodes
             RaisePropertyChanged("IsFrozen");
             //return all nodes that were visited during this traversal
             //which includes this node, and the new downstream nodes we discovered
+            //and all previously visited nodes
             visitedNodes.Add(this);
             visitedNodes.UnionWith(downStreamNodes);
             return visitedNodes;

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1509,7 +1509,7 @@ namespace Dynamo.Graph.Workspaces
         /// Return the nodes in the graph that have no inputs or have none of their inputs filled
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<NodeModel> GetSourceNodes()
+        internal IEnumerable<NodeModel> GetSourceNodes()
         {
             return
                 Nodes.Where(

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -725,8 +725,6 @@ namespace Dynamo.Graph.Workspaces
             if (args.Id == this.Guid)
             {
                 this.workspaceLoaded = true;
-                //var frozenNodes = nodes.Where(x => x.isFrozenExplicitly).ToList();
-                //frozenNodes.ForEach(z => z.ComputeUpstreamOnDownstreamNodes());
                 this.ComputeUpstreamCacheForEntireGraph();
             }
         }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -281,7 +281,7 @@ namespace Dynamo.Graph.Workspaces
             //given node.
             if (workspaceLoaded)
             {
-                obj.End.Owner.ComputeUpstreamOnDownstreamNodes();               
+                obj.End.Owner.ComputeUpstreamOnDownstreamNodes(new HashSet<NodeModel>());               
             }
         }
 
@@ -308,7 +308,7 @@ namespace Dynamo.Graph.Workspaces
             //given node.
             if (workspaceLoaded)
             {
-                obj.End.Owner.ComputeUpstreamOnDownstreamNodes();
+                obj.End.Owner.ComputeUpstreamOnDownstreamNodes(new HashSet<NodeModel>());
             }
         }
 
@@ -725,8 +725,9 @@ namespace Dynamo.Graph.Workspaces
             if (args.Id == this.Guid)
             {
                 this.workspaceLoaded = true;
-                var frozenNodes = nodes.Where(x => x.isFrozenExplicitly).ToList();
-                frozenNodes.ForEach(z => z.ComputeUpstreamOnDownstreamNodes());
+                //var frozenNodes = nodes.Where(x => x.isFrozenExplicitly).ToList();
+                //frozenNodes.ForEach(z => z.ComputeUpstreamOnDownstreamNodes());
+                this.ComputeUpstreamCacheForEntireGraph();
             }
         }
 
@@ -1504,6 +1505,40 @@ namespace Dynamo.Graph.Workspaces
                 Nodes.Where(
                     node =>
                         node.OutPortData.Any() && node.OutPorts.Any(port => !port.Connectors.Any()));
+        }
+
+        /// <summary>
+        /// Return the nodes in the graph that have no inputs or have none of their inputs filled
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<NodeModel> GetSourceNodes()
+        {
+            return
+                Nodes.Where(
+                    node =>
+                       !node.InPorts.Any()||node.InPorts.All(port => !port.Connectors.Any()));
+        }
+
+        /// <summary>
+        /// This method ensures that all upstream node caches are correct by calling
+        /// ComputeUpstreamOnDownstream on all source nodes in the graph,
+        /// this is done in such a way that each node is only computed once.
+        /// </summary>
+        private void ComputeUpstreamCacheForEntireGraph()
+        {
+            //get the source nodes or roots of the DAG
+            var sources = GetSourceNodes();
+            var allVisited = new HashSet<NodeModel>();
+            foreach(var source in sources)
+            {
+                //call computeUpstreamOnDownstream to propogate the upstream Cache down to all nodes
+               foreach(var visitedNode in source.ComputeUpstreamOnDownstreamNodes(allVisited))
+                {
+                    //continue filling the visited list with all nodes we have already computed
+                    //this will avoid redudant calls
+                    allVisited.Add(visitedNode);
+                }
+            }
         }
 
         public void ReportPosition()

--- a/src/Libraries/Watch3DNodeModelsWpf/HelixWatch3DNodeViewModel.cs
+++ b/src/Libraries/Watch3DNodeModelsWpf/HelixWatch3DNodeViewModel.cs
@@ -74,14 +74,14 @@ namespace Watch3DNodeModelsWpf
 
         protected override void OnNodePropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            var updatedNode = sender as NodeModel;
+            //var updatedNode = sender as NodeModel;
 
-            // Don't bother with node property changes 
-            // that are not in this branch.
+            //// Don't bother with node property changes 
+            //// that are not in this branch.
 
-            if (!updatedNode.IsUpstreamOf(watchNode))
-                return;
-
+            //if (!updatedNode.IsUpstreamOf(watchNode))
+            //    return;
+            
             switch (e.PropertyName)
             {
                 case "IsUpstreamVisible":

--- a/src/Libraries/Watch3DNodeModelsWpf/HelixWatch3DNodeViewModel.cs
+++ b/src/Libraries/Watch3DNodeModelsWpf/HelixWatch3DNodeViewModel.cs
@@ -74,14 +74,7 @@ namespace Watch3DNodeModelsWpf
 
         protected override void OnNodePropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            //var updatedNode = sender as NodeModel;
-
-            //// Don't bother with node property changes 
-            //// that are not in this branch.
-
-            //if (!updatedNode.IsUpstreamOf(watchNode))
-            //    return;
-            
+           
             switch (e.PropertyName)
             {
                 case "IsUpstreamVisible":

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -800,5 +800,22 @@ namespace Dynamo.Tests
 
             Assert.IsFalse(CurrentDynamoModel.CurrentWorkspace.Connectors.Any());
         }
+
+        [Test]
+        public void UpstreamNodesComputedCorrectly()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\transpose.dyn");
+            //this should compute all upstream nodes on each node from the roots down
+            OpenModel(openPath);
+            
+            //this asserts that each node's UpstreamCache contains the same list as the recursively computed AllUpstreamNodes
+            foreach(var node in CurrentDynamoModel.CurrentWorkspace.Nodes)
+            {
+                Assert.IsTrue(node.UpstreamCache.SetEquals(node.AllUpstreamNodes(new List<NodeModel>())));
+            }
+
+
+
+        }
     }
 }


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9093

large file does not load - file containing 2000 nodes does not load even after 30 + minutes in .91 because both Freeze and Watch3d perform recursive calls to find upstream nodes, these recursive calls happen for all sorts of node modified, connector addition, and property change events.... no caching is done. The problem does not present itself until nodes number in the hundreds and many modifications happen all at once, like during file load where every connector added event triggers these functions... also copy/paste etc.

In the previous PR: https://github.com/DynamoDS/Dynamo/pull/5777

we've added a new property to `NodeModel` - `UpstreamCache` which is a cache of the upstream nodes relative to the current node. and a method `ComputeUpstreamOnDownStreamNodes` which essentially propagates the currently precomputed cache of upstream nodes, down to all downstream nodes. This method is used to update the graph during topological changes without rebuilding the entire graph.

We can use this `UpstreamCache` for other functionality that must look into the graph to determine upstream nodes, like the `Freeze` functionality without adding additional properties for each.

In this PR:
* I've removed an unnecessary check that Watch3d performed to attempt to avoid responding to property changes, but this check was inefficient and performed upstream recursive gatherings on every node model property change... I have removed it. In the future we can just check `UpstreamCache` if there is any need.

* I've also added a new method to workspace that computes the entire graph's upstream cache (for all nodes) by calling `ComputeUpstreamOnDownstreamNodes` for the source nodes(roots) of the graph. I have modified `ComputeUpstreamOnDownstreamNodes` so that it takes a hashset of the visited nodes and returns the old hashset + the newly discovered nodes during traversal, this way we avoid recomputing upstream nodes on any node twice. This method is called when a workspace is finished loading - and should guarantee that on load, every node has the correct `UpstreamCache`.

* Previously, on .91 this graph would take about 30 -45 minutes... or more to load on dell 4800 laptop - with these changes the graph takes 2 minutes to open, similar to the .82 time of 1-2 minutes.



### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] All tests pass using the self-service CI.

### Reviewers

@ramramps 

### FYIs

@pboyer for your perusal


please do not merge until I add tests and remove commented out code.