### PR TITLE
Fix MAGN-9129 Preview broken when creating family instances based on Revit References

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -468,9 +468,14 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        /// Use to indicated if a node was involved in the most recent graph evaluation.
+        /// Use to indicate if a node was involved in the most recent graph evaluation.
         /// </summary>
         internal bool WasInvolvedInExecution { get; set; }
+
+        /// <summary>
+        /// Used to indicate wheter the render package of a node has been updated after last execution.
+        /// </summary>
+        internal bool WasRenderPackageUpdatedAfterExecution { get; set; }
 
         /// <summary>
         ///     Search tags for this Node.

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -468,12 +468,18 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        /// Use to indicate if a node was involved in the most recent graph evaluation.
+        /// This flag is used to determine if a node was involved in a recent execution.
+        /// The primary purpose of this flag is to determine if the node's render packages 
+        /// should be returned to client browser when it requests for them. This is mainly 
+        /// to avoid returning redundant data that has not changed during an execution.
         /// </summary>
         internal bool WasInvolvedInExecution { get; set; }
 
         /// <summary>
-        /// Used to indicate wheter the render package of a node has been updated after last execution.
+        /// This flag indicates if render packages of a NodeModel has been updated 
+        /// since the last execution. UpdateRenderPackageAsyncTask will always be 
+        /// generated for a NodeModel that took part in the evaluation, if this flag 
+        /// is false.
         /// </summary>
         internal bool WasRenderPackageUpdatedAfterExecution { get; set; }
 

--- a/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
@@ -127,6 +127,7 @@ namespace Dynamo.Scheduler
                 foreach (var modifiedNode in ModifiedNodes)
                 {
                     modifiedNode.WasInvolvedInExecution = true;
+                    modifiedNode.WasRenderPackageUpdatedAfterExecution = false;
                     if (modifiedNode.State == ElementState.Warning)
                         modifiedNode.ClearRuntimeError();
                 }

--- a/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
@@ -87,7 +87,7 @@ namespace Dynamo.Scheduler
                 throw new ArgumentNullException("initParams.DrawableIds");
 
             var nodeModel = initParams.Node;
-            if (!nodeModel.WasInvolvedInExecution && !initParams.ForceUpdate)
+            if (nodeModel.WasRenderPackageUpdatedAfterExecution && !initParams.ForceUpdate)
                 return false; // Not has not been updated at all.
 
             // If a node is in either of the following states, then it will not 
@@ -110,6 +110,7 @@ namespace Dynamo.Scheduler
             previewIdentifierName = initParams.PreviewIdentifierName;
 
             nodeGuid = nodeModel.GUID;
+            nodeModel.WasRenderPackageUpdatedAfterExecution = true;
             return true;
         }
 


### PR DESCRIPTION
### Purpose

This is to fix MAGN-9129 Preview broken when creating family instances based on Revit References. This pull request is based on the existing pull request: https://github.com/DynamoDS/Dynamo/pull/5754

Before scheduling a UpdateGraphAsyncTask task, all nodes will be set to indicate that they will not require to update their render packages. After the task is completed, those modified nodes will be set to indicate that they need to update their render packages. This usually works. But when two UpdateGraphAsyncTask tasks are scheduled immediately one after another, the status of those modified nodes in the first run will be reset before the second task run. As a result, some nodes may not update their render packages.

In the case of this defect, this is happening. When the model curve element is moved, it will trigger 5 nodes of the graph to run. When the task is completed, the family instance is modified and a new UpdateGraphAsynTask task will be scheduled before any other tasks are scheduled. The Element.Geometry node is not taken as a modified node in the second run and will not update its render package later.

The fix here is to add a new flag WasRenderPackageUpdatedAfterExecution in NodeModel to indicate whether the render package has been updated or not. Every time the node is executed, the flag will be marked as false. When the UpdateRenderPackageAsyncTask task is initialized, this will be marked as true.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@Benglin 

### FYIs

@ikeough @pboyer 