### PR TITLE
MAGN-9183 Dynamo crashes when trying to create a connector

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -222,9 +222,10 @@ namespace Dynamo.ViewModels
          
         public bool IsFrozen
         {
-            get { return Nodevm.IsFrozen; }            
+            get { return _model == null ? _activeStartPort.Owner.IsFrozen : Nodevm.IsFrozen; }
         }
-#endregion
+
+        #endregion
 
         /// <summary>
         /// Construct a view and start drawing.


### PR DESCRIPTION
### Purpose

Fix connector creation: when a connector is being created `_model` is null and it leads to exception

### Reviewers

@ramramps 