### PR TITLE
Fix geometry freeze  - MAGN 8958

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.1.3355")]
+[assembly: AssemblyVersion("0.9.1.3374")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.1.3355")]
+[assembly: AssemblyFileVersion("0.9.1.3374")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("0.9.1.3374")]
+[assembly: AssemblyVersion("0.9.1.3404")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("0.9.1.3374")]
+[assembly: AssemblyFileVersion("0.9.1.3404")]

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/AttachedProperties.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/AttachedProperties.cs
@@ -11,7 +11,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// </summary>
     public static class AttachedProperties
     {
-        private const float transparentGeometry = 0.5f;
+        private const float alphaPropertyFactor = 0.5f;
         /// <summary>
         /// A flag indicating whether the geometry renders as selected.
         /// </summary>
@@ -99,17 +99,17 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
                 for (int i = 0; i < colors.Length; i++)
                 {
-                    colors[i].Alpha = colors[i].Alpha * transparentGeometry;
+                    colors[i].Alpha = colors[i].Alpha * alphaPropertyFactor;
                 }
 
                 geom.Geometry.Colors.Clear();
                 geom.Geometry.Colors.AddRange(colors);
 
-                var vertex = geom as DynamoGeometryModel3D;
-                if (vertex != null)
+                var dynamoGeom3D = geom as DynamoGeometryModel3D;
+                if (dynamoGeom3D != null)
                 {
-                    vertex.RequiresPerVertexColoration = true;
-                    geom = vertex;
+                    dynamoGeom3D.RequiresPerVertexColoration = true;
+                    geom = dynamoGeom3D;
                 }
 
                 if (geom.IsAttached)

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/AttachedProperties.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/AttachedProperties.cs
@@ -11,6 +11,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// </summary>
     public static class AttachedProperties
     {
+        private const float transparentGeometry = 0.5f;
         /// <summary>
         /// A flag indicating whether the geometry renders as selected.
         /// </summary>
@@ -63,5 +64,62 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         {
             return (bool) element.GetValue(HasTransparencyProperty);
         }
+
+        /// <summary>
+        /// A flag indicating whether the geometry is frozen
+        /// </summary>
+        public static readonly DependencyProperty IsFrozenProperty = DependencyProperty.RegisterAttached(
+            "IsFrozen",
+            typeof(bool),
+            typeof(GeometryModel3D),
+            new PropertyMetadata(false, IsFrozenPropertyChanged));
+
+        public static void SetIsFrozen(UIElement element, bool value)
+        {
+            element.SetValue(IsFrozenProperty, value);
+        }
+
+        public static bool GetIsFrozen(UIElement element)
+        {
+            return (bool)element.GetValue(IsFrozenProperty);
+        }
+
+
+        /// <summary>
+        /// This updates the transparency on the Geometry object.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.</param>
+        private static void IsFrozenPropertyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+        {
+            if (obj is GeometryModel3D && obj.GetType() != typeof(BillboardTextModel3D))
+            {
+                var geom = (GeometryModel3D)obj;
+                var colors = geom.Geometry.Colors.ToArray();
+
+                for (int i = 0; i < colors.Length; i++)
+                {
+                    colors[i].Alpha = colors[i].Alpha * transparentGeometry;
+                }
+
+                geom.Geometry.Colors.Clear();
+                geom.Geometry.Colors.AddRange(colors);
+
+                var vertex = geom as DynamoGeometryModel3D;
+                if (vertex != null)
+                {
+                    vertex.RequiresPerVertexColoration = true;
+                    geom = vertex;
+                }
+
+                if (geom.IsAttached)
+                {
+                    var host = geom.RenderHost;
+                    geom.Detach();
+                    geom.Attach(host);
+                }
+            }
+        }
+
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -603,7 +603,12 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     }
 
                     node.RequestVisualUpdateAsync(scheduler, engineManager.EngineController, renderPackageFactory, true);
+                    break;
 
+                case "IsFrozen":
+                    HashSet<NodeModel> gathered = new HashSet<NodeModel>();
+                    node.GetDownstreamNodes(node, gathered);
+                    SetGeometryFrozen(gathered);
                     break;
             }
         }
@@ -810,6 +815,26 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
 
             return geometryModels;
+        }
+
+        private void SetGeometryFrozen(HashSet<NodeModel> gathered)
+        {
+            foreach (var node in gathered)
+            {
+                var geometryModels = FindAllGeometryModel3DsForNode(node.AstIdentifierBase);
+
+                if (!geometryModels.Any())
+                {
+                    continue;
+                }
+
+                var modelValues = geometryModels.Select(x => x.Value);
+
+                foreach (GeometryModel3D g in modelValues)
+                {
+                    g.SetValue(AttachedProperties.IsFrozenProperty, node.IsFrozen);
+                }
+            }
         }
 
         private void SetSelection(IEnumerable items, bool isSelected)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -16,16 +16,7 @@
              MouseRightButtonDown="topControl_MouseRightButtonDown"
              MouseEnter="OnNodeViewMouseEnter"
              MouseLeave="OnNodeViewMouseLeave">
-    <UserControl.Resources>
-        <Style TargetType="{x:Type controls:NodeView}">
-            <Style.Triggers>
-                <DataTrigger Binding="{Binding IsFrozen}" Value="True">                    
-                    <Setter Property="Opacity" Value ="0.7"/>
-                </DataTrigger>
-            </Style.Triggers>
-        </Style>
-    </UserControl.Resources>
-
+    
     <Grid Name="grid"
           x:FieldModifier="public"
           HorizontalAlignment="Left">
@@ -168,7 +159,16 @@
                    Grid.Row="1"
                    Grid.ColumnSpan="3"
                    Grid.RowSpan="3"
-                   Canvas.ZIndex="10">             
+                   Canvas.ZIndex="10">
+            <Rectangle.Style>
+                <Style TargetType="{x:Type Rectangle}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsFrozen}" Value="True">
+                            <Setter Property="Opacity" Value ="0.5"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Rectangle.Style>
             <Rectangle.Fill>                
                 <Binding Path="State"
                          UpdateSourceTrigger="PropertyChanged"
@@ -196,6 +196,15 @@
                          Converter="{StaticResource StateToColorConverter}">
                 </Binding>
             </Rectangle.Stroke>
+            <Rectangle.Style>
+                <Style TargetType="{x:Type Rectangle}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsFrozen}" Value="True">
+                            <Setter Property="Opacity" Value ="0.5"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Rectangle.Style>
             <Rectangle.Fill>
                 <Binding Path="State"
                          UpdateSourceTrigger="PropertyChanged"


### PR DESCRIPTION
## Purpose

The purpose of this PR is to add frozen state on geometry. As part of this PR,
1. alpha color component was changed to 0.5 for all the frozen nodes.
2. Nodes opacity is changed to 0.5 and will reflect only on the nodes. Preview bubble stays the same.
![default](https://cloud.githubusercontent.com/assets/8495197/11572885/6e3b06f8-99d1-11e5-8f35-8abc158e53f9.PNG)

![capture](https://cloud.githubusercontent.com/assets/8495197/11572840/3abf8628-99d1-11e5-9e0a-91a194c8158c.PNG)


This PR refers to the below tasks 
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8958

## Design Document
 https://docs.google.com/a/adsk-oss.com/presentation/d/1MUhSzoDo-QFPysDv1E6gRslpq2pnb6eoPjKSsJN6g-o/edit?usp=sharing  

## Declaration
Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

## Reviewers
 @mjkkirschner 