### PR TITLE
MAGN-9193 Freeze state is not updated when frozen connector connected/disconnected

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -758,7 +758,7 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         public virtual void Clear()
         {
-            this.workspaceLoaded = false;
+            workspaceLoaded = false;
             Log(Resources.ClearingWorkSpace);
 
             DynamoSelection.Instance.ClearSelection();
@@ -797,6 +797,7 @@ namespace Dynamo.Graph.Workspaces
             X = 0.0;
             Y = 0.0;
             Zoom = 1.0;
+            workspaceLoaded = true;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -382,30 +382,8 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                //this is the default case.
-                if (!this.NodeLogic.isFrozenExplicitly &&
-                      !this.NodeLogic.IsFrozen)
-                {
-                    return true;
-                }
-
-                //If any of the node is set to freeze by the user and 
-                // if that node is frozen by itself, then disable the Freeze property                              
-                if (this.nodeLogic.isFrozenExplicitly && NodeModel.IsAnyUpstreamFrozen())
-                {
-                    return false;
-                }
-                               
-                //if the node is set to freeze by the user     
-                // then enable the Freeze property
-                if (this.NodeLogic.isFrozenExplicitly)                   
-                {
-                    return true;
-                }
-                                
-                return false;
+                return !NodeModel.IsAnyUpstreamFrozen();
             }
-            
         }
 
         #endregion


### PR DESCRIPTION
### Purpose

When workspace is cleared its `workspaceLoaded` property becomes false for ever. But when a connector is added/removed it needs to update its end node's `IsFrozen` value. Updating is being performed only when `workspaceLoaded=true`.

### Reviewers

@ramramps 