### PR TITLE
Fix for automation regression due to recent DM changes

### DIFF
--- a/src/DynamoManipulation/Gizmo.cs
+++ b/src/DynamoManipulation/Gizmo.cs
@@ -122,7 +122,16 @@ namespace Dynamo.Manipulation
                 var cameraPos = cameraPosition != null ?
                     Point.ByCoordinates(cameraPosition.Value.X, cameraPosition.Value.Y, cameraPosition.Value.Z) : null;
 
-                if (cameraPos == null) throw new Exception("camera position is null");
+                if (cameraPos == null)
+                {
+                    // cameraPos will be null if HelixWatch3DViewModel is not initialized
+                    // this happens on an out of memory exception in SharpDX probably due to 
+                    // DynamoEffectsManager not being disposed off promptly.
+                    // TODO: revisit to fix this properly later
+                    // For the time being return a default position instead of throwing an exception
+                    // to the effect that camerPos should not be null
+                    return Point.ByCoordinates(ManipulatorOrigin.X, ManipulatorOrigin.Y, ManipulatorOrigin.Z);
+                }
 
                 var vec = Vector.ByTwoPoints(cameraPos, ManipulatorOrigin).Normalized();
                 return cameraPos.Add(vec.Scale(zDepth));


### PR DESCRIPTION
This fixes `CompleteInstall` automation failures due to recent changes for DM. An exception was being explicitly thrown on receiving a `null` camera position as it is not expected to be `null`.

`CameraPos` will be null if `HelixWatch3DViewModel` is not initialized thus falling back to creating an instance of `DefaultWatch3DViewModel`. This happens on an out of memory exception in `SharpDX` probably due to `DynamoEffectsManager` not being disposed off promptly. Here is the call stack for the exception thrown from `SharpDX`.
```
 at SharpDX.Result.CheckError()
   at SharpDX.Direct3D11.Device.GetSupportedFeatureLevel(Adapter adapter)
   at HelixToolkit.Wpf.SharpDX.DefaultEffectsManager.GetBestAdapter() in C:\projects\helix-toolkit\Source\HelixToolkit.Wpf.SharpDX\Controls\Effects.cs:line 88
   at HelixToolkit.Wpf.SharpDX.DefaultEffectsManager..ctor(IRenderTechniquesManager renderTechniquesManager) in C:\projects\helix-toolkit\Source\HelixToolkit.Wpf.SharpDX\Controls\Effects.cs:line 50
   at Dynamo.Wpf.ViewModels.Watch3D.DynamoEffectsManager..ctor(IRenderTechniquesManager renderTechniquesManager) in e:\Github\Dynamo\Dynamo\src\DynamoCoreWpf\ViewModels\Watch3D\DynamoEffectsManager.cs:line 18
   at Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel..ctor(Watch3DViewModelStartupParams parameters) in e:\Github\Dynamo\Dynamo\src\DynamoCoreWpf\ViewModels\Watch3D\HelixWatch3DViewModel.cs:line 388
   at Dynamo.Wpf.ViewModels.Watch3D.HelixWatch3DViewModel.TryCreateHelixWatch3DViewModel(Watch3DViewModelStartupParams parameters, DynamoLogger logger) in e:\Github\Dynamo\Dynamo\src\DynamoCoreWpf\ViewModels\Watch3D\HelixWatch3DViewModel.cs:line 366
```
### TODO: 
Revisit to fix this properly later.

For the time being we are returning a default position instead of throwing an exception to the effect that `camerPos` should not be null.