### PR TITLE
MAGN 9198 List.Chop does not accept double input

### DIFF
--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -613,7 +613,7 @@ namespace DSCore
 
             // If there are not any lengths more than 0,
             // we return incoming list.
-            if (lengths.Cast<int>().All(x => x <= 0))
+            if (lengths.All(x => x <= 0))
             {
                 return list;
             }
@@ -623,7 +623,7 @@ namespace DSCore
                 // If number of items in current list equals length in list of lengths,
                 // we should add current list in final list.
                 // Or if length in list of lengths <= 0, we should process this length and move further.
-                if (count == ((int)lengths[lengthIndex]) || ((int)lengths[lengthIndex] <= 0))
+                if (count == lengths[lengthIndex] || lengths[lengthIndex] <= 0)
                 {
                     finalList.Add(currList);
                     currList = new ArrayList();

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -604,7 +604,7 @@ namespace DSCore
         /// <param name="lengths">Lengths of consecutive sublists to be created from the input list</param>
         /// <returns name="lists">Sublists created from the list</returns>
         /// <search>sublists,build sublists,slices,partitions,cut,listcontains,chop</search>
-        public static IList Chop(IList list, IList lengths)
+        public static IList Chop(IList list, List<int> lengths)
         {
             var finalList = new ArrayList();
             var currList = new ArrayList();

--- a/test/DynamoCoreTests/Nodes/ListTests.cs
+++ b/test/DynamoCoreTests/Nodes/ListTests.cs
@@ -2247,5 +2247,18 @@ namespace Dynamo.Tests
             RunModel(openPath);
             AssertPreviewValue("404af9cd-3668-4aa8-aea1-314a228bd6e1", new object[] { 0, 2 });
         }
+
+        [Test]
+        [Category("Regression")]
+        public void TestListChop()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\list\testListChop.dyn");
+            RunModel(openPath);
+            AssertPreviewValue("f805b9b9-1a1f-4a63-ad9e-e4c9722ef1c7", 
+                new object[] {
+                    new object[] {1, 2 },
+                    new object[] {3, 4 },
+                    new object[] {5 } });
+        }
     }
 }

--- a/test/Libraries/CoreNodesTests/ListTests.cs
+++ b/test/Libraries/CoreNodesTests/ListTests.cs
@@ -462,7 +462,7 @@ namespace DSCoreNodesTests
         {
             Assert.AreEqual(
                 new ArrayList { new ArrayList { 0, 1 }, new ArrayList { 2, 3 } },
-                List.Chop(new ArrayList { 0, 1, 2, 3 }, new ArrayList { 2 }));
+                List.Chop(new ArrayList { 0, 1, 2, 3 }, new List<int> { 2 }));
         }
 
         [Test]
@@ -886,7 +886,7 @@ namespace DSCoreNodesTests
         public static void Chop1()
         {
             var list = new ArrayList { 1, 2, 3, 4, 5 };
-            var lengths = new ArrayList { 3, 2 };
+            var lengths = new List<int> { 3, 2 };
 
             var output = List.Chop(list, lengths);
             var expected = new ArrayList { new ArrayList { 1, 2, 3 }, new ArrayList { 4, 5 } };
@@ -898,7 +898,7 @@ namespace DSCoreNodesTests
         public static void Chop2()
         {
             var list = new ArrayList { 1, 2, 3, 4, 5 };
-            var lengths = new ArrayList { 0, 2 };
+            var lengths = new List<int> { 0, 2 };
 
             var output = List.Chop(list, lengths);
             var expected = new ArrayList { new ArrayList { }, new ArrayList { 1, 2 }, new ArrayList { 3, 4 }, new ArrayList { 5 } };
@@ -910,7 +910,7 @@ namespace DSCoreNodesTests
         public static void Chop3()
         {
             var list = new ArrayList { 1, 2, 3, 4, 5 };
-            var lengths = new ArrayList { -1, -1 };
+            var lengths = new List<int> { -1, -1 };
 
             var output = List.Chop(list, lengths);
             var expected = new ArrayList { 1, 2, 3, 4, 5 };
@@ -922,7 +922,7 @@ namespace DSCoreNodesTests
         public static void Chop4()
         {
             var list = new ArrayList { 1, 2, 3 };
-            var lengths = new ArrayList { 2, 5 };
+            var lengths = new List<int> { 2, 5 };
 
             var output = List.Chop(list, lengths);
             var expected = new ArrayList { new ArrayList { 1, 2 }, new ArrayList { 3 } };
@@ -934,21 +934,11 @@ namespace DSCoreNodesTests
         public static void Chop5()
         {
             var list = new ArrayList { 1, "a", 3 };
-            var lengths = new ArrayList { 2, 1 };
+            var lengths = new List<int> { 2, 1 };
 
             var output = List.Chop(list, lengths);
             var expected = new ArrayList { new ArrayList { 1, "a" }, new ArrayList { 3 } };
             Assert.AreEqual(expected, output);
-        }
-
-        [Test]
-        [Category("UnitTests")]
-        public static void Chop6()
-        {
-            var list = new ArrayList { 1, 2, 3 };
-            var lengths = new ArrayList { 1, "a" };
-
-            Assert.Throws<InvalidCastException>(() => { List.Chop(list, lengths); });
         }
 
         [Test]

--- a/test/core/list/testListChop.dyn
+++ b/test/core/list/testListChop.dyn
@@ -1,0 +1,20 @@
+<Workspace Version="0.9.1.3440" X="-435.40504678125" Y="-225.88682878125" zoom="1.545620359375" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="a9126d99-b054-42e0-9176-9a6bae8b7668" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.Chop" x="689.5" y="328.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.List.Chop@var[]..[],int[]" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="b9e20dfe-5fdd-457e-b7b9-48e6d6549e7e" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="404.885476677988" y="312.825264821104" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="{1,2,3,4,5};" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="4a9bcafd-188d-4345-9fa4-5b3fec8f42ac" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="403.056671621831" y="429.416762684781" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="2.4;" ShouldFocus="false" />
+    <DSCoreNodesUI.Watch guid="f805b9b9-1a1f-4a63-ad9e-e4c9722ef1c7" type="DSCoreNodesUI.Watch" nickname="Watch" x="893.714295664636" y="337.615113361188" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="a9126d99-b054-42e0-9176-9a6bae8b7668" start_index="0" end="f805b9b9-1a1f-4a63-ad9e-e4c9722ef1c7" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b9e20dfe-5fdd-457e-b7b9-48e6d6549e7e" start_index="0" end="a9126d99-b054-42e0-9176-9a6bae8b7668" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="4a9bcafd-188d-4345-9fa4-5b3fec8f42ac" start_index="0" end="a9126d99-b054-42e0-9176-9a6bae8b7668" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR fixes defect [MAGN 9198 regression: integer inputs failing with doubles](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9198#).

This is because the signature of this node is
```
List.Chop(IList list, IList lengths)
```

And internally the implementation tries to cast `lengths` to `IEnumerable<int>`. But it would fail for double values because `IList` doesn't support covariance. In this PR we change the signature to
```
List.Chop(IList list, List<int> lengths)
```

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers
@sharadkjaiswal 