### PR TITLE
MAGN 9202 Fix crash in opening file when the focus is still in code block node

### DIFF
--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -75,6 +75,7 @@ namespace Dynamo.ViewModels
             if (Model.DebugSettings.VerboseLogging)
                 model.Logger.Log("Command: " + command);
 
+            ReturnFocusToSearch(); 
             this.model.ExecuteCommand(command);
         }
 


### PR DESCRIPTION
### Purpose

This PR fixes defect [MAGN 9202 Opening file crashes when input focus is still in node](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9202).

Following diagram shows all happened events when opening a .dyn file but the input focus is still in code block node (or any other editor nodes like `Number`):
```
Execute open command 
        |
        v
Set current homeworkspace to the new one
        |
        v
Code completion editor lost focus
        |
        v
Code block editor commit change
        |
        v
Save node to its host workspace
        |
        v
As the previous homeworkspace has been removed, this operation fail
```

So to fix this defect we have two options: 
  1. Disable all global commands and short cuts when the input focus is still in node, or
  2. Return focus back to the main view when executing any command so that nodes will commit changes before command execution

In this PR we use the second option.

### Reviewer

@Benglin 