### PR TITLE
Fix MAGN 9143 Geometry disappears when input slider is deleted

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -433,6 +433,18 @@ namespace Dynamo.Graph.Workspaces
             var updateTask = (UpdateGraphAsyncTask)task;
             var messages = new Dictionary<Guid, string>();
 
+            // Mark all modified nodes as being updated.
+            // 
+            // In addition to marking modified nodes as being updated, their 
+            // warning states are cleared (which include the tool-tip).
+            foreach (var modifiedNode in updateTask.ModifiedNodes)
+            {
+                modifiedNode.WasInvolvedInExecution = true;
+                modifiedNode.WasRenderPackageUpdatedAfterExecution = false;
+                if (modifiedNode.State == ElementState.Warning)
+                    modifiedNode.ClearRuntimeError();
+            }
+
             // Runtime warnings take precedence over build warnings.
             foreach (var warning in updateTask.RuntimeWarnings)
             {

--- a/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
@@ -113,24 +113,6 @@ namespace Dynamo.Scheduler
                 // Retrieve warnings in the context of ISchedulerThread.
                 BuildWarnings = engineController.GetBuildWarnings();
                 RuntimeWarnings = engineController.GetRuntimeWarnings();
-
-                // Mark all modified nodes as being updated (if the task has been 
-                // successfully scheduled, executed and completed, it is expected 
-                // for "modifiedNodes" to be both non-null and non-empty.
-                // 
-                // In addition to marking modified nodes as being updated, their 
-                // warning states are cleared (which include the tool-tip). Any node
-                // that has build/runtime warnings assigned to it will properly be 
-                // restored to warning state when task completion handler sets the 
-                // corresponding build/runtime warning on it.
-                // 
-                foreach (var modifiedNode in ModifiedNodes)
-                {
-                    modifiedNode.WasInvolvedInExecution = true;
-                    modifiedNode.WasRenderPackageUpdatedAfterExecution = false;
-                    if (modifiedNode.State == ElementState.Warning)
-                        modifiedNode.ClearRuntimeError();
-                }
             }
         }
 


### PR DESCRIPTION
### Purpose

This PR is to fix [MAGN 9143 Geometry disappears when input slider is deleted](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9143)

Fundamentally, it is because of data racing: node's some state is changed both in main thread and scheduler thread.

When a node or its direct input is modified, we expect the following events happen sequentially (so `UpdateGraphAsyncTask` will be executed for the change and `RequestValueUpdateAsyncTask` will be executed to update preview value):
```
Main Thread                                    |     Scheduler Thread
-----------------------------------------------+--------------------------------------------------
1. NodeModel.OnModified()                      |
                                               |
2. ...trigger HomeWorkspaceModel.Run()         |
                                               |
3. ...clearing modified nodes' execution state | 
   by setting WasInvolvedInExecution = false   |
                                               |
4. ...schedule UpdateGraphAsyncTask            |
                                               | 5. ...execute UpdateGraphAsyncTask
                                               |                                    
                                               | 6. ...complete, set WasInvolvedInExecution=true 
                                               |
                                               | 7. ...schedule RequestValueUpdateAsyncTask 
                                               |
                                               | 8. ...query value for nodes whose
                                               |    WasInvolvedInExecution is true
```
Notice `WasInvolvedInExecution` is modified in different thread. As deleting a node will trigger twice `HomeWorkspace.Run()` in run automatically mode (one is by `NodeModel.PortDisconnect` and the other one is by `NodeModel.Remove`), after step 6 and before step 7, the other `HomeWorkspaceModel.Run()` may kick in:
```
Main Thread                                    |     Scheduler Thread
-----------------------------------------------+--------------------------------------------------
1. NodeModel.OnModified()                      |
                                               |
2. ...trigger HomeWorkspaceModel.Run()         |
                                               |
3. ...clearing modified nodes' execution state | 
   by setting WasInvolvedInExecution = false   |
                                               |
4. ...schedule UpdateGraphAsyncTask            |
                                               | 5. ...execute UpdateGraphAsyncTask
                                               |                                    
                                               | 6. ...complete, set WasInvolvedInExecution=true 
                                               |
     >>...HomeWorkspace.Run()                  |
     >>...setting WasInvolvedInExecution= false|
     >>...                                     |
                                               |
                                               | 7. ...schedule RequestValueUpdateAsyncTask 
                                               |
                                               | 8. ...query value for nodes whose
                                               |    WasInvolvedInExecution is true (FAILED)
```
Now in step 8, as `WasInvokedInExecution` has been modified to `false`, the preview value won't be updated.

So this PR moves step 6 to main thread, there won't be the other `HomeWorkspace.Run()` scheduled *before* `RequestValueUpdateAsyncTask`. 

### Reviewer
@Benglin 