### PR TITLE
Offset gizmo axes from origin to avoid overlapping point being manipulated

### DIFF
--- a/src/DynamoManipulation/TranslationGizmo.cs
+++ b/src/DynamoManipulation/TranslationGizmo.cs
@@ -38,6 +38,12 @@ namespace Dynamo.Manipulation
         #region Private members
 
         /// <summary>
+        /// An offset distance from the gizmo Origin
+        /// at which to place the axes in their respective directions
+        /// </summary>
+        private const double axisOriginOffset = 0.2;
+
+        /// <summary>
         /// List of axis available for manipulation
         /// </summary>
         private readonly List<Vector> axes = new List<Vector>();
@@ -463,12 +469,13 @@ namespace Dynamo.Manipulation
             var axisType = GetAlignedAxis(axis);
             package.Description = string.Format("{0}_{1}_{2}", RenderDescriptions.ManipulatorAxis, Name, axisType);
 
+            using (var axisStart = Origin.Add(axis.Scale(axisOriginOffset)))
             using (var axisEnd = Origin.Add(axis.Scale(scale)))
             {
                 var color = GetAxisColor(axisType);
                 package.AddLineStripVertexCount(2);
                 package.AddLineStripVertexColor(color.R, color.G, color.B, color.A);
-                package.AddLineStripVertex(Origin.X, Origin.Y, Origin.Z);
+                package.AddLineStripVertex(axisStart.X, axisStart.Y, axisStart.Z);
                 package.AddLineStripVertexColor(color.R, color.G, color.B, color.A);
                 package.AddLineStripVertex(axisEnd.X, axisEnd.Y, axisEnd.Z);
             }


### PR DESCRIPTION
Refer to discussion on https://github.com/DynamoDS/Dynamo/pull/5834
The new gizmo looks like this so that it does not overlap base point being manipulated:
![image](https://cloud.githubusercontent.com/assets/5710686/11800156/0d517db6-a315-11e5-912e-dce0a8ad5c8f.png)
