### PR TITLE
RGBA converter

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2750,19 +2750,18 @@ namespace Dynamo.Controls
         {
             public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
             {
-                // string example: "R=255, G=60, B=0, A=255"
-                var rgba = (value as string).Split(new char[] { 'R', 'G', 'B', 'A', ',', '=', ' ' },
-                    StringSplitOptions.RemoveEmptyEntries);
-
-                if (rgba.Count() == 4)
+                // example conversion: "R=255, G=60, B=0, A=255" beccomes "#FF3C00"
+                try
                 {
-                    try
+                    var rgba = (value as string).Split(new char[] { 'R', 'G', 'B', 'A', ',', '=', ' ' },
+                        StringSplitOptions.RemoveEmptyEntries);
+
+                    if (rgba.Count() == 4)
                     {
                         return new SolidColorBrush(Color.FromRgb(
                            Byte.Parse(rgba[0]), Byte.Parse(rgba[1]), Byte.Parse(rgba[2])));
                     }
-                    catch { }
-                }
+                } catch { }
 
                 return "Black"; // if not able to parse color
             }

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2745,4 +2745,31 @@ namespace Dynamo.Controls
                 throw new Exception("The method or operation is not implemented.");
             }
         }
+
+        public class RgbaStringToBrushConverter : IValueConverter
+        {
+            public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            {
+                // string example: "R=255, G=60, B=0, A=255"
+                var rgba = (value as string).Split(new char[] { 'R', 'G', 'B', 'A', ',', '=', ' ' },
+                    StringSplitOptions.RemoveEmptyEntries);
+
+                if (rgba.Count() == 4)
+                {
+                    try
+                    {
+                        return new SolidColorBrush(Color.FromRgb(
+                           Byte.Parse(rgba[0]), Byte.Parse(rgba[1]), Byte.Parse(rgba[2])));
+                    }
+                    catch { }
+                }
+
+                return "Black"; // if not able to parse color
+            }
+
+            public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            {
+                throw new NotImplementedException();
+            }
+        }
     }

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -160,6 +160,7 @@
     <controls:NestedContentMarginConverter x:Key="NestedContentMarginConverter"/>
     <controls:ClassViewMarginConverter x:Key="ClassViewMarginConverter" />
     <controls:ElementGroupToColorConverter x:Key="ElementGroupToColorConverter" />
+    <controls:RgbaStringToBrushConverter x:Key="RgbaStringToBrushConverter" />
     <controls:BooleanToBrushConverter x:Key="FilterIsSelertedCategoryToBrushConverter"
                                       TrueBrush="{StaticResource CommonSidebarTextColor}"
                                       FalseBrush="{StaticResource FilterCategoryIsNotSelectedColor}">


### PR DESCRIPTION
### Purpose

References:
- [MAGN-9254](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9254)

Adding a new converter to convert an RGBA string into WPF SolidColorBrush.

Example conversion:
`"R=255, G=60, B=0, A=255"` becomes `"#FF3C00"`

### Reviewers

@Randy-Ma 

### FYIs

@Benglin 