### PR TITLE
Dispose temporary geometry created in direct manipulation to prevent memory bloat

### DIFF
--- a/src/DynamoManipulation/MousePointManipulator.cs
+++ b/src/DynamoManipulation/MousePointManipulator.cs
@@ -39,7 +39,6 @@ namespace Dynamo.Manipulation
         {
             //Default axes
             var axes = new Vector[] { Vector.XAxis(), Vector.YAxis(), Vector.ZAxis() };
-
             //Holds manipulator axis and input node pair for each input port.
             indexedAxisNodePairs = new Dictionary<int, Tuple<Vector, NodeModel>>(3);
 
@@ -222,11 +221,6 @@ namespace Dynamo.Manipulation
             origin = Point.ByCoordinates(pt.X, pt.Y, pt.Z);
             
             Active = true;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);    
         }
 
         #endregion

--- a/src/DynamoManipulation/MousePointManipulator.cs
+++ b/src/DynamoManipulation/MousePointManipulator.cs
@@ -39,6 +39,7 @@ namespace Dynamo.Manipulation
         {
             //Default axes
             var axes = new Vector[] { Vector.XAxis(), Vector.YAxis(), Vector.ZAxis() };
+
             //Holds manipulator axis and input node pair for each input port.
             indexedAxisNodePairs = new Dictionary<int, Tuple<Vector, NodeModel>>(3);
 
@@ -222,6 +223,7 @@ namespace Dynamo.Manipulation
             
             Active = true;
         }
+
 
         #endregion
 

--- a/src/DynamoManipulation/MousePointManipulator.cs
+++ b/src/DynamoManipulation/MousePointManipulator.cs
@@ -224,6 +224,10 @@ namespace Dynamo.Manipulation
             Active = true;
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);    
+        }
 
         #endregion
 

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -15,6 +15,7 @@ using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Visualization;
 using Dynamo.Wpf.ViewModels.Watch3D;
+using ProtoCore.AST.AssociativeAST;
 using ProtoCore.Mirror;
 using Point = Autodesk.DesignScript.Geometry.Point;
 using Vector = Autodesk.DesignScript.Geometry.Vector;
@@ -352,6 +353,13 @@ namespace Dynamo.Manipulation
             CommandExecutive.ExecuteCommand(command, UniqueId, ExtensionName);
 
             var inputNode = WorkspaceModel.Nodes.FirstOrDefault(node => node.GUID == command.ModelGuid) as DoubleSlider;
+
+            if (inputNode != null)
+            {
+                // Assign the input slider to the default value of the node's input port
+                var doubleNode = Node.InPorts[inputPortIndex].DefaultValue as DoubleNode;
+                if (doubleNode != null) inputNode.Value = doubleNode.Value;
+            }
             return inputNode;
         }
 

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -496,10 +496,10 @@ namespace Dynamo.Manipulation
 
         public void Dispose()
         {
+            Dispose(true);
+
             DeleteGizmos();
             DetachHandlers();
-
-            Dispose(true);
         }
 
         /// <summary>

--- a/src/DynamoManipulation/PointOnCurveManipulator.cs
+++ b/src/DynamoManipulation/PointOnCurveManipulator.cs
@@ -103,14 +103,13 @@ namespace Dynamo.Manipulation
             if (pt == null) return; //The node output is not Point, could be a function object.
 
             var param = curve.ParameterAtPoint(pt);
-            using (tangent = curve.TangentAtParameter(param))
-            {
-                //Don't cache pt directly here, need to create a copy, because 
-                //pt may be GC'ed by VM.
-                pointOnCurve = Point.ByCoordinates(pt.X, pt.Y, pt.Z);
+            tangent = curve.TangentAtParameter(param);
+            
+            //Don't cache pt directly here, need to create a copy, because 
+            //pt may be GC'ed by VM.
+            pointOnCurve = Point.ByCoordinates(pt.X, pt.Y, pt.Z);
 
-                Active = tangent != null;
-            }
+            Active = tangent != null;
         }
 
         protected override IEnumerable<NodeModel> OnGizmoClick(IGizmo gizmoInAction, object hitObject)
@@ -145,6 +144,13 @@ namespace Dynamo.Manipulation
             }
 
             return newPosition;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if(tangent != null) tangent.Dispose();
+
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/src/DynamoManipulation/TranslationGizmo.cs
+++ b/src/DynamoManipulation/TranslationGizmo.cs
@@ -492,5 +492,12 @@ namespace Dynamo.Manipulation
 
         #endregion
 
+        protected override void Dispose(bool disposing)
+        {
+            axes.ForEach(x => x.Dispose());
+            planes.ForEach(x => x.Dispose());
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/DynamoManipulation/TranslationGizmo.cs
+++ b/src/DynamoManipulation/TranslationGizmo.cs
@@ -364,7 +364,9 @@ namespace Dynamo.Manipulation
             // Update gizmo geometry wrt to current Origin
             var newPlanes = planes.Select(
                 plane => Plane.ByOriginXAxisYAxis(Origin, plane.XAxis, plane.YAxis)).ToList();
+
             planes.Clear();
+
             planes.AddRange(newPlanes);
 
             DeleteTransientGraphics();
@@ -440,23 +442,30 @@ namespace Dynamo.Manipulation
         /// <param name="name"></param>
         private void DrawPlane(ref IRenderPackage package, Plane plane, Planes name)
         {
-            package.Description = string.Format("{0}_{1}_{2}", RenderDescriptions.ManipulatorPlane, Name, name); 
-            var p1 = Origin.Add(plane.XAxis.Scale(scale/3));
-            var p2 = p1.Add(plane.YAxis.Scale(scale/3));
-            var p3 = Origin.Add(plane.YAxis.Scale(scale/3));
+            package.Description = string.Format("{0}_{1}_{2}", RenderDescriptions.ManipulatorPlane, Name, name);
+            using (var vec1 = plane.XAxis.Scale(scale/3))
+            using (var vec2 = plane.YAxis.Scale(scale/3))
+            using (var vec3 = plane.YAxis.Scale(scale/3))
+            {
+                using (var p1 = Origin.Add(vec1))
+                using (var p2 = p1.Add(vec2))
+                using (var p3 = Origin.Add(vec3))
+                {
+                    var axis = plane.Normal;
+                    var color = GetAxisColor(GetAlignedAxis(axis));
 
-            var axis = plane.Normal;
-            var color = GetAxisColor(GetAlignedAxis(axis));
-            
-            package.AddLineStripVertexCount(3);
-            package.AddLineStripVertexColor(color.R, color.G, color.B, color.A);
-            package.AddLineStripVertex(p1.X, p1.Y, p1.Z);
+                    package.AddLineStripVertexCount(3);
+                    package.AddLineStripVertexColor(color.R, color.G, color.B, color.A);
+                    package.AddLineStripVertex(p1.X, p1.Y, p1.Z);
 
-            package.AddLineStripVertexColor(color.R, color.G, color.B, color.A);
-            package.AddLineStripVertex(p2.X, p2.Y, p2.Z);
+                    package.AddLineStripVertexColor(color.R, color.G, color.B, color.A);
+                    package.AddLineStripVertex(p2.X, p2.Y, p2.Z);
 
-            package.AddLineStripVertexColor(color.R, color.G, color.B, color.A);
-            package.AddLineStripVertex(p3.X, p3.Y, p3.Z);
+                    package.AddLineStripVertexColor(color.R, color.G, color.B, color.A);
+                    package.AddLineStripVertex(p3.X, p3.Y, p3.Z);
+                    
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
I have tried to dispose temporary geometry created for direct manipulation calculations wherever possible. 

Eventually I'm planning on having our [own light-weight implementation] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9179) for all of the geometric computations involved in DM; just didn't include these in right now as it's too close to release and new code will involve a lot more testing.

@sharadkjaiswal please review