### PR TITLE
MAGN-9142 Analysis : Graph with valid Revit element ids gives nothing but "null " values for those elements

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -2789,20 +2789,28 @@ namespace ProtoAssociative
             }
             else if (node is ArrayNode)
             {
-                ArrayNode arrayNode = node as ArrayNode;
+                var arrayNode = node as ArrayNode;
                 DFSEmitSSA_AST(arrayNode.Expr, ssaStack, ref astlist);
 
-                BinaryExpressionNode bnode = new BinaryExpressionNode();
-                bnode.Optr = ProtoCore.DSASM.Operator.assign;
+                var bnode = new BinaryExpressionNode { Optr = Operator.assign };
 
                 // Left node
-                AssociativeNode tmpIdent =AstFactory.BuildIdentifier(ProtoCore.Utils.CoreUtils.BuildSSATemp(core));
+                var tmpIdent = AstFactory.BuildIdentifier(CoreUtils.BuildSSATemp(core));
                 Validity.Assert(null != tmpIdent);
                 bnode.LeftNode = tmpIdent;
 
+                if (arrayNode.Expr == null && arrayNode.Type == null)
+                {
+                    // Right node
+                    bnode.RightNode = new NullNode();
+                    astlist.Add(bnode);
+                    ssaStack.Push(bnode);
+                    return;
+                }
+
                 // pop off the dimension
-                AssociativeNode dimensionNode = ssaStack.Pop();
-                ArrayNode currentDimensionNode = null;
+                var dimensionNode = ssaStack.Pop();
+                ArrayNode currentDimensionNode;
                 if (dimensionNode is BinaryExpressionNode)
                 {
                     currentDimensionNode = new ArrayNode((dimensionNode as BinaryExpressionNode).LeftNode, null);

--- a/src/Libraries/GeometryUI/ExportWithUnits.cs
+++ b/src/Libraries/GeometryUI/ExportWithUnits.cs
@@ -54,10 +54,8 @@ namespace GeometryUI
             SelectedExportedUnitsSource =
                 Conversions.ConversionMetricLookup[ConversionMetricUnit.Length];
 
-            AssociativeNode geometryNode = new ArrayNode();
-            AssociativeNode stringNode = new StringNode();
-            InPortData.Add(new PortData("geometry", Resources.ExportToSatGeometryInputDescription, geometryNode));
-            InPortData.Add(new PortData("filePath", Resources.ExportToSatFilePathDescription, stringNode));
+            InPortData.Add(new PortData("geometry", Resources.ExportToSatGeometryInputDescription));
+            InPortData.Add(new PortData("filePath", Resources.ExportToSatFilePathDescription, new StringNode()));
             OutPortData.Add(new PortData("string", Resources.ExportToSatFilePathOutputDescription));
 
             ShouldDisplayPreviewCore = true;


### PR DESCRIPTION
### Purpose

First of all, the problem has no connection to either Revit or large graphs.

ExportToSAT node has empty ArrayNode as default value for geometry input. Re-computation a graph with this node (default value is on) cause to an exception in CodeGen.cs because `ssaStack.Pop()` is called when it is empty. The exception causes whole graph fails and all nodes have null values.

In this PR:
- default value for ExportToSAT node is removed because it does not make any sense.
- computation is fixed for empty ArrayNode (if it turns out some port of another node has such value, the graph won't fail)

### Reviewers

I am not sure who should review this PR. @ke-yu, I assign this to you just because I saw you are often contributing to ProtoAssociative :)

### FYIs

@jnealb @mccrone 