### PR TITLE
MAGN-9268 Wrong node is created when it is dragged from non-root category

### DIFF
--- a/src/DynamoCoreWpf/Utilities/LibraryDragAndDrop.cs
+++ b/src/DynamoCoreWpf/Utilities/LibraryDragAndDrop.cs
@@ -33,7 +33,7 @@ namespace Dynamo.Wpf.Utilities
             nodeViewModel = null;
         } 
 
-        internal void HandleMouseMove(FrameworkElement sender, Point currentPosition)
+        internal void HandleMouseMove(DependencyObject sender, Point currentPosition)
         {
             if (isDragging || nodeViewModel == null)
                 return;
@@ -56,10 +56,12 @@ namespace Dynamo.Wpf.Utilities
 
         }
 
-        private void StartDrag(FrameworkElement sender, NodeSearchElementViewModel node)
+        private void StartDrag(DependencyObject sender, NodeSearchElementViewModel node)
         {
             isDragging = true;
             DragDrop.DoDragDrop(sender, new DragDropNodeSearchElementInfo(node.Model), DragDropEffects.Copy);
+            // reset when dragging ends
+            Clear();
             isDragging = false;
         }
     }

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -295,33 +295,47 @@ namespace Dynamo.UI.Views
 
         private void OnExpanderButtonMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
-            var senderButton = e.OriginalSource as FrameworkElement;
-            if (senderButton != null)
-            {
-                var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
+            var searchElementVm = GetDataContext(e.OriginalSource);
 
-                //sender can be RootSearchElementVM or ClassInformationViewModel. 
-                //And we should just fire HandleMouseLeftButtonDown, when ViewModel is NodeSearchElementViewModel
-                if (searchElementVM != null)
-                    dragDropHelper.HandleMouseDown(e.GetPosition(null), searchElementVM);
+            //sender can be RootSearchElementVM or ClassInformationViewModel. 
+            //And we should just fire HandleMouseLeftButtonDown, when ViewModel is NodeSearchElementViewModel
+            if (searchElementVm != null)
+            {
+                dragDropHelper.HandleMouseDown(e.GetPosition(null), searchElementVm);
             }
         }
 
         private void OnExpanderButtonPreviewMouseMove(object sender, MouseEventArgs e)
         {
-            if (e.LeftButton != MouseButtonState.Pressed)
+            if (e.LeftButton != MouseButtonState.Pressed || !(e.OriginalSource is DependencyObject))
                 return;
 
-            var senderButton = e.OriginalSource as FrameworkElement;
-            if (senderButton != null)
-            {
-                var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
-
-                //sender can be RootSearchElementVM or ClassInformationViewModel. 
+            var searchElementVm = GetDataContext(e.OriginalSource);
+            
+            //sender can be RootSearchElementVM or ClassInformationViewModel. 
                 //And we should just fire HandleMouseMove, when ViewModel is NodeSearchElementViewModel
-                if (searchElementVM != null)
-                    dragDropHelper.HandleMouseMove(senderButton, e.GetPosition(null));
+            if (searchElementVm != null)
+            {
+                dragDropHelper.HandleMouseMove((DependencyObject)e.OriginalSource, e.GetPosition(null));
             }
+        }
+
+        private NodeSearchElementViewModel GetDataContext(object source)
+        {
+            var frameworkElement = source as FrameworkElement;
+            
+            if (frameworkElement != null)
+            {
+                return frameworkElement.DataContext as NodeSearchElementViewModel;
+            }
+
+            var frameworkContentElement = source as FrameworkContentElement;
+            if (frameworkContentElement != null)
+            {
+                return frameworkContentElement.DataContext as NodeSearchElementViewModel;
+            }
+
+            return null;
         }
 
         #endregion


### PR DESCRIPTION
### Purpose

When mouse is pressed on node name, `NodeSearchElementViewModel` is not retrieved because node name is not `FrameworkElement` (it is `FrameworkContentElement`) and therefore dragging occurs with previous `NodeSearchElementViewModel`.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@pbidenko 