### PR TITLE
MAGN-9023 Remove Dynamo.Wpf namespace from CoreNodeModelsWpf

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml
@@ -1,9 +1,9 @@
-﻿<UserControl x:Class="Dynamo.Wpf.Controls.DateTimeInputControl"
+﻿<UserControl x:Class="CoreNodeModelsWpf.Controls.DateTimeInputControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:converters="clr-namespace:Dynamo.Wpf.Converters"
+             xmlns:converters="clr-namespace:CoreNodeModelsWpf.Converters"
              xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
              mc:Ignorable="d" 
              Width="200">

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DateTimeInputControl.xaml.cs
@@ -2,7 +2,7 @@
 using System.Windows.Forms;
 using UserControl = System.Windows.Controls.UserControl;
 
-namespace Dynamo.Wpf.Controls
+namespace CoreNodeModelsWpf.Controls
 {
     /// <summary>
     /// Interaction logic for DateTimeInputControl.xaml

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DoubleSliderSettingsControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DoubleSliderSettingsControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Dynamo.Wpf.DoubleSliderSettingsControl"
+﻿<UserControl x:Class="CoreNodeModelsWpf.DoubleSliderSettingsControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DoubleSliderSettingsControl.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DoubleSliderSettingsControl.xaml.cs
@@ -3,7 +3,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using Dynamo.Controls;
 
-namespace Dynamo.Wpf
+namespace CoreNodeModelsWpf
 {
     /// <summary>
     /// Interaction logic for SliderSettingsControl.xaml

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoConverterControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoConverterControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Dynamo.Wpf.Controls.DynamoConverterControl"
+﻿<UserControl x:Class="CoreNodeModelsWpf.Controls.DynamoConverterControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoConverterControl.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoConverterControl.xaml.cs
@@ -4,7 +4,7 @@ using Dynamo.Controls;
 using DSCoreNodesUI;
 using Dynamo.UI.Commands;
 
-namespace Dynamo.Wpf.Controls
+namespace CoreNodeModelsWpf.Controls
 {
     /// <summary>
     /// Interaction logic for ConverterControl.xaml

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Dynamo.Wpf.Controls.DynamoSlider"
+﻿<UserControl x:Class="CoreNodeModelsWpf.Controls.DynamoSlider"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
@@ -12,7 +12,7 @@ using Dynamo.Models;
 using Dynamo.UI;
 using Dynamo.ViewModels;
 
-namespace Dynamo.Wpf.Controls
+namespace CoreNodeModelsWpf.Controls
 {
     /// <summary>
     /// Interaction logic for DynamoSlider.xaml

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ElementSelectionControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ElementSelectionControl.xaml
@@ -1,9 +1,9 @@
-﻿<UserControl x:Class="Dynamo.Wpf.ElementSelectionControl"
+﻿<UserControl x:Class="CoreNodeModelsWpf.ElementSelectionControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:converters="clr-namespace:Dynamo.Wpf.Converters"
+             xmlns:converters="clr-namespace:CoreNodeModelsWpf.Converters"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="200">
     <UserControl.Resources>

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ElementSelectionControl.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ElementSelectionControl.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using System.Windows.Controls;
 
-namespace Dynamo.Wpf
+namespace CoreNodeModelsWpf
 {
     /// <summary>
     /// Interaction logic for ElementSelectionControl.xaml

--- a/src/Libraries/CoreNodeModelsWpf/Controls/IntegerSliderSettingsControl.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/IntegerSliderSettingsControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Dynamo.Wpf.IntegerSliderSettingsControl"
+﻿<UserControl x:Class="CoreNodeModelsWpf.IntegerSliderSettingsControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 

--- a/src/Libraries/CoreNodeModelsWpf/Controls/IntegerSliderSettingsControl.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/IntegerSliderSettingsControl.xaml.cs
@@ -3,7 +3,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using Dynamo.Controls;
 
-namespace Dynamo.Wpf
+namespace CoreNodeModelsWpf
 {
     /// <summary>
     /// Interaction logic for UserControl1.xaml

--- a/src/Libraries/CoreNodeModelsWpf/ConverterViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/ConverterViewModel.cs
@@ -13,7 +13,7 @@ using Dynamo.UI.Commands;
 using Dynamo.ViewModels;
 using DynamoConversions;
 
-namespace Dynamo.Wpf
+namespace CoreNodeModelsWpf
 {
     public class ConverterViewModel : NotificationObject
     {

--- a/src/Libraries/CoreNodeModelsWpf/Converters/SelectionButtonContentConverter.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Converters/SelectionButtonContentConverter.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Windows.Data;
 
-namespace Dynamo.Wpf.Converters
+namespace CoreNodeModelsWpf.Converters
 {
     public class SelectionButtonContentConverter : IValueConverter
     {
@@ -13,10 +13,10 @@ namespace Dynamo.Wpf.Converters
             if (value is IEnumerable<object>)
             {
                 if (!(value as IEnumerable<object>).Any())
-                    return Properties.Resources.SelectNodeButtonSelect;
+                    return Dynamo.Wpf.Properties.Resources.SelectNodeButtonSelect;
             }
 
-            return Properties.Resources.SelectNodeButtonChange;
+            return Dynamo.Wpf.Properties.Resources.SelectNodeButtonChange;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Libraries/CoreNodeModelsWpf/Converters/StringToDateTimeOffsetConverter.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Converters/StringToDateTimeOffsetConverter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Windows.Data;
 using Dynamo.Configuration;
 
-namespace Dynamo.Wpf.Converters
+namespace CoreNodeModelsWpf.Converters
 {
     public class StringToDateTimeConverter : IValueConverter
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/BoolSelector.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/BoolSelector.cs
@@ -7,8 +7,9 @@ using System.Windows.Data;
 using Dynamo.Controls;
 using Dynamo.ViewModels;
 using DSCoreNodesUI.Input;
+using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     public class BoolSelectorNodeViewCustomization : INodeViewCustomization<BoolSelector>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorRange.cs
@@ -19,8 +19,9 @@ using Dynamo.Models;
 using Dynamo.ViewModels;
 using ProtoCore.Mirror;
 using Color = DSCore.Color;
+using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     public class ColorRangeNodeViewCustomization : INodeViewCustomization<ColorRange>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ConverterNodeViewCustomization.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ConverterNodeViewCustomization.cs
@@ -10,8 +10,10 @@ using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using DynamoConversions;
 using ProtoCore.AST;
+using Dynamo.Wpf;
+using CoreNodeModelsWpf.Controls;
 
-namespace Dynamo.Wpf.NodeViewCustomizations
+namespace CoreNodeModelsWpf.NodeViewCustomizations
 {
     class ConverterNodeViewCustomization : INodeViewCustomization<DynamoConvert>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CreateList.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/CreateList.cs
@@ -1,6 +1,7 @@
 using DSCoreNodesUI;
+using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     public class CreateListNodeViewCustomization : VariableInputNodeViewCustomization, INodeViewCustomization<CreateList>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DSDropDownBase.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DSDropDownBase.cs
@@ -9,7 +9,7 @@ using Dynamo.Controls;
 using Dynamo.UI;
 using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     public class DropDownNodeViewCustomization : INodeViewCustomization<DSDropDownBase>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DateTime.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DateTime.cs
@@ -1,8 +1,10 @@
-﻿using DSCoreNodesUI.Input;
+﻿using CoreNodeModelsWpf.Controls;
+using DSCoreNodesUI.Input;
 using Dynamo.Controls;
+using Dynamo.Wpf;
 using Dynamo.Wpf.Controls;
 
-namespace Dynamo.Wpf.NodeViewCustomizations
+namespace CoreNodeModelsWpf.NodeViewCustomizations
 {
     public class DateTimeNodeViewCustomization : INodeViewCustomization<DateTime>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Directory.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Directory.cs
@@ -3,8 +3,9 @@ using System.Windows.Forms;
 using DSCore.File;
 using DSCoreNodesUI.Input;
 using Dynamo.Controls;
+using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     public class DirectoryNodeViewCustomization : FileSystemBrowserNodeViewCustomization, INodeViewCustomization<Directory>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
@@ -5,8 +5,9 @@ using System.Windows.Media;
 using DSCoreNodesUI.Input;
 using Dynamo.Controls;
 using Dynamo.Nodes;
+using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     public class DoubleInputNodeViewCustomization : INodeViewCustomization<DoubleInput>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleSlider.cs
@@ -1,9 +1,10 @@
+using CoreNodeModelsWpf.Controls;
 using DSCoreNodesUI.Input;
-
 using Dynamo.Controls;
+using Dynamo.Wpf;
 using Dynamo.Wpf.Controls;
 
-namespace Dynamo.Wpf.NodeViewCustomizations
+namespace CoreNodeModelsWpf.NodeViewCustomizations
 {
     public class DoubleSliderNodeViewCustomization : INodeViewCustomization<DoubleSlider>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DummyNode.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DummyNode.cs
@@ -5,7 +5,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Nodes;
 using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     public class DummyNodeNodeViewCustomization : INodeViewCustomization<DummyNode>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Formula.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Formula.cs
@@ -7,7 +7,7 @@ using Dynamo.Controls;
 using Dynamo.Nodes;
 using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     public class FormulaNodeViewCustomization : INodeViewCustomization<Formula>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/IntegerSlider.cs
@@ -1,9 +1,10 @@
+using CoreNodeModelsWpf.Controls;
 using DSCoreNodesUI.Input;
-
 using Dynamo.Controls;
+using Dynamo.Wpf;
 using Dynamo.Wpf.Controls;
 
-namespace Dynamo.Wpf.NodeViewCustomizations
+namespace CoreNodeModelsWpf.NodeViewCustomizations
 {
     public class IntegerSliderNodeViewCustomization : INodeViewCustomization<IntegerSlider>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/SelectionBase.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/SelectionBase.cs
@@ -3,8 +3,9 @@ using DSCoreNodesUI;
 using Dynamo.Controls;
 
 using Microsoft.Practices.Prism.Commands;
+using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     // Note: Because this is a generic class, it can't be a NodeViewCustomization!
     //       We have to supply a non-generic implementation for NodeViewCustomization

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/StringInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/StringInput.cs
@@ -8,8 +8,9 @@ using Dynamo.UI.Prompts;
 using Dynamo.ViewModels;
 using Binding = System.Windows.Data.Binding;
 using VerticalAlignment = System.Windows.VerticalAlignment;
+using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     public class StringInputNodeViewCustomization : INodeViewCustomization<StringInput>
     {
@@ -24,7 +25,7 @@ namespace Dynamo.Wpf.Nodes
 
             this.editWindowItem = new MenuItem
             {
-                Header = Properties.Resources.StringInputNodeEditMenu, 
+                Header = Dynamo.Wpf.Properties.Resources.StringInputNodeEditMenu, 
                 IsCheckable = false
             };
             nodeView.MainContextMenu.Items.Add(editWindowItem);

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -14,8 +14,9 @@ using Dynamo.Interfaces;
 using Dynamo.Scheduler;
 using Dynamo.ViewModels;
 using ProtoCore.AST.AssociativeAST;
+using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     public class WatchNodeViewCustomization : INodeViewCustomization<Watch>
     {
@@ -76,7 +77,7 @@ namespace Dynamo.Wpf.Nodes
 
             var rawDataMenuItem = new MenuItem
             {
-                Header = Properties.Resources.WatchNodeRawDataMenu,
+                Header = Dynamo.Wpf.Properties.Resources.WatchNodeRawDataMenu,
                 IsCheckable = true,
             };
             rawDataMenuItem.SetBinding(MenuItem.IsCheckedProperty, checkedBinding);

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/WatchImage.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/WatchImage.cs
@@ -7,8 +7,9 @@ using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
 using Dynamo.Utilities;
 using Image = System.Windows.Controls.Image;
+using Dynamo.Wpf;
 
-namespace Dynamo.Wpf.Nodes
+namespace CoreNodeModelsWpf.Nodes
 {
     internal class WatchImageNodeViewCustomization : INodeViewCustomization<WatchImageCore>
     {

--- a/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
+++ b/src/Libraries/CoreNodeModelsWpf/SliderViewModel.cs
@@ -5,7 +5,7 @@ using DSCoreNodesUI.Input;
 
 using Dynamo.Core;
 
-namespace Dynamo.Wpf
+namespace CoreNodeModelsWpf
 {
     /// <summary>
     /// The SliderViewModel acts as the converter

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -12,6 +12,7 @@ using Dynamo.Utilities;
 using Dynamo.Wpf.Controls;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
+using CoreNodeModelsWpf.Controls;
 
 namespace DynamoCoreWpfTests
 {


### PR DESCRIPTION
### Purpose

All classes in CoreNodeModelsWpf are moved in  Dynamo.Wpf  to CoreNodeModelsWpf  namespace

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers
@ramramps 