### PR TITLE
Remove all backup files and folders before uploading a package version

### DIFF
--- a/src/DynamoPackages/Interfaces/IFileSystem.cs
+++ b/src/DynamoPackages/Interfaces/IFileSystem.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Dynamo.PackageManager.Interfaces;
 
 namespace Dynamo.PackageManager
@@ -7,8 +8,12 @@ namespace Dynamo.PackageManager
     /// </summary>
     public interface IFileSystem
     {
+        IEnumerable<string> GetFiles(string dir);
+        IEnumerable<string> GetDirectories(string dir);
+
         void CopyFile(string filePath, string destinationPath);
         void DeleteFile(string filePath);
+        void DeleteDirectory(string directoryPath);
         IDirectoryInfo TryCreateDirectory(string directoryPath);
 
         bool DirectoryExists(string directoryPath);

--- a/src/DynamoPackages/Interfaces/MutatingFileSystem.cs
+++ b/src/DynamoPackages/Interfaces/MutatingFileSystem.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Collections.Generic;
 using Dynamo.Annotations;
 using Dynamo.PackageManager.Interfaces;
 
@@ -9,6 +10,16 @@ namespace Dynamo.PackageManager
     /// </summary>
     public class MutatingFileSystem : IFileSystem
     {
+        public IEnumerable<string> GetFiles(string dir)
+        {
+            return Directory.GetFiles(dir, "*", SearchOption.AllDirectories);
+        }
+
+        public IEnumerable<string> GetDirectories(string dir)
+        {
+            return Directory.GetDirectories(dir, "*", SearchOption.AllDirectories);
+        }
+
         public void CopyFile(string filePath, string destinationPath)
         {
             File.Copy(filePath, destinationPath);
@@ -17,6 +28,11 @@ namespace Dynamo.PackageManager
         public void DeleteFile(string filePath)
         {
             File.Delete(filePath);
+        }
+
+        public void DeleteDirectory(string directoryPath)
+        {
+            Directory.Delete(directoryPath);
         }
 
         public  IDirectoryInfo TryCreateDirectory(string path)

--- a/src/DynamoPackages/Package.cs
+++ b/src/DynamoPackages/Package.cs
@@ -201,11 +201,15 @@ namespace Dynamo.PackageManager
         {
             if (String.IsNullOrEmpty(RootDirectory) || !Directory.Exists(RootDirectory)) return;
 
+            var backupFolderName = @"\" + Configuration.Configurations.BackupFolderName + @"\";
+
             var nonDyfDllFiles = Directory.EnumerateFiles(
                 RootDirectory,
                 "*",
                 SearchOption.AllDirectories)
-                .Where(x => !x.ToLower().EndsWith(".dyf") && !x.ToLower().EndsWith(".dll") && !x.ToLower().EndsWith("pkg.json") && !x.ToLower().EndsWith(".backup"))
+                .Where(x => !x.ToLower().EndsWith(".dyf") && !x.ToLower().EndsWith(".dll") &&
+                       !x.ToLower().EndsWith("pkg.json") && !x.ToLower().EndsWith(".backup") &&
+                       !x.ToLower().Contains(backupFolderName))
                 .Select(x => new PackageFileInfo(RootDirectory, x));
 
             AdditionalFiles.Clear();

--- a/src/DynamoPackages/PackageDirectoryBuilder.cs
+++ b/src/DynamoPackages/PackageDirectoryBuilder.cs
@@ -65,6 +65,7 @@ namespace Dynamo.PackageManager
             CopyFilesIntoPackageDirectory(files, dyfDir, binDir, extraDir);
             RemoveDyfFiles(files, dyfDir);
             RemapCustomNodeFilePaths(files, dyfDir.FullName);
+            RemoveUnselectedFiles(files, rootDir);
 
             return rootDir;
         }
@@ -89,6 +90,25 @@ namespace Dynamo.PackageManager
             foreach (var dyf in dyfsToRemove)
             {
                 fileSystem.DeleteFile(dyf);
+            }
+        }
+
+        private void RemoveUnselectedFiles(IEnumerable<string> filePaths, IDirectoryInfo dir)
+        {
+            // Remove all files which are not listed in the files list
+            filePaths = filePaths.Select(x => x.ToLower());
+            foreach (var path in fileSystem.GetFiles(dir.FullName).Select(x => x.ToLower())
+                .Where(x => !x.EndsWith("pkg.json") && !filePaths.Contains(x)))
+            {
+                fileSystem.DeleteFile(path);
+            }
+
+            // Remove all backup folders
+            var backupFolderName = Configuration.Configurations.BackupFolderName.ToLower();
+            foreach (var path in fileSystem.GetDirectories(dir.FullName)
+                .Where(x => x.Split(new[] { '/', '\\' }).Select(y => y.ToLower()).Contains(backupFolderName)))
+            {
+                fileSystem.DeleteDirectory(path);
             }
         }
 

--- a/test/Libraries/PackageManagerTests/RecordedFileSystem.cs
+++ b/test/Libraries/PackageManagerTests/RecordedFileSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Dynamo.PackageManager.Interfaces;
 using Moq;
 
@@ -10,7 +11,10 @@ namespace Dynamo.PackageManager.Tests
     /// </summary>
     public class RecordedFileSystem : IFileSystem
     {
+        private List<string> allFiles = new List<string>();
+        private List<string> allDirectories = new List<string>();
         private readonly List<string> deletedFiles = new List<string>();
+        private readonly List<string> deletedDirectories = new List<string>();
         private readonly List<IDirectoryInfo> directoriesCreated = new List<IDirectoryInfo>();
         private readonly List<Tuple<string, string>> copiedFiles = new List<Tuple<string, string>>();
         private readonly List<Tuple<string, string>> newFilesWritten = new List<Tuple<string, string>>();
@@ -19,15 +23,42 @@ namespace Dynamo.PackageManager.Tests
         private readonly Func<string, bool> dirExistsFunc;
 
         public IEnumerable<string> DeletedFiles { get { return deletedFiles; } }
+        public IEnumerable<string> DeletedDirectories { get { return deletedDirectories; } }
         public IEnumerable<IDirectoryInfo> DirectoriesCreated { get { return directoriesCreated; } }
         public IEnumerable<Tuple<string, string>> CopiedFiles { get { return copiedFiles; } }
         public IEnumerable<Tuple<string, string>> NewFilesWritten { get { return newFilesWritten; } }
+
+        #region Constructors and initializers
 
         public RecordedFileSystem(Func<string, bool> fileExistsFunc = null, Func<string, bool> dirExistsFunc = null)
         {
             this.fileExistsFunc = fileExistsFunc ?? ((x) => false);
             this.dirExistsFunc = dirExistsFunc ?? ((x) => false);
         } 
+
+        internal void SetFiles(IEnumerable<string> paths)
+        {
+            allFiles = paths.ToList();
+        }
+
+        internal void SetDirectories(IEnumerable<string> paths)
+        {
+            allDirectories = paths.ToList();
+        }
+
+        #endregion
+
+        #region IFileSystem implementation
+
+        public IEnumerable<string> GetFiles(string dir)
+        {
+            return allFiles;
+        }
+
+        public IEnumerable<string> GetDirectories(string dir)
+        {
+            return allDirectories;
+        }
 
         public void CopyFile(string filePath, string destinationPath)
         {
@@ -37,6 +68,11 @@ namespace Dynamo.PackageManager.Tests
         public void DeleteFile(string filePath)
         {
             this.deletedFiles.Add(filePath);
+        }
+
+        public void DeleteDirectory(string directoryPath)
+        {
+            this.deletedDirectories.Add(directoryPath);
         }
 
         public IDirectoryInfo TryCreateDirectory(string directoryPath)
@@ -63,5 +99,7 @@ namespace Dynamo.PackageManager.Tests
         {
             this.newFilesWritten.Add(new Tuple<string, string>(filePath, content));
         }
+
+        #endregion
     }
 }


### PR DESCRIPTION
### Purpose

References:
- [MAGN-7676](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7676) Do not include backup folders when uploading a package
- #4699 Disregard backup folders when uploading a new package version

When uploading a package, PackageManager copies selected files from their respective original locations to the target package folder and then zips the whole package folder for upload.

For the case when the user performs Publish Version, the original location is the same as the target package folder. PackageManager automatically selects and sorts the files in the old folder (skipping the backup files), but the files that have been skipped during the listing here will still reside in this folder, hence they will be included for zip and upload.

An implementation using `IFileSystem` has been added to delete the files in the package folder which are already not selected. All sub-folders named "backup" will also be deleted entirely before zipping the package folder.

A test case for this defect has also been added.

### Declarations

- [x] The level of testing this PR includes is appropriate
- [x] All tests pass using the self-service CI.

### Reviewers

@pboyer @Benglin 

### FYIs

@riteshchandawar @kronz 