### PR TITLE
MAGN-9203 Selected nodes are erroneously deleted when edit text in Search textbox

### DIFF
--- a/desktop.ini
+++ b/desktop.ini
@@ -1,4 +1,0 @@
-[ViewState]
-Mode=
-Vid=
-FolderType=Documents

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -75,7 +75,7 @@ namespace Dynamo.ViewModels
             if (Model.DebugSettings.VerboseLogging)
                 model.Logger.Log("Command: " + command);
 
-            ReturnFocusToSearch(); 
+            OnRequestReturnFocusToView(); 
             this.model.ExecuteCommand(command);
         }
 

--- a/src/DynamoCoreWpf/Commands/SearchCommands.cs
+++ b/src/DynamoCoreWpf/Commands/SearchCommands.cs
@@ -7,45 +7,25 @@ namespace Dynamo.ViewModels
         private DelegateCommand focusSearch;
         public DelegateCommand FocusSearchCommand
         {
-            get
-            {
-                if (focusSearch == null)
-                    focusSearch = new DelegateCommand(this.FocusSearch, this.CanFocusSearch);
-                return focusSearch;
-            }
+            get { return focusSearch ?? (focusSearch = new DelegateCommand(FocusSearch, CanFocusSearch)); }
         }
 
         private DelegateCommand search;
         public DelegateCommand SearchCommand
         {
-            get
-            {
-                if (search == null)
-                    search = new DelegateCommand(this.Search, this.CanSearch);
-                return search;
-            }
+            get { return search ?? (search = new DelegateCommand(Search, CanSearch)); }
         }
 
         private DelegateCommand showSearch;
         public DelegateCommand ShowSearchCommand
         {
-            get
-            {
-                if (showSearch == null)
-                    showSearch = new DelegateCommand(this.ShowSearch, this.CanShowSearch);
-                return showSearch;
-            }
+            get { return showSearch ?? (showSearch = new DelegateCommand(ShowSearch, CanShowSearch)); }
         }
 
         private DelegateCommand hideSearch;
         public DelegateCommand HideSearchCommand
         {
-            get
-            {
-                if (hideSearch == null)
-                    hideSearch = new DelegateCommand(this.HideSearch, this.CanHideSearch);
-                return hideSearch;
-            }
+            get { return hideSearch ?? (hideSearch = new DelegateCommand(HideSearch, CanHideSearch)); }
         }
 
         public DelegateCommand ImportLibraryCommand
@@ -62,14 +42,7 @@ namespace Dynamo.ViewModels
         private DelegateCommand toggleLayoutCommand;
         public DelegateCommand ToggleLayoutCommand
         {
-            get
-            {
-                if (toggleLayoutCommand == null)
-                {
-                    toggleLayoutCommand = new DelegateCommand(ToggleLayout);
-                }
-                return toggleLayoutCommand;
-            }
+            get { return toggleLayoutCommand ?? (toggleLayoutCommand = new DelegateCommand(ToggleLayout)); }
         }
 
         private DelegateCommand selectAllCategoriesCommand;
@@ -77,11 +50,8 @@ namespace Dynamo.ViewModels
         {
             get
             {
-                if (selectAllCategoriesCommand == null)
-                {
-                    selectAllCategoriesCommand = new DelegateCommand(SelectAllCategories);
-                }
-                return selectAllCategoriesCommand;
+                return selectAllCategoriesCommand ??
+                       (selectAllCategoriesCommand = new DelegateCommand(SelectAllCategories));
             }
         }        
     }

--- a/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
+++ b/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
@@ -65,14 +65,6 @@ namespace Dynamo.Nodes
 
     public class DynamoTextBox : ClickSelectTextBox
     {
-        public event RequestReturnFocusToSearchHandler RequestReturnFocusToSearch;
-        public delegate void RequestReturnFocusToSearchHandler();
-        protected void OnRequestReturnFocusToSearch()
-        {
-            if (RequestReturnFocusToSearch != null)
-                RequestReturnFocusToSearch();
-        }
-
         public event Action OnChangeCommitted;
 
         private static Brush clear = new SolidColorBrush(Color.FromArgb(100, 255, 255, 255));
@@ -112,15 +104,6 @@ namespace Dynamo.Nodes
             Pending = false;
             Style = (Style)SharedDictionaryManager.DynamoModernDictionary["SZoomFadeTextBox"];
             MinHeight = 20;
-
-            RequestReturnFocusToSearch += TryFocusSearch;
-        }
-
-        private void TryFocusSearch()
-        {
-            if (NodeViewModel == null) return;
-
-            NodeViewModel.DynamoViewModel.ReturnFocusToSearch();
         }
 
         public void BindToProperty(Binding binding)
@@ -182,9 +165,9 @@ namespace Dynamo.Nodes
 
         protected override void OnPreviewKeyDown(KeyEventArgs e)
         {
-            if (e.Key == Key.Return || e.Key == Key.Enter)
+            if (e.Key == Key.Enter && NodeViewModel != null)
             {
-                OnRequestReturnFocusToSearch();
+                NodeViewModel.DynamoViewModel.OnRequestReturnFocusToView();
             }
         }
 

--- a/src/DynamoCoreWpf/Controls/RunSettingsControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/RunSettingsControl.xaml.cs
@@ -45,7 +45,7 @@ namespace Dynamo.Wpf.Controls
         {
             var dynamoView = WpfUtilities.FindUpVisualTree<DynamoView>(this);
             var dynamoVm = dynamoView.DataContext as DynamoViewModel;
-            dynamoVm.ReturnFocusToSearch();
+            dynamoVm.OnRequestReturnFocusToView();
         }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -540,8 +540,8 @@ namespace Dynamo.ViewModels
                 case "CanNavigateBackground":
                     if (!BackgroundPreviewViewModel.CanNavigateBackground)
                     {
-                        // Return focus back to Search View (Search Field)
-                        SearchViewModel.OnRequestReturnFocusToSearch(this, new EventArgs());
+                        // Return focus back to Dynamo View
+                        OnRequestReturnFocusToView();
                     }
                     break;
             }
@@ -699,11 +699,6 @@ namespace Dynamo.ViewModels
 
             // Reset workspace state
             CurrentSpaceViewModel.CancelActiveState();
-        }
-
-        public void ReturnFocusToSearch()
-        {
-            this.SearchViewModel.OnRequestReturnFocusToSearch(null, EventArgs.Empty);
         }
 
         internal void ForceRunExprCmd(object parameters)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEvents.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEvents.cs
@@ -118,5 +118,12 @@ namespace Dynamo.ViewModels
                 RequestPaste();
             }
         }
+
+        internal event Action RequestReturnFocusToView;
+        internal void OnRequestReturnFocusToView()
+        {
+            if (RequestReturnFocusToView != null)
+                RequestReturnFocusToView();
+        }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -487,15 +487,15 @@ namespace Dynamo.ViewModels
 
             internal bool HandleLeftButtonDown(object sender, MouseButtonEventArgs e)
             {
-                if (false != ignoreMouseClick)
+                if (ignoreMouseClick)
                 {
                     ignoreMouseClick = false;
                     return false;
                 }
 
-                bool eventHandled = false;
-                bool returnFocusToSearch = true;
-                if (this.currentState == State.Connection)
+                var eventHandled = false;
+                var returnFocus = true;
+                if (currentState == State.Connection)
                 {
                     // Clicking on the canvas while connecting simply cancels 
                     // the operation and drop the temporary connector.
@@ -503,10 +503,10 @@ namespace Dynamo.ViewModels
 
                     eventHandled = true; // Mouse event handled.
                 }
-                else if (this.currentState == State.None)
+                else if (currentState == State.None)
                 {
                     // Record the mouse down position.
-                    IInputElement element = sender as IInputElement;
+                    var element = sender as IInputElement;
                     mouseDownPos = e.GetPosition(element);
 
                     // We'll see if there is any node being clicked on. If so, 
@@ -514,7 +514,7 @@ namespace Dynamo.ViewModels
                     if (null != GetSelectableFromPoint(mouseDownPos))
                     {
                         InitiateDragSequence();
-                        returnFocusToSearch = ShouldDraggingReturnFocusToSearch();
+                        returnFocus = ShouldDraggingReturnFocus();
                     }
                     else
                     {
@@ -533,27 +533,26 @@ namespace Dynamo.ViewModels
                             // Shift Modifier indicates, that user tries to call InCanvasSearch
                             // by using Shift + DoubleClick.
                             if (Keyboard.Modifiers != ModifierKeys.Shift)
+                            {
                                 CreateCodeBlockNode(mouseDownPos);
+                            }
 
-                            returnFocusToSearch = false;
+                            returnFocus = false;
                         }
                     }
 
                     eventHandled = true; // Mouse event handled.
                 }
-                else if (this.currentState == State.PanMode)
-                {
-                    var c = CursorLibrary.GetCursor(CursorSet.HandPanActive);
-                    owningWorkspace.CurrentCursor = c;
-                }
-                else if (this.currentState == State.OrbitMode)
+                else if (currentState == State.PanMode || currentState == State.OrbitMode)
                 {
                     var c = CursorLibrary.GetCursor(CursorSet.HandPanActive);
                     owningWorkspace.CurrentCursor = c;
                 }
 
-                if (returnFocusToSearch != false)
-                    owningWorkspace.DynamoViewModel.ReturnFocusToSearch();
+                if (returnFocus)
+                {
+                    owningWorkspace.DynamoViewModel.OnRequestReturnFocusToView();
+                }
 
                 return eventHandled;
             }
@@ -793,7 +792,7 @@ namespace Dynamo.ViewModels
                 SetCurrentState(State.DragSetup);
             }
 
-            private bool ShouldDraggingReturnFocusToSearch()
+            private bool ShouldDraggingReturnFocus()
             {
                 if (currentState != State.DragSetup)
                     throw new InvalidOperationException();

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -31,17 +31,10 @@ namespace Dynamo.ViewModels
         #region events
 
         public event EventHandler RequestFocusSearch;
-        public virtual void OnRequestFocusSearch(object sender, EventArgs e)
+        public virtual void OnRequestFocusSearch()
         {
             if (RequestFocusSearch != null)
-                RequestFocusSearch(this, e);
-        }
-
-        public event EventHandler RequestReturnFocusToSearch;
-        public void OnRequestReturnFocusToSearch(object sender, EventArgs e)
-        {
-            if (RequestReturnFocusToSearch != null)
-                RequestReturnFocusToSearch(this, e);
+                RequestFocusSearch(this, EventArgs.Empty);
         }
 
         public event EventHandler SearchTextChanged;
@@ -1022,8 +1015,9 @@ namespace Dynamo.ViewModels
             dynamoViewModel.ExecuteCommand(new DynamoModel.CreateNodeCommand(
                 nodeModel, position.X, position.Y, useDeafultPosition, true));
 
-            dynamoViewModel.ReturnFocusToSearch();
+            dynamoViewModel.OnRequestReturnFocusToView();
         }
+
         #endregion
 
         #region Commands
@@ -1060,7 +1054,7 @@ namespace Dynamo.ViewModels
 
         public void FocusSearch(object parameter)
         {
-            OnRequestFocusSearch(dynamoViewModel, EventArgs.Empty);
+            OnRequestFocusSearch();
         }
 
         internal bool CanFocusSearch(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -634,7 +634,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
 #if DEBUG
             renderTimer.Stop();
-            Debug.WriteLine(string.Format("RENDER: {0} ellapsed fkor compiling assets for rendering.", renderTimer.Elapsed));
+            Debug.WriteLine(string.Format("RENDER: {0} ellapsed for compiling assets for rendering.", renderTimer.Elapsed));
             renderTimer.Reset();
             renderTimer.Start();
 #endif

--- a/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
@@ -139,7 +139,7 @@ namespace Dynamo.UI.Controls
         /// </summary>
         protected void ReturnFocus()
         {
-            dynamoViewModel.ReturnFocusToSearch();
+            dynamoViewModel.OnRequestReturnFocusToView();
         }
 
         private IEnumerable<ICompletionData> GetCompletionData(string code, string stringToComplete)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1659,7 +1659,7 @@
             </Grid.Background>
         </Grid>
 
+        <Grid Name="FocusableGrid" Width="0" Height="0" Focusable="True"/>
     </Grid>
-
 
 </Window>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -161,6 +161,16 @@ namespace Dynamo.Controls
             }
 
             this.dynamoViewModel.RequestPaste += OnRequestPaste;
+            this.dynamoViewModel.RequestReturnFocusToView += OnRequestReturnFocusToView;
+            FocusableGrid.InputBindings.Clear();
+        }
+
+        private void OnRequestReturnFocusToView()
+        {
+            // focusing grid allows to remove focus from current textbox
+            FocusableGrid.Focus();
+            // keep handling input bindings of DynamoView
+            Keyboard.Focus(this);
         }
 
         private void OnRequestPaste()
@@ -1702,7 +1712,7 @@ namespace Dynamo.Controls
             {
                 dynamoViewModel.Model.AuthenticationManager.AuthProvider.RequestLogin -= loginService.ShowLogin;
             }
-        }        
+        }
     }
 
     public static class DispatcherExtension

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -334,7 +334,7 @@ namespace Dynamo.Controls
             if (ViewModel == null) return;
 
             var view = WpfUtilities.FindUpVisualTree<DynamoView>(this);
-            ViewModel.DynamoViewModel.ReturnFocusToSearch();
+            ViewModel.DynamoViewModel.OnRequestReturnFocusToView();
             view.mainGrid.Focus();
 
             Guid nodeGuid = ViewModel.NodeModel.GUID;

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -495,10 +495,12 @@ namespace Dynamo.Views
 
         private void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
-            WorkspaceViewModel wvm = (DataContext as WorkspaceViewModel);
+            var wvm = (DataContext as WorkspaceViewModel);
 
-            if (this.snappedPort != null)
-                wvm.HandlePortClicked(this.snappedPort);
+            if (snappedPort != null)
+            {
+                wvm.HandlePortClicked(snappedPort);
+            }
             else
             {
                 wvm.HandleLeftButtonDown(workBench, e);

--- a/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
@@ -1,27 +1,24 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
 using Dynamo.Controls;
 using Dynamo.Logging;
-using Dynamo.Selection;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Utilities;
 
 using TextBox = System.Windows.Controls.TextBox;
-using UserControl = System.Windows.Controls.UserControl;
 
 namespace Dynamo.Search
 {
     /// <summary>
     ///     Interaction logic for SearchView.xaml
     /// </summary>
-    public partial class SearchView : UserControl
+    public partial class SearchView
     {
         private readonly SearchViewModel viewModel;
         private readonly DynamoViewModel dynamoViewModel;
@@ -45,21 +42,17 @@ namespace Dynamo.Search
 
             SearchTextBox.IsVisibleChanged += delegate
             {
-                if (SearchTextBox.IsVisible)
-                {
-                    this.viewModel.SearchCommand.Execute(null);
-                    Keyboard.Focus(this.SearchTextBox);
-                    var view = WpfUtilities.FindUpVisualTree<DynamoView>(this);
-                    SearchTextBox.InputBindings.AddRange(view.InputBindings);
-                    SearchTextBlock.Text = Properties.Resources.SearchTextBlockText;
-                }
+                if (!SearchTextBox.IsVisible) return;
+
+                this.viewModel.SearchCommand.Execute(null);
+                Keyboard.Focus(SearchTextBox);
+                SearchTextBlock.Text = Properties.Resources.SearchTextBlockText;
             };
         }
 
         private void OnSearchViewUnloaded(object sender, EventArgs e)
         {
             viewModel.RequestFocusSearch -= OnSearchViewModelRequestFocusSearch;
-            viewModel.RequestReturnFocusToSearch -= OnSearchViewModelRequestReturnFocusToSearch;
         }
 
         private void OnSearchViewLoaded(object sender, RoutedEventArgs e)
@@ -67,14 +60,9 @@ namespace Dynamo.Search
             MouseEnter += OnSearchViewMouseEnter;
             MouseLeave += OnSearchViewMouseLeave;
 
-            PreviewKeyDown += KeyHandler;
-            SearchTextBox.PreviewKeyDown += OnSearchBoxPreviewKeyDown;
-            SearchTextBox.KeyDown += OnSearchBoxKeyDown;
-
+            SearchTextBox.PreviewKeyDown += KeyHandler;
 
             viewModel.RequestFocusSearch += OnSearchViewModelRequestFocusSearch;
-            viewModel.RequestReturnFocusToSearch += OnSearchViewModelRequestReturnFocusToSearch;
-
         }
 
         private void OnSearchViewMouseLeave(object sender, MouseEventArgs e)
@@ -87,34 +75,6 @@ namespace Dynamo.Search
             viewModel.SearchScrollBarVisibility = true;
         }
 
-        private void OnSearchBoxKeyDown(object sender, KeyEventArgs e)
-        {
-            bool handleIt = false;
-            e.Handled = handleIt;
-
-            if (e.Key == Key.Escape)
-            {
-                ClearSearchBox();
-            }
-        }
-
-        private void OnSearchBoxPreviewKeyDown(object sender, KeyEventArgs e)
-        {
-            bool handleIt = false;
-            e.Handled = handleIt;
-        }
-
-        protected override void OnPreviewKeyDown(KeyEventArgs e)
-        {
-            bool handleIt = false;
-
-            if (false != handleIt)
-            {
-                base.OnPreviewKeyDown(e);
-                e.Handled = true;
-            }
-        }
-
         /// <summary>
         ///     A KeyHandler method used by SearchView, increments decrements and executes based on input.
         /// </summary>
@@ -122,122 +82,55 @@ namespace Dynamo.Search
         /// <param name="e">Parameters describing the key push</param>
         public void KeyHandler(object sender, KeyEventArgs e)
         {
-            // ignore the key command if modifiers are present
-            if (e.KeyboardDevice.IsKeyDown(Key.LeftCtrl) ||
-                e.KeyboardDevice.IsKeyDown(Key.RightCtrl) ||
-                e.KeyboardDevice.IsKeyDown(Key.LeftAlt) ||
-                e.KeyboardDevice.IsKeyDown(Key.RightAlt))
-            {
-                return;
-            }
-
             switch (e.Key)
             {
-                case Key.Delete:
-                    if (DynamoSelection.Instance.Selection.Count > 0)
+                case Key.Escape:
                     {
+                        ClearSearchBox();
                         e.Handled = true;
-                        dynamoViewModel.DeleteCommand.Execute(null);
+                        break;
                     }
 
-                    //if there are no nodes being selected, the delete key should 
-                    //delete the text in the search box of library preview
-                    else
-                    {
-
-                        //if there is no text, then jump out of the switch
-                        if (String.IsNullOrEmpty(SearchTextBox.Text))
-                        {
-                            break;
-                        }
-                        else
-                        {
-                            int cursorPosition = SearchTextBox.SelectionStart;
-                            string searchBoxText = SearchTextBox.Text;
-
-                            //if some piece of text is seleceted by users.
-                            //delete this piece of text
-                            if (SearchTextBox.SelectedText != "")
-                            {
-                                searchBoxText = searchBoxText.Remove(cursorPosition,
-                                    SearchTextBox.SelectionLength);
-                            }
-
-                            //if there is no text selected, delete the character after the cursor
-                            else
-                            {
-
-                                //the cursor is at the end of this text string
-                                if (cursorPosition == searchBoxText.Length)
-                                {
-                                    break;
-                                }
-                                else
-                                {
-                                    searchBoxText = searchBoxText.Remove(cursorPosition, 1);
-                                }
-                            }
-
-                            //update the SearchTextBox's text and the cursor position
-                            SearchTextBox.Text = searchBoxText;
-                            SearchTextBox.SelectionStart = cursorPosition;
-                        }
-                    }
-                    break;
                 case Key.Enter:
                     {
-                        if (viewModel.CurrentMode != SearchViewModel.ViewMode.LibrarySearchView
-                            || !viewModel.IsAnySearchResult)
+                        e.Handled = true;
+                        if (IsAnySearchResult())
                         {
-                            break;
+                            viewModel.ExecuteSelectedItem();
+                            Keyboard.Focus(SearchTextBox);
                         }
 
-                        viewModel.ExecuteSelectedItem();
                         break;
                     }
 
                 case Key.Down:
                     {
-                        if (viewModel.CurrentMode != SearchViewModel.ViewMode.LibrarySearchView
-                            || !viewModel.IsAnySearchResult)
+                        e.Handled = true;
+                        if (IsAnySearchResult())
                         {
-                            break;
+                            viewModel.MoveSelection(SearchViewModel.Direction.Down);
                         }
-
-                        viewModel.MoveSelection(SearchViewModel.Direction.Down);
+                        
                         break;
                     }
 
                 case Key.Up:
                     {
-                        if (viewModel.CurrentMode != SearchViewModel.ViewMode.LibrarySearchView
-                            || !viewModel.IsAnySearchResult)
+                        e.Handled = true;
+                        if (IsAnySearchResult())
                         {
-                            break;
+                            viewModel.MoveSelection(SearchViewModel.Direction.Up);
                         }
-
-                        viewModel.MoveSelection(SearchViewModel.Direction.Up);
+                        
                         break;
                     }
             }
         }
 
-        private void OnSearchViewModelRequestReturnFocusToSearch(object sender, EventArgs e)
+        private bool IsAnySearchResult()
         {
-            if (Visibility != Visibility.Collapsed)
-                Keyboard.Focus(SearchTextBox);
-            else
-                MoveFocusToNextUIElement();
-        }
-
-        private void MoveFocusToNextUIElement()
-        {
-            // Gets the element with keyboard focus.
-            UIElement elementWithFocus = Keyboard.FocusedElement as UIElement;
-
-            // Change keyboard focus.
-            if (elementWithFocus != null)
-                elementWithFocus.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+            return viewModel.CurrentMode == SearchViewModel.ViewMode.LibrarySearchView
+                   && viewModel.IsAnySearchResult;
         }
 
         private void OnSearchViewModelRequestFocusSearch(object sender, EventArgs e)
@@ -247,7 +140,7 @@ namespace Dynamo.Search
 
         public void OnSearchTextBoxTextChanged(object sender, TextChangedEventArgs e)
         {
-            BindingExpression binding = ((TextBox)sender).GetBindingExpression(TextBox.TextProperty);
+            var binding = ((TextBox)sender).GetBindingExpression(TextBox.TextProperty);
             if (binding != null)
                 binding.UpdateSource();
 
@@ -261,44 +154,20 @@ namespace Dynamo.Search
             Keyboard.Focus(SearchTextBox);
         }
 
-        // Not used anywhere.
-        private void Back_Click(object sender, RoutedEventArgs e)
-        {
-            ((SearchViewModel)DataContext).RemoveLastPartOfSearchText();
-            Keyboard.Focus(SearchTextBox);
-        }
-
-        private void OnTreeViewScrollViewerPreviewMouseWheel(object sender, MouseWheelEventArgs e)
-        {
-            ScrollViewer scv = (ScrollViewer)sender;
-            scv.ScrollToVerticalOffset(scv.VerticalOffset - e.Delta);
-            e.Handled = true;
-        }
-
         private void OnLibraryExpanderClick(object sender, RoutedEventArgs e)
         {
-            //this.Width = 5;
-            //if (this.Visibility == Visibility.Collapsed)
-            //    this.Visibility = Visibility.Visible;
-            //else
-            //{
-            //    dynamoModel.DynamoViewModel.OnSidebarClosed(this, EventArgs.Empty);
-            //   this.Visibility = Visibility.Collapsed;
-            //}
             dynamoViewModel.OnSidebarClosed(this, EventArgs.Empty);
         }
 
         private void OnLibraryExpanderMouseEnter(object sender, MouseEventArgs e)
         {
-            Button b = (Button)sender;
-            Grid g = (Grid)b.Parent;
-            Label lb = (Label)(g.Children[0]);
+            var b = (Button)sender;
+            var g = (Grid)b.Parent;
+            var lb = (Label)(g.Children[0]);
             var bc = new BrushConverter();
             lb.Foreground = (Brush)bc.ConvertFromString("#cccccc");
-            Image collapsestate = (Image)(b).Content;
-            var collapsestateSource = new Uri(@"pack://application:,,,/DynamoCoreWpf;component/UI/Images/expand_hover.png");
-            BitmapImage bmi = new BitmapImage(collapsestateSource);
-            RotateTransform rotateTransform = new RotateTransform(-90, 16, 16);
+            var collapsestate = (Image)(b).Content;
+            var collapsestateSource = new Uri(baseUrl + "expand_hover.png");
             collapsestate.Source = new BitmapImage(collapsestateSource);
 
             Cursor = CursorLibrary.GetCursor(CursorSet.LinkSelect);
@@ -306,13 +175,13 @@ namespace Dynamo.Search
 
         private void OnLibraryExpanderMouseLeave(object sender, MouseEventArgs e)
         {
-            Button b = (Button)sender;
-            Grid g = (Grid)b.Parent;
-            Label lb = (Label)(g.Children[0]);
+            var b = (Button)sender;
+            var g = (Grid)b.Parent;
+            var lb = (Label)(g.Children[0]);
             var bc = new BrushConverter();
             lb.Foreground = (Brush)bc.ConvertFromString("#aaaaaa");
-            Image collapsestate = (Image)(b).Content;
-            var collapsestateSource = new Uri(@"pack://application:,,,/DynamoCoreWpf;component/UI/Images/expand_normal.png");
+            var collapsestate = (Image)(b).Content;
+            var collapsestateSource = new Uri(baseUrl + "expand_normal.png");
             collapsestate.Source = new BitmapImage(collapsestateSource);
 
             Cursor = null;
@@ -344,23 +213,22 @@ namespace Dynamo.Search
         private void TextBoxGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {
             if (viewModel != null)
-                viewModel.SearchIconAlignment = System.Windows.HorizontalAlignment.Left;
+                viewModel.SearchIconAlignment = HorizontalAlignment.Left;
         }
 
         private void TextBoxLostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {
-            if (viewModel != null)
-            {
-                if (string.IsNullOrEmpty(viewModel.SearchText))
-                    viewModel.SearchIconAlignment = System.Windows.HorizontalAlignment.Center;
-                else
-                    viewModel.SearchIconAlignment = System.Windows.HorizontalAlignment.Left;
-            }
+            if (viewModel == null) return;
+
+            viewModel.SearchIconAlignment = string.IsNullOrEmpty(viewModel.SearchText)
+                ? HorizontalAlignment.Center
+                : HorizontalAlignment.Left;
         }
 
         private void OnLibraryViewPreviewKeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key != Key.Escape) return;
+
             SearchTextBox.Text = "";
         }
 
@@ -373,7 +241,9 @@ namespace Dynamo.Search
             e.UseDefaultCursors = e.Effects.HasFlag(DragDropEffects.Copy) || e.Effects.HasFlag(DragDropEffects.Move);
 
             if (!e.UseDefaultCursors)
+            {
                 Mouse.SetCursor(CursorLibrary.GetCursor(CursorSet.DragMove));
+            }
 
             e.Handled = true;
         }

--- a/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/DynamoSlider.xaml.cs
@@ -31,7 +31,7 @@ namespace Dynamo.Wpf.Controls
 
             slider.PreviewMouseUp += delegate
             {
-                nodeUI.ViewModel.DynamoViewModel.ReturnFocusToSearch();
+                nodeUI.ViewModel.DynamoViewModel.OnRequestReturnFocusToView();
             };
 
         }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/BoolSelector.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/BoolSelector.cs
@@ -16,7 +16,7 @@ namespace Dynamo.Wpf.Nodes
 
         private void OnRadioButtonClicked(object sender, RoutedEventArgs e)
         {
-            dynamoViewModel.ReturnFocusToSearch();
+            dynamoViewModel.OnRequestReturnFocusToView();
         }
 
         public void CustomizeView(BoolSelector model, NodeView nodeView)

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/FileSystemBrowser.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/FileSystemBrowser.cs
@@ -42,7 +42,7 @@ namespace DSCore.File
             tb.TextChanged += delegate
             {
                 tb.ScrollToHorizontalOffset(double.PositiveInfinity);
-                nodeView.ViewModel.DynamoViewModel.ReturnFocusToSearch();
+                nodeView.ViewModel.DynamoViewModel.OnRequestReturnFocusToView();
             };
             tb.Margin = new Thickness(0, 5, 0, 5);
 


### PR DESCRIPTION
### Purpose

It had been implemented that search textbox always had focus and it handled keyboard input from DynamoView as well. That's why when key or key combination is bound to some action in DynamoView, this action overrides original action of textbox. 
For example, if `ctrl+c` is pressed, selected nodes are copied rather than selected text from search textbox. 
Or another example, when `delete` key is pressed selected nodes are deleted rather than selected text or the next symbol after cursor in search textbox.

The solution is:
- do not mix handling keyboard input for window and for search textbox;
- always return focus to DynamoView, so that key combinations are handled as it is specified for DynamoView, except those cases when a text input needs to have focus.

As result:
- when search textbox is focused it handles keyboard inputs in its natural way (`ctrl+c` copies text, `delete` deletes text, `ctrl+v` pastes text and so on);
- when search textbox is not focused, DynamoView handles keyboard inputs as it was specified (`ctrl+c` copies workspace selected content, `delete` deletes workspace selected content, `ctrl+v` pastes workspace selected content and so on);
- when some text is typed and a corresponding node is created by pressing `enter` search textbox keeps being focused, so that the user can create other nodes by changing text and pressing `enter`.

Also, code is enhanced

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.

### Reviewers

@ramramps 