### PR TITLE
MAGN-9239 Copy/Paste group gives malformed paste

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1727,8 +1727,12 @@ namespace Dynamo.Models
             {
                 var annotationNodeModel = new List<NodeModel>();
                 var annotationNoteModel = new List<NoteModel>();
-                //checked condition here that supports pasting of multiple groups
-                foreach (var models in annotation.SelectedModels)
+                // some models can be deleted after copying them, 
+                // so they need to be in pasted annotation as well
+                var modelsToRestore = annotation.DeletedModelBases.Intersect(ClipBoard);
+                var modelsToAdd = annotation.SelectedModels.Concat(modelsToRestore);
+                // checked condition here that supports pasting of multiple groups
+                foreach (var models in modelsToAdd)
                 {
                     ModelBase mbase;
                     modelLookup.TryGetValue(models.GUID, out mbase);


### PR DESCRIPTION
### Purpose

When a node is deleted after copying its group it is deleted from the copied group too. That's why pasted group does not have the node.

### Reviewers

@ramramps 