### PR TITLE
MAGN-9067 Clicking on class name of search results...

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -1090,27 +1090,19 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Sets IsExpanded = false to all categories and subcategories.
+        /// Sets IsExpanded = false to open category and all subcategories.
         /// </summary>
-        internal bool CollapseRecursively(IEnumerable<NodeCategoryViewModel> categories)
+        internal void CollapseAll(IEnumerable<NodeCategoryViewModel> categories)
         {
-            bool collapsedAll = true;
-            foreach (var category in categories)
+            while (categories != null)
             {
+                var category = categories.FirstOrDefault(cat => cat.IsExpanded);
+
+                if (category == null) break;
                 category.IsExpanded = false;
-                collapsedAll = collapsedAll && (category.SubCategories.Count == 0);
-            }
 
-            if (!collapsedAll)
-            {
-                collapsedAll = true;
-                foreach (var category in categories)
-                {
-                    collapsedAll = collapsedAll && CollapseRecursively(category.SubCategories);
-                }
+                categories = category.SubCategories;
             }
-
-            return collapsedAll;
         }
 
         /// <summary>
@@ -1121,7 +1113,8 @@ namespace Dynamo.ViewModels
         {
             // Clear search text.
             SearchText = String.Empty;
-            CollapseRecursively(BrowserRootCategories);
+            CollapseAll(BrowserRootCategories);
+
             if (String.IsNullOrEmpty(className)) return;
 
             var categoryNames = className.Split(Configurations.CategoryDelimiterString.ToCharArray());

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -1089,10 +1089,16 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// This method is fired, when user clicks on class name in the search library view.
+        /// </summary>
+        /// <param name="className">Name of the class, that should be opened.</param>
         internal void OpenSelectedClass(string className)
         {
             // Clear search text.
             SearchText = String.Empty;
+            if (String.IsNullOrEmpty(className)) return;
+
             var categoryNames = className.Split(Configurations.CategoryDelimiterString.ToCharArray());
 
             IEnumerable<NodeCategoryViewModel> categories = BrowserRootCategories;

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -1090,6 +1090,30 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Sets IsExpanded = false to all categories and subcategories.
+        /// </summary>
+        internal bool CollapseRecursively(IEnumerable<NodeCategoryViewModel> categories)
+        {
+            bool collapsedAll = true;
+            foreach (var category in categories)
+            {
+                category.IsExpanded = false;
+                collapsedAll = collapsedAll && (category.SubCategories.Count == 0);
+            }
+
+            if (!collapsedAll)
+            {
+                collapsedAll = true;
+                foreach (var category in categories)
+                {
+                    collapsedAll = collapsedAll && CollapseRecursively(category.SubCategories);
+                }
+            }
+
+            return collapsedAll;
+        }
+
+        /// <summary>
         /// This method is fired, when user clicks on class name in the search library view.
         /// </summary>
         /// <param name="className">Name of the class, that should be opened.</param>
@@ -1097,6 +1121,7 @@ namespace Dynamo.ViewModels
         {
             // Clear search text.
             SearchText = String.Empty;
+            CollapseRecursively(BrowserRootCategories);
             if (String.IsNullOrEmpty(className)) return;
 
             var categoryNames = className.Split(Configurations.CategoryDelimiterString.ToCharArray());

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -1089,6 +1089,37 @@ namespace Dynamo.ViewModels
             }
         }
 
+        internal void OpenSelectedClass(string className)
+        {
+            // Clear search text.
+            SearchText = String.Empty;
+            var categoryNames = className.Split(Configurations.CategoryDelimiterString.ToCharArray());
+
+            IEnumerable<NodeCategoryViewModel> categories = BrowserRootCategories;
+            foreach (var name in categoryNames)
+            {
+                var category = categories.FirstOrDefault(cat => cat.Name == name);
+                if (category != null)
+                {
+                    category.IsExpanded = true;
+                    categories = category.SubCategories;
+                }
+                // Category is null means that we are at the last level of hierarchy.
+                // The next level is class level.
+                else
+                {
+                    category = categories.FirstOrDefault(cat => cat is ClassesNodeCategoryViewModel);
+                    if (category == null) break;
+                    category.IsExpanded = true;
+
+                    var classItem = category.Items.FirstOrDefault(item => item.Name == name) as NodeCategoryViewModel;
+                    if (classItem == null) break;
+                    classItem.IsExpanded = true;
+                    break;
+                }
+            }
+        }
+
         #endregion
     }
 }

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -73,7 +73,23 @@
                                     <!-- Node class, group icon, node category -->
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="{Binding Class}"
-                                                   Foreground="{StaticResource NodeCategoryForeground}" />
+                                                   PreviewMouseDown="OnClassNamePreviewMouseDown">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Foreground"
+                                                            Value="{StaticResource NodeCategoryForeground}" />
+                                                    <Style.Triggers>
+                                                        <Trigger Property="IsMouseOver"
+                                                                 Value="True">
+                                                            <Setter Property="Foreground"
+                                                                    Value="White" />
+                                                            <Setter Property="Cursor"
+                                                                    Value="Hand" />
+                                                        </Trigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
                                         <fa:ImageAwesome Icon="{Binding GroupIconName}"
                                                          Foreground="{Binding Group, 
                                                                               Converter={StaticResource ElementGroupToColorConverter}}"

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -85,6 +85,8 @@
                                                                     Value="White" />
                                                             <Setter Property="Cursor"
                                                                     Value="Hand" />
+                                                            <Setter Property="TextBlock.TextDecorations"
+                                                                    Value="Underline" />
                                                         </Trigger>
                                                     </Style.Triggers>
                                                 </Style>

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -140,5 +140,35 @@ namespace Dynamo.UI.Views
         }
 
         #endregion
+
+        private void OnClassNamePreviewMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            var senderButton = e.OriginalSource as FrameworkElement;
+            if (senderButton == null)
+            {
+                return;
+            }
+
+            var searchElementVM = senderButton.DataContext as NodeSearchElementViewModel;
+            if (searchElementVM == null)
+            {
+                return;
+            }
+
+            int lastIndex =
+                searchElementVM.FullName.LastIndexOf(Configuration.Configurations.CategoryDelimiterString,
+                    StringComparison.Ordinal);
+            string selectedClassWithCategory;
+            if (lastIndex != -1)
+            {
+                selectedClassWithCategory = searchElementVM.FullName.Substring(0,
+                    lastIndex);
+            }
+            else
+            {
+                selectedClassWithCategory = searchElementVM.FullName;
+            }
+            viewModel.OpenSelectedClass(selectedClassWithCategory);
+        }
     }
 }

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -158,16 +158,11 @@ namespace Dynamo.UI.Views
             int lastIndex =
                 searchElementVM.FullName.LastIndexOf(Configuration.Configurations.CategoryDelimiterString,
                     StringComparison.Ordinal);
-            string selectedClassWithCategory;
-            if (lastIndex != -1)
-            {
-                selectedClassWithCategory = searchElementVM.FullName.Substring(0,
+
+            var selectedClassWithCategory = lastIndex == -1
+                ? searchElementVM.FullName
+                : searchElementVM.FullName.Substring(0,
                     lastIndex);
-            }
-            else
-            {
-                selectedClassWithCategory = searchElementVM.FullName;
-            }
             viewModel.OpenSelectedClass(selectedClassWithCategory);
         }
     }

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml
@@ -812,6 +812,7 @@
                 <TreeView ItemsSource="{Binding BrowserRootCategories}"
                           ItemTemplateSelector="{StaticResource LibraryTreeTemplateSelector}"
                           ItemContainerStyle="{StaticResource LibraryTreeViewItem}"
+                          TreeViewItem.Expanded="OnTreeViewItemExpanded"
                           Name="CategoryTreeView"
                           FocusManager.IsFocusScope="true">
                     <TreeView.Template>

--- a/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryView.xaml.cs
@@ -340,5 +340,11 @@ namespace Dynamo.UI.Views
 
         #endregion
 
+        private void OnTreeViewItemExpanded(object sender, RoutedEventArgs e)
+        {
+            var treeViewItem = e.OriginalSource as FrameworkElement;
+            if (treeViewItem == null) return;
+            treeViewItem.BringIntoView();
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -774,7 +774,7 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
-        public void CollapseRecursivelyTest()
+        public void CollapseAllTest()
         {
             var element = CreateCustomNode("AMember", "CategoryA.SubCategoryA.ClassA");
             model.Add(element);
@@ -782,14 +782,11 @@ namespace Dynamo.Tests
             element = CreateCustomNode("BMember", "CategoryB.SubCategoryB.ClassB");
             model.Add(element);
 
-            viewModel.BrowserRootCategories[0].IsExpanded = true;
             viewModel.BrowserRootCategories[1].IsExpanded = true;
-
             viewModel.BrowserRootCategories[1].SubCategories[0].IsExpanded = true;
 
-            viewModel.CollapseRecursively(viewModel.BrowserRootCategories);
+            viewModel.CollapseAll(viewModel.BrowserRootCategories);
 
-            Assert.IsFalse(viewModel.BrowserRootCategories[0].IsExpanded);
             Assert.IsFalse(viewModel.BrowserRootCategories[1].IsExpanded);
             Assert.IsFalse(viewModel.BrowserRootCategories[1].SubCategories[0].IsExpanded);
         }

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -772,6 +772,28 @@ namespace Dynamo.Tests
             Assert.IsTrue((classVM.Items[0] as NodeCategoryViewModel).IsExpanded);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void CollapseRecursivelyTest()
+        {
+            var element = CreateCustomNode("AMember", "CategoryA.SubCategoryA.ClassA");
+            model.Add(element);
+
+            element = CreateCustomNode("BMember", "CategoryB.SubCategoryB.ClassB");
+            model.Add(element);
+
+            viewModel.BrowserRootCategories[0].IsExpanded = true;
+            viewModel.BrowserRootCategories[1].IsExpanded = true;
+
+            viewModel.BrowserRootCategories[1].SubCategories[0].IsExpanded = true;
+
+            viewModel.CollapseRecursively(viewModel.BrowserRootCategories);
+
+            Assert.IsFalse(viewModel.BrowserRootCategories[0].IsExpanded);
+            Assert.IsFalse(viewModel.BrowserRootCategories[1].IsExpanded);
+            Assert.IsFalse(viewModel.BrowserRootCategories[1].SubCategories[0].IsExpanded);
+        }
+
         #endregion
 
         #region Helpers

--- a/test/DynamoCoreWpfTests/SearchViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewModelTests.cs
@@ -754,6 +754,24 @@ namespace Dynamo.Tests
             Assert.IsTrue(viewModel.SearchCategories.All(c => c.IsSelected));
         }
 
+
+        [Test]
+        [Category("UnitTests")]
+        public void OpenSelectedClassTest()
+        {
+            var element = CreateCustomNode("AMember", "CategoryA.ClassA");
+            model.Add(element);
+
+            element = CreateCustomNode("BMember", "CategoryB.ClassB");
+            model.Add(element);
+
+            viewModel.OpenSelectedClass("CategoryB.ClassB");
+
+            Assert.IsTrue(viewModel.BrowserRootCategories[1].IsExpanded);
+            var classVM = viewModel.BrowserRootCategories[1].Items[0] as NodeCategoryViewModel;
+            Assert.IsTrue((classVM.Items[0] as NodeCategoryViewModel).IsExpanded);
+        }
+
         #endregion
 
         #region Helpers


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9067](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9067) Clicking on class name of search results brings the user to the expanded tree view of that class

When user moves mouse over class name cursor is changed into hand; text is highlighted and underlined.
When user clicks on text, search view is closed, search text box is cleared. Selected class is opened and brought into view.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@ramramps 

### FYIs

@Racel 