### PR TITLE
Fix regression with connectors.

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -11,6 +11,7 @@
              mc:Ignorable="d"
              d:DesignHeight="300"
              d:DesignWidth="300"
+             MouseLeftButtonDown="OnMouseLeftButtonDown"
              PreviewMouseLeftButtonDown="OnPreviewMouseLeftButtonDown"
              MouseUp="OnMouseRelease"
              MouseMove="OnMouseMove"

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -496,6 +496,14 @@ namespace Dynamo.Views
 
         private void OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                startMousePosition = e.GetPosition(null);
+            }
+        }
+
+        private void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
 
             if (snappedPort != null)
             {
@@ -508,8 +516,6 @@ namespace Dynamo.Views
                     ViewModel.HandleLeftButtonDown(workBench, e);
                 }
             }
-
-            startMousePosition = e.GetPosition(null);
 
             InCanvasSearchBar.IsOpen = false;
         }


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9306](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9306) Connectors no longer function
[MAGN-9204](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9204) Dynamo has crashed when CTRL + multiclicked on elements "preview bubble"

The reason of regression is that I changed `MouseDown` into `PreviewMouseDown`. There was reason for it: when user clicks on node with ctrl, node should be copied. But not immediately, when click was made. That's why we need to store start point and point where user's mouse is currently situated.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@ramramps 
@pbidenko 

### FYIs

@jnealb 
