### PR TITLE
Modify IconServices to support dotted assembly name

### DIFF
--- a/src/DynamoCoreWpf/Services/IconServices.cs
+++ b/src/DynamoCoreWpf/Services/IconServices.cs
@@ -54,7 +54,11 @@ namespace Dynamo.Wpf.Services
             if (resAssembly != null)
             {
                 resourceAssembly = resAssembly;
-                assemblyName = resAssembly.GetName().Name.Split('.').First();
+
+                // "Name" can be "Some.Assembly.Name.customization" with multiple dots, 
+                // we are interested in removal of the "customization" part and the middle dots.
+                var temp = resAssembly.GetName().Name.Split('.');
+                assemblyName = String.Join("", temp.Take(temp.Length - 1));
             }
         }
 


### PR DESCRIPTION
### Purpose

Reference: [MAGN-9261](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9261)

This PR is to make the library icon services support assembly names containing dots.
The dots will be skipped to acquire the `Images.resx` file.

**Example**
Resource assembly: `Example.Library.customization.dll`
Resource file name: `ExampleLibraryImages.resx`

### Declarations

- [x] All tests pass using the self-service CI.

### Reviewers

@Benglin 