### PR TITLE
Fix to show first use migration settings dialog

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -7,7 +7,7 @@
                     xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
                     xmlns:avalonedit="clr-namespace:ICSharpCode.AvalonEdit;assembly=ICSharpCode.AvalonEdit"
                     xmlns:dynui="clr-namespace:Dynamo.UI.Controls;assembly=DynamoCoreWpf"
-                    xmlns:fa="http://schemas.fontawesome.io/icons/">
+                    xmlns:fa="clr-namespace:FontAwesome.WPF;assembly=FontAwesome.WPF">
 
     <ResourceDictionary.MergedDictionaries>
         <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />

--- a/src/DynamoSandbox/Program.cs
+++ b/src/DynamoSandbox/Program.cs
@@ -22,8 +22,9 @@ namespace DynamoSandbox
         
         private static void MakeStandaloneAndRun(string commandFilePath, out DynamoViewModel viewModel)
         {
-            var model = Dynamo.Applications.StartupUtils.MakeModel(false);
             DynamoModel.RequestMigrationStatusDialog += MigrationStatusDialogRequested;
+
+            var model = Dynamo.Applications.StartupUtils.MakeModel(false);
 
             viewModel = DynamoViewModel.Start(
                 new DynamoViewModel.StartConfiguration()


### PR DESCRIPTION
The first use migration settings dialog stopped appearing during migration of settings (packages, custom nodes, etc.) from an older Dynamo major version to the latest one. This has been fixed in this PR.