### PR TITLE
Migration updates to node names after the renaming of DSCoreNodesUI assembly to CoreNodeModels

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
+++ b/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
@@ -50,7 +50,7 @@ namespace CoreNodeModels.Input
     [NodeDescription("BooleanDescription", typeof(Resources))]
     [NodeSearchTags("BooleanSelectorSearchTags", typeof(Resources))]
     [IsDesignScriptCompatible]
-    [AlsoKnownAs("DSCoreNodesUI.BoolSelector", "DSCoreNodesUI.Input.BoolSelector")]
+    [AlsoKnownAs("DSCoreNodesUI.BoolSelector", "DSCoreNodesUI.Input.BoolSelector", "Dynamo.Nodes.BoolSelector")]
     public class BoolSelector : Bool
     {
         public BoolSelector()

--- a/src/Migrations/CoreNodes/dynBaseTypes.cs
+++ b/src/Migrations/CoreNodes/dynBaseTypes.cs
@@ -2142,6 +2142,7 @@ namespace Dynamo.Nodes
 
 namespace CoreNodeModels
 {
+    [AlsoKnownAs("DSCoreNodesUI.DummyNode")]
     public class DummyNode : MigrationNode
     {
         [NodeMigration(@from: "0.7.0.0")]


### PR DESCRIPTION
This should fix current CI regressions.

### FYIs
@marimano 
