### PR TITLE
Fix for crash when connecting wire from already deleted node

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -296,11 +296,16 @@ namespace Dynamo.Models
 
         void EndConnection(Guid nodeId, int portIndex, PortType portType)
         {
-            bool isInPort = portType == PortType.Input;
+            // Check if the node from which the connector starts is valid and has not been deleted
+            if (activeStartPort.Owner == null) return;
+
+            var startNode = CurrentWorkspace.GetModelInternal(activeStartPort.Owner.GUID);
+            if (startNode == null) return;
 
             var node = CurrentWorkspace.GetModelInternal(nodeId) as NodeModel;
-            if (node == null)
-                return;
+            if (node == null) return;
+
+            bool isInPort = portType == PortType.Input;
             
             PortModel portModel = isInPort ? node.InPorts[portIndex] : node.OutPorts[portIndex];
 

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -113,6 +113,7 @@ namespace Dynamo.ViewModels
 
                 case "DeleteModelCommand":
                     CurrentSpaceViewModel.CancelActiveState();
+                    RaiseCanExecuteUndoRedo();
                     break;
                 case "CreateNodeCommand":
                 case "CreateProxyNodeCommand":

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -112,6 +112,8 @@ namespace Dynamo.ViewModels
                     break;
 
                 case "DeleteModelCommand":
+                    CurrentSpaceViewModel.CancelActiveState();
+                    break;
                 case "CreateNodeCommand":
                 case "CreateProxyNodeCommand":
                 case "CreateNoteCommand":

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1001,6 +1001,17 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(group.SelectedModels.Any(m => m.GUID == Guid.Parse("7dc3b638-284f-4296-a793-8185ef42cd71")));
         }
 
+        [Test, RequiresSTA]
+        public void TestNodeDeletionWhileMakingConnectionToOtherNode()
+        {
+            RunCommandsFromFile("DeleteNodeWhileConnecting.xml");
+
+            // 1 node and no connectors
+            Assert.AreEqual(1, workspace.Nodes.Count());
+            Assert.AreEqual(false, workspace.Connectors.Any());
+        }
+
+
         #endregion
 
         #region General Node Operations Test Cases

--- a/test/core/recorded/DeleteNodeWhileConnecting.xml
+++ b/test/core/recorded/DeleteNodeWhileConnecting.xml
@@ -1,0 +1,35 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <CreateNodeCommand X="566" Y="213" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>53e78e6b-a7cf-4080-ae85-7d5ae08942ee</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="53e78e6b-a7cf-4080-ae85-7d5ae08942ee" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="566" y="213" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="341" Y="201" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>424dc40d-2514-45ae-8b70-77ccea4ff464</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="424dc40d-2514-45ae-8b70-77ccea4ff464" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="249" y="170" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="1;" ShouldFocus="false" />
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="1" WorkspaceGuid="46434cdc-9918-462a-8cd7-7f170fa669b0">
+    <ModelGuid>424dc40d-2514-45ae-8b70-77ccea4ff464</ModelGuid>
+  </UpdateModelValueCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>424dc40d-2514-45ae-8b70-77ccea4ff464</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>424dc40d-2514-45ae-8b70-77ccea4ff464</ModelGuid>
+  </SelectModelCommand>
+  <DeleteModelCommand>
+    <ModelGuid>424dc40d-2514-45ae-8b70-77ccea4ff464</ModelGuid>
+  </DeleteModelCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>53e78e6b-a7cf-4080-ae85-7d5ae08942ee</ModelGuid>
+  </MakeConnectionCommand>
+</Commands>


### PR DESCRIPTION
### Purpose
This PR fixes issue: https://github.com/DynamoDS/Dynamo/issues/5734 tracked [here] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9127).

### Declarations

- [X] The level of testing this PR includes is appropriate
- [X] The code base is in a better state after this PR

### Reviewers
@Benglin 

The solution is to check for the start node of the connector to be valid and non null before finalizing the connection in `EndConnection()`.