### PR TITLE
 CTRL + multiclick on preview bubble

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -529,10 +529,11 @@ namespace Dynamo.ViewModels
                             // should keep the input focus on the code block to 
                             // avoid it being dismissed (with empty content).
                             //
-                            // If Shift is pressed, CBN shouldn't be created.
+                            // If Shift/Ctrl is pressed, CBN shouldn't be created.
                             // Shift Modifier indicates, that user tries to call InCanvasSearch
                             // by using Shift + DoubleClick.
-                            if (Keyboard.Modifiers != ModifierKeys.Shift)
+                            // Ctrl Modifier indicates, that user tries to copy node.
+                            if (Keyboard.Modifiers != ModifierKeys.Shift && Keyboard.Modifiers != ModifierKeys.Control)
                             {
                                 CreateCodeBlockNode(mouseDownPos);
                             }

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -468,7 +468,8 @@ namespace Dynamo.Controls
 
         private void OnPreviewControlMouseLeave(object sender, MouseEventArgs e)
         {
-            if (!PreviewControl.StaysOpen && !PreviewControl.IsInTransition)
+            if (!PreviewControl.StaysOpen && !PreviewControl.IsInTransition 
+                && Keyboard.Modifiers != System.Windows.Input.ModifierKeys.Control)
             {
                 PreviewControl.TransitionToState(PreviewControl.State.Condensed);
             }

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -393,7 +393,8 @@ namespace Dynamo.Controls
         private void OnNodeViewMouseLeave(object sender, MouseEventArgs e)
         {
             // If mouse in over node/preview control or preview control is pined, we can not hide preview control.
-            if (IsMouseOver || PreviewControl.IsMouseOver || PreviewControl.StaysOpen) return;
+            if (IsMouseOver || PreviewControl.IsMouseOver || PreviewControl.StaysOpen ||
+                (Mouse.Captured != null && IsMouseInsideNodeOrPreview(e.GetPosition(this)))) return;
 
             // If it's expanded, then first condense it.
             if (PreviewControl.IsExpanded)
@@ -480,6 +481,23 @@ namespace Dynamo.Controls
         {
             if (Mouse.Captured == null) return;
 
+            bool isInside = IsMouseInsideNodeOrPreview(e.GetPosition(this));
+
+            if (!isInside && previewControl.IsCondensed)
+            {
+                PreviewControl.TransitionToState(PreviewControl.State.Hidden);
+            }
+        }
+
+        /// <summary>
+        /// When Mouse is captured, all mouse events are handled by element, that captured it.
+        /// So we can't use MouseLeave/MouseEnter events.
+        /// In this case, when we want to ensure, that mouse really left node, we use HitTest.
+        /// </summary>
+        /// <param name="mousePosition">Currect position of mouse</param>
+        /// <returns>bool</returns>
+        private bool IsMouseInsideNodeOrPreview(Point mousePosition)
+        {
             bool isInside = false;
             VisualTreeHelper.HitTest(
                 this,
@@ -493,14 +511,8 @@ namespace Dynamo.Controls
                     return HitTestFilterBehavior.Stop;
                 },
                 ht => HitTestResultBehavior.Stop,
-                new PointHitTestParameters(e.GetPosition(this)));
-            if (!isInside)
-            {
-                if (previewControl.IsCondensed)
-                {
-                    PreviewControl.TransitionToState(PreviewControl.State.Hidden);
-                }
-            }
+                new PointHitTestParameters(mousePosition));
+            return isInside;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -331,7 +331,7 @@ namespace Dynamo.Controls
 
         private void topControl_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (ViewModel == null) return;
+            if (ViewModel == null || Keyboard.Modifiers == System.Windows.Input.ModifierKeys.Control) return;
 
             var view = WpfUtilities.FindUpVisualTree<DynamoView>(this);
             ViewModel.DynamoViewModel.OnRequestReturnFocusToView();

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -444,7 +444,10 @@ namespace Dynamo.Controls
                     }
                     if (!IsMouseOver)
                     {
-                        preview.TransitionToState(PreviewControl.State.Hidden);
+                        if (!(Mouse.Captured != null && IsMouseInsideNodeOrPreview(Mouse.GetPosition(this))))
+                        {
+                            preview.TransitionToState(PreviewControl.State.Hidden);
+                        }
                     }
                     break;
                 }


### PR DESCRIPTION
### Purpose
Link to YouTrack:
[MAGN-9204](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9204) Dynamo has crashed when CTRL + multiclicked on elements "preview bubble"

I added more checks for Ctrl modifier.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@ramramps 