### PR TITLE
Raise maximum package size to 1 GB

### DIFF
--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -7,7 +7,7 @@
     
     The primary goals of this format is to allow a simple XML format 
     that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+    various data types are done through the TypeConverter classes p
     associated with the data types.
     
     Example:
@@ -353,7 +353,7 @@ Sorry about that.</value>
     <value>The package was found to be empty and was not installed.</value>
   </data>
   <data name="PackageTooLarge" xml:space="preserve">
-    <value>The package is too large!  The package must be less than 15 MB!</value>
+    <value>The package is too large!  The package must be less than 1 GB!</value>
   </data>
   <data name="PathNotRegconizableAsStableOrDailyBuild" xml:space="preserve">
     <value>The specified file path is not recognizable as a stable or a daily build</value>

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -7,7 +7,7 @@
     
     The primary goals of this format is to allow a simple XML format 
     that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes p
+    various data types are done through the TypeConverter classes 
     associated with the data types.
     
     Example:

--- a/src/DynamoPackages/PackageUploadBuilder.cs
+++ b/src/DynamoPackages/PackageUploadBuilder.cs
@@ -31,7 +31,7 @@ namespace Dynamo.PackageManager
             }
         }
 
-        internal const long MaximumPackageSize = 100 * 1024 * 1024;
+        internal const long MaximumPackageSize = 1000 * 1024 * 1024; // 1 GB
 
         internal PackageUploadBuilder(IPackageDirectoryBuilder builder, IFileCompressor fileCompressor)
         {


### PR DESCRIPTION
### Purpose

I raised the max package size to 1GB. I also fixed the user facing string when it fails. The unit test for this is resistant to the change: 

https://github.com/DynamoDS/Dynamo/blob/pkgmax/test/Libraries/PackageManagerTests/PackageUploadBuilderTests.cs#L18

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.

### Reviewers

@ramramps 

### FYI

@mccrone 