### PR TITLE
Fixed for new custom node (created by collapsing nodes) not appearing in library view

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -1137,7 +1137,8 @@ namespace Dynamo.Core
                         Category = args.Category,
                         Description = args.Description,
                         ID = newId.ToString(),
-                        FileName = string.Empty
+                        FileName = string.Empty,
+                        IsVisibleInDynamoLibrary = true
                     });
                 
                 newWorkspace.HasUnsavedChanges = true;


### PR DESCRIPTION
### Purpose

This fixes defect: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9338, where new custom nodes created by collapsing existing nodes does not appear in the library readily unless it is saved and Dynamo restarted.

It is a regression since 090. Refer to: https://github.com/DynamoDS/Dynamo/pull/5058 that introduces a new `IsVisibleInDynamoLibrary` property to disable showing custom nodes in migration scenarios. 

This property should always be set to `true` before collapsing nodes to create a new custom node so that the custom node is displayed in the library by default. 

### Reviewer
@Benglin 

Merging this in as it has already been discussed briefly. 