### PR TITLE
Clicking on class name

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -282,6 +282,11 @@ namespace Dynamo.ViewModels
 
         public NodeSearchModel Model { get; private set; }
         private readonly DynamoViewModel dynamoViewModel;
+
+        /// <summary>
+        /// Class name, that has been clicked in library search view.
+        /// </summary>
+        internal string ClassNameToBeOpened;
         #endregion
 
         #region Initialization
@@ -1108,6 +1113,7 @@ namespace Dynamo.ViewModels
             // Clear search text.
             SearchText = String.Empty;
             CollapseAll(BrowserRootCategories);
+            ClassNameToBeOpened = className;
 
             if (String.IsNullOrEmpty(className)) return;
 


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9067](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9067) Clicking on class name of search results brings the user to the expanded tree view of that class

`BringIntoView` was not good enough, because it can bring item into view, but it can't bring it at the top position in scrollviewer.
Another solution is to set  `VerticalOffset`. `VerticalOffset` is set, when treeview item is expanded, but it is set only for special item (class item, that was clicked). Also it's set with help of `Dispatcher`, because UI should first be rendered and only then we should set `VerticalOffset`.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@ramramps 

### FYIs

@Racel 