### PR TITLE
MAGN-9330 Pasted groups land in different locations with Ctrl-v and context menu "Paste" pick

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -173,17 +173,15 @@ namespace Dynamo.Controls
             var clipBoard = dynamoViewModel.Model.ClipBoard;
             var locatableModels = clipBoard.Where(item => item is NoteModel || item is NodeModel);
 
-            // Find node views, that were copied. Translate them into rect.
-            var nodeBounds = this.ChildrenOfType<NodeView>()
-                            .Where(nodeView => locatableModels
-                                .Any(locatable => locatable.GUID == nodeView.ViewModel.NodeModel.GUID))
-                                .Select(view => view.BoundsRelativeTo(this));
+            var modelBounds = locatableModels.Select(lm =>
+                new Rect {X = lm.X, Y = lm.Y, Height = lm.Height, Width = lm.Width});
 
             // Find workspace view.
             var workspace = this.ChildOfType<WorkspaceView>();
-            var workspaceBounds = workspace.BoundsRelativeTo(this);
+            var workspaceBounds = workspace.GetVisibleBounds();
 
-            bool outOfView = nodeBounds.Any(node => !workspaceBounds.Contains(node));
+            // is at least one note/node located out of visible workspace part
+            var outOfView = modelBounds.Any(m => !workspaceBounds.Contains(m));
 
             // If copied nodes are out of view, we paste their copies under mouse cursor or at the center of workspace.
             if (outOfView)
@@ -197,6 +195,7 @@ namespace Dynamo.Controls
                 {
                     PasteNodeAtTheCenter(workspace);
                 }
+
                 return;
             }
 
@@ -214,7 +213,7 @@ namespace Dynamo.Controls
             var shiftY = rightMostItem.Y - leftMostItem.Y;
 
             // Find new node bounds.
-            var newNodeBounds = nodeBounds
+            var newNodeBounds = modelBounds
                 .Select(node => new Rect(node.X + shiftX + workspace.ViewModel.Model.CurrentPasteOffset,
                                          node.Y + shiftY + workspace.ViewModel.Model.CurrentPasteOffset,
                                          node.Width, node.Height));
@@ -242,9 +241,8 @@ namespace Dynamo.Controls
         /// <param name="workspace">workspace view</param>
         private void PasteNodeAtTheCenter(WorkspaceView workspace)
         {
-            var centerX = (workspace.ActualWidth / 2 - workspace.ViewModel.Model.X) / workspace.ViewModel.Zoom;
-            var centerY = (workspace.ActualHeight / 2 - workspace.ViewModel.Model.Y) / workspace.ViewModel.Zoom;
-            dynamoViewModel.Model.Paste(new Point2D(centerX, centerY));
+            var centerPoint = workspace.GetCenterPoint().AsDynamoType();
+            dynamoViewModel.Model.Paste(centerPoint);
         }
 
         #region NodeViewCustomization

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -160,7 +160,24 @@ namespace Dynamo.Views
             };
         }
 
-        void OnSelectionCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        internal Point GetCenterPoint()
+        {
+            var x = outerCanvas.ActualWidth / 2.0;
+            var y = outerCanvas.ActualHeight / 2.0;
+            var centerPt = new Point(x, y);
+            var transform = outerCanvas.TransformToDescendant(WorkspaceElements);
+            return transform.Transform(centerPt);
+        }
+
+        internal Rect GetVisibleBounds()
+        {
+            var t = outerCanvas.TransformToDescendant(WorkspaceElements);
+            var topLeft = t.Transform(new Point());
+            var bottomRight = t.Transform(new Point(outerCanvas.ActualWidth, outerCanvas.ActualHeight));
+            return new Rect(topLeft, bottomRight);
+        }
+
+        void OnSelectionCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             if (ViewModel == null) return;
             ViewModel.NodeFromSelectionCommand.RaiseCanExecuteChanged();
@@ -340,12 +357,6 @@ namespace Dynamo.Views
             // center the node at the drop point
             if (!Double.IsNaN(node.Width))
                 dropPt.X -= (node.Width / 2.0);
-
-            if (!Double.IsNaN(node.Height))
-                dropPt.Y -= (node.Height / 2.0);
-
-            if (!Double.IsNaN(node.Width))
-                dropPt.X -= (node.Height / 2.0);
 
             if (!Double.IsNaN(node.Height))
                 dropPt.Y -= (node.Height / 2.0);


### PR DESCRIPTION
### Purpose

There is a flaw in the current implementation of copy-pasting with `Ctrl+V` - it uses bounds of `NodeView`s which are being copied. But if to paste a copied selection into a new workspace, all views of copied items will be deleted and point to paste will be computed incorrectly.

In this PR coordinates of `NodeModel`s/`NoteModel`s are used because they can be obtained even if copied models were removed before pasting. To use these coordinates it needs to compute workspace bounds in terms of `WorkspaceView.WorkspaceElements`.

As result, a copied selection is being pasted in the same way as when all copied items are present in the workspace.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@ramramps 

### FYIs

@aosyatnik 