### PR TITLE
Click on CBN crash fix

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -542,6 +542,7 @@ namespace Dynamo.Controls
 
             if (previewEnabled == false && !PreviewControl.StaysOpen)
             {
+                PreviewControl.TransitionToState(PreviewControl.State.Condensed);
                 PreviewControl.TransitionToState(PreviewControl.State.Hidden);
             }
         }


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9348](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9348) Click on code block node , when the preview pin is displayed and it crashes Dynamo

After adding delay, when we move mouse on CBN, preview is in expanded state. We should first condense then hide it.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### FYIs

Fix is trivial. Merging it in order to get rid of dhow-stopper bug.

@ramramps 
@monikaprabhu 