### PR TITLE
MAGN-9318 Clicking in library search area should keep the focus in the search text box

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -103,6 +103,15 @@ namespace Dynamo.Wpf.ViewModels
         private bool isExpanded;
         private bool isSelected;
 
+        public event Action RequestReturnFocusToSearch;
+        private void OnRequestReturnFocusToSearch()
+        {
+            if (RequestReturnFocusToSearch != null)
+            {
+                RequestReturnFocusToSearch();
+            }
+        }
+        
         public event RequestBitmapSourceHandler RequestBitmapSource;
         public void OnRequestBitmapSource(IconRequestEventArgs e)
         {
@@ -397,8 +406,10 @@ namespace Dynamo.Wpf.ViewModels
         {
             var endState = !IsExpanded;
 
-            foreach (var ele in SubCategories.Where(cat => cat.IsExpanded == true))
+            foreach (var ele in SubCategories.Where(cat => cat.IsExpanded))
+            {
                 ele.IsExpanded = false;
+            }
 
             //Walk down the tree expanding anything nested one layer deep
             //this can be removed when we have the hierachy implemented properly
@@ -423,6 +434,8 @@ namespace Dynamo.Wpf.ViewModels
                 //ClassDetails.IsExpanded = IsExpanded;
                 TreeViewItems[0].IsExpanded = IsExpanded;
             }
+
+            OnRequestReturnFocusToSearch();
         }
 
         private void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -348,8 +348,7 @@ namespace Dynamo.ViewModels
 
         private IEnumerable<RootNodeCategoryViewModel> CategorizeEntries(IEnumerable<NodeSearchElement> entries, bool expanded)
         {
-            var tempRoot =
-                entries.GroupByRecursive<NodeSearchElement, string, NodeCategoryViewModel>(
+            var tempRoot = entries.GroupByRecursive<NodeSearchElement, string, NodeCategoryViewModel>(
                     element => element.Categories,
                     (name, subs, es) =>
                     {
@@ -357,15 +356,21 @@ namespace Dynamo.ViewModels
                             new NodeCategoryViewModel(name, es.OrderBy(en => en.Name).Select(MakeNodeSearchElementVM), subs);
                         category.IsExpanded = expanded;
                         category.RequestBitmapSource += SearchViewModelRequestBitmapSource;
+                        category.RequestReturnFocusToSearch += OnRequestFocusSearch;
                         return category;
                     }, "");
-            var result =
-                tempRoot.SubCategories.Select(
-                    cat =>
-                        new RootNodeCategoryViewModel(cat.Name, cat.Entries, cat.SubCategories)
-                        {
-                            IsExpanded = expanded
-                        });
+
+            var result = tempRoot.SubCategories.Select(cat =>
+            {
+                var rootCat = new RootNodeCategoryViewModel(cat.Name, cat.Entries, cat.SubCategories)
+                {
+                    IsExpanded = expanded
+                };
+
+                rootCat.RequestReturnFocusToSearch += OnRequestFocusSearch;
+                return rootCat;
+            });
+
             tempRoot.Dispose();
             return result.OrderBy(cat => cat.Name);
         }
@@ -1020,7 +1025,7 @@ namespace Dynamo.ViewModels
             dynamoViewModel.ExecuteCommand(new DynamoModel.CreateNodeCommand(
                 nodeModel, position.X, position.Y, useDeafultPosition, true));
 
-            dynamoViewModel.OnRequestReturnFocusToView();
+            OnRequestFocusSearch();
         }
 
         #endregion

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -535,11 +535,17 @@ namespace Dynamo.Views
         {
             if (e == null) return; // in certain bizarre cases, e can be null
 
-            this.snappedPort = null;
+            snappedPort = null;
+            if (ViewModel == null) return;
 
-            var wvm = (DataContext as WorkspaceViewModel);
-            if (wvm == null) return;
-            wvm.HandleMouseRelease(workBench, e);
+            // check IsInIdleState before finishing an action with HandleMouseRelease
+            var returnToSearch = ViewModel.IsInIdleState && Keyboard.Modifiers == ModifierKeys.Control;
+
+            ViewModel.HandleMouseRelease(workBench, e);
+            if (returnToSearch)
+            {
+                ViewModel.DynamoViewModel.SearchViewModel.OnRequestFocusSearch();
+            }
         }
 
         private void OnMouseMove(object sender, MouseEventArgs e)

--- a/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibraryContainerView.xaml.cs
@@ -50,6 +50,14 @@ namespace Dynamo.Search
             };
         }
 
+        protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
+        {
+            if (e.ClickCount == 1)
+            {
+                SearchTextBox.Focus();
+            }
+        }
+
         private void OnSearchViewUnloaded(object sender, EventArgs e)
         {
             viewModel.RequestFocusSearch -= OnSearchViewModelRequestFocusSearch;

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -166,6 +166,7 @@
     <Compile Include="RunSettingsTests.cs" />
     <Compile Include="SearchSideEffects.cs" />
     <Compile Include="SearchViewModelTests.cs" />
+    <Compile Include="SearchViewTests.cs" />
     <Compile Include="SerializationTests.cs" />
     <Compile Include="Setup.cs" />
     <Compile Include="SliderTests.cs" />

--- a/test/DynamoCoreWpfTests/SearchViewTests.cs
+++ b/test/DynamoCoreWpfTests/SearchViewTests.cs
@@ -1,0 +1,72 @@
+﻿using Dynamo.Utilities;
+using DynamoCoreWpfTests.Utility;
+using NUnit.Framework;
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Dynamo.Search;
+using Dynamo.UI.Views;
+using Dynamo.Wpf.ViewModels;
+
+namespace DynamoCoreWpfTests
+{
+    class SearchViewTests : DynamoTestUIBase
+    {
+        private TextBox SearchTextBox
+        {
+            get { return View.ChildOfType<SearchView>().SearchTextBox; }
+        }
+
+        private void RemoveFocusFromSearch()
+        {
+            View.FocusableGrid.Focus();
+            Keyboard.Focus(View);
+            Assert.IsFalse(SearchTextBox.IsFocused);
+        }
+
+        public override void Open(string path)
+        {
+            base.Open(path);
+            DispatcherUtil.DoEvents();
+        }
+
+        public override void Run()
+        {
+            base.Run();
+            DispatcherUtil.DoEvents();
+        }
+
+        [Test]
+        public void ClickOnLibraryBackgroundReturnsFocusToSearch()
+        {
+            RemoveFocusFromSearch();
+
+            var libGrid = View.ChildOfType<LibraryView>().LibraryGrid;
+            // Raise a click event to check returning focus
+            libGrid.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, Environment.TickCount, MouseButton.Left)
+            {
+                RoutedEvent = UIElement.MouseUpEvent
+            });
+
+            Assert.IsTrue(SearchTextBox.IsFocused);
+        }
+
+        [Test]
+        public void ClickOnLibraryItemReturnsFocusToSearch()
+        {
+            RemoveFocusFromSearch();
+
+            var category = View.ChildOfType<LibraryView>().ChildOfType<TreeViewItem>();
+            Assert.IsTrue(category.DataContext is NodeCategoryViewModel);
+            
+            // Raise a click event to check returning focus
+            category.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, Environment.TickCount, MouseButton.Left)
+            {
+                RoutedEvent = UIElement.MouseUpEvent
+            });
+
+            Assert.IsTrue(SearchTextBox.IsFocused);
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

Return focus to search textbox if click everywhere in library search, i.e. when clicking on:
- a category;
- a search item;
- search library background.

### Reviewers

@ramramps 