### PR TITLE
Pinned preview bubble does not automatically show updated info

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -475,7 +475,7 @@ namespace Dynamo.Controls
                     }
                 case PreviewControl.State.Expanded:
                     {
-                        if (!IsMouseOver && !preview.IsMouseOver)
+                        if (!IsMouseOver && !preview.IsMouseOver && !preview.StaysOpen)
                         {
                             preview.TransitionToState(PreviewControl.State.Condensed);
                         }

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -452,6 +452,8 @@ namespace Dynamo.UI.Controls
         /// </summary>
         private void ComputeWatchContentSize(object sender, RoutedEventArgs e)
         {
+            if (IsExpanded == false || StaysOpen == false) return;
+
             // Used delay invoke, because TreeView hasn't changed its'appearance with usual Dispatcher call.
             Dispatcher.DelayInvoke(50,() =>
             {


### PR DESCRIPTION
### Purpose
Link to YouTrack:
[MAGN-9364](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9364) Pinned preview bubble does not automatically show updated detailed view when ports are disconnected/reconnected
[MAGN-9362](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9362) Preview bubble can be blank or not expand to detail view

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@ramramps 

### FYIs

@Racel 