### PR TITLE
 Clicking on class name

### DIFF
--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -156,7 +156,8 @@ namespace Dynamo.UI.Views
             }
 
             int lastIndex =
-                searchElementVM.FullName.LastIndexOf(Configuration.Configurations.CategoryDelimiterString,
+                searchElementVM.FullName.LastIndexOf(
+                Configuration.Configurations.CategoryDelimiterString + searchElementVM.Name,
                     StringComparison.Ordinal);
 
             var selectedClassWithCategory = lastIndex == -1


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9067](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9067) Clicking on class name of search results brings the user to the expanded tree view of that class

I didn't think, that someone can call node with dot inside and with first part, that is the same as class name...
As you can see here "Vector" is in category and in node name:
![image](https://cloud.githubusercontent.com/assets/8158404/12517865/be700cb6-c13d-11e5-875a-9b6a3387aaa4.png)

So, I updated a little the way, how we determine clicked class.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@ramramps 
