### PR TITLE
Fix crash during view manipulation

### DIFF
--- a/src/DynamoManipulation/Gizmo.cs
+++ b/src/DynamoManipulation/Gizmo.cs
@@ -166,7 +166,8 @@ namespace Dynamo.Manipulation
 
         private void Redraw()
         {
-            BackgroundPreviewViewModel.AddGeometryForRenderPackages(GetDrawables());
+            if(manipulator.IsEnabled())
+                BackgroundPreviewViewModel.AddGeometryForRenderPackages(GetDrawables());
         }
 
         private void OnViewCameraChanged(object o, RoutedEventArgs routedEventArgs)

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -178,7 +178,7 @@ namespace Dynamo.Manipulation
             GizmoInAction = null; //Reset Drag.
 
             var gizmos = GetGizmos(false);
-            if (!Active || !IsEnabled() || null == gizmos || !gizmos.Any()) return;
+            if (!IsEnabled() || null == gizmos || !gizmos.Any()) return;
 
             var ray = BackgroundPreviewViewModel.GetClickRay(mouseButtonEventArgs);
             if (ray == null) return;
@@ -439,7 +439,7 @@ namespace Dynamo.Manipulation
 
             UpdatePosition();
 
-            if (!Active || !IsEnabled())
+            if (!IsEnabled())
             {
                 return packages;
             }
@@ -540,7 +540,7 @@ namespace Dynamo.Manipulation
                 return false;
             }
 
-            return true;
+            return Active;
         }
         #endregion
     }


### PR DESCRIPTION
### Purpose

This PR fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9349

#### Analysis
- When a node is fully constrained and can't be manipulated it's inactive, but manipulator gizmo is still responding to view change events. At this moment, some of the properties of Gizmo are invalid, and hence, it crashes while drawing the gizmo. Ideally, gizmo should not be drawn, because all axes of the point are constrained.
- As a resolution ensured that gizmo's are not drawn if manipulator is not enabled or inactive.

### Reviewer
- [ ] @aparajit-pratap 