### PR TITLE
Merge branch 'mutireturnsingleout' into upmaster

### DIFF
--- a/src/DynamoCore/Graph/Nodes/FunctionCallNodeController.cs
+++ b/src/DynamoCore/Graph/Nodes/FunctionCallNodeController.cs
@@ -110,8 +110,9 @@ namespace Dynamo.Graph.Nodes
         /// <param name="resultAst">Result accumulator: add all new output AST to this list.</param>
         protected virtual void AssignIdentifiersForFunctionCall(NodeModel model, AssociativeNode rhs, List<AssociativeNode> resultAst)
         {
-            resultAst.Add(AstFactory.BuildAssignment(model.AstIdentifierForPreview, rhs));
 
+           resultAst.Add(AstFactory.BuildAssignment(model.AstIdentifierForPreview, rhs));
+          
             var keys = Definition.ReturnKeys ?? Enumerable.Empty<string>();
             resultAst.AddRange(
                 from item in keys.Zip(Enumerable.Range(0, keys.Count()), (key, idx) => new { key, idx })
@@ -120,8 +121,11 @@ namespace Dynamo.Graph.Nodes
                 let getValueCall = AstFactory.BuildFunctionCall(
                     BuiltInMethods.GetMethodName(BuiltInMethods.MethodID.kTryGetValueFromNestedDictionaries),
                     new List<AssociativeNode> {model.AstIdentifierForPreview, AstFactory.BuildStringNode(item.key)})
-                select
-                AstFactory.BuildAssignment(outputIdentiferNode, getValueCall));
+                select 
+             
+             Definition.ReturnKeys.Count() == 1 ? AstFactory.BuildAssignment(model.AstIdentifierForPreview, getValueCall)
+                    : AstFactory.BuildAssignment(outputIdentiferNode, getValueCall));
+              
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9009

we found that when a zero touch node has the `[multireturn]` attribute but only has one output present in the output dictionary that sometimes the entire dictionary is returned on the node's output port instead of the value at the specified key.

This happens on first load of the graph.

As a solution I've modified the function `AssignIdentifiersForFunctionCall` in FunctionalCallNodeController to assign the output to the AstIdentifier for the node if there is only one output, if there is more than one output we do as before and assign the function call result to each output identifier.

I'm not sure why this fixes the issue but can only guess that the output identifier for a node with one output creates some conflict between the node identifier and the output identifier, and somehow the node gets assigned the value of the entire dictionary when the graph is first run.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] All tests pass using the self-service CI.

### Reviewers

@ke-yu  - can you help me understand why this fix works? Is there something better we could do?

please do not merge until I finish a run on the self serve CI.
