### PR TITLE
Fix several regressions of preview

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -29,6 +29,7 @@ namespace Dynamo.ViewModels
         private string _link;
         private bool _showRawData;
         private string _path = "";
+        private bool _isOneRowContent;
 
         public DelegateCommand FindNodeForPathCommand { get; set; }
 
@@ -121,6 +122,21 @@ namespace Dynamo.ViewModels
         }
 
         public bool IsNodeExpanded { get; set; }
+
+        /// <summary>
+        /// If Content is 1 string, e.g. "Empty", "null", "_SingleFunctionObject", margin should be more to the left side.
+        /// For this purpose used this value. When it's true, margin in DataTrigger is set to -15,5,5,5; otherwise
+        /// it's set to 5,5,5,5
+        /// </summary>
+        public bool IsOneRowContent
+        {
+            get { return _isOneRowContent; }
+            set
+            {
+                _isOneRowContent = value;
+                RaisePropertyChanged("IsOneRowContent");
+            }
+        }
 
         #endregion
 

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -24,8 +24,7 @@
             <clr:Double x:Key="MinPreviewControlHeight">28.0</clr:Double>
 
             <!-- MaxContentGrid = (MaxPreviewControl - (2 * Margin)) -->
-            <fwk:Thickness x:Key="PreviewContentMargin">5.0</fwk:Thickness>
-            <fwk:Thickness x:Key="PreviewContentEmptyMargin">-15.0,5.0,5.0,5.0</fwk:Thickness>
+            <fwk:Thickness x:Key="PreviewContentMargin">5</fwk:Thickness>            
             <clr:Double x:Key="MaxContentGridWidth">488.0</clr:Double>
             <clr:Double x:Key="MaxContentGridHeight">288</clr:Double>
 

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -386,12 +386,7 @@ namespace Dynamo.UI.Controls
                     {
                         var tree = new WatchTree
                         {
-                            DataContext = new WatchViewModel(),
-
-                            // If Content is 1 string, e.g. "Empty", "null", margin should be more to the left side. 
-                            Margin = newViewModel.Children.Count > 0
-                                ? (System.Windows.Thickness)this.Resources["PreviewContentMargin"]
-                                : (System.Windows.Thickness)this.Resources["PreviewContentEmptyMargin"]
+                            DataContext = new WatchViewModel()
                         };
                         tree.treeView1.ItemContainerGenerator.StatusChanged += WatchContainer_StatusChanged;
 
@@ -403,6 +398,7 @@ namespace Dynamo.UI.Controls
 
                     cachedLargeContent = newViewModel;
 
+                    rootDataContext.IsOneRowContent = cachedLargeContent.Children.Count == 0;
                     rootDataContext.Children.Clear();
                     rootDataContext.Children.Add(cachedLargeContent);
 
@@ -452,7 +448,7 @@ namespace Dynamo.UI.Controls
         /// </summary>
         private void ComputeWatchContentSize(object sender, RoutedEventArgs e)
         {
-            if (IsExpanded == false || StaysOpen == false) return;
+            if (IsExpanded == false) return;
 
             // Used delay invoke, because TreeView hasn't changed its'appearance with usual Dispatcher call.
             Dispatcher.DelayInvoke(50,() =>

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -448,7 +448,7 @@ namespace Dynamo.UI.Controls
         /// </summary>
         private void ComputeWatchContentSize(object sender, RoutedEventArgs e)
         {
-            if (IsExpanded == false) return;
+            if (!IsExpanded) return;
 
             // Used delay invoke, because TreeView hasn't changed its'appearance with usual Dispatcher call.
             Dispatcher.DelayInvoke(50,() =>

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -77,7 +77,7 @@
     <Grid>
         <TreeView Name="treeView1"
                   ItemsSource="{Binding Children}"
-                  Background="Transparent"
+                  Background="White"
                   Opacity=".5"
                   BorderBrush="{x:Null}"
                   VirtualizingStackPanel.IsVirtualizing="True"

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -83,6 +83,28 @@
                   VirtualizingStackPanel.IsVirtualizing="True"
                   VirtualizingStackPanel.VirtualizationMode="Recycling"
                   SelectedItemChanged="TreeView1_OnSelectedItemChanged">
+            <TreeView.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel>
+                        <VirtualizingPanel.Style>
+                            <Style TargetType="{x:Type VirtualizingPanel}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsOneRowContent}"
+                                                 Value="True">
+                                        <Setter Property="Margin"
+                                                Value="-15,5,5,5" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding IsOneRowContent}"
+                                                 Value="False">
+                                        <Setter Property="Margin"
+                                                Value="5,5,5,5" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </VirtualizingPanel.Style>
+                    </VirtualizingStackPanel>
+                </ItemsPanelTemplate>
+            </TreeView.ItemsPanel>
             <TreeView.ItemTemplate>
                 <HierarchicalDataTemplate ItemsSource="{Binding Path=Children}"
                                           DataType="{x:Type viewModels:WatchViewModel}">


### PR DESCRIPTION
### Purpose

[MAGN-9386](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9386) Regression: Contents of preview bubble should not appear outside of the preview bubble container
[MAGN-9388](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9388) Watch nodes have gone grey

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@ramramps 
