### PR TITLE
Port Connected/Disconnected Event Handler

### DIFF
--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -16,20 +16,6 @@ namespace Dynamo.Graph.Nodes
 
     public class PortModel : ModelBase
     {
-        #region events
-
-        /// <summary>
-        /// Event triggered when a port is connected.
-        /// </summary>
-        public event Action<PortModel, ConnectorModel> PortConnected;
-
-        /// <summary>
-        /// Event triggered when a port is disconnected.
-        /// </summary>
-        public event Action<PortModel> PortDisconnected;
-
-        #endregion
-
         #region private fields
         ObservableCollection<ConnectorModel> connectors = new ObservableCollection<ConnectorModel>();
         private bool usingDefaultValue;
@@ -234,8 +220,8 @@ namespace Dynamo.Graph.Nodes
         /// <param name="connector"></param>
         protected virtual void OnPortConnected(ConnectorModel connector)
         {
-            if (PortConnected != null)
-                PortConnected(this, connector);
+            if (Owner != null)
+                Owner.RaisePortConnectedEvent(this, connector);
         }
 
         /// <summary>
@@ -244,8 +230,8 @@ namespace Dynamo.Graph.Nodes
         /// <param name="e"></param>
         protected virtual void OnPortDisconnected()
         {
-            if (PortDisconnected != null)
-                PortDisconnected(this);
+            if (Owner != null)
+                Owner.RaisePortDisconnectedEvent(this);
         }
 
         #region Serialization/Deserialization Methods

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -494,20 +494,14 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         protected void RegisterPortEventHandlers(NodeModel node)
         {
-            foreach (var p in node.InPorts)
-            {
-                p.PortDisconnected += PortDisconnectedHandler;
-                p.PortConnected += PortConnectedHandler;
-            }
+            node.PortConnected += PortConnectedHandler;
+            node.PortDisconnected += PortDisconnectedHandler;
         }
 
         private void UnregisterPortEventHandlers(NodeModel node)
         {
-            foreach (var p in node.InPorts)
-            {
-                p.PortDisconnected -= PortDisconnectedHandler;
-                p.PortConnected -= PortConnectedHandler;
-            }
+            node.PortConnected -= PortConnectedHandler;
+            node.PortDisconnected -= PortDisconnectedHandler;
         }
 
         protected virtual void PortConnectedHandler(PortModel arg1, ConnectorModel arg2)
@@ -517,7 +511,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         protected virtual void PortDisconnectedHandler(PortModel port)
         {
-            DeleteGeometryForIdentifier(port.Owner.AstIdentifierBase);
+            if (port.PortType == PortType.Input)
+            {
+                DeleteGeometryForIdentifier(port.Owner.AstIdentifierBase);
+            }
         }
 
         protected virtual void SelectionChangedHandler(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -90,8 +90,8 @@ namespace CoreNodeModelsWpf.Nodes
             this.dynamoViewModel.Model.PreferenceSettings.PropertyChanged += PreferenceSettingsOnPropertyChanged;
             rootWatchViewModel.PropertyChanged += RootWatchViewModelOnPropertyChanged;
 
-            watch.InPorts[0].PortConnected += OnPortConnected;
-            watch.InPorts[0].PortDisconnected += OnPortDisconnected;
+            watch.PortConnected += OnPortConnected;
+            watch.PortDisconnected += OnPortDisconnected;
         }
 
         public void Dispose()
@@ -100,8 +100,8 @@ namespace CoreNodeModelsWpf.Nodes
             dynamoViewModel.Model.PreferenceSettings.PropertyChanged -= PreferenceSettingsOnPropertyChanged;
             rootWatchViewModel.PropertyChanged -= RootWatchViewModelOnPropertyChanged;
 
-            watch.InPorts[0].PortConnected -= OnPortConnected;
-            watch.InPorts[0].PortDisconnected -= OnPortDisconnected;
+            watch.PortConnected -= OnPortConnected;
+            watch.PortDisconnected -= OnPortDisconnected;
         }
 
         private void OnPortConnected(PortModel port, ConnectorModel connectorModel)


### PR DESCRIPTION
### Purpose

This PR fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9172 when a user disconnects the input port, geometry for the node continue to display in the background preview. Ideally, the display should disappear.

#### Analysis
Code block and variable input arg nodes create input ports dynamically and clients interested in registering for connect/disconnect event notification on ports, they need to keep track of newly added or removed ports to register the event handler appropriately. This behavior causes various defects, such as MAGN-9172.

#### Resolution
The `PortConnected` and `PortDisconnected` events are now moved to `NodeModel`, so that clients don't need to keep track of ports of the node. These events are removed from `PortModel`, and now the port requests to raise this event on its owner node when the port connector is modified.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

- [x] @ke-yu 
- [ ] @ramramps 