### PR TITLE
MAGN 9140 Regenerate render package if background preview is on

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -90,6 +90,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 RaisePropertyChanged("Active");
 
                 OnActiveStateChanged();
+
+                if (active)
+                {
+                    RegenerateAllPackages();
+                }
             }
         }
 

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -827,6 +827,20 @@ namespace WpfVisualizationTests
             Assert.AreEqual(2, BackgroundPreviewGeometry.TotalPoints());
         }
 
+        [Test]
+        [Category("RegressionTests")]
+        public void Switch3DBackgroundPreview()
+        {
+            // Regression test for MAGN-9140 that all geometries that created
+            // when the background preview is off should display when the
+            // background preview is switched to on.
+            ViewModel.Watch3DViewModels.First().Active = false;
+            OpenVisualizationTest("OnePoint.dyn");
+            Assert.AreEqual(0, BackgroundPreviewGeometry.TotalPoints());
+            ViewModel.Watch3DViewModels.First().Active = true;
+            Assert.AreEqual(1, BackgroundPreviewGeometry.TotalPoints());
+        }
+
         private Watch3DView FindFirstWatch3DNodeView()
         {
             var views = View.ChildrenOfType<Watch3DView>();

--- a/test/core/visualization/OnePoint.dyn
+++ b/test/core/visualization/OnePoint.dyn
@@ -1,0 +1,16 @@
+<Workspace Version="1.0.0.310" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="bf33a5d4-d78d-472a-ac29-c09361c7825f" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="739.5" y="339" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR is to fix defect [MAGN-9140 Display not updated for actions done during the background preview is off](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9140)

That's because when the background preview is off, render package will not be added to the watch view model. So if the background preview is on, it should regenerate all render packages. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewer

@aparajit-pratap 