### PR TITLE
MAGN-9149: Overlapping geometry selection for manipulation

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -568,9 +568,13 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         public event Action<object, MouseButtonEventArgs> ViewMouseDown;
         internal void OnViewMouseDown(object sender, MouseButtonEventArgs e)
         {
+            HandleViewClick(sender, e);
             var handler = ViewMouseDown;
             if (handler != null) handler(sender, e);
         }
+
+        protected virtual void HandleViewClick(object sender, MouseButtonEventArgs e)
+        { }
 
         public event Action<object, MouseButtonEventArgs> ViewMouseUp;
         internal void OnViewMouseUp(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
### Purpose

This PR enhances the selection of overlapping geometry by considering every geometry in the hit test result rather than the first result as returned by helix3d. It fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9149

The existing geometry selection was based on MouseDown3D event on Geometry sent by helix3d, where it sends notification for only one geometry when there is overlapping geometry. Now HelixWatch3DViewModel handles the mouse down event on the view and performs hit test to get all the geometry under the mouse, finds corresponding nodes in the workspace and selects them. So now we select all the nodes corresponding to overlapping selection.

### Reviewer
- [x] @aparajit-pratap 