### PR TITLE
When node is created, it's set the highest z-index.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -172,6 +172,16 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// ZIndex is used to order nodes, when some node is clicked.
+        /// This selected node should be moved above others.
+        /// Start value of zIndex is 3, because 1 is for groups and 2 is for connectors.
+        /// Nodes should be always at the top.
+        /// 
+        /// Static is used because every node should know what is the highest z-index right now.
+        /// </summary>
+        public static int StaticZIndex = Configurations.NodeStartZIndex;
+
+        /// <summary>
         /// ZIndex represents the order on the z-plane in which nodes appear.
         /// </summary>
         public int ZIndex
@@ -432,9 +442,9 @@ namespace Dynamo.ViewModels
         {
             WorkspaceViewModel = workspaceViewModel;
             DynamoViewModel = workspaceViewModel.DynamoViewModel;
-           
+
             nodeLogic = logic;
-            
+
             //respond to collection changed events to add
             //and remove port model views
             logic.InPorts.CollectionChanged += inports_collectionChanged;
@@ -461,7 +471,8 @@ namespace Dynamo.ViewModels
 
             ShowExecutionPreview = workspaceViewModel.DynamoViewModel.ShowRunPreview;
             IsNodeAddedRecently = true;
-            DynamoSelection.Instance.Selection.CollectionChanged += SelectionOnCollectionChanged;             
+            DynamoSelection.Instance.Selection.CollectionChanged += SelectionOnCollectionChanged;
+            ZIndex = StaticZIndex++;
         }
  
         public NodeViewModel(WorkspaceViewModel workspaceViewModel, NodeModel logic, Size preferredSize)

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -179,7 +179,7 @@ namespace Dynamo.ViewModels
         /// 
         /// Static is used because every node should know what is the highest z-index right now.
         /// </summary>
-        public static int StaticZIndex = Configurations.NodeStartZIndex;
+        internal static int StaticZIndex = Configurations.NodeStartZIndex;
 
         /// <summary>
         /// ZIndex represents the order on the z-plane in which nodes appear.

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -321,7 +321,7 @@ namespace Dynamo.Controls
                 PrepareZIndex();
             }
 
-            ViewModel.ZIndex = NodeViewModel.StaticZIndex++;
+            ViewModel.ZIndex = ++NodeViewModel.StaticZIndex;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -35,15 +35,6 @@ namespace Dynamo.Controls
         /// </summary>
         private bool previewEnabled = true;
 
-        /// <summary>
-        /// ZIndex is used to order nodes, when some node is clicked.
-        /// This selected node should be moved above others.
-        /// Start value of zIndex is 3, because 1 is for groups and 2 is for connectors.
-        /// Nodes should be always at the top.
-        /// </summary>
-        private static int zIndex = Configurations.NodeStartZIndex;
-
-
         public NodeView TopControl
         {
             get { return topControl; }
@@ -325,12 +316,12 @@ namespace Dynamo.Controls
 
         private void OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (zIndex == Int32.MaxValue)
+            if (NodeViewModel.StaticZIndex == Int32.MaxValue)
             {
                 PrepareZIndex();
             }
 
-            ViewModel.ZIndex = zIndex++;
+            ViewModel.ZIndex = NodeViewModel.StaticZIndex++;
         }
 
         /// <summary>
@@ -338,7 +329,7 @@ namespace Dynamo.Controls
         /// </summary>
         private void PrepareZIndex()
         {
-            zIndex = Configurations.NodeStartZIndex;
+            NodeViewModel.StaticZIndex = Configurations.NodeStartZIndex;
 
             var parent = TemplatedParent as ContentPresenter;
             if (parent == null) return;

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -370,5 +370,24 @@ namespace DynamoCoreWpfTests
 
             Assert.Pass(); // We should reach here safely without exception.
         }
+
+        [Test]
+        public void ZIndex_Test()
+        {
+            Open(@"UI\CoreUINodes.dyn");
+
+            var nodeView = NodeViewWithGuid("b8c2a62f-f1ce-4327-8d98-c4e0cc0ebed4"); // NodeViewOf<PythonStringNode>();
+
+            Assert.AreEqual(3, nodeView.ViewModel.ZIndex);
+            Assert.AreEqual(3 + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NodeViewModel.StaticZIndex);
+            nodeView.RaiseEvent(new System.Windows.Input.MouseButtonEventArgs(System.Windows.Input.Mouse.PrimaryDevice, 0, System.Windows.Input.MouseButton.Left)
+            {
+                RoutedEvent = System.Windows.Input.Mouse.PreviewMouseDownEvent,
+                Source = this,
+            });
+
+            Assert.AreEqual(4 + ViewModel.HomeSpace.Nodes.Count(), nodeView.ViewModel.ZIndex);
+            Assert.AreEqual(4 + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NodeViewModel.StaticZIndex);
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -376,8 +376,9 @@ namespace DynamoCoreWpfTests
         {
             Open(@"UI\CoreUINodes.dyn");
 
-            var nodeView = NodeViewWithGuid("b8c2a62f-f1ce-4327-8d98-c4e0cc0ebed4"); // NodeViewOf<PythonStringNode>();
+            var nodeView = NodeViewWithGuid("b8c2a62f-f1ce-4327-8d98-c4e0cc0ebed4");
 
+            // Index of first node == 3.
             Assert.AreEqual(3, nodeView.ViewModel.ZIndex);
             Assert.AreEqual(3 + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NodeViewModel.StaticZIndex);
             nodeView.RaiseEvent(new System.Windows.Input.MouseButtonEventArgs(System.Windows.Input.Mouse.PrimaryDevice, 0, System.Windows.Input.MouseButton.Left)
@@ -386,6 +387,7 @@ namespace DynamoCoreWpfTests
                 Source = this,
             });
 
+            // After click node should have The highest index.
             Assert.AreEqual(4 + ViewModel.HomeSpace.Nodes.Count(), nodeView.ViewModel.ZIndex);
             Assert.AreEqual(4 + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NodeViewModel.StaticZIndex);
         }


### PR DESCRIPTION
### Purpose

There is no YouTrack task. But the issue is that, when node is created it's set Zindex = 3. But the newly created node should be set the highest index. That's why I moved zIndex from NodeView into NodeViewModel and set in constructor increased index.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers

@ramramps 
