### PR TITLE
MAGN-9166: Fix for gizmo being displayed for Point preview off

### DIFF
--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -533,7 +533,7 @@ namespace Dynamo.Manipulation
         /// <returns>True if enabled and can be manipulated.</returns>
         public bool IsEnabled()
         {
-            if (Node.IsFrozen) return false;
+            if (Node.IsFrozen || !Node.IsVisible) return false;
 
             if (Node.CachedValue == null || Node.CachedValue.IsNull)
             {


### PR DESCRIPTION
### Purpose
This fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9166.

The behaviour after the fix is such that the gizmo appears/hides as the point node preview for a selected node is turned on/off respectively. If a deselected node with point preview on is selected, its gizmo should be displayed. If a deselected node with preview off is selected, its gizmo should continue to be hidden as is the point geometry.

### Declarations

- [X] The code base is in a better state after this PR

### Reviewers
@sharadkjaiswal 

### FYIs
@monikaprabhu  (for testing)