### PR TITLE
MAGN-9394 Watch node gets erroneously cleared in Manual mode

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -23,6 +23,7 @@ namespace CoreNodeModelsWpf.Nodes
         #region Private fields
 
         private IdentifierNode astBeingWatched;
+        private IdentifierNode astBeingComputed;
 
         private DynamoViewModel dynamoViewModel;
 
@@ -108,15 +109,19 @@ namespace CoreNodeModelsWpf.Nodes
         {
             Tuple<int, NodeModel> input;
 
-            if (watch.TryGetInput(watch.InPorts.IndexOf(connectorModel.End), out input))
+            if (!watch.TryGetInput(watch.InPorts.IndexOf(connectorModel.End), out input)) return;
+
+            astBeingWatched = input.Item2.GetAstIdentifierForOutputIndex(input.Item1);
+            if (astBeingComputed == null) return;
+
+            if (astBeingComputed.Value != astBeingWatched.Value)
             {
-                var oldId = astBeingWatched;
-                astBeingWatched = input.Item2.GetAstIdentifierForOutputIndex(input.Item1);
-                if (oldId != null && astBeingWatched.Value != oldId.Value)
-                {
-                    // the input node has changed, we clear preview
-                    rootWatchViewModel.Children.Clear();
-                }
+                // the input node has changed, we clear preview
+                rootWatchViewModel.Children.Clear();
+            }
+            else
+            {
+                ResetWatch();
             }
         }
 
@@ -206,6 +211,7 @@ namespace CoreNodeModelsWpf.Nodes
         private void WatchOnEvaluationComplete(object o)
         {
             ResetWatch();
+            astBeingComputed = astBeingWatched;
         }
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -22,7 +22,6 @@ namespace CoreNodeModelsWpf.Nodes
     {
         #region Private fields
 
-        private IdentifierNode astBeingWatched;
         private IdentifierNode astBeingComputed;
 
         private DynamoViewModel dynamoViewModel;
@@ -109,11 +108,10 @@ namespace CoreNodeModelsWpf.Nodes
         {
             Tuple<int, NodeModel> input;
 
-            if (!watch.TryGetInput(watch.InPorts.IndexOf(connectorModel.End), out input)) return;
+            if (!watch.TryGetInput(watch.InPorts.IndexOf(connectorModel.End), out input)
+                || astBeingComputed == null) return;
 
-            astBeingWatched = input.Item2.GetAstIdentifierForOutputIndex(input.Item1);
-            if (astBeingComputed == null) return;
-
+            var astBeingWatched = input.Item2.GetAstIdentifierForOutputIndex(input.Item1);
             if (astBeingComputed.Value != astBeingWatched.Value)
             {
                 // the input node has changed, we clear preview
@@ -211,7 +209,7 @@ namespace CoreNodeModelsWpf.Nodes
         private void WatchOnEvaluationComplete(object o)
         {
             ResetWatch();
-            astBeingComputed = astBeingWatched;
+            astBeingComputed = watch.InPorts[0].Connectors[0].Start.Owner.AstIdentifierForPreview;
         }
     }
 }

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-
+using System.Windows.Threading;
 using Dynamo.Controls;
 using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
@@ -357,14 +358,12 @@ namespace DynamoCoreWpfTests
         [Test]
         public void InvalidValueShouldNotCrashColorRangeNode()
         {
-            var guid0 = System.Guid.Parse("1a245b04-ad9e-4b9c-8301-730afbd4e6fc");
-            var guid1 = System.Guid.Parse("cece298a-22de-4f4a-a323-fdb04af406a4");
+            var guid0 = Guid.Parse("1a245b04-ad9e-4b9c-8301-730afbd4e6fc");
+            var guid1 = Guid.Parse("cece298a-22de-4f4a-a323-fdb04af406a4");
 
             OpenAndRun(@"UI\InvalidValueShouldNotCrashColorRangeNode.dyn");
-            var nodes0 = Model.CurrentWorkspace.Nodes.Where(n => n.GUID == guid0);
-            var nodes1 = Model.CurrentWorkspace.Nodes.Where(n => n.GUID == guid0);
-            var node0 = nodes0.ElementAt(0) as CodeBlockNodeModel;
-            var node1 = nodes0.ElementAt(0) as CodeBlockNodeModel;
+            var node0 = Model.CurrentWorkspace.Nodes.First(n => n.GUID == guid0);
+            var node1 = Model.CurrentWorkspace.Nodes.First(n => n.GUID == guid1);
             node0.OnNodeModified(); // Mark node as dirty to tigger an immediate run.
             node1.OnNodeModified(); // Mark node as dirty to tigger an immediate run.
 
@@ -391,6 +390,53 @@ namespace DynamoCoreWpfTests
 
             // After click node should have The highest index.
             Assert.AreEqual(nodeView.ViewModel.ZIndex, Dynamo.ViewModels.NodeViewModel.StaticZIndex);
+        }
+
+        [Test]
+        public void WatchConnectDisconnectTest()
+        {
+            WatchIsEmptyWhenLoaded();
+            Run();
+
+            var watchGuid = "ed970d46-4fe0-4640-b13b-0fe313f94fe4";
+            var cbnGuid = "b4fc5d9a-4c5a-4dba-b7a0-b2e1d8876d33";
+            var anotherNodeGuid = "84509ca2-09bc-4294-82a0-3844021c1a65";
+
+            var nodeView = NodeViewWithGuid(watchGuid);
+
+            var tree = nodeView.ChildrenOfType<WatchTree>();
+            Assert.AreEqual(1, tree.Count());
+
+            var items = tree.First().treeView1.ChildrenOfType<TextBlock>();
+            // watch is computed with cbn and has its value
+            Assert.AreEqual(8, items.Count());
+
+            // disconnect watch
+            Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchGuid, 0, PortType.Input,
+                DynamoModel.MakeConnectionCommand.Mode.Begin));
+            Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(Guid.Empty, -1, PortType.Input,
+                DynamoModel.MakeConnectionCommand.Mode.Cancel));
+            // value should be empty
+            Assert.AreEqual(0, items.Count());
+
+            // connect another node to watch
+            Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(anotherNodeGuid, 0, PortType.Output,
+                DynamoModel.MakeConnectionCommand.Mode.Begin));
+            Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchGuid, 0, PortType.Input,
+                DynamoModel.MakeConnectionCommand.Mode.End));
+            // value should be empty
+            Assert.AreEqual(0, items.Count());
+
+            // connect back cbn whose value watch node has
+            Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(cbnGuid, 0, PortType.Output,
+                DynamoModel.MakeConnectionCommand.Mode.Begin));
+            Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchGuid, 0, PortType.Input,
+                DynamoModel.MakeConnectionCommand.Mode.End));
+            View.Dispatcher.BeginInvoke(new Action(() =>
+            {
+                // value should not be empty
+                Assert.AreEqual(8, items.Count());
+            }), DispatcherPriority.Loaded);
         }
     }
 }


### PR DESCRIPTION
### Purpose

In Manual mode 
- if watch node is disconnected it gets cleared as it used to be;
- if watch node has a value from one node after the last computation and is connected by another node, watch node will be empty;
- if watch node has value from the same node which is connected to it, watch node will have this value.

To be specific:
- if watch node has been computed with Point node connected, after connecting Line node to it watch node will be empty:
![image](https://cloud.githubusercontent.com/assets/7658189/12746234/3b7f9b02-c9a6-11e5-8dcb-272ddc51d101.png)

- if watch node has been computed with Point node connected, after re-connecting the Point node watch node will have the Point node value:
![image](https://cloud.githubusercontent.com/assets/7658189/12746258/5fcbf69a-c9a6-11e5-9e22-287127a90f4e.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@ramramps 