### PR TITLE
Enable "List.ShiftIndices" to accept amounts greater than list length

### DIFF
--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -393,6 +393,9 @@ namespace DSCore
         /// <search>shift,offset</search>
         public static IList ShiftIndices(IList list, int amount)
         {
+            if (System.Math.Abs(amount) > list.Count)
+                amount = amount % list.Count;
+            
             if (amount == 0)
                 return list;
 

--- a/test/Libraries/CoreNodesTests/ListTests.cs
+++ b/test/Libraries/CoreNodesTests/ListTests.cs
@@ -332,6 +332,8 @@ namespace DSCoreNodesTests
         {
             Assert.AreEqual(new List<int> { 2, 0, 1 }, List.ShiftIndices(new List<int> { 0, 1, 2 }, 1));
             Assert.AreEqual(new List<int> { 1, 2, 0 }, List.ShiftIndices(new List<int> { 0, 1, 2 }, -1));
+            Assert.AreEqual(new List<int> { 2, 0, 1 }, List.ShiftIndices(new List<int> { 0, 1, 2 }, 4));
+            Assert.AreEqual(new List<int> { 1, 2, 0 }, List.ShiftIndices(new List<int> { 0, 1, 2 }, -4));
         }
 
         [Test]


### PR DESCRIPTION
### Purpose
Currently "List.ShiftIndices" borks if the amount of shifts is greater than the total list length.
![2016-02-03_12-02-05](https://cloud.githubusercontent.com/assets/7148394/12772995/19781fe4-ca72-11e5-9873-41a9474e0338.png)
![2016-02-03_11-58-46](https://cloud.githubusercontent.com/assets/7148394/12772994/19745bd4-ca72-11e5-8e51-0f9ef1df652e.png)

With this tiny change, we can remove this limitation:
![2016-02-03_11-58-54](https://cloud.githubusercontent.com/assets/7148394/12773007/2ef1ecec-ca72-11e5-8c4d-9e429a4a5357.png)
![2016-02-03_12-01-56](https://cloud.githubusercontent.com/assets/7148394/12773008/2efaa3e6-ca72-11e5-991b-2b8be158f8f2.png)

### Declarations

- [X] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] All tests pass using the self-service CI.


### Reviewers
@aparajit-pratap @kronz 

Any chance you can fit this in 0.91 stable?