### PR TITLE
Another fix for Package Manager

### DIFF
--- a/src/DynamoPackages/Package.cs
+++ b/src/DynamoPackages/Package.cs
@@ -201,11 +201,15 @@ namespace Dynamo.PackageManager
         {
             if (String.IsNullOrEmpty(RootDirectory) || !Directory.Exists(RootDirectory)) return;
 
+            var backupFolderName = @"\" + Configuration.Configurations.BackupFolderName + @"\";
+
             var nonDyfDllFiles = Directory.EnumerateFiles(
                 RootDirectory,
                 "*",
                 SearchOption.AllDirectories)
-                .Where(x => !x.ToLower().EndsWith(".dyf") && !x.ToLower().EndsWith(".dll") && !x.ToLower().EndsWith("pkg.json") && !x.ToLower().EndsWith(".backup"))
+                .Where(x => !x.ToLower().EndsWith(".dyf") && !x.ToLower().EndsWith(".dll") &&
+                    !x.ToLower().EndsWith("pkg.json") && !x.ToLower().EndsWith(".backup") &&
+                    !x.ToLower().Contains(backupFolderName))
                 .Select(x => new PackageFileInfo(RootDirectory, x));
 
             AdditionalFiles.Clear();

--- a/src/DynamoPackages/PackageDirectoryBuilder.cs
+++ b/src/DynamoPackages/PackageDirectoryBuilder.cs
@@ -62,6 +62,7 @@ namespace Dynamo.PackageManager
             package.RootDirectory = rootDir.FullName;
 
             WritePackageHeader(package, rootDir);
+            RemoveUnselectedFiles(files, rootDir);
             CopyFilesIntoPackageDirectory(files, dyfDir, binDir, extraDir);
             RemoveDyfFiles(files, dyfDir);
             RemapCustomNodeFilePaths(files, dyfDir.FullName);
@@ -89,6 +90,25 @@ namespace Dynamo.PackageManager
             foreach (var dyf in dyfsToRemove)
             {
                 fileSystem.DeleteFile(dyf);
+            }
+        }
+
+        private void RemoveUnselectedFiles(IEnumerable<string> filePaths, IDirectoryInfo dir)
+        {
+            // Remove all files which are not listed in the files list
+            filePaths = filePaths.Select(x => x.ToLower());
+            foreach (var path in fileSystem.GetFiles(dir.FullName).Select(x => x.ToLower())
+                .Where(x => !x.EndsWith("pkg.json") && !filePaths.Contains(x)))
+            {
+                fileSystem.DeleteFile(path);
+            }
+
+            // Remove all backup folders
+            var backupFolderName = Configuration.Configurations.BackupFolderName.ToLower();
+            foreach (var path in fileSystem.GetDirectories(dir.FullName)
+                .Where(x => x.Split(new[] { '/', '\\' }).Select(y => y.ToLower()).Contains(backupFolderName)))
+            {
+                fileSystem.DeleteDirectory(path);
             }
         }
 

--- a/test/Libraries/PackageManagerTests/PackageDirectoryBuilderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageDirectoryBuilderTests.cs
@@ -80,7 +80,8 @@ namespace Dynamo.PackageManager.Tests
             db.BuildDirectory(pkg, pkgsDir, files);
 
             var rootDir = Path.Combine(pkgsDir, pkg.Name);
-            
+
+            Assert.AreEqual(1, fs.NewFilesWritten.Count());
             Assert.IsTrue(fs.NewFilesWritten.Any(x => x.Item1 == Path.Combine(rootDir, PackageDirectoryBuilder.PackageJsonName)));
         }
 
@@ -159,6 +160,10 @@ namespace Dynamo.PackageManager.Tests
 
             var dyfDir = Path.Combine(pkgsDir, pkg.Name, PackageDirectoryBuilder.CustomNodeDirectoryName);
 
+            Assert.AreEqual(2, fs.CopiedFiles.Count());
+            Assert.AreEqual(2, fs.DeletedFiles.Count());
+            Assert.AreEqual(0, fs.DeletedDirectories.Count());
+
             Assert.IsTrue(fs.CopiedFiles.Any(x => ComparePaths(x.Item2, Path.Combine(dyfDir, "file1.dyf"))));
             Assert.IsTrue(fs.CopiedFiles.Any(x => ComparePaths(x.Item2, Path.Combine(dyfDir, "file2.dyf"))));
         }
@@ -181,10 +186,42 @@ namespace Dynamo.PackageManager.Tests
 
             // The original files are moved
 
+            Assert.AreEqual(2, fs.DeletedFiles.Count());
+            Assert.AreEqual(0, fs.DeletedDirectories.Count());
+
             Assert.Contains(files[0], fs.DeletedFiles.ToList());
             Assert.Contains(files[1], fs.DeletedFiles.ToList());
         }
 
+        [Test]
+        public void BuildPackageDirectory_DoesNotIncludeUnselectedFiles()
+        {
+            // For http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7676
+
+            var files = new[] { "C:/pkg/bin/file1.dll", "C:/pkg/dyf/file2.dyf",
+                "C:/pkg/extra/file3.txt", "C:/pkg/extra/subfolder/file4.dwg" };
+            var pkg = new Package("C:/pkg", "Foo", "0.1.0", "MIT");
+            var fs = new RecordedFileSystem((fn) => files.Any((x) => ComparePaths(x, fn)));
+
+            // Specifying directory contents in the disk
+            fs.SetFiles(new List<string>() {
+                "C:/pkg/bin/file1.dll", "C:/pkg/dyf/file2.dyf", "C:/pkg/dyf/backup/file2.dyf.0.backup",
+                "C:/pkg/extra/file3.txt", "C:/pkg/extra/Backup/file3.txt.backup", "C:/pkg/extra/subfolder/file4.dwg" });
+            fs.SetDirectories(new List<string>() {
+                "C:/pkg/bin", "C:/pkg/dyf", "C:/pkg/dyf/backup", "C:/pkg/extra",
+                "C:/pkg/extra/Backup", "C:/pkg/extra/subfolder" });
+
+            var db = new PackageDirectoryBuilder(fs, MockMaker.Empty<IPathRemapper>());
+            var pkgsDir = @"C:\dynamopackages";
+            db.BuildDirectory(pkg, pkgsDir, files);
+
+            Assert.AreEqual(4, fs.DirectoriesCreated.Count());
+            Assert.AreEqual(4, fs.CopiedFiles.Count());
+            Assert.AreEqual(3, fs.DeletedFiles.Count());
+            Assert.AreEqual(2, fs.DeletedDirectories.Count());
+            Assert.AreEqual(1, fs.NewFilesWritten.Count());
+        }
+        
         #endregion
 
         #region CopyFilesIntoPackageDirectory

--- a/test/Libraries/PackageManagerTests/RecordedFileSystem.cs
+++ b/test/Libraries/PackageManagerTests/RecordedFileSystem.cs
@@ -63,6 +63,7 @@ namespace Dynamo.PackageManager.Tests
         public void CopyFile(string filePath, string destinationPath)
         {
             this.copiedFiles.Add(new Tuple<string, string>(filePath, destinationPath));
+            this.allFiles.Add(destinationPath);
         }
 
         public void DeleteFile(string filePath)


### PR DESCRIPTION
### References

- #5877 Remove all backup files and folders before uploading a package version
- #6063 Revert changes in pull request #5877 
- [MAGN-7676](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7676) Do not include backup folders when uploading a package
- [MAGN-9414](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9414) Publish Package :package: is broken

### Purpose

- A better fix for [MAGN-7676](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7676) which does not cause [MAGN-9414](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9414)
- Adding more adequate checkings to the NUnit test cases so that such situations can be caught.

Updated test cases before this fix:

![image](https://cloud.githubusercontent.com/assets/6386550/12804669/0686f1bc-cb30-11e5-9d07-4670dfd7d92d.png)

Updated test cases after this fix:

![image](https://cloud.githubusercontent.com/assets/6386550/12804678/17d05e86-cb30-11e5-9112-b2660a3a60d9.png)

### Declarations

- [x] The level of testing this PR includes is appropriate
- [x] All tests pass using the self-service CI.

### Reviewers

@Benglin 

### FYIs

@riteshchandawar @jnealb @monikaprabhu 