### PR TITLE
MAGN-9340 Cursor focus is not in search box on second consecutive right-click

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -3,19 +3,12 @@ using Dynamo.Wpf.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using System.Windows.Threading;
-using Dynamo.Models;
 using Dynamo.Controls;
 using Dynamo.Utilities;
 using Dynamo.Views;
@@ -25,7 +18,7 @@ namespace Dynamo.UI.Controls
     /// <summary>
     /// Interaction logic for IncanvasLibrarySearchControl.xaml
     /// </summary>
-    public partial class InCanvasSearchControl : UserControl
+    public partial class InCanvasSearchControl
     {
         ListBoxItem HighlightedItem;
 
@@ -43,15 +36,19 @@ namespace Dynamo.UI.Controls
         {
             InitializeComponent();
 
-            this.Loaded += (sender, e) =>
+            Loaded += (sender, e) =>
             {
                 if (workspaceView == null)
-                    workspaceView = WpfUtilities.FindUpVisualTree<WorkspaceView>(this.Parent);
-                if (dynamoView == null)
                 {
-                    dynamoView = WpfUtilities.FindUpVisualTree<DynamoView>(this.Parent);
-                    if (dynamoView != null)
-                        dynamoView.Deactivated += (s, args) => { OnRequestShowInCanvasSearch(ShowHideFlags.Hide); };
+                    workspaceView = WpfUtilities.FindUpVisualTree<WorkspaceView>(Parent);
+                }
+
+                if (dynamoView != null) return;
+
+                dynamoView = WpfUtilities.FindUpVisualTree<DynamoView>(Parent);
+                if (dynamoView != null)
+                {
+                    dynamoView.Deactivated += (s, args) => { OnRequestShowInCanvasSearch(ShowHideFlags.Hide); };
                 }
             };
         }
@@ -101,7 +98,6 @@ namespace Dynamo.UI.Controls
 
             toolTipPopup.DataContext = fromSender.DataContext;
             toolTipPopup.IsOpen = true;
-
         }
 
         private void OnMouseLeave(object sender, MouseEventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -15,8 +15,6 @@
              PreviewMouseLeftButtonDown="OnPreviewMouseLeftButtonDown"
              MouseUp="OnMouseRelease"
              MouseMove="OnMouseMove"
-             KeyDown="WorkspaceView_KeyDown"
-             KeyUp="WorkspaceView_KeyUp"
              IsHitTestVisible="{Binding IsCurrentSpace}"
              AllowDrop="True"
              Drop="OnWorkspaceDrop">
@@ -113,6 +111,11 @@
 
         <Grid.ContextMenu>
             <ContextMenu Style="{StaticResource WorkspaceContextMenuStyle}">
+                <ContextMenu.Resources>
+                    <Style TargetType="{x:Type MenuItem}">
+                        <Setter Property="Focusable" Value="False" />
+                    </Style>
+                </ContextMenu.Resources>
                 <MenuItem Name="WorkspaceLacingMenu"
                           Header="{x:Static p:Resources.ContextMenuLacing}">
                     


### PR DESCRIPTION
### Purpose

The topic of this PR is focus of in-canvas search textbox which is in the workspace context menu:
![image](https://cloud.githubusercontent.com/assets/7658189/12812880/3d59342c-cb3d-11e5-84b6-91e7adc76cab.png)

When context menu is already opened and we do quick right click (very small delay between pressing and releasing mouse button) on the canvas, newly opened context menu does not have focus in its textbox.
This happens because context menu has not been unloaded and loaded (`Unloaded` and `Loaded` events have not been triggered by WPF) and therefore `IsVisibleChanged` event has not been triggered too, but focus is supposed to be set inside subscription on `IsVisibleChanged`. As result, we cannot rely on `IsVisibleChanged` to set focus.
`ContextMenu.Opened` is triggering without any issues, so focus is set inside the subscription on this event.

Also, code is better now: not used usings and methods, redundant qualifiers are removed

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate - **cannot add a test for this because the test won't catch this WPF specific issue**
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@ramramps 