### PR TITLE
MAGN-8423 Moving a node in an executing graph removes the Run status message

### DIFF
--- a/src/DynamoCoreWpf/Controls/NotificationsControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NotificationsControl.xaml.cs
@@ -1,13 +1,48 @@
-﻿namespace Dynamo.Wpf.Controls
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+using Dynamo.Controls;
+using Dynamo.Utilities;
+using Dynamo.ViewModels;
+using Dynamo.Wpf.ViewModels.Core;
+
+namespace Dynamo.Wpf.Controls
 {
     /// <summary>
     /// Interaction logic for NotificationsControl.xaml
     /// </summary>
-    public partial class NotificationsControl
+    public partial class NotificationsControl : UserControl
     {
         public NotificationsControl()
         {
             InitializeComponent();
+
+            this.Loaded += NotificationsControl_Loaded;  
+        }
+
+        void NotificationsControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            var window = WpfUtilities.FindUpVisualTree<DynamoView>(this);
+            if (window == null)
+            {
+                return;
+            }
+
+            window.PreviewMouseDown += window_PreviewMouseDown;
+        }
+
+        /// <summary>
+        /// Handle the DynamoView's PreviewMouseDown event.
+        /// When the user click anywhere in the view, clear the ViewModel's warning.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        void window_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            var hsvm = (HomeWorkspaceViewModel)((DynamoViewModel)DataContext).HomeSpaceViewModel;
+            // Commented this after MAGN - 8423
+            // hsvm.ClearWarning();
         }
     }
 }

--- a/src/DynamoCoreWpf/Controls/NotificationsControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/NotificationsControl.xaml.cs
@@ -1,47 +1,13 @@
-﻿using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
-
-using Dynamo.Controls;
-using Dynamo.Utilities;
-using Dynamo.ViewModels;
-using Dynamo.Wpf.ViewModels.Core;
-
-namespace Dynamo.Wpf.Controls
+﻿namespace Dynamo.Wpf.Controls
 {
     /// <summary>
     /// Interaction logic for NotificationsControl.xaml
     /// </summary>
-    public partial class NotificationsControl : UserControl
+    public partial class NotificationsControl
     {
         public NotificationsControl()
         {
             InitializeComponent();
-
-            this.Loaded += NotificationsControl_Loaded;  
-        }
-
-        void NotificationsControl_Loaded(object sender, RoutedEventArgs e)
-        {
-            var window = WpfUtilities.FindUpVisualTree<DynamoView>(this);
-            if (window == null)
-            {
-                return;
-            }
-
-            window.PreviewMouseDown += window_PreviewMouseDown;
-        }
-
-        /// <summary>
-        /// Handle the DynamoView's PreviewMouseDown event.
-        /// When the user click anywhere in the view, clear the ViewModel's warning.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        void window_PreviewMouseDown(object sender, MouseButtonEventArgs e)
-        {
-            var hsvm = (HomeWorkspaceViewModel)((DynamoViewModel)DataContext).HomeSpaceViewModel;
-            hsvm.ClearWarning();
         }
     }
 }


### PR DESCRIPTION
### Purpose

Make RUN status message always stick around:
![image](https://cloud.githubusercontent.com/assets/7658189/12852189/64435e10-cc36-11e5-9586-ba9cd471c51b.png)
![image](https://cloud.githubusercontent.com/assets/7658189/12852171/50c33b44-cc36-11e5-894a-93704735e3c2.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate - nothing to test, message is just stopped getting cleared
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@ramramps 