### PR TITLE
Fix MAGN 9432 stackoverflow in recorded test case recursion_6415

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CustomNodes/CustomNodeController.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/CustomNodeController.cs
@@ -163,7 +163,8 @@ namespace Dynamo.Graph.Nodes.CustomNodes
             if (Definition.Returns != null)
             {
                 var tooltips = model.OutPortData.Select(p => p.ToolTipString);
-                if (!Definition.Returns.Select(r => r.Item2).SequenceEqual(tooltips))
+                if (!Definition.Returns.Select(r => string.IsNullOrEmpty(r.Item2) ? Properties.Resources.ToolTipReturnValue : r.Item2)
+                                       .SequenceEqual(tooltips))
                     return false;
             }
             return true;

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -3961,7 +3961,6 @@ namespace DynamoCoreWpfTests
 
         }
         [Test]
-        [Category("Failure")]
         public void recursion_6415()
         {
 


### PR DESCRIPTION
### Purpose

It is because the recorded test case recursion_6415 tries to open a recursive custom node. As the tooltip of output port of that custom node (by default is "return value") is different from the description of that output port (null), Dynamo tries to update all custom node instances, including the recursive instance in custom workspace, which consequently makes the custom node as dirty and starts the other synchronization process. 

Need to skip the checking if the description of output is null or empty.

### Reviewer

@aparajit-pratap 