### PR TITLE
Magn 9325: temporally bring node infront

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -324,7 +324,7 @@ namespace Dynamo.Controls
         private void OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             nodeWasClicked = true;
-            BringInFront();
+            BringToFront();
         }
 
         /// <summary>
@@ -407,7 +407,7 @@ namespace Dynamo.Controls
                 Dispatcher.DelayInvoke(previewDelay, ExpandPreviewControl);
             }
 
-            Dispatcher.DelayInvoke(previewDelay, BringInFront);
+            Dispatcher.DelayInvoke(previewDelay, BringToFront);
         }
 
         private void OnNodeViewMouseLeave(object sender, MouseEventArgs e)
@@ -498,7 +498,7 @@ namespace Dynamo.Controls
         /// <summary>
         /// Sets ZIndex of node the maximum value.
         /// </summary>
-        private void BringInFront()
+        private void BringToFront()
         {
             if (IsMouseOver || PreviewControl.IsMouseOver || DynCmd.IsTestMode)
             {

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -500,7 +500,7 @@ namespace Dynamo.Controls
         /// </summary>
         private void BringInFront()
         {
-            if (IsMouseOver || PreviewControl.IsMouseOver)
+            if (IsMouseOver || PreviewControl.IsMouseOver || DynCmd.IsTestMode)
             {
                 if (NodeViewModel.StaticZIndex == Int32.MaxValue)
                 {

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -506,8 +506,10 @@ namespace Dynamo.Controls
                 {
                     PrepareZIndex();
                 }
-                oldZIndex = nodeWasClicked ? ++NodeViewModel.StaticZIndex : ViewModel.ZIndex;
-                ViewModel.ZIndex = ++NodeViewModel.StaticZIndex;
+                var index = ++NodeViewModel.StaticZIndex;
+
+                oldZIndex = nodeWasClicked ? index : ViewModel.ZIndex;
+                ViewModel.ZIndex = index;
             }
         }
 

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -131,6 +131,7 @@
     <Compile Include="..\..\src\AssemblySharedInfoGenerator\AssemblySharedInfo.cs">
       <Link>AssemblySharedInfo.cs</Link>
     </Compile>
+    <Compile Include="NodeViewTests.cs" />
     <Compile Include="NodeExecutionUITest.cs" />
     <Compile Include="CustomNodeTests.cs" />
     <Compile Include="DateTimeTests.cs" />

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -6,9 +6,11 @@ using System.Reflection;
 using System.Threading;
 using Dynamo.Configuration;
 using Dynamo.Controls;
+using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.Scheduler;
 using Dynamo.ViewModels;
+using DynamoCoreWpfTests.Utility;
 using DynamoShapeManager;
 using NUnit.Framework;
 using TestServices;
@@ -178,6 +180,24 @@ namespace DynamoCoreWpfTests
 
             if (!Directory.Exists(TempFolder))
                 Directory.CreateDirectory(TempFolder);
+        }
+
+        public NodeView NodeViewOf<T>() where T : NodeModel
+        {
+            var nodeViews = View.NodeViewsInFirstWorkspace();
+            var nodeViewsOfType = nodeViews.OfNodeModelType<T>();
+            Assert.AreEqual(1, nodeViewsOfType.Count(), "Expected a single NodeView of provided type in the workspace!");
+
+            return nodeViewsOfType.First();
+        }
+
+        public NodeView NodeViewWithGuid(string guid)
+        {
+            var nodeViews = View.NodeViewsInFirstWorkspace();
+            var nodeViewsOfType = nodeViews.Where(x => x.ViewModel.NodeLogic.GUID.ToString() == guid);
+            Assert.AreEqual(1, nodeViewsOfType.Count(), "Expected a single NodeView with guid: " + guid);
+
+            return nodeViewsOfType.First();
         }
 
         #endregion

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Threading;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -5,12 +5,10 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
 using Dynamo.Controls;
-using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.Nodes;
 using Dynamo.Utilities;
-using Dynamo.Wpf.Controls;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
 using CoreNodeModelsWpf.Controls;
@@ -20,24 +18,6 @@ namespace DynamoCoreWpfTests
     public class NodeViewCustomizationTests : DynamoTestUIBase
     {
         // adapted from: http://stackoverflow.com/questions/9336165/correct-method-for-using-the-wpf-dispatcher-in-unit-tests
-
-        public NodeView NodeViewOf<T>() where T : NodeModel
-        {
-            var nodeViews = View.NodeViewsInFirstWorkspace();
-            var nodeViewsOfType = nodeViews.OfNodeModelType<T>();
-            Assert.AreEqual(1, nodeViewsOfType.Count(), "Expected a single NodeView of provided type in the workspace!");
-
-            return nodeViewsOfType.First();
-        }
-
-        public NodeView NodeViewWithGuid(string guid)
-        {
-            var nodeViews = View.NodeViewsInFirstWorkspace();
-            var nodeViewsOfType = nodeViews.Where(x => x.ViewModel.NodeLogic.GUID.ToString() == guid);
-            Assert.AreEqual(1, nodeViewsOfType.Count(), "Expected a single NodeView with guid: " + guid);
-
-            return nodeViewsOfType.First();
-        }
 
         public override void Open(string path)
         {
@@ -368,28 +348,6 @@ namespace DynamoCoreWpfTests
             node1.OnNodeModified(); // Mark node as dirty to tigger an immediate run.
 
             Assert.Pass(); // We should reach here safely without exception.
-        }
-
-        [Test]
-        public void ZIndex_Test()
-        {
-            // Reset zindex to start value.
-            Dynamo.ViewModels.NodeViewModel.StaticZIndex = 3;
-            Open(@"UI\CoreUINodes.dyn");
-
-            var nodeView = NodeViewWithGuid("b8c2a62f-f1ce-4327-8d98-c4e0cc0ebed4");
-
-            // Index of first node == 4.
-            Assert.AreEqual(4, nodeView.ViewModel.ZIndex);
-            Assert.AreEqual(3 + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NodeViewModel.StaticZIndex);
-            nodeView.RaiseEvent(new System.Windows.Input.MouseButtonEventArgs(System.Windows.Input.Mouse.PrimaryDevice, 0, System.Windows.Input.MouseButton.Left)
-            {
-                RoutedEvent = System.Windows.Input.Mouse.PreviewMouseDownEvent,
-                Source = this,
-            });
-
-            // After click node should have The highest index.
-            Assert.AreEqual(nodeView.ViewModel.ZIndex, Dynamo.ViewModels.NodeViewModel.StaticZIndex);
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/NodeViewTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using DynamoCoreWpfTests.Utility;
+using NUnit.Framework;
+using System.Windows.Input;
+
+namespace DynamoCoreWpfTests
+{
+    public class NodeViewTests : DynamoTestUIBase
+    {
+        // adapted from: http://stackoverflow.com/questions/9336165/correct-method-for-using-the-wpf-dispatcher-in-unit-tests
+
+        public override void Open(string path)
+        {
+            base.Open(path);
+
+            DispatcherUtil.DoEvents();
+        }
+
+        public override void Run()
+        {
+            base.Run();
+
+            DispatcherUtil.DoEvents();
+        }
+
+        [Test]
+        public void ZIndex_Test_MouseDown()
+        {
+            // Reset zindex to start value.
+            Dynamo.ViewModels.NodeViewModel.StaticZIndex = 3;
+            Open(@"UI\CoreUINodes.dyn");
+
+            var nodeView = NodeViewWithGuid("b8c2a62f-f1ce-4327-8d98-c4e0cc0ebed4");
+
+            // Index of first node == 4.
+            Assert.AreEqual(4, nodeView.ViewModel.ZIndex);
+            Assert.AreEqual(3 + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NodeViewModel.StaticZIndex);
+            nodeView.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Mouse.PreviewMouseDownEvent,
+                Source = this,
+            });
+
+            // After click node should have The highest index.
+            Assert.AreEqual(nodeView.ViewModel.ZIndex, Dynamo.ViewModels.NodeViewModel.StaticZIndex);
+        }
+
+        [Test]
+        public void ZIndex_Test_MouseEnter_Leave()
+        {
+            // Reset zindex to start value.
+            Dynamo.ViewModels.NodeViewModel.StaticZIndex = 3;
+            Open(@"UI\CoreUINodes.dyn");
+
+            var nodeView = NodeViewWithGuid("b8c2a62f-f1ce-4327-8d98-c4e0cc0ebed4");
+
+            // Index of first node == 4.
+            Assert.AreEqual(4, nodeView.ViewModel.ZIndex);
+            Assert.AreEqual(3 + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NodeViewModel.StaticZIndex);
+
+            var dispatcherOperation = View.Dispatcher.BeginInvoke(new Action(
+                () => nodeView.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
+                 {
+                     RoutedEvent = Mouse.MouseEnterEvent
+                 })));
+            DispatcherUtil.DoEvents();
+            //dispatcherOperation.Task.Wait();
+
+            dispatcherOperation.Completed += (s, args) =>
+            {
+                // After mouse enter node should have the highest index.
+                Assert.AreEqual(nodeView.ViewModel.ZIndex, Dynamo.ViewModels.NodeViewModel.StaticZIndex);
+            };
+
+            dispatcherOperation = View.Dispatcher.BeginInvoke(new Action(
+                () => nodeView.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
+                {
+                    RoutedEvent = Mouse.MouseLeaveEvent
+                })));
+            DispatcherUtil.DoEvents();
+
+            dispatcherOperation.Completed += (s, args) =>
+            {
+                // After mouse leave node should have the old index.
+                Assert.AreEqual(nodeView.ViewModel.ZIndex, Dynamo.ViewModels.NodeViewModel.StaticZIndex);
+                Assert.AreEqual(4, nodeView.ViewModel.ZIndex);
+            };
+        }
+    }
+}

--- a/test/DynamoCoreWpfTests/NodeViewTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewTests.cs
@@ -65,7 +65,6 @@ namespace DynamoCoreWpfTests
                      RoutedEvent = Mouse.MouseEnterEvent
                  })));
             DispatcherUtil.DoEvents();
-            //dispatcherOperation.Task.Wait();
 
             dispatcherOperation.Completed += (s, args) =>
             {


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9325](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9325) On hover over the node or compact view, the node and its preview bubble should be temporarily brought to the front of the view order

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.


### Reviewers

@ramramps 
