### PR TITLE
Expose DelegateBasedTask for UI node authors and task extensions

### DIFF
--- a/src/DynamoCore/Scheduler/AsyncTaskExtensions.cs
+++ b/src/DynamoCore/Scheduler/AsyncTaskExtensions.cs
@@ -8,13 +8,13 @@ namespace Dynamo.Scheduler
     /// <summary>
     ///     Tools for working productively with AsyncTask's
     /// </summary>
-    internal static class AsyncTaskExtensions
+    public static class AsyncTaskExtensions
     {
         /// <summary>
         ///     Upon completion of the task, invoke the specified action
         /// </summary>
         /// <returns>An IDisposable representing the event subscription</returns>
-        internal static IDisposable Then(this AsyncTask task, AsyncTaskCompletedHandler action)
+        public static IDisposable Then(this AsyncTask task, AsyncTaskCompletedHandler action)
         {
             task.Completed += action;
             return Disposable.Create(() => task.Completed -= action);
@@ -25,7 +25,7 @@ namespace Dynamo.Scheduler
         ///     SynchronizationContext
         /// </summary>
         /// <returns>An IDisposable representing the event subscription</returns>
-        internal static IDisposable ThenPost(this AsyncTask task, AsyncTaskCompletedHandler action, SynchronizationContext context = null)
+        public static IDisposable ThenPost(this AsyncTask task, AsyncTaskCompletedHandler action, SynchronizationContext context = null)
         {
             if (context == null) context = new SynchronizationContext(); // uses the default
             return task.Then((t) => context.Post((_) => action(task), null));
@@ -36,7 +36,7 @@ namespace Dynamo.Scheduler
         ///     SynchronizationContext
         /// </summary>
         /// <returns>An IDisposable representing the event subscription</returns>
-        internal static IDisposable ThenSend(this AsyncTask task, AsyncTaskCompletedHandler action, SynchronizationContext context = null)
+        public static IDisposable ThenSend(this AsyncTask task, AsyncTaskCompletedHandler action, SynchronizationContext context = null)
         {
             if (context == null) context = new SynchronizationContext(); // uses the default
             return task.Then((t) => context.Send((_) => action(task), null));
@@ -49,7 +49,7 @@ namespace Dynamo.Scheduler
         ///     executed.
         /// </summary>
         /// <returns>An IDisposable representing all of the event subscription</returns>
-        internal static IDisposable AllComplete(this IEnumerable<AsyncTask> tasks, Action<IEnumerable<AsyncTask>> action)
+        public static IDisposable AllComplete(this IEnumerable<AsyncTask> tasks, Action<IEnumerable<AsyncTask>> action)
         {
             // If the task list is empty, we immediately invoke the action
             if (!tasks.Any())

--- a/src/DynamoCore/Scheduler/DelegateBasedAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/DelegateBasedAsyncTask.cs
@@ -18,12 +18,12 @@ namespace Dynamo.Scheduler
 
         #region Public Class Operational Methods
 
-        internal DelegateBasedAsyncTask(IScheduler scheduler)
+        public DelegateBasedAsyncTask(IScheduler scheduler)
             : base(scheduler)
         {
         }
         
-        internal DelegateBasedAsyncTask(IScheduler scheduler, Action action)
+        public DelegateBasedAsyncTask(IScheduler scheduler, Action action)
             : base(scheduler)
         {
             this.Initialize(action);

--- a/src/DynamoCore/Scheduler/DelegateBasedAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/DelegateBasedAsyncTask.cs
@@ -18,11 +18,20 @@ namespace Dynamo.Scheduler
 
         #region Public Class Operational Methods
 
+        /// <summary>
+        /// construct a new empty DelegateBasedAsyncTask
+        /// </summary>
+        /// <param name="scheduler"> the scheduler to run the task on</param>
         public DelegateBasedAsyncTask(IScheduler scheduler)
             : base(scheduler)
         {
         }
-        
+        /// <summary>
+        /// construct a new DelegateBasedAsyncTask by supplying an action delegate that will run
+        /// on the scheduler specified
+        /// </summary>
+        /// <param name="scheduler"> the scheduler to run the task on</param>
+        /// <param name="action"> the action to perform when this task is executed</param>
         public DelegateBasedAsyncTask(IScheduler scheduler, Action action)
             : base(scheduler)
         {

--- a/src/DynamoCore/Scheduler/Disposable.cs
+++ b/src/DynamoCore/Scheduler/Disposable.cs
@@ -19,6 +19,11 @@ namespace Dynamo.Scheduler
             }
         }
 
+        /// <summary>
+        /// construct a new disposable that calls the delegate when disposed 
+        /// </summary>
+        /// <param name="disposeAction"> an action that is run when this object is disposed</param>
+        /// <returns></returns>
         public static IDisposable Create(Action disposeAction)
         {
             return new SimpleDisposable(disposeAction);

--- a/src/DynamoCore/Scheduler/Disposable.cs
+++ b/src/DynamoCore/Scheduler/Disposable.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Scheduler
             }
         }
 
-        internal static IDisposable Create(Action disposeAction)
+        public static IDisposable Create(Action disposeAction)
         {
             return new SimpleDisposable(disposeAction);
         }


### PR DESCRIPTION


### Purpose

This PR relates to the robot work UI nodes that use  `DelegateBasedAsyncTasks`, as well as `disposable` constructor for tasks disposal.... These classes are used by complex UI nodes that run some computations on the scheduler and some on the dispatcher, like the `ColorRange` node, except that the color range node can reference internal classes in `DynamoCore`. I think opening these classes back up, is useful for third party developers attempting to create UI nodes, if there is a better current alternative for third party devs running code on the scheduler for a UI node customization please let me know.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.


### Reviewers
@ramramps 

### FYIs

@ikeough 