### PR TITLE
MAGN-9404 Preview Bubble expands and contracts like a beating heart

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -451,7 +451,7 @@ namespace Dynamo.Controls
                     }
                 case PreviewControl.State.Condensed:
                     {
-                        if (preview.IsMouseOver)
+                        if (preview.IsMouseOver || IsMouseOver)
                         {
                             Dispatcher.DelayInvoke(previewDelay, ExpandPreviewControl);
                         }

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -24,7 +24,7 @@
             <clr:Double x:Key="MinPreviewControlHeight">28.0</clr:Double>
 
             <!-- MaxContentGrid = (MaxPreviewControl - (2 * Margin)) -->
-            <fwk:Thickness x:Key="PreviewContentMargin">5</fwk:Thickness>            
+            <fwk:Thickness x:Key="PreviewContentMargin">12,5,5,5</fwk:Thickness>
             <clr:Double x:Key="MaxContentGridWidth">488.0</clr:Double>
             <clr:Double x:Key="MaxContentGridHeight">288</clr:Double>
 
@@ -150,6 +150,10 @@
 
         <Grid Grid.Column="0"
               Grid.Row="0"
+              HorizontalAlignment="Left"
+              Width="{Binding RelativeSource={RelativeSource FindAncestor, 
+                             AncestorType={x:Type controls:NodeView}}, 
+                             Path=ActualWidth}"
               Background="#01000000" />
 
         <Grid Grid.Column="0"

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -148,7 +148,8 @@
         <!-- Invisible part. Background is set to #01000000. It's almost invisible color.
               But with this color we can handle mouse moves.-->
 
-        <Grid Grid.Column="0"
+        <Grid Name="HiddenDummy"
+              Grid.Column="0"
               Grid.Row="0"
               HorizontalAlignment="Left"
               Width="{Binding RelativeSource={RelativeSource FindAncestor, 

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -166,7 +166,6 @@
             <Grid Name="smallContentGrid"
                   HorizontalAlignment="Left"
                   VerticalAlignment="Center"
-                  Margin="3,0,0,0"
                   MinWidth="{Binding RelativeSource={RelativeSource FindAncestor, 
                              AncestorType={x:Type controls:NodeView}}, 
                              Path=ActualWidth}">

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -156,5 +156,45 @@ namespace DynamoCoreWpfTests
         }
 
         #endregion
+
+        [Test]
+        public void PreviewBubble_HiddenDummyVerticalBoundaries()
+        {
+            Open(@"core\DetailedPreviewMargin_Test.dyn");
+
+            var nodeView = NodeViewWithGuid("1382aaf9-9432-4cf0-86ae-c586d311767e");
+            nodeView.PreviewControl.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+                        
+            // preview is hidden
+            Assert.IsTrue(ElementIsInContainer(nodeView.PreviewControl.HiddenDummy, nodeView.PreviewControl));
+
+            View.Dispatcher.Invoke(() =>
+            {
+                nodeView.PreviewControl.BindToDataSource(nodeView.ViewModel.NodeModel.CachedValue);
+                nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Condensed);
+            });
+
+            DispatcherUtil.DoEvents();
+
+            // preview is condensed
+            Assert.IsTrue(ElementIsInContainer(nodeView.PreviewControl.HiddenDummy, nodeView.PreviewControl));
+
+            View.Dispatcher.Invoke(() =>
+            {
+                nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Expanded);
+            });
+
+            DispatcherUtil.DoEvents();
+
+            // preview is expanded
+            Assert.IsTrue(ElementIsInContainer(nodeView.PreviewControl.HiddenDummy, nodeView));
+        }        
+
+        private bool ElementIsInContainer(FrameworkElement element, FrameworkElement container)
+        {
+            var relativePosition = element.TranslatePoint(new Point(), container);
+            
+            return (relativePosition.X == 0) && (element.ActualWidth <= container.ActualWidth);
+        }
     }
 }


### PR DESCRIPTION
### Purpose

I painted preview in green just to illustrate the issue:
![image](https://cloud.githubusercontent.com/assets/7658189/12916114/91ceaf9c-cf38-11e5-8e54-0ef1ad857297.png)
When mouse is over that protruding part of preview control `MouseEnter` is triggering but it looks as if `MouseEnter` should not be triggering. It causes to the small preview appear and then expand to large preview. But the large preview is 3px narrower and now mouse is not over preview control, therefore `MouseLeave` is triggering and cause to collapsing to the small preview. The small preview is 3px wider and mouse becames over it back, so `MouseEnter` is triggering again and we have an infinite loop here.

Fix is to remove margin that causes nothing but issues and now small preview is not wider than large preview:
![image](https://cloud.githubusercontent.com/assets/7658189/12916371/94cbd47a-cf3a-11e5-8bf1-fb3d73d1a47b.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@aosyatnik 