### PR TITLE
Enable colors for meshes, lines and points in render packages

### DIFF
--- a/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
@@ -170,6 +170,10 @@ namespace Dynamo.Scheduler
                 try
                 {
                     graphicItem.Tessellate(package, factory.TessellationParameters);
+                    if (package.MeshVertexColors.Count() > 0)
+                    {
+                        package.RequiresPerVertexColoration = true;
+                    }
 
                     if (factory.TessellationParameters.ShowEdges)
                     {
@@ -268,12 +272,12 @@ namespace Dynamo.Scheduler
                     // color of 0,0,0,255 (Black), we adjust the color components here.
                     if (graphicItem is Curve || graphicItem is Surface || graphicItem is Solid || graphicItem is Point)
                     {
-                        if (package.LineVertexCount > 0)
+                        if (package.LineVertexCount > 0 && package.LineStripVertexColors.Count() <= 0)
                         {
                             package.ApplyLineVertexColors(CreateColorByteArrayOfSize(package.LineVertexCount, DefR, DefG, DefB, DefA));
                         }
 
-                        if (package.PointVertexCount > 0)
+                        if (package.PointVertexCount > 0 && package.PointVertexColors.Count() <= 0)
                         {
                             package.ApplyPointVertexColors(CreateColorByteArrayOfSize(package.PointVertexCount, DefR, DefG, DefB, DefA));
                         }


### PR DESCRIPTION
### Purpose

This is to make it possible to render colors for meshes, linear segements and vertices if their color is provided in the render package.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers
@aparajit-pratap 

### FYIs
@ikeough 