### PR TITLE
MAGN 9418 Replication should use zip first approach

### DIFF
--- a/src/Engine/ProtoCore/DebuggerProperties.cs
+++ b/src/Engine/ProtoCore/DebuggerProperties.cs
@@ -416,7 +416,7 @@ namespace ProtoCore
                 return;
             }
 
-            // Comment Jun: A dot call does no>t replicate and  must be handled immediately
+            // Comment Jun: A dot call does not replicate and  must be handled immediately
             if (fNode.Name == Constants.kDotMethodName)
             {
                 isReplicating = false;

--- a/src/Engine/ProtoCore/DebuggerProperties.cs
+++ b/src/Engine/ProtoCore/DebuggerProperties.cs
@@ -416,7 +416,7 @@ namespace ProtoCore
                 return;
             }
 
-            // Comment Jun: A dot call does not replicate and  must be handled immediately
+            // Comment Jun: A dot call does no>t replicate and  must be handled immediately
             if (fNode.Name == Constants.kDotMethodName)
             {
                 isReplicating = false;

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -503,7 +503,7 @@ namespace ProtoCore
             #region First Case: Replicate only according to the replication guides
 
             {
-                FunctionEndPoint fep = Case1GetCompleteMatchFEP(context, arguments, funcGroup, replicationControl,
+                FunctionEndPoint fep = Case1GetCompleteMatchFEP(context, arguments, funcGroup, replicationControl.Instructions,
                                                                 stackFrame,
                                                                 runtimeCore, new StringBuilder());
                 if (fep != null)
@@ -519,18 +519,11 @@ namespace ProtoCore
 
             {
                 //Build the possible ways in which we might replicate
-                replicationTrials =
-                    Replicator.BuildReplicationCombinations(replicationControl.Instructions, arguments, runtimeCore);
-
+                replicationTrials = Replicator.BuildReplicationCombinations(replicationControl.Instructions, arguments, runtimeCore);
 
                 foreach (List<ReplicationInstruction> replicationOption in replicationTrials)
                 {
-                    ReplicationControl rc = new ReplicationControl() { Instructions = replicationOption };
-
-
-                    List<List<StackValue>> reducedParams = Replicator.ComputeAllReducedParams(arguments,
-                                                                                              rc.
-                                                                                                  Instructions, runtimeCore);
+                    List<List<StackValue>> reducedParams = Replicator.ComputeAllReducedParams(arguments, replicationOption, runtimeCore);
                     int resolutionFailures;
 
                     funcGroup.GetExactMatchStatistics(context, reducedParams, stackFrame, runtimeCore, out resolutionFailures);
@@ -713,13 +706,60 @@ namespace ProtoCore
 
         #region Target resolution
 
-        private void ComputeFeps(StringBuilder log, Context context, List<StackValue> arguments, FunctionGroup funcGroup, ReplicationControl replicationControl,
-                                      List<List<ReplicationGuide>> partialReplicationGuides, StackFrame stackFrame, RuntimeCore runtimeCore,
-            out List<FunctionEndPoint> resolvesFeps, out List<ReplicationInstruction> replicationInstructions)
+        private FunctionEndPoint GetCompliantFEP(
+            Context context, 
+            List<StackValue> arguments, 
+            FunctionGroup funcGroup, 
+            List<ReplicationInstruction> replicationInstructions,
+            StackFrame stackFrame, 
+            RuntimeCore runtimeCore,
+            bool allowArrayPromotion = false)
         {
+            Dictionary<FunctionEndPoint, int> candidatesWithDistances = 
+                funcGroup.GetConversionDistances(
+                    context, 
+                    arguments, 
+                    replicationInstructions, 
+                    runtimeCore.DSExecutable.classTable, 
+                    runtimeCore,
+                    allowArrayPromotion);
 
-            
+            Dictionary<FunctionEndPoint, int> candidatesWithCastDistances =
+                funcGroup.GetCastDistances(
+                    context, 
+                    arguments, 
+                    replicationInstructions, 
+                    runtimeCore.DSExecutable.classTable, 
+                    runtimeCore);
 
+            List<FunctionEndPoint> candidateFunctions = GetCandidateFunctions(stackFrame, candidatesWithDistances);
+
+            FunctionEndPoint compliantTarget = 
+                GetCompliantTarget(
+                    context, 
+                    arguments, 
+                    replicationInstructions, 
+                    stackFrame,
+                    runtimeCore, 
+                    candidatesWithCastDistances, 
+                    candidateFunctions, 
+                    candidatesWithDistances);
+
+            return compliantTarget;
+        }
+
+        private void ComputeFeps(
+            StringBuilder log, 
+            Context context, 
+            List<StackValue> arguments,
+            FunctionGroup funcGroup,
+            ReplicationControl replicationControl, 
+            List<List<ReplicationGuide>> partialReplicationGuides,
+            StackFrame stackFrame,
+            RuntimeCore runtimeCore,
+            out List<FunctionEndPoint> resolvesFeps,
+            out List<ReplicationInstruction> replicationInstructions)
+        {
             //With replication guides only
 
             //Exact match
@@ -734,23 +774,22 @@ namespace ProtoCore
             //Try replication + type casting
 
             //Try replication + type casting + Array promotion
+            List<ReplicationInstruction> instructions = replicationControl.Instructions;
 
             #region First Case: Replicate only according to the replication guides
-
             {
                 log.AppendLine("Case 1: Exact Match");
 
-                FunctionEndPoint fep = Case1GetCompleteMatchFEP(context, arguments, funcGroup, replicationControl,
+                FunctionEndPoint fep = Case1GetCompleteMatchFEP(context, arguments, funcGroup, instructions,
                                                                 stackFrame,
                                                                 runtimeCore, log);
                 if (fep != null)
                 {
-                    //log.AppendLine("Resolution completed in " + sw.ElapsedMilliseconds + "ms");
                     if (runtimeCore.Options.DumpFunctionResolverLogic)
                         runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
 
                     resolvesFeps = new List<FunctionEndPoint>() { fep };
-                    replicationInstructions = replicationControl.Instructions;
+                    replicationInstructions = instructions;
 
                     return;
                 }
@@ -759,75 +798,53 @@ namespace ProtoCore
             #endregion
 
             #region Case 1a: Replicate only according to the replication guides, but with a sub-typing match
-
             {
                 log.AppendLine("Case 1a: Replication guides + auto-replication + no cases");
+                List<List<StackValue>> reducedParams = Replicator.ComputeAllReducedParams(arguments, instructions, runtimeCore);
+                int resolutionFailures;
 
+                Dictionary<FunctionEndPoint, int> lookups = funcGroup.GetExactMatchStatistics(
+                    context, reducedParams, stackFrame, runtimeCore,
+                    out resolutionFailures);
 
-                List<ReplicationInstruction> replicationOption = replicationControl.Instructions;
-                    ReplicationControl rc = new ReplicationControl() { Instructions = replicationOption };
+                if (resolutionFailures == 0)
+                {
+                    log.AppendLine("Resolution succeeded against FEP Cluster");
+                    foreach (FunctionEndPoint fep in lookups.Keys)
+                        log.AppendLine("\t - " + fep);
 
-                    log.AppendLine("Attempting replication control: " + rc);
+                    List<FunctionEndPoint> feps = new List<FunctionEndPoint>();
+                    feps.AddRange(lookups.Keys);
 
-                    List<List<StackValue>> reducedParams = Replicator.ComputeAllReducedParams(arguments,
-                                                                                              rc.Instructions, runtimeCore);
-                    int resolutionFailures;
+                    if (runtimeCore.Options.DumpFunctionResolverLogic)
+                        runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
 
-                    Dictionary<FunctionEndPoint, int> lookups = funcGroup.GetExactMatchStatistics(
-                        context, reducedParams, stackFrame, runtimeCore,
-                        out resolutionFailures);
+                    //Otherwise we have a cluster of FEPs that can be used to dispatch the array
+                    resolvesFeps = feps;
+                    replicationInstructions = instructions;
 
-
-                    if (resolutionFailures == 0)
-                    {
-
-                        log.AppendLine("Resolution succeeded against FEP Cluster");
-                        foreach (FunctionEndPoint fep in lookups.Keys)
-                            log.AppendLine("\t - " + fep);
-
-                        List<FunctionEndPoint> feps = new List<FunctionEndPoint>();
-                        feps.AddRange(lookups.Keys);
-
-                        //log.AppendLine("Resolution completed in " + sw.ElapsedMilliseconds + "ms");
-                        if (runtimeCore.Options.DumpFunctionResolverLogic)
-                            runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
-
-                        //Otherwise we have a cluster of FEPs that can be used to dispatch the array
-                        resolvesFeps = feps;
-                        replicationInstructions = rc.Instructions;
-
-                        return;
-                    }
+                    return;
                 }
-            
+            }
 
             #endregion
 
 
+            var replicationTrials = Replicator.BuildReplicationCombinations(instructions, arguments, runtimeCore);
             #region Case 2: Replication with no type cast
 
             {
                 log.AppendLine("Case 2: Beginning Auto-replication, no casts");
 
                 //Build the possible ways in which we might replicate
-                List<List<ReplicationInstruction>> replicationTrials =
-                    Replicator.BuildReplicationCombinations(replicationControl.Instructions, arguments, runtimeCore);
-
-
-                foreach (List<ReplicationInstruction> replicationOption in replicationTrials)
+                foreach (List<ReplicationInstruction> repOption in replicationTrials)
                 {
-                    ReplicationControl rc = new ReplicationControl() { Instructions = replicationOption };
-
-                    log.AppendLine("Attempting replication control: " + rc);
-
-                    List<List<StackValue>> reducedParams = Replicator.ComputeAllReducedParams(arguments,
-                                                                                              rc.Instructions, runtimeCore);
+                    List<List<StackValue>> reducedParams = Replicator.ComputeAllReducedParams(arguments, repOption, runtimeCore);
                     int resolutionFailures;
 
                     Dictionary<FunctionEndPoint, int> lookups = funcGroup.GetExactMatchStatistics(
                         context, reducedParams, stackFrame, runtimeCore,
                         out resolutionFailures);
-
 
                     if (resolutionFailures > 0)
                         continue;
@@ -839,13 +856,12 @@ namespace ProtoCore
                     List<FunctionEndPoint> feps = new List<FunctionEndPoint>();
                     feps.AddRange(lookups.Keys);
 
-                    //log.AppendLine("Resolution completed in " + sw.ElapsedMilliseconds + "ms");
                     if (runtimeCore.Options.DumpFunctionResolverLogic)
                         runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
 
                     //Otherwise we have a cluster of FEPs that can be used to dispatch the array
                     resolvesFeps = feps;
-                    replicationInstructions = rc.Instructions;
+                    replicationInstructions = repOption;
 
                     return;
                 }
@@ -854,23 +870,10 @@ namespace ProtoCore
             #endregion
 
             #region Case 3: Match with type conversion, but no array promotion
-
             {
                 log.AppendLine("Case 3: Type conversion");
 
-
-                Dictionary<FunctionEndPoint, int> candidatesWithDistances =
-                    funcGroup.GetConversionDistances(context, arguments, replicationControl.Instructions,
-                                                     runtimeCore.DSExecutable.classTable, runtimeCore);
-                Dictionary<FunctionEndPoint, int> candidatesWithCastDistances =
-                    funcGroup.GetCastDistances(context, arguments, replicationControl.Instructions, runtimeCore.DSExecutable.classTable,
-                                               runtimeCore);
-
-                List<FunctionEndPoint> candidateFunctions = GetCandidateFunctions(stackFrame, candidatesWithDistances);
-                FunctionEndPoint compliantTarget = GetCompliantTarget(context, arguments,
-                                                                      replicationControl.Instructions, stackFrame, runtimeCore,
-                                                                      candidatesWithCastDistances, candidateFunctions,
-                                                                      candidatesWithDistances);
+                FunctionEndPoint compliantTarget = GetCompliantFEP(context, arguments, funcGroup, replicationControl.Instructions, stackFrame, runtimeCore);
 
                 if (compliantTarget != null)
                 {
@@ -893,32 +896,10 @@ namespace ProtoCore
             {
                 if (arguments.Any(arg => arg.IsArray))
                 {
-                    //Build the possible ways in which we might replicate
-                    List<List<ReplicationInstruction>> replicationTrials =
-                        Replicator.BuildReplicationCombinations(replicationControl.Instructions, arguments, runtimeCore);
-
-
                     foreach (List<ReplicationInstruction> replicationOption in replicationTrials)
                     {
-                        ReplicationControl rc = new ReplicationControl() { Instructions = replicationOption };
-
-                        log.AppendLine("Attempting replication control: " + rc);
-
                         //@TODO: THis should use the proper reducer?
-
-                        Dictionary<FunctionEndPoint, int> candidatesWithDistances =
-                            funcGroup.GetConversionDistances(context, arguments, rc.Instructions, runtimeCore.DSExecutable.classTable, runtimeCore);
-                        Dictionary<FunctionEndPoint, int> candidatesWithCastDistances =
-                            funcGroup.GetCastDistances(context, arguments, rc.Instructions, runtimeCore.DSExecutable.classTable, runtimeCore);
-
-                        List<FunctionEndPoint> candidateFunctions = GetCandidateFunctions(stackFrame,
-                                                                                          candidatesWithDistances);
-                        FunctionEndPoint compliantTarget = GetCompliantTarget(context, arguments,
-                                                                              rc.Instructions, stackFrame, runtimeCore,
-                                                                              candidatesWithCastDistances,
-                                                                              candidateFunctions,
-                                                                              candidatesWithDistances);
-
+                        FunctionEndPoint compliantTarget = GetCompliantFEP(context, arguments, funcGroup, replicationOption, stackFrame, runtimeCore);
                         if (compliantTarget != null)
                         {
                             log.AppendLine("Resolution Succeeded: " + compliantTarget);
@@ -927,7 +908,7 @@ namespace ProtoCore
                                 runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
 
                             resolvesFeps = new List<FunctionEndPoint>() { compliantTarget };
-                            replicationInstructions = rc.Instructions;
+                            replicationInstructions = replicationOption;
                             return;
                         }
                     }
@@ -940,38 +921,13 @@ namespace ProtoCore
 
             log.AppendLine("Case 5: Replication + Type conversion + Array promotion");
             {
-                //Build the possible ways in which we might replicate
-                List<List<ReplicationInstruction>> replicationTrials =
-                    Replicator.BuildReplicationCombinations(replicationControl.Instructions, arguments, runtimeCore);
-
                 //Add as a first attempt a no-replication, but allowing up-promoting
-                replicationTrials.Insert(0,
-                                         new List<ReplicationInstruction>()
-                    );
-
+                replicationTrials.Insert(0, new List<ReplicationInstruction>());
 
                 foreach (List<ReplicationInstruction> replicationOption in replicationTrials)
                 {
-                    ReplicationControl rc = new ReplicationControl() { Instructions = replicationOption };
-
-                    log.AppendLine("Attempting replication control: " + rc);
-
                     //@TODO: THis should use the proper reducer?
-
-                    Dictionary<FunctionEndPoint, int> candidatesWithDistances =
-                        funcGroup.GetConversionDistances(context, arguments, rc.Instructions, runtimeCore.DSExecutable.classTable, runtimeCore,
-                                                         true);
-                    Dictionary<FunctionEndPoint, int> candidatesWithCastDistances =
-                        funcGroup.GetCastDistances(context, arguments, rc.Instructions, runtimeCore.DSExecutable.classTable, runtimeCore);
-
-                    List<FunctionEndPoint> candidateFunctions = GetCandidateFunctions(stackFrame,
-                                                                                      candidatesWithDistances);
-                    FunctionEndPoint compliantTarget = GetCompliantTarget(context, arguments,
-                                                                          rc.Instructions, stackFrame, runtimeCore,
-                                                                          candidatesWithCastDistances,
-                                                                          candidateFunctions,
-                                                                          candidatesWithDistances);
-
+                    FunctionEndPoint compliantTarget = GetCompliantFEP(context, arguments, funcGroup, replicationOption, stackFrame, runtimeCore, true);
                     if (compliantTarget != null)
                     {
                         log.AppendLine("Resolution Succeeded: " + compliantTarget);
@@ -979,7 +935,7 @@ namespace ProtoCore
                         if (runtimeCore.Options.DumpFunctionResolverLogic)
                             runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
                         resolvesFeps = new List<FunctionEndPoint>() { compliantTarget };
-                        replicationInstructions = rc.Instructions;
+                        replicationInstructions = replicationOption;
                         return;
                     }
                 }
@@ -1035,14 +991,12 @@ namespace ProtoCore
         /// <returns></returns>
         private FunctionEndPoint Case1GetCompleteMatchFEP(Context context, List<StackValue> arguments,
                                                           FunctionGroup funcGroup,
-                                                          ReplicationControl replicationControl, StackFrame stackFrame,
+                                                          List<ReplicationInstruction> replicationInstructions, StackFrame stackFrame,
                                                           RuntimeCore runtimeCore, StringBuilder log)
         {
-            log.AppendLine("Attempting Dispatch with ---- RC: " + replicationControl);
-
             //Exact match
             List<FunctionEndPoint> exactTypeMatchingCandindates =
-                funcGroup.GetExactTypeMatches(context, arguments, replicationControl.Instructions, stackFrame, runtimeCore);
+                funcGroup.GetExactTypeMatches(context, arguments, replicationInstructions, stackFrame, runtimeCore);
 
             FunctionEndPoint fep = null;
 

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -497,8 +497,10 @@ namespace ProtoCore
             //Ordering implies containment, so element 0 is the outer most forloop, element 1 is nested within it etc.
             //Take the explicit replication guides and build the replication structure
             //Turn the replication guides into a guide -> List args data structure
-            ReplicationControl replicationControl =
-                Replicator.Old_ConvertGuidesToInstructions(partialReplicationGuides);
+            ReplicationControl replicationControl = new ReplicationControl()
+            {
+                Instructions = Replicator.BuildPartialReplicationInstructions(partialReplicationGuides)
+            };
 
             #region First Case: Replicate only according to the replication guides
 
@@ -830,7 +832,7 @@ namespace ProtoCore
             #endregion
 
 
-            var replicationTrials = Replicator.BuildReplicationCombinations_New(instructions, arguments, runtimeCore);
+            var replicationTrials = Replicator.BuildReplicationCombinations(instructions, arguments, runtimeCore);
             #region Case 2: Replication with no type cast
 
             {
@@ -1426,8 +1428,10 @@ namespace ProtoCore
             //Ordering implies containment, so element 0 is the outer most forloop, element 1 is nested within it etc.
             //Take the explicit replication guides and build the replication structure
             //Turn the replication guides into a guide -> List args data structure
-            ReplicationControl replicationControl =
-                Replicator.Old_ConvertGuidesToInstructions(partialReplicationGuides);
+            ReplicationControl replicationControl = new ReplicationControl()
+            {
+                Instructions = Replicator.BuildPartialReplicationInstructions(partialReplicationGuides)
+            };
 
             log.AppendLine("Replication guides processed to: " + replicationControl);
 

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -830,7 +830,7 @@ namespace ProtoCore
             #endregion
 
 
-            var replicationTrials = Replicator.BuildReplicationCombinations(instructions, arguments, runtimeCore);
+            var replicationTrials = Replicator.BuildReplicationCombinations_New(instructions, arguments, runtimeCore);
             #region Case 2: Replication with no type cast
 
             {

--- a/src/Engine/ProtoCore/Lang/FunctionGroup.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionGroup.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Linq;
 using System.Collections.Generic;
 using ProtoCore.DSASM;
 using ProtoCore.Lang.Replication;
@@ -118,10 +118,7 @@ namespace ProtoCore
             List<StackValue> formalParams, List<ReplicationInstruction> replicationInstructions, StackFrame stackFrame, RuntimeCore runtimeCore)
         {
             List<FunctionEndPoint> ret = new List<FunctionEndPoint>();
-
-
             List<List<StackValue>> allReducedParamSVs = Replicator.ComputeAllReducedParams(formalParams, replicationInstructions, runtimeCore);
-
             
             //@TODO(Luke): Need to add type statistics checks to the below if it is an array to stop int[] matching char[]
             
@@ -133,9 +130,6 @@ namespace ProtoCore
             foreach (FunctionEndPoint fep in FunctionEndPoints)
             {
                 var proc = fep.procedureNode;
-
-
-
 
                 // Member functions are overloaded with thisptr as the first
                 // parameter, so if member function replicates on the left hand
@@ -163,7 +157,6 @@ namespace ProtoCore
 
                 if (typesOK)
                     ret.Add(fep);
-
             }
 
             return ret;

--- a/src/Engine/ProtoCore/Lang/Replication/ReplicationInstruction.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/ReplicationInstruction.cs
@@ -34,8 +34,7 @@ namespace ProtoCore.Lang.Replication
                 string indecies = "";
 
                 for (int i = 0; i < ZipIndecies.Count - 1; i++)
-                    indecies += i + ", ";
-
+                    indecies += ZipIndecies[i] + ", ";
 
                 indecies += ZipIndecies[ZipIndecies.Count - 1];
 

--- a/src/Engine/ProtoCore/Lang/Replication/ReplicationInstruction.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/ReplicationInstruction.cs
@@ -46,25 +46,4 @@ namespace ProtoCore.Lang.Replication
 
         }
     }
-
-    public struct ReplicationControl
-    {
-        public List<ReplicationInstruction> Instructions;
-
-
-        public override string ToString()
-        {
-            StringBuilder sb = new StringBuilder();
-
-            sb.AppendLine("Replication Control Instructions: "+ Instructions.Count);
-
-                foreach (ReplicationInstruction ri in Instructions)
-                    sb.AppendLine("\t" + ri.ToString());
-
-                return sb.ToString();
-        }
-
-
-    }
-
 }

--- a/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
@@ -59,7 +59,7 @@ namespace ProtoCore.Lang.Replication
             for (int guideCounter = 1; guideCounter <= maxGuide; guideCounter++)
             {
                 index.Add(guideCounter, new List<int>());
-                indexLace.Add(guideCounter, ZipAlgorithm.Shortest);
+                // indexLace.Add(guideCounter, ZipAlgorithm.Shortest);
 
                 for (int i = 0; i < partialGuides.Count; i++)
                     if (partialGuides[i].Contains(guideCounter))
@@ -70,26 +70,35 @@ namespace ProtoCore.Lang.Replication
 
                         if (partialGuidesLace[i][indexOfGuide] == ZipAlgorithm.Longest)
                         {
-                            //If we've previous seen a shortest node with this guide
-                            if (i > 0 && indexLace[guideCounter] == ZipAlgorithm.Shortest)
+                            ZipAlgorithm zipAlgorithm;
+                            if (indexLace.TryGetValue(guideCounter, out zipAlgorithm))
                             {
-                                throw new ReplicationCaseNotCurrentlySupported(Resources.ZipAlgorithmError);
+                                //If we've previous seen a shortest node with this guide
+                                if (i > 0 && indexLace[guideCounter] == ZipAlgorithm.Shortest)
+                                {
+                                    throw new ReplicationCaseNotCurrentlySupported(Resources.ZipAlgorithmError);
+                                }
                             }
-
-                            //Overwrite the default behaviour
-                            indexLace[guideCounter] = ZipAlgorithm.Longest;
+                            else
+                            {
+                                //Overwrite the default behaviour
+                                indexLace[guideCounter] = ZipAlgorithm.Longest;
+                            }
                         }
                         else
                         {
                             //it's shortest, if we had something previous saying it should be longest
                             //then we've created a violation foo(a<1>, b1<1L>) is not allowed
-                            if (indexLace[guideCounter] == ZipAlgorithm.Longest)
+                            ZipAlgorithm zipAlgorithm;
+                            if (indexLace.TryGetValue(guideCounter, out zipAlgorithm))
                             {
-                                throw new ReplicationCaseNotCurrentlySupported(Resources.ZipAlgorithmError);
+                                if (zipAlgorithm == ZipAlgorithm.Longest)
+                                {
+                                    throw new ReplicationCaseNotCurrentlySupported(Resources.ZipAlgorithmError);
+                                }
                             }
                             else
                             {
-                                //Shortest lacing is actually the default, this call should be redundant
                                 indexLace[guideCounter] = ZipAlgorithm.Shortest;
                             }
                         }

--- a/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
@@ -384,13 +384,15 @@ namespace ProtoCore.Lang.Replication
 
             for (int i = 0; i < reductions.Count; i++)
             {
-                if (reductions[i] > 0)
+                int reduction = reductions[i];
+                while (reduction > 0) 
                 {
                     ReplicationInstruction ri = new ReplicationInstruction()
                     {
                         CartesianIndex = i, ZipIndecies = null, Zipped = false
                     };
                     ret.Add(ri);
+                    reduction--;
                 }
             }
 
@@ -796,7 +798,7 @@ namespace ProtoCore.Lang.Replication
             //All options being suggested should be possible
             foreach (List<int> reduction in cleanedReductions)
             {
-                ret.Add(ReductionToInstructions(reduction, providedControl));
+                ret.Add(ReductionToInstructions_New(reduction, providedControl));
             }
 
             return ret;

--- a/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
@@ -373,6 +373,40 @@ namespace ProtoCore.Lang.Replication
             return reducedParamTypes;
         }
 
+        public static List<List<int>> BuildAllocation_New(List<int> reductionDepths)
+        {
+            int argumentCount = reductionDepths.Count;
+            if (argumentCount == 0)
+                return new List<List<int>>();
+
+            int count = reductionDepths.Aggregate(1, (acc, x) => acc * (x + 1));
+            List<List<int>> retList = new List<List<int>>(count);
+            for (int r = 0; r <= reductionDepths[0]; r++)
+            {
+                List<int> reductions = new List<int>(argumentCount);
+                reductions.Add(r);
+                retList.Add(reductions);
+            }
+
+            for (int i = 1; i < argumentCount; i++)
+            {
+                List<List<int>> tempRetList = new List<List<int>>(retList);
+                retList.Clear();
+
+                for (int r = 0; r <= reductionDepths[i]; r++)
+                {
+                    foreach (var reductions in tempRetList)
+                    {
+                        List<int> newReductions = new List<int>(reductions);
+                        newReductions.Add(r);
+                        retList.Add(newReductions);
+                    }
+                }
+            }
+
+            return retList;
+        }
+
         /// <summary>
         /// 
         /// </summary>
@@ -431,7 +465,8 @@ namespace ProtoCore.Lang.Replication
                 return new List<List<ReplicationInstruction>>();
 
             // Generate reduction lists (x1, x2, ..., xn) where x1 + x2 + ... + xn <= maxDepth
-            List<List<int>> reductions = BuildAllocation(formalParams.Count, maxDepth);
+            // List<List<int>> reductions = BuildAllocation(formalParams.Count, maxDepth);
+            List<List<int>> reductions = BuildAllocation_New(maxReductionDepths);
 
             // Reduce reduction level on parameter if the parameter has replication guides 
             if (providedControl.Count > 0)

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -639,7 +639,6 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [Category("Failure")]
         [Category("RegressionTests")]
         public void Defect_MAGN_3264()
         {

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -991,7 +991,7 @@ namespace Dynamo.Tests
             CurrentDynamoModel.ForceRun();
 
             // Fix expected result after MAGN-7639 is fixed.
-            AssertPreviewValue("980dcd47-84e7-412c-8d9e-d66f166d2370", new object[] { new object[] { false }, new object[] { false }, new object[] { false }, new object[] { false }, new object[] { false } });
+            AssertPreviewValue("980dcd47-84e7-412c-8d9e-d66f166d2370", true);
 
         }
 

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1449,11 +1449,11 @@ namespace DynamoCoreWpfTests
             {
                 var workspace = ViewModel.Model.CurrentWorkspace;
                 NodeModel nodeModel = workspace.NodeFromWorkspace("37c9b30b-1b78-442a-b433-ec31da996c52");
-                Assert.AreEqual(ElementState.Warning, nodeModel.State);
+                Assert.AreEqual(ElementState.Active, nodeModel.State);
                 if (commandTag == "First")
                 {
                     NodeModel nodeModel2 = workspace.NodeFromWorkspace("37c9b30b-1b78-442a-b433-ec31da996c52");
-                    Assert.AreEqual(ElementState.Warning, nodeModel2.State);
+                    Assert.AreEqual(ElementState.Active, nodeModel2.State);
                 }
             });
         }

--- a/test/Engine/ProtoTest/Associative/MethodsFocusTeam.cs
+++ b/test/Engine/ProtoTest/Associative/MethodsFocusTeam.cs
@@ -1025,58 +1025,6 @@ import(""FFITarget.dll"");p = DummyPoint.ByCoordinates(1..3, 20, 30);a = p.X[0
             thisTest.RunScriptSource(code);
         }
 
-        [Test]
-        public void R001_Replicator_Internal_ReductionsToGuides_SimpleCartesian()
-        {
-
-            List<int> reductionC0 = new List<int>() { 1 };
-            List<ReplicationInstruction> instructionsC0 = Replicator.ReductionToInstructions(reductionC0);
-            Assert.IsTrue(instructionsC0.Count == 1);
-            Assert.IsTrue(instructionsC0[0].CartesianIndex == 0);
-            Assert.IsTrue(instructionsC0[0].Zipped == false);
-        }
-
-        [Test]
-        public void R001_Replicator_Internal_ReductionsToGuides_SimpleCartesian2()
-        {
-            List<int> reductionC0 = new List<int>() { 2 };
-            List<ReplicationInstruction> instructionsC0 = Replicator.ReductionToInstructions(reductionC0);
-            Assert.IsTrue(instructionsC0.Count == 2);
-            Assert.IsTrue(instructionsC0[0].CartesianIndex == 0);
-            Assert.IsTrue(instructionsC0[0].Zipped == false);
-            Assert.IsTrue(instructionsC0[1].CartesianIndex == 0);
-            Assert.IsTrue(instructionsC0[1].Zipped == false);
-
-        }
-
-        [Test]
-        public void R002_Replicator_Internal_ReductionsToGuides_SimpleZipped()
-        {
-            List<int> reductionZ01 = new List<int>() { 1, 1 };
-            List<ReplicationInstruction> instructionsZ01 = Replicator.ReductionToInstructions(reductionZ01);
-            Assert.IsTrue(instructionsZ01.Count == 1);
-            Assert.IsTrue(instructionsZ01[0].ZipIndecies.Count == 2);
-            Assert.IsTrue(instructionsZ01[0].ZipIndecies.Contains(0));
-            Assert.IsTrue(instructionsZ01[0].ZipIndecies.Contains(1));
-            Assert.IsTrue(instructionsZ01[0].Zipped == true);
-        }
-
-        [Test]
-        public void R002_Replicator_Internal_ReductionsToGuides_SimpleZipped2()
-        {
-            List<int> reductionZ01 = new List<int>() { 2, 2 };
-            List<ReplicationInstruction> instructionsZ01 = Replicator.ReductionToInstructions(reductionZ01);
-            Assert.IsTrue(instructionsZ01.Count == 2);
-            Assert.IsTrue(instructionsZ01[0].ZipIndecies.Count == 2);
-            Assert.IsTrue(instructionsZ01[0].ZipIndecies.Contains(0));
-            Assert.IsTrue(instructionsZ01[0].ZipIndecies.Contains(1));
-            Assert.IsTrue(instructionsZ01[0].Zipped == true);
-            Assert.IsTrue(instructionsZ01[1].ZipIndecies.Contains(0));
-            Assert.IsTrue(instructionsZ01[1].ZipIndecies.Contains(1));
-            Assert.IsTrue(instructionsZ01[1].Zipped == true);
-        }
-        /*
-[Test]        public void T039_Inheritance_()        {            String code =@"class A extends var{    fx = 0;    constructor A() : base var();    {        fx = 1;    }}a = A.A();b = a.fx;";            thisTest.RunScriptSource(code);            thisTest.Verify("fx", 1);        }*/
 
         [Test]
         [Ignore][Category("DSDefinedClass_Ignored_DSClassInheritance")]

--- a/test/Engine/ProtoTest/Associative/ReplicatorTest.cs
+++ b/test/Engine/ProtoTest/Associative/ReplicatorTest.cs
@@ -17,14 +17,13 @@ namespace ProtoTest.Associative
         public override void Setup()
         {
             // Specify some of the requirements of IDE.
+            base.Setup();
             fsr = new DebugRunner(core);
             DLLFFIHandler.Register(FFILanguage.CSharp, new CSModuleHelper());
             CLRModuleType.ClearTypes();
         }
 
         [Test]
-        [Category("Failure")]
-        //Test "SomeNulls()"
         public void ComputeReducedParams()
         {
             // Tracked by http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4115
@@ -54,8 +53,6 @@ namespace ProtoTest.Associative
             List<List<StackValue>> combin = ProtoCore.Lang.Replication.Replicator.ComputeAllReducedParams(args, ris, runtimeCore);
             Assert.IsTrue(combin[0][0].opdata == 1);
             Assert.IsTrue(combin[0][1].opdata == 3);
-            Assert.IsTrue(combin[1][0].opdata == 2);
-            Assert.IsTrue(combin[1][1].opdata == 4);
         }
     }
 }

--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -2003,5 +2003,21 @@ namespace ProtoTest.TD.Associative
             // Should get clear after running
             Assert.AreEqual(0, thisTest.GetTestRuntimeCore().ReplicationGuides.Count);
         }
+
+        [Test]
+        [Category("Replication")]
+        public void TestZipFirstReplication()
+        {
+            string code = @"
+def foo(x:var, y:var)
+{
+    return = x + y;
+}
+xs = {{""a"", ""b""}, {""c"", ""d""}};
+ys = {1, 2};
+zs = foo(xs, ys);";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("zs", new object[] { new object[] { "a1", "b1" }, new object[] { "c2", "d2" } });
+        }
     }
 }

--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -748,7 +748,7 @@ namespace ProtoTest.TD.Associative
             string code = @"            def foo : int(a : int,b:int)            {                return = a * b;            }            list1 = {1,2};            list2 = {1,2};            list3 = foo(foo(foo(list1<1>, list2<2>)<1>, list2<2>)<1>, list2<2>);";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("list3", new object[] { new object[] { new object[] { new object[] { 1 }, new object[] { 2 } }, new object[] { new object[] { 2 }, new object[] { 4 } } }, new object[] { new object[] { new object[] { 2 }, new object[] { 4 } }, new object[] { new object[] { 4 }, new object[] { 8 } } } } );
+            thisTest.Verify("list3", new object[] { new object[] { new object[] { new object[] { 1 }, new object[] { 2 } }, new object[] { new object[] { 2 }, new object[] { 4 } } }  } );
         }
 
         [Test]

--- a/test/core/dsevaluation/removekey.dyn
+++ b/test/core/dsevaluation/removekey.dyn
@@ -1,18 +1,22 @@
-<Workspace Version="0.8.2.1594" X="-318.766568006852" Y="-60.1422250630171" zoom="0.762244377638742" Name="Home" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
+<Workspace Version="1.0.0.413" X="-147.237936791578" Y="-140.432016885207" zoom="1.00138630120146" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.DSFunction guid="980dcd47-84e7-412c-8d9e-d66f166d2370" type="Dynamo.Nodes.DSFunction" nickname="RemoveKey" x="747.310179626332" y="155.321420986519" isVisible="true" isUpstreamVisible="true" lacing="Longest" assembly="" function="RemoveKey@var[]..[],var" />
-    <Dynamo.Nodes.CodeBlockNodeModel guid="259d923d-4c14-4ebc-9437-1ab198877c91" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="435.705330037962" y="294.443685627674" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="1..5;" ShouldFocus="false" />
-    <Dynamo.Nodes.CodeBlockNodeModel guid="742e65ea-fd19-4643-b3a3-d951e01ad59f" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="542.110600983689" y="432.277814215451" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="4;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction guid="bd89982a-c3e6-4a4e-898c-2bdc8f1f8c3e" type="Dynamo.Nodes.DSFunction" nickname="RemoveKey" x="787.196746844777" y="587.02450771216" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="RemoveKey@var[]..[],var" />
-    <Dynamo.Nodes.CodeBlockNodeModel guid="f3ea0f4d-a881-4c40-b038-c7d9a8c09bbd" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="450.926297667508" y="554.386899895723" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="null;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="980dcd47-84e7-412c-8d9e-d66f166d2370" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="RemoveKey" x="747.310179626332" y="155.321420986519" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="BuiltIn" function="RemoveKey@var[]..[],var" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="259d923d-4c14-4ebc-9437-1ab198877c91" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="435.705330037962" y="294.443685627674" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="1..5;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="742e65ea-fd19-4643-b3a3-d951e01ad59f" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="542.110600983689" y="432.277814215451" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="4;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="bd89982a-c3e6-4a4e-898c-2bdc8f1f8c3e" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="RemoveKey" x="787.196746844777" y="587.02450771216" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="BuiltIn" function="RemoveKey@var[]..[],var" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="f3ea0f4d-a881-4c40-b038-c7d9a8c09bbd" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="450.926297667508" y="554.386899895723" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="null;" ShouldFocus="false" />
   </Elements>
   <Connectors>
-    <Dynamo.Models.ConnectorModel start="259d923d-4c14-4ebc-9437-1ab198877c91" start_index="0" end="980dcd47-84e7-412c-8d9e-d66f166d2370" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="742e65ea-fd19-4643-b3a3-d951e01ad59f" start_index="0" end="bd89982a-c3e6-4a4e-898c-2bdc8f1f8c3e" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="742e65ea-fd19-4643-b3a3-d951e01ad59f" start_index="0" end="980dcd47-84e7-412c-8d9e-d66f166d2370" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f3ea0f4d-a881-4c40-b038-c7d9a8c09bbd" start_index="0" end="bd89982a-c3e6-4a4e-898c-2bdc8f1f8c3e" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="259d923d-4c14-4ebc-9437-1ab198877c91" start_index="0" end="980dcd47-84e7-412c-8d9e-d66f166d2370" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="742e65ea-fd19-4643-b3a3-d951e01ad59f" start_index="0" end="bd89982a-c3e6-4a4e-898c-2bdc8f1f8c3e" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="742e65ea-fd19-4643-b3a3-d951e01ad59f" start_index="0" end="980dcd47-84e7-412c-8d9e-d66f166d2370" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f3ea0f4d-a881-4c40-b038-c7d9a8c09bbd" start_index="0" end="bd89982a-c3e6-4a4e-898c-2bdc8f1f8c3e" end_index="0" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>


### PR DESCRIPTION
### Purpose

This PR is to update replicator (`Replicator.BuildReplicationCombinations()` and `Replicator.ReductionToInstructions()`) so that zip-first approach is used. Besides, extra catersian replication instructions are generate to ensure the following case will generate expected result:

```
def add(x: var, y: var)
{
    return = x + y;
}

xs = {{"a", "b"}, {"c", "d"}};
ys = {1, 2};
r = add(xs, ys); // expect {{"a1", "b1"}, {"c2", "d2"}}
```

The replicator will check the ranks of parameters -- for this case they are 2 and 1 respectively -- and calculate all reduction combinations. As using zip-first approach, the replicator will use zip replication on parameters firstly, so the possible reduction will be reduced to 1 and 0, and finally cartesian replication is applied on the first parameter. 

Informally, suppose the ranks of parameters are 1 and all arguments are normal array (not jagged array), and the ranks of arguments are `(r1, r2, ..., rn)` which is also a reduction list. If replication guides provided, then set reduction to
```
   ri = ri - number_of_replication_guide
``` 

For example, for function call `foo(xs<1>, ys<2><3>, z)` and suppose the ranks of `xs`, `ys` and `zs` are `(4, 4, 0)`, after this step, reduction list will be `(3, 2, 0)`. 

Then use zip-first approach to generate the following replication instructions (each step reduce the corresponding reduction):
`(3, 2, 0)` -> Zip on 0, 1
`(2, 1, 0)` -> Zip on 0, 1
`(1, 0, 0)` -> Cartesian on 0.

Plus the replication guides, finally generated replication instructions will be
```
1. Cartesian on 0
2. Cartesian on 1
3. Cartesian on 1
4. Zip on 0, 1
5. Zip on 0, 1
6. Cartesian on 0
```

Also did some code cleanup and formatting work in this PR.

Defects fixed in this PR:
* [MAGN-9418Replication for function call should start with zip replication](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9418)
* [MAGN-6101This operation on multi-dimensional lists should work](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6101)
* [MAGN-3264 Longest lacing does not work, for nodes with default value if one of the arguments is an array](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6101)

### Reviewer
@Benglin 
