### PR TITLE
MAGN-9409 When the system clock is 48 hrs ahead both Share Workspace... and Publish New Package... do not give the correct message

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2552,6 +2552,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not sign in at this moment. Check the date, time and time zone settings and try to sign in again..
+        /// </summary>
+        public static string InvalidTimeZoneMessage {
+            get {
+                return ResourceManager.GetString("InvalidTimeZoneMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to For two lists {a,b,c}{1,2,3} returns {a1,a2,a3}{b1,b2,b3}{c1,c2,c3}..
         /// </summary>
         public static string LacingCrossProductToolTip {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1981,4 +1981,7 @@ Do you want to install the latest Dynamo update?</value>
   <data name="PreviewListLabel" xml:space="preserve">
     <value>List</value>
   </data>
+  <data name="InvalidTimeZoneMessage" xml:space="preserve">
+    <value>Could not sign in at this moment. Check the date, time and time zone settings and try to sign in again.</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1982,4 +1982,7 @@ Do you want to install the latest Dynamo update?</value>
   <data name="PreviewListLabel" xml:space="preserve">
     <value>List</value>
   </data>
+  <data name="InvalidTimeZoneMessage" xml:space="preserve">
+    <value>Could not sign in at this moment. Check the date, time and time zone settings and try to sign in again.</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Services/LoginService.cs
+++ b/src/DynamoCoreWpf/Services/LoginService.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Reflection;
 using Shapeways=ShapewaysClient.ShapewaysClient;
+using Dynamo.Wpf.Properties;
 
 namespace Dynamo.Wpf.Authentication
 {
@@ -20,18 +21,25 @@ namespace Dynamo.Wpf.Authentication
 
         public bool ShowLogin(object o)
         {
-            var url = new Uri(o.ToString());
+            if (string.IsNullOrEmpty(o as string))
+            {
+                MessageBox.Show(Resources.InvalidTimeZoneMessage, 
+                                Resources.InvalidLoginUrl, 
+                                MessageBoxButton.OK, 
+                                MessageBoxImage.Error);
+                return false;
+            }
 
-            if (o == null) throw new ArgumentException(Dynamo.Wpf.Properties.Resources.InvalidLoginUrl);
+            var url = new Uri(o.ToString());
 
             var navigateSuccess = false;
 
             // show the login
-            context.Send((_) => {
+            context.Send(_ => {
 
                 var window = new BrowserWindow(url)
                 {
-                    Title = Dynamo.Wpf.Properties.Resources.AutodeskSignIn,
+                    Title = Resources.AutodeskSignIn,
                     Owner = parent,
                     WindowStartupLocation = WindowStartupLocation.CenterOwner
                 };


### PR DESCRIPTION
### Purpose

When date is incorrect greg sends an empty url instead of url of page where login and password can be entered. So, in this case the next message is shown to user:
![image](https://cloud.githubusercontent.com/assets/7658189/12982306/dfd8ecec-d0ec-11e5-8c07-f42d762028af.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.


### Reviewers

@mjkkirschner @ramramps 