### PR TITLE
Fix MAGN-9325

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -454,6 +454,8 @@ namespace Dynamo.UI.Controls
         {
             if (!IsExpanded) return;
 
+            SetCurrentStateAndNotify(State.PreTransition);
+
             // Used delay invoke, because TreeView hasn't changed its'appearance with usual Dispatcher call.
             Dispatcher.DelayInvoke(50, () => RefreshExpandedDisplay(() =>
             {
@@ -463,7 +465,7 @@ namespace Dynamo.UI.Controls
                 // The real transition starts
                 SetCurrentStateAndNotify(State.InTransition);
                 var largeContentSize = ComputeLargeContentSize();
-                UpdateAnimatorTargetSize(SizeAnimator.Expansion, largeContentSize);                    
+                UpdateAnimatorTargetSize(SizeAnimator.Expansion, largeContentSize);
 
                 // If it's test mode - skip storyboard.
                 if (!DynamoModel.IsTestMode)

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -452,15 +452,33 @@ namespace Dynamo.UI.Controls
         /// </summary>
         private void ComputeWatchContentSize(object sender, RoutedEventArgs e)
         {
-           if (!IsExpanded) return;
+            if (!IsExpanded) return;
 
             // Used delay invoke, because TreeView hasn't changed its'appearance with usual Dispatcher call.
-            Dispatcher.DelayInvoke(50,() =>
+            Dispatcher.DelayInvoke(50, () => RefreshExpandedDisplay(() =>
             {
+                largeContentGrid.Visibility = Visibility.Visible;
+                bubbleTools.Visibility = Visibility.Visible;
+
+                // The real transition starts
+                SetCurrentStateAndNotify(State.InTransition);
                 var largeContentSize = ComputeLargeContentSize();
-                UpdateAnimatorTargetSize(SizeAnimator.Expansion, largeContentSize);
-                this.expandStoryboard.Begin(this, true);
-            });
+                UpdateAnimatorTargetSize(SizeAnimator.Expansion, largeContentSize);                    
+
+                // If it's test mode - skip storyboard.
+                if (!DynamoModel.IsTestMode)
+                {
+                    expandStoryboard.Begin(this, true);
+                }
+                else
+                {
+                    largeContentGrid.Opacity = 1.0;
+                    smallContentGrid.Opacity = 0.0;
+                    centralizedGrid.Width = largeContentSize.Width;
+                    centralizedGrid.Height = largeContentSize.Height;
+                    OnPreviewControlExpanded(null, null);
+                }
+            }));
         }
 
         private Size ComputeSmallContentSize()


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9325](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9325) On hover over the node or compact view, the node and its preview bubble should be temporarily brought to the front of the view order

We need to update preview bubble in `RefreshExpandedDisplay`, because this method will run UI changes in Dynamo Scheduler.

This PR addresses next situation: 
![image](https://cloud.githubusercontent.com/assets/8158404/13044913/4fe07502-d3d9-11e5-900e-d9c2919b0253.png)

I could reproduce it just once, but then I couldn't reproduce it at all :(
I assume the problem is because we are running this process not in Scheduler thread. After I moved this event in Scheduler thread, bug has gone.

Also added test.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ramramps 