### PR TITLE
Processing replication guides level by level

### DIFF
--- a/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
@@ -171,6 +171,34 @@ namespace ProtoCore.Lang.Replication
             return ret;
         }
 
+        /// <summary>
+        /// Calculate partial replication instruciton based on replication guide level.
+        /// For example, for foo(xs<1><2><3>, ys<1><1><2>, zs<1><1><3>), the guides
+        /// are:
+        /// 
+        ///     level |  0  |  1  |  2  |
+        ///     ------+-----+-----+-----+
+        ///       xs  |  1  |  2  |  3  |
+        ///     ------+-----+-----+-----+
+        ///       ys  |  1  |  1  |  2  |
+        ///     ------+-----+-----+-----+
+        ///       zs  |  1  |  1  |  3  |
+        ///
+        /// This function goes through each level and calculate replication instructions.
+        /// 
+        /// replication instructions on level 0:
+        ///     Zip replication on (0, 1, 2) (i.e., zip on xs, ys, zs)
+        ///
+        /// replication instructions on level 1:
+        ///     Zip replication on (1, 2)    (i.e., zip on ys, zs)
+        ///     Cartesian replication on 0   (i.e., on xs)
+        ///
+        /// replication instructions on level 2:
+        ///     Cartesian replication on 1   (i.e., on ys)
+        ///     Zip replication on (0, 2)    (i.e., zip on xs, zs)
+        /// </summary>
+        /// <param name="partialRepGuides"></param>
+        /// <returns></returns>
         private static List<ReplicationInstruction> BuildPartialReplicationInstructions(List<List<ReplicationGuide>> partialRepGuides)
         {
             if (!partialRepGuides.Any())

--- a/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
@@ -221,7 +221,11 @@ namespace ProtoCore.Lang.Replication
                     if (replicationGuides == null || replicationGuides.Count <= level)
                         continue;
 
+                    // If it is negative or 0, treat it as a stub
                     var guide = replicationGuides[level].guideNumber;
+                    if (guide <= 0)
+                        continue;
+
                     var algorithm = replicationGuides[level].isLongest ? ZipAlgorithm.Longest : ZipAlgorithm.Shortest;
 
                     guides.Add(guide);

--- a/test/Engine/ProtoTest/TD/Associative/Replication.cs
+++ b/test/Engine/ProtoTest/TD/Associative/Replication.cs
@@ -3457,31 +3457,20 @@ y = sum(a, b);
             String errmsg = "";//DNL-1467315 rev 3830 : System.NotImplementedException : only <1> and <2> are supported as replication guides";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
             // verification 
-            thisTest.Verify("x", new Object[] { new Object[] { new Object[] { new Object[] { 5, 6 }, new Object[] { 5, 6 } }, new Object[] { new Object[] { 6, 7 }, new Object[] { 6, 7 } } }, new Object[] { new Object[] { new Object[] { 5, 6 }, new Object[] { 5, 6 } }, new Object[] { new Object[] { 6, 7 }, new Object[] { 6, 7 } } } });
+            thisTest.Verify("x", new Object[] 
+            {
+                new Object[] 
+                {
+                    new Object[] { new Object[] { 5, 6 }, new Object[] { 6, 7 } },
+                    new Object[] { new Object[] { 5, 6 }, new Object[] { 6, 7 } }
+                },
+                new Object[] 
+                {
+                    new Object[] { new Object[] { 5, 6 }, new Object[] { 6, 7 } },
+                    new Object[] { new Object[] { 5, 6 }, new Object[] { 6, 7 } }
+                }
+            });
             thisTest.Verify("y", new Object[] { new Object[] { 5, 7 }, new Object[] { 5, 7 } });
-        }
-
-        [Test]
-        [Category("Replication")]
-        public void T75_Defect_1467282_3()
-        {
-            String code =
-@"
-def sum ( a : int, b : int)
-{
-    return = a + b;
-}
-a = { {5, 6}, {5,6} };
-b = { {0, 1}, {0,1} };
-test = sum(a<1><2>, b<3><4> );
-//expected :   test = { { { { 5, 6 }, { 5, 6 } }, { { 6, 7 }, { 6, 7 } } }, { { { 5, 6 }, { 5, 6 } }, { { 6, 7 }, { 6, 7 } } } }
-//recieved :   System.NotImplemented exception
-";
-            ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
-            String errmsg = "";//DNL-1467315 rev 3830 : System.NotImplementedException : only <1> and <2> are supported as replication guides";
-            ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
-            // verification 
-            thisTest.Verify("test", new Object[] { new Object[] { new Object[] { new Object[] { 5, 6 }, new Object[] { 5, 6 } }, new Object[] { new Object[] { 6, 7 }, new Object[] { 6, 7 } } }, new Object[] { new Object[] { new Object[] { 5, 6 }, new Object[] { 5, 6 } }, new Object[] { new Object[] { 6, 7 }, new Object[] { 6, 7 } } } });
         }
 
         [Test]
@@ -4985,28 +4974,6 @@ c = foo(a,b);
             string errmsg = "MAGN-1673 Sprint 27 - Rev4014 - function argument with jagged array - its expected to replicate for the attached code";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("c", new object[] { new object[] { 6, 7 }, new object[] { 9, 10 } });
-        }
-
-        [Test]
-        [Category("DSDefinedClass_Ported")]
-        [Category("Replication")]
-        public void T93_Defect_1467315()
-        {
-            String code =
-@"
-def foo(a : int, b : int)
-{
-    return = a + b;
-}
-a = { {5, 6}, {5,6} };
-b = { {0, 1}, {0,1} };
-y = foo(a<1><2>,b<3><4>);
-";
-            ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
-            String errmsg = "";//DNL-1467315 rev 3830 : System.NotImplementedException : only <1> and <2> are supported as replication guides";
-            ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
-            // verification 
-            thisTest.Verify("y", new Object[] { new Object[] { new Object[] { new Object[] { 5, 6 }, new Object[] { 5, 6 } }, new Object[] { new Object[] { 6, 7 }, new Object[] { 6, 7 } } }, new Object[] { new Object[] { new Object[] { 5, 6 }, new Object[] { 5, 6 } }, new Object[] { new Object[] { 6, 7 }, new Object[] { 6, 7 } } } });
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -2003,5 +2003,22 @@ namespace ProtoTest.TD.Associative
             // Should get clear after running
             Assert.AreEqual(0, thisTest.GetTestRuntimeCore().ReplicationGuides.Count);
         }
+
+        [Test]
+        [Category("ReplicationGuide")]
+        public void ZachExample()
+        {
+            string code = @"
+def firstItem(list: var[]..[])
+{
+    return=list[0];
+}
+
+xs = {{{1, 2, 3}, {4, 5, 6}},{{7, 8, 9}, {10, 11, 12}}};
+result = firstItem(xs<1><1>);
+";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("result", new object[] { new object[] { 1, 4 }, new object[] { 7, 10 } });
+        }
     }
 }

--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -1312,7 +1312,7 @@ namespace ProtoTest.TD.Associative
 @"def foo (x1,y1){    return = x1 + y1;}x = {{0, 1},{2,3}};y = {{4,5},{6,7}};test1 = foo(x<1><2>, y<3><4>) ;          ";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4, 5 }, new object[] { 6, 7 } }, new object[] { new object[] { 5, 6 }, new object[] { 7, 8 } } }, new object[] { new object[] { new object[] { 6, 7 }, new object[] { 8, 9 } }, new object[] { new object[] { 7, 8 }, new object[] { 9, 10 } } } });
+            thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4, 5 }, new object[] { 5, 6 } }, new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } } }, new object[] { new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } }, new object[] { new object[] { 8, 9 }, new object[] { 9, 10 } } } });
         }
 
         [Test]
@@ -1334,7 +1334,7 @@ namespace ProtoTest.TD.Associative
 @"def foo (x1,y1){    return = x1 + y1;}x = {{0, 1},{2,3}};y = {{4,5},{6,7}};test1 = foo(x<1><3>, y<4><5>) ;        ";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4, 5 }, new object[] { 6, 7 } }, new object[] { new object[] { 5, 6 }, new object[] { 7, 8 } } }, new object[] { new object[] { new object[] { 6, 7 }, new object[] { 8, 9 } }, new object[] { new object[] { 7, 8 }, new object[] { 9, 10 } } } });
+            thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4, 5 }, new object[] { 5, 6 } }, new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } } }, new object[] { new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } }, new object[] { new object[] { 8, 9 }, new object[] { 9, 10 } } } });
         }
 
         [Test]
@@ -1433,7 +1433,7 @@ namespace ProtoTest.TD.Associative
 @" import(""FFITarget.dll"");def foo (x1:double,y1:TestObjectA){    return = x1 + y1.a;}x = {{0.0,1.0}, {2.0, 3.0} };y = { {TestObjectA.TestObjectA(4), TestObjectA.TestObjectA(5)}, { TestObjectA.TestObjectA(6), TestObjectA.TestObjectA(7) } };test1 = foo(x<1><2>, y<3><4>) ;            ";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4.0, 5.0 }, new object[] { 6.0, 7.0 } }, new object[] { new object[] { 5.0, 6.0 }, new object[] { 7.0, 8.0 } } }, new object[] { new object[] { new object[] { 6.0, 7.0 }, new object[] { 8.0, 9.0 } }, new object[] { new object[] { 7.0, 8.0 }, new object[] { 9.0, 10.0 } } } });
+            thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4.0, 5.0 }, new object[] { 5.0, 6.0 } }, new object[] { new object[] { 6.0, 7.0 }, new object[] { 7.0, 8.0 } } }, new object[] { new object[] { new object[] { 6.0, 7.0 }, new object[] { 7.0, 8.0 } }, new object[] { new object[] { 8.0, 9.0 }, new object[] { 9.0, 10.0 } } } });
         }
 
         [Test]
@@ -1740,7 +1740,7 @@ namespace ProtoTest.TD.Associative
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("c1", new Object[] { new Object[] { 4, 6 }, new Object[] { 8, 10 } });
-            thisTest.Verify("c2", new Object[] { new Object[] { new Object[] { new Object[] { -4, -5 }, new Object[] { -6, -7 } }, new Object[] { new Object[] { -3, -4 }, new Object[] { -5, -6 } } }, new Object[] { new Object[] { new Object[] { -2, -3 }, new Object[] { -4, -5 } }, new Object[] { new Object[] { -1, -2 }, new Object[] { -3, -4 } } } });
+            thisTest.Verify("c2", new Object[] { new Object[] { new Object[] { new Object[] { -4, -5 }, new Object[] { -3, -4 } }, new Object[] { new Object[] { -6, -7 }, new Object[] { -5, -6 } } }, new Object[] { new Object[] { new Object[] { -2, -3 }, new Object[] { -1, -2 } }, new Object[] { new Object[] { -4, -5 }, new Object[] { -3, -4 } } } });
             thisTest.Verify("c3", new Object[] { new Object[] { 0.0, 0.2 }, new Object[] { 0.33333333333333331, 0.42857142857142855 } });
             thisTest.Verify("c4", new Object[] { new Object[] { new Object[] { 0, 5 }, new Object[] { 0, 7 } }, new Object[] { new Object[] { 8, 15 }, new Object[] { 12, 21 } } });
             thisTest.Verify("c5", new Object[] { new Object[] { 0, 1 }, new Object[] { 2, 3 } });


### PR DESCRIPTION
### Purpose

This PR updates replication guide processing. 

Previously, replication guide processing is based on the numeric value of replication guide number. For example, in `foo(xs<1>, ys<2><3>, zs<3>)`, replication guide numbers are processed in ascendant order one by one: 1 -> 2 -> 3. For replication guide number that appears in multiple locations, zip replication will be applied to; otherwise Cartesian replication will be applied to, so the execution engine will generate the following replications:
  * Cartesian replication on xs
  * Cartesian replication on ys
  * Zip replication on ys and zs

Though this approach works for most cases, it has a prerequisite that replication guides for each arguments should be in ascendant order as well. For example, replication guides in `foo(xs<3><1>, ys<4><2>)` are considered as invalid.

As there is no "level" concept in replication guide processing, `foo(xs<1><1>)` is meaningless because we cannot zip on the same argument. It also has limitation like for two arguments, how to do zip replication on the first level and Cartesian replication on the second level. 

This PR changes replication guides processing. Now the processing is done level by level. For example, for the following function call, there are two levels for replication guides:

![untitled](https://cloud.githubusercontent.com/assets/2600379/13031204/5ef3b66a-d2ff-11e5-91b8-c27339d507f1.png)

For each replication level - 
* Sort replication guides in ascendant order
* For each replication guide number
  - If it appears in multiple locations, zip replication will be applied to. By default using shortest lacing. If any replication guide number has suffix “L”, longest lacing applies.
  - Otherwise Cartesian replication will be applied to.

So for this example, the following replications will be applied to the arguments:
* Zip replication on `as`, `cs`
* Cartesian replication on `ds`
* Zip replication on `as`, `ds`
* Cartesian replication on `cs`

Now for `foo(xs<1><1>)`, its meaning is zooming into the third level of `xs` and call function `foo()`. For example, 
```
def firstItem(xs: var[]..[])
{
    return = xs[0];
}
xs = {{{1, 2, 3}, {4, 5, 6}}, {{7, 8, 9}, {10, 11, 12}}};
rs = firstItem(xs<1><1>);
```
Here `firstItem(xs<1><1>)` will return the first item of each sub-list, so `rs` is `{{1, 4}, {7, 10}}`. 

### Reviewer
@Benglin 

### FYIs
@kronz @Racel @mccrone 









