### PR TITLE
Remove some language test cases from Failure category

### DIFF
--- a/test/Engine/ProtoTest/TD/Associative/Replication.cs
+++ b/test/Engine/ProtoTest/TD/Associative/Replication.cs
@@ -2646,7 +2646,6 @@ rad = foo(a, d);
 
         [Test]
         [Category("Replication")]
-        [Category("Failure")]
         public void T66_Defect_1467198_Inline_Condition_With_Jagged_Array()
         {
             String code =
@@ -4961,7 +4960,6 @@ a = { 5, 6, 7, 8 };
 
         [Test]
         [Category("Replication")]
-        [Category("Failure")]
         public void T92_add()
         {
             String code =

--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -13,7 +13,13 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg()
         {
             String code =
-@"def foo(a,b){    return = a + b;}test = foo( {0,1}<1>,{2,3}<2> );";
+@"
+def foo(a,b)
+{
+    return = a + b;
+}
+test = foo( {0,1}<1>,{2,3}<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -25,7 +31,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_a()
         {
             String code =
-@"def foo(a,b){    return = a + b;}f = {0,1};g = {2,3};test = foo( f<1>, g<2> );";
+@"
+def foo(a,b)
+{
+    return = a + b;
+}
+f = {0,1};
+g = {2,3};
+test = foo( f<1>, g<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -37,7 +51,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_2()
         {
             String code =
-@"def foo(a,b){    return = a + b;}x = 0..1;y = 2..3;test = foo( x<1>,y<2> );";
+@"
+def foo(a,b)
+{
+    return = a + b;
+}
+x = 0..1;
+y = 2..3;
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -49,7 +71,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_3()
         {
             String code =
-@"def foo(a,b){    return = a + b;}x = {0,1};y = {2,3};test = foo( x<1>,y<2> );";
+@"
+def foo(a,b)
+{
+    return = a + b;
+}
+x = {0,1};
+y = {2,3};
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -61,7 +91,13 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_4()
         {
             String code =
-@"def foo(a,b){    return = a + b;}test = foo( (0..1)<1>,(2..3)<2> );";
+@"
+def foo(a,b)
+{
+    return = a + b;
+}
+test = foo( (0..1)<1>,(2..3)<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -73,7 +109,13 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_5()
         {
             String code =
-@"def foo(a,b){    return = a + b;}test = foo( {0..1}<1>,{2..3}<2> );";
+@"
+def foo(a,b)
+{
+    return = a + b;
+}
+test = foo( {0..1}<1>,{2..3}<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -85,7 +127,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_6()
         {
             String code =
-@"def foo(a:var,b:var){    return = a + b;}x = {0,1};y = {2,3};test = foo( x<1>,y<2> );";
+@"
+def foo(a:var,b:var)
+{
+    return = a + b;
+}
+x = {0,1};
+y = {2,3};
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -97,7 +147,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_7()
         {
             String code =
-@"def foo(a:var,b:var){    return = a + b;}x = {0,1};y = {2,3};test = foo( x<1>,y<1> );";
+@"
+def foo(a:var,b:var)
+{
+    return = a + b;
+}
+x = {0,1};
+y = {2,3};
+test = foo( x<1>,y<1> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -109,7 +167,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_8()
         {
             String code =
-@"def foo(a:int,b:double){    return = a + b;}x = {0,1};y = {2,3};test = foo( x<1>,y<2> );";
+@"
+def foo(a:int,b:double)
+{
+    return = a + b;
+}
+x = {0,1};
+y = {2,3};
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -122,7 +188,16 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_9()
         {
             String code =
-@"import(""FFITarget.dll"");def foo(a:TestObjectA, b:TestObjectA){    return = a.a + b.a;}x = TestObjectA.TestObjectA({0,1});y = TestObjectA.TestObjectA({2,3});test = foo( x<1>,y<2> );";
+@"
+import(""FFITarget.dll"");
+def foo(a:TestObjectA, b:TestObjectA)
+{
+    return = a.a + b.a;
+}
+x = TestObjectA.TestObjectA({0,1});
+y = TestObjectA.TestObjectA({2,3});
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -134,7 +209,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_10()
         {
             String code =
-@"def foo(a:int,b:double){    return = a + b;}x = {{0,1},{2,3}};y = {{0,1},{2,3}};test = foo( x<1>,y<2> );";
+@"
+def foo(a:int,b:double)
+{
+    return = a + b;
+}
+x = {{0,1},{2,3}};
+y = {{0,1},{2,3}};
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -147,7 +230,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_11()
         {
             String code =
-@"def foo(a:int,b:double){    return = a + b;}x = {{0,1}};y = {{2,3}};test = foo( x<1>,y<2> );";
+@"
+def foo(a:int,b:double)
+{
+    return = a + b;
+}
+x = {{0,1}};
+y = {{2,3}};
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -160,7 +251,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_12()
         {
             String code =
-@"def foo(a:var[],b:var[]){    return = a + b;}x = {{0,1}};y = {{2,3}};test = foo( x<1>,y<2> );";
+@"
+def foo(a:var[],b:var[])
+{
+    return = a + b;
+}
+x = {{0,1}};
+y = {{2,3}};
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -172,7 +271,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_14()
         {
             String code =
-@"def foo(a,b:int){    return = a + b;}x = {0,1};y = {2,3};test = foo( x<1>,y<2> );";
+@"
+def foo(a,b:int)
+{
+    return = a + b;
+}
+x = {0,1};
+y = {2,3};
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -185,7 +292,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_15()
         {
             String code =
-@"def foo(a:int,b:int){    return = a + b;}x = {0,1};y = {2,3};test = foo( x<1>,y );";
+@"
+def foo(a:int,b:int)
+{
+    return = a + b;
+}
+x = {0,1};
+y = {2,3};
+test = foo( x<1>,y );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "DNL-1467580 IndexOutOfRange Exception when replication guides are not applied on all arguments";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -199,7 +314,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_16()
         {
             String code =
-@"def foo(a:int,b:int){    return = a + b;}x = {0,1};y = {2,3};test = foo( x,y<1> );";
+@"
+def foo(a:int,b:int)
+{
+    return = a + b;
+}
+x = {0,1};
+y = {2,3};
+test = foo( x,y<1> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "DNL-1467580 IndexOutOfRange Exception when replication guides are not applied on all arguments";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -212,7 +335,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_17()
         {
             String code =
-@"def foo(a:int,b:int){    return = a + b;}x = {0,1};y = {2,3,4};test = foo( x<1>,y<2> );";
+@"
+def foo(a:int,b:int)
+{
+    return = a + b;
+}
+x = {0,1};
+y = {2,3,4};
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -224,7 +355,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_18()
         {
             String code =
-@"def foo(a:int,b:int){    return = a + b;}x = {0,1,3};y = {4,5};test = foo( x<1>,y<2> );";
+@"
+def foo(a:int,b:int)
+{
+    return = a + b;
+}
+x = {0,1,3};
+y = {4,5};
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -236,7 +375,15 @@ namespace ProtoTest.TD.Associative
         public void T0001_Replication_Guide_Function_With_2_Arg_19()
         {
             String code =
-@"def foo(a:int,b:int){    return = a + b;}x = {0,1};y = 4;test = foo( x<1>,y<2> );";
+@"
+def foo(a:int,b:int)
+{
+    return = a + b;
+}
+x = {0,1};
+y = 4;
+test = foo( x<1>,y<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -248,7 +395,16 @@ namespace ProtoTest.TD.Associative
         public void T0002_Replication_Guide_Function_With_3_Arg()
         {
             String code =
-@"def foo(a:int,b:int,c){    return = a + b +c;}x = {0,1};y = {2,3};z = {4,5};test = foo( x<1>,y<2>,z<3> );";
+@"
+def foo(a:int,b:int,c)
+{
+    return = a + b +c;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5};
+test = foo( x<1>,y<2>,z<3> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -261,7 +417,16 @@ namespace ProtoTest.TD.Associative
         public void T0002_Replication_Guide_Function_With_3_Arg_2()
         {
             String code =
-@"def foo(a:int,b:int,c:int){    return = a + b +c;}x = {0,1};y = {2,3};z = {4,5};test = foo( x<1>,y<2>,z<1> );";
+@"
+def foo(a:int,b:int,c:int)
+{
+    return = a + b +c;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5};
+test = foo( x<1>,y<2>,z<1> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -276,7 +441,16 @@ namespace ProtoTest.TD.Associative
         public void T0002_Replication_Guide_Function_With_3_Arg_3()
         {
             String code =
-@"def foo(a:int,b:int,c:int){    return = a + b +c;}x = {0,1};y = {2,3};z = {4,5};test = foo( x<1>,y,z<2> );";
+@"
+def foo(a:int,b:int,c:int)
+{
+    return = a + b +c;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5};
+test = foo( x<1>,y,z<2> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "DNL-1467580 IndexOutOfRange Exception when replication guides are not applied on all arguments";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -290,7 +464,16 @@ namespace ProtoTest.TD.Associative
         public void T0002_Replication_Guide_Function_With_3_Arg_4()
         {
             String code =
-@"def foo(a,b,c){    return = a + b +c;}x = {0,1};y = {2,3};z = {4,5};test = foo( x<1>,y<2>,z<3> );";
+@"
+def foo(a,b,c)
+{
+    return = a + b +c;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5};
+test = foo( x<1>,y<2>,z<3> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -304,7 +487,16 @@ namespace ProtoTest.TD.Associative
         public void T0002_Replication_Guide_Function_With_3_Arg_5()
         {
             String code =
-@"def foo(a,b,c){    return = a + b +c;}x = {0,1};y = {2,3,4};z = {5,6,7,8};test = foo( x<1>,y<2>,z<3> );";
+@"
+def foo(a,b,c)
+{
+    return = a + b +c;
+}
+x = {0,1};
+y = {2,3,4};
+z = {5,6,7,8};
+test = foo( x<1>,y<2>,z<3> );
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -318,7 +510,10 @@ namespace ProtoTest.TD.Associative
         public void T0003_Replication_Guide_Class_Constructor_With_2_Arg_1()
         {
             String code =
-@"import(""FFITarget.dll"");test = TestObjectC.TestObjectC({0,1}<1>,{2,3}<2>).z;";
+@"
+import(""FFITarget.dll"");
+test = TestObjectC.TestObjectC({0,1}<1>,{2,3}<2>).z;
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -332,7 +527,10 @@ namespace ProtoTest.TD.Associative
         public void T0003_Replication_Guide_Class_Constructor_With_2_Arg_2()
         {
             String code =
-@"import(""FFITarget.dll"");test = TestObjectC.TestObjectC((0..1)<1>,(2..3)<2>).z;";
+@"
+import(""FFITarget.dll"");
+test = TestObjectC.TestObjectC((0..1)<1>,(2..3)<2>).z;
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -345,7 +543,12 @@ namespace ProtoTest.TD.Associative
         public void T0003_Replication_Guide_Class_Constructor_With_2_Arg_3()
         {
             String code =
-@"import(""FFITarget.dll"");x = {0,1};y = {2,3};test = TestObjectC.TestObjectC(x<1>,y<2>).z;";
+@"
+import(""FFITarget.dll"");
+x = {0,1};
+y = {2,3};
+test = TestObjectC.TestObjectC(x<1>,y<2>).z;
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -359,7 +562,12 @@ namespace ProtoTest.TD.Associative
         public void T0003_Replication_Guide_Class_Constructor_With_2_Arg_4()
         {
             String code =
-@"import(""FFITarget.dll"");x = {0,1};y = 2;test = TestObjectC.TestObjectC(x<1>,y<2>).z;";
+@"
+import(""FFITarget.dll"");
+x = {0,1};
+y = 2;
+test = TestObjectC.TestObjectC(x<1>,y<2>).z;
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "DNL-1467459 NotImplemented Exception occurs when replication guides are used on a combination of collection and singleton";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -372,7 +580,13 @@ namespace ProtoTest.TD.Associative
         public void T0004_Replication_Guide_Class_Constructor_With_3_Arg()
         {
             String code =
-@"import(""FFITarget.dll"");x = {0,1};y = {2,3};z = {4,5};test = TestObjectD.TestObjectD(x<1>,y<2>,z<3>).t;";
+@"
+import(""FFITarget.dll"");
+x = {0,1};
+y = {2,3};
+z = {4,5};
+test = TestObjectD.TestObjectD(x<1>,y<2>,z<3>).t;
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -386,7 +600,13 @@ namespace ProtoTest.TD.Associative
         public void T0004_Replication_Guide_Class_Constructor_With_3_Arg_2()
         {
             String code =
-@"import(""FFITarget.dll"");x = {0,1};y = {2,3};z = {4,5};test = TestObjectD.TestObjectD(x<1>,y<2>,z<1>).t;";
+@"
+import(""FFITarget.dll"");
+x = {0,1};
+y = {2,3};
+z = {4,5};
+test = TestObjectD.TestObjectD(x<1>,y<2>,z<1>).t;
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -402,7 +622,13 @@ namespace ProtoTest.TD.Associative
         public void T0004_Replication_Guide_Class_Constructor_With_3_Arg_3()
         {
             String code =
-@"import(""FFITarget.dll"");x = {0,1};y = {2,3};z = {4,5};test = TestObjectD.TestObjectD(x<1>,y<2>,z).t;";
+@"
+import(""FFITarget.dll"");
+x = {0,1};
+y = {2,3};
+z = {4,5};
+test = TestObjectD.TestObjectD(x<1>,y<2>,z).t;
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "DNL-1467580 IndexOutOfRange Exception when replication guides are not applied on all arguments";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -416,7 +642,16 @@ namespace ProtoTest.TD.Associative
         public void T032_replicationguide_usecase()
         {
             String code =
-@"a = 0..10;b = a;b[2] = 100;c = a;d = b[0..(Count(b) - 1)..2];a_singleton = 10;b_1DArray = 10..100..10;//c_2D_Array = (10..100..10) < 1 > + (10..100..10) < 2 >;";
+@"
+a = 0..10;
+b = a;
+b[2] = 100;
+c = a;
+d = b[0..(Count(b) - 1)..2];
+a_singleton = 10;
+b_1DArray = 10..100..10;
+//c_2D_Array = (10..100..10) < 1 > + (10..100..10) < 2 >;
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -438,7 +673,15 @@ namespace ProtoTest.TD.Associative
         public void T033_Replication_Guide_1467383()
         {
             String code =
-@"import(""FFITarget.dll"");def ByPoints(pts : DummyPoint2D){    return = pts;}p = DummyPoint2D.ByCoordinates((1..2..1)<1>, (3..4..1)<2> );test = ByPoints(p).X;";
+@"
+import(""FFITarget.dll"");
+def ByPoints(pts : DummyPoint2D)
+{
+    return = pts;
+}
+p = DummyPoint2D.ByCoordinates((1..2..1)<1>, (3..4..1)<2> );
+test = ByPoints(p).X;
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";//1467383 - Validation Required -  [USER MANUAL] Select Trim Method Failure - Requested Coercion not implemented ";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -451,7 +694,17 @@ namespace ProtoTest.TD.Associative
         public void T033_Replication_Guide_1467382()
         {
             String code =
-                @"import(""FFITarget.dll"");def ByStartPointEndPoint(p1:DummyPoint, p2:DummyPoint){    return = p1;}height = 5;p1 = DummyPoint.ByCoordinates((0..1)<1>, (0..1)<2>,1);p2 = DummyPoint.ByCoordinates((0..1)<1>, (0..1)<2>,height);l = ByStartPointEndPoint(p1, p2);test = l.X;                ";
+                @"
+import(""FFITarget.dll"");
+def ByStartPointEndPoint(p1:DummyPoint, p2:DummyPoint)
+{
+    return = p1;
+}
+height = 5;
+p1 = DummyPoint.ByCoordinates((0..1)<1>, (0..1)<2>,1);
+p2 = DummyPoint.ByCoordinates((0..1)<1>, (0..1)<2>,height);
+l = ByStartPointEndPoint(p1, p2);
+test = l.X;                ";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -463,7 +716,14 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments()
         {
             String code =
-                @"def sum ( a, b, c){    return = a + b + c ;}x = 1..2;y = 3..4;z = 1;test = sum ( z, x<1>, y<2> ); ";
+                @"def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+x = 1..2;
+y = 3..4;
+z = 1;
+test = sum ( z, x<1>, y<2> ); ";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";//DNL-1467386 Rev 4247 : WARNING: Replication unbox requested on Singleton warning coming from using replication guides on only some, not all arguments of a function gives incorrect output";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -476,7 +736,14 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments_a()
         {
             String code =
-                @"def sum ( a, b, c){    return = a + b + c ;}x = 1..2;y = 3..4;z = {1, 1};test = sum ( z<1>, x<1>, y<2> ); ";
+                @"def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+x = 1..2;
+y = 3..4;
+z = {1, 1};
+test = sum ( z<1>, x<1>, y<2> ); ";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";//DNL-1467386 Rev 4247 : WARNING: Replication unbox requested on Singleton warning coming from using replication guides on only some, not all arguments of a function gives incorrect output";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -489,7 +756,14 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments_b()
         {
             String code =
-                @"def sum ( a, b, c){    return = a + b + c ;}x = 1..2;y = 3..4;z = 1;test = sum ( x<1>, y<2>, z ); ";
+                @"def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+x = 1..2;
+y = 3..4;
+z = 1;
+test = sum ( x<1>, y<2>, z ); ";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";//DNL-1467386 Rev 4247 : WARNING: Replication unbox requested on Singleton warning coming from using replication guides on only some, not all arguments of a function gives incorrect output";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -502,7 +776,14 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments_c()
         {
             String code =
-                @"def sum ( a, b, c){    return = a + b + c ;}x = {1,2};y = {3,4};z = 1;test = sum ( z, x<1>, y<2> ); ";
+                @"def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+x = {1,2};
+y = {3,4};
+z = 1;
+test = sum ( z, x<1>, y<2> ); ";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";//DNL-1467386 Rev 4247 : WARNING: Replication unbox requested on Singleton warning coming from using replication guides on only some, not all arguments of a function gives incorrect output";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -515,7 +796,14 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments_2()
         {
             String code =
-@"def sum ( a, b, c){    return = a + b + c ;}x = 1..2;y = 3..4;z = 1;test = sum ( z, x<1>, y<2> );";
+@"def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+x = 1..2;
+y = 3..4;
+z = 1;
+test = sum ( z, x<1>, y<2> );";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";//DNL-1467386 Rev 4247 : WARNING: Replication unbox requested on Singleton warning coming from using replication guides on only some, not all arguments of a function gives incorrect output";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -528,7 +816,14 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments_3()
         {
             String code =
-@"def sum ( a, b, c){    return = a + b + c ;}x = 1..2;y = 3..4;z = 1;test = sum ( x<1>, z, y<2> );";
+@"def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+x = 1..2;
+y = 3..4;
+z = 1;
+test = sum ( x<1>, z, y<2> );";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";//DNL-1467386 Rev 4247 : WARNING: Replication unbox requested on Singleton warning coming from using replication guides on only some, not all arguments of a function gives incorrect output";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -541,7 +836,13 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments_4()
         {
             String code =
-@"def sum ( a, b){    return = a + b  ;}x = 1..2;z = 1;test = sum ( x<1>, z );";
+@"def sum ( a, b)
+{
+    return = a + b  ;
+}
+x = 1..2;
+z = 1;
+test = sum ( x<1>, z );";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -554,7 +855,13 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments_5()
         {
             String code =
-@"def sum ( a, b){    return = a + b  ;}x = 1..2;z = 1;test = sum ( z, x<1> );";
+@"def sum ( a, b)
+{
+    return = a + b  ;
+}
+x = 1..2;
+z = 1;
+test = sum ( z, x<1> );";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -568,7 +875,12 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments_6()
         {
             String code =
-@"import(""FFITarget.dll"");x1 = 1..2;y1 = 1;a = DummyPoint2D.ByCoordinates(y1, x1<1>);test = a.Y;";
+@"
+import(""FFITarget.dll"");
+x1 = 1..2;
+y1 = 1;
+a = DummyPoint2D.ByCoordinates(y1, x1<1>);
+test = a.Y;";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";//DNL-1467386 Rev 4247 : WARNING: Replication unbox requested on Singleton warning coming from using replication guides on only some, not all arguments of a function gives incorrect output";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -581,7 +893,17 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments_7()
         {
             String code =
-@"def foo ( a, b){    x = a;    y = b;    return = x + y;}x1 = 1..2;y1 = 1;dummy = foo(y1, x1);";
+@"
+def foo ( a, b)
+{
+    x = a;
+    y = b;
+    return = x + y;
+}
+x1 = 1..2;
+y1 = 1;
+dummy = foo(y1, x1);
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";//DNL-1467386 Rev 4247 : WARNING: Replication unbox requested on Singleton warning coming from using replication guides on only some, not all arguments of a function gives incorrect output";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -595,7 +917,11 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments_8()
         {
             String code =
-@"import(""FFITarget.dll"");a = (0..1..#2);cs = DummyPoint.ByCoordinates(1, a<1>, a<2>); test = cs.Y;
+@"
+import(""FFITarget.dll"");
+a = (0..1..#2);
+cs = DummyPoint.ByCoordinates(1, a<1>, a<2>); 
+test = cs.Y;
 ";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, "");
@@ -608,7 +934,19 @@ namespace ProtoTest.TD.Associative
         public void T034_Replication_Guides_Not_On_All_Arguments_9()
         {
             String code =
-@"import(""DSCoreNodes.dll"");def sum ( a, b, c ){    return = a + b + c;}temp1 = (Math.Sin(0..180..#2) * 2);temp2 = (Math.Sin(0..180..#3) * 1);zArray = temp1<1> + temp2<2>;zArray1 = zArray + 1;ceilingPoints = sum((0..10..#2)<1>, (0..15..#3)<2>, zArray1 );// expected :  ceilingPoints = { { 1.000, 9.500, 16.000 }, { 11.000, 19.500, 26.000 } }// received :  ceilingPoints = null";
+@"
+import(""DSCoreNodes.dll"");
+def sum ( a, b, c )
+{
+    return = a + b + c;
+}
+temp1 = (Math.Sin(0..180..#2) * 2);
+temp2 = (Math.Sin(0..180..#3) * 1);
+zArray = temp1<1> + temp2<2>;
+zArray1 = zArray + 1;
+ceilingPoints = sum((0..10..#2)<1>, (0..15..#3)<2>, zArray1 );
+// expected :  ceilingPoints = { { 1.000, 9.500, 16.000 }, { 11.000, 19.500, 26.000 } }
+// received :  ceilingPoints = null";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "MAGN-1707 IndexOutOfRange Exception when replication guides are not applied on all arguments";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -625,7 +963,12 @@ namespace ProtoTest.TD.Associative
             //Analysis: The Rep Guides are being resolved to C0C1, rather than C1C2. This needs to
             //have the fix applied for function calls applied to ctors as well.
             String code =
-@"import(""FFITarget.dll"");a = (0..1..#2);b = { 0, 1}; // fails with this as wellcs = DummyPoint.ByCoordinates(1, a<1>, b<2>); test = cs.Y;";
+@"
+import(""FFITarget.dll"");
+a = (0..1..#2);
+b = { 0, 1}; // fails with this as well
+cs = DummyPoint.ByCoordinates(1, a<1>, b<2>); 
+test = cs.Y;";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code);
             thisTest.Verify("test", new Object[] { new Object[] { 0.0, 0.0 }, new Object[] { 1.0, 1.0 } });
@@ -637,7 +980,11 @@ namespace ProtoTest.TD.Associative
         public void T035_Defect_1467317_Replication_Guide_On_Instances()
         {
             String code =
-@"import(""FFITarget.dll"");a = ArrayMember.Ctor({1,2});b = ArrayMember.Ctor({1,2});test = a.X<1> + b.X<2>;
+@"
+import(""FFITarget.dll"");
+a = ArrayMember.Ctor({1,2});
+b = ArrayMember.Ctor({1,2});
+test = a.X<1> + b.X<2>;
 ";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
@@ -651,7 +998,16 @@ namespace ProtoTest.TD.Associative
         public void T035_Defect_1467317_Replication_Guide_On_Instances_2()
         {
             String code =
-@"import(""FFITarget.dll"");def foo (){    a = ArrayMember.Ctor({1,2});    b = ArrayMember.Ctor({1,2});    test = a.X<1> + b.X<2>;    return = test;}test = foo();
+@"
+import(""FFITarget.dll"");
+def foo ()
+{
+    a = ArrayMember.Ctor({1,2});
+    b = ArrayMember.Ctor({1,2});
+    test = a.X<1> + b.X<2>;
+    return = test;
+}
+test = foo();
 ";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
@@ -665,7 +1021,25 @@ namespace ProtoTest.TD.Associative
         public void T035_Defect_1467317_Replication_Guide_On_Instances_3()
         {
             String code =
-@"import(""FFITarget.dll"");test = { { } };test2 = [Associative]{    test2 = { } ;    [Imperative]    {        a = ArrayMember.Ctor({1,2});        b = ArrayMember.Ctor({1,2});        [Associative]        {            test = a.X<1> + b.X<2>;            test2 = a.X + b.X;        }    }    return = test2;}";
+@"
+import(""FFITarget.dll"");
+test = { { } };
+test2 = [Associative]
+{
+    test2 = { } ;
+    [Imperative]
+    {
+        a = ArrayMember.Ctor({1,2});
+        b = ArrayMember.Ctor({1,2});
+        [Associative]
+        {
+            test = a.X<1> + b.X<2>;
+            test2 = a.X + b.X;
+        }
+    }
+    return = test2;
+}
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -679,7 +1053,10 @@ namespace ProtoTest.TD.Associative
         public void T036_Defect_1467383_Replication_Guide_On_Collection()
         {
             String code =
-@"import(""FFITarget.dll"");p = DummyPoint2D.ByCoordinates((1..2..1)<1>, (3..4..1)<2> ).X;";
+@"
+import(""FFITarget.dll"");
+p = DummyPoint2D.ByCoordinates((1..2..1)<1>, (3..4..1)<2> ).X;
+";
             ProtoScript.Runners.ProtoScriptRunner fsr = new ProtoScript.Runners.ProtoScriptRunner();
             String errmsg = "";
             ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
@@ -692,7 +1069,13 @@ namespace ProtoTest.TD.Associative
         [Category("Replication")]
         public void T037_ReplicationGuideAfterArray()
         {
-            string code = @"def sum ( a, b, c){    return = a + b + c ;}y = 3..4;r = sum(1, { 1, 2}<1>, y<2>);";
+            string code = @"
+def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+y = 3..4;
+r = sum(1, { 1, 2}<1>, y<2>);";
             string errmsg = "DNL-1467580 IndexOutOfRange Exception when replication guides are not applied on all arguments";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("r", new object[] { new object[] { 5, 6 }, new object[] { 6, 7 } });
@@ -702,7 +1085,10 @@ namespace ProtoTest.TD.Associative
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328()
         {
-            string code = @"            xHeight = 2.0;            yHeight = 1.0;            zArray1 = ((1..2..1)* xHeight)<1> + ((1..2..1)* yHeight)<2>;";
+            string code = @"
+            xHeight = 2.0;
+            yHeight = 1.0;
+            zArray1 = ((1..2..1)* xHeight)<1> + ((1..2..1)* yHeight)<2>;";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("zArray1", new object[] { new object[] { 3.000000, 4.000000 }, new object[] { 5.000000, 6.000000 } });
@@ -712,7 +1098,12 @@ namespace ProtoTest.TD.Associative
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328_2()
         {
-            string code = @"            a = 0..10;            b = a;            b[2] = 100;            c = a;              e = b[0..(Count(b) - 1)..2]<1>+b[0..(Count(b) - 1)..2]<2>;";
+            string code = @"
+            a = 0..10;
+            b = a;
+            b[2] = 100;
+            c = a;  
+            e = b[0..(Count(b) - 1)..2]<1>+b[0..(Count(b) - 1)..2]<2>;";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("e", new object[] { new object[] { 0, 100, 4, 6, 8, 10 }, new object[] { 100, 200, 104, 106, 108, 110 }, new object[] { 4, 104, 8, 10, 12, 14 }, new object[] { 6, 106, 10, 12, 14, 16 }, new object[] { 8, 108, 12, 14, 16, 18 }, new object[] { 10, 110, 14, 16, 18, 20 } });
@@ -723,7 +1114,10 @@ namespace ProtoTest.TD.Associative
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328_3()
         {
-            string code = @"import(""FFITarget.dll"");x = (TestObjectA.TestObjectA(1..3))[0];x = (TestObjectA.TestObjectA(1..3))[0..2].a<1> +(TestObjectA.TestObjectA(1..3))[0..2].a<2> ;
+            string code = @"
+import(""FFITarget.dll"");
+x = (TestObjectA.TestObjectA(1..3))[0];
+x = (TestObjectA.TestObjectA(1..3))[0..2].a<1> +(TestObjectA.TestObjectA(1..3))[0..2].a<2> ;
 ";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
@@ -735,7 +1129,10 @@ namespace ProtoTest.TD.Associative
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328_4()
         {
-            string code = @"import(""FFITarget.dll"");            x = (TestObjectA.TestObjectA(1..3))[0];            x = (TestObjectA.TestObjectA(1..3))[0..2].a<1> +(TestObjectA.TestObjectA(1..3))[0..2].a<2> ;";
+            string code = @"
+import(""FFITarget.dll"");
+            x = (TestObjectA.TestObjectA(1..3))[0];
+            x = (TestObjectA.TestObjectA(1..3))[0..2].a<1> +(TestObjectA.TestObjectA(1..3))[0..2].a<2> ;";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("x", new object[] { new object[] { 2, 3, 4 }, new object[] { 3, 4, 5 }, new object[] { 4, 5, 6 } });
@@ -745,7 +1142,14 @@ namespace ProtoTest.TD.Associative
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328_5()
         {
-            string code = @"            def foo : int(a : int,b:int)            {                return = a * b;            }            list1 = {1,2};            list2 = {1,2};            list3 = foo(foo(foo(list1<1>, list2<2>)<1>, list2<2>)<1>, list2<2>);";
+            string code = @"
+            def foo : int(a : int,b:int)
+            {
+                return = a * b;
+            }
+            list1 = {1,2};
+            list2 = {1,2};
+            list3 = foo(foo(foo(list1<1>, list2<2>)<1>, list2<2>)<1>, list2<2>);";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("list3", new object[] { new object[] { new object[] { new object[] { 1 }, new object[] { 2 } }, new object[] { new object[] { 2 }, new object[] { 4 } } }  } );
@@ -755,7 +1159,12 @@ namespace ProtoTest.TD.Associative
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328_6()
         {
-            string code = @"def sum ( a, b){     return = a + b;}test2 = sum ( (0..1)<1>, (2..3)<2>);";
+            string code = @"
+def sum ( a, b)
+{ 
+    return = a + b;
+}
+test2 = sum ( (0..1)<1>, (2..3)<2>);";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test2", new object[] { new object[] { 2, 3 }, new object[] { 3, 4 } });
@@ -765,7 +1174,8 @@ namespace ProtoTest.TD.Associative
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328_7()
         {
-            string code = @"test2 = (1..5..1) < 1 > + (1..5..1) < 2 >;";
+            string code = @"
+test2 = (1..5..1) < 1 > + (1..5..1) < 2 >;";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test2", new object[] { new object[] { 2, 3, 4, 5, 6 }, new object[] { 3, 4, 5, 6, 7 }, new object[] { 4, 5, 6, 7, 8 }, new object[] { 5, 6, 7, 8, 9 }, new object[] { 6, 7, 8, 9, 10 } }
@@ -776,7 +1186,10 @@ namespace ProtoTest.TD.Associative
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328_8()
         {
-            string code = @"xHeight = 2.0;yHeight = 1.0;test2 = ((1..2..1)* xHeight)<1> + ((1..2..1)* yHeight)<2>;";
+            string code = @"
+xHeight = 2.0;
+yHeight = 1.0;
+test2 = ((1..2..1)* xHeight)<1> + ((1..2..1)* yHeight)<2>;";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test2", new object[] { new object[] { 3.0, 4.0 }, new object[] { 5.0, 6.0 } }
@@ -787,7 +1200,12 @@ namespace ProtoTest.TD.Associative
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328_9()
         {
-            string code = @"def foo(x:var[]){    return = x;}test2 = foo({2,3})<1> + ({5,7})<2>;";
+            string code = @"
+def foo(x:var[])
+{
+    return = x;
+}
+test2 = foo({2,3})<1> + ({5,7})<2>;";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test2", new object[] { new object[] { 7, 9 }, new object[] { 8, 10 } }
@@ -798,7 +1216,13 @@ namespace ProtoTest.TD.Associative
         [Category("Replication")]
         public void T037_ReplicationGuidebrackets_1467328_10()
         {
-            string code = @"def foo(x:var[]){    return = x;}x = {1,2,3,4,5,6,7,8,9};test2 = x[foo({1,2})]<1> + ({5, 7})<2>;";
+            string code = @"
+def foo(x:var[])
+{
+    return = x;
+}
+x = {1,2,3,4,5,6,7,8,9};
+test2 = x[foo({1,2})]<1> + ({5, 7})<2>;";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test2", new object[] { new object[] { 7, 9 }, new object[] { 8, 10 } }
@@ -808,7 +1232,12 @@ namespace ProtoTest.TD.Associative
         [Test]
         public void T037_ReplicationGuidebrackets_1467328_11()
         {
-            string code = @"def foo(x:var[]){    return = x;}test2 = foo({2,3}<1> + ({5,7})<2>);";
+            string code = @"
+def foo(x:var[])
+{
+    return = x;
+}
+test2 = foo({2,3}<1> + ({5,7})<2>);";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test2", new object[] { new object[] { 7, 9 }, new object[] { 8, 10 } });
@@ -817,7 +1246,10 @@ namespace ProtoTest.TD.Associative
         [Test]
         public void T037_ReplicationGuidebrackets_1467328_12()
         {
-            string code = @"b = 0..5;t1 = 0..(Count(b) - 1)..2;test2 = b[t1]<1>+b[t1]<2>;";
+            string code = @"
+b = 0..5;
+t1 = 0..(Count(b) - 1)..2;
+test2 = b[t1]<1>+b[t1]<2>;";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test2", new object[] { new object[] { 0, 2, 4 }, new object[] { 2, 4, 6 }, new object[] { 4, 6, 8 } });
@@ -829,7 +1261,14 @@ namespace ProtoTest.TD.Associative
         public void T038_ReplicationGuide_Not_In_Sequence()
         {
             string code =
-@"def foo(x1,y1){    return = x1 + y1;}x = {0,1};y = {2, 3};test = foo(x<1>,y<3>);
+@"
+def foo(x1,y1)
+{
+    return = x1 + y1;
+}
+x = {0,1};
+y = {2, 3};
+test = foo(x<1>,y<3>);
 ";
             string errmsg = "DNL-1467460 NotImplemented Exception occurs when replication guides are not in sequence";
             thisTest.VerifyRunScriptSource(code, errmsg);
@@ -841,7 +1280,13 @@ namespace ProtoTest.TD.Associative
         public void T039_1467423_replication_guide_on_array_1()
         {
             string code =
-@"def sum ( a, b, c){    return = a + b + c ;}y = 3..4;test = sum(1, { 1, 2}<1>, y<2>);";
+@"def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+y = 3..4;
+test = sum(1, { 1, 2}<1>, y<2>);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 5, 6 }, new object[] { 6, 7 } });
@@ -853,7 +1298,14 @@ namespace ProtoTest.TD.Associative
         public void T039_1467423_replication_guide_on_array_2()
         {
             string code =
-@"def sum ( a, b, c){    return = a + b + c ;}y = 3..4;test = sum(1, { 1, 2}<1>, y<2>);";
+@"
+def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+y = 3..4;
+test = sum(1, { 1, 2}<1>, y<2>);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 5, 6 }, new object[] { 6, 7 } });
@@ -865,7 +1317,17 @@ namespace ProtoTest.TD.Associative
         public void T039_1467423_replication_guide_on_array_3()
         {
             string code =
-@"def sum ( a, b, c){    return = a + b + c ;}test = [Associative]{    y = 3..4;    return = sum(1, { 1, 2}<1>, y<2>);}";
+@"
+def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+test = [Associative]
+{
+    y = 3..4;
+    return = sum(1, { 1, 2}<1>, y<2>);
+}
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 5, 6 }, new object[] { 6, 7 } });
@@ -877,7 +1339,17 @@ namespace ProtoTest.TD.Associative
         public void T039_1467423_replication_guide_on_array_4()
         {
             string code =
-@"def sum ( a, b, c){    return = a + b + c ;}test = [Associative]{    y = 3..4;    return = sum(1, { 1, 2}<1>, y<2>);}";
+@"
+def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+test = [Associative]
+{
+    y = 3..4;
+    return = sum(1, { 1, 2}<1>, y<2>);
+}
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 5, 6 }, new object[] { 6, 7 } });
@@ -889,7 +1361,17 @@ namespace ProtoTest.TD.Associative
         public void T039_1467423_replication_guide_on_array_5()
         {
             string code =
-@"def sum ( a, b, c){    return = a + b + c ;}test = [Associative]{    y = 3..4;    return = Count ( sum(1, { 1, 2}<1>, y<2>) ) > 1 ? sum(1, { 1, 2}<1>, y<2>) : 0;}";
+@"
+def sum ( a, b, c)
+{
+    return = a + b + c ;
+}
+test = [Associative]
+{
+    y = 3..4;
+    return = Count ( sum(1, { 1, 2}<1>, y<2>) ) > 1 ? sum(1, { 1, 2}<1>, y<2>) : 0;
+}
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 5, 6 }, new object[] { 6, 7 } });
@@ -900,7 +1382,16 @@ namespace ProtoTest.TD.Associative
         public void T039_1467423_replication_guide_on_array_6()
         {
             string code =
-@"def foo ( a, b, c){    x = a + b + c ;    return = x;}y = 3..4;test2 = 0..foo(1, { 1, 2}<1>, y<2>);test = test2[1][1];";
+@"
+def foo ( a, b, c)
+{
+    x = a + b + c ;
+    return = x;
+}
+y = 3..4;
+test2 = 0..foo(1, { 1, 2}<1>, y<2>);
+test = test2[1][1];
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { 0, 1, 2, 3, 4, 5, 6, 7 });
@@ -911,7 +1402,15 @@ namespace ProtoTest.TD.Associative
         public void T039_1467423_replication_guide_on_array_7()
         {
             string code =
-@"def foo ( a, b, c){    x = a + b + c ;    return = x;}y = 3..4;test = foo(1, (1..2)<1>, y<2>);";
+@"
+def foo ( a, b, c)
+{
+    x = a + b + c ;
+    return = x;
+}
+y = 3..4;
+test = foo(1, (1..2)<1>, y<2>);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 5, 6 }, new object[] { 6, 7 } });
@@ -922,7 +1421,15 @@ namespace ProtoTest.TD.Associative
         public void T039_1467423_replication_guide_on_array_8()
         {
             string code =
-@"def foo ( a, b, c){    x = a + b + c ;    return = x;}y = 3..4;test = 1 + foo(1, (1..2)<1>, y<2>);";
+@"
+def foo ( a, b, c)
+{
+    x = a + b + c ;
+    return = x;
+}
+y = 3..4;
+test = 1 + foo(1, (1..2)<1>, y<2>);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } });
@@ -934,7 +1441,17 @@ namespace ProtoTest.TD.Associative
         public void T039_1467423_replication_guide_on_array_9()
         {
             string code =
-@"def foo ( a, b, c){    return = a + b + c;}test = [Associative]{    y = 3..4;    return = Count ( foo(1, (1..2..1)<1>, y<2>) ) > 1 ? foo(1, (1..2)<1>, y<2>) : 0;}";
+@"
+def foo ( a, b, c)
+{
+    return = a + b + c;
+}
+test = [Associative]
+{
+    y = 3..4;
+    return = Count ( foo(1, (1..2..1)<1>, y<2>) ) > 1 ? foo(1, (1..2)<1>, y<2>) : 0;
+}
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[]{5, 6}, new object[] {6, 7}});
@@ -946,7 +1463,17 @@ namespace ProtoTest.TD.Associative
         public void T039_1467423_replication_guide_on_array_10()
         {
             string code =
-@"def foo ( a, b, c){    return = a + b + c;}test = [Associative]{    y = 3..4;    return = Count (foo(1, (1..2..1)<1>, y<2>) ) > 1 ? foo(1, (1..2..#2)<1>, y<2>) : 0;}";
+@"
+def foo ( a, b, c)
+{
+    return = a + b + c;
+}
+test = [Associative]
+{
+    y = 3..4;
+    return = Count (foo(1, (1..2..1)<1>, y<2>) ) > 1 ? foo(1, (1..2..#2)<1>, y<2>) : 0;
+}
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] {5, 6}, new object[]{6, 7} } );
@@ -954,11 +1481,16 @@ namespace ProtoTest.TD.Associative
 
         [Test]
         [Category("Replication")]
-        [Category("Failure")]
         public void T039_1467423_replication_guide_on_array_11()
         {
             string code =
-@"test;[Associative]{   test = 1 + (1..2..#2)<2> + {3,4}<2>;}";
+@"
+test;
+[Associative]
+{
+   test = 1 + (1..2..#2)<2> + {3,4}<2>;
+}
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 5, 6 }, new object[] { 6, 7 } });
@@ -969,7 +1501,11 @@ namespace ProtoTest.TD.Associative
         public void T040_1467488_replication_guide_on_array_slices_1()
         {
             string code =
-@"b = 0..5;t1 = 0..(Count(b) - 1)..2;test = b[t1]<1>+b[t1]<2>;";
+@"
+b = 0..5;
+t1 = 0..(Count(b) - 1)..2;
+test = b[t1]<1>+b[t1]<2>;
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 0, 2, 4 }, new object[] { 2, 4, 6 }, new object[] { 4, 6, 8 } });
@@ -980,7 +1516,10 @@ namespace ProtoTest.TD.Associative
         public void T040_1467488_replication_guide_on_array_slices_2()
         {
             string code =
-@"b = 0..3;test = b[0..1]<1>+b[{2,3}]<2>;";
+@"
+b = 0..3;
+test = b[0..1]<1>+b[{2,3}]<2>;
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 2, 3 }, new object[] { 3, 4 } });
@@ -991,7 +1530,14 @@ namespace ProtoTest.TD.Associative
         public void T040_1467488_replication_guide_on_array_slices_3()
         {
             string code =
-@"def foo ( a ){    return = a ;}b = 0..3;test = foo ( b[0..1]<1>+b[{2,3}]<2> );";
+@"
+def foo ( a )
+{
+    return = a ;
+}
+b = 0..3;
+test = foo ( b[0..1]<1>+b[{2,3}]<2> );
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 2, 3 }, new object[] { 3, 4 } });
@@ -1003,7 +1549,14 @@ namespace ProtoTest.TD.Associative
         public void T040_1467488_replication_guide_on_array_slices_4()
         {
             string code =
-@"def foo ( a ){    return = a ;}b = 0..3;test = foo( b[0..1]<1>+b[{2,3}]<2> );";
+@"
+def foo ( a )
+{
+    return = a ;
+}
+b = 0..3;
+test = foo( b[0..1]<1>+b[{2,3}]<2> );
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 2, 3 }, new object[] { 3, 4 } });
@@ -1015,7 +1568,21 @@ namespace ProtoTest.TD.Associative
         public void T040_1467488_replication_guide_on_array_slices_5()
         {
             string code =
-@"def foo ( a ){    return = a ;}b = { { 0, 1}, { 2, 3} };test1;test2;[Imperative]{    test1 = foo ( b[0][0..1] );    test2 = foo ( b[1][{0, 1}] );}";
+@"
+def foo ( a )
+{
+    return = a ;
+}
+
+b = { { 0, 1}, { 2, 3} };
+test1;
+test2;
+[Imperative]
+{
+    test1 = foo ( b[0][0..1] );
+    test2 = foo ( b[1][{0, 1}] );
+}
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", 0);
@@ -1029,7 +1596,20 @@ namespace ProtoTest.TD.Associative
         public void T040_1467488_replication_guide_on_array_slices_6()
         {
             string code =
-@"def foo ( a ){    return = a ;}b = { { 0, 1}, { 2, 3} };test1;test2;[Associative]{    test1 = foo ( b[ {0, 0} ][ 0..1 ] );    test2 = foo ( b[ { 1, 1} ][ {0, 1} ] );}";
+@"
+def foo ( a )
+{
+    return = a ;
+}
+b = { { 0, 1}, { 2, 3} };
+test1;
+test2;
+[Associative]
+{
+    test1 = foo ( b[ {0, 0} ][ 0..1 ] );
+    test2 = foo ( b[ { 1, 1} ][ {0, 1} ] );
+}
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { 0, 1 });
@@ -1042,7 +1622,17 @@ namespace ProtoTest.TD.Associative
         public void T040_1467488_replication_guide_on_array_slices_7()
         {
             string code =
-@"def foo ( a ){    return = a ;}b = { { 0, 1}, { 2, 3} };test = [Associative]{    return = foo ( b[ {0, 1}<1> ][( 0..1 )<2>] );}";
+@"
+def foo ( a )
+{
+    return = a ;
+}
+b = { { 0, 1}, { 2, 3} };
+test = [Associative]
+{
+    return = foo ( b[ {0, 1}<1> ][( 0..1 )<2>] );
+}
+";
             string errmsg = "DNL-1467298 rev 4245 :  replication guides with partial array indexing is not giving the expected output";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { 0, 1 }, new object[] { 2, 3 } });
@@ -1056,7 +1646,20 @@ namespace ProtoTest.TD.Associative
         public void T040_1467488_replication_guide_on_array_slices_8()
         {
             string code =
-@"def foo ( a ){    return = a ;}b = { { 0, 1}, { 2, 3} };def foo2 ( ){    t = foo ( b[ {0, 1} ][( 0..1 ) ] );    return = t;}test = foo2();";
+@"
+def foo ( a )
+{
+    return = a ;
+}
+
+b = { { 0, 1}, { 2, 3} };
+def foo2 ( )
+{
+    t = foo ( b[ {0, 1} ][( 0..1 ) ] );
+    return = t;
+}
+test = foo2();
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { 0, 3 });
@@ -1067,7 +1670,15 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_01()
         {
             string code =
-@"def foo (x1,y1){    return = x1 + y1;}x = {0,1};y = {2, 3};test = foo(x<1>,y<3>);";
+@"
+def foo (x1,y1)
+{
+    return = x1 + y1;
+}
+x = {0,1};
+y = {2, 3};
+test = foo(x<1>,y<3>);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new Object[] { 2, 3 }, new Object[] { 3, 4 } });
@@ -1079,7 +1690,16 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_02()
         {
             string code =
-@"def foo (x1,y1,z1){    return = y1;}x = {0,1};y = {2,3};z = {4,5 };test = foo(x<1>,y<3>,z); // expect this to be treated as :  foo(x<1>,y<2>,z<1>);";
+@"
+def foo (x1,y1,z1)
+{
+    return = y1;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+test = foo(x<1>,y<3>,z); // expect this to be treated as :  foo(x<1>,y<2>,z<1>);
+";
             string errmsg = "MAGN-1707 IndexOutOfRange Exception when replication guides are not applied on all arguments";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new Object[] { 2, 3 }, new Object[] { 2, 3 } });
@@ -1091,7 +1711,16 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_03()
         {
             string code =
-@"def foo (x1,y1,z1){    return = y1;}x = {0,1};y = {2,3};z = {4,5 };test = foo(x, y<2>, z<3>); // expect this to be treated as :  foo(x<1>,y<2>,z<3>);";
+@"
+def foo (x1,y1,z1)
+{
+    return = y1;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+test = foo(x, y<2>, z<3>); // expect this to be treated as :  foo(x<1>,y<2>,z<3>);
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             Object[] t1 = new Object[] { new Object[] { 2, 2 }, new Object[] { 3, 3 } };
@@ -1104,7 +1733,16 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_04()
         {
             string code =
-@"def foo (x1,y1,z1){    return = y1;}x = {0,1};y = {2,3};z = {4,5 };test = foo(x<1>, y, z<3>); // expect this to be treated as :  foo(x<1>,y<1>,z<2>);";
+@"
+def foo (x1,y1,z1)
+{
+    return = y1;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+test = foo(x<1>, y, z<3>); // expect this to be treated as :  foo(x<1>,y<1>,z<2>);
+";
             string errmsg = "MAGN-1707 IndexOutOfRange Exception when replication guides are not applied on all arguments";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new Object[] { 2, 2 }, new Object[] { 3, 3 } });
@@ -1115,7 +1753,16 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_05()
         {
             string code =
-@"def foo (x1,y1,z1){    return = y1;}x = {0,1};y = {2,3};z = {4,5 };test = foo(x<1>, y<1>, z<3>); // expect this to be treated as :  foo(x<1>,y<1>,z<2>);";
+@"
+def foo (x1,y1,z1)
+{
+    return = y1;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+test = foo(x<1>, y<1>, z<3>); // expect this to be treated as :  foo(x<1>,y<1>,z<2>);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new Object[] { 2, 2 }, new Object[] { 3, 3 } });
@@ -1126,7 +1773,16 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_06()
         {
             string code =
-@"def foo (x1,y1,z1){    return = y1;}x = {0,1};y = {2,3};z = {4,5 };test = foo(x<3>, y<1>, z<5>); // expect this to be treated as :  foo(x<2>,y<1>,z<3>); ";
+@"
+def foo (x1,y1,z1)
+{
+    return = y1;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+test = foo(x<3>, y<1>, z<5>); // expect this to be treated as :  foo(x<2>,y<1>,z<3>); 
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test", new object[] { new object[] { new object[] { 2, 2 }, new object[] { 2, 2 } }, new object[] { new object[] { 3, 3 }, new object[] { 3, 3 } } });
@@ -1137,7 +1793,16 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_07()
         {
             string code =
-@"def foo (x1,y1,z1){    return = z1;}x = {0,1};y = {2,3};z = {4,5 };test = foo(x<4>, y<3>, z<1>); // expect this to be treated as :  foo(x<3>,y<2>,z<1>); ";
+@"
+def foo (x1,y1,z1)
+{
+    return = z1;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+test = foo(x<4>, y<3>, z<1>); // expect this to be treated as :  foo(x<3>,y<2>,z<1>); 
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             Object[] t1 = new Object[] { new Object[] { 4, 4 }, new Object[] { 4, 4 } };
@@ -1150,7 +1815,16 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_08()
         {
             string code =
-@"def foo (x1,y1,z1){    return = y1;}x = {0,1};y = {2,3};z = {4,5 };test = foo(x<7>, y<3>, z<6>); // expect this to be treated as :  foo(x<3>,y<1>,z<2>); ";
+@"
+def foo (x1,y1,z1)
+{
+    return = y1;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+test = foo(x<7>, y<3>, z<6>); // expect this to be treated as :  foo(x<3>,y<1>,z<2>); 
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             Object[] t1 = new Object[] { new Object[] { 2, 2 }, new Object[] { 2, 2 } };
@@ -1163,7 +1837,16 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_09()
         {
             string code =
-@"def foo (x1,y1,z1){    return = y1;}x = {0,1};y = {2,3};z = {4,5 };test = foo(x<7>, y<3>, z<6>); // expect this to be treated as :  foo(x<3>,y<1>,z<2>); ";
+@"
+def foo (x1,y1,z1)
+{
+    return = y1;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+test = foo(x<7>, y<3>, z<6>); // expect this to be treated as :  foo(x<3>,y<1>,z<2>); 
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             Object[] t1 = new Object[] { new Object[] { 2, 2 }, new Object[] { 2, 2 } };
@@ -1175,7 +1858,16 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_010()
         {
             string code =
-@"def foo (x1,y1,z1){    return = y1;}x = {0,1};y = {2,3};z = {4,5 };test = foo(x<7>, y<3>, z<6>); // expect this to be treated as :  foo(x<3>,y<1>,z<2>); ";
+@"
+def foo (x1,y1,z1)
+{
+    return = y1;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+test = foo(x<7>, y<3>, z<6>); // expect this to be treated as :  foo(x<3>,y<1>,z<2>); 
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             Object[] t1 = new Object[] { new Object[] { 2, 2 }, new Object[] { 2, 2 } };
@@ -1187,7 +1879,23 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_011()
         {
             string code =
-@"def foo (x1,y1,z1){    return = y1;}test;[Imperative]{    x = {0,1};    y = {2,3};    z = {4,5 };    test = [Associative]    {        return = foo(x<7>, y<3>, z<6>); // expect this to be treated as :  foo(x<3>,y<1>,z<2>);     }}";
+@"
+def foo (x1,y1,z1)
+{
+    return = y1;
+}
+test;
+[Imperative]
+{
+    x = {0,1};
+    y = {2,3};
+    z = {4,5 };
+    test = [Associative]
+    {
+        return = foo(x<7>, y<3>, z<6>); // expect this to be treated as :  foo(x<3>,y<1>,z<2>); 
+    }
+}
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             Object[] t1 = new Object[] { new Object[] { 2, 2 }, new Object[] { 2, 2 } };
@@ -1199,7 +1907,30 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_012()
         {
             string code =
-@"def foo (x1,y1,z1){    return = y1;}a1;a2;a3;test;[Imperative]{    x = {0,1};    y = {2,3};    z = {4,5 };    test = [Associative]    {        a = { foo(x<7>, y<3>, z<6>) => a1; // expect this to be treated as :  foo(x<3>,y<1>,z<2>);               foo(x<2>, y<2>, z<3>) => a2; // expect this to be treated as :  foo(x<1>,y<1>,z<2>);              foo(x<1>, y<3>, z<3>) => a3; // expect this to be treated as :  foo(x<1>,y<2>,z<2>);            }        return = a1;    }}";
+@"
+def foo (x1,y1,z1)
+{
+    return = y1;
+}
+a1;
+a2;
+a3;
+test;
+[Imperative]
+{
+    x = {0,1};
+    y = {2,3};
+    z = {4,5 };
+    test = [Associative]
+    {
+        a = { foo(x<7>, y<3>, z<6>) => a1; // expect this to be treated as :  foo(x<3>,y<1>,z<2>); 
+              foo(x<2>, y<2>, z<3>) => a2; // expect this to be treated as :  foo(x<1>,y<1>,z<2>);
+              foo(x<1>, y<3>, z<3>) => a3; // expect this to be treated as :  foo(x<1>,y<2>,z<2>);
+            }
+        return = a1;
+    }
+}
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             Object[] t1 = new Object[] { new Object[] { 2, 2 }, new Object[] { 2, 2 } };
@@ -1213,7 +1944,18 @@ namespace ProtoTest.TD.Associative
         public void T041_1467460_replication_guide_not_in_sequence_013()
         {
             string code =
-@"def foo (x1,y1,z1){    return = y1;}x = {0,1};y = {2,3};z = {4,5 };test1 = foo(x<2>, y<2>, z<3>) ; // expect this to be treated as :  foo(x<1>,y<1>,z<2>);test2 = foo(x<1>, y<3>, z<3>) ; // expect this to be treated as :  foo(x<1>,y<2>,z<2>);            ";
+@"
+def foo (x1,y1,z1)
+{
+    return = y1;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+test1 = foo(x<2>, y<2>, z<3>) ; // expect this to be treated as :  foo(x<1>,y<1>,z<2>);
+test2 = foo(x<1>, y<3>, z<3>) ; // expect this to be treated as :  foo(x<1>,y<2>,z<2>);
+            
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new Object[] { 2, 2, }, new Object[] { 3, 3 } });
@@ -1226,7 +1968,24 @@ namespace ProtoTest.TD.Associative
         public void T042_1467555_cartesion_product_in_dot_operation_1()
         {
             string code =
-@"class A{    a;    def foo (x1,y1,z1)    {        a = y1;        return = a;    }}x = {0,1};y = {2,3};z = {4,5 };aa = { A.A(), A.A() };test1 = aa.foo(x<2>, y<2>, z<3>) ; // expect this to be treated as :  foo(x<1>,y<1>,z<2>);//test2 = aa.foo(x<1>, y<3>, z<3>) ; // expect this to be treated as :  foo(x<1>,y<2>,z<2>);            ";
+@"
+class A
+{
+    a;
+    def foo (x1,y1,z1)
+    {
+        a = y1;
+        return = a;
+    }
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+aa = { A.A(), A.A() };
+test1 = aa.foo(x<2>, y<2>, z<3>) ; // expect this to be treated as :  foo(x<1>,y<1>,z<2>);
+//test2 = aa.foo(x<1>, y<3>, z<3>) ; // expect this to be treated as :  foo(x<1>,y<2>,z<2>);
+            
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new Object[] { 2, 2, }, new Object[] { 3, 3 } });
@@ -1238,7 +1997,17 @@ namespace ProtoTest.TD.Associative
         public void T0100_FuncCall_Int_AllGuides()
         {
             string code =
-@"def foo (x1,y1,z1){    return = x1+y1+z1;}x = {0,1};y = {2,3};z = {4,5 };test1 = foo(x<1>, y<2>, z<3>) ; ";
+@"
+def foo (x1,y1,z1)
+{
+    return = x1+y1+z1;
+}
+x = {0,1};
+y = {2,3};
+z = {4,5 };
+test1 = foo(x<1>, y<2>, z<3>) ; 
+
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } }, new object[] { new object[] { 7, 8 }, new object[] { 8, 9 } } });
@@ -1246,11 +2015,19 @@ namespace ProtoTest.TD.Associative
 
         [Test]
         [Category("DSDefinedClass_Ported")]
-        [Category("Failure")]
         public void T0101_FuncCall_Double_SomeGuides()
         {
             string code =
-@"def foo (x1,y1,z1){    return = x1+y1+z1;}x = {0.0,1.0};y = {2.0,3.0};z = {4.0,5.0 };test1 = foo(x, y<2>, z<3>) ;       ";
+@"
+def foo (x1,y1,z1)
+{
+    return = x1+y1+z1;
+}
+x = {0.0,1.0};
+y = {2.0,3.0};
+z = {4.0,5.0 };
+test1 = foo(x, y<2>, z<3>) ;       
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { 6.0, 7.0 }, new object[] { 7.0, 8.0 } }, new object[] { new object[] { 7.0, 8.0 }, new object[] { 8.0, 9.0 } } });
@@ -1261,7 +2038,42 @@ namespace ProtoTest.TD.Associative
         public void T0102_FuncCall_Double_SomeGuides()
         {
             string code =
-@"def foo (x1,y1,z1){    return = x1+y1+z1;}x = {0.0,1.0};y = {2.0,3.0};z = {4.0,5.0 };test1 = foo(x, y<2>, z) ;   {    x : int;    y : int;    z : int;    a : int;    constructor A ( x2, y2, z2)    {        y = y2;        x = x2;        z = z2;        a = x + y + z;    }    def foo (x1,y1,z1)    {        return = x1+y1+z1;    }     static def foo2 (x1,y1,z1)    {        return = x1+y1+z1;    }}t1 = A.A(x, y<2>, z);  test2 = t1.a;test = A.A(0,0,0);test3 = test.foo(x, y<2>, z); test4 = A.foo2(x, y<2>, z);      ";
+@"
+def foo (x1,y1,z1)
+{
+    return = x1+y1+z1;
+}
+x = {0.0,1.0};
+y = {2.0,3.0};
+z = {4.0,5.0 };
+test1 = foo(x, y<2>, z) ;   
+{
+    x : int;
+    y : int;
+    z : int;
+    a : int;
+    constructor A ( x2, y2, z2)
+    {
+        y = y2;
+        x = x2;
+        z = z2;
+        a = x + y + z;
+    }
+    def foo (x1,y1,z1)
+    {
+        return = x1+y1+z1;
+    } 
+    static def foo2 (x1,y1,z1)
+    {
+        return = x1+y1+z1;
+    }
+}
+t1 = A.A(x, y<2>, z);  
+test2 = t1.a;
+test = A.A(0,0,0);
+test3 = test.foo(x, y<2>, z); 
+test4 = A.foo2(x, y<2>, z);      
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { 6.0, 7.0 }, new object[] { 8.0, 9.0 } });
@@ -1275,7 +2087,16 @@ namespace ProtoTest.TD.Associative
         public void T0103_FuncCall_Bool_NotInSeq()
         {
             string code =
-@"def foo (x1,y1,z1){    return = x1 == true ? y1 : z1;}x = {true, false};y = {false, true};z = {true, true};test1 = foo(x<2>, y<4>, z<5>) ;          ";
+@"
+def foo (x1,y1,z1)
+{
+    return = x1 == true ? y1 : z1;
+}
+x = {true, false};
+y = {false, true};
+z = {true, true};
+test1 = foo(x<2>, y<4>, z<5>) ;          
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { false, false }, new object[] { true, true } }, new object[] { new object[] { true, true }, new object[] { true, true } } });
@@ -1286,7 +2107,16 @@ namespace ProtoTest.TD.Associative
         public void T0104_FuncCall_Bool_NotInSeq()
         {
             string code =
-@"def foo (x1,y1,z1){    return = x1 == true ? y1 : z1;}x = {true, false};y = {false, true};z = {true, true};test1 = foo(x<4>, y<3>, z<5>) ;   ";
+@"
+def foo (x1,y1,z1)
+{
+    return = x1 == true ? y1 : z1;
+}
+x = {true, false};
+y = {false, true};
+z = {true, true};
+test1 = foo(x<4>, y<3>, z<5>) ;   
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { false, false }, new object[] { true, true } }, new object[] { new object[] { true, true }, new object[] { true, true } } });
@@ -1298,7 +2128,16 @@ namespace ProtoTest.TD.Associative
         public void T0105_FuncCall_Int_NotAllGuides_NotInSeq()
         {
             string code =
-@"def foo (x1,y1,z1){    return = x1 + y1 + z1;}x = {0, 1};y = {2, 3};z = {4, 5};test1 = foo(x, y<2>, z<2>) ;       ";
+@"
+def foo (x1,y1,z1)
+{
+    return = x1 + y1 + z1;
+}
+x = {0, 1};
+y = {2, 3};
+z = {4, 5};
+test1 = foo(x, y<2>, z<2>) ;       
+";
             string errmsg = "DNL-1467580 IndexOutOfRange Exception when replication guides are not applied on all arguments";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { 6, 8 }, new object[] { 7, 9 } });
@@ -1309,7 +2148,15 @@ namespace ProtoTest.TD.Associative
         public void T0106_FuncCall_Int_MultipleGuides()
         {
             string code =
-@"def foo (x1,y1){    return = x1 + y1;}x = {{0, 1},{2,3}};y = {{4,5},{6,7}};test1 = foo(x<1><2>, y<3><4>) ;          ";
+@"
+def foo (x1,y1)
+{
+    return = x1 + y1;
+}
+x = {{0, 1},{2,3}};
+y = {{4,5},{6,7}};
+test1 = foo(x<1><2>, y<3><4>) ;          
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4, 5 }, new object[] { 5, 6 } }, new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } } }, new object[] { new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } }, new object[] { new object[] { 8, 9 }, new object[] { 9, 10 } } } });
@@ -1320,7 +2167,15 @@ namespace ProtoTest.TD.Associative
         public void T0107_FuncCall_Int_MultipleGuides_NotAllInSeq()
         {
             string code =
-@"def foo (x1,y1){    return = x1 + y1;}x = {{0, 1},{2,3}};y = {{4,5},{6,7}};test1 = foo(x<1><1>, y<2><3>) ;         ";
+@"
+def foo (x1,y1)
+{
+    return = x1 + y1;
+}
+x = {{0, 1},{2,3}};
+y = {{4,5},{6,7}};
+test1 = foo(x<1><1>, y<2><3>) ;         
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4, 5 }, new object[] { 5, 6 } }, new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } } }, new object[] { new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } }, new object[] { new object[] { 8, 9 }, new object[] { 9, 10 } } } });
@@ -1331,7 +2186,15 @@ namespace ProtoTest.TD.Associative
         public void T0108_FuncCall_Int_MultipleGuides_NotAllInSeq()
         {
             string code =
-@"def foo (x1,y1){    return = x1 + y1;}x = {{0, 1},{2,3}};y = {{4,5},{6,7}};test1 = foo(x<1><3>, y<4><5>) ;        ";
+@"
+def foo (x1,y1)
+{
+    return = x1 + y1;
+}
+x = {{0, 1},{2,3}};
+y = {{4,5},{6,7}};
+test1 = foo(x<1><3>, y<4><5>) ;        
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4, 5 }, new object[] { 5, 6 } }, new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } } }, new object[] { new object[] { new object[] { 6, 7 }, new object[] { 7, 8 } }, new object[] { new object[] { 8, 9 }, new object[] { 9, 10 } } } });
@@ -1342,7 +2205,15 @@ namespace ProtoTest.TD.Associative
         public void T0109_FuncCall_Int_MultipleGuides_NotAllInSeq()
         {
             string code =
-@"def foo (x1,y1){    return = x1 + y1;}x = {{0, 1},{2,3}};y = {{4,5},{6,7}};test1 = foo(x<2><4>, y<3><1>) ;            ";
+@"
+def foo (x1,y1)
+{
+    return = x1 + y1;
+}
+x = {{0, 1},{2,3}};
+y = {{4,5},{6,7}};
+test1 = foo(x<2><4>, y<3><1>) ;            
+";
             string errmsg = "MAGN-1708 NotImplemented Exception when multiple non-sequential replication guides are used on multidimensional arrays";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4, 5 }, new object[] { 6, 7 } }, new object[] { new object[] { 5, 6 }, new object[] { 7, 8 } } }, new object[] { new object[] { new object[] { 6, 7 }, new object[] { 8, 9 } }, new object[] { new object[] { 7, 8 }, new object[] { 9, 10 } } } });
@@ -1353,7 +2224,15 @@ namespace ProtoTest.TD.Associative
         public void T0110_FuncCall_Int_MultipleGuides_NotAllInSeq()
         {
             string code =
-@"def foo (x1,y1){    return = x1 + y1;}x = {{0, 1},{2,3}};y = {{4,5},{6,7}};test1 = foo(x<4><8>, y<7><3>) ;            ";
+@"
+def foo (x1,y1)
+{
+    return = x1 + y1;
+}
+x = {{0, 1},{2,3}};
+y = {{4,5},{6,7}};
+test1 = foo(x<4><8>, y<7><3>) ;            
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4, 5 }, new object[] { 6, 7 } }, new object[] { new object[] { 5, 6 }, new object[] { 7, 8 } } }, new object[] { new object[] { new object[] { 6, 7 }, new object[] { 8, 9 } }, new object[] { new object[] { 7, 8 }, new object[] { 9, 10 } } } });
@@ -1364,7 +2243,15 @@ namespace ProtoTest.TD.Associative
         public void T0111_FuncCall_Int_MultipleGuides_NotAllInSeq()
         {
             string code =
-@"def foo (x1,y1){    return = x1 + y1;}x = {{0, 1},{2,3}};y = {{4,5},{6,7}};test1 = foo(x<3><5>, y<4><1>) ;            ";
+@"
+def foo (x1,y1)
+{
+    return = x1 + y1;
+}
+x = {{0, 1},{2,3}};
+y = {{4,5},{6,7}};
+test1 = foo(x<3><5>, y<4><1>) ;            
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4, 5 }, new object[] { 6, 7 } }, new object[] { new object[] { 5, 6 }, new object[] { 7, 8 } } }, new object[] { new object[] { new object[] { 6, 7 }, new object[] { 8, 9 } }, new object[] { new object[] { 7, 8 }, new object[] { 9, 10 } } } });
@@ -1375,7 +2262,15 @@ namespace ProtoTest.TD.Associative
         public void T0112_FuncCall_Int_SingleAndMultipleGuides()
         {
             string code =
-@"def foo (x1,y1){    return = x1 + y1;}x = {0,1};y = {{4,5},{6,7}};test1 = foo(x<1>, y<2><3>) ;        ";
+@"
+def foo (x1,y1)
+{
+    return = x1 + y1;
+}
+x = {0,1};
+y = {{4,5},{6,7}};
+test1 = foo(x<1>, y<2><3>) ;        
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { 4, 5 }, new object[] { 6, 7 } }, new object[] { new object[] { 5, 6 }, new object[] { 7, 8 } } });
@@ -1387,7 +2282,15 @@ namespace ProtoTest.TD.Associative
         public void T0113_FuncCall_Int_SingleAndMultipleGuides_NotInSeq()
         {
             string code =
-@"def foo (x1,y1){    return = x1 + y1;}x = {0,1};y = {{4,5},{6,7}};test1 = foo(x, y<2><3>) ;        ";
+@"
+def foo (x1,y1)
+{
+    return = x1 + y1;
+}
+x = {0,1};
+y = {{4,5},{6,7}};
+test1 = foo(x, y<2><3>) ;        
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { 4, 5 }, new object[] { 6, 7 } }, new object[] { new object[] { 5, 6 }, new object[] { 7, 8 } } });
@@ -1397,7 +2300,15 @@ namespace ProtoTest.TD.Associative
         public void T0114_FuncCall_Int_SingleAndMultipleGuides_NotInSeq()
         {
             string code =
-@"def foo (x1,y1){    return = x1 + y1;}x = {0,1};y = {{4,5},{6,7}};test1 = foo(x<1>, y<1><3>) ;            ";
+@"
+def foo (x1,y1)
+{
+    return = x1 + y1;
+}
+x = {0,1};
+y = {{4,5},{6,7}};
+test1 = foo(x<1>, y<1><3>) ;            
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { 4, 5 }, new object[] { 7, 8 } });
@@ -1408,7 +2319,16 @@ namespace ProtoTest.TD.Associative
         public void T0115_FuncCall_HeterogenousInput()
         {
             string code =
-@" import(""FFITarget.dll"");def foo (x1:int,y1:TestObjectA){    return = x1 + y1.a;}x = {0,1};y = {TestObjectA.TestObjectA(2), TestObjectA.TestObjectA(3)};test1 = foo(x<1>, y<3>) ;            ";
+@" 
+import(""FFITarget.dll"");
+def foo (x1:int,y1:TestObjectA)
+{
+    return = x1 + y1.a;
+}
+x = {0,1};
+y = {TestObjectA.TestObjectA(2), TestObjectA.TestObjectA(3)};
+test1 = foo(x<1>, y<3>) ;            
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { 2, 3 }, new object[] { 3, 4 } });
@@ -1419,7 +2339,16 @@ namespace ProtoTest.TD.Associative
         public void T0116_FuncCall_HeterogenousInput_MultipleGuides()
         {
             string code =
-@" import(""FFITarget.dll"");def foo (x1:double,y1:TestObjectA){    return = x1 + y1.a;}x = {{0.0,1.0}, {2.0, 3.0} };y = { TestObjectA.TestObjectA(2), TestObjectA.TestObjectA(3)};test1 = foo(x<1><2>, y<1>) ;            ";
+@" 
+import(""FFITarget.dll"");
+def foo (x1:double,y1:TestObjectA)
+{
+    return = x1 + y1.a;
+}
+x = {{0.0,1.0}, {2.0, 3.0} };
+y = { TestObjectA.TestObjectA(2), TestObjectA.TestObjectA(3)};
+test1 = foo(x<1><2>, y<1>) ;            
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { 2.0, 3.0 }, new object[] { 5.0, 6.0 } });
@@ -1430,7 +2359,16 @@ namespace ProtoTest.TD.Associative
         public void T0117_FuncCall_HeterogenousInput_MultipleGuides()
         {
             string code =
-@" import(""FFITarget.dll"");def foo (x1:double,y1:TestObjectA){    return = x1 + y1.a;}x = {{0.0,1.0}, {2.0, 3.0} };y = { {TestObjectA.TestObjectA(4), TestObjectA.TestObjectA(5)}, { TestObjectA.TestObjectA(6), TestObjectA.TestObjectA(7) } };test1 = foo(x<1><2>, y<3><4>) ;            ";
+@" 
+import(""FFITarget.dll"");
+def foo (x1:double,y1:TestObjectA)
+{
+    return = x1 + y1.a;
+}
+x = {{0.0,1.0}, {2.0, 3.0} };
+y = { {TestObjectA.TestObjectA(4), TestObjectA.TestObjectA(5)}, { TestObjectA.TestObjectA(6), TestObjectA.TestObjectA(7) } };
+test1 = foo(x<1><2>, y<3><4>) ;            
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { new object[] { 4.0, 5.0 }, new object[] { 5.0, 6.0 } }, new object[] { new object[] { 6.0, 7.0 }, new object[] { 7.0, 8.0 } } }, new object[] { new object[] { new object[] { 6.0, 7.0 }, new object[] { 7.0, 8.0 } }, new object[] { new object[] { 8.0, 9.0 }, new object[] { 9.0, 10.0 } } } });
@@ -1442,7 +2380,16 @@ namespace ProtoTest.TD.Associative
         public void T0118_FuncCall_HeterogenousInput_SingleGuides()
         {
             string code =
-@" import(""FFITarget.dll"");def foo (x1:double,y1:TestObjectA){    return = x1 + y1.a;}x = {0.0,1.0 };y = { TestObjectA.TestObjectA(2), TestObjectA.TestObjectA(3) };test1 = foo(x<1>, y) ;            ";
+@" 
+import(""FFITarget.dll"");
+def foo (x1:double,y1:TestObjectA)
+{
+    return = x1 + y1.a;
+}
+x = {0.0,1.0 };
+y = { TestObjectA.TestObjectA(2), TestObjectA.TestObjectA(3) };
+test1 = foo(x<1>, y) ;            
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { 2.0, 4.0 });
@@ -1454,7 +2401,17 @@ namespace ProtoTest.TD.Associative
         public void T0119_FuncCall_HeterogenousInput_SingleGuides()
         {
             string code =
-@" import(""FFITarget.dll"");def foo (x1:double,y1:TestObjectA, z : int){    return = x1 + y1.a + z;}x = { 0.0,1.0 };y = { TestObjectA.TestObjectA(2), TestObjectA.TestObjectA(3) };z = {4, 5};test1 = foo(x<1>, y, z<2>) ;            ";
+@" 
+import(""FFITarget.dll"");
+def foo (x1:double,y1:TestObjectA, z : int)
+{
+    return = x1 + y1.a + z;
+}
+x = { 0.0,1.0 };
+y = { TestObjectA.TestObjectA(2), TestObjectA.TestObjectA(3) };
+z = {4, 5};
+test1 = foo(x<1>, y, z<2>) ;            
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { 6.0, 7.0 }, new object[] { 8.0, 9.0 } });
@@ -1465,7 +2422,17 @@ namespace ProtoTest.TD.Associative
         public void T0120_FuncCall_HeterogenousInput_jagged_SingleGuides()
         {
             string code =
-@" import(""FFITarget.dll"");def foo (x1:double,y1:TestObjectA, z : int){    return = x1 + y1.a + z;}x = { 0.0 };y = { TestObjectA.TestObjectA(2), TestObjectA.TestObjectA(3) };z = {4, 5};test1 = foo(x<1>, y<2>, z<3>) ;            ";
+@" 
+import(""FFITarget.dll"");
+def foo (x1:double,y1:TestObjectA, z : int)
+{
+    return = x1 + y1.a + z;
+}
+x = { 0.0 };
+y = { TestObjectA.TestObjectA(2), TestObjectA.TestObjectA(3) };
+z = {4, 5};
+test1 = foo(x<1>, y<2>, z<3>) ;            
+";
             // This is just a sample test case of replication guides on jagged array. Replication on jagged array is not yet defined properly
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
@@ -1477,7 +2444,26 @@ namespace ProtoTest.TD.Associative
         public void T0121_InstanceCall_Int_SingleGuides()
         {
             string code =
-@" class A{    x : int;    y : int;    z : int;    a : int;    constructor A ( x2, y2, z2)    {        y = y2;        x = x2;        z = z2;        a = x + y + z;    }}x = { 1, 2 };y = { 3, 4 };z = { 5, 6 };test1 = A.A(x<1>, y<2>, z<3>).a ;            ";
+@" 
+class A
+{
+    x : int;
+    y : int;
+    z : int;
+    a : int;
+    constructor A ( x2, y2, z2)
+    {
+        y = y2;
+        x = x2;
+        z = z2;
+        a = x + y + z;
+    }
+}
+x = { 1, 2 };
+y = { 3, 4 };
+z = { 5, 6 };
+test1 = A.A(x<1>, y<2>, z<3>).a ;            
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new object[] { new object[] { new object[] { 9, 10 }, new object[] { 10, 11 } }, new object[] { new object[] { 10, 11 }, new object[] { 11, 12 } } });
@@ -1489,7 +2475,62 @@ namespace ProtoTest.TD.Associative
         public void T0122_ReplicationGudes_Inside_ClassAndFunctionBody()
         {
             string code =
-@" def func (x1:int[],y1:int[],z1:int[]){    return = A.foo6( x1<2> , y1<2> , z1<5> );}class A{    x : int[];    y : int[];    z : int[];    a ;    p1 = x<2> + y<2> + z<5>;    constructor A ( )    {        this.x = {0,1};        this.y = {2,3};        this.z = {4,5};        a = this.foo(this.x<2>, this.y<2>, this.z<5>) ;      }    def foo (x1,y1,z1)    {        return = x1+y1+z1;    }     def foo2 ()    {        return = this.foo(this.x<2>, this.y<2>, this.z<5>) ;     }    def foo3 ()    {        return = this.foo(x<2>, y<2>, z<5>) ;     }    static def foo4(x1, y1, z1)    {        return = x1 + y1 + z1;    }    static def foo5(x1:int[], y1:int[], z1:int[])    {        return = this.foo6( x1<2>, y1<2>, z1<5> );    }    static def foo6(x1:int, y1:int, z1:int)    {        return = x1 + y1 + z1;    }}x = {0,1};y = {2,3};z = {4,5};test = A.A();  test1 = test.a;test2 = test.p1;test3 = test.foo2(); test4 = test.foo3();test5 = A.foo4(x<2>, y<2>, z<5>);test6 = A.foo5(x, y, z);test7 = func(x, y, z);            ";
+@" 
+def func (x1:int[],y1:int[],z1:int[])
+{
+    return = A.foo6( x1<2> , y1<2> , z1<5> );
+}
+class A
+{
+    x : int[];
+    y : int[];
+    z : int[];
+    a ;
+    p1 = x<2> + y<2> + z<5>;
+    constructor A ( )
+    {
+        this.x = {0,1};
+        this.y = {2,3};
+        this.z = {4,5};
+        a = this.foo(this.x<2>, this.y<2>, this.z<5>) ;  
+    }
+    def foo (x1,y1,z1)
+    {
+        return = x1+y1+z1;
+    } 
+    def foo2 ()
+    {
+        return = this.foo(this.x<2>, this.y<2>, this.z<5>) ; 
+    }
+    def foo3 ()
+    {
+        return = this.foo(x<2>, y<2>, z<5>) ; 
+    }
+    static def foo4(x1, y1, z1)
+    {
+        return = x1 + y1 + z1;
+    }
+    static def foo5(x1:int[], y1:int[], z1:int[])
+    {
+        return = this.foo6( x1<2>, y1<2>, z1<5> );
+    }
+    static def foo6(x1:int, y1:int, z1:int)
+    {
+        return = x1 + y1 + z1;
+    }
+}
+x = {0,1};
+y = {2,3};
+z = {4,5};
+test = A.A();  
+test1 = test.a;
+test2 = test.p1;
+test3 = test.foo2(); 
+test4 = test.foo3();
+test5 = A.foo4(x<2>, y<2>, z<5>);
+test6 = A.foo5(x, y, z);
+test7 = func(x, y, z);            
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new Object[] { new Object[] { 6, 7 }, new Object[] { 8, 9 } });
@@ -1506,7 +2547,22 @@ namespace ProtoTest.TD.Associative
         public void T0123_Replication_BuiltinMethods()
         {
             string code =
-@" [Associative]{    x = {0,1,2,3};    y = {0,1};    z = { ""int"", ""double"" };    test1 = Contains ( x, y);    test2 = IndexOf ( x, y) ;    test3 = Remove ( x, y) ;    test4 = Insert ( x, y, y) ;     test5 = NormalizeDepth ( x, y) ;     test6 = RemoveIfNot ( x, z) ;     test7 = SortIndexByValue ( x, y) ;     test8 = Map ( {1,2}, {3,4}, {2,3}) ;   }     ";
+@" 
+[Associative]
+{
+    x = {0,1,2,3};
+    y = {0,1};
+    z = { ""int"", ""double"" };
+    test1 = Contains ( x, y);
+    test2 = IndexOf ( x, y) ;
+    test3 = Remove ( x, y) ;
+    test4 = Insert ( x, y, y) ; 
+    test5 = NormalizeDepth ( x, y) ; 
+    test6 = RemoveIfNot ( x, z) ; 
+    test7 = SortIndexByValue ( x, y) ; 
+    test8 = Map ( {1,2}, {3,4}, {2,3}) ;   
+}     
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
 
@@ -1525,7 +2581,31 @@ namespace ProtoTest.TD.Associative
         public void T0124_ReplicationGuides_BuiltinMethods()
         {
             string code =
-@" test1;test2;test3;test4;test5;test6;test7;test8;[Associative]{    x = {{0,1},{2,3}};    y = {0,1};    z = { ""int"", ""double"" };    test1 = Contains ( x<1>, y<2>);    test2 = IndexOf ( x<1>, y<2>) ;    test3 = Remove ( x<1>, y<2>) ;     test4 = Insert ( x<1>, y<2>, y<2>) ;    test5 = NormalizeDepth ( x<1>, y<2>) ;     test6 = RemoveIfNot ( x<1>, z<2>) ;     test7 = SortIndexByValue ( x<1>, y<2>) ;     test8 = Map ( {1,2}<1>, {5,6}<2>, {2,3}<2>) ;     }    ";
+@" 
+test1;
+test2;
+test3;
+test4;
+test5;
+test6;
+test7;
+test8;
+[Associative]
+{
+    x = {{0,1},{2,3}};
+    y = {0,1};
+    z = { ""int"", ""double"" };
+    test1 = Contains ( x<1>, y<2>);
+    test2 = IndexOf ( x<1>, y<2>) ;
+    test3 = Remove ( x<1>, y<2>) ; 
+    test4 = Insert ( x<1>, y<2>, y<2>) ;
+    test5 = NormalizeDepth ( x<1>, y<2>) ; 
+    test6 = RemoveIfNot ( x<1>, z<2>) ; 
+    test7 = SortIndexByValue ( x<1>, y<2>) ; 
+    test8 = Map ( {1,2}<1>, {5,6}<2>, {2,3}<2>) ; 
+    
+}    
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new Object[] { new Object[] { true, true }, new Object[] { false, false } });
@@ -1542,7 +2622,16 @@ namespace ProtoTest.TD.Associative
         public void T0125_ReplicationGudes_MathFunctions()
         {
             string code =
-@" import(""DSCoreNodes.dll"");x = {0,1,2,3};y = {0,1};test1 = Math.Min( x, y); test2 = Math.Min( x<1>, y<2>);test3 = Math.Max( x, y); test4 = Math.Max( x<1>, y<2>);    ";
+@" 
+import(""DSCoreNodes.dll"");
+x = {0,1,2,3};
+y = {0,1};
+test1 = Math.Min( x, y); 
+test2 = Math.Min( x<1>, y<2>);
+test3 = Math.Max( x, y); 
+test4 = Math.Max( x<1>, y<2>);
+    
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new Object[] { 0, 1 });
@@ -1555,7 +2644,50 @@ namespace ProtoTest.TD.Associative
         public void T0126_ReplicationGudes_ModifierBlock()
         {
             string code =
-@" test1;test2;test3;test4;test5;test6;test7;test8;[Associative]{    x = {{0,1},{2,3}};    y = {0,1};    z = { ""int"", ""double"" };    test1 = { x;	                        Contains ( x<1>, y<2>);              }                  test2 = { IndexOf ( x<1>, y<2>);              }     test3 = { y;              Remove ( x<1>, y<2>);              }     test4 = { x;              y;              Insert ( x<1>, y<2>, y<2>) ;               }    test5 = { x=>a1;	                        NormalizeDepth ( a1<1>, y<2>) ;               }    test6 = { 0;              1;              RemoveIfNot ( x<1>, z<2>) ;              }    test7 = { x => a1;              y => a2;              SortIndexByValue ( a1<1>, a2<2>) ;               }    test8 = {               Map ( {1,2}<1>, {5,6}<2>, {2,3}<2>) ;               }	}    ";
+@" 
+test1;
+test2;
+test3;
+test4;
+test5;
+test6;
+test7;
+test8;
+[Associative]
+{
+    x = {{0,1},{2,3}};
+    y = {0,1};
+    z = { ""int"", ""double"" };
+    test1 = { x;	          
+              Contains ( x<1>, y<2>);
+              }
+              
+    test2 = { IndexOf ( x<1>, y<2>);
+              } 
+    test3 = { y;
+              Remove ( x<1>, y<2>);
+              } 
+    test4 = { x;
+              y;
+              Insert ( x<1>, y<2>, y<2>) ; 
+              }
+    test5 = { x=>a1;	          
+              NormalizeDepth ( a1<1>, y<2>) ; 
+              }
+    test6 = { 0;
+              1;
+              RemoveIfNot ( x<1>, z<2>) ;
+              }
+    test7 = { x => a1;
+              y => a2;
+              SortIndexByValue ( a1<1>, a2<2>) ; 
+              }
+    test8 = { 
+              Map ( {1,2}<1>, {5,6}<2>, {2,3}<2>) ; 
+              }	
+}
+    
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new Object[] { new Object[] { true, true }, new Object[] { false, false } });
@@ -1575,7 +2707,58 @@ namespace ProtoTest.TD.Associative
         public void T0127_ReplicationGudes_ModifierBlock()
         {
             string code =
-@" class A{    a;    constructor A (a1)    {        a = a1;    }    def foo ( a1 , b1 )    {        return = a1 + b1;    }    static def foo2 ( a1, b1 )    {        return = a1 + b1;    }}def foo ( x, y ){   return = x + y;}[Associative]{    x = {0,1};    y = {2,3};        test1 = { foo ( x<1>, y<2>);            }                  test2 = { A.A(0) => a1;              a1.foo(x<1>, y<2>);            }                   test3 = { a1.foo(x<1>,y<1>);            }                 test4 = { A.foo2(x,y<2>) ;            }                  test5 = { A.A({0,1})=>a2;	                        a2<1>.foo(y<2>);             }                  //test6 = { A.A({0,1})=>a2;	                        //a2<1>.foo(y)<2>;            //}                  test7 = { 1 == 1 ? foo ( x<1>, y<2>) : 0;	                       }    }  ";
+@" 
+class A
+{
+    a;
+    constructor A (a1)
+    {
+        a = a1;
+    }
+    def foo ( a1 , b1 )
+    {
+        return = a1 + b1;
+    }
+    static def foo2 ( a1, b1 )
+    {
+        return = a1 + b1;
+    }
+}
+def foo ( x, y )
+{
+   return = x + y;
+}
+[Associative]
+{
+    x = {0,1};
+    y = {2,3};
+    
+    test1 = { foo ( x<1>, y<2>);
+            }
+              
+    test2 = { A.A(0) => a1;
+              a1.foo(x<1>, y<2>);
+            } 
+              
+    test3 = { a1.foo(x<1>,y<1>);
+            } 
+            
+    test4 = { A.foo2(x,y<2>) ;
+            }
+              
+    test5 = { A.A({0,1})=>a2;	          
+              a2<1>.foo(y<2>); 
+            }
+              
+    //test6 = { A.A({0,1})=>a2;	          
+              //a2<1>.foo(y)<2>;
+            //}
+              
+    test7 = { 1 == 1 ? foo ( x<1>, y<2>) : 0;	           
+            }
+    
+}  
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("test1", new Object[] { new Object[] { 2, 3 }, new Object[] { 3, 4 } });
@@ -1593,7 +2776,69 @@ namespace ProtoTest.TD.Associative
         public void T0128_ReplicationGudes_InlineCondition()
         {
             string code =
-@" import(""DSCoreNodes.dll"");def foo1(x,y){    return = x + y;}def foo2(){    return = {1, 2};}def foo3(){    return = {3, 4};}b = Count(foo1(foo2()<1>,foo3()<2>));a = Count(foo1(foo2()<1>,foo3()<2>)) == 2 ? foo1((5..6)<1>, (7..8)<2>) : foo1(foo2()<1>,foo3()<2>);c1 = 5..6;c2 = Math.Min ({0,1},{0,1} );c3 = foo1 ( c1<1>, c2<2>); // {{5,6},{6,7}}c4 = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;class A{    a : int;    constructor A()    {        a = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;    }    def func ()    {        return = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;    }}def func ( ) {    return = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;}t1 = [Imperative]{    return = [Associative]    {        return = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;    }}t2 = [Imperative]{    return = [Associative]    {        return = [Imperative]        {            return = [Associative]            {                return = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;            }        }    }}	t3 = func();t = A.A();t4 = t.a;t5 = t.func();	";
+@" 
+import(""DSCoreNodes.dll"");
+def foo1(x,y)
+{
+    return = x + y;
+}
+def foo2()
+{
+    return = {1, 2};
+}
+def foo3()
+{
+    return = {3, 4};
+}
+b = Count(foo1(foo2()<1>,foo3()<2>));
+a = Count(foo1(foo2()<1>,foo3()<2>)) == 2 ? foo1((5..6)<1>, (7..8)<2>) : foo1(foo2()<1>,foo3()<2>);
+c1 = 5..6;
+c2 = Math.Min ({0,1},{0,1} );
+c3 = foo1 ( c1<1>, c2<2>); // {{5,6},{6,7}}
+c4 = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;
+class A
+{
+    a : int;
+    constructor A()
+    {
+        a = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;
+    }
+    def func ()
+    {
+        return = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;
+    }
+}
+def func ( ) 
+{
+    return = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;
+}
+t1 = 
+[Imperative]
+{
+    return = [Associative]
+    {
+        return = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;
+    }
+}
+t2 = 
+[Imperative]
+{
+    return = [Associative]
+    {
+        return = [Imperative]
+        {
+            return = [Associative]
+            {
+                return = Average ( foo1 ( (5..6)<1>, Math.Min ({0,1},{0,1} )<2>) ) > 5 ? Average (c3) :  0;
+            }
+        }
+    }
+}	
+t3 = func();
+t = A.A();
+t4 = t.a;
+t5 = t.func();	
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("a", new Object[] { new Object[] { 12, 13 }, new Object[] { 13, 14 } });
@@ -1612,7 +2857,26 @@ namespace ProtoTest.TD.Associative
         public void T0129_ReplicationGudes_InlineCondition()
         {
             string code =
-@" def foo1(x,y){    return = x + y;}def foo2(){    return = {1, 2};}def foo3(){    return = {3, 4};}def foo ( x ){    return = x;}x = 2;t1 = foo ( x > 1 ? foo1(foo2()<1>,foo3()<2>) : 0);";
+@" 
+def foo1(x,y)
+{
+    return = x + y;
+}
+def foo2()
+{
+    return = {1, 2};
+}
+def foo3()
+{
+    return = {3, 4};
+}
+def foo ( x )
+{
+    return = x;
+}
+x = 2;
+t1 = foo ( x > 1 ? foo1(foo2()<1>,foo3()<2>) : 0);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[] { new Object[] { 4, 5 }, new Object[] { 5, 6 } });
@@ -1623,7 +2887,26 @@ namespace ProtoTest.TD.Associative
         public void T0130_ReplicationGudes_InlineCondition()
         {
             string code =
-@" def foo1(x,y){    return = x + y;}def foo2(){    return = {1, 2};}def foo3(){    return = {3, 4};}def foo ( x ){    return = x;}x = 2;t1 = foo ( x > 1 ? foo1(foo2()<1>,foo3()<2>) : 0);";
+@" 
+def foo1(x,y)
+{
+    return = x + y;
+}
+def foo2()
+{
+    return = {1, 2};
+}
+def foo3()
+{
+    return = {3, 4};
+}
+def foo ( x )
+{
+    return = x;
+}
+x = 2;
+t1 = foo ( x > 1 ? foo1(foo2()<1>,foo3()<2>) : 0);
+";
             string errmsg = "DNL-1467591 replication guides in class instantiation is not giving expected output";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new [] { new object[] {4, 5}, new object[]{5, 6} });
@@ -1634,7 +2917,30 @@ namespace ProtoTest.TD.Associative
         public void T0131_ReplicationGudes_InlineCondition()
         {
             string code =
-@" def foo1(x,y){    return = x + y;}def foo2(){    return = {1, 2};}def foo3(){    return = {3, 4};}def fooo ( x ){    return = x;}def foo ( x ){    return = fooo ( x > 1 ? foo1(foo2()<1>,foo3()<2>) : 0);}x = 2;t1 = foo ( x );";
+@" 
+def foo1(x,y)
+{
+    return = x + y;
+}
+def foo2()
+{
+    return = {1, 2};
+}
+def foo3()
+{
+    return = {3, 4};
+}
+def fooo ( x )
+{
+    return = x;
+}
+def foo ( x )
+{
+    return = fooo ( x > 1 ? foo1(foo2()<1>,foo3()<2>) : 0);
+}
+x = 2;
+t1 = foo ( x );
+";
             string errmsg = "DNL-1467591 replication guides in class instantiation is not giving expected output";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[] { new object[]{4, 5}, new object[] {5, 6}});
@@ -1645,7 +2951,26 @@ namespace ProtoTest.TD.Associative
         public void T0132_ReplicationGudes_InlineCondition()
         {
             string code =
-@" def foo (x,y,z){    return = x + y + z;}x = 2;t1 = x > 2 ? 0 : foo({1,2}<1>,{3,4}<5>, {5,6}<3>);t2 = x > 2 ? 0 : foo({1,2}<1>,{3,4}<3>, x);t3 = x > 2 ? 0 : foo({1,2}<1>,{3,4}<5>, {5,6}<3>);t4 = [Associative]{     return = [Imperative]     {          return = [Associative]          {               return = x > 2 ? 0 : foo({1,2}<1>,{3,4}<3>, x);          }     }}";
+@" 
+def foo (x,y,z)
+{
+    return = x + y + z;
+}
+x = 2;
+t1 = x > 2 ? 0 : foo({1,2}<1>,{3,4}<5>, {5,6}<3>);
+t2 = x > 2 ? 0 : foo({1,2}<1>,{3,4}<3>, x);
+t3 = x > 2 ? 0 : foo({1,2}<1>,{3,4}<5>, {5,6}<3>);
+t4 = [Associative]
+{
+     return = [Imperative]
+     {
+          return = [Associative]
+          {
+               return = x > 2 ? 0 : foo({1,2}<1>,{3,4}<3>, x);
+          }
+     }
+}
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[] { new Object[] { new Object[] { 9, 10 }, new Object[] { 10, 11 } }, new Object[] { new Object[] { 10, 11 }, new Object[] { 11, 12 } } });
@@ -1659,7 +2984,17 @@ namespace ProtoTest.TD.Associative
         public void T0133_ReplicationGudes_RangeExpr()
         {
             string code =
-@" def foo (x,y,z){    return = x + y + z;}x = 2;t1 = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));t2 = Count(foo({1,2}<1>,{3,4}<3>, x))..4..#3;t3 = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));t4 = Count(foo({1,2}<1>,{3,4}<3>, x))..4..#3;";
+@" 
+def foo (x,y,z)
+{
+    return = x + y + z;
+}
+x = 2;
+t1 = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));
+t2 = Count(foo({1,2}<1>,{3,4}<3>, x))..4..#3;
+t3 = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));
+t4 = Count(foo({1,2}<1>,{3,4}<3>, x))..4..#3;
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[] { 0, 1, 2 });
@@ -1673,7 +3008,35 @@ namespace ProtoTest.TD.Associative
         public void T0134_ReplicationGudes_RangeExpr()
         {
             string code =
-@" def foo(){    return = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));}    def foo (x,y,z){    return = x + y + z;}def foo2 (){    return = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));}x = 2;t1 = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));t2 = foo();t3 = foo2();t4 = [Associative]{    return = [Imperative]    {         return = [Associative]         {              return = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));                       }    }}";
+@" 
+def foo()
+{
+    return = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));
+}
+    
+def foo (x,y,z)
+{
+    return = x + y + z;
+}
+def foo2 ()
+{
+    return = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));
+}
+x = 2;
+t1 = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));
+t2 = foo();
+t3 = foo2();
+t4 = [Associative]
+{
+    return = [Imperative]
+    {
+         return = [Associative]
+         {
+              return = 0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>));              
+         }
+    }
+}
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[] { 0, 1, 2 });
@@ -1687,7 +3050,34 @@ namespace ProtoTest.TD.Associative
         public void T0135_ReplicationGudes_ArraySlicingScope()
         {
             string code =
-@" def foo (x,y,z){    return = x + y + z;}def foo2 : int[] (){    return = a[0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>))];}def foo: int[] (){    return = a[0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>))];}a = {1,2,3,4};b = a[0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>))];c = foo2();d = foo();f = [Associative]{    return = [Imperative]    {         return = [Associative]         {              return = a[0..Count(foo({1,2}<1>,{3,4}<5>, 5))];                       }    }}";
+@" 
+def foo (x,y,z)
+{
+    return = x + y + z;
+}
+def foo2 : int[] ()
+{
+    return = a[0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>))];
+}
+def foo: int[] ()
+{
+    return = a[0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>))];
+}
+a = {1,2,3,4};
+b = a[0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>))];
+c = foo2();
+d = foo();
+f = [Associative]
+{
+    return = [Imperative]
+    {
+         return = [Associative]
+         {
+              return = a[0..Count(foo({1,2}<1>,{3,4}<5>, 5))];              
+         }
+    }
+}
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("b", new Object[] { 1, 2, 3 });
@@ -1701,7 +3091,14 @@ namespace ProtoTest.TD.Associative
         public void T0136_ReplicationGudes_ArraySlicingScope()
         {
             string code =
-@" def foo (x,y,z){    return = x + y + z;}a = {{1},{2,3},{4,5,6}};b = a[0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>))][0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>))];";
+@" 
+def foo (x,y,z)
+{
+    return = x + y + z;
+}
+a = {{1},{2,3},{4,5,6}};
+b = a[0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>))][0..Count(foo({1,2}<1>,{3,4}<5>, {5,6}<3>))];
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("b", new Object[] { 1, 3, 6 });
@@ -1711,7 +3108,14 @@ namespace ProtoTest.TD.Associative
         public void T0137_ReplicationGudes_RelationalOperators()
         {
             string code =
-@" a = 0..1;b = 2..3;c1 = a<1> > b<2> ? 1 : 0;c2 = a<1> <= b<2>;c3 = a<1> == b<2> ? 1 : 0;c4 = a<1> != b<2> ? 1 : 0;";
+@" 
+a = 0..1;
+b = 2..3;
+c1 = a<1> > b<2> ? 1 : 0;
+c2 = a<1> <= b<2>;
+c3 = a<1> == b<2> ? 1 : 0;
+c4 = a<1> != b<2> ? 1 : 0;
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("c1", new Object[] { new Object[] { 0, 0 }, new Object[] { 0, 0 } });
@@ -1724,7 +3128,16 @@ namespace ProtoTest.TD.Associative
         public void T0138_ReplicationGudes_LogicalOperators()
         {
             string code =
-@" a1 = { true, false};b1 = {false, false};c1 = a1<1> && b1<2>;c2 = (!a1)<1> || (!b1)<1>;//c3 = (~a1)<1> && (~b1)<1>;//c4 = {0,0}<1> | {1,1}<2>;//c5 = {0,1}<1> & {0,1}<2>;//c6 = {1,2}<1> ^ {1,2}<2>;";
+@" 
+a1 = { true, false};
+b1 = {false, false};
+c1 = a1<1> && b1<2>;
+c2 = (!a1)<1> || (!b1)<1>;
+//c3 = (~a1)<1> && (~b1)<1>;
+//c4 = {0,0}<1> | {1,1}<2>;
+//c5 = {0,1}<1> & {0,1}<2>;
+//c6 = {1,2}<1> ^ {1,2}<2>;
+";
             string errmsg = "DNL-1467593 Support for some logical operators like | & ^ ~ missing"; // because of this defect, the above lines are commented out
 
             thisTest.VerifyRunScriptSource(code, errmsg);
@@ -1736,7 +3149,19 @@ namespace ProtoTest.TD.Associative
         public void T0139_ReplicationGudes_MathematicalOperators()
         {
             string code =
-@"def foo (x,y,z){    return = x + y + z;}a = {{0,1},{2,3}}; b = {{4,5},{6,7}};c1 = a<1><2> + b<1><2>;c2 = a<1><2> - b<3><4>;c3 = a<1> / b<1>;c4 = a<1> * b<2>;c5 = a<1> % b<1>;";
+@"
+def foo (x,y,z)
+{
+    return = x + y + z;
+}
+a = {{0,1},{2,3}}; 
+b = {{4,5},{6,7}};
+c1 = a<1><2> + b<1><2>;
+c2 = a<1><2> - b<3><4>;
+c3 = a<1> / b<1>;
+c4 = a<1> * b<2>;
+c5 = a<1> % b<1>;
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("c1", new Object[] { new Object[] { 4, 6 }, new Object[] { 8, 10 } });
@@ -1750,7 +3175,11 @@ namespace ProtoTest.TD.Associative
         public void T0140_ReplicationGudes_StringConcat()
         {
             string code =
-@"a = { ""1"", ""2""};b = {""3"", ""4""};c = a<1> + b<2>;";
+@"
+a = { ""1"", ""2""};
+b = {""3"", ""4""};
+c = a<1> + b<2>;
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("c", new Object[] { new Object[] { "13", "14" }, new Object[] { "23", "24" } });
@@ -1760,7 +3189,17 @@ namespace ProtoTest.TD.Associative
         public void T0141_ReplicationGudes_LogicalOperators()
         {
             string code =
-@"def foo (x,y,z){    return = x + y + z;}a = {{0,1},{2,3}}; b = {{4,5},{6,7}};c = a<1><2> > b<1><2> ? 1 : 0;d = a > b ? 1 : 0;f = a<1><2> > b<3><4> ? 1 : 0;";
+@"
+def foo (x,y,z)
+{
+    return = x + y + z;
+}
+a = {{0,1},{2,3}}; 
+b = {{4,5},{6,7}};
+c = a<1><2> > b<1><2> ? 1 : 0;
+d = a > b ? 1 : 0;
+f = a<1><2> > b<3><4> ? 1 : 0;
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("c", new Object[] { new Object[] { 0, 0 }, new Object[] { 0, 0 } });
@@ -1773,7 +3212,47 @@ namespace ProtoTest.TD.Associative
         public void T0142_ReplicationGudes_On_Both_Instance_And_Method_Call()
         {
             string code =
-@"class A{    a;    constructor A(a1)    {        a = a1;    }    def foo2(x)    {        a = x;        return = a;    }}class B extends A{    b;    constructor B(a1, b1) : base.A(a1)    {        b = b1;    }    def foo(x, y)    {        a = x;        b = y;        return = a + b;    }    }x = 0..1;y = 2..3;b1 = B.B(x, y);b2 = B.B(x<1>, y<1>);b3 = B.B(x<1>, y<2>);t = { b1, b1, b3 };t1 = Flatten(t).b;t2 = b1.foo(x, y);t3 = b1<1> .foo(x<2>, y<2>);t4 = b1<1> .foo(x<1>, y<1>);t5 = b1.foo2(x);t6 = b1<1>.foo2(x<2>);";
+@"
+class A
+{
+    a;
+    constructor A(a1)
+    {
+        a = a1;
+    }
+    def foo2(x)
+    {
+        a = x;
+        return = a;
+    }
+}
+class B extends A
+{
+    b;
+    constructor B(a1, b1) : base.A(a1)
+    {
+        b = b1;
+    }
+    def foo(x, y)
+    {
+        a = x;
+        b = y;
+        return = a + b;
+    }    
+}
+x = 0..1;
+y = 2..3;
+b1 = B.B(x, y);
+b2 = B.B(x<1>, y<1>);
+b3 = B.B(x<1>, y<2>);
+t = { b1, b1, b3 };
+t1 = Flatten(t).b;
+t2 = b1.foo(x, y);
+t3 = b1<1> .foo(x<2>, y<2>);
+t4 = b1<1> .foo(x<1>, y<1>);
+t5 = b1.foo2(x);
+t6 = b1<1>.foo2(x<2>);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[] { 2, 3, 2, 3, 2, 3, 2, 3 });
@@ -1790,7 +3269,39 @@ namespace ProtoTest.TD.Associative
         public void T0143_ReplicationGudes_On_Both_Instance_And_Method_Call()
         {
             string code =
-@"class A{    a;    constructor A(a1)    {        a = a1;    }    def foo(x, y)    {        return = x + y;    }}class B extends A{    b;    constructor B(a1, b1) : base.A(a1)    {        b = b1;    }        }x = 0..1;y = 2..3;b1 = B.B(x, y);t2 = b1.foo(0..1, 2..3);t3 = b1.foo((0..1)<1>, (2..3)<2>);t4 = b1.foo({0,1}<1>, {2,3}<2>);t5 = b1<1>.foo({0,1}<1>, {2,3}<2>);t6 = b1<1>.foo((0..1)<1>, (2..3)<2>);t7 = b1<1>.foo((0..1)<2>, (2..3)<2>);t8 = b1<1>.foo({0,1}<1>, {2,3}<1>);";
+@"
+class A
+{
+    a;
+    constructor A(a1)
+    {
+        a = a1;
+    }
+    def foo(x, y)
+    {
+        return = x + y;
+    }
+}
+class B extends A
+{
+    b;
+    constructor B(a1, b1) : base.A(a1)
+    {
+        b = b1;
+    }
+        
+}
+x = 0..1;
+y = 2..3;
+b1 = B.B(x, y);
+t2 = b1.foo(0..1, 2..3);
+t3 = b1.foo((0..1)<1>, (2..3)<2>);
+t4 = b1.foo({0,1}<1>, {2,3}<2>);
+t5 = b1<1>.foo({0,1}<1>, {2,3}<2>);
+t6 = b1<1>.foo((0..1)<1>, (2..3)<2>);
+t7 = b1<1>.foo((0..1)<2>, (2..3)<2>);
+t8 = b1<1>.foo({0,1}<1>, {2,3}<1>);
+";
             string errmsg = "MAGN-4113[Design] - spec for rep guides when skip a guide";
             thisTest.VerifyRunScriptSource(code, errmsg);
 
@@ -1809,7 +3320,15 @@ namespace ProtoTest.TD.Associative
         {
 
             string code =
-@" def foo (x,y,z){    return = x + y + z;}t1 = foo((0..1)<1>, (0..2)<1>, (0..2)<1>);";
+@" 
+def foo (x,y,z)
+{
+    return = x + y + z;
+}
+
+t1 = foo((0..1)<1>, (0..2)<1>, (0..2)<1>);
+
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[] { 0, 3 });
@@ -1821,7 +3340,18 @@ namespace ProtoTest.TD.Associative
         {
 
             string code =
-@" def foo (x,y){    return = x + y;}a = 0;b = 0..1;t1 = foo(a<1>, b<2>);";
+@" 
+def foo (x,y)
+{
+    return = x + y;
+}
+
+a = 0;
+b = 0..1;
+
+t1 = foo(a<1>, b<2>);
+
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[]
@@ -1836,7 +3366,18 @@ namespace ProtoTest.TD.Associative
         {
 
             string code =
-@" def foo (x,y){    return = x + y;}a = {0};b = 0..1;t1 = foo(a<1>, b<2>);";
+@" 
+def foo (x,y)
+{
+    return = x + y;
+}
+
+a = {0};
+b = 0..1;
+
+t1 = foo(a<1>, b<2>);
+
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[]
@@ -1850,7 +3391,18 @@ namespace ProtoTest.TD.Associative
         {
 
             string code =
-@" def foo (x,y){    return = x + y;}a = {0};b = 0..1;t1 = foo(a<1>, b<1>);";
+@" 
+def foo (x,y)
+{
+    return = x + y;
+}
+
+a = {0};
+b = 0..1;
+
+t1 = foo(a<1>, b<1>);
+
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[] { 0 });
@@ -1862,7 +3414,18 @@ namespace ProtoTest.TD.Associative
         {
 
             string code =
-@" def foo (x,y){    return = x + y;}a = 0;b = 0..1;t1 = foo(a<1L>, b<1L>);";
+@" 
+def foo (x,y)
+{
+    return = x + y;
+}
+
+a = 0;
+b = 0..1;
+
+t1 = foo(a<1L>, b<1L>);
+
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[] { 0, 1 });
@@ -1873,7 +3436,19 @@ namespace ProtoTest.TD.Associative
         {
 
             string code =
-@" def foo (x,y,z){    return = x + y + z;}a = 0;b = 0..1;c = 0..2;t1 = foo(a<1L>, b<1L>, c<1L>);";
+@" 
+def foo (x,y,z)
+{
+    return = x + y + z;
+}
+
+a = 0;
+b = 0..1;
+c = 0..2;
+
+t1 = foo(a<1L>, b<1L>, c<1L>);
+
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[] { 0, 2, 3  });
@@ -1884,7 +3459,18 @@ namespace ProtoTest.TD.Associative
         {
 
             string code =
-@" def foo (x,y){    return = x + y;}a = 1;b = 2;t1 = foo(a<1>, b<2>);";
+@" 
+def foo (x,y)
+{
+    return = x + y;
+}
+
+a = 1;
+b = 2;
+
+t1 = foo(a<1>, b<2>);
+
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", 3);
@@ -1895,7 +3481,18 @@ namespace ProtoTest.TD.Associative
         {
 
             string code =
-@" def foo (x,y){    return = x + y;}a = 1;b = 2;t1 = foo(a<1>, b<1>);";
+@" 
+def foo (x,y)
+{
+    return = x + y;
+}
+
+a = 1;
+b = 2;
+
+t1 = foo(a<1>, b<1>);
+
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", 3);
@@ -1906,7 +3503,18 @@ namespace ProtoTest.TD.Associative
         {
 
             string code =
-@" def foo (x,y){    return = x + y;}a = 1;b = 2;t1 = foo(a<1L>, b<1L>);";
+@" 
+def foo (x,y)
+{
+    return = x + y;
+}
+
+a = 1;
+b = 2;
+
+t1 = foo(a<1L>, b<1L>);
+
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", 3);
@@ -1917,7 +3525,18 @@ namespace ProtoTest.TD.Associative
         {
 
             string code =
-@" def foo (x,y){    return = x + y;}a = { 1 };b = { 2 };t1 = foo(a<1>, b<2>);";
+@" 
+def foo (x,y)
+{
+    return = x + y;
+}
+
+a = { 1 };
+b = { 2 };
+
+t1 = foo(a<1>, b<2>);
+
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             thisTest.Verify("t1", new Object[]
@@ -1931,7 +3550,13 @@ namespace ProtoTest.TD.Associative
         public void RegressMagn4853_1()
         {
             string code =
-            @" def foo(x){}x = foo(""xyz"");";
+            @" 
+def foo(x)
+{
+}
+
+x = foo(""xyz"");
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
 
@@ -1945,7 +3570,13 @@ namespace ProtoTest.TD.Associative
         {
             // Test replication on singleton
             string code =
-            @" import(""FFITarget.dll"");t = TestObjectA.TestObjectA(1);r1 = t.Set(1);r2 = t<1>.Set(1);r3 = t<1L>.Set(1);";
+            @" 
+import(""FFITarget.dll"");
+t = TestObjectA.TestObjectA(1);
+r1 = t.Set(1);
+r2 = t<1>.Set(1);
+r3 = t<1L>.Set(1);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             // Should get clear after running
@@ -1958,7 +3589,15 @@ namespace ProtoTest.TD.Associative
         {
             // Test replication on singleton 
             string code =
-            @" import(""FFITarget.dll"");t = TestObjectA.TestObjectA(1);v = 42;r1 = t.Set(v);r2 = t<1>.Set(v<1>);r3 = t<1L>.Set(v<1L>);r4 = t<1>.Set(v<2>);";
+            @" 
+import(""FFITarget.dll"");
+t = TestObjectA.TestObjectA(1);
+v = 42;
+r1 = t.Set(v);
+r2 = t<1>.Set(v<1>);
+r3 = t<1L>.Set(v<1L>);
+r4 = t<1>.Set(v<2>);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             // Should get clear after running
@@ -1971,7 +3610,13 @@ namespace ProtoTest.TD.Associative
         {
             // Test replication on LHS
             string code =
-            @" import(""FFITarget.dll"");ts = {TestObjectA.TestObjectA(), TestObjectA.TestObjectA()};r1 = ts.Set(1);r2 = ts<1>.Set(1);r3 = ts<1L>.Set(1);";
+            @" 
+import(""FFITarget.dll"");
+ts = {TestObjectA.TestObjectA(), TestObjectA.TestObjectA()};
+r1 = ts.Set(1);
+r2 = ts<1>.Set(1);
+r3 = ts<1L>.Set(1);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             // Should get clear after running
@@ -1984,7 +3629,15 @@ namespace ProtoTest.TD.Associative
         {
             // Test replication on LHS
             string code =
-            @" import(""FFITarget.dll"");ts = {TestObjectA.TestObjectA(), TestObjectA.TestObjectA()};vs = {42, 43};r1 = ts.Set(vs);r2 = ts<1>.Set(vs<1>);r3 = ts<1L>.Set(vs<1L>);r4 = ts<1>.Set(vs<2>);";
+            @" 
+import(""FFITarget.dll"");
+ts = {TestObjectA.TestObjectA(), TestObjectA.TestObjectA()};
+vs = {42, 43};
+r1 = ts.Set(vs);
+r2 = ts<1>.Set(vs<1>);
+r3 = ts<1L>.Set(vs<1L>);
+r4 = ts<1>.Set(vs<2>);
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             // Should get clear after running
@@ -1997,7 +3650,13 @@ namespace ProtoTest.TD.Associative
         {
             // Test replication on LHS
             string code =
-            @" import(""FFITarget.dll"");t = TestObjectA.TestObjectA(42);r1 = t.a;ts = {TestObjectA.TestObjectA(42), TestObjectA.TestObjectA(42)};r2 = ts.a;";
+            @" 
+import(""FFITarget.dll"");
+t = TestObjectA.TestObjectA(42);
+r1 = t.a;
+ts = {TestObjectA.TestObjectA(42), TestObjectA.TestObjectA(42)};
+r2 = ts.a;
+";
             string errmsg = "";
             thisTest.VerifyRunScriptSource(code, errmsg);
             // Should get clear after running


### PR DESCRIPTION
### Purpose

Remove following test cases from Failure category. They start passing.
* ProtoTest.TD.Associative.Replication.T66_Defect_1467198_Inline_Condition_With_Jagged_Array
* ProtoTest.TD.Associative.Replication.T92_add
* ProtoTest.TD.Associative.ReplicationGuide.T0101_FuncCall_Double_SomeGuides
* ProtoTest.TD.Associative.ReplicationGuide.T039_1467423_replication_guide_on_array_11

### FYIs
@riteshchandawar , @monikaprabhu 