### PR TITLE
Nodes behind groups fix

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -392,6 +392,9 @@ namespace Dynamo.Controls
         {
             nodeWasClicked = false;
 
+            // Always set old ZIndex to the last value, even if mouse is not over the node.
+            oldZIndex = NodeViewModel.StaticZIndex;
+
             if (!previewEnabled) return; // Preview is hidden. There is no need run further.
 
             if (PreviewControl.IsInTransition) // In transition state, come back later.


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9503](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9503) Nodes are behind its group

The reason of bug:
When user moves mouse over node, the node should be brought to front. It's brought to front in `BringToFront`, but just in case if mouse is over node. When mouse leaves node, the node should be brought to the old position. Old position is also set in `BringToFront`. But if user moves mouse too fast, `BringToFront` is not fired. The result is old position = 0. So, when mouse leaves the node, position is set to 0. And since groups have position = 2, nodes appear under group.

The fix:
We set old position in mouse enter event. So that it's always set and won't be undefined.

Result:
![image](https://cloud.githubusercontent.com/assets/8158404/13105157/53bf80d6-d56a-11e5-92d3-cbdf70a08b72.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.


### Reviewers

@pbidenko 

### FYIs

@ramramps 
@Racel 
@jnealb 