### PR TITLE
Add regression test cases for some defects

### DIFF
--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -3408,5 +3408,19 @@ zero = 0;
             thisTest.RunScriptSource(code);
             thisTest.Verify("rs", new object[] { new object[] { 0.0, 0.0 }, new object[] { 0.0, 0.0 } }) ;
         }
+
+        [Test]
+        [Category("Replication")]
+        public void RegressMAGN1705()
+        {
+            string code = @"
+val = { 0.5 , 0.5 };
+def foo( x : var, y : var ) { return = (x+y)/2.0 ; }
+answer=foo({ val }[0]<1> , { val }[0]<2>)[0]; // expected : { 0.5, 0.5 }
+";
+
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("answer", new object[] { 0.5, 0.5 });
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This PR adds regression test cases for the following replication guide related defects:
*  [MAGN-1705 Replication guides on array of the form {{1}}[0]<1> is throwing error and returning null](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1705)
* [MAGN-1536 Regression : Use of the array index after replicated constructor yields complier error now](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1536)

### FYIs
@monikaprabhu 