### PR TITLE
Multiple in-canvas searches should not appear simultaneously

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -807,7 +807,9 @@ namespace Dynamo.Views
             // If in-canvas search box is open already, close it
             // to avoid opening multiple instances.
             if (InCanvasSearchBar.IsOpen)
+            {
                 InCanvasSearchBar.IsOpen = false;
+            }
             ViewModel.InCanvasSearchViewModel.SearchText = string.Empty;
 
             var ctrl = outerCanvas.ContextMenu.ChildOfType<InCanvasSearchControl>();

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -804,6 +804,10 @@ namespace Dynamo.Views
 
         private void OnContextMenuOpened(object sender, RoutedEventArgs e)
         {
+            // If in-canvas search box is open already, close it
+            // to avoid opening multiple instances.
+            if (InCanvasSearchBar.IsOpen)
+                InCanvasSearchBar.IsOpen = false;
             ViewModel.InCanvasSearchViewModel.SearchText = string.Empty;
 
             var ctrl = outerCanvas.ContextMenu.ChildOfType<InCanvasSearchControl>();


### PR DESCRIPTION
If in-canvas search box is open already, close it to avoid opening
multiple instances.