### PR TITLE
Magn 9504 multiple in canvas searches should not appear simultaneously

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -807,7 +807,9 @@ namespace Dynamo.Views
             // If in-canvas search box is open already, close it
             // to avoid opening multiple instances.
             if (InCanvasSearchBar.IsOpen)
+            {
                 InCanvasSearchBar.IsOpen = false;
+            }
             ViewModel.InCanvasSearchViewModel.SearchText = string.Empty;
 
             var ctrl = outerCanvas.ContextMenu.ChildOfType<InCanvasSearchControl>();

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -804,6 +804,10 @@ namespace Dynamo.Views
 
         private void OnContextMenuOpened(object sender, RoutedEventArgs e)
         {
+            // If in-canvas search box is open already, close it
+            // to avoid opening multiple instances.
+            if (InCanvasSearchBar.IsOpen)
+                InCanvasSearchBar.IsOpen = false;
             ViewModel.InCanvasSearchViewModel.SearchText = string.Empty;
 
             var ctrl = outerCanvas.ContextMenu.ChildOfType<InCanvasSearchControl>();


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9504
Multiple in-canvas searches should not appear simultaneously

Fix: while opening context menu, check if inCanvasSearchBox is open, if yes close it.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
   - No new tests required. This is on the View Layer.
- [ ] User facing strings, if any, are extracted into `*.resx` files
   - No new strings created.


### Reviewers

@mjkkirschner 

### FYIs

@sm6srw 