### PR TITLE
MAGN 9329 MapTo gives incorrect results when target range min is greater than target range max

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -984,7 +984,7 @@ namespace ProtoCore.Lang
             double targetRangeMin,
             double targetRangeMax) 
         {
-            double percent = Map(rangeMin, rangeMin, inputValue); 
+            double percent = Map(rangeMin, rangeMax, inputValue); 
             return targetRangeMin + (targetRangeMax - targetRangeMin) * percent;
         }
     }

--- a/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
@@ -4693,6 +4693,7 @@ y = ContainsKey(x, x);
             string code = @"
 r = MapTo(5, 10, 5..10, 2, 0);
 ";
+            thisTest.RunScriptSource(code);
             thisTest.Verify("r", new object[] { 2.0, 1.6, 1.2, 0.8, 0.4, 0 });
         }
     }

--- a/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
@@ -4686,6 +4686,15 @@ y = ContainsKey(x, x);
             Assert.DoesNotThrow(() => thisTest.RunScriptSource(code));
             thisTest.Verify("y", false);
         }
+
+        [Test]
+        public void TestMapToWithReverserRange()
+        {
+            string code = @"
+r = MapTo(5, 10, 5..10, 2, 0);
+";
+            thisTest.Verify("r", new object[] { 2.0, 1.6, 1.2, 0.8, 0.4, 0 });
+        }
     }
 
 }


### PR DESCRIPTION
### Purpose

Fix defect [MAGN 9329 MapTo gives incorrect results when target range min is greater than target range max] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9329#)

Language test case `TestMapToWithReverserRange` added.

### Reviewers
@aparajit-pratap 