### PR TITLE
Include selected notes during conversion to custom node

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -727,12 +727,16 @@ namespace Dynamo.Core
         ///     Collapse a set of nodes in a given workspace.
         /// </summary>
         /// <param name="selectedNodes"> The function definition for the user-defined node </param>
+        /// <param name="selectedNotes"> The note models in current selection </param>
         /// <param name="currentWorkspace"> The workspace where</param>
         /// <param name="isTestMode"></param>
         /// <param name="args"></param>
         internal CustomNodeWorkspaceModel Collapse(
-            IEnumerable<NodeModel> selectedNodes, WorkspaceModel currentWorkspace,
-            bool isTestMode, FunctionNamePromptEventArgs args)
+            IEnumerable<NodeModel> selectedNodes,
+            IEnumerable<NoteModel> selectedNotes,
+            WorkspaceModel currentWorkspace,
+            bool isTestMode,
+            FunctionNamePromptEventArgs args)
         {
             var selectedNodeSet = new HashSet<NodeModel>(selectedNodes);
             // Note that undoable actions are only recorded for the "currentWorkspace", 
@@ -901,9 +905,10 @@ namespace Dynamo.Core
                 #region Transfer nodes and connectors to new workspace
 
                 var newNodes = new List<NodeModel>();
+                var newNotes = new List<NoteModel>();
                 var newAnnotations = new List<AnnotationModel>();
             
-                // Step 4: move all nodes to new workspace remove from old
+                // Step 4: move all nodes and notes to new workspace remove from old
                 // PB: This could be more efficiently handled by a copy paste, but we
                 // are preservering the node 
                 foreach (var node in selectedNodeSet)
@@ -921,6 +926,17 @@ namespace Dynamo.Core
                     node.Y = node.Y - topMost;
                  
                     newNodes.Add(node);
+                }
+
+                foreach(var note in selectedNotes)
+                {
+                    undoRecorder.RecordDeletionForUndo(note);
+                    currentWorkspace.RemoveNote(note);
+
+                    note.GUID = Guid.NewGuid();
+                    note.X = note.X - leftShift;
+                    note.Y = note.Y - topMost;
+                    newNotes.Add(note);
                 }
 
                 //Copy the group from newNodes
@@ -1132,7 +1148,7 @@ namespace Dynamo.Core
                 newWorkspace = new CustomNodeWorkspaceModel(
                     nodeFactory,
                     newNodes,
-                    Enumerable.Empty<NoteModel>(),
+                    newNotes,
                     newAnnotations,
                     Enumerable.Empty<PresetModel>(),
                     currentWorkspace.ElementResolver,

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -978,7 +978,7 @@ namespace Dynamo.Graph.Workspaces
             OnNotesCleared();
         }
 
-        private void RemoveNote(NoteModel note)
+        internal void RemoveNote(NoteModel note)
         {
             lock (notes)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1422,9 +1422,7 @@ namespace Dynamo.ViewModels
 
         private void CreateNodeFromSelection(object parameter)
         {
-            CurrentSpaceViewModel.CollapseNodes(
-                DynamoSelection.Instance.Selection.Where(x => x is NodeModel)
-                    .Select(x => (x as NodeModel)));
+            CurrentSpaceViewModel.CollapseSelectedNodes();
         }
 
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -907,9 +907,7 @@ namespace Dynamo.ViewModels
 
         private void CreateNodeFromSelection(object parameter)
         {
-            CollapseNodes(
-                DynamoSelection.Instance.Selection.Where(x => x is NodeModel)
-                    .Select(x => (x as NodeModel)));
+            CollapseSelectedNodes();
         }
 
         //private void NodeFromSelectionCanExecuteChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -1063,10 +1061,9 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        ///     Collapse a set of nodes in this workspace
+        /// Collapse a set of nodes and notes currently selected in workspace
         /// </summary>
-        /// <param name="selectedNodes"> The function definition for the user-defined node </param>
-        internal void CollapseNodes(IEnumerable<NodeModel> selectedNodes)
+        internal void CollapseSelectedNodes()
         {
             var args = new FunctionNamePromptEventArgs();
             DynamoViewModel.Model.OnRequestsFunctionNamePrompt(null, args);
@@ -1074,9 +1071,12 @@ namespace Dynamo.ViewModels
             if (!args.Success)
                 return;
 
+            var selectedNodes = DynamoSelection.Instance.Selection.OfType<NodeModel>();
+            var selectedNotes = DynamoSelection.Instance.Selection.OfType<NoteModel>();
+
             DynamoViewModel.Model.AddCustomNodeWorkspace(
-                DynamoViewModel.Model.CustomNodeManager.Collapse(
-                    selectedNodes, Model, DynamoModel.IsTestMode, args));
+                DynamoViewModel.Model.CustomNodeManager.Collapse(selectedNodes,
+                selectedNotes, Model, DynamoModel.IsTestMode, args));
         }
 
         internal void Loaded()

--- a/src/VisualizationTests/CustomNodeTests.cs
+++ b/src/VisualizationTests/CustomNodeTests.cs
@@ -63,6 +63,7 @@ namespace WpfVisualizationTests
             List<NodeModel> selectionSet = new List<NodeModel>() { node };
             var customWorkspace = model.CustomNodeManager.Collapse(
                 selectionSet.AsEnumerable(),
+                Enumerable.Empty<Dynamo.Graph.Notes.NoteModel>(),
                 model.CurrentWorkspace,
                 true,
                 new FunctionNamePromptEventArgs

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -14,6 +14,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Graph.Notes;
 
 namespace Dynamo.Tests
 {
@@ -57,6 +58,7 @@ namespace Dynamo.Tests
 
             CurrentDynamoModel.CustomNodeManager.Collapse(
                 DynamoSelection.Instance.Selection.OfType<NodeModel>(),
+                Enumerable.Empty<NoteModel>(),
                 CurrentDynamoModel.CurrentWorkspace,
                 true,
                 new FunctionNamePromptEventArgs
@@ -100,6 +102,7 @@ namespace Dynamo.Tests
 
             CurrentDynamoModel.CustomNodeManager.Collapse(
                 DynamoSelection.Instance.Selection.OfType<NodeModel>(),
+                Enumerable.Empty<NoteModel>(),
                 CurrentDynamoModel.CurrentWorkspace,
                 true,
                 new FunctionNamePromptEventArgs
@@ -140,6 +143,7 @@ namespace Dynamo.Tests
 
             CurrentDynamoModel.CustomNodeManager.Collapse(
                 DynamoSelection.Instance.Selection.OfType<NodeModel>(),
+                Enumerable.Empty<NoteModel>(),
                 CurrentDynamoModel.CurrentWorkspace,
                 true,
                 new FunctionNamePromptEventArgs
@@ -203,6 +207,7 @@ namespace Dynamo.Tests
 
             CurrentDynamoModel.CustomNodeManager.Collapse(
                 selectionSet.AsEnumerable(),
+                Enumerable.Empty<NoteModel>(),
                 CurrentDynamoModel.CurrentWorkspace,
                 true,
                 new FunctionNamePromptEventArgs
@@ -302,6 +307,7 @@ namespace Dynamo.Tests
 
             var ws = CurrentDynamoModel.CustomNodeManager.Collapse(
                 DynamoSelection.Instance.Selection.OfType<NodeModel>(),
+                Enumerable.Empty<NoteModel>(),
                 CurrentDynamoModel.CurrentWorkspace,
                 true,
                 new FunctionNamePromptEventArgs
@@ -625,7 +631,8 @@ namespace Dynamo.Tests
 
             CurrentDynamoModel.AddCustomNodeWorkspace(
                 CurrentDynamoModel.CustomNodeManager.Collapse(
-                    selectionSet, CurrentDynamoModel.CurrentWorkspace, DynamoModel.IsTestMode, arg));
+                    selectionSet, Enumerable.Empty<NoteModel>(), 
+                    CurrentDynamoModel.CurrentWorkspace, DynamoModel.IsTestMode, arg));
 
             Assert.IsNotNull(CurrentDynamoModel.CurrentWorkspace.FirstNodeFromWorkspace<Function>());
 
@@ -653,6 +660,7 @@ namespace Dynamo.Tests
             var selectionSet = new[] { node };
             var customWorkspace = CurrentDynamoModel.CustomNodeManager.Collapse(
                 selectionSet,
+                Enumerable.Empty<NoteModel>(),
                 CurrentDynamoModel.CurrentWorkspace,
                 true,
                 new FunctionNamePromptEventArgs
@@ -777,6 +785,7 @@ namespace Dynamo.Tests
             var selectionSet = new List<NodeModel> { node };
             CurrentDynamoModel.CustomNodeManager.Collapse(
                 selectionSet,
+                Enumerable.Empty<NoteModel>(),
                 CurrentDynamoModel.CurrentWorkspace,
                 true,
                 new FunctionNamePromptEventArgs
@@ -851,6 +860,7 @@ namespace Dynamo.Tests
 
             var ws = CurrentDynamoModel.CustomNodeManager.Collapse(
                 DynamoSelection.Instance.Selection.OfType<NodeModel>(),
+                Enumerable.Empty<NoteModel>(),
                 CurrentDynamoModel.CurrentWorkspace,
                 true,
                 new FunctionNamePromptEventArgs
@@ -891,6 +901,7 @@ namespace Dynamo.Tests
 
             var ws = CurrentDynamoModel.CustomNodeManager.Collapse(
                 DynamoSelection.Instance.Selection.OfType<NodeModel>(),
+                Enumerable.Empty<NoteModel>(),
                 CurrentDynamoModel.CurrentWorkspace,
                 true,
                 new FunctionNamePromptEventArgs

--- a/test/DynamoCoreWpfTests/CustomNodeTests.cs
+++ b/test/DynamoCoreWpfTests/CustomNodeTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Dynamo.Tests;
 using Dynamo.Selection;
 using Dynamo.Models;
+using Dynamo.Graph.Notes;
 
 namespace DynamoCoreWpfTests
 {
@@ -23,6 +24,7 @@ namespace DynamoCoreWpfTests
 
             var ws = ViewModel.Model.CustomNodeManager.Collapse(
                 DynamoSelection.Instance.Selection.OfType<NodeModel>(),
+                Enumerable.Empty<NoteModel>(),
                 ViewModel.Model.CurrentWorkspace,
                 true,
                 new FunctionNamePromptEventArgs


### PR DESCRIPTION
### Purpose

This pull request is meant to fix an internally tracked defect:

- [MAGN-9339](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9339) Notes are not copied to new custom nodes with other nodes

Selected `NoteModel` objects, something that represent notes in Dynamo, are not included in the conversion process when a custom node is created from a selection. This pull request fixes that by adding `selectedNotes` parameter to the following method:

```csharp
internal CustomNodeWorkspaceModel Collapse(
    IEnumerable<NodeModel> selectedNodes,
    IEnumerable<NoteModel> selectedNotes, // Newly added parameter
    ...)
{
    ...
}
```

![collapse-to-node-fix](https://cloud.githubusercontent.com/assets/5086849/13240612/e9d40e44-da1e-11e5-9c6c-14d071fc887a.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

Hi @ke-yu, I'm assigning this to you based on what's left of each individual for the sprint. Thanks in advance!

### FYIs

@mccrone, sorry it took so long!

