### PR TITLE
Input nodes copied from custom nodes

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1656,7 +1656,7 @@ namespace Dynamo.Models
 
                 var lacing = node.ArgumentLacing.ToString();
                 newNode.UpdateValue(new UpdateValueParams("ArgumentLacing", lacing));
-                if (!string.IsNullOrEmpty(node.NickName))
+                if (!string.IsNullOrEmpty(node.NickName) && !(node is Symbol) && !(node is Output))
                     newNode.NickName = node.NickName;
 
                 newNode.Width = node.Width;


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8984](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8984) Input nodes copied from custom nodes become code blocks but those should not be renamed "input"

it's very simple fix. When node is pasted, it's set nickname. I added one more condition - `&& !(node is Symbol) && !(node is Output)`.

Symbol - it's Input node.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@marimano 