### PR TITLE
MAGN-9147: IsFrozen event handling for manipulators

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/AttachedProperties.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/AttachedProperties.cs
@@ -81,7 +81,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         public static bool GetIsFrozen(UIElement element)
         {
-            return (bool)element.GetValue(IsFrozenProperty);
+            return (bool)element.GetValue(IsFrozenProperty) &&
+                !IsSpecialRenderPackage(element);
         }
 
 
@@ -124,6 +125,25 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     geom.Attach(host);
                 }
             }
+        }
+
+        /// <summary>
+        /// A flag indicating whether the geometry is special render package, such as used to draw manipulators.
+        /// </summary>
+        public static readonly DependencyProperty IsSpecialRenderPackageProperty = DependencyProperty.RegisterAttached(
+            "IsSpecialRenderPackage",
+            typeof(bool),
+            typeof(GeometryModel3D),
+            new PropertyMetadata(false));
+
+        public static void SetIsSpecialRenderPackage(UIElement element, bool value)
+        {
+            element.SetValue(IsSpecialRenderPackageProperty, value);
+        }
+
+        public static bool IsSpecialRenderPackage(UIElement element)
+        {
+            return (bool)element.GetValue(IsSpecialRenderPackageProperty);
         }
 
     }

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1395,7 +1395,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 case RenderDescriptions.ManipulatorAxis:
                     var manipulator = model as DynamoGeometryModel3D;
                     if (null == manipulator)
+                    {
                         manipulator = CreateDynamoGeometryModel3D(rp);
+                        AttachedProperties.SetIsSpecialRenderPackage(manipulator, true);
+                    }
                     
                     var mb = new MeshBuilder();
                     mb.AddArrow(rp.Lines.Positions[0], rp.Lines.Positions[1], 0.1);
@@ -1413,14 +1416,20 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 case RenderDescriptions.AxisLine:
                     var centerline = model as DynamoLineGeometryModel3D;
                     if (null == centerline)
+                    {
                         centerline = CreateLineGeometryModel3D(rp, 0.3);
+                        AttachedProperties.SetIsSpecialRenderPackage(centerline, true);
+                    }
                     centerline.Geometry = rp.Lines;
                     Model3DDictionary[id] = centerline;
                     return true;
                 case RenderDescriptions.ManipulatorPlane:
                     var plane = model as DynamoLineGeometryModel3D;
                     if (null == plane)
+                    {
                         plane = CreateLineGeometryModel3D(rp, 0.7);
+                        AttachedProperties.SetIsSpecialRenderPackage(plane, true);
+                    }
                     plane.Geometry = rp.Lines;
                     Model3DDictionary[id] = plane;
                     return true;

--- a/src/DynamoManipulation/ManipulatorDaemon.cs
+++ b/src/DynamoManipulation/ManipulatorDaemon.cs
@@ -12,6 +12,17 @@ namespace Dynamo.Manipulation
 
         public IEnumerable<string> NodeNames { get; private set; }
 
+        /// <summary>
+        /// Checks if the given node has any manipulator attached with it.
+        /// </summary>
+        /// <param name="node">Input Node</param>
+        /// <returns>true if node has any manipulator</returns>
+        public bool HasNodeManipulator(NodeModel node)
+        {
+            IDisposable manipulator;
+            return activeManipulators.TryGetValue(node.GUID, out manipulator);
+        }
+
         private ManipulatorDaemon(Dictionary<Type, IEnumerable<INodeManipulatorFactory>> creators, IEnumerable<string> nodeNames)
         {
             registeredManipulatorCreators = creators;


### PR DESCRIPTION
### Purpose

This PR fixes [MAGN-9147 Manipulators are not updated upon freeze and unfreeze of node](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9147)

- When a node is frozen the Manipulator Geometry is frozen by the graphics system and it can't be erased even if manipulator is killed. This PR defines and attaches SpecialRenderPackage property to the node manipulator `GeometryModel3D`, so that this geometry can't be frozen and can be erased when a manipulator is killed.
- The `DynamoManipulationExtension` class registers PropertyChanged event handler with every selected node even if the node is frozen or manipulator can't be created. This event handler is unregistered when the node is unselected and the manipulator is killed.
- When the node is frozen the manipulator is killed and when the node is unfrozen manipulator is created again.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @aparajit-pratap 

### FYIs
@monikaprabhu 
