### PR TITLE
Fix issue that replication guides are ignored in some cases

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -916,7 +916,7 @@ namespace ProtoCore
             log.AppendLine("Case 5: Replication + Type conversion + Array promotion");
             {
                 //Add as a first attempt a no-replication, but allowing up-promoting
-                replicationTrials.Insert(0, new List<ReplicationInstruction>());
+                replicationTrials.Add(new List<ReplicationInstruction>());
 
                 foreach (List<ReplicationInstruction> replicationOption in replicationTrials)
                 {

--- a/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
@@ -534,7 +534,7 @@ namespace ProtoCore.Lang.Replication
 
             // Generate reduction lists (x1, x2, ..., xn) 
             if (maxReductionDepths.Any(r => r < 0) || maxReductionDepths.All(r => r == 0))
-                return new List<List<ReplicationInstruction>>();
+                return new List<List<ReplicationInstruction>> { providedControl };
 
             List<List<int>> reductions = BuildReductions(maxReductionDepths);
             var ret = reductions.Select(rs => ReductionToInstructions(rs, providedControl)).ToList();

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -966,7 +966,7 @@ namespace Dynamo.Tests
 
             RunModel(dynFilePath);
 
-            AssertPreviewValue("c739b941-ece7-4b87-ae69-9a16f04dbe5d", null);
+            AssertPreviewValue("c739b941-ece7-4b87-ae69-9a16f04dbe5d", new object[] { null, null, null, null });
 
             // Reset engine and mark all nodes as dirty. A.k.a., force re-execute.
             CurrentDynamoModel.ForceRun();

--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -3442,5 +3442,25 @@ r = foo(xs<1>, ys, zs);
             thisTest.RunScriptSource(code);
             thisTest.Verify("r", new object[] { "1-foo-bar", "2-foo-bar", "3-foo-bar" });
         }
+
+        [Test]
+        [Category("Replication")]
+        public void TestReplicationGuideTakesPriotry2()
+        {
+            // Verify it always replicates on the first parameter
+            string code = @"
+def foo(xs:var[], ys:var, zs:var)
+{
+    return = Sum(xs) + ys + zs;
+};
+xs = {1, 2, 3};
+ys = ""-foo"";
+zs = ""-bar"";
+r = foo(xs<1L>, ys<1L>, zs<1L>);
+            ";
+
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("r", new object[] { "1-foo-bar", "2-foo-bar", "3-foo-bar" });
+        }
     }
 }

--- a/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
+++ b/test/Engine/ProtoTest/TD/Associative/ReplicationGuide.cs
@@ -3422,5 +3422,25 @@ answer=foo({ val }[0]<1> , { val }[0]<2>)[0]; // expected : { 0.5, 0.5 }
             thisTest.RunScriptSource(code);
             thisTest.Verify("answer", new object[] { 0.5, 0.5 });
         }
+
+        [Test]
+        [Category("Replication")]
+        public void TestReplicationGuideTakesPriotry()
+        {
+            // Verify it always replicates on the first parameter
+            string code = @"
+def foo(xs:var[], ys:var, zs:var)
+{
+    return = Sum(xs) + ys + zs;
+};
+xs = {1, 2, 3};
+ys = ""-foo"";
+zs = ""-bar"";
+r = foo(xs<1>, ys, zs);
+            ";
+
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("r", new object[] { "1-foo-bar", "2-foo-bar", "3-foo-bar" });
+        }
     }
 }

--- a/test/core/list/Average_SimpleTest.dyn
+++ b/test/core/list/Average_SimpleTest.dyn
@@ -1,23 +1,25 @@
-<Workspace Version="0.6.3.5265" X="-856.952807201931" Y="-1167.18497077962" zoom="1.3" Description="" Category="" Name="Home">
+<Workspace Version="1.0.0.541" X="-697.952807201931" Y="-1170.18497077962" zoom="1.3" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.Average type="Dynamo.Nodes.Average" guid="cafe8fae-55f0-4e58-977e-80edcbc90d2b" nickname="Average" x="999.719483728426" y="1007.0644880123" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
-    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="2d27f28f-96e7-4c72-92a0-e6c3927b435b" nickname="Number" x="669.854265613208" y="1072.75766983048" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="cafe8fae-55f0-4e58-977e-80edcbc90d2b" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Average" x="999.719483728426" y="1007.0644880123" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Average@double[]" />
+    <CoreNodeModels.Input.DoubleInput guid="2d27f28f-96e7-4c72-92a0-e6c3927b435b" type="CoreNodeModels.Input.DoubleInput" nickname="Number" x="669.854265613208" y="1072.75766983048" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
       <System.Double value="5" />
-    </Dynamo.Nodes.DoubleInput>
-    <Dynamo.Nodes.NewList type="Dynamo.Nodes.NewList" guid="f1641ee7-f28d-4b61-aad5-10d971cc11f3" nickname="List" x="798.721481730423" y="1082.77529803561" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
-      <Input name="index0" />
-      <Input name="index1" />
-      <Input name="index2" />
-    </Dynamo.Nodes.NewList>
-    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="72a31534-5e7c-48c2-ab50-5a564a9500ea" nickname="Number" x="664.020932279875" y="1142.75766983048" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </CoreNodeModels.Input.DoubleInput>
+    <CoreNodeModels.CreateList guid="f1641ee7-f28d-4b61-aad5-10d971cc11f3" type="CoreNodeModels.CreateList" nickname="Create List" x="798.721481730423" y="1082.77529803561" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" inputcount="3" />
+    <CoreNodeModels.Input.DoubleInput guid="72a31534-5e7c-48c2-ab50-5a564a9500ea" type="CoreNodeModels.Input.DoubleInput" nickname="Number" x="664.020932279875" y="1142.75766983048" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
       <System.Double value="8" />
-    </Dynamo.Nodes.DoubleInput>
+    </CoreNodeModels.Input.DoubleInput>
   </Elements>
   <Connectors>
-    <Dynamo.Models.ConnectorModel start="2d27f28f-96e7-4c72-92a0-e6c3927b435b" start_index="0" end="f1641ee7-f28d-4b61-aad5-10d971cc11f3" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="2d27f28f-96e7-4c72-92a0-e6c3927b435b" start_index="0" end="f1641ee7-f28d-4b61-aad5-10d971cc11f3" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f1641ee7-f28d-4b61-aad5-10d971cc11f3" start_index="0" end="cafe8fae-55f0-4e58-977e-80edcbc90d2b" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="72a31534-5e7c-48c2-ab50-5a564a9500ea" start_index="0" end="f1641ee7-f28d-4b61-aad5-10d971cc11f3" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="2d27f28f-96e7-4c72-92a0-e6c3927b435b" start_index="0" end="f1641ee7-f28d-4b61-aad5-10d971cc11f3" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="2d27f28f-96e7-4c72-92a0-e6c3927b435b" start_index="0" end="f1641ee7-f28d-4b61-aad5-10d971cc11f3" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f1641ee7-f28d-4b61-aad5-10d971cc11f3" start_index="0" end="cafe8fae-55f0-4e58-977e-80edcbc90d2b" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="72a31534-5e7c-48c2-ab50-5a564a9500ea" start_index="0" end="f1641ee7-f28d-4b61-aad5-10d971cc11f3" end_index="1" portType="0" />
   </Connectors>
   <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>

--- a/test/core/migration/TestAverage.dyn
+++ b/test/core/migration/TestAverage.dyn
@@ -1,27 +1,33 @@
-<Workspace Version="0.6.2.29585" X="158" Y="41" zoom="1" Description="" Category="" Name="Home">
+<Workspace Version="1.0.0.541" X="158" Y="41" zoom="1" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.Average type="Dynamo.Nodes.Average" guid="d4f242c5-9c20-4633-b661-157ab45a416c" nickname="Average" x="210" y="110.5" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
-    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="e440ddff-97d0-4eed-9df6-1896400fcd2b" nickname="Number" x="-58" y="112.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="d4f242c5-9c20-4633-b661-157ab45a416c" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Average" x="210" y="110.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Average@double[]" />
+    <CoreNodeModels.Input.DoubleInput guid="e440ddff-97d0-4eed-9df6-1896400fcd2b" type="CoreNodeModels.Input.DoubleInput" nickname="Number" x="-58" y="112.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
       <System.Double value="1..10" />
-    </Dynamo.Nodes.DoubleInput>
-    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="a7cd33ea-74fe-441f-bacf-f7a4f16876a7" nickname="Number" x="-61" y="203.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </CoreNodeModels.Input.DoubleInput>
+    <CoreNodeModels.Input.DoubleInput guid="a7cd33ea-74fe-441f-bacf-f7a4f16876a7" type="CoreNodeModels.Input.DoubleInput" nickname="Number" x="-61" y="203.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
       <System.Double value="0.5..10.5..1" />
-    </Dynamo.Nodes.DoubleInput>
-    <Dynamo.Nodes.Average type="Dynamo.Nodes.Average" guid="3d59ccad-57ed-44bc-9d55-27574fc725de" nickname="Average" x="215" y="200.5" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
-    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="6b9eec3d-37c2-477f-b0b0-ec2c6ffd2434" nickname="Number" x="-64" y="305.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </CoreNodeModels.Input.DoubleInput>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="3d59ccad-57ed-44bc-9d55-27574fc725de" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Average" x="215" y="200.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Average@double[]" />
+    <CoreNodeModels.Input.DoubleInput guid="6b9eec3d-37c2-477f-b0b0-ec2c6ffd2434" type="CoreNodeModels.Input.DoubleInput" nickname="Number" x="-64" y="305.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
       <System.Double value="-10..-1" />
-    </Dynamo.Nodes.DoubleInput>
-    <Dynamo.Nodes.Average type="Dynamo.Nodes.Average" guid="d65de7e9-f7f7-4f2b-9be7-daad3b3c837a" nickname="Average" x="218" y="293.5" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
-    <Dynamo.Nodes.Average type="Dynamo.Nodes.Average" guid="af486a6c-a558-4a0b-860f-8c3800f5b8b5" nickname="Average" x="218" y="391.5" isVisible="true" isUpstreamVisible="true" lacing="Longest" />
-    <Dynamo.Nodes.DoubleInput type="Dynamo.Nodes.DoubleInput" guid="a57c0257-e9a4-41ed-baa5-02474c35e347" nickname="Number" x="-66" y="403.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </CoreNodeModels.Input.DoubleInput>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="d65de7e9-f7f7-4f2b-9be7-daad3b3c837a" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Average" x="218" y="293.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Average@double[]" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="af486a6c-a558-4a0b-860f-8c3800f5b8b5" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Average" x="218" y="391.5" isVisible="true" isUpstreamVisible="true" lacing="Longest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Average@double[]" />
+    <CoreNodeModels.Input.DoubleInput guid="a57c0257-e9a4-41ed-baa5-02474c35e347" type="CoreNodeModels.Input.DoubleInput" nickname="Number" x="-66" y="403.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
       <System.Double value="5" />
-    </Dynamo.Nodes.DoubleInput>
+    </CoreNodeModels.Input.DoubleInput>
   </Elements>
   <Connectors>
-    <Dynamo.Models.ConnectorModel start="e440ddff-97d0-4eed-9df6-1896400fcd2b" start_index="0" end="d4f242c5-9c20-4633-b661-157ab45a416c" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="a7cd33ea-74fe-441f-bacf-f7a4f16876a7" start_index="0" end="3d59ccad-57ed-44bc-9d55-27574fc725de" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="6b9eec3d-37c2-477f-b0b0-ec2c6ffd2434" start_index="0" end="d65de7e9-f7f7-4f2b-9be7-daad3b3c837a" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="a57c0257-e9a4-41ed-baa5-02474c35e347" start_index="0" end="af486a6c-a558-4a0b-860f-8c3800f5b8b5" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e440ddff-97d0-4eed-9df6-1896400fcd2b" start_index="0" end="d4f242c5-9c20-4633-b661-157ab45a416c" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="a7cd33ea-74fe-441f-bacf-f7a4f16876a7" start_index="0" end="3d59ccad-57ed-44bc-9d55-27574fc725de" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="6b9eec3d-37c2-477f-b0b0-ec2c6ffd2434" start_index="0" end="d65de7e9-f7f7-4f2b-9be7-daad3b3c837a" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="a57c0257-e9a4-41ed-baa5-02474c35e347" start_index="0" end="af486a6c-a558-4a0b-860f-8c3800f5b8b5" end_index="0" portType="0" />
   </Connectors>
   <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>


### PR DESCRIPTION
### Purpose

When investigating the broken test case `AdaptiveComponentByCurve`, found an issue in replicator that if input arguments match function parameters, replication guides are skipped. For example:
```
def foo(xs:var[], y:var, z:var)
{
    return = Sum(xs) + y + z;
}
xs = {1, 2, 3};
y = "-foo";
z = "-bar";
r = foo(xs<1>, y, z);
```

As the ranks of these arguments are the same as the ranks of parameters, replication guide `<1>` is skipped. But the expected behavior is to do cartesian replication on `xs` firstly (and the expected result for `r` is `{"1-foo-bar", "2-foo-bar", "3-foo-bar"}`.

It also means that if a node uses longest lacing, and it only has one input, the replication is guaranteed to happen on that input.
 
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@monikaprabhu, @kronz , @Racel 

After this fix, replication *is guaranteed to happen* in the way that replication guide specifies. But our lacing doesn't cover all replication cases. For a function `foo(x, y, z)`, currently
  * Shortest lacing will generate function call `foo(x, y, z)` (it is **not** shortest lacing)
  * Longest lacing will generate function call `foo(x<1L>, y<1L>, z<1L>)`
  * Cross product will generate function call `foo(x<1>, y<2>, z<3>)`
But one case is missing: `foo(x<1>, y<1>, z<1>)`, it does real shortest zip replication. We need an option on UI for no lacing.
