### PR TITLE
Engine cleanup - remove dead instruction and dead code

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -655,21 +655,6 @@ namespace ProtoAssociative
             //AppendInstruction(instr);
         }
 
-        private void EmitRetc(int line = ProtoCore.DSASM.Constants.kInvalidIndex, int col = ProtoCore.DSASM.Constants.kInvalidIndex,
-            int eline = ProtoCore.DSASM.Constants.kInvalidIndex, int ecol = ProtoCore.DSASM.Constants.kInvalidIndex)
-        {
-            Instruction instr = new Instruction();
-            instr.opCode = ProtoCore.DSASM.OpCode.RETC;
-
-            ++pc;
-            instr.debug = GetDebugObject(line, col, eline, ecol, ProtoCore.DSASM.Constants.kInvalidIndex);
-            codeBlock.instrStream.instrList.Add(instr);
-
-            // TODO: Figure out why using AppendInstruction fails for adding these instructions to ExpressionInterpreter
-            //AppendInstruction(instr, line, col);
-            updatePcDictionary(line, col);
-        }
-        
         protected override void EmitRetb( int line = ProtoCore.DSASM.Constants.kInvalidIndex, int col = ProtoCore.DSASM.Constants.kInvalidIndex,
             int endline = ProtoCore.DSASM.Constants.kInvalidIndex, int endcol = ProtoCore.DSASM.Constants.kInvalidIndex)
         {
@@ -5487,7 +5472,7 @@ namespace ProtoAssociative
                 int startpc = pc;
 
                 // Constructors auto return
-                EmitInstrConsole(ProtoCore.DSASM.kw.retc);
+                EmitInstrConsole(ProtoCore.DSASM.kw.ret);
 
                 // Stepping out of a constructor body will have the execution cursor 
                 // placed right at the closing curly bracket of the constructor definition.
@@ -5504,7 +5489,7 @@ namespace ProtoAssociative
                 // because end-column of "FunctionBody" here is *after* the closing 
                 // curly bracket, so we want one before that.
                 // 
-                EmitRetc(closeCurlyBracketLine, closeCurlyBracketColumn - 1,
+                EmitReturn(closeCurlyBracketLine, closeCurlyBracketColumn - 1,
                     closeCurlyBracketLine, closeCurlyBracketColumn);
 
                 // Build and append a graphnode for this return statememt

--- a/src/Engine/ProtoCore/DSASM/DSasmDefs.cs
+++ b/src/Engine/ProtoCore/DSASM/DSasmDefs.cs
@@ -102,7 +102,6 @@ namespace ProtoCore.DSASM
         public const string pushrepguide = "pushguide";
         public const string pushlevel = "pushlevel";
         public const string ret = "ret";
-        public const string retc = "retc";
         public const string retb = "retb";
         public const string retcn = "retcn";
         public const string pop = "pop";

--- a/src/Engine/ProtoCore/DSASM/Executable.cs
+++ b/src/Engine/ProtoCore/DSASM/Executable.cs
@@ -84,7 +84,6 @@ namespace ProtoCore.DSASM
         // Recursion handling
         public List<FunctionCounter> recursivePoint { get; set; }
         public List<FunctionCounter> funcCounterTable { get; set; }
-        public bool calledInFunction;
 #endregion
 
 #region RUNTIME_GENERATED
@@ -119,7 +118,6 @@ namespace ProtoCore.DSASM
             CurrentDSFileName = string.Empty;
             recursivePoint = new List<FunctionCounter>();
             funcCounterTable = new List<FunctionCounter>();
-            calledInFunction = false;
             UpdatedSymbols = new HashSet<SymbolNode>();
         }
     }

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -1,12 +1,10 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using ProtoCore.Exceptions;
 using ProtoCore.Utils;
 using ProtoCore.Runtime;
-using System.Diagnostics;
 using ProtoCore.Properties;
 
 namespace ProtoCore.DSASM
@@ -29,19 +27,13 @@ namespace ProtoCore.DSASM
         public Language executingLanguage = Language.Associative;
 
         protected int pc = Constants.kInvalidPC;
-        public int PC
-        {
-            get
-            {
-                return pc;
-            }
-        }
+        public int PC { get { return pc; } }
 
         private bool fepRun;
         bool terminate;
 
         private InstructionStream istream;
-        public Runtime.RuntimeMemory rmem { get; set; }
+        public RuntimeMemory rmem { get; set; }
 
         private StackValue AX;
         private StackValue BX;
@@ -158,9 +150,7 @@ namespace ProtoCore.DSASM
             List<StackValue> registers = stackFrame.GetRegisters();
 
             rmem.PushStackFrame(svThisPtr, ci, fi, returnAddr, blockDecl, blockCaller, callerFrameType, frameType, depth + 1, framePointer, registers, locals, 0);
-            
         }
-
 
         /// <summary>
         /// Bounce instantiates a new Executive 
@@ -249,7 +239,6 @@ namespace ProtoCore.DSASM
             }
         }
 
-
         private void BounceExplicit(int exeblock, int entry, Language language, StackFrame frame)
         {
             fepRun = false;
@@ -311,7 +300,6 @@ namespace ProtoCore.DSASM
             rmem.FramePointer = fpRestore;
             return false;
         }
-
 
         private void RestoreRegistersFromStackFrame()
         {
@@ -442,13 +430,11 @@ namespace ProtoCore.DSASM
             logVMMessage("End JIL Execution - " + CoreUtils.GetLanguageString(currentLang));
         }
 
-
         private void RestoreExecutive(int exeblock)
         {
             // Jun Comment: the stackframe mpof the current language must still be present for this this method to restore the executuve
             // It must be popped off after this call
             executingLanguage = exe.instrStreamList[exeblock].language;
-
 
             // TODO Jun: Remove this check once the global bounce stackframe is pushed
             if (rmem.FramePointer >= StackFrame.kStackFrameSize)
@@ -606,7 +592,6 @@ namespace ProtoCore.DSASM
                 UpdateMethodDependencyGraph(pc, fi, ci);
             }
         }
-
 
         public void GetCallerInformation(out int classIndex, out int functionIndex)
         {
@@ -1037,19 +1022,6 @@ namespace ProtoCore.DSASM
 
             return sv;
         }
-
-        private void FindRecursivePoints()
-        {
-            foreach (FunctionCounter c in exe.funcCounterTable)
-            {
-                if (c.times == Constants.kRecursionTheshold || c.times == Constants.kRecursionTheshold - 1)
-                {
-                    exe.recursivePoint.Add(c);
-                }
-                exe.recursivePoint.Add(c);
-            }
-        }
-
 
         private FunctionCounter FindCounter(int funcIndex, int classScope, string name)
         {
@@ -3620,7 +3592,6 @@ namespace ProtoCore.DSASM
                 bool allowGC = sn.classScope == classIndex 
                     && sn.functionIndex == functionIndex 
                     && !sn.name.Equals(Constants.kWatchResultVar);
-                    /*&& !CoreUtils.IsSSATemp(sn.name)*/
 
                 if (runtimeCore.Options.GCTempVarsOnDebug && runtimeCore.Options.ExecuteSSA)
                 {
@@ -3657,42 +3628,6 @@ namespace ProtoCore.DSASM
 
         public void ReturnSiteGC(int blockId, int classIndex, int functionIndex)
         {
-            SymbolTable st;
-            List<StackValue> ptrList = new List<StackValue>();
-            if (Constants.kInvalidIndex == classIndex)
-            {
-                st = exe.CompleteCodeBlocks[blockId].symbolTable;
-            }
-            else
-            {
-                st = exe.classTable.ClassNodes[classIndex].Symbols;
-            }
-
-            foreach (SymbolNode symbol in st.symbolList.Values)
-            {
-                bool allowGC = symbol.functionIndex == functionIndex
-                    && !symbol.name.Equals(Constants.kWatchResultVar);
-
-                if (runtimeCore.Options.GCTempVarsOnDebug && runtimeCore.Options.ExecuteSSA)
-                {
-                    if (runtimeCore.Options.IDEDebugMode)
-                    {
-                        allowGC = symbol.functionIndex == functionIndex
-                            && !symbol.name.Equals(Constants.kWatchResultVar)
-                            && !CoreUtils.IsSSATemp(symbol.name);
-                    }
-                }
-
-                if (allowGC)
-                {
-                    StackValue sv = rmem.GetSymbolValue(symbol);
-                    if (sv.IsPointer || sv.IsArray)
-                    {
-                        ptrList.Add(sv);
-                    }
-                }
-            }
-
             foreach (CodeBlock cb in exe.CompleteCodeBlocks[blockId].children)
             {
                 if (cb.blockType == CodeBlockType.kConstruct)

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -2364,10 +2364,7 @@ namespace ProtoCore.DSASM
                 Instruction executeInstruction = instructions[pc];
                 Exec(instructions[pc]);
 
-                bool restoreInstructionStream =
-                    executeInstruction.opCode == OpCode.CALLR ||
-                    executeInstruction.opCode == OpCode.RETURN
-                    || executeInstruction.opCode == OpCode.RETC;
+                bool restoreInstructionStream = executeInstruction.opCode == OpCode.CALLR || executeInstruction.opCode == OpCode.RETURN;
                 if (restoreInstructionStream && IsExplicitCall)
                 {
                     // The instruction stream list is updated on callr
@@ -2380,7 +2377,7 @@ namespace ProtoCore.DSASM
                 // Check if the current instruction is a return from a function call or constructor
 
                 DebugFrame tempFrame = null;
-                if (!IsExplicitCall && (instructions[runtimeCore.DebugProps.DebugEntryPC].opCode == OpCode.RETURN || instructions[runtimeCore.DebugProps.DebugEntryPC].opCode == OpCode.RETC))
+                if (!IsExplicitCall && instructions[runtimeCore.DebugProps.DebugEntryPC].opCode == OpCode.RETURN)
                 {
                     int ci, fi;
                     bool isReplicating;
@@ -5167,8 +5164,7 @@ namespace ProtoCore.DSASM
 
         private void RETC_Handler()
         {
-            runtimeVerify(rmem.ValidateStackFrame());
-            RestoreFromCall();
+            RETURN_Handler();
         }
 
         private void RETB_Handler()
@@ -5851,12 +5847,6 @@ namespace ProtoCore.DSASM
                 case OpCode.CALLR:
                     {
                         CALLR_Handler(instruction);
-                        return;
-                    }
-
-                case OpCode.RETC:
-                    {
-                        RETC_Handler();
                         return;
                     }
 

--- a/src/Engine/ProtoCore/DSASM/InstructionSet.cs
+++ b/src/Engine/ProtoCore/DSASM/InstructionSet.cs
@@ -93,7 +93,6 @@ namespace ProtoCore.DSASM
         CALL,
         CALLR,
         RETURN,         // Return from function call
-        RETC,           // Return from constructor
         RETB,           // Return from code block (pushed by BOUNCE)
         RETCN,          // Return from local block
 

--- a/src/Engine/ProtoCore/DebuggerProperties.cs
+++ b/src/Engine/ProtoCore/DebuggerProperties.cs
@@ -617,8 +617,7 @@ namespace ProtoCore
                 {
                     Instruction instr = istream.instrList[pc];
                     // We still want to break at the closing brace of a function or ctor call or language block
-                    if (instr.debug != null && instr.opCode != OpCode.RETC && instr.opCode != OpCode.RETURN && 
-                        (instr.opCode != OpCode.RETB)) 
+                    if (instr.debug != null && instr.opCode != OpCode.RETURN && (instr.opCode != OpCode.RETB)) 
                     {
                         if (runtimeCore.Breakpoints.Contains(instr))
                             runtimeCore.Breakpoints.Remove(instr);

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -327,6 +327,11 @@ namespace ProtoCore.Utils
             return methodName.Equals(DSDefinitions.Keyword.Dispose);
         }
 
+        public static bool IsDotMethod(string methodName)
+        {
+            return methodName.Equals(Constants.kDotMethodName);
+        }
+
         public static bool IsGetTypeMethod(string methodName)
         {
             Validity.Assert(!string.IsNullOrEmpty(methodName));


### PR DESCRIPTION
### Purpose

Engine cleanup work. 
* Remove instruction `RETC` -- it could be replaced by `RETURN` instruction. 
* Remove dead reference counting GC code. 
* Remove dead mark & sweep GC code.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
