### PR TITLE
Unregister WorkspaceAdded event handler

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -757,9 +757,12 @@ namespace Dynamo.Graph.Workspaces
             foreach (var connector in Connectors)
                 OnConnectorDeleted(connector);
 
+            WorkspaceEvents.WorkspaceAdded -= computeUpstreamNodesWhenWorkspaceAdded;
+
             var handler = Disposed;
             if (handler != null) 
                 handler();
+
             Disposed = null;
         }
 


### PR DESCRIPTION
### Purpose

Notice `DynamoCoreTests` consumes over 9GB after running. This memory leak is because `WorkspaceModel` registers an event handler for `DynamoServices.WorkspaceEvents.WorkspaceAdded` event. As `DynamoServices.WorkspaceEvents` is a static class, its life cycle is across the whole unit test session, therefore `WorkspaceModel` will never be released.

Un-register this event handler when the `WorkspaceModel` is disposed. The memory usage of nunit is down to few hundred mega bytes after running.  

The other benefit is running time is halved: locally it is from 30 minutes to 15 minutes.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 

