### PR TITLE
MAGN-9563 Regression:  Watch nodes no longer show Label behavior

### DIFF
--- a/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
+++ b/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
@@ -9,6 +9,7 @@ using ProtoCore.DSASM;
 using ProtoCore.Mirror;
 using ProtoCore.Utils;
 using Dynamo.Extensions;
+
 namespace Dynamo.Interfaces
 {
     /// <summary>
@@ -20,6 +21,7 @@ namespace Dynamo.Interfaces
     /// </summary>
     public interface IWatchHandler
     {
+        event Action<string> RequestSelectGeometry;
         WatchViewModel Process(dynamic value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback);
     }
 
@@ -56,7 +58,7 @@ namespace Dynamo.Interfaces
             {
                 var list = (value as IEnumerable).Cast<dynamic>().ToList();
 
-                node = new WatchViewModel(list.Count == 0 ? "Empty List" : "List", tag, true);
+                node = new WatchViewModel(list.Count == 0 ? "Empty List" : "List", tag, OnRequestSelectGeometry, true);
                 foreach (var e in list.Select((element, idx) => new { element, idx }))
                 {
                     node.Children.Add(callback(e.element, runtimeCore, tag + ":" + e.idx, showRawData));
@@ -76,15 +78,15 @@ namespace Dynamo.Interfaces
                     int typeId = runtimeCore.DSExecutable.TypeSystem.GetType(stackValue);
                     stringValue = runtimeCore.DSExecutable.classTable.ClassNodes[typeId].Name;
                 }
-                node = new WatchViewModel(stringValue, tag);
+                node = new WatchViewModel(stringValue, tag, OnRequestSelectGeometry);
             }
             else if (value is Enum)
             {
-                return new WatchViewModel(((Enum)value).GetDescription(), tag);
+                return new WatchViewModel(((Enum)value).GetDescription(), tag, OnRequestSelectGeometry);
             }
             else
             {
-                node = new WatchViewModel(ToString(value), tag);
+                node = new WatchViewModel(ToString(value), tag, OnRequestSelectGeometry);
             }
 
             return node;
@@ -95,28 +97,28 @@ namespace Dynamo.Interfaces
             return showRawData
                 ? new WatchViewModel(
                     unit.Value.ToString(preferences.NumberFormat, CultureInfo.InvariantCulture),
-                    tag)
-                : new WatchViewModel(unit.ToString(), tag);
+                    tag, OnRequestSelectGeometry)
+                : new WatchViewModel(unit.ToString(), tag, OnRequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(double value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(numberFormat, CultureInfo.InvariantCulture), tag);
+            return new WatchViewModel(value.ToString(numberFormat, CultureInfo.InvariantCulture), tag, OnRequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(DateTime value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture), tag);
+            return new WatchViewModel(value.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture), tag, OnRequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(long value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(CultureInfo.InvariantCulture), tag);
+            return new WatchViewModel(value.ToString(CultureInfo.InvariantCulture), tag, OnRequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(string value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value, tag);
+            return new WatchViewModel(value, tag, OnRequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(MirrorData data, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
@@ -125,7 +127,7 @@ namespace Dynamo.Interfaces
             {
                 var list = data.GetElements();
 
-                var node = new WatchViewModel(list.Count == 0 ? "Empty List" : "List", tag, true);
+                var node = new WatchViewModel(list.Count == 0 ? "Empty List" : "List", tag, OnRequestSelectGeometry, true);
                 foreach (var e in list.Select((element, idx) => new { element, idx }))
                 {
                     node.Children.Add(ProcessThing(e.element, runtimeCore, tag + ":" + e.idx, showRawData, callback));
@@ -135,7 +137,7 @@ namespace Dynamo.Interfaces
             }
             if (data.Data is Enum)
             {
-                return new WatchViewModel(((Enum)data.Data).GetDescription(), tag);
+                return new WatchViewModel(((Enum)data.Data).GetDescription(), tag, OnRequestSelectGeometry);
             }
 
             if (data.Data == null)
@@ -144,7 +146,7 @@ namespace Dynamo.Interfaces
                 // representation instead of casting it as dynamic (that leads to 
                 // a crash).
                 if (data.IsNull)
-                    return new WatchViewModel(NULL_STRING, tag);
+                    return new WatchViewModel(NULL_STRING, tag, OnRequestSelectGeometry);
                 
                 //If the input data is an instance of a class, create a watch node
                 //with the class name and let WatchHandler process the underlying CLR data
@@ -170,8 +172,18 @@ namespace Dynamo.Interfaces
         public WatchViewModel Process(dynamic value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
             return Object.ReferenceEquals(value, null)
-                ? new WatchViewModel(NULL_STRING, tag)
+                ? new WatchViewModel(NULL_STRING, tag, OnRequestSelectGeometry)
                 : ProcessThing(value, runtimeCore, tag, showRawData, callback);
+        }
+
+        public event Action<string> RequestSelectGeometry;
+
+        private void OnRequestSelectGeometry(string path)
+        {
+            if (RequestSelectGeometry != null)
+            {
+                RequestSelectGeometry(path);
+            }
         }
     }
 }

--- a/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
+++ b/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
@@ -58,7 +58,7 @@ namespace Dynamo.Interfaces
             {
                 var list = (value as IEnumerable).Cast<dynamic>().ToList();
 
-                node = new WatchViewModel(list.Count == 0 ? "Empty List" : "List", tag, OnRequestSelectGeometry, true);
+                node = new WatchViewModel(list.Count == 0 ? "Empty List" : "List", tag, RequestSelectGeometry, true);
                 foreach (var e in list.Select((element, idx) => new { element, idx }))
                 {
                     node.Children.Add(callback(e.element, runtimeCore, tag + ":" + e.idx, showRawData));
@@ -78,15 +78,15 @@ namespace Dynamo.Interfaces
                     int typeId = runtimeCore.DSExecutable.TypeSystem.GetType(stackValue);
                     stringValue = runtimeCore.DSExecutable.classTable.ClassNodes[typeId].Name;
                 }
-                node = new WatchViewModel(stringValue, tag, OnRequestSelectGeometry);
+                node = new WatchViewModel(stringValue, tag, RequestSelectGeometry);
             }
             else if (value is Enum)
             {
-                return new WatchViewModel(((Enum)value).GetDescription(), tag, OnRequestSelectGeometry);
+                return new WatchViewModel(((Enum)value).GetDescription(), tag, RequestSelectGeometry);
             }
             else
             {
-                node = new WatchViewModel(ToString(value), tag, OnRequestSelectGeometry);
+                node = new WatchViewModel(ToString(value), tag, RequestSelectGeometry);
             }
 
             return node;
@@ -97,28 +97,28 @@ namespace Dynamo.Interfaces
             return showRawData
                 ? new WatchViewModel(
                     unit.Value.ToString(preferences.NumberFormat, CultureInfo.InvariantCulture),
-                    tag, OnRequestSelectGeometry)
-                : new WatchViewModel(unit.ToString(), tag, OnRequestSelectGeometry);
+                    tag, RequestSelectGeometry)
+                : new WatchViewModel(unit.ToString(), tag, RequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(double value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(numberFormat, CultureInfo.InvariantCulture), tag, OnRequestSelectGeometry);
+            return new WatchViewModel(value.ToString(numberFormat, CultureInfo.InvariantCulture), tag, RequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(DateTime value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture), tag, OnRequestSelectGeometry);
+            return new WatchViewModel(value.ToString(PreferenceSettings.DefaultDateFormat, CultureInfo.InvariantCulture), tag, RequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(long value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value.ToString(CultureInfo.InvariantCulture), tag, OnRequestSelectGeometry);
+            return new WatchViewModel(value.ToString(CultureInfo.InvariantCulture), tag, RequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(string value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
-            return new WatchViewModel(value, tag, OnRequestSelectGeometry);
+            return new WatchViewModel(value, tag, RequestSelectGeometry);
         }
 
         private WatchViewModel ProcessThing(MirrorData data, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
@@ -127,7 +127,7 @@ namespace Dynamo.Interfaces
             {
                 var list = data.GetElements();
 
-                var node = new WatchViewModel(list.Count == 0 ? "Empty List" : "List", tag, OnRequestSelectGeometry, true);
+                var node = new WatchViewModel(list.Count == 0 ? "Empty List" : "List", tag, RequestSelectGeometry, true);
                 foreach (var e in list.Select((element, idx) => new { element, idx }))
                 {
                     node.Children.Add(ProcessThing(e.element, runtimeCore, tag + ":" + e.idx, showRawData, callback));
@@ -137,7 +137,7 @@ namespace Dynamo.Interfaces
             }
             if (data.Data is Enum)
             {
-                return new WatchViewModel(((Enum)data.Data).GetDescription(), tag, OnRequestSelectGeometry);
+                return new WatchViewModel(((Enum)data.Data).GetDescription(), tag, RequestSelectGeometry);
             }
 
             if (data.Data == null)
@@ -146,7 +146,7 @@ namespace Dynamo.Interfaces
                 // representation instead of casting it as dynamic (that leads to 
                 // a crash).
                 if (data.IsNull)
-                    return new WatchViewModel(NULL_STRING, tag, OnRequestSelectGeometry);
+                    return new WatchViewModel(NULL_STRING, tag, RequestSelectGeometry);
                 
                 //If the input data is an instance of a class, create a watch node
                 //with the class name and let WatchHandler process the underlying CLR data
@@ -172,18 +172,10 @@ namespace Dynamo.Interfaces
         public WatchViewModel Process(dynamic value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
             return Object.ReferenceEquals(value, null)
-                ? new WatchViewModel(NULL_STRING, tag, OnRequestSelectGeometry)
+                ? new WatchViewModel(NULL_STRING, tag, RequestSelectGeometry)
                 : ProcessThing(value, runtimeCore, tag, showRawData, callback);
         }
 
         public event Action<string> RequestSelectGeometry;
-
-        private void OnRequestSelectGeometry(string path)
-        {
-            if (RequestSelectGeometry != null)
-            {
-                RequestSelectGeometry(path);
-            }
-        }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -35,6 +35,7 @@ using Dynamo.Wpf.ViewModels.Core;
 using Dynamo.Wpf.ViewModels.Watch3D;
 using DynCmd = Dynamo.ViewModels.DynamoViewModel;
 using ISelectable = Dynamo.Selection.ISelectable;
+using Autodesk.DesignScript.Interfaces;
 
 namespace Dynamo.ViewModels
 {
@@ -496,6 +497,7 @@ namespace Dynamo.ViewModels
 
             BackgroundPreviewViewModel = startConfiguration.Watch3DViewModel;
             BackgroundPreviewViewModel.PropertyChanged += Watch3DViewModelPropertyChanged;
+            WatchHandler.RequestSelectGeometry += BackgroundPreviewViewModel.AddLabelForPath;
             RegisterWatch3DViewModel(BackgroundPreviewViewModel, RenderPackageFactoryViewModel.Factory);
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -30,6 +30,7 @@ namespace Dynamo.ViewModels
         private bool _showRawData;
         private string _path = "";
         private bool _isOneRowContent;
+        private readonly Action<string> tagGeometry;
 
         public DelegateCommand FindNodeForPathCommand { get; set; }
 
@@ -140,19 +141,15 @@ namespace Dynamo.ViewModels
 
         #endregion
 
-        public WatchViewModel()
-        {
-            FindNodeForPathCommand = new DelegateCommand(FindNodeForPath, CanFindNodeForPath);
-            IsNodeExpanded = true;
-            _showRawData = false;
-        }
+        public WatchViewModel(Action<string> tagGeometry): this(null, null, tagGeometry, true) { }
 
-        public WatchViewModel(string label, string path, bool expanded = false)
+        public WatchViewModel(string label, string path, Action<string> tagGeometry, bool expanded = false)
         {
             FindNodeForPathCommand = new DelegateCommand(FindNodeForPath, CanFindNodeForPath);
             _path = path;
             _label = label;
             IsNodeExpanded = expanded;
+            this.tagGeometry = tagGeometry;
         }
 
         private bool CanFindNodeForPath(object obj)
@@ -162,6 +159,10 @@ namespace Dynamo.ViewModels
 
         private void FindNodeForPath(object obj)
         {
+            if (tagGeometry != null)
+            {
+                tagGeometry(obj.ToString());
+            }
             //visualizationManager.TagRenderPackageForPath(obj.ToString());
         }
     }

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -471,6 +471,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             // Override in inherited classes.
         }
 
+        public virtual void AddLabelForPath(string path)
+        {
+            // Override in inherited classes.
+        }
+
         public void Invoke(Action action)
         {
             var dynamoViewModel = viewModel as DynamoViewModel;

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -102,6 +102,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private static readonly Color4 defaultPointColor = new Color4(new Color3(0, 0, 0));
         private static readonly Color4 defaultDeadColor = new Color4(new Color3(0.7f,0.7f,0.7f));
         private static readonly float defaultDeadAlphaScale = 0.2f;
+        private const float defaultLabelOffset = 0.025f;
 
         internal const string DefaultGridName = "Grid";
         internal const string DefaultAxesName = "Axes";
@@ -1236,6 +1237,55 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         }
 
         /// <summary>
+        /// Display a label for geometry based on the paths.
+        /// </summary>
+        public override void AddLabelForPath(string path)
+        {
+            // make var_guid from var_guid:0:1
+            var nodePath = path.Contains(':') ? path.Remove(path.IndexOf(':')) : path;
+            var labelName = nodePath + TextKey;
+            lock (Model3DDictionaryMutex)
+            {
+                // first, remove current labels of the node
+                // it does not crash if there is no such key in dictionary
+                Model3DDictionary.Remove(labelName);
+                
+                // second, add requested labels
+                var textGeometry = HelixRenderPackage.InitText3D();
+                var bbText = new BillboardTextModel3D
+                {
+                    Geometry = textGeometry
+                };
+
+                // it may be requested an array of items to put labels
+                // for example, the first item in 2-dim array - path will look like var_guid:0
+                // and it will select var_guid:0:0, var_guid:0:1, var_guid:0:2 and so on
+                var nodeLabelKeys = Model3DDictionary.Keys.Where(k => k.StartsWith(path + ':')).ToList();
+                foreach (var key in nodeLabelKeys)
+                {
+                    var geom = Model3DDictionary[key] as GeometryModel3D;
+                    if (geom == null) continue;
+
+                    var id = key.Remove(key.LastIndexOf(':'));
+
+                    var pt = geom.Geometry.Positions[0];
+                    var off = defaultLabelOffset;
+                    var text = HelixRenderPackage.CleanTag(id.Remove(0, nodePath.Length));
+                    var textInfo = new TextInfo(text, new Vector3(pt.X + off, pt.Y + off, pt.Z + off));
+                    textGeometry.TextInfo.Add(textInfo);
+                }
+
+                if (textGeometry.TextInfo.Any())
+                {
+                    Model3DDictionary.Add(nodePath + TextKey, bbText);
+                }
+
+                AttachAllGeometryModel3DToRenderHost();
+                OnSceneItemsChanged();
+            }
+        }
+
+        /// <summary>
         /// Given a collection of render packages, generates
         /// corresponding <see cref="GeometryModel3D"/> objects for visualization, and
         /// attaches them to the visual scene.
@@ -1243,14 +1293,13 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// <param name="packages">An <see cref="IEnumerable"/> of <see cref="HelixRenderPackage"/>.</param>
         private void AggregateRenderPackages(IEnumerable<HelixRenderPackage> packages)
         {
-            
             IEnumerable<string> customNodeIdents = null;
             if (InCustomNode())
             {
                 var hs = model.Workspaces.OfType<HomeWorkspaceModel>().FirstOrDefault();
                 if (hs != null)
                 {
-                    customNodeIdents = FindIdentifiersForCustomNodes((HomeWorkspaceModel)hs);
+                    customNodeIdents = FindIdentifiersForCustomNodes(hs);
                 }
             }
 
@@ -1264,26 +1313,27 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     // with `points`, `lines`, or `mesh`. For each RenderPackage, we check whether the geometry dictionary
                     // has entries for the points, lines, or mesh already. If so, we add the RenderPackage's geometry
                     // to those geometry objects.
-                    
+
                     var baseId = rp.Description;
                     if (baseId.IndexOf(":", StringComparison.Ordinal) > 0)
                     {
                         baseId = baseId.Split(':')[0];
                     }
-                    var id = baseId;
+                    
                     //If this render package belongs to special render package, then create
                     //and update the corresponding GeometryModel. Sepcial renderpackage are
                     //defined based on its description containing one of the constants from
                     //RenderDescriptions struct.
-                    if (UpdateGeometryModelForSpecialRenderPackage(rp, id))
+                    if (UpdateGeometryModelForSpecialRenderPackage(rp, baseId))
                         continue;
 
                     var drawDead = InCustomNode() && !customNodeIdents.Contains(baseId);
 
+                    string id;
                     var p = rp.Points;
                     if (p.Positions.Any())
                     {
-                        id = baseId + PointsKey;
+                        id = rp.Description + PointsKey;
 
                         PointGeometryModel3D pointGeometry3D;
 
@@ -1327,7 +1377,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     var l = rp.Lines;
                     if (l.Positions.Any())
                     {
-                        id = baseId + LinesKey;
+                        id = rp.Description + LinesKey;
 
                         LineGeometryModel3D lineGeometry3D;
 

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -381,7 +381,7 @@ namespace Dynamo.UI.Controls
                 () =>
                 {
                     newViewModel = nodeViewModel.DynamoViewModel.WatchHandler.GenerateWatchViewModelForData(
-                        mirrorData, null, string.Empty, false);
+                        mirrorData, null, nodeViewModel.NodeModel.AstIdentifierForPreview.Name, false);
                 },
                 (m) =>
                 {
@@ -389,7 +389,7 @@ namespace Dynamo.UI.Controls
                     {
                         var tree = new WatchTree
                         {
-                            DataContext = new WatchViewModel()
+                            DataContext = new WatchViewModel(nodeViewModel.DynamoViewModel.BackgroundPreviewViewModel.AddLabelForPath)
                         };
                         tree.treeView1.ItemContainerGenerator.StatusChanged += WatchContainer_StatusChanged;
 

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -41,7 +41,7 @@ namespace CoreNodeModelsWpf.Nodes
             var watchTree = new WatchTree();
 
             // make empty watchViewModel
-            rootWatchViewModel = new WatchViewModel();
+            rootWatchViewModel = new WatchViewModel(dynamoViewModel.BackgroundPreviewViewModel.AddLabelForPath);
 
             // Fix the maximum width/height of watch node.
             nodeView.PresentationGrid.MaxWidth = Configurations.MaxWatchNodeWidth;

--- a/test/core/visualization/MAGN_3815.dyn
+++ b/test/core/visualization/MAGN_3815.dyn
@@ -1,0 +1,17 @@
+<Workspace Version="0.7.0.32659" X="153.12438364821" Y="138.911191408532" zoom="0.965566782607742" Description="" Category="" Name="Home">
+  <Elements>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="ee1744e5-409f-498c-a019-97ec80a05cb7" nickname="Point.ByCoordinates" x="30.6845657580702" y="-18.8567422071499" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="6be1af3b-bfd0-4018-b35b-d7062655c992" nickname="Code Block" x="-122.988360624713" y="-16.6417579254424" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0..100..10;" ShouldFocus="false" />
+    <Dynamo.Nodes.Watch type="Dynamo.Nodes.Watch" guid="fce2bf5b-558f-4bba-a516-0809d4fcfe30" nickname="Watch" x="213.197365233978" y="-79.2351495048878" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="ee1744e5-409f-498c-a019-97ec80a05cb7" start_index="0" end="fce2bf5b-558f-4bba-a516-0809d4fcfe30" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="6be1af3b-bfd0-4018-b35b-d7062655c992" start_index="0" end="ee1744e5-409f-498c-a019-97ec80a05cb7" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="6be1af3b-bfd0-4018-b35b-d7062655c992" start_index="0" end="ee1744e5-409f-498c-a019-97ec80a05cb7" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
### Purpose

Label functionality was removed with VisualizationManager and was not added into new code. I put this functionality into `HelixWatch3DViewModel` and to have a possibility to access to separate geometry items of array node I store array items separately.
So, when clicking on TreeViewItem in Preview Bubble or in Watch node it looks like the next:
![image](https://cloud.githubusercontent.com/assets/7658189/13389865/8cee3ee8-ded3-11e5-848b-09e44ea2f187.png)
![image](https://cloud.githubusercontent.com/assets/7658189/13389890/b0c02ac0-ded3-11e5-8acf-6bb11fec76aa.png)
![image](https://cloud.githubusercontent.com/assets/7658189/13389908/c992da0c-ded3-11e5-8077-29738bd38381.png)
![image](https://cloud.githubusercontent.com/assets/7658189/13389922/d5b32dc8-ded3-11e5-8e16-09e60e5aa8cf.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate (**4 tests are added**)
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@aosyatnik 