### PR TITLE
Dynamo install lookup using fileLocator function

### DIFF
--- a/src/Tools/DynamoInstallDetective/Utilities.cs
+++ b/src/Tools/DynamoInstallDetective/Utilities.cs
@@ -30,6 +30,26 @@ namespace DynamoInstallDetective
         }
 
         /// <summary>
+        /// Finds all unique Dynamo installation on the system that has file 
+        /// identifiable by the given fileLocator.
+        /// </summary>
+        /// <param name="additionalDynamoPath">Additional path for Dynamo binaries
+        /// to be included in search</param>
+        /// <param name="fileLocator">A callback method to locate dynamo specific files.</param>
+        /// <returns>List of KeyValuePair of install location and version info 
+        /// as Tuple. The returned list is sorted based on version info.</returns>
+        public static IEnumerable LocateDynamoInstallations(string additionalDynamoPath, Func<string, string> fileLocator)
+        {
+            var installs = DynamoProducts.FindDynamoInstallations(additionalDynamoPath, new InstalledProductLookUp("Dynamo", fileLocator));
+            return
+                installs.Products.Select(
+                    p =>
+                        new KeyValuePair<string, Tuple<int, int, int, int>>(
+                        p.InstallLocation,
+                        p.VersionInfo));
+        }
+
+        /// <summary>
         /// Finds all products installed on the system with given product name
         /// search pattern and file name search pattern. e.g. to find Dynamo
         /// installations, we can use Dynamo as product search pattern and


### PR DESCRIPTION
### Purpose

This PR enhances DynamoInstallDetective to search different flavors of Dynamo installed on the system by using fileLocator function so that caller can search for Dynamo based on specific file presence in the installation. For example, to search installation of `Dynamo For Revit` we need to look for DynamoRevitDS.dll instead of DynamoCore.dll in the installation.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @Randy-Ma 

