### PR TITLE
Fix broken test cases

### DIFF
--- a/src/Engine/ProtoCore/RuntimeCore.cs
+++ b/src/Engine/ProtoCore/RuntimeCore.cs
@@ -261,7 +261,6 @@ namespace ProtoCore
             RunningBlock = 0;
             ExecutionState = (int)ExecutionStateEventArgs.State.kInvalid;
             StartPC = Constants.kInvalidPC;
-            executedAstGuids.Clear();
         }
 
         protected void OnDispose()
@@ -387,6 +386,14 @@ namespace ProtoCore
             {
                 executedAstGuids.Add(graphNode.guid);
             }
+        }
+
+        /// <summary>
+        /// Clear all recorded AST guids
+        /// </summary>
+        public void RemoveExecutedAstGuids()
+        {
+            executedAstGuids.Clear();
         }
     }
 }

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1670,6 +1670,7 @@ namespace ProtoScript.Runners
 
             var guids = runtimeCore.ExecutedAstGuids.ToList();
             executedAstGuids[syncData.SessionID] = guids;
+            runtimeCore.RemoveExecutedAstGuids();
         }
 
         private void SynchronizeInternal(string code)


### PR DESCRIPTION
### Purpose

Test cases `MAGN_7348_Math_Point_Formula` and `WriteModifyGraph_3` are broken by my recent PR #6185. In that PR the recorded AST GUIDs are cleared off in `ResetForDeltaExecution()`. But this method will be invoked multiple times during execution, therefore GUIDs might be cleared off incorrectly and the preview value of the corresponding UI node is not updated. 

Explicitly clear GUIDs after execution.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers
@Benglin I merge it now so that the complete install test could pass, please help to review it later.

