### PR TITLE
MAGN-9571 Sub Commit - Delete the unit test in question

### DIFF
--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -745,26 +745,6 @@ namespace DynamoCoreWpfTests
             System.Windows.Threading.Dispatcher.CurrentDispatcher.InvokeShutdown();
         }
 
-        [Test]
-        [Category("UnitTests")]
-        public void WorkspaceContextMenu_TestIfInCanvasSearchHidesOnOpeningContextMenu()
-        {
-            var currentWs = View.ChildOfType<WorkspaceView>();
-
-            // show in-canvas search
-            ViewModel.CurrentSpaceViewModel.ShowInCanvasSearchCommand.Execute(ShowHideFlags.Show);
-            Assert.IsTrue(currentWs.InCanvasSearchBar.IsOpen);
-
-            // open context menu
-            RightClick(currentWs.zoomBorder);
-
-            Assert.IsTrue(currentWs.ContextMenuPopup.IsOpen);
-            Assert.IsFalse(currentWs.InCanvasSearchBar.IsOpen);
-
-            // for not throwing 'System.Runtime.InteropServices.InvalidComObjectException' in PresentationCore.dll
-            System.Windows.Threading.Dispatcher.CurrentDispatcher.InvokeShutdown();
-        }
-
         private void RightClick(IInputElement element)
         {
             element.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Right)


### PR DESCRIPTION
### Purpose

MAGN-9571 When the search box is up a shift double click should bring the box down and put up the single search. The behavior is fixed by Masha's 
https://github.com/DynamoDS/Dynamo/pull/6206 but one of the unit test added is not proper and will fail all the time. Removing it in this PR.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 


### FYIs

@jnealb 

Mike, we have discussed about if we need to (or have a way to) unit test this behavior. Masha's unit test is a good example which will fail all the time and she will not be available Monday, so I'm removing this now in this PR. Either way we call out searchBar (using shift double click or right click), isOpen will always be true to the searchBar. So no way to unit test this I believe.