### PR TITLE
Fix MAGN 9548 comments in output port of custom node doesn't work if it has Class name instead of variable name.

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -568,8 +568,8 @@ namespace Dynamo.Graph.Nodes.CustomNodes
             var resolver = workspaceElementResolver ?? ElementResolver;
             var parseParam = new ParseParam(GUID, expression + ";", resolver);
 
-            if (EngineController.CompilationServices.PreCompileCodeBlock(ref parseParam) 
-                && parseParam.ParsedNodes.Any())
+            EngineController.CompilationServices.PreCompileCodeBlock(ref parseParam);
+            if (parseParam.ParsedNodes.Any())
             {
                 var parsedComments = parseParam.ParsedComments;
                 if (parsedComments.Any())

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -970,5 +970,19 @@ namespace Dynamo.Tests
             Assert.AreEqual("y2", customInstance.OutPortData[2].NickName);
             Assert.AreEqual("comment1\ncomment2\ncomment3", customInstance.OutPortData[2].ToolTipString);
         }
+
+        [Test]
+        public void Regress9548_OutputNameIsClassName()
+        {
+            var filePath = Path.Combine(TestDirectory, @"core\CustomNodes\PointAsOutput.dyn");
+            OpenModel(filePath);
+
+            var customInstance = CurrentDynamoModel.CurrentWorkspace.Nodes.FirstOrDefault(x => x is Function) as Function;
+            Assert.AreEqual("comment", customInstance.OutPortData[0].ToolTipString);
+            Assert.AreEqual("Point", customInstance.OutPortData[0].NickName);
+
+            var previewValue = GetPreviewValue(customInstance.GUID.ToString());
+            Assert.AreEqual(21, previewValue);
+        }
     }
 }

--- a/test/core/CustomNodes/PointAsOutput.dyf
+++ b/test/core/CustomNodes/PointAsOutput.dyf
@@ -1,0 +1,18 @@
+<Workspace Version="1.0.0.631" X="-229.299618228538" Y="-215.562774740192" zoom="2.05668026833428" Name="PointAsOutput" Description="" ID="4641aca2-786a-488b-8431-8f19484a2138" Category="CustomNodeTest">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CustomNodes.Output guid="a4dc157d-d3b4-4d00-b6ba-16c717d1c7f6" type="Dynamo.Graph.Nodes.CustomNodes.Output" nickname="Output" x="291.812987221359" y="147.368111820792" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false">
+      <Symbol value="//comment&#xD;&#xA;Point" />
+    </Dynamo.Graph.Nodes.CustomNodes.Output>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="a496d056-1522-4a65-a492-986cb07e51a2" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="156.988185304197" y="145.551182108439" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="21;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="a496d056-1522-4a65-a492-986cb07e51a2" start_index="0" end="a4dc157d-d3b4-4d00-b6ba-16c717d1c7f6" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>

--- a/test/core/CustomNodes/PointAsOutput.dyn
+++ b/test/core/CustomNodes/PointAsOutput.dyn
@@ -1,0 +1,21 @@
+<Workspace Version="1.0.0.631" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CustomNodes.Function guid="3621e235-e1c9-4a0e-a1d6-e3332b682c1f" type="Dynamo.Graph.Nodes.CustomNodes.Function" nickname="PointAsOutput" x="283.5" y="188.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="True" IsFrozen="false">
+      <ID value="4641aca2-786a-488b-8431-8f19484a2138" />
+      <Name value="PointAsOutput" />
+      <Description value="" />
+      <Inputs />
+      <Outputs>
+        <Output value="Point" />
+      </Outputs>
+    </Dynamo.Graph.Nodes.CustomNodes.Function>
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR fixes [MAGN-9548comments in output port of custom node doesn't work if it has Class name instead of variable name](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9548).

Let the parser be more tolerant when parsing output node, unless the parser is not able to get comment node and identifier node.  

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.