### PR TITLE
Fix regression by restore some settings in .dyn file 

### DIFF
--- a/doc/distrib/Samples/en-US/Basics/Basics_Basic01.dyn
+++ b/doc/distrib/Samples/en-US/Basics/Basics_Basic01.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="0.9.0.3067" X="-2980.90574841856" Y="-645.555610468664" zoom="1.04864451542255" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="False">
+<Workspace Version="0.9.0.3067" X="-3732.93901097413" Y="-827.405442288027" zoom="1.30071118175869" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="False">
   <NamespaceResolutionMap />
   <Elements>
     <Dynamo.Nodes.DoubleInput guid="a8d28be4-5b93-4b68-a182-6e7d09b6147e" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="2898.69722477541" y="870.914556274731" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">


### PR DESCRIPTION
### Purpose

Fix regressed test cases 
* Dynamo.Tests.WorkspaceOpeningTests.ManipulatingWorkspaceDoesNotAffectZoom
* Dynamo.Tests.WorkspaceOpeningTests.OpeningWorkspaceSetsPosition
* Dynamo.Tests.WorkspaceOpeningTests.OpeningWorkspaceSetsZoom

They fail because Basics_Basic01.dyn was modified in PR #6216. Restore some settings in this file.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@riteshchandawar 

