### PR TITLE
Fix MAGN 9009 MultiReturn Nodes with single output return dictionary instead of value at key

### DIFF
--- a/src/DynamoCore/Graph/Nodes/ZeroTouch/DSFunctionBase.cs
+++ b/src/DynamoCore/Graph/Nodes/ZeroTouch/DSFunctionBase.cs
@@ -45,10 +45,6 @@ namespace Dynamo.Graph.Nodes.ZeroTouch
                 string id = AstIdentifierBase + "_out" + outputIndex;
                 return AstFactory.BuildIdentifier(id);
             }
-            else if (OutPortData.Count == 1)
-            {
-                return AstIdentifierForPreview;
-            }
             else
             {
                 return base.GetAstIdentifierForOutputIndex(outputIndex); 

--- a/src/DynamoCore/Graph/Nodes/ZeroTouch/DSFunctionBase.cs
+++ b/src/DynamoCore/Graph/Nodes/ZeroTouch/DSFunctionBase.cs
@@ -40,11 +40,19 @@ namespace Dynamo.Graph.Nodes.ZeroTouch
 
         public override IdentifierNode GetAstIdentifierForOutputIndex(int outputIndex)
         {
-            return Controller.ReturnKeys != null && Controller.ReturnKeys.Any()
-                ? base.GetAstIdentifierForOutputIndex(outputIndex)
-                : (OutPortData.Count == 1
-                    ? AstIdentifierForPreview
-                    : base.GetAstIdentifierForOutputIndex(outputIndex));
+            if (Controller.ReturnKeys != null && Controller.ReturnKeys.Any())
+            {
+                string id = AstIdentifierBase + "_out" + outputIndex;
+                return AstFactory.BuildIdentifier(id);
+            }
+            else if (OutPortData.Count == 1)
+            {
+                return AstIdentifierForPreview;
+            }
+            else
+            {
+                return base.GetAstIdentifierForOutputIndex(outputIndex); 
+            }
         }
 
         /// <summary>

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AtLevelTest.cs" />
+    <Compile Include="MultiOutputNodeTest.cs" />
     <Compile Include="NodeExecutionTest.cs" />
     <Compile Include="AnnotationModelTest.cs" />
     <Compile Include="AstBuilderTest.cs" />

--- a/test/DynamoCoreTests/MultiOutputNodeTest.cs
+++ b/test/DynamoCoreTests/MultiOutputNodeTest.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Dynamo.Graph.Connectors;
+
+namespace Dynamo.Tests
+{
+    class MultiOutputNodeTest : DynamoModelTestBase
+    {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("FFITarget.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        [Test]
+        public void TestSingleOutputNode()
+        {
+            // Regress test for defect MAGN-9009
+            RunModel(@"core\multiout\singleoutput.dyn");
+            AssertPreviewValue("060e57e1-b889-4b94-a440-8adb0067ae79", null);
+
+            var instanceNode = CurrentDynamoModel.CurrentWorkspace.Nodes.First(n => n.GUID.ToString().Equals("306c8777-ecff-4106-bfdd-dd331e61cf2b"));
+            var dictNode = CurrentDynamoModel.CurrentWorkspace.Nodes.First(n => n.GUID.ToString().Equals("41271769-11b8-46fc-bb16-fffd022dc9bc"));
+            var connector = ConnectorModel.Make(instanceNode, dictNode, 0, 0);
+
+            RunCurrentModel();
+            AssertPreviewValue("060e57e1-b889-4b94-a440-8adb0067ae79", "green");
+        }
+    }
+}

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -431,6 +431,18 @@ namespace FFITarget
             };
         }
 
+        [MultiReturn(new string[] { "color"})]
+        public Dictionary<string, object> SingleKeyDictionary()
+        {
+            return new Dictionary<string, object>() 
+            {
+                {"color", "green"},
+                {"weight", 42},
+                {"ok", false},
+                {"nums", new int[] {101, 202}}
+            };
+        }
+
         public static Hashtable GetHashTable()
         {
             var hashTable = new Hashtable();

--- a/test/core/multiout/singleoutput.dyn
+++ b/test/core/multiout/singleoutput.dyn
@@ -1,9 +1,9 @@
 <Workspace Version="1.0.0.672" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="41271769-11b8-46fc-bb16-fffd022dc9bc" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="TestData.SingleKeyDictionary" x="282" y="204" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="..\..\..\bin\AnyCPU\Debug\FFITarget.dll" function="FFITarget.TestData.SingleKeyDictionary" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="41271769-11b8-46fc-bb16-fffd022dc9bc" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="TestData.SingleKeyDictionary" x="282" y="204" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="FFITarget.dll" function="FFITarget.TestData.SingleKeyDictionary" />
     <CoreNodeModels.Watch guid="060e57e1-b889-4b94-a440-8adb0067ae79" type="CoreNodeModels.Watch" nickname="Watch" x="527" y="211" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
-    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="306c8777-ecff-4106-bfdd-dd331e61cf2b" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="TestData.TestData" x="75" y="202" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="..\..\..\bin\AnyCPU\Debug\FFITarget.dll" function="FFITarget.TestData.TestData" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="306c8777-ecff-4106-bfdd-dd331e61cf2b" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="TestData.TestData" x="75" y="202" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="FFITarget.dll" function="FFITarget.TestData.TestData" />
   </Elements>
   <Connectors>
     <Dynamo.Graph.Connectors.ConnectorModel start="41271769-11b8-46fc-bb16-fffd022dc9bc" start_index="0" end="060e57e1-b889-4b94-a440-8adb0067ae79" end_index="0" portType="0" />

--- a/test/core/multiout/singleoutput.dyn
+++ b/test/core/multiout/singleoutput.dyn
@@ -1,0 +1,17 @@
+<Workspace Version="1.0.0.672" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="41271769-11b8-46fc-bb16-fffd022dc9bc" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="TestData.SingleKeyDictionary" x="282" y="204" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="..\..\..\bin\AnyCPU\Debug\FFITarget.dll" function="FFITarget.TestData.SingleKeyDictionary" />
+    <CoreNodeModels.Watch guid="060e57e1-b889-4b94-a440-8adb0067ae79" type="CoreNodeModels.Watch" nickname="Watch" x="527" y="211" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="306c8777-ecff-4106-bfdd-dd331e61cf2b" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="TestData.TestData" x="75" y="202" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="..\..\..\bin\AnyCPU\Debug\FFITarget.dll" function="FFITarget.TestData.TestData" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="41271769-11b8-46fc-bb16-fffd022dc9bc" start_index="0" end="060e57e1-b889-4b94-a440-8adb0067ae79" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

Fix [MAGN 9009 MultiReturn Nodes with single output return dictionary instead of value at key](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9009)

The root cause is in the engine. The live runner has no idea if it should execute self-modifying expression or not. Considering the following code block node:
```
x = {1};
x = Count(x);
```
Internally this piece of code is compiled to the following code
```
x = {1};
t1 = x;
t2 = Count(t1);
x = t2;     // x depends on t2
```
Now the code block node is updated to 
```
x = {1, 2, 3};
x = Count(x);
```
After delta computation, only `x = {1, 2, 3}` will be executed, but this assignment means `x` should only depends on `{1, 2, 3}`, thought `x` will be updated to `{1, 2, 3}`, `x = t2` won't be executed.

Compared with the following case where self-modifying expression shouldn't be executed:
```
x = {1};
x = Count(x);
x = {1, 2, 3};
```

A multi return node with single output will be compiled to a self modifying expression:
```
var_x = __TryGetValueFromNestedDictionary(var_x, "some_key");
```

Multi-return nodes with multi outputs avoid this problem by assigning a unique variable name to each output port. For example:
```
var_x_output_index = __TryGetValueFromNestedDictionary(var_x, "some_key");
``` 
This PR uses this workaround. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin probably you could have to review it?