### PR TITLE
Fix MAGN 4702 Unneccessary warnings are coming up for variable over indexed.

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -2681,8 +2681,7 @@ namespace ProtoCore.DSASM
 
                         if (t.rank < 0)
                         {
-                            string message = String.Format(Resources.kSymbolOverIndexed, symbolnode.name);
-                            runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, message);
+                            runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, Resources.IndexIntoNonArrayObject);
                         }
                     }
 
@@ -2966,8 +2965,7 @@ namespace ProtoCore.DSASM
                     return thisArray;
                 }
 
-                string message = String.Format(Resources.kSymbolOverIndexed, varname);
-                runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, message);
+                runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, Resources.IndexIntoNonArrayObject);
                 return StackValue.Null;
             }
 
@@ -2978,8 +2976,7 @@ namespace ProtoCore.DSASM
             }
             catch (ArgumentOutOfRangeException)
             {
-                string message = String.Format(Resources.kSymbolOverIndexed, varname);
-                runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, message);
+                runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, Resources.IndexIntoNonArrayObject);
                 return StackValue.Null;
             }
 
@@ -3011,8 +3008,7 @@ namespace ProtoCore.DSASM
                     return thisArray;
                 }
 
-                string message = String.Format(Resources.kSymbolOverIndexed, varname);
-                runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, message);
+                runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, Resources.IndexIntoNonArrayObject);
                 return StackValue.Null;
             }
 
@@ -3030,8 +3026,7 @@ namespace ProtoCore.DSASM
             }
             catch (ArgumentOutOfRangeException)
             {
-                string message = String.Format(Resources.kSymbolOverIndexed, varname);
-                runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, message);
+                runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, Resources.IndexIntoNonArrayObject);
                 return StackValue.Null;
             }
 
@@ -4005,8 +4000,7 @@ namespace ProtoCore.DSASM
 
                                 if (targetType.rank < 0)
                                 {
-                                    string message = String.Format(Resources.kSymbolOverIndexed, symbolnode.name);
-                                    runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, message);
+                                    runtimeCore.RuntimeStatus.LogWarning(WarningID.kOverIndexing, Resources.IndexIntoNonArrayObject);
                                 }
                             }
 

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -566,7 +566,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot apply indexing to non-array object.
+        ///   Looks up a localized string similar to No item exists at specified index address.
         /// </summary>
         public static string IndexIntoNonArrayObject {
             get {

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -566,6 +566,15 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot apply indexing to non-array object.
+        /// </summary>
+        public static string IndexIntoNonArrayObject {
+            get {
+                return ResourceManager.GetString("IndexIntoNonArrayObject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Inserts an element into a list at specified index.
         /// </summary>
         public static string InsertsAnElementIntoList {
@@ -1561,15 +1570,6 @@ namespace ProtoCore.Properties {
         public static string kStringOverIndexed {
             get {
                 return ResourceManager.GetString("kStringOverIndexed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is over indexed.
-        /// </summary>
-        public static string kSymbolOverIndexed {
-            get {
-                return ResourceManager.GetString("kSymbolOverIndexed", resourceCulture);
             }
         }
         

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -906,6 +906,6 @@ Parameter name: {0}</value>
     <value>Only one dominant list is allowed</value>
   </data>
   <data name="IndexIntoNonArrayObject" xml:space="preserve">
-    <value>Cannot apply indexing to non-array object</value>
+    <value>No item exists at specified index address</value>
   </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -381,9 +381,6 @@
   <data name="kStringOverIndexed" xml:space="preserve">
     <value>String is over indexed</value>
   </data>
-  <data name="kSymbolOverIndexed" xml:space="preserve">
-    <value>'{0}' is over indexed</value>
-  </data>
   <data name="kTypeUndefined" xml:space="preserve">
     <value>Type '{0}' is not defined</value>
   </data>
@@ -907,5 +904,8 @@ Parameter name: {0}</value>
   </data>
   <data name="MoreThanOneDominantList" xml:space="preserve">
     <value>Only one dominant list is allowed</value>
+  </data>
+  <data name="IndexIntoNonArrayObject" xml:space="preserve">
+    <value>Cannot apply indexing to non-array object</value>
   </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -906,6 +906,6 @@ Parameter name: {0}</value>
     <value>Only one dominant list is allowed</value>
   </data>
   <data name="IndexIntoNonArrayObject" xml:space="preserve">
-    <value>Cannot apply indexing to non-array object</value>
+    <value>No item exists at specified index address</value>
   </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -384,9 +384,6 @@
   <data name="kStringOverIndexed" xml:space="preserve">
     <value>String is over indexed</value>
   </data>
-  <data name="kSymbolOverIndexed" xml:space="preserve">
-    <value>'{0}' is over indexed</value>
-  </data>
   <data name="kTypeUndefined" xml:space="preserve">
     <value>Type '{0}' is not defined</value>
   </data>
@@ -907,5 +904,8 @@ Parameter name: {0}</value>
   </data>
   <data name="MoreThanOneDominantList" xml:space="preserve">
     <value>Only one dominant list is allowed</value>
+  </data>
+  <data name="IndexIntoNonArrayObject" xml:space="preserve">
+    <value>Cannot apply indexing to non-array object</value>
   </data>
 </root>

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1812,10 +1812,14 @@ namespace ProtoScript.Runners
                                      .OrderBy(w => w.GraphNodeGuid)
                                      .GroupBy(w => w.GraphNodeGuid);
 
-            foreach (var w in warnings)
+            foreach (var warningGroup in warnings)
             {
-                Guid guid = w.FirstOrDefault().GraphNodeGuid;
-                ret[guid] = new List<ProtoCore.Runtime.WarningEntry>(w);
+                Guid guid = warningGroup.FirstOrDefault().GraphNodeGuid;
+                // If there are two warnings in the same expression, take the first one.
+                var trimmedWarnings = warningGroup.OrderBy(w => w.ExpressionID)
+                                                  .GroupBy(w => w.ExpressionID)
+                                                  .Select(g => g.FirstOrDefault());
+                ret[guid] = new List<ProtoCore.Runtime.WarningEntry>(trimmedWarnings);
             }
 
             return ret;


### PR DESCRIPTION
### Purpose

This PR provides a workaround for defect [MAGN 4702 Unneccessary warnings are coming up for variable over indexed](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4702).

Because of SSA transformation, an array indexing expression like `a[x][y][z]` will be transformed to the following code
```
t1 = a;
t2 = t1[x];
t3 = t2[y];
t4 = t3[z];
```
So if `a`'s dimension is less than 3, there are warnings about applying indexing to non-array object `t1`, `t2`, `t3`. These warnings will confuse user as they are not explicitly defined.

Though for this case a warning message like "'a' is over-indexed" makes more sense, not all targets that are indexed into are variables. For example, `(foo() + bar())[x][y][z]`. 

To avoid confusion, this PR updates warning message and simply gives "Cannot apply indexing to non-array object". 

![untitled](https://cloud.githubusercontent.com/assets/2600379/13630212/23bd4f7a-e619-11e5-9d4d-4230ad995a00.png)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers
@riteshchandawar : this PR doesn't have much code change, just update the warning message. Please let me know if it is good to you. 
