### PR TITLE
(Tests are fixed) MAGN-9571 When the search box is up a shift double click should bring the box down and put up the single search

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -9,9 +9,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
-using Dynamo.Controls;
 using Dynamo.Utilities;
-using Dynamo.Views;
 
 namespace Dynamo.UI.Controls
 {
@@ -29,28 +27,13 @@ namespace Dynamo.UI.Controls
             get { return DataContext as SearchViewModel; }
         }
 
-        private WorkspaceView workspaceView;
-        private DynamoView dynamoView;
-
         public InCanvasSearchControl()
         {
             InitializeComponent();
-
-            Loaded += (sender, e) =>
+            if (Application.Current != null)
             {
-                if (workspaceView == null)
-                {
-                    workspaceView = WpfUtilities.FindUpVisualTree<WorkspaceView>(Parent);
-                }
-
-                if (dynamoView != null) return;
-
-                dynamoView = WpfUtilities.FindUpVisualTree<DynamoView>(Parent);
-                if (dynamoView != null)
-                {
-                    dynamoView.Deactivated += (s, args) => { OnRequestShowInCanvasSearch(ShowHideFlags.Hide); };
-                }
-            };
+                Application.Current.Deactivated += (s, args) => { OnRequestShowInCanvasSearch(ShowHideFlags.Hide); };
+            }
         }
 
         private void OnRequestShowInCanvasSearch(ShowHideFlags flags)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -278,7 +278,6 @@ namespace Dynamo.ViewModels
         public WorkspaceViewModel(WorkspaceModel model, DynamoViewModel dynamoViewModel)
         {
             this.DynamoViewModel = dynamoViewModel;
-            this.DynamoViewModel.PropertyChanged += DynamoViewModel_PropertyChanged;
 
             Model = model;
             stateMachine = new StateMachine(this);
@@ -339,25 +338,6 @@ namespace Dynamo.ViewModels
         {
             RaisePropertyChanged("CanPaste", "CanCopy", "CanCopyOrPaste");
             PasteCommand.RaiseCanExecuteChanged();
-        }
-
-        void RunSettingsViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            // If any property changes on the run settings object
-            // Raise a property change notification for the RunSettingsViewModel
-            // property
-            RaisePropertyChanged("RunSettingsViewModel");
-        }
-
-        void DynamoViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            switch (e.PropertyName)
-            {
-                case "CurrentSpace":
-                    // When workspace is changed(e.g. from home to custom), close InCanvasSearch.
-                    OnRequestShowInCanvasSearch(ShowHideFlags.Hide);
-                    break;                
-            }
         }
 
         void Connectors_ConnectorAdded(ConnectorModel c)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -47,7 +47,7 @@
                 </DataTrigger>
             </Style.Triggers>
         </Style>
-        <Style TargetType="{x:Type ContextMenu}"
+        <Style TargetType="{x:Type ItemsControl}"
                x:Key="WorkspaceContextMenuStyle">
             <Setter Property="SnapsToDevicePixels"
                     Value="True" />
@@ -55,17 +55,15 @@
                     Value="True" />
             <Setter Property="Grid.IsSharedSizeScope"
                     Value="true" />
-            <Setter Property="HasDropShadow"
-                    Value="True" />
             <Setter Property="Template">
                 <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type ContextMenu}">
+                    <ControlTemplate TargetType="{x:Type ItemsControl}">
                         <Border Style="{StaticResource ShadowBorder}">
                             <StackPanel Margin="8,4,8,8"
                                     Name="ContextMenuPanel"
                                     Height="{Binding ElementName=MenuItems, Path=ActualHeight, 
                                                      Converter={StaticResource WorkspaceContextMenuHeightConverter}}">
-                            <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}"
+                                <ui:InCanvasSearchControl DataContext="{Binding InCanvasSearchViewModel}" RequestShowInCanvasSearch="ShowHideContextMenu"
                                                       Width="{Binding ElementName=ContextMenuPanel, Path=ActualWidth}" />
                             <Border BorderThickness="1"
                                     Name="MenuItems"
@@ -102,8 +100,8 @@
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
-            <EventSetter Event="Opened"
-                         Handler="OnContextMenuOpened" />
+        </Style>
+        <Style TargetType="{x:Type Popup}" x:Key="WorkspaceContextMenuStylePopup">
             <EventSetter Event="PreviewKeyDown"
                          Handler="OnInCanvasSearchContextMenuKeyDown" />
             <EventSetter Event="PreviewMouseUp"
@@ -131,164 +129,9 @@
     <Grid  Name="outerCanvas"
            ClipToBounds="True"
            PreviewMouseDown="OnCanvasClicked"
+           MouseDown="OnCanvasMouseDown"
            HorizontalAlignment="Stretch"
            VerticalAlignment="Stretch">
-
-        <Grid.ContextMenu>
-            <ContextMenu Style="{StaticResource WorkspaceContextMenuStyle}">
-                <ContextMenu.Resources>
-                    <Style TargetType="{x:Type MenuItem}">
-                        <Setter Property="Focusable" Value="False" />
-                    </Style>
-                </ContextMenu.Resources>
-                <MenuItem Name="WorkspaceLacingMenu"
-                          Header="{x:Static p:Resources.ContextMenuLacing}">
-                    
-                    <MenuItem IsCheckable="True"
-                              Command="{Binding Path=SetArgumentLacingCommand}"
-                              CommandParameter="Shortest"
-                              Header="{x:Static p:Resources.ContextMenuLacingShortest}">
-                        <MenuItem.IsChecked>
-                            <Binding Path="SelectionArgumentLacing"
-                                     Mode="OneWay"
-                                     Converter="{StaticResource EnumToBoolConverter}"
-                                     ConverterParameter="Shortest" />
-                        </MenuItem.IsChecked>
-                    </MenuItem>
-                    
-                    <MenuItem IsCheckable="True"
-                              Command="{Binding Path=SetArgumentLacingCommand}"
-                              CommandParameter="Longest"
-                              Header="{x:Static p:Resources.ContextMenuLacingLongest}">
-                        <MenuItem.IsChecked>
-                            <Binding Path="SelectionArgumentLacing"
-                                     Mode="OneWay"
-                                     Converter="{StaticResource EnumToBoolConverter}"
-                                     ConverterParameter="Longest" />
-                        </MenuItem.IsChecked>
-                    </MenuItem>
-
-                    <MenuItem IsCheckable="True"
-                              Command="{Binding Path=SetArgumentLacingCommand}"
-                              CommandParameter="CrossProduct"
-                              Header="{x:Static p:Resources.ContextMenuLacingCrossProduct}">
-                        <MenuItem.IsChecked>
-                            <Binding Path="SelectionArgumentLacing"
-                                     Mode="OneWay"
-                                     Converter="{StaticResource EnumToBoolConverter}"
-                                     ConverterParameter="CrossProduct" />
-                        </MenuItem.IsChecked>
-                    </MenuItem>
-                    
-                </MenuItem>                
-                <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
-                          Header="{x:Static  p:Resources.ContextMenuShowAllGeometry}"
-                          Command="{Binding Path=ShowHideAllGeometryPreviewCommand}"
-                          CommandParameter="true"
-                          Visibility="{Binding Path=AnyNodeVisible, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
-
-                <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
-                          Header="{x:Static p:Resources.ContextMenuHideAllGeometry}"
-                          Command="{Binding Path=ShowHideAllGeometryPreviewCommand}"
-                          CommandParameter="false"
-                          Visibility="{Binding Path=AnyNodeVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-
-                <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
-                          Header="{x:Static  p:Resources.ContextMenuShowUpstreamPreview}"
-                          Command="{Binding Path=ShowHideAllUpstreamPreviewCommand}"
-                          CommandParameter="true"
-                          Visibility="{Binding Path=AnyNodeUpstreamVisible, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
-
-                <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
-                          Header="{x:Static p:Resources.ContextMenuHideUpstreamPreview}"
-                          Command="{Binding Path=ShowHideAllUpstreamPreviewCommand}"
-                          CommandParameter="false"
-                          Visibility="{Binding Path=AnyNodeUpstreamVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-
-                <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignSelection}"
-                           Name="Align">
-                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignXAverage}"
-                               Command="{Binding AlignSelectedCommand}"
-                               CommandParameter="HorizontalCenter" />
-                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignLeft}"
-                               Command="{Binding AlignSelectedCommand}"
-                               CommandParameter="HorizontalLeft" />
-                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignRight}"
-                               Command="{Binding AlignSelectedCommand}"
-                               CommandParameter="HorizontalRight" />
-                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignYAverage}"
-                               Command="{Binding AlignSelectedCommand}"
-                               CommandParameter="VerticalCenter" />
-                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignTop}"
-                               Command="{Binding AlignSelectedCommand}"
-                               CommandParameter="VerticalTop" />
-                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlighBottom}"
-                               Command="{Binding AlignSelectedCommand}"
-                               CommandParameter="VerticalBottom" />
-                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignYDistribute}"
-                               Command="{Binding AlignSelectedCommand}"
-                               CommandParameter="VerticalDistribute" />
-                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignXDistribute}"
-                               Command="{Binding AlignSelectedCommand}"
-                               CommandParameter="HorizontalDistribute" />
-                </MenuItem>
-
-                <MenuItem  Header="{x:Static p:Resources.ContextMenuNodesFromSelection}"
-                           Command="{Binding NodeFromSelectionCommand}" />
-
-                <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuCreatePreset}"
-                           Command="{Binding DynamoViewModel.ShowNewPresetsDialogCommand}" />
-
-                <MenuItem  Header="{x:Static p:Resources.ContextMenuNodeToCode}"
-                           Command="{Binding NodeToCodeCommand}"
-                           Visibility="{Binding Path=CanRunNodeToCode, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-
-                <MenuItem  Header="{x:Static p:Resources.ContextCreateGroupFromSelection}"
-                           Command="{Binding DynamoViewModel.AddAnnotationCommand}" />
-
-               
-                <MenuItem  Header="{x:Static p:Resources.ContextMenuNodesFromGeometry}"
-                           Visibility="{Binding Path=CanFindNodesFromElements, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
-                           Command="{Binding FindNodesFromSelectionCommand}" />
-
-                <Separator Visibility="{Binding Path=CanCopyOrPaste, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-
-                <MenuItem  Header="{x:Static p:Resources.ContextMenuCopy}"
-                           Visibility="{Binding Path=CanCopy, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
-                           Command="{Binding CopyCommand}" />
-
-                <MenuItem  Header="{x:Static p:Resources.ContextMenuPaste}"
-                           Visibility="{Binding Path=CanPaste, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
-                           Command="{Binding PasteCommand}" /> 
-
-                <Separator Visibility="{Binding Path=IsHomeSpace, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
-
-                <MenuItem  Header="{x:Static p:Resources.ContextMenuEditCustomNodeProperty}"
-                           Click="WorkspacePropertyEditClick"
-                           Visibility="{Binding Path=IsHomeSpace, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
-                <MenuItem  Header="{x:Static p:Resources.ContextMenuPublishCustomNode}"
-                           Name="Publish"
-                           Command="{Binding DynamoViewModel.PublishCurrentWorkspaceCommand }"
-                           Visibility="{Binding Path=IsHomeSpace, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
-
-                <Separator />
-
-                <MenuItem Header="{x:Static p:Resources.ContextMenuGeometryView}"
-                          Command="{Binding DynamoViewModel.BackgroundPreviewViewModel.ToggleCanNavigateBackgroundCommand}"
-                          Visibility="{Binding DynamoViewModel.BackgroundPreviewViewModel.Active, 
-                          Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"/>
-                <MenuItem Header="{x:Static p:Resources.ContextMenuPan}"
-                          Command="{Binding DynamoViewModel.BackgroundPreviewViewModel.TogglePanCommand}">
-                    <MenuItem.IsChecked>
-                        <Binding Path="DynamoViewModel.BackgroundPreviewViewModel.IsPanning"
-                                 Mode="OneWay" />
-                    </MenuItem.IsChecked>
-                </MenuItem>
-                <MenuItem Header="{x:Static p:Resources.ContextMenuFitToScreen}"
-                          Command="{Binding DynamoViewModel.FitViewCommand}" />
-
-            </ContextMenu>
-        </Grid.ContextMenu>
 
         <!-- Infinite grid view should not be hittable by mouse -->
 
@@ -486,7 +329,165 @@
                IsOpen="False"
                Placement="MousePoint"
                DataContext="{Binding InCanvasSearchViewModel}">
-            <ui:InCanvasSearchControl />
+            <ui:InCanvasSearchControl RequestShowInCanvasSearch="ShowHideInCanvasControl" />
+        </Popup>
+
+        <Popup Name="ContextMenuPopup" Style="{StaticResource WorkspaceContextMenuStylePopup}"
+               Opened="OnContextMenuOpened" StaysOpen="True" AllowsTransparency="True" Placement="MousePoint">
+            <Popup.Resources>
+                <Style TargetType="{x:Type MenuItem}">
+                    <Setter Property="Focusable" Value="False" />
+                </Style>
+            </Popup.Resources>
+            <ItemsControl Style="{StaticResource WorkspaceContextMenuStyle}">
+                <ItemsControl.Items>
+                    <MenuItem Name="WorkspaceLacingMenu"
+                          Header="{x:Static p:Resources.ContextMenuLacing}">
+
+                        <MenuItem IsCheckable="True"
+                              Command="{Binding Path=SetArgumentLacingCommand}"
+                              CommandParameter="Shortest"
+                              Header="{x:Static p:Resources.ContextMenuLacingShortest}">
+                            <MenuItem.IsChecked>
+                                <Binding Path="SelectionArgumentLacing"
+                                     Mode="OneWay"
+                                     Converter="{StaticResource EnumToBoolConverter}"
+                                     ConverterParameter="Shortest" />
+                            </MenuItem.IsChecked>
+                        </MenuItem>
+
+                        <MenuItem IsCheckable="True"
+                              Command="{Binding Path=SetArgumentLacingCommand}"
+                              CommandParameter="Longest"
+                              Header="{x:Static p:Resources.ContextMenuLacingLongest}">
+                            <MenuItem.IsChecked>
+                                <Binding Path="SelectionArgumentLacing"
+                                     Mode="OneWay"
+                                     Converter="{StaticResource EnumToBoolConverter}"
+                                     ConverterParameter="Longest" />
+                            </MenuItem.IsChecked>
+                        </MenuItem>
+
+                        <MenuItem IsCheckable="True"
+                              Command="{Binding Path=SetArgumentLacingCommand}"
+                              CommandParameter="CrossProduct"
+                              Header="{x:Static p:Resources.ContextMenuLacingCrossProduct}">
+                            <MenuItem.IsChecked>
+                                <Binding Path="SelectionArgumentLacing"
+                                     Mode="OneWay"
+                                     Converter="{StaticResource EnumToBoolConverter}"
+                                     ConverterParameter="CrossProduct" />
+                            </MenuItem.IsChecked>
+                        </MenuItem>
+
+                    </MenuItem>
+                    <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
+                          Header="{x:Static  p:Resources.ContextMenuShowAllGeometry}"
+                          Command="{Binding Path=ShowHideAllGeometryPreviewCommand}"
+                          CommandParameter="true"
+                          Visibility="{Binding Path=AnyNodeVisible, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
+
+                    <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
+                          Header="{x:Static p:Resources.ContextMenuHideAllGeometry}"
+                          Command="{Binding Path=ShowHideAllGeometryPreviewCommand}"
+                          CommandParameter="false"
+                          Visibility="{Binding Path=AnyNodeVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+                    <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
+                          Header="{x:Static  p:Resources.ContextMenuShowUpstreamPreview}"
+                          Command="{Binding Path=ShowHideAllUpstreamPreviewCommand}"
+                          CommandParameter="true"
+                          Visibility="{Binding Path=AnyNodeUpstreamVisible, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
+
+                    <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
+                          Header="{x:Static p:Resources.ContextMenuHideUpstreamPreview}"
+                          Command="{Binding Path=ShowHideAllUpstreamPreviewCommand}"
+                          CommandParameter="false"
+                          Visibility="{Binding Path=AnyNodeUpstreamVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignSelection}"
+                           Name="Align">
+                        <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignXAverage}"
+                               Command="{Binding AlignSelectedCommand}"
+                               CommandParameter="HorizontalCenter" />
+                        <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignLeft}"
+                               Command="{Binding AlignSelectedCommand}"
+                               CommandParameter="HorizontalLeft" />
+                        <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignRight}"
+                               Command="{Binding AlignSelectedCommand}"
+                               CommandParameter="HorizontalRight" />
+                        <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignYAverage}"
+                               Command="{Binding AlignSelectedCommand}"
+                               CommandParameter="VerticalCenter" />
+                        <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignTop}"
+                               Command="{Binding AlignSelectedCommand}"
+                               CommandParameter="VerticalTop" />
+                        <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlighBottom}"
+                               Command="{Binding AlignSelectedCommand}"
+                               CommandParameter="VerticalBottom" />
+                        <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignYDistribute}"
+                               Command="{Binding AlignSelectedCommand}"
+                               CommandParameter="VerticalDistribute" />
+                        <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignXDistribute}"
+                               Command="{Binding AlignSelectedCommand}"
+                               CommandParameter="HorizontalDistribute" />
+                    </MenuItem>
+
+                    <MenuItem  Header="{x:Static p:Resources.ContextMenuNodesFromSelection}"
+                           Command="{Binding NodeFromSelectionCommand}" CommandTarget="{Binding ElementName=_this}" />
+
+                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuCreatePreset}"
+                           Command="{Binding DynamoViewModel.ShowNewPresetsDialogCommand}" />
+
+                    <MenuItem  Header="{x:Static p:Resources.ContextMenuNodeToCode}"
+                           Command="{Binding NodeToCodeCommand}"
+                           Visibility="{Binding Path=CanRunNodeToCode, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+                    <MenuItem  Header="{x:Static p:Resources.ContextCreateGroupFromSelection}"
+                           Command="{Binding DynamoViewModel.AddAnnotationCommand}" />
+
+
+                    <MenuItem  Header="{x:Static p:Resources.ContextMenuNodesFromGeometry}"
+                           Visibility="{Binding Path=CanFindNodesFromElements, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                           Command="{Binding FindNodesFromSelectionCommand}" />
+
+                    <Separator Visibility="{Binding Path=CanCopyOrPaste, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+                    <MenuItem  Header="{x:Static p:Resources.ContextMenuCopy}"
+                           Visibility="{Binding Path=CanCopy, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                           Command="{Binding CopyCommand}" />
+
+                    <MenuItem  Header="{x:Static p:Resources.ContextMenuPaste}"
+                           Visibility="{Binding Path=CanPaste, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                           Command="{Binding PasteCommand}" />
+
+                    <Separator Visibility="{Binding Path=IsHomeSpace, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
+
+                    <MenuItem  Header="{x:Static p:Resources.ContextMenuEditCustomNodeProperty}"
+                           Click="WorkspacePropertyEditClick"
+                           Visibility="{Binding Path=IsHomeSpace, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
+                    <MenuItem  Header="{x:Static p:Resources.ContextMenuPublishCustomNode}"
+                           Name="Publish"
+                           Command="{Binding DynamoViewModel.PublishCurrentWorkspaceCommand }"
+                           Visibility="{Binding Path=IsHomeSpace, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}" />
+
+                    <Separator />
+
+                    <MenuItem Header="{x:Static p:Resources.ContextMenuGeometryView}"
+                          Command="{Binding DynamoViewModel.BackgroundPreviewViewModel.ToggleCanNavigateBackgroundCommand}"
+                          Visibility="{Binding DynamoViewModel.BackgroundPreviewViewModel.Active, 
+                          Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"/>
+                    <MenuItem Header="{x:Static p:Resources.ContextMenuPan}"
+                          Command="{Binding DynamoViewModel.BackgroundPreviewViewModel.TogglePanCommand}">
+                        <MenuItem.IsChecked>
+                            <Binding Path="DynamoViewModel.BackgroundPreviewViewModel.IsPanning"
+                                 Mode="OneWay" />
+                        </MenuItem.IsChecked>
+                    </MenuItem>
+                    <MenuItem Header="{x:Static p:Resources.ContextMenuFitToScreen}"
+                          Command="{Binding DynamoViewModel.FitViewCommand}" />
+                </ItemsControl.Items>
+            </ItemsControl>
         </Popup>
 
     </Grid>

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -21,6 +21,10 @@ using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using NUnit.Framework;
 using DynamoCoreWpfTests.Utility;
+using Dynamo.Views;
+using System.Windows.Input;
+using ModifierKeys = System.Windows.Input.ModifierKeys;
+using System.Windows.Controls;
 
 namespace DynamoCoreWpfTests
 {
@@ -707,6 +711,65 @@ namespace DynamoCoreWpfTests
             dn.Update(new Point2D(-16, 72));
             Assert.AreEqual(-8, locatable.X);
             Assert.AreEqual(40, locatable.Y);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WorkspaceContextMenu_TestIfOpenOnRightClick()
+        {
+            var currentWs = View.ChildOfType<WorkspaceView>();
+            Assert.IsNotNull(currentWs, "DynamoView does not have any WorkspaceView");
+            RightClick(currentWs.zoomBorder);
+
+            Assert.IsTrue(currentWs.ContextMenuPopup.IsOpen);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WorkspaceContextMenu_TestIfNotOpenOnNodeRightClick()
+        {
+            var currentWs = View.ChildOfType<WorkspaceView>();
+            Assert.IsNotNull(currentWs, "DynamoView does not have any WorkspaceView");
+            CreateNodeOnCurrentWorkspace();
+
+            DispatcherUtil.DoEvents();
+            var node = currentWs.ChildOfType<NodeView>();
+            RightClick(node);
+
+            // workspace context menu shouldn't be open
+            Assert.IsFalse(currentWs.ContextMenuPopup.IsOpen);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WorkspaceContextMenu_TestIfInCanvasSearchHidesOnOpeningContextMenu()
+        {
+            var currentWs = View.ChildOfType<WorkspaceView>();
+
+            // show in-canvas search
+            ViewModel.CurrentSpaceViewModel.ShowInCanvasSearchCommand.Execute(ShowHideFlags.Show);
+            Assert.IsTrue(currentWs.InCanvasSearchBar.IsOpen);
+
+            // open context menu
+            RightClick(currentWs.zoomBorder);
+
+            Assert.IsTrue(currentWs.ContextMenuPopup.IsOpen);
+            Assert.IsFalse(currentWs.InCanvasSearchBar.IsOpen);
+        }
+
+        private void RightClick(IInputElement element)
+        {
+            element.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Right)
+            {
+                RoutedEvent = Mouse.MouseDownEvent
+            });
+
+            element.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Right)
+            {
+                RoutedEvent = Mouse.MouseUpEvent
+            });
+
+            DispatcherUtil.DoEvents();
         }
     }
 }


### PR DESCRIPTION
### Purpose

It looks as if WPF ContextMenu control is not that good to use. When it is opened it captures mouse and it causes to filching one click. I.e. double-click on canvas is interpreted as single click and triple-click is interpreted as double-click. There is no way to release mouse without closing the context menu itself (deriving from ContextMenu with overriding `ReleaseMouseCapture` without closing ContextMenu didn't help).
That also causes an issue that while ContextMenu is opened, double-click does not create CodeBlock node.

In this PR ContextMenu control is replaced with Popup, any of its styles have not been changed, so there is no UI change.

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI:
All DynamoCoreWpfTests are passed on CI:
![image](https://cloud.githubusercontent.com/assets/7658189/13636345/2624984a-e60a-11e5-9b1b-6f86cdfe213f.png)
- [ ] Snapshot of UI changes, if any.

### Reviewers

@QilongTang 