### PR TITLE
Clean up Mirror and ProtoVMState

### DIFF
--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1218,9 +1218,8 @@ namespace ProtoScript.Runners
         }
 
         private ProtoScriptRunner runner;
-        private ProtoRunner.ProtoVMState vmState;
-        private ProtoCore.Core runnerCore = null;
-        public ProtoCore.Core Core
+        private Core runnerCore = null;
+        public Core Core
         {
             get
             {
@@ -1314,8 +1313,6 @@ namespace ProtoScript.Runners
             {
                 runnerCore.Configurations[item.Key] = item.Value;
             }
-
-            vmState = null;
 
             CreateRuntimeCore();
         }
@@ -1482,22 +1479,6 @@ namespace ProtoScript.Runners
 
         #region Internal Implementation
 
-        /// <summary>
-        /// This is being called currently as it uses the Expression interpreter which does not
-        /// work well with delta execution. Instead we are currently inspecting into the VM using Mirrors
-        /// </summary>
-        /// <param name="varname"></param>
-        /// <returns></returns>
-        private ProtoCore.Mirror.RuntimeMirror InternalGetNodeValue(string varname)
-        {
-            Validity.Assert(null != vmState);
-
-            // Comment Jun: all symbols are in the global block as there is no notion of scoping the the graphUI yet.
-            const int blockID = 0;
-
-            return vmState.LookupName(varname, blockID);
-        }
-
         private bool Compile(List<AssociativeNode> astList, Core targetCore)
         {
             bool succeeded = runner.CompileAndGenerateExe(astList, targetCore, new ProtoCore.CompileTime.Context());
@@ -1510,7 +1491,7 @@ namespace ProtoScript.Runners
             return succeeded;
         }
 
-        private ProtoRunner.ProtoVMState Execute(bool isCodeCompiled)
+        private void Execute(bool isCodeCompiled)
         {
             try
             {
@@ -1522,7 +1503,6 @@ namespace ProtoScript.Runners
                 runtimeCore.Cleanup();
                 ReInitializeLiveRunner();
             }
-            return new ProtoRunner.ProtoVMState(runnerCore, runtimeCore);
         }
 
         private bool CompileAndExecute(string code)
@@ -1531,7 +1511,7 @@ namespace ProtoScript.Runners
             bool succeeded = runner.CompileAndGenerateExe(code, runnerCore, new ProtoCore.CompileTime.Context());
             if (succeeded)
             {
-                vmState = Execute(!string.IsNullOrEmpty(code));
+                Execute(!string.IsNullOrEmpty(code));
             }
             return succeeded;
         }
@@ -1541,7 +1521,7 @@ namespace ProtoScript.Runners
             bool succeeded = Compile(astList, runnerCore);
             if (succeeded)
             {
-                vmState = Execute(astList.Count > 0);
+                Execute(astList.Count > 0);
             }
             return succeeded;
         }

--- a/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
@@ -4615,8 +4615,8 @@ r = foo(3);
             Dictionary<string, Object> context = new Dictionary<string, object>();
             context.Add("x", 1);
             context.Add("y", 2);
-            ProtoScript.Runners.ProtoRunner.ProtoVMState vmstate = runner.PreStart(code, context);
-            runner.RunToNextBreakpoint(vmstate);
+            runner.PreStart(code, context);
+            runner.RunToNextBreakpoint();
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Clean up `RuntimeMirror` and `ProtoVMState` classes in the engine. Delete some dead code.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

