### PR TITLE
Fix MAGN-9568 Crash in preview control

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -445,7 +445,7 @@ namespace Dynamo.Graph.Nodes
                     return cachedValue;
                 }
             }
-            set
+            private set
             {
                 lock (cachedValueMutex)
                 {

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -445,7 +445,7 @@ namespace Dynamo.Graph.Nodes
                     return cachedValue;
                 }
             }
-            private set
+            set
             {
                 lock (cachedValueMutex)
                 {
@@ -1921,13 +1921,11 @@ namespace Dynamo.Graph.Nodes
         #region Visualization Related Methods
 
         /// <summary>
-        /// Call this method to asynchronously update the cached MirrorData for 
-        /// this NodeModel through DynamoScheduler. AstIdentifierForPreview is 
-        /// being accessed within this method, therefore the method is typically
-        /// called from the main/UI thread.
+        /// Call this method to update the cached MirrorData for this NodeModel.
+        /// Note this method should be called from scheduler thread. 
         /// </summary>
         /// 
-        internal void RequestValueUpdateAsync(IScheduler scheduler, EngineController engine)
+        internal void RequestValueUpdate(EngineController engine)
         {
             // A NodeModel should have its cachedMirrorData reset when it is 
             // requested to update its value. When the QueryMirrorDataAsyncTask 
@@ -1944,29 +1942,11 @@ namespace Dynamo.Graph.Nodes
             if (string.IsNullOrEmpty(variableName))
                 return;
 
-            var task = new QueryMirrorDataAsyncTask(new QueryMirrorDataParams
+            var runtimeMirror = engine.GetMirror(variableName);
+            if (runtimeMirror != null)
             {
-                Scheduler = scheduler,
-                EngineController = engine,
-                VariableName = variableName
-            });
-
-            task.Completed += QueryMirrorDataAsyncTaskCompleted;
-            scheduler.ScheduleForExecution(task);
-        }
-
-        private void QueryMirrorDataAsyncTaskCompleted(AsyncTask asyncTask)
-        {
-            asyncTask.Completed -= QueryMirrorDataAsyncTaskCompleted;
-
-            var task = asyncTask as QueryMirrorDataAsyncTask;
-            if (task == null)
-            {
-                throw new InvalidOperationException("Expected a " + typeof(QueryMirrorDataAsyncTask).Name
-                    + ", but got a " + asyncTask.GetType().Name);
+                CachedValue = runtimeMirror.GetData();
             }
-
-            this.CachedValue = task.MirrorData;
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -457,39 +457,6 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        /// WARNING: This method is meant for unit test only. It directly accesses
-        /// the EngineController for the mirror data without waiting for any 
-        /// possible execution to complete (which, in single-threaded nature of 
-        /// unit test, is an okay thing to do). The right way to get the cached 
-        /// value for a NodeModel is by going through its RequestValueUpdateAsync
-        /// method).
-        /// </summary>
-        /// <param name="engine">Instance of EngineController from which the node
-        /// value is to be retrieved.</param>
-        /// <returns>Returns the MirrorData if the node's value is computed, or 
-        /// null otherwise.</returns>
-        /// 
-        internal MirrorData GetCachedValueFromEngine(EngineController engine)
-        {
-            if (cachedValue != null)
-                return cachedValue;
-
-            // Do not have an identifier for preview right now. For an example,
-            // this can be happening at the beginning of a code block node creation.
-            if (AstIdentifierForPreview.Value == null)
-                return null;
-
-            cachedValue = null;
-
-            var runtimeMirror = engine.GetMirror(AstIdentifierForPreview.Value);
-
-            if (runtimeMirror != null)
-                cachedValue = runtimeMirror.GetData();
-
-            return cachedValue;
-        }
-
-        /// <summary>
         /// This flag is used to determine if a node was involved in a recent execution.
         /// The primary purpose of this flag is to determine if the node's render packages 
         /// should be returned to client browser when it requests for them. This is mainly 

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -504,7 +504,7 @@ namespace Dynamo.Graph.Workspaces
             // Refresh values of nodes that took part in update.
             foreach (var executedNode in updateTask.ExecutedNodes)
             {
-                executedNode.RequestValueUpdateAsync(scheduler, EngineController);
+                executedNode.RequestValueUpdate(EngineController);
             }
 
             scheduler.Tasks.AllComplete(_ =>

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -223,19 +223,17 @@ namespace Dynamo.Controls
                 // transition
                 if (previewControl.IsInTransition)
                 {
-                    previewControl.EnqueueBindToDataSource(ViewModel.NodeModel.CachedValue);
+                    previewControl.RequestForRefresh();
                     return;
                 }
 
                 if (previewControl.IsHidden) // The preview control is hidden.
                 {
-                    // Invalidate the previously bound data, if any.
-                    if (previewControl.IsDataBound)
-                        previewControl.BindToDataSource(null);
+                    previewControl.IsDataBound = false;
                     return;
                 }
 
-                previewControl.BindToDataSource(ViewModel.NodeModel.CachedValue);
+                previewControl.BindToDataSource();
             }));
         }
 
@@ -422,8 +420,8 @@ namespace Dynamo.Controls
 
             if (PreviewControl.IsHidden)
             {
-                if (PreviewControl.IsDataBound == false)
-                    PreviewControl.BindToDataSource(ViewModel.NodeModel.CachedValue);
+                if (!previewControl.IsDataBound)
+                    PreviewControl.BindToDataSource();
 
                 PreviewControl.TransitionToState(PreviewControl.State.Condensed);
 

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -57,7 +57,6 @@ namespace Dynamo.UI.Controls
         private Canvas hostingCanvas = null;
 
         // Data source and display.
-        private MirrorData mirrorData = null;
         private String cachedSmallContent = null;
         private WatchViewModel cachedLargeContent = null;
 
@@ -73,7 +72,6 @@ namespace Dynamo.UI.Controls
 
         // Queued data refresh
         private bool queuedRefresh;
-        private MirrorData queuedMirrorData;
 
         private static readonly DependencyProperty StaysOpenProperty =
             DependencyProperty.Register("StaysOpen", typeof(bool), typeof(PreviewControl));
@@ -106,7 +104,7 @@ namespace Dynamo.UI.Controls
             if (this.nodeViewModel.PreviewPinned)
             {
                 StaysOpen = true;
-                BindToDataSource(this.nodeViewModel.NodeModel.CachedValue);
+                BindToDataSource();
                 TransitionToState(State.Condensed);
                 TransitionToState(State.Expanded);
             }
@@ -162,12 +160,11 @@ namespace Dynamo.UI.Controls
         /// to. This value can be null to reset the preview control to its 
         /// initial state.</param>
         /// 
-        internal void BindToDataSource(MirrorData mirrorData)
+        internal void BindToDataSource()
         {
             // First detach the bound data from its view.
             ResetContentViews();
 
-            this.mirrorData = mirrorData;
             this.cachedLargeContent = null; // Reset expanded content.
             this.cachedSmallContent = null; // Reset condensed content.
 
@@ -181,6 +178,8 @@ namespace Dynamo.UI.Controls
             {
                 RefreshExpandedDisplay(delegate { BeginViewSizeTransition(ComputeLargeContentSize()); });
             }
+
+            IsDataBound = true;
         }
 
         /// <summary>
@@ -188,9 +187,8 @@ namespace Dynamo.UI.Controls
         /// in transition.  In these situations, we can store the MirrorData and
         /// set a flag to refresh the display.
         /// </summary>
-        internal void EnqueueBindToDataSource(MirrorData mirrorData)
+        internal void RequestForRefresh()
         {
-            this.queuedMirrorData = mirrorData;
             this.queuedRefresh = true;
         }
 
@@ -198,7 +196,7 @@ namespace Dynamo.UI.Controls
 
         #region Public Class Properties
 
-        internal bool IsDataBound { get { return mirrorData != null; } }
+        internal bool IsDataBound { get; set;}
         internal bool IsHidden { get { return currentState == State.Hidden; } }
         internal bool IsCondensed { get { return currentState == State.Condensed; } }
         internal bool IsExpanded { get { return currentState == State.Expanded; } }
@@ -223,8 +221,7 @@ namespace Dynamo.UI.Controls
             if (queuedRefresh)
             {
                 queuedRefresh = false;
-                BindToDataSource(queuedMirrorData);
-                this.queuedMirrorData = null;
+                BindToDataSource();
                 return;
             }
 
@@ -320,6 +317,7 @@ namespace Dynamo.UI.Controls
             RunOnSchedulerSync(
                 () =>
                 {
+                    var mirrorData = nodeViewModel.NodeModel.CachedValue;
                     if (mirrorData != null)
                     {
                         if (mirrorData.IsCollection)
@@ -391,7 +389,7 @@ namespace Dynamo.UI.Controls
                 () =>
                 {
                     newViewModel = nodeViewModel.DynamoViewModel.WatchHandler.GenerateWatchViewModelForData(
-                        mirrorData, null, nodeViewModel.NodeModel.AstIdentifierForPreview.Name, false);
+                        nodeViewModel.NodeModel.CachedValue, null, nodeViewModel.NodeModel.AstIdentifierForPreview.Name, false);
                 },
                 (m) =>
                 {

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -940,7 +940,7 @@ namespace WpfVisualizationTests
                 nodeView.PreviewControl.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
                 View.Dispatcher.Invoke(() =>
                 {
-                    nodeView.PreviewControl.BindToDataSource(nodeView.ViewModel.NodeModel.CachedValue);
+                    nodeView.PreviewControl.BindToDataSource();
                     nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Condensed);
                     nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Expanded);
                 });

--- a/test/DynamoCoreTests/DynamoDefects.cs
+++ b/test/DynamoCoreTests/DynamoDefects.cs
@@ -114,7 +114,7 @@ namespace Dynamo.Tests
             RunModel(openPath);
 
             var add = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSFunction>("ccb2eda9-0966-4ab8-a186-0d5f844559c1");
-            AssertPreviewValue(add.GUID.ToString(), 20);
+            AssertPreviewValue("ccb2eda9-0966-4ab8-a186-0d5f844559c1", 20);
         }
 
         [Test, Category("RegressionTests")]

--- a/test/DynamoCoreTests/DynamoDefects.cs
+++ b/test/DynamoCoreTests/DynamoDefects.cs
@@ -114,7 +114,7 @@ namespace Dynamo.Tests
             RunModel(openPath);
 
             var add = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DSFunction>("ccb2eda9-0966-4ab8-a186-0d5f844559c1");
-            Assert.AreEqual(20, add.GetCachedValueFromEngine(CurrentDynamoModel.EngineController).Data);
+            AssertPreviewValue(add.GUID.ToString(), 20);
         }
 
         [Test, Category("RegressionTests")]

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -102,7 +102,7 @@ namespace DynamoCoreWpfTests
             // Fire transition on dynamo main ui thread.
             View.Dispatcher.Invoke(() =>
             {
-                nodeView.PreviewControl.BindToDataSource(nodeView.ViewModel.NodeModel.CachedValue);
+                nodeView.PreviewControl.BindToDataSource();
                 nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Condensed);
                 nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Expanded);
             });
@@ -124,7 +124,7 @@ namespace DynamoCoreWpfTests
             // Fire transition on dynamo main ui thread.
             View.Dispatcher.Invoke(() =>
             {
-                nodeView.PreviewControl.BindToDataSource(nodeView.ViewModel.NodeModel.CachedValue);
+                nodeView.PreviewControl.BindToDataSource();
                 nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Condensed);
                 nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Expanded);
             });
@@ -145,7 +145,7 @@ namespace DynamoCoreWpfTests
 
             View.Dispatcher.Invoke(() =>
             {
-                nodeView.PreviewControl.BindToDataSource(nodeView.ViewModel.NodeModel.CachedValue);
+                nodeView.PreviewControl.BindToDataSource();
                 nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Condensed);
             });
             DispatcherUtil.DoEvents();
@@ -229,7 +229,7 @@ namespace DynamoCoreWpfTests
             // Fire transition on dynamo main ui thread.
             View.Dispatcher.Invoke(() =>
             {
-                nodeView.PreviewControl.BindToDataSource(nodeView.ViewModel.NodeModel.CachedValue);
+                nodeView.PreviewControl.BindToDataSource();
                 nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Condensed);
                 nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Expanded);
             });
@@ -293,7 +293,7 @@ namespace DynamoCoreWpfTests
 
             View.Dispatcher.Invoke(() =>
             {
-                nodeView.PreviewControl.BindToDataSource(nodeView.ViewModel.NodeModel.CachedValue);
+                nodeView.PreviewControl.BindToDataSource();
                 nodeView.PreviewControl.TransitionToState(Dynamo.UI.Controls.PreviewControl.State.Condensed);
             });
 

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -2595,11 +2595,7 @@ namespace DynamoCoreWpfTests
                 "3f309016-7b00-4487-9b68-f0640e892d39");
 
             Assert.AreNotEqual(ElementState.Warning, nodeModel.State);
-
-            Assert.IsNotNull(nodeModel.GetCachedValueFromEngine(ViewModel.Model.EngineController).Data);
-
             AssertPreviewValue("3f309016-7b00-4487-9b68-f0640e892d39", 11);
-
         }
 
         [Test, RequiresSTA]

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -2574,6 +2574,7 @@ namespace DynamoCoreWpfTests
         public void Defect_MAGN_2100()
         {
             // more details available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-2100
+            string nodeGuid = "3f309016-7b00-4487-9b68-f0640e892d39";
 
             RunCommandsFromFile("Defect_MAGN_2100.xml", (commandTag) =>
             {
@@ -2591,11 +2592,9 @@ namespace DynamoCoreWpfTests
 
             });
 
-            NodeModel nodeModel = ViewModel.Model.CurrentWorkspace.NodeFromWorkspace(
-                "3f309016-7b00-4487-9b68-f0640e892d39");
-
+            NodeModel nodeModel = ViewModel.Model.CurrentWorkspace.NodeFromWorkspace(nodeGuid);
             Assert.AreNotEqual(ElementState.Warning, nodeModel.State);
-            AssertPreviewValue("3f309016-7b00-4487-9b68-f0640e892d39", 11);
+            AssertPreviewValue(nodeGuid, 11);
         }
 
         [Test, RequiresSTA]


### PR DESCRIPTION
### Purpose

Fix [MAGN-9568 Crash in preview control](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9568)

There are two issues, both related to outdated mirror data that used in preview control to query the node value from the DesignScript virtual machine.

Updating a graph will update mirror data in all executed UI nodes. Ideally, the following preview operation will get the latest mirror data to display value. But because updating graph (`UpdateGraphAsyncTask`), querying mirror data (`QueryMirrorDataAsyncTask`) and displaying preview value (wrapped in `DelegateBasedAsyncTask`) are all asynchronous operations, and their creation is not necessarily in scheduler thread, their execution order is not guaranteed and the outdated mirror data will be used and cause crash.

**The first issue** is `DelegateBasedAsyncTask` is scheduled before `QueryMirrorDataAsyncTask`.

In this case, `UpdateGraphAsyncTask` has been executed and node's value *has been updated*. Now a `DelegateBasedAsyncTask` is created and put in scheduler thread (because of previewing operation on the UI thread). It will be executed immediately because `QueryMirrorDataAsyncTask`has not been scheduled yet:

```
Scheduler task queue
--------------------

         +----------if complete, schedule query task -----+
         |                                                |
         |                                                v
+----------------------+------------------------+--------------------------+
| UpdateGraphAsyncTask | DelegateBasedAsyncTask | QueryMirrorDataAsyncTask |
+----------------------+------------------------+--------------------------+
                                ^
                                |
                                +----- Scheduled from UI thread

```
`NodeModel.CachedValue` has not been updated yet, but the value of node has been changed, so `NodeModel.CachedValue` becomes invalid. 

There are three ways to fix this case:
  1. Set `NodeModel.CachedValue` to some invalid state. In `DelegateBasedAsyncTask` we will check if mirror data is invalid or not, and display "..." in the preview control accordingly. Mirror data will finally be updated in `QueryMirrorDataAsyncTask`. But introducing more states will make the code be harder to maintain.
  2. As `MirrorData` is a snapshot of value, we could add the other kind of mirror data which always reflects current value. But `MirrorData` is widely used now, making this change will incur too many other changes. Besides, always querying value from the engine would be a potential performance issue.
  3. Or, immediately updating mirror data after `UpdateGraphAysncTask` is executed. Firstly, it is a trivial change; secondly, if we can ensure all these operations happen in scheduler thread, `DelegateBasedAsyncTask` would never get a change to kick in and get executed. This PR uses this option.

Related change: `NodeModel.RequestValueUpdateAsync()` is updated to synchronous `NodeModel.RequestValueUpdate()`. 

**The second issue** is, `PreviewControl` holds a cached of mirror data (`PreviewControl.mirrordata`), this `mirrordata` will only be updated after `UpdateGraphAsyncTask` is scheduled, but before that, `DelegateBasedAsyncTask` may be scheduled already:
```
Scheduler task queue
--------------------

         +----------if complete, update preview control's mirror data .....
         |                                                                +
         |                                                                |
+----------------------+------------------------+                         |
| UpdateGraphAsyncTask | DelegateBasedAsyncTask |                         |
+----------------------+------------------------+                         |
                                ^                                         |
                                |                                         |
                        Scheduled from UI thread                           |
                                                                          v
                                                     Update preview control's mirror data
```
Again, invalid mirror data is used.

As `PreviewControl` knows about `NodeModel`, it can always get the latest mirror data from `NodeModel`. So this PR removes `PreviewControl.mirrorData`.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers
@Benglin : @riteshchandawar  has helped to do some play testing. 

@aosyatnik please help to review preview control part in case I miss something, and sorry for stealing the task from you... :-)