### PR TITLE
MAGN-9649 After a Preset application a pinned Preview Bubble is not sticky after saving the dyn

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1634,6 +1634,7 @@ namespace Dynamo.Graph.Workspaces
                         //overwrite the xy coords of the serialized node with the current position, so the node is not moved
                         serializedNode.SetAttribute("x", originalpos.X.ToString(CultureInfo.InvariantCulture));
                         serializedNode.SetAttribute("y", originalpos.Y.ToString(CultureInfo.InvariantCulture));
+                        serializedNode.SetAttribute("isPinned", node.PreviewPinned.ToString());
 
                         this.undoRecorder.RecordModificationForUndo(node);
                         this.ReloadModel(serializedNode);

--- a/test/DynamoCoreTests/PresetsTests.cs
+++ b/test/DynamoCoreTests/PresetsTests.cs
@@ -69,6 +69,40 @@ namespace Dynamo.Tests
             return new List<NodeModel>() { numberNode1, numberNode2,addNode };
         }
 
+        [Test]
+        [Category("UnitTest")]
+        public void CanSavePinState()
+        {
+            var model = CurrentDynamoModel;
+            var cbn = new CodeBlockNodeModel(model.LibraryServices);
+            var command = new DynamoModel.CreateNodeCommand(cbn, 0, 0, true, false);
+
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            UpdateCodeBlockNodeContent(cbn, "42");
+            cbn.SetPinStatus(true);
+
+            DynamoSelection.Instance.Selection.Add(cbn);
+            var ids = DynamoSelection.Instance.Selection.OfType<NodeModel>().Select(x => x.GUID).ToList();
+            model.ExecuteCommand(new DynamoModel.AddPresetCommand("state1", "3", ids));
+
+            UpdateCodeBlockNodeContent(cbn, "146");
+            DynamoSelection.Instance.Selection.Remove(cbn);
+
+            model.CurrentWorkspace.ApplyPreset(model.CurrentWorkspace.Presets.Where(
+               x => x.Name == "state1").First());
+
+            RunCurrentModel();
+
+            Assert.IsTrue(cbn.PreviewPinned);
+        }
+
+        private void UpdateCodeBlockNodeContent(CodeBlockNodeModel cbn, string value)
+        {
+            var command = new DynCmd.UpdateModelValueCommand(Guid.Empty, cbn.GUID, "Code", value);
+            CurrentDynamoModel.ExecuteCommand(command);
+        }
+
 
         [Test]
         [Category("UnitTests")]


### PR DESCRIPTION
### Purpose

Nodes preserve their pinned bubbles  after preset moves described here: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9649 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@aosyatnik 