### PR TITLE
MAGN-9501 Mouse wheel scroll doesn't work for the list displayed in In-Canvas search.

### DIFF
--- a/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/IncanvasSearchControl.xaml.cs
@@ -231,6 +231,8 @@ namespace Dynamo.UI.Controls
             // Make delta less to achieve smooth scrolling and not jump over other elements.
             var delta = e.Delta / 100;
             scrollViewer.ScrollToVerticalOffset(scrollViewer.VerticalOffset - delta);
+            // do not propagate to child items with scrollable content
+            e.Handled = true;
         }
     }
 }


### PR DESCRIPTION
### Purpose

Do not scroll items of in-canvas search by mouse wheel and scroll only the container:
![image](https://cloud.githubusercontent.com/assets/7658189/13672126/1c35949c-e6dc-11e5-82c4-b2305f88d8ac.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@aosyatnik
