### PR TITLE
fixed bug for changing selection of menuItem when user selects none

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("1.0.0.526")]
+[assembly: AssemblyVersion("1.0.0.700")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.0.526")]
+[assembly: AssemblyFileVersion("1.0.0.700")]

--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -78,6 +78,29 @@ namespace CoreNodeModels
             }
         }
 
+        public string getNameOfSelectedDropDownItem ()
+        {
+            return (items.ElementAt(selectedIndex)).Name;
+        }
+
+        public object getItemOfSelectedDropDownItem()
+        {
+            return (items.ElementAt(selectedIndex)).Item;
+        }
+
+        public int getIndexOfItem(string itemName)
+        {
+            int index = 0;
+           for(int i = 0; i< items.Count;i++)
+            {
+                if ((items.ElementAt(i)).Name.Equals(itemName))
+                {
+                    index = i;
+                }
+            }
+            return index;
+        }
+
         protected DSDropDownBase(string outputName)
         {
             OutPortData.Add(new PortData(outputName, string.Format(Resources.DropDownPortDataResultToolTip, outputName)));

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DSDropDownBase.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DSDropDownBase.cs
@@ -36,17 +36,16 @@ namespace CoreNodeModelsWpf.Nodes
             combo.SelectionChanged += delegate
             {
                 if (combo.SelectedIndex != -1)
-                    model.OnNodeModified();
-            };
-
-            combo.DropDownClosed += delegate
-            {
-                //disallow selection of nothing
-                if (combo.SelectedIndex == -1)
                 {
-                    model.SelectedIndex = 0;
+                    model.OnNodeModified();
+                }
+                else
+                {
+                    combo.SelectedIndex = model.SelectedIndex;
                 }
             };
+
+  
 
             combo.DataContext = model;
             //bind this combo box to the selected item hash
@@ -74,7 +73,9 @@ namespace CoreNodeModelsWpf.Nodes
         /// <param name="e"></param>
         void combo_DropDownOpened(object sender, EventArgs e)
         {
+            string itemName = model.getNameOfSelectedDropDownItem();
             this.model.PopulateItems();
+            model.SelectedIndex = model.getIndexOfItem(itemName); 
         }
 
     }


### PR DESCRIPTION
### Purpose

References: [MAGN-8904](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8904)
This PR is to fix the issue when the dropdown selection resets to first dropdownitem when the user does not select any item. It does not include the undo/redo aspect of the issue.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 

