### PR TITLE
MAGN-3215 Rename CoreNodes/strings

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeCategories.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeCategories.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Graph.Nodes
     {
         public const string CORE = "Core";
         public const string CORE_INPUT = "Core.Input";
-        public const string CORE_STRINGS = "Core.Strings";
+        public const string CORE_WEB = "Core.Web";
         public const string CORE_LISTS_CREATE = "Core.List.Create";
         public const string CORE_LISTS_ACTION = "Core.List.Actions";
         public const string CORE_LISTS_QUERY = "Core.List.Query";

--- a/src/Libraries/CoreNodeModels/WebRequest.cs
+++ b/src/Libraries/CoreNodeModels/WebRequest.cs
@@ -9,7 +9,7 @@ namespace CoreNodeModels
 {
     [NodeName("Web Request")]
     [NodeDescription("WebRequestDescription", typeof(Resources))]
-    [NodeCategory(BuiltinNodeCategories.CORE_STRINGS)]
+    [NodeCategory(BuiltinNodeCategories.CORE_WEB)]
     [IsDesignScriptCompatible]
     [AlsoKnownAs("DSCoreNodesUI.WebRequest")]
     public class WebRequest : NodeModel


### PR DESCRIPTION
### Purpose

Nothing special, just renaming of category:
![image](https://cloud.githubusercontent.com/assets/7658189/13701903/97417b58-e793-11e5-80d5-f2bda5371992.png)

The change does not affect file saving: before and after renaming the only node from this category is being saved as `CoreNodeModels.WebRequest`. So, there is no migration for this.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@pbidenko 
