### PR TITLE
Set product name as "Dynamo Core" for DynamoCore.msi

### DIFF
--- a/src/DynamoInstall/DynamoInstall.wixproj
+++ b/src/DynamoInstall/DynamoInstall.wixproj
@@ -61,7 +61,7 @@
     <CreateProperty Value="$(FullVersion.Split('.')[3])">
       <Output TaskParameter="Value" PropertyName="Build" />
     </CreateProperty>
-    <CreateProperty Value="Dynamo">
+    <CreateProperty Value="Dynamo Core">
       <Output TaskParameter="Value" PropertyName="ProductName" />
     </CreateProperty>
     <CreateProperty Value="FullVersion=$(FullVersion);ProductName=$(ProductName);Major=$(Major);Minor=$(Minor);Rev=$(Rev);Build=$(Build);$(DefineConstants)">

--- a/src/DynamoInstall/Product.wxs
+++ b/src/DynamoInstall/Product.wxs
@@ -24,8 +24,8 @@
     <MediaTemplate EmbedCab="yes" />
 
     <Property Id="INSTALLDIR"/>
-    <CustomAction Id="DIRCA_DEFAULT_INSTALLDIR" Property="DYNAMO_INSTALLDIR" Value="[ProgramFiles64Folder][Manufacturer]\DynamoCore\$(var.Major).$(var.Minor)" Execute="immediate" />
-    <CustomAction Id="DIRCA_SET_INSTALLDIR" Property="DYNAMO_INSTALLDIR" Value="[INSTALLDIR]\DynamoCore\$(var.Major).$(var.Minor)" Execute="immediate" />
+    <CustomAction Id="DIRCA_DEFAULT_INSTALLDIR" Property="DYNAMO_INSTALLDIR" Value="[ProgramFiles64Folder][Manufacturer]\$(var.ProductName)\$(var.Major).$(var.Minor)" Execute="immediate" />
+    <CustomAction Id="DIRCA_SET_INSTALLDIR" Property="DYNAMO_INSTALLDIR" Value="[INSTALLDIR]\$(var.ProductName)\$(var.Major).$(var.Minor)" Execute="immediate" />
 
     <InstallExecuteSequence>
       <Custom Action="DIRCA_DEFAULT_INSTALLDIR" Before="CostInitialize">INSTALLDIR=""</Custom>


### PR DESCRIPTION
### Purpose

This PR sets DynamoCore product name as "Dynamo Core" instead of "Dynamo".

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @sh4nnongoh 

### FYIs
- [ ] @riteshchandawar 
