### PR TITLE
MAGN-9693: Update File Search logic for import module in ProtoCore

### DIFF
--- a/src/Engine/ProtoCore/Utils/FileUtils.cs
+++ b/src/Engine/ProtoCore/Utils/FileUtils.cs
@@ -104,8 +104,8 @@ namespace ProtoCore.Utils
         {
             if (string.IsNullOrEmpty(mInstallPath))
             {
-                var protoInterface = typeof(Autodesk.DesignScript.Interfaces.IExtensionApplication).Assembly;
-                var uri = new UriBuilder(protoInterface.CodeBase);
+                var protoCore = Assembly.GetExecutingAssembly();
+                var uri = new UriBuilder(protoCore.CodeBase);
                 mInstallPath = Path.GetDirectoryName(Uri.UnescapeDataString(uri.Path));
             }
 


### PR DESCRIPTION
### Purpose

Fixes http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9693

### Background

With Dynamo Core MSI separation some of the modules on Dynamo Studio are not getting loaded properly because the file search logic for import module was looking for the presence of ProtoInterface.dll to consider the install location. ProtoInterface.dll was copied in Dynamo Studio install location due to some build dependency and hence the core libraries were searched in Dynamo Studio install location thus these libraries were not loaded properly.

Update the logic to base on Executing assembly, which is ProtoCore in the current scenario. In the long run, the file search heuristic should be updated to resolve the library path using Dynamo Path resolver logic.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @ke-yu 

### FYIs

@Benglin 
@kronz 
