### PR TITLE
MAGN-9701: HostApplicationDirectory to resolve additional extension apps

### DIFF
--- a/src/DynamoCore/Configuration/IPathResolver.cs
+++ b/src/DynamoCore/Configuration/IPathResolver.cs
@@ -65,6 +65,12 @@ namespace Dynamo.Interfaces
         string DynamoCoreDirectory { get; }
 
         /// <summary>
+        /// The directory in which the host application such as DynamoRevit or 
+        /// DynamoStudio to be found.
+        /// </summary>
+        string HostApplicationDirectory { get; }
+
+        /// <summary>
         /// The local directory that contains user specific data files.
         /// </summary>
         string UserDataDirectory { get; }
@@ -118,14 +124,14 @@ namespace Dynamo.Interfaces
         IEnumerable<string> PackagesDirectories { get; }
 
         /// <summary>
-        /// The directory, which contains ExtensionDefinition .xml files
+        /// The directories, which contains ExtensionDefinition .xml files
         /// </summary>
-        string ExtensionsDirectory { get; }
+        IEnumerable<string> ExtensionsDirectories { get; }
 
         /// <summary>
-        /// The directory, which contains ViewExtensionDefinition.xml files
+        /// The directories, which contains ViewExtensionDefinition.xml files
         /// </summary>
-        string ViewExtensionsDirectory { get; }
+        IEnumerable<string> ViewExtensionsDirectories { get; }
 
         /// <summary>
         /// The root directory where all sample files are stored. This directory

--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -37,6 +37,11 @@ namespace Dynamo.Core
         internal string CorePath { get; set; }
 
         /// <summary>
+        /// The full path of the host application such as DynamoRevit or DynamoStudio
+        /// </summary>
+        internal string HostPath { get; set; }
+
+        /// <summary>
         /// Reference of an IPathResolver object that supplies 
         /// additional path information. This argument is optional.
         /// </summary>
@@ -60,13 +65,12 @@ namespace Dynamo.Core
         private readonly int majorFileVersion;
         private readonly int minorFileVersion;
         private readonly string dynamoCoreDir;
+        private readonly string hostApplicationDirectory;
         private readonly string userDataDir;
         private readonly string commonDataDir;
 
         private readonly string commonDefinitions;
         private readonly string logDirectory;
-        private readonly string extensionsDirectory;
-        private readonly string viewExtensionsDirectory;
         private readonly string samplesDirectory;
         private readonly string backupDirectory;
         private readonly string preferenceFilePath;
@@ -76,7 +80,9 @@ namespace Dynamo.Core
         private readonly HashSet<string> nodeDirectories;
         private readonly HashSet<string> additionalResolutionPaths;
         private readonly HashSet<string> preloadedLibraries;
-
+        private readonly HashSet<string> extensionsDirectories;
+        private readonly HashSet<string> viewExtensionsDirectories;
+        
         #endregion
 
         #region IPathManager Interface Implementation
@@ -84,6 +90,11 @@ namespace Dynamo.Core
         public string DynamoCoreDirectory
         {
             get { return dynamoCoreDir; }
+        }
+
+        public string HostApplicationDirectory
+        {
+            get { return hostApplicationDirectory; }
         }
 
         public string UserDataDirectory
@@ -126,14 +137,14 @@ namespace Dynamo.Core
             get { return rootDirectories.Select(path => TransformPath(path, PackagesDirectoryName)); }
         }
 
-        public string ExtensionsDirectory
+        public IEnumerable<string> ExtensionsDirectories
         {
-            get { return extensionsDirectory; }
+            get { return extensionsDirectories; }
         }
 
-        public string ViewExtensionsDirectory
+        public IEnumerable<string> ViewExtensionsDirectories
         {
-            get { return viewExtensionsDirectory; }
+            get { return viewExtensionsDirectories; }
         }
 
         public string SamplesDirectory
@@ -280,8 +291,18 @@ namespace Dynamo.Core
                     "TestServices.dll.config.");
             }
 
-            extensionsDirectory = Path.Combine(dynamoCoreDir, ExtensionsDirectoryName);
-            viewExtensionsDirectory = Path.Combine(dynamoCoreDir, ViewExtensionsDirectoryName);
+            hostApplicationDirectory = pathManagerParams.HostPath;
+            extensionsDirectories = new HashSet<string>();
+            viewExtensionsDirectories = new HashSet<string>();
+
+            extensionsDirectories.Add(Path.Combine(dynamoCoreDir, ExtensionsDirectoryName));
+            viewExtensionsDirectories.Add(Path.Combine(dynamoCoreDir, ViewExtensionsDirectoryName));
+
+            if(!string.IsNullOrEmpty(hostApplicationDirectory))
+            {
+                extensionsDirectories.Add(Path.Combine(hostApplicationDirectory, ExtensionsDirectoryName));
+                viewExtensionsDirectories.Add(Path.Combine(hostApplicationDirectory, ViewExtensionsDirectoryName));
+            }
 
             // If both major/minor versions are zero, get from assembly.
             majorFileVersion = pathManagerParams.MajorFileVersion;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -400,6 +400,7 @@ namespace Dynamo.Models
         {
             string Context { get; set; }
             string DynamoCorePath { get; set; }
+            string DynamoHostPath { get; set; }
             IPreferences Preferences { get; set; }
             IPathResolver PathResolver { get; set; }
             bool StartInTestMode { get; set; }
@@ -418,6 +419,7 @@ namespace Dynamo.Models
         {
             public string Context { get; set; }
             public string DynamoCorePath { get; set; }
+            public string DynamoHostPath { get; set; }
             public IPreferences Preferences { get; set; }
             public IPathResolver PathResolver { get; set; }
             public bool StartInTestMode { get; set; }
@@ -459,6 +461,7 @@ namespace Dynamo.Models
             pathManager = new PathManager(new PathManagerParams
             {
                 CorePath = config.DynamoCorePath,
+                HostPath = config.DynamoHostPath,
                 PathResolver = config.PathResolver
             });
 
@@ -543,7 +546,7 @@ namespace Dynamo.Models
 
             extensionManager = new ExtensionManager();
             extensionManager.MessageLogged += LogMessage;
-            var extensions = config.Extensions ?? ExtensionManager.ExtensionLoader.LoadDirectory(pathManager.ExtensionsDirectory);
+            var extensions = config.Extensions ?? LoadExtensions();
 
             Loader = new NodeModelAssemblyLoader();
             Loader.MessageLogged += LogMessage;
@@ -620,6 +623,16 @@ namespace Dynamo.Models
                     Logger.Log(ex.Message);
                 }
             }
+        }
+
+        private IEnumerable<IExtension> LoadExtensions()
+        {
+            var extensions = new List<IExtension>();
+            foreach (var dir in pathManager.ExtensionsDirectories)
+            {
+                extensions.AddRange(ExtensionManager.ExtensionLoader.LoadDirectory(dir));
+            }
+            return extensions;
         }
             
         private void RemoveExtension(IExtension ext)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -44,6 +44,7 @@ using Dynamo.Wpf.Views.Gallery;
 using Dynamo.Wpf.Extensions;
 using Dynamo.Wpf.Views.PackageManager;
 using Dynamo.Views;
+using System.Collections.Generic;
 
 namespace Dynamo.Controls
 {
@@ -133,7 +134,12 @@ namespace Dynamo.Controls
                 dynamoViewModel.Model.AuthenticationManager.AuthProvider.RequestLogin += loginService.ShowLogin;
             }
 
-            var viewExtensions = viewExtensionManager.ExtensionLoader.LoadDirectory(dynamoViewModel.Model.PathManager.ViewExtensionsDirectory);
+            var viewExtensions = new List<IViewExtension>();
+            foreach (var dir in dynamoViewModel.Model.PathManager.ViewExtensionsDirectories)
+            {
+                viewExtensions.AddRange(viewExtensionManager.ExtensionLoader.LoadDirectory(dir));
+            }
+
             viewExtensionManager.MessageLogged += Log;
 
             var startupParams = new ViewStartupParams(dynamoViewModel);


### PR DESCRIPTION
### Purpose

This PR addresses [MAGN-9701](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9701), to allow Dynamo host applications to pass the host application path via start configuration so that Dynamo core can load additional view extension or extension applications implemented by the host application. 

For example, DynamoStudio implements DynamoPublish view extension and that can be loaded by dynamo core once it has information about the location of viewextension directory.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @Randy-Ma 
- [x] @ke-yu 

### FYIs

- [ ] @pboyer 
- [ ] @Benglin 
