### PR TITLE
Fix MAGN-9716 [Crash] Side effect of Preview Control crash fix in Dynamo 0.9.2.

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/WatchImage.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/WatchImage.cs
@@ -60,7 +60,7 @@ namespace CoreNodeModelsWpf.Nodes
             var bitmap = data.Data as Bitmap;
             if (bitmap != null)
             {
-                nodeView.Dispatcher.BeginInvoke(new Action<Bitmap>(SetImageSource), new object[] { bitmap });
+                nodeView.Dispatcher.Invoke(new Action<Bitmap>(SetImageSource), new object[] { bitmap });
             }
         }
 


### PR DESCRIPTION
### Purpose

This is to fix defec [ MAGN-9716 [Crash] Side effect of Preview Control crash fix in Dynamo 0.9.2](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9716#).

The actually crash doesn't happen in preview control but in `WatchImage` node. The root cause is outdated data is used. Following diagram shows this case:
```
[1] Update Graph 
  --> [2] Update NodeModel's CachedValue 
    --> [3] Schedule WatchImage.SetImageSource [*] 
      --> [4] Update Graph
        --> [5] Update NodeModel's CachedValue
          --> [6] SetImageSource by using data in [*]  
            --> ...
```
In step [6], although the graph has been updated again, `SetImageSource` still uses outdated data. It is because `SetImageSource` is scheduled as an asynchronous operation.  Change it to a synchronous operation.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 

### FYIs

@jnealb @monikaprabhu @riteshchandawar 
