### PR TITLE
Call WatchImage.SetImageSource synchronously

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/WatchImage.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/WatchImage.cs
@@ -60,7 +60,7 @@ namespace CoreNodeModelsWpf.Nodes
             var bitmap = data.Data as Bitmap;
             if (bitmap != null)
             {
-                nodeView.Dispatcher.BeginInvoke(new Action<Bitmap>(SetImageSource), new object[] { bitmap });
+                nodeView.Dispatcher.Invoke(new Action<Bitmap>(SetImageSource), new object[] { bitmap });
             }
         }
 


### PR DESCRIPTION
### Purpose

Cross merge the [fix](#6268) for  [ MAGN-9716 [Crash] Side effect of Preview Control crash fix in Dynamo 0.9.2](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9716#) to master branch.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

