### PR TITLE
MAGN-9565 Convert Between Units node is not supported on the Reach/Flood platform

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1315,7 +1315,7 @@ namespace Dynamo.Models
                     workspace.SaveAs(savePath, null, true);
                     workspace.FileName = oldFileName;
                     workspace.Name = oldName;
-                    backupFilesDict.Add(workspace.Guid, savePath);
+                    backupFilesDict[workspace.Guid] = savePath;
                     Logger.Log("Backup file is saved: " + savePath);
                 }
                 PreferenceSettings.BackupFiles.AddRange(backupFilesDict.Values);

--- a/src/Libraries/CoreNodeModels/DynamoConvert.cs
+++ b/src/Libraries/CoreNodeModels/DynamoConvert.cs
@@ -171,6 +171,30 @@ namespace CoreNodeModels
 
         }
 
+        protected override bool UpdateValueCore(UpdateValueParams updateValueParams)
+        {
+            switch (updateValueParams.PropertyName)
+            {
+                case "Values":
+                    // Here we expect a string that represents an array of [ metric, from, to ] values which are separated by ";"
+                    // For example "Length;Meters;Feet"
+                    var vals = updateValueParams.PropertyValue.Split(';');
+                    ConversionMetricUnit metric;
+                    ConversionUnit from, to;
+                    if (vals.Length == 3 && Enum.TryParse(vals[0], out metric)
+                        && Enum.TryParse(vals[1], out from) && Enum.TryParse(vals[2], out to))
+                    {
+                        SelectedMetricConversion = metric;
+                        SelectedFromConversion = from;
+                        SelectedToConversion = to;
+                    }
+
+                    return true;
+            }
+
+            return base.UpdateValueCore(updateValueParams);
+        }
+
         #endregion
     }      
 }


### PR DESCRIPTION
### Purpose

Add an ability to update values of DynamoConvert via UpdateModelValueCommand. This functionality is needed to set DynamoConvert values from Flood/Customizer.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@pbidenko 