### PR TITLE
Preview bubble is hidden in custom ws.

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -413,7 +413,7 @@ namespace Dynamo.Controls
             // Always set old ZIndex to the last value, even if mouse is not over the node.
             oldZIndex = NodeViewModel.StaticZIndex;
 
-            if (!previewEnabled) return; // Preview is hidden. There is no need run further.
+            if (!previewEnabled || !ViewModel.IsPreviewInsetVisible) return; // Preview is hidden. There is no need run further.
 
             if (PreviewControl.IsInTransition) // In transition state, come back later.
                 return;

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -65,6 +65,22 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void PreviewBubbleVisible_MouseMoveOverNode_InCustomWorkspace()
+        {
+            Open(@"core\custom_node_saving\Constant2.dyf");
+            var nodeView = NodeViewWithGuid("9ce91e89-c087-49cd-9fd9-540cca086475");
+            nodeView.PreviewControl.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+            View.Dispatcher.Invoke(() =>
+            {
+                nodeView.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0) { RoutedEvent = Mouse.MouseEnterEvent });
+            });
+            DispatcherUtil.DoEvents();
+
+            Assert.IsTrue(nodeView.PreviewControl.IsHidden);
+        }
+
+        [Test]
         public void PreviewBubbleVisible_MouseMoveOutOfNode()
         {
             Open(@"core\DetailedPreviewMargin_Test.dyn");


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9645](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9645) Custom Node pane supports Preview Bubble displays, with all Null values

Preview bubble isn't shown in custom workspace. So, there is no UI changes :)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@marimano 
