### PR TITLE
Mirror mirror with the engine is it still valid after all?

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
@@ -994,6 +994,7 @@ namespace ProtoFFI
                 {
                     DSObjectMap.Remove(dsObject);
                     CLRObjectMap.Remove(clrobject);
+                    NotifyObjectDisposed(dsObject, dsi.runtime.RuntimeCore);
                 }
             }
         }
@@ -1286,8 +1287,9 @@ namespace ProtoFFI
             //Dispose all disposable CLR objects.
             foreach (var item in DSObjectMap)
             {
-                IDisposable disposable = item.Value as IDisposable;
+                NotifyObjectDisposed(item.Key, sender);
 
+                IDisposable disposable = item.Value as IDisposable;
                 if (null != disposable)
                     disposable.Dispose();
             }

--- a/src/Engine/ProtoCore/FFI/FFIHandler.cs
+++ b/src/Engine/ProtoCore/FFI/FFIHandler.cs
@@ -37,11 +37,38 @@ namespace ProtoFFI
     }
 
     /// <summary>
+    /// Represents StackValue argument
+    /// </summary>
+    public class StackValueArgs : EventArgs
+    {
+        public StackValueArgs(StackValue data, ProtoCore.RuntimeCore core)
+        {
+            Data = data;
+            Core = core;
+        }
+
+        /// <summary>
+        /// The StackValue Data
+        /// </summary>
+        public StackValue Data { get; private set; }
+
+        /// <summary>
+        /// The RuntimeCore to which this StackValue belongs
+        /// </summary>
+        public ProtoCore.RuntimeCore Core { get; private set; }
+    }
+
+    /// <summary>
     /// This class is responsible for marshaling of FFI objects to DS world and 
     /// vice-versa.
     /// </summary>
     public abstract class FFIObjectMarshler
     {
+        /// <summary>
+        /// Event handler to get notified when a StackValue is disposed.
+        /// </summary>
+        public event EventHandler<StackValueArgs> ObjectDisposed;
+
         /// <summary>
         /// Marshales a given FFI object to DS Object of given ProtoCore.Type
         /// </summary>
@@ -85,6 +112,17 @@ namespace ProtoFFI
         /// <param name="dsObject">DS Object</param>
         /// <returns>string representation of a DS object</returns>
         public abstract string GetStringValue(StackValue dsObject);
+
+        /// <summary>
+        /// Raises event notification for object disposed.
+        /// </summary>
+        /// <param name="data">The StackValue data being disposed</param>
+        /// <param name="core">The RuntimCore to which the data belongs</param>
+        protected void NotifyObjectDisposed(StackValue data, ProtoCore.RuntimeCore core)
+        {
+            if (ObjectDisposed != null)
+                ObjectDisposed(this, new StackValueArgs(data, core));
+        }
     }
 
     public enum FFILanguage


### PR DESCRIPTION
### Purpose

This PR enhances MirrorData validity check and hopefully prevents a possible crash due to access of invalid mirror data during preview.

- `FFIObjectMarshaler` implements ObjectDisposed event handler.
- `MirrorData` registers for object disposed event handler, if the stack value owned by it is an FFI object.
- When the StackValue is disposed, the mirror data is marked as invalid and it's cached clrData is set null.
- StringData property returns "Invalid" string if the mirror data object is invalid.
- UI can check for IsValid flag on mirror data and either avoid any call on it or request for a refresh of CachedValue on node.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [x] @ke-yu 
- [ ] @ikeough 

### FYIs
@ramramps 
