### PR TITLE
Fix preview bubble crash for custom node

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -502,7 +502,8 @@ namespace Dynamo.Graph.Workspaces
             EngineController.ReconcileTraceDataAndNotify();
 
             // Refresh values of nodes that took part in update.
-            foreach (var executedNode in updateTask.ExecutedNodes)
+            var nodes = new HashSet<NodeModel>(updateTask.ExecutedNodes.Concat(updateTask.ModifiedNodes));
+            foreach (var executedNode in nodes)
             {
                 executedNode.RequestValueUpdate(EngineController);
             }

--- a/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
@@ -25,7 +25,7 @@ namespace Dynamo.Scheduler
             get { return TaskPriority.AboveNormal; }
         }
 
-        public IEnumerable<NodeModel> ModifiedNodes { get; set; }
+        public IEnumerable<NodeModel> ModifiedNodes { get; protected set; }
         private List<NodeModel> executedNodes;
         public IEnumerable<NodeModel> ExecutedNodes { get { return executedNodes; } }
 

--- a/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
@@ -25,7 +25,7 @@ namespace Dynamo.Scheduler
             get { return TaskPriority.AboveNormal; }
         }
 
-        protected IEnumerable<NodeModel> ModifiedNodes { get; set; }
+        public IEnumerable<NodeModel> ModifiedNodes { get; set; }
         private List<NodeModel> executedNodes;
         public IEnumerable<NodeModel> ExecutedNodes { get { return executedNodes; } }
 


### PR DESCRIPTION
### Purpose

This crash is side effect introduced by PR #6185. In that PR, we update preview values for all nodes that *executed* in the session of graph update, instead of nodes that *modified*. 

Now for the modification of custom node, this is how the crash happens:
  1. All custom node instances are marked as dirty. `CompileCustomNodeAsyncTask` will be scheduled to update the custom node definition. When the engine updates the corresponding custom node definition, it will updates all custom node instances.
  2. `UpdateGraphAsyncTask` will be scheduled. As all custom node instances have been updated, no node will be executed in this run, so the preview value for custom node instance will not be updated.

As all custom node instances are modified when custom node is modified, and `UpdateGraphAsyncTask` will be scheduled, this PR updates preview value for both executed nodes and modified nodes.

Related defects
  * [MAGN-9729 Double click on freshly created custom node gives crash](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9729)
  * [MAGN-9727 Updating slider in Custom Node gives crash](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9727)
  * [MAGN-9737 Crash in Preview control when clicking on custom nodes after modifying them](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9737)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 

### FYIs
@kronz @jnealb @monikaprabhu @riteshchandawar 

