### PR TITLE
Not display preview bubble in custom workspace

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -385,7 +385,8 @@ namespace Dynamo.Controls
 
         private void OnNodeViewMouseEnter(object sender, MouseEventArgs e)
         {
-            if (!previewEnabled) return; // Preview is hidden. There is no need run further.
+            if (!previewEnabled || !ViewModel.IsPreviewInsetVisible)
+                return; // Preview is hidden. There is no need run further.
 
             if (PreviewControl.IsInTransition) // In transition state, come back later.
                 return;


### PR DESCRIPTION
### Purpose

This PR applies the fix (PR #6271) to RC branch to fix [MAGN-9750 Hovering over a Preview Bubble in a Custom Node gives a crash](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9750#)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs
@jnealb @monikaprabhu @kronz 