### PR TITLE
MAGN-9745 Align Selection tools missing from context menu in 1.0

### DIFF
--- a/src/DynamoCoreWpf/Controls/ParentMenuItem.cs
+++ b/src/DynamoCoreWpf/Controls/ParentMenuItem.cs
@@ -1,0 +1,29 @@
+﻿using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Dynamo.Controls
+{
+    /// <summary>
+    /// Overriden MenuItem which can be put outside Menu container. 
+    /// Base MenuItem is not able to open its submenu on mouse hover
+    /// </summary>
+    class ParentMenuItem : MenuItem
+    {
+        public ParentMenuItem()
+        {
+            MouseLeave += OkMenuItem_MouseLeave;
+            MouseEnter += OkMenuItem_MouseEnter;
+        }
+
+        private void OkMenuItem_MouseEnter(object sender, MouseEventArgs e)
+        {
+            IsSubmenuOpen = true;
+        }
+
+        private void OkMenuItem_MouseLeave(object sender, MouseEventArgs e)
+        {
+            IsHighlighted = false;
+            IsSubmenuOpen = false;
+        }
+    }
+}

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Controls\NotificationsControl.xaml.cs">
       <DependentUpon>NotificationsControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\ParentMenuItem.cs" />
     <Compile Include="Controls\RunSettingsControl.xaml.cs">
       <DependentUpon>RunSettingsControl.xaml</DependentUpon>
     </Compile>

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -28,8 +28,7 @@
             </Setter>
 
             <Style.Triggers>
-                <DataTrigger Binding="{Binding Path=InCanvasSearchViewModel.SearchRootCategories.Count}"
-                                                         Value="0">
+                <DataTrigger Binding="{Binding Path=InCanvasSearchViewModel.SearchRootCategories.Count}" Value="0">
                     <Setter Property="Effect">
                         <Setter.Value>
                             <DropShadowEffect BlurRadius="20" ShadowDepth="0" Opacity="0.7" />
@@ -341,7 +340,7 @@
             </Popup.Resources>
             <ItemsControl Style="{StaticResource WorkspaceContextMenuStyle}">
                 <ItemsControl.Items>
-                    <MenuItem Name="WorkspaceLacingMenu"
+                    <controls:ParentMenuItem x:Name="WorkspaceLacingMenu"
                           Header="{x:Static p:Resources.ContextMenuLacing}">
 
                         <MenuItem IsCheckable="True"
@@ -380,7 +379,7 @@
                             </MenuItem.IsChecked>
                         </MenuItem>
 
-                    </MenuItem>
+                    </controls:ParentMenuItem>
                     <MenuItem IsEnabled="{Binding Path=IsGeometryOperationEnabled}"
                           Header="{x:Static  p:Resources.ContextMenuShowAllGeometry}"
                           Command="{Binding Path=ShowHideAllGeometryPreviewCommand}"
@@ -405,8 +404,7 @@
                           CommandParameter="false"
                           Visibility="{Binding Path=AnyNodeUpstreamVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
-                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignSelection}"
-                           Name="Align">
+                    <controls:ParentMenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignSelection}" x:Name="Align">
                         <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignXAverage}"
                                Command="{Binding AlignSelectedCommand}"
                                CommandParameter="HorizontalCenter" />
@@ -431,7 +429,7 @@
                         <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuAlignXDistribute}"
                                Command="{Binding AlignSelectedCommand}"
                                CommandParameter="HorizontalDistribute" />
-                    </MenuItem>
+                    </controls:ParentMenuItem>
 
                     <MenuItem  Header="{x:Static p:Resources.ContextMenuNodesFromSelection}"
                            Command="{Binding NodeFromSelectionCommand}" CommandTarget="{Binding ElementName=_this}" />

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -757,6 +757,24 @@ namespace DynamoCoreWpfTests
             Assert.IsFalse(currentWs.InCanvasSearchBar.IsOpen);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void WorkspaceContextMenu_IfSubmenuOpenOnMouseHover()
+        {
+            var currentWs = View.ChildOfType<WorkspaceView>();
+            RightClick(currentWs.zoomBorder);
+            Assert.IsTrue(currentWs.ContextMenuPopup.IsOpen);
+
+            currentWs.WorkspaceLacingMenu.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
+            {
+                RoutedEvent = Mouse.MouseEnterEvent
+            });
+
+            DispatcherUtil.DoEvents();
+
+            Assert.IsTrue(currentWs.WorkspaceLacingMenu.IsSubmenuOpen);
+        }
+
         private void RightClick(IInputElement element)
         {
             element.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Right)


### PR DESCRIPTION
### Purpose

When MenuItem is put not in Menu container, it is not able to open its submenu on mouse hover automatically.
Several solutions were tried:
- setting trigger for MenuItem as next
```
<Trigger Property="IsMouseOver" Value="True">
   <Setter Property="IsSubmenuOpen" Value="True"/>
</Trigger>
<Trigger Property="IsMouseOver" Value="False">
  <Setter Property="IsSubmenuOpen" Value="False"/>
</Trigger>
```
works fine unless an item in submenu is clicked: `IsMouseOver` stops triggering
- subscribing on `MouseEnter` event interferes with highlighting mechanism: highlight disappers from item with a delay, so at a time you can see several highlighted items:
![image](https://cloud.githubusercontent.com/assets/7658189/13950782/9496816e-f035-11e5-87d9-b85811b5d4fa.png)
and when a subitem is clicked the item stays highlighted on context menu re-opening. `IsHighlighted` property has protected setter, so we cannot set desired value in our `MouseLeave` handler

So, MenuItem is overriden to open its submenu on `MouseEnter` and hide it on `MouseLeave` with immediate removing highlight:
![image](https://cloud.githubusercontent.com/assets/7658189/13950869/1f37fc6c-f036-11e5-9395-1fa5ee60869a.png)

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI:
![image](https://cloud.githubusercontent.com/assets/7658189/13950884/419ebffc-f036-11e5-88ef-63f710f2e834.png)
- [x] Snapshot of UI changes, if any.

### Reviewers

@aosyatnik 