### PR TITLE
Adds error message display for "add file.." button

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("1.0.0.774")]
+[assembly: AssemblyVersion("1.0.0.806")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.0.774")]
+[assembly: AssemblyFileVersion("1.0.0.806")]

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2778,6 +2778,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to add file: {0}.
+        /// </summary>
+        public static string MessageFailedToAddFile {
+            get {
+                return ResourceManager.GetString("MessageFailedToAddFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to apply NodeViewCustomization for {0}.
         /// </summary>
         public static string MessageFailedToApplyCustomization {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1989,4 +1989,8 @@ Do you want to install the latest Dynamo update?</value>
 Next assemblies were loaded several times:
 </value>
   </data>
+  <data name="MessageFailedToAddFile" xml:space="preserve">
+    <value>Failed to add file: {0}</value>
+    <comment>Message box content</comment>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1990,4 +1990,8 @@ Do you want to install the latest Dynamo update?</value>
 Next assemblies were loaded several times:
 </value>
   </data>
+  <data name="MessageFailedToAddFile" xml:space="preserve">
+    <value>Failed to add file: {0}</value>
+    <comment>Message box content</comment>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -5,31 +5,21 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Security;
-using System.Security.AccessControl;
-using System.Security.Permissions;
-using System.Security.Principal;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Dynamo.Core;
-using Dynamo.Graph;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
-using Dynamo.Nodes;
 using Dynamo.PackageManager.UI;
-using Dynamo.UI;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
-
-using DynamoUtilities;
-
+using Dynamo.Wpf.Properties;
 using Greg.Requests;
 using Microsoft.Practices.Prism.Commands;
 using Double = System.Double;
-using String = System.String;
-using Dynamo.Wpf.Properties;
 using NotificationObject = Microsoft.Practices.Prism.ViewModel.NotificationObject;
+using String = System.String;
 
 namespace Dynamo.PackageManager
 {

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -943,6 +943,8 @@ namespace Dynamo.PackageManager
             }
             catch (Exception e)
             {
+                UploadState = PackageUploadHandle.State.Error;
+                ErrorString = String.Format(Resources.MessageFailedToAddFile, filename);
                 dynamoViewModel.Model.Logger.Log(e);
             }
         }
@@ -986,6 +988,8 @@ namespace Dynamo.PackageManager
             }
             catch (Exception e)
             {
+                UploadState = PackageUploadHandle.State.Error;
+                ErrorString = String.Format(Resources.MessageFailedToAddFile, filename);
                 dynamoViewModel.Model.Logger.Log(e);
             }
         }


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9484
Unsupported DLL format does not generate a proper Package Manager error message.
This is the second PR related to the story. The other ones are related to import dll in library view:
https://github.com/DynamoDS/Dynamo/pull/6263
https://github.com/DynamoDS/Dynamo/pull/6275
This PR adds error message display for "add file.." button. It escaped the net while other exception messages were caught and displayed.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

I failed to get the UI change picture because I was not able to run dynamo with Revit on my personal machine now. But new error message should appear at the buttom of the package manager dialog.

### Reviewers

@marimano 

### FYIs

@jnealb 

