### PR TITLE
Short cuts alignment

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -378,12 +378,12 @@
                                   Header="{x:Static p:Resources.DynamoViewEditMenuUndo}"
                                   Command="{Binding UndoCommand}"
                                   Name="undo"
-                                  InputGestureText="Ctrl+Z" />
+                                  InputGestureText="Ctrl + Z" />
                         <MenuItem Focusable="False"
                                   Header="{x:Static p:Resources.DynamoViewEditMenuRedo}"
                                   Command="{Binding RedoCommand}"
                                   Name="redo"
-                                  InputGestureText="Ctrl+Y" />
+                                  InputGestureText="Ctrl + Y" />
                         <Separator />
                         <MenuItem Focusable="False"
                                   Header="{x:Static p:Resources.DynamoViewEditMenuCopy}"


### PR DESCRIPTION
### Purpose

Adjust short cuts alignment for undo and redo in 0.9.2

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
## Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

Before:
![short-cuts do not align in 9_2](https://cloud.githubusercontent.com/assets/3942418/13974658/1a9fdac8-f084-11e5-8ca1-ee32c0982cc4.png)


After:
![new edit menu](https://cloud.githubusercontent.com/assets/3942418/13974579/54cd646e-f083-11e5-86bc-8995155253da.png)

### Reviewers

@Racel Pure UI change here in this PR. It's hard to believe that even after space inserted, these short cuts still do not align perfectly. "Ctrl + W" there is much wider.. It seems different character has different width there and I did not find any reference around WPF. @aosyatnik @marimano @ramramps @pbidenko @mjkkirschner @sm6srw If you guys know any tricks on aligning characters in this case, please let me know.


### FYIs

@jnealb 

