### PR TITLE
MAGN-9761 Preview Bubble Collapses when pinned

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -806,16 +806,6 @@ namespace Dynamo.Graph.Nodes
             return engine.GetMirror(GetAstIdentifierForOutputIndex(outPortIndex).Value).GetData();
         }
 
-        public void SetPinStatus(bool pinned)
-        {
-            if (PreviewPinned != pinned)
-            {
-                PreviewPinned = pinned;
-                OnNodeModified();
-            }
-            
-        }
-
         /// <summary>
         ///     Sets the nickname of this node from the attributes on the class definining it.
         /// </summary>
@@ -1731,6 +1721,15 @@ namespace Dynamo.Graph.Nodes
                         IsFrozen = newIsFrozen;
                     }
                     return true;
+
+                case "PreviewPinned":
+                    bool newIsPinned;
+                    if (bool.TryParse(value, out newIsPinned))
+                    {
+                        PreviewPinned = newIsPinned;
+                    }
+                    return true;
+
             }
 
             return base.UpdateValueCore(updateValueParams);

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -257,7 +257,7 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         ///     Indicates if node preview is pinned
         /// </summary>
-        public bool PreviewPinned { get; private set; }
+        public bool PreviewPinned { get; internal set; }
 
         /// <summary>
         ///     Text that is displayed as this Node's tooltip.

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -35,7 +35,6 @@ namespace Dynamo.ViewModels
 
         #region events
         public event SnapInputEventHandler SnapInputEvent;
-        public event PreviewPinStatusHandler PreviewPinEvent;
         #endregion
 
         #region private members
@@ -62,8 +61,10 @@ namespace Dynamo.ViewModels
             {
                 if (previewPinned == value) return;
                 previewPinned = value;
-                if (PreviewPinEvent != null)
-                    PreviewPinEvent(previewPinned);
+
+                DynamoViewModel.ExecuteCommand(
+              new DynamoModel.UpdateModelValueCommand(
+                        System.Guid.Empty, NodeModel.GUID, "PreviewPinned", previewPinned.ToString()));
             }
         }
 
@@ -458,8 +459,7 @@ namespace Dynamo.ViewModels
             DynamoViewModel = workspaceViewModel.DynamoViewModel;
 
             nodeLogic = logic;
-            PreviewPinned = logic.PreviewPinned;
-            PreviewPinEvent += logic.SetPinStatus;
+            previewPinned = logic.PreviewPinned;
 
             //respond to collection changed events to add
             //and remove port model views

--- a/test/DynamoCoreTests/PresetsTests.cs
+++ b/test/DynamoCoreTests/PresetsTests.cs
@@ -80,7 +80,7 @@ namespace Dynamo.Tests
             CurrentDynamoModel.ExecuteCommand(command);
 
             UpdateCodeBlockNodeContent(cbn, "42");
-            cbn.SetPinStatus(true);
+            cbn.PreviewPinned = true;
 
             DynamoSelection.Instance.Selection.Add(cbn);
             var ids = DynamoSelection.Instance.Selection.OfType<NodeModel>().Select(x => x.GUID).ToList();


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9761](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9761) Preview Bubble Collapses when pinned

Reason:
`OnNodeModified` , that we used to set in `SetPinStatus`, causes run graph every time, when preview bubble is pinned. That is incorrect. We shouldn't run graph every time, when we pin preview bubble.

We should updated `PreviewPinned` as we update node nickname or isFrozen state, i.e. by calling `UpdateModelValueCommand`.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ramramps 
@pbidenko 
