### PR TITLE
MAGN-9746 Analysis : Graphic Occlusion errors in 1.0

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -355,7 +355,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 }
 
                 var values = Model3DDictionary.Values.ToList();
-                //values.Sort(new Model3DComparer(Camera.Position));
+                values.Sort(new Model3DComparer(Camera.Position));
                 return values;
             }
         }
@@ -1931,10 +1931,12 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// The Model3DComparer is used to sort arrays of Model3D objects. 
     /// After sorting, the target array's objects will be organized
     /// as follows:
-    /// 1. All opaque geometry.
-    /// 2. All text.
-    /// 3. All transparent geometry, ordered by distance from
-    /// the camera.
+    /// 1. All not GeometryModel3D objects
+    /// 2. All opaque mesh geometry
+    /// 3. All opaque line geometry
+    /// 4. All opaque point geometry
+    /// 5. All transparent geometry, ordered by distance from the camera.
+    /// 6. All text.
     /// </summary>
     public class Model3DComparer : IComparer<Model3D>
     {
@@ -1950,6 +1952,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var a = x as GeometryModel3D;
             var b = y as GeometryModel3D;
 
+            // if at least one of them is not GeometryModel3D
+            // we either sort by being GeometryModel3D type (result is 1 or -1) 
+            // or don't care about order (result is 0)
             if (a == null && b == null)
             {
                 return 0;
@@ -1969,7 +1974,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var textB = b.GetType() == typeof(BillboardTextModel3D);
             var result = textA.CompareTo(textB);
 
-            if (result == 0 && textA)
+            // if at least one of them is text
+            // we either sort by being text type (result is 1 or -1) 
+            // or don't care about order (result is 0)
+            if (textA || textB)
             {
                 return result;
             }
@@ -1978,16 +1986,36 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var transB = (bool) b.GetValue(AttachedProperties.HasTransparencyProperty);
             result = transA.CompareTo(transB);
 
-            if (result != 0 || !transA) return result;
+            // if only one of transA and transB has transparency, sort by having this property
+            if (result != 0) return result;
 
-            // compare distance
-            var boundsA = a.Bounds;
-            var boundsB = b.Bounds;
-            var cpA = (boundsA.Maximum + boundsA.Minimum)/2;
-            var cpB = (boundsB.Maximum + boundsB.Minimum)/2;
-            var dA = Vector3.DistanceSquared(cpA, cameraPosition);
-            var dB = Vector3.DistanceSquared(cpB, cameraPosition);
-            return -dA.CompareTo(dB);
+            // if both items has transparency, sort by distance
+            if (transA)
+            {
+                // compare distance
+                var boundsA = a.Bounds;
+                var boundsB = b.Bounds;
+                var cpA = (boundsA.Maximum + boundsA.Minimum) / 2;
+                var cpB = (boundsB.Maximum + boundsB.Minimum) / 2;
+                var dA = Vector3.DistanceSquared(cpA, cameraPosition);
+                var dB = Vector3.DistanceSquared(cpB, cameraPosition);
+                result = -dA.CompareTo(dB);
+                return result;
+            }
+
+            // if both items does not have transparency, sort following next order: mesh, line, point
+            var pointA = a is PointGeometryModel3D;
+            var pointB = b is PointGeometryModel3D;
+            result = pointA.CompareTo(pointB);
+
+            if (pointA || pointB)
+            {
+                return result;
+            }
+
+            var lineA = a is LineGeometryModel3D;
+            var lineB = b is LineGeometryModel3D;
+            return lineA.CompareTo(lineB);
         }
     }
 


### PR DESCRIPTION
### Purpose

From time to time Dynamo renders geometry items in not correct order:
- lines which should not be visible from current camera position may appear in front
![image](https://cloud.githubusercontent.com/assets/7658189/14016271/bc0b5254-f1c7-11e5-8b2d-f2999fc8f714.png)
- labels may appear behind all other geometry items and as result some of them is never visible even if to rotate camera

![image](https://cloud.githubusercontent.com/assets/7658189/14016306/09a04b14-f1c8-11e5-9a29-c49533a0b322.png)

There already exists `Model3DComparer` to order geometry objects but it has not been used and had some flaws:
- it puts labels even behind the grid;
- it does not sort opaque geometry that may result in for example having geometry border behind its surface:

![image](https://cloud.githubusercontent.com/assets/7658189/14016418/f330d8b6-f1c8-11e5-8fb6-f32c65c29fa4.png)

So, I use here `Model3DComparer` and fix the flaws in it, now geometry with labels looks like next:

![image](https://cloud.githubusercontent.com/assets/7658189/14017661/c1e2f466-f1d1-11e5-9431-342fe10a42c5.png)
and without labels:

![image](https://cloud.githubusercontent.com/assets/7658189/14020303/3e43ca0a-f1df-11e5-9103-69df66814cb5.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 