### PR TITLE
Fixed crash in DM when switching workspaces (MAGN-9589)

### DIFF
--- a/src/DynamoManipulation/DynamoManipulationExtension.cs
+++ b/src/DynamoManipulation/DynamoManipulationExtension.cs
@@ -249,6 +249,12 @@ namespace Dynamo.Manipulation
             // so that it always references the current workspace
             WorkspaceModel = wsm;
             manipulatorNodes = new List<NodeModel>();
+
+            // kill all manipulators in current workspace
+            if (manipulatorDaemon != null)
+            {
+                manipulatorDaemon.KillAll();
+            }
         }
 
         private void UpdateManipulators(NotifyCollectionChangedEventArgs e)

--- a/src/DynamoManipulation/DynamoManipulationExtension.cs
+++ b/src/DynamoManipulation/DynamoManipulationExtension.cs
@@ -305,8 +305,8 @@ namespace Dynamo.Manipulation
                 node.PropertyChanged += OnNodePropertyChanged;
             }
             
-            //No manipulator for frozen node
-            if (node.IsFrozen) return false;
+            //No manipulator for frozen node or node in state of error
+            if (node.IsFrozen || node.IsInErrorState) return false;
 
             //If the node already has a manipulator, then skip creating new one.
             if (manipulatorDaemon.HasNodeManipulator(node)) return false;


### PR DESCRIPTION
### Purpose

This fixes [MAGN-9589] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9589) in which there was a crash when switching between workspaces while manipulators were displayed in geometry view. 

Also fixes [MAGN-9588] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9588)

The reason was that the manipulators from the previous workspace were still alive and their event handlers still registered with mouse events. As a result even after switching to the new w/s the mouse down handler for the non-existent manipulator was triggered resulting in a crash.

The fix is to dispose all active manipulators from the current w/s before switching to a new one (new file or empty w/s).

### Declarations

- [X] The code base is in a better state after this PR


### Reviewers

@sharadkjaiswal 
