### PR TITLE
MAGN-9784 Package Manager Add File should invoke a multi-select Windows dialog

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -849,36 +849,35 @@ namespace Dynamo.PackageManager
         private void ShowAddFileDialogAndAdd()
         {
             // show file open dialog
-            FileDialog fDialog = null;
-
-            if (fDialog == null)
+            var fDialog = new OpenFileDialog()
             {
-                fDialog = new OpenFileDialog()
-                {
-                    Filter = string.Format(Resources.FileDialogCustomNodeDLLXML, "*.dyf;*.dll;*.xml") + "|" +
+                Filter = string.Format(Resources.FileDialogCustomNodeDLLXML, "*.dyf;*.dll;*.xml") + "|" +
                          string.Format(Resources.FileDialogAllFiles, "*.*"),
-                    Title = Resources.AddCustomFileToPackageDialogTitle
-                };
+                Title = Resources.AddCustomFileToPackageDialogTitle,
+                Multiselect = true
+            };
+
+            // if you've got the current space path, add it to shortcuts 
+            // so that user is able to easily navigate there
+            var currentFileName = dynamoViewModel.Model.CurrentWorkspace.FileName;
+            if (!string.IsNullOrEmpty(currentFileName))
+            {
+                var fi = new FileInfo(currentFileName);
+                fDialog.CustomPlaces.Add(fi.DirectoryName);
+            }
+            
+            // add the definitions directory to shortcuts as well
+            var pathManager = dynamoViewModel.Model.PathManager;
+            if (Directory.Exists(pathManager.DefaultUserDefinitions))
+            {
+                fDialog.CustomPlaces.Add(pathManager.DefaultUserDefinitions);
             }
 
-            // if you've got the current space path, use it as the inital dir
-            if (!string.IsNullOrEmpty(dynamoViewModel.Model.CurrentWorkspace.FileName))
-            {
-                var fi = new FileInfo(dynamoViewModel.Model.CurrentWorkspace.FileName);
-                fDialog.InitialDirectory = fi.DirectoryName;
-            }
-            else // use the definitions directory
-            {
-                var pathManager = dynamoViewModel.Model.PathManager;
-                if (Directory.Exists(pathManager.DefaultUserDefinitions))
-                {
-                    fDialog.InitialDirectory = pathManager.DefaultUserDefinitions;
-                }
-            }
+            if (fDialog.ShowDialog() != DialogResult.OK) return;
 
-            if (fDialog.ShowDialog() == DialogResult.OK)
+            foreach (var file in fDialog.FileNames)
             {
-                AddFile(fDialog.FileName);
+                AddFile(file);
             }
         }
 


### PR DESCRIPTION
### Purpose

Allow multiselect and memorize the last folder. Memorizing the last folder is default behavior of `OpenFileDialog`, but current folder was set to current workspace location or to definitions one.
In this PR InitialDirectory is not set anymore to remember the last visited folder which a file has been opened from. The current workspace location and definitions folder are added to shortcuts of the dialog:
![image](https://cloud.githubusercontent.com/assets/7658189/14076438/4b27ad14-f4ea-11e5-9977-bdead9b26a33.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@pbidenko 