### PR TITLE
Restore RegisterForTraceAttribute for build fix.

### DIFF
--- a/src/NodeServices/Attributes.cs
+++ b/src/NodeServices/Attributes.cs
@@ -247,13 +247,6 @@ namespace Autodesk.DesignScript.Runtime
     }
 
     /// <summary>
-    /// This attribute can be applied to methods that register callsite with
-    /// trace mechanism.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
-    public sealed class RegisterForTraceAttribute: Attribute { }
-
-    /// <summary>
     /// This attribute can be applied to parameter to specify a default 
     /// argument expressions.
     /// </summary>

--- a/src/NodeServices/TraceSupport.cs
+++ b/src/NodeServices/TraceSupport.cs
@@ -5,6 +5,17 @@ using System.Threading;
 
 namespace DynamoServices
 {
+    /// <summary>
+    /// This attribute can be applied to methods that register callsite with
+    /// trace mechanism.
+    /// </summary>
+    public class RegisterForTraceAttribute : Attribute
+    {
+    }
+
+    /// <summary>
+    /// Utility class to Get/Set TraceData
+    /// </summary>
     public static class TraceUtils
     {
         /// <summary>


### PR DESCRIPTION
### Purpose

Moving RegisterForTraceAttribute to DynamoServices namespace to support Revit build. We might remove this attribute eventually, need to understand the impact.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @lukechurch 
