### PR TITLE
Fix regression: call EmitIdentifierNode() for both identifier node and typed identifier node

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -6950,6 +6950,7 @@ namespace ProtoAssociative
             switch (node.Kind)
             {
                 case AstKind.Identifier:
+                case AstKind.TypedIdentifier:
                     EmitIdentifierNode(node, ref inferedType, isBooleanOp, graphNode, subPass, parentNode as BinaryExpressionNode);
                     break;
                 case AstKind.Integer:

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -2890,6 +2890,7 @@ namespace ProtoImperative
             switch (node.Kind)
             {
                 case AstKind.Identifier:
+                case AstKind.TypedIdentifier:
                     EmitIdentifierNode(node, ref inferedType, isBooleanOp, graphNode);
                     break;
                 case AstKind.Integer:


### PR DESCRIPTION
### Purpose

Fix regression introduced in PR #6318. Call `EmitIdentiferNode()` for both identifer node and typed identifier node.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
