### PR TITLE
MAGN-9799: ResolveAssembly for ProtoInterface

### DIFF
--- a/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
+++ b/src/Engine/ProtoCore/FFI/ExtensionAppLoader.cs
@@ -21,7 +21,10 @@ namespace ProtoFFI
 
         private ExtensionAppLoader()
         {
-            mProtoInterface = typeof(IExtensionApplication).Assembly.GetName().Name;
+            var assembly = typeof(IExtensionApplication).Assembly;
+            mProtoInterface = assembly.GetName().Name;
+            //Let's resolve ProtoInterface, with the assembly implementing IExtensionApplication i.e. DynamoServices
+            mAssemblies.Add("ProtoInterface", assembly);
             Initialize();
         }
 


### PR DESCRIPTION
### Purpose

This PR fixes the issue of loading libraries that depends on ProtoInterface. The ProtoInterface has been removed from Dynamo in PR #6296 and because of this any existing zero touch libraries linking with ProtoInterface can't be loaded.

*Solution:* Handle the assembly resolve request for ProtoInteface to load DynamoServices dll which implements all the interfaces defined in old ProtoInterface DLL.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @ke-yu 

### FYIs

- [ ] @Benglin 