### PR TITLE
MAGN-9781: Preview bubble Crash with Freeze

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -214,7 +214,9 @@ namespace Dynamo.Controls
                 // There is no preview control or the preview control is 
                 // currently in transition state (it can come back to handle
                 // the new data later on when it is ready).
-                if ((previewControl == null))
+                // If node is frozen, we shouldn't update cached value.
+                // We keep value, that was before freezing. 
+                if ((previewControl == null) || ViewModel.IsFrozen)
                 {
                     return;
                 }
@@ -413,7 +415,11 @@ namespace Dynamo.Controls
             // Always set old ZIndex to the last value, even if mouse is not over the node.
             oldZIndex = NodeViewModel.StaticZIndex;
 
-            if (!previewEnabled || !ViewModel.IsPreviewInsetVisible) return; // Preview is hidden. There is no need run further.
+            // Preview is hidden.
+            // Or preview shouldn't be shown for some nodes (e.g. number sliders, watch nodes etc.)
+            // Or node is frozen.
+            // There is no need run further.
+            if (!previewEnabled || !ViewModel.IsPreviewInsetVisible || ViewModel.IsFrozen) return; 
 
             if (PreviewControl.IsInTransition) // In transition state, come back later.
                 return;

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -108,6 +108,23 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void PreviewBubbleHiiden_OnFrozenNode()
+        {
+            Open(@"core\DetailedPreviewMargin_Test.dyn");
+            var nodeView = NodeViewWithGuid("7828a9dd-88e6-49f4-9ed3-72e355f89bcc");
+            nodeView.ViewModel.IsFrozen = true;
+            nodeView.PreviewControl.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+            View.Dispatcher.Invoke(() =>
+            {
+                nodeView.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0) { RoutedEvent = Mouse.MouseEnterEvent });
+            });
+            DispatcherUtil.DoEvents();
+
+            Assert.IsTrue(nodeView.PreviewControl.IsHidden);
+        }
+
+        [Test]
         public void PreviewBubble_ListMargin()
         {
             OpenAndRun(@"core\DetailedPreviewMargin_Test.dyn");


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9781](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9781) Preview bubble Crash with Freeze

If the preview bubble is pinned before freezing ,then it should retain the cached state.
if the preview bubble is not pinned before freezing, then don't show the preview bubble on freeze nodes

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ramramps 

