### PR TITLE
Select node and show gizmo, when node is pinned.

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -800,6 +800,14 @@ namespace Dynamo.UI.Controls
         {
             StaysOpen = !StaysOpen;
             nodeViewModel.PreviewPinned = StaysOpen;
+
+
+            // Select node.
+            nodeViewModel.DynamoViewModel.ExecuteCommand(
+               new DynamoModel.SelectModelCommand(nodeViewModel.NodeModel.GUID, Keyboard.Modifiers.AsDynamoType()));
+
+            // Handle event here is order not to bubble it to parent control like DragCanvas.
+            e.Handled = true;
         }
 
         #endregion


### PR DESCRIPTION
### Purpose

Link to YouTack:
[MAGN-9657](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9657) Clicking on "Preview Pin" of a Point Node  changes gizmo's display like a toggle

# Problem:
There are 3 `MouseLeftButtonDown` events: on pin icon, on node view and on drag canvas.
Since `MouseLeftButtonDown` is bubbling event, it starts in child control and finishes in parent control. I.e. next schema:
![image](https://cloud.githubusercontent.com/assets/8158404/14104706/40ac974e-f5af-11e5-99e1-4e3cd599d4f7.png)

In `OnMapPinMouseClick` (PreviewControl) we pin preview.
In `topControl_MouseLeftButtonDown` (NodeView) we select node.
In `OnMouseLeftButtonDown` (DragCanvas) we unselect everything, if there is nothing in selection rectangle.

When we click on pin icon, DragCanvas thinks that we clicked on canvas (because mouse pointer is actually over canvas, not over node), DragCanvas tries to clear selection. That's why node appears as not selected. I'm not sure why gizmo is not cleared... maybe threading issue. I've seen `BuildRenderPackage` is called on Dispatcher... Maybe, it's the reason why gizmos are not cleared.

But initial problem is that DragCanvas clears selection.

# Fix:
I propose add selection directly in PreviewControl, in `OnMapPinMouseClick`, handle event at that place and do not bubble it to parent controls.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 
