### PR TITLE
MAGN-9604: Preview Bubble fails to expand after right click

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -487,7 +487,8 @@ namespace Dynamo.Controls
                         }
                         if (!IsMouseOver)
                         {
-                            if (!(Mouse.Captured != null && IsMouseInsideNodeOrPreview(Mouse.GetPosition(this))))
+                            // If mouse is captured by DragCanvas and mouse is still over node, preview should stay open.
+                            if (!(Mouse.Captured is DragCanvas && IsMouseInsideNodeOrPreview(Mouse.GetPosition(this))))
                             {
                                 preview.TransitionToState(PreviewControl.State.Hidden);
                             }


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-9604](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9604) Preview Bubble fails to expand on hover after a reset of Lacing options from the context menu

Reason:
Mouse can be captured by 2 elements: `DragCanvas` and `ContextMenu`.
In case mouse was captured by `DragCanvas`, we shouldn't hide preview.
But if mouse was captured by `ContextMenu`, preview should be hidden.

Fix:
Check if mouse was captured by `DragCanvas`.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ramramps 
