### PR TITLE
MAGN-9761 Preview Bubble Collapses when pinned

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -471,30 +471,7 @@ namespace Dynamo.UI.Controls
             SetCurrentStateAndNotify(State.PreTransition);
 
             // Used delay invoke, because TreeView hasn't changed its'appearance with usual Dispatcher call.
-            Dispatcher.DelayInvoke(50, () => RefreshExpandedDisplay(() =>
-            {
-                largeContentGrid.Visibility = Visibility.Visible;
-                bubbleTools.Visibility = Visibility.Visible;
-
-                // The real transition starts
-                SetCurrentStateAndNotify(State.InTransition);
-                var largeContentSize = ComputeLargeContentSize();
-                UpdateAnimatorTargetSize(SizeAnimator.Expansion, largeContentSize);
-
-                // If it's test mode - skip storyboard.
-                if (!DynamoModel.IsTestMode)
-                {
-                    expandStoryboard.Begin(this, true);
-                }
-                else
-                {
-                    largeContentGrid.Opacity = 1.0;
-                    smallContentGrid.Opacity = 0.0;
-                    centralizedGrid.Width = largeContentSize.Width;
-                    centralizedGrid.Height = largeContentSize.Height;
-                    OnPreviewControlExpanded(null, null);
-                }
-            }));
+            Dispatcher.DelayInvoke(50, () => RefreshExpandedDisplay(RefreshExpandedDisplayAction));
         }
 
         private Size ComputeSmallContentSize()
@@ -519,7 +496,8 @@ namespace Dynamo.UI.Controls
 
         private Size ComputeLargeContentSize()
         {
-            this.largeContentGrid.Measure(new Size()
+            largeContentGrid.UpdateLayout();
+            largeContentGrid.Measure(new Size()
             {
                 Width = Configurations.MaxExpandedPreviewWidth,
                 Height = Configurations.MaxExpandedPreviewHeight
@@ -688,31 +666,32 @@ namespace Dynamo.UI.Controls
             // indicate a new transition is about to be started
             SetCurrentStateAndNotify(State.PreTransition);
 
-            RefreshExpandedDisplay(() =>
-                {
-                    largeContentGrid.Visibility = Visibility.Visible;
-                    bubbleTools.Visibility = Visibility.Visible;
+            RefreshExpandedDisplay(RefreshExpandedDisplayAction);
+        }
 
-                    // The real transition starts
-                    SetCurrentStateAndNotify(State.InTransition);
-                    var largeContentSize = ComputeLargeContentSize();
-                    UpdateAnimatorTargetSize(SizeAnimator.Expansion, largeContentSize);                    
+        private void RefreshExpandedDisplayAction()
+        {
+            largeContentGrid.Visibility = Visibility.Visible;
+            bubbleTools.Visibility = Visibility.Visible;
 
-                    // If it's test mode - skip storyboard.
-                    if (!DynamoModel.IsTestMode)
-                    {
-                        expandStoryboard.Begin(this, true);
-                    }
-                    else
-                    {
-                        largeContentGrid.Opacity = 1.0;
-                        smallContentGrid.Opacity = 0.0;
-                        centralizedGrid.Width = largeContentSize.Width;
-                        centralizedGrid.Height = largeContentSize.Height;
-                        OnPreviewControlExpanded(null, null);
-                    }
-                }
-            );
+            // The real transition starts
+            SetCurrentStateAndNotify(State.InTransition);
+            var largeContentSize = ComputeLargeContentSize();
+            UpdateAnimatorTargetSize(SizeAnimator.Expansion, largeContentSize);
+
+            // If it's test mode - skip storyboard.
+            if (!DynamoModel.IsTestMode)
+            {
+                expandStoryboard.Begin(this, true);
+            }
+            else
+            {
+                largeContentGrid.Opacity = 1.0;
+                smallContentGrid.Opacity = 0.0;
+                centralizedGrid.Width = largeContentSize.Width;
+                centralizedGrid.Height = largeContentSize.Height;
+                OnPreviewControlExpanded(null, null);
+            }
         }
 
         private void BeginViewSizeTransition(Size targetSize)


### PR DESCRIPTION
### Purpose

Fix erroneous collapsing when pinned: 
![image](https://cloud.githubusercontent.com/assets/7658189/14136764/302299e6-f66d-11e5-8605-96b3ed9698a4.png)
bug is happening when preview is pinned, node width (and therefore preview bubble width) is more than `Configurations.MaxExpandedPreviewWidth`, preview height is maximum and we change the value of node. 

Fix is trivial - force finishing layout update, so that tree view is rendered and size for it can be computed properly + code enhancement: move the same code into a method 

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@aosyatnik 
