### PR TITLE
Add stack trace and message to extension loader logging.

### DIFF
--- a/src/DynamoCore/Extensions/ExtensionLoader.cs
+++ b/src/DynamoCore/Extensions/ExtensionLoader.cs
@@ -22,10 +22,12 @@ namespace Dynamo.Extensions
                 var result = assembly.CreateInstance(extension.TypeName) as IExtension;
                 return result;
             }
-            catch
+            catch(Exception ex)
             {
                 var name = extension.TypeName == null ? "null" : extension.TypeName;
                 Log("Could not create an instance of " + name);
+                Log(ex.Message);
+                Log(ex.StackTrace);
                 return null;
             }
         }


### PR DESCRIPTION
### Purpose

This PR adds the exception stack trace and message to log output during extension loading. This is required to debug extension loading failures on Reach.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ramramps  
