### PR TITLE
Set GUID for deleted ASTs properly

### DIFF
--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -423,9 +423,11 @@ namespace ProtoScript.Runners
             {
                 foreach (var st in deletedSubTrees)
                 {
+                    var deletedBinaryExpressions = new List<AssociativeNode>();
+
                     if (st.AstNodes != null && st.AstNodes.Count > 0)
                     {
-                        csData.DeletedBinaryExprASTNodes.AddRange(st.AstNodes);
+                        deletedBinaryExpressions.AddRange(st.AstNodes);
                     }
                     else
                     {
@@ -436,7 +438,7 @@ namespace ProtoScript.Runners
                         {
                             if (removeSubTree.AstNodes != null)
                             {
-                                csData.DeletedBinaryExprASTNodes.AddRange(removeSubTree.AstNodes);
+                                deletedBinaryExpressions.AddRange(removeSubTree.AstNodes);
                             }
                         }
                     }
@@ -453,10 +455,8 @@ namespace ProtoScript.Runners
                     }
 
                     // Build the nullify ASTs
-                    var nullNodes = BuildNullAssignments(csData.DeletedBinaryExprASTNodes);
-                    deltaAstList.AddRange(nullNodes);
-
-                    foreach (AssociativeNode node in deltaAstList)
+                    var nullNodes = BuildNullAssignments(deletedBinaryExpressions);
+                    foreach (AssociativeNode node in nullNodes)
                     {
                         var bnode = node as BinaryExpressionNode;
                         if (bnode != null)
@@ -464,10 +464,12 @@ namespace ProtoScript.Runners
                             bnode.guid = st.GUID;
                         }
                     }
+                    deltaAstList.AddRange(nullNodes);
 
                     core.BuildStatus.ClearWarningsForGraph(st.GUID);
 
                     runtimeCore.RuntimeStatus.ClearWarningsForGraph(st.GUID);
+                    csData.DeletedBinaryExprASTNodes.AddRange(deletedBinaryExpressions);
                 }
             }
             return deltaAstList;

--- a/test/DynamoCoreTests/NodeExecutionTest.cs
+++ b/test/DynamoCoreTests/NodeExecutionTest.cs
@@ -342,13 +342,18 @@ namespace Dynamo.Tests
             //to frozen and not executing state
             Assert.AreEqual(addNode.IsFrozen, true);
             
-            //check the value on add node. Add node is not executed in the run,
-            // becuase the frozen nodes are removed from AST. So the value of add node
-            // should be 0. But the cached value should be 3, which is from the previous execution.
+            // For the new model, as freezing a node is equivallent to delete
+            // a node, the node will be nullified.
+            //
+            // On the UI, the node may choose to display the same previous
+            // value as before, but its real value *should* have been changed.
             AssertPreviewValue(addNode.GUID.ToString(), 0);
+            Assert.IsNull(addNode.CachedValue.Data);
+            /*
             Assert.IsNotNull(addNode.CachedValue.Data);
             Assert.AreEqual(Convert.ToInt32(addNode.CachedValue.Data),3);
             Assert.AreEqual(Convert.ToInt32(watchNode.CachedValue), 3);
+            */
         }
 
         [Test]

--- a/test/DynamoCoreTests/NodeExecutionTest.cs
+++ b/test/DynamoCoreTests/NodeExecutionTest.cs
@@ -349,11 +349,6 @@ namespace Dynamo.Tests
             // value as before, but its real value *should* have been changed.
             AssertPreviewValue(addNode.GUID.ToString(), 0);
             Assert.IsNull(addNode.CachedValue.Data);
-            /*
-            Assert.IsNotNull(addNode.CachedValue.Data);
-            Assert.AreEqual(Convert.ToInt32(addNode.CachedValue.Data),3);
-            Assert.AreEqual(Convert.ToInt32(watchNode.CachedValue), 3);
-            */
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

This PR is to fix defect [MAGN-9656 Unfreezing a Point after direct manipulation crashes Dynamo](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9656).

The crash is because the point manipulator tries to get invalid cached value from the frozen node model.

Details -

Freezing a node is equivalent to delete that node and all its downstream nodes, therefore these nodes will be nullified. 

Internally, the live runner will generate an AST binary expressions like `var_x = null` to nullify a node. The binary expression will have the same GUID as its corresponding UI node. During graph update, the live runner will record the GUID of each executed binary expression, therefore Dynamo will know which UI node is modified. 

But there is a bug in the delta computation. The GUIDs of  *all* binary expressions are set to the GUID of one of frozen node's downstream node. In other word, only that particular downstream node will be recorded as being executed, so only that node's cached value will be updated and all others have invalid cached value. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 

### FYIs
@aosyatnik @ramramps 
