### PR TITLE
Fix MAGN-9773 Code Block Node Crash When clicking a restructured port after making changes

### DIFF
--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -20,6 +20,7 @@ namespace Dynamo.Graph.Nodes
         ObservableCollection<ConnectorModel> connectors = new ObservableCollection<ConnectorModel>();
         private bool usingDefaultValue;
         private PortData portData;
+        private bool isEnabled = true;
         #endregion
 
         #region public members
@@ -81,7 +82,15 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         public bool IsEnabled
         {
-            get; private set;
+            get
+            {
+                return isEnabled;
+            }
+            set
+            {
+                isEnabled = value;
+                RaisePropertyChanged("IsEnabled");
+            }
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -77,6 +77,14 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
+        /// Indicates whether the port is enabled or not.
+        /// </summary>
+        public bool IsEnabled
+        {
+            get; private set;
+        }
+
+        /// <summary>
         /// Center is used by connected connectors to update their shape
         /// The "center" of a port is derived from the type of port and
         /// offsets from the node origin based on the port's index in the 

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -38,6 +38,7 @@
               Margin="{Binding Path=MarginThickness}"
               Height="{Binding Path=Height}"
               ToolTipService.ShowDuration="60000"
+              IsEnabled="{Binding Path=IsEnabled}"
              >
 
             <interactivity:Interaction.Triggers>

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -189,6 +189,9 @@ namespace Dynamo.ViewModels
                 case "IsConnected":
                     RaisePropertyChanged("IsConnected");
                     break;
+                case "IsEnabled":
+                    RaisePropertyChanged("IsEnabled");
+                    break;
                 case "Center":
                     RaisePropertyChanged("Center");
                     break;

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -45,6 +45,11 @@ namespace Dynamo.ViewModels
             get { return _port.IsConnected; }
         }
 
+        public bool IsEnabled
+        {
+            get { return _port.IsEnabled; }
+        }
+
         public double Height
         {
             get { return _port.Height; }

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
@@ -123,17 +123,22 @@ namespace Dynamo.UI.Controls
             switch (state)
             {
                 case EditorStateMachine.EditorState.Editing:
-                    EnableOutputPorts(false); 
+                    EnableInputOutputPorts(false); 
                     break;
 
                 case EditorStateMachine.EditorState.Commited:
-                    EnableOutputPorts(true); 
+                    EnableInputOutputPorts(true); 
                     break;
             }
         }
 
-        private void EnableOutputPorts(bool isEnabled)
+        private void EnableInputOutputPorts(bool isEnabled)
         {
+            for (int i = 0; i < codeBlockNode.InPorts.Count; i++)
+            {
+                codeBlockNode.InPorts[i].IsEnabled = isEnabled;
+            }
+
             for (int i = 0; i < codeBlockNode.OutPorts.Count; i++)
             {
                 codeBlockNode.OutPorts[i].IsEnabled = isEnabled;

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
@@ -11,23 +11,23 @@ namespace Dynamo.UI.Controls
     /// </summary>
     internal class EditorStateMachine
     {
-        internal enum EditorState
+        internal enum State
         {
             Editing,
             Commited
         }
 
-        private EditorState state;
+        private State state;
 
         /// <summary>
         /// Event handler for editor state changed.
         /// </summary>
-        public event Action<EditorState> OnStateChanged;
+        internal event Action<State> OnStateChanged;
 
         /// <summary>
         /// Constructor state machine. 
         /// </summary>
-        public EditorStateMachine(EditorState startState)
+        internal EditorStateMachine(State startState)
         {
             state = startState;
         }
@@ -36,7 +36,7 @@ namespace Dynamo.UI.Controls
         /// Transit to the new state.
         /// </summary>
         /// <param name="newState"></param>
-        public void Transit(EditorState newState)
+        internal void Transit(State newState)
         {
             if (state != newState)
             {
@@ -56,7 +56,7 @@ namespace Dynamo.UI.Controls
     {
         private bool createdForNewCodeBlock;
         private readonly CodeBlockNodeModel codeBlockNode;
-        private EditorStateMachine stateMachine = new EditorStateMachine(EditorStateMachine.EditorState.Commited);
+        private EditorStateMachine stateMachine = new EditorStateMachine(EditorStateMachine.State.Commited);
 
         /// <summary>
         /// Create code block editor by the view of code block node.
@@ -110,23 +110,23 @@ namespace Dynamo.UI.Controls
 
             createdForNewCodeBlock = false; // First commit is now over.
 
-            stateMachine.Transit(EditorStateMachine.EditorState.Commited);
+            stateMachine.Transit(EditorStateMachine.State.Commited);
         }
 
         protected override void OnEditorTextChanged()
         {
-            stateMachine.Transit(EditorStateMachine.EditorState.Editing);
+            stateMachine.Transit(EditorStateMachine.State.Editing);
         }
 
-        private void OnEditorStateChanged(EditorStateMachine.EditorState state)
+        private void OnEditorStateChanged(EditorStateMachine.State state)
         {
             switch (state)
             {
-                case EditorStateMachine.EditorState.Editing:
+                case EditorStateMachine.State.Editing:
                     EnableInputOutputPorts(false); 
                     break;
 
-                case EditorStateMachine.EditorState.Commited:
+                case EditorStateMachine.State.Commited:
                     EnableInputOutputPorts(true); 
                     break;
             }

--- a/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
@@ -121,6 +121,14 @@ namespace Dynamo.UI.Controls
         }
 
         /// <summary>
+        /// Derived class overrides this function to handle the text changed event.
+        /// </summary>
+        protected virtual void OnEditorTextChanged()
+        {
+
+        }
+
+        /// <summary>
         /// Update the value of specified property of node to the input code.
         /// </summary>
         /// <param name="property"></param>
@@ -175,6 +183,8 @@ namespace Dynamo.UI.Controls
         {
             if (WatermarkLabel.Visibility == Visibility.Visible)
                 WatermarkLabel.Visibility = Visibility.Collapsed;
+
+            OnEditorTextChanged();
         }
 
         private void OnTextAreaTextEntering(object sender, TextCompositionEventArgs e)


### PR DESCRIPTION
### Purpose

Fix [MAGN-9773 Code Block Node Crash When clicking a restructured port after making changes](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9773).

Clicking the output port while code block editor is still in editing mode will make the code block editor commit changes, then output ports of code block node might be adjusted because of changes, and the output port that was clicked might be invalid anymore.

This PR introduces state machine into code block editor. While code block editor is in editing mode, all input and output ports are disabled; ports are enabled again after code block editor commits changes. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 
