### PR TITLE
ExecutionSession for Dynamo ExecutionEvents

### DIFF
--- a/src/DynamoCore/Configuration/ExecutionSession.cs
+++ b/src/DynamoCore/Configuration/ExecutionSession.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using Dynamo.Interfaces;
+using Dynamo.Models;
+using Dynamo.Session;
+
+namespace Dynamo.Configuration
+{
+    class ExecutionSession : IExecutionSession
+    {
+        private IPathManager pathManager;
+        private Dictionary<string, object> parameters = new Dictionary<string,object>();
+        
+        /// <summary>
+        /// Constructs a new execution session.
+        /// </summary>
+        public ExecutionSession(Scheduler.UpdateGraphAsyncTask updateTask, DynamoModel model, string geometryFactoryPath)
+        {
+            CurrentWorkspacePath = updateTask.TargetedWorkspace.FileName;
+            pathManager = model.PathManager;
+            parameters[ParameterKeys.GeometryFactory] = geometryFactoryPath;
+            parameters[ParameterKeys.MajorVersion] = pathManager.MajorFileVersion;
+            parameters[ParameterKeys.MinorVersion] = pathManager.MinorFileVersion;
+            parameters[ParameterKeys.NumberFormat] = model.PreferenceSettings.NumberFormat;
+        }
+
+        /// <summary>
+        /// File path for the current workspace in execution. Could be null or
+        /// empty string if workspace is not yet saved.
+        /// </summary>
+        public string CurrentWorkspacePath { get; private set; }
+
+        /// <summary>
+        /// Gets session parameter value for the given parameter name.
+        /// </summary>
+        /// <param name="parameter">Name of session parameter</param>
+        /// <returns>Session parameter value as object</returns>
+        public object GetParameterValue(string parameter)
+        {
+            return parameters[parameter];
+        }
+
+        /// <summary>
+        /// Gets list of session parameter keys available in the session.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<string> GetParameterKeys()
+        {
+            return parameters.Keys;
+        }
+
+        /// <summary>
+        /// A helper method to resolve the given file path. The given file path
+        /// will be resolved by searching into the current workspace, packages and
+        /// definitions folder, core and host application installation folders etc.
+        /// </summary>
+        /// <param name="filepath">Input file path</param>
+        /// <returns>True if the file is found</returns>
+        public bool ResolveFilePath(ref string filepath)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -107,6 +107,7 @@ limitations under the License.
     <Compile Include="..\AssemblySharedInfoGenerator\AssemblySharedInfo.cs">
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
+    <Compile Include="Configuration\ExecutionSession.cs" />
     <Compile Include="Core\CrashPromptArgs.cs" />
     <Compile Include="Configuration\DebugSettings.cs" />
     <Compile Include="Configuration\Context.cs" />

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.IO;
-using System.Linq;  
+using System.Linq;
 using System.Xml;
 using Dynamo.Core;
 using Dynamo.Engine;
 using Dynamo.Engine.CodeGeneration;
 using Dynamo.Engine.NodeToCode;
+using Dynamo.Events;
 using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
@@ -23,7 +23,6 @@ using Dynamo.Models;
 using Dynamo.Properties;
 using Dynamo.Selection;
 using Dynamo.Utilities;
-using DynamoServices;
 using ProtoCore.Namespace;
 using Utils = Dynamo.Graph.Nodes.Utilities;
 

--- a/src/DynamoCore/Models/DynamoModelEvents.cs
+++ b/src/DynamoCore/Models/DynamoModelEvents.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Specialized;
 using System.ComponentModel;
 using Dynamo.Annotations;
 using Dynamo.Core;
-using Dynamo.Graph;
+using Dynamo.Events;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
-using DynamoServices;
 
 namespace Dynamo.Models
 {

--- a/src/NodeServices/DynamoServices.csproj
+++ b/src/NodeServices/DynamoServices.csproj
@@ -49,6 +49,7 @@
     </Compile>
     <Compile Include="Attributes.cs" />
     <Compile Include="ExecutionEvents.cs" />
+    <Compile Include="ExecutionSession.cs" />
     <Compile Include="GraphicsDataInterfaces.cs" />
     <Compile Include="Interfaces.cs" />
     <Compile Include="MessageEvents.cs" />

--- a/src/NodeServices/ExecutionEvents.cs
+++ b/src/NodeServices/ExecutionEvents.cs
@@ -1,6 +1,7 @@
-﻿namespace DynamoServices
+﻿using Dynamo.Session;
+namespace Dynamo.Events
 {
-    public delegate void ExecutionStateHandler();
+    public delegate void ExecutionStateHandler(IExecutionSession session);
 
     /// <summary>
     /// Communication bridge between Dynamo and client libraries to notify
@@ -21,19 +22,19 @@
         /// <summary>
         /// Notify observers that the graph is about to evaluate
         /// </summary>
-        public static void OnGraphPreExecution()
+        internal static void OnGraphPreExecution(IExecutionSession session)
         {
             if (GraphPreExecution != null)
-                GraphPreExecution();
+                GraphPreExecution(session);
         }
 
         /// <summary>
         /// Notify observers that the graph has evaluated
         /// </summary>
-        public static void OnGraphPostExecution()
+        internal static void OnGraphPostExecution(IExecutionSession session)
         {
             if (GraphPostExecution != null)
-                GraphPostExecution();
+                GraphPostExecution(session);
         }
     }
 }

--- a/src/NodeServices/ExecutionSession.cs
+++ b/src/NodeServices/ExecutionSession.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+
+namespace Dynamo.Session
+{
+    /// <summary>
+    /// Represents a session object for current execution.
+    /// </summary>
+    public interface IExecutionSession
+    {
+        /// <summary>
+        /// File path for the current workspace in execution. Could be null or
+        /// empty string if workspace is not yet saved.
+        /// </summary>
+        string CurrentWorkspacePath { get; }
+
+        /// <summary>
+        /// Gets session parameter value for the given parameter name.
+        /// </summary>
+        /// <param name="parameter">Name of session parameter</param>
+        /// <returns>Session parameter value as object</returns>
+        object GetParameterValue(string parameter);
+
+        /// <summary>
+        /// Gets list of session parameter keys available in the session.
+        /// </summary>
+        /// <returns></returns>
+        IEnumerable<string> GetParameterKeys();
+
+        /// <summary>
+        /// A helper method to resolve the given file path. The given file path
+        /// will be resolved by searching into the current workspace, packages and
+        /// definitions folder, core and host application installation folders etc.
+        /// </summary>
+        /// <param name="filepath">Input file path</param>
+        /// <returns>True if the file is found</returns>
+        bool ResolveFilePath(ref string filepath);
+    }
+
+    /// <summary>
+    /// List of possible session parameter keys to obtain the session parameters.
+    /// </summary>
+    public class ParameterKeys
+    {
+        /// <summary>
+        /// This key is used to get the full path for library, which implements 
+        /// IGeometryFactory interface.
+        /// </summary>
+        public static readonly string GeometryFactory = "GeometryFactoryFileName";
+
+        /// <summary>
+        /// This key is used to get the number format used by Dynamo to format 
+        /// the preview values. The returned value is string.
+        /// </summary>
+        public static readonly string NumberFormat = "NumberFormat";
+
+        /// <summary>
+        /// This key is used to get the Major version of Dynamo. The returned value
+        /// is a number.
+        /// </summary>
+        public static readonly string MajorVersion = "MajorFileVersion";
+
+        /// <summary>
+        /// This key is used to get the Major version of Dynamo. The returned value
+        /// is a number.
+        /// </summary>
+        public static readonly string MinorVersion = "MinorFileVersion";
+    }
+}

--- a/src/NodeServices/Properties/AssemblyInfo.cs
+++ b/src/NodeServices/Properties/AssemblyInfo.cs
@@ -9,3 +9,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("bb5cae3b-3d5a-4a69-91eb-718791cad422")]
+
+[assembly: InternalsVisibleTo("DynamoCore")]

--- a/src/NodeServices/WorkspaceEvents.cs
+++ b/src/NodeServices/WorkspaceEvents.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace DynamoServices
+namespace Dynamo.Events
 {
     public delegate void WorkspaceAddedEventHandler(WorkspacesModificationEventArgs args);
     public delegate void WorkspaceRemoveStartedEventHandler(WorkspacesModificationEventArgs args);
@@ -15,7 +15,7 @@ namespace DynamoServices
         /// to the DynamoModel's Workspaces collection.
         /// </summary>
         public static event WorkspaceAddedEventHandler WorkspaceAdded;
-        public static void OnWorkspaceAdded(Guid id, string name, Type type)
+        internal static void OnWorkspaceAdded(Guid id, string name, Type type)
         {
             if (WorkspaceAdded != null)
                 WorkspaceAdded(new WorkspacesModificationEventArgs(id, name, type));
@@ -26,7 +26,7 @@ namespace DynamoServices
         /// from the Workspaces collection.
         /// </summary>
         public static event WorkspaceRemoveStartedEventHandler WorkspaceRemoveStarted;
-        public static void OnWorkspaceRemoveStarted(Guid id, string name, Type type)
+        internal static void OnWorkspaceRemoveStarted(Guid id, string name, Type type)
         {
             if (WorkspaceRemoveStarted != null)
                 WorkspaceRemoveStarted(new WorkspacesModificationEventArgs(id, name, type));
@@ -37,7 +37,7 @@ namespace DynamoServices
         /// from the DynamoModel's Workspaces collection.
         /// </summary>
         public static event WorkspaceRemovedEventHandler WorkspaceRemoved;
-        public static void OnWorkspaceRemoved(Guid id, string name, Type type)
+        internal static void OnWorkspaceRemoved(Guid id, string name, Type type)
         {
             if (WorkspaceRemoved != null)
                 WorkspaceRemoved(new WorkspacesModificationEventArgs(id, name, type));
@@ -47,7 +47,7 @@ namespace DynamoServices
         /// An event that is triggered before a workspace is cleared.
         /// </summary>
         public static event WorkspaceClearingEventHandler WorkspaceClearing;
-        public static void OnWorkspaceClearing()
+        internal static void OnWorkspaceClearing()
         {
             if (WorkspaceClearing != null)
                 WorkspaceClearing();
@@ -57,7 +57,7 @@ namespace DynamoServices
         /// An event that is triggered after a workspace is cleared.
         /// </summary>
         public static event WorkspaceClearedEventHandler WorkspaceCleared;
-        public static void OnWorkspaceCleared()
+        internal static void OnWorkspaceCleared()
         {
             if (WorkspaceCleared != null)
                 WorkspaceCleared();

--- a/test/Libraries/NodeServicesTest/WorkspaceEventTests.cs
+++ b/test/Libraries/NodeServicesTest/WorkspaceEventTests.cs
@@ -1,12 +1,9 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Reflection;
-
-using SystemTestServices;
-
-using DynamoServices;
-
+using Dynamo.Events;
 using NUnit.Framework;
+using SystemTestServices;
 
 namespace DynamoServicesTests
 {

--- a/test/System/IntegrationTests/ExecutionEventsObserver.cs
+++ b/test/System/IntegrationTests/ExecutionEventsObserver.cs
@@ -1,11 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-
 using Dynamo;
+using Dynamo.Events;
+using Dynamo.Session;
 using Dynamo.Tests;
-
-using DynamoServices;
-
 using NUnit.Framework;
 
 namespace IntegrationTests
@@ -21,12 +19,12 @@ namespace IntegrationTests
         private static bool postSeen = false;
 
 
-        private static void PreSeen()
+        private static void PreSeen(IExecutionSession session)
         {
             preSeen = true;
         }
 
-        private static void PostSeen()
+        private static void PostSeen(IExecutionSession session)
         {
             postSeen = true;
         }


### PR DESCRIPTION
### Purpose

This PR enhances ExecutionEvents notification and provides access to session parameters during execution events.

- ExecutionEvents and WorkspaceEvents are moved to Dynamo.Events namespace
- Methods to raise events are made internal and internals are visible to DynamoCore.
- ExecutionStateEventHandler now passes IExecutionSession object.
- IExecutionSession interface represents a session object and provides data related to the current execution session.

This submission is partial implementation for http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6615.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [x] @ke-yu 
- [ ] @Benglin 

### FYI
@lukechurch 
@ikeough 