### PR TITLE
MAGN-9744 Studio 1.0.0.775 partially renders graphics on first try

### DIFF
--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -149,14 +149,14 @@ namespace WpfVisualizationTests
             p1.UpdateValue(new UpdateValueParams("IsVisible", "false"));
 
             Assert.True(BackgroundPreviewGeometry.HasNumberOfPointsCurvesAndMeshes(7, 6, 0));
-            Assert.AreEqual(6, BackgroundPreviewGeometry.NumberOfInvisiblePoints());
+            Assert.AreEqual(1, BackgroundPreviewGeometry.NumberOfInvisiblePoints());
 
             //flip off the lines node
             var l1 = model.CurrentWorkspace.Nodes.First(x => x.GUID.ToString() == "7c1cecee-43ed-43b5-a4bb-5f71c50341b2");
             l1.UpdateValue(new UpdateValueParams("IsVisible", "false"));
 
             Assert.True(BackgroundPreviewGeometry.HasNumberOfPointsCurvesAndMeshes(7, 6, 0));
-            Assert.AreEqual(6, BackgroundPreviewGeometry.NumberOfInvisibleCurves());
+            Assert.AreEqual(1, BackgroundPreviewGeometry.NumberOfInvisibleCurves());
 
             //flip those back on and ensure the visualization returns
             p1.UpdateValue(new UpdateValueParams("IsVisible", "true"));
@@ -322,7 +322,7 @@ namespace WpfVisualizationTests
             p1.UpdateValue(new UpdateValueParams("IsVisible", "false"));
 
             Assert.True(BackgroundPreviewGeometry.HasNumberOfPointsCurvesAndMeshes(7, 6, 0));
-            Assert.AreEqual(6, BackgroundPreviewGeometry.NumberOfInvisiblePoints());
+            Assert.AreEqual(1, BackgroundPreviewGeometry.NumberOfInvisiblePoints());
 
             // Now change the number of points
             var cbn =


### PR DESCRIPTION
### Purpose

First of all, task name is not accurate because geometry is fully rendered after some time.
When there is a lot of geometry, Dynamo computes and renders it quite slowly. The PR adds some optimization to partly overcome the issue:
- `SceneItems` is constantly being called, so each time it generates new list and sorts it. 
In this PR `SceneItems` is computed only after changes in its source;
- To implement label behavior it had stored graphic array items separately to have an ability to find an array item by index (geometry doesn't know which node array item it belongs to) and such solution had slowed down rendering.
In this PR node array geometry items are stored together as it had used to be and instead label positions are stored in a separate place, so when a node requests displaying label for its array item we know where to place the label.

### Analysis

I made a competition between Dynamo without my changes and Dynamo with them. It was used `lotsofstuff.dyn` from [the task](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9744).
- when code block value is 0..10..2:
![image](https://cloud.githubusercontent.com/assets/7658189/14204908/1a7e3d76-f810-11e5-89e5-eec037632880.png)
Render time for each node means time to generate geometry objects from render packages for the node.
`setting properties and rendering time` means time to render already generated geometry. Render packages for each node are coming separately and between receiving packages, Helix renders what it already has.
`sum` time means time passed from receiving the very first render packages to finishing render of all geometry.
So, it this case we have 9 seconds of gain in time.
- when code block value is 0..20..2:
![image](https://cloud.githubusercontent.com/assets/7658189/14205148/bab88098-f811-11e5-9ae7-e2a81e6d3eae.png)
In this case designations are the same, code block just gives much more array items, we have 1 minute and 19 seconds of gain in time.

These time values are got from output window in Visual Studio. Also, I noted the time on my smartphone starting at pressing Run button and stopping at all geometry appears. The results are next:
- when code block value is 0..15..2, not optimized Dynamo takes 1 minute and 45 seconds and optimized Dynamo takes only 40 seconds, so gain in time is *1 minute and 5 seconds*;
- when code block value is 0..20..2, not optimized Dynamo takes 3 minutes and 20 seconds and optimized Dynamo takes 1 minute and 44 seconds, so gain in time is *1 minute and 36 seconds*;

By the way computing render packages for a node with many array items is time-consuming operation as well. The PR does not consider this component of the delay in rendering

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any - nothing is changed in UI

### Reviewers

@mjkkirschner 

### FYIs

@jnealb @kronz @ikeough 