### PR TITLE
Engine code cleanup 

### DIFF
--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -721,7 +721,7 @@ namespace ProtoAssociative
             instr.opCode = ProtoCore.DSASM.OpCode.DEP;
 
             instr.op1 = StackValue.BuildInt(exprUID);
-            instr.op2 = StackValue.BuildInt(isSSAAssign ? 1 : 0);
+            instr.op2 = StackValue.BuildBoolean(isSSAAssign);
 
             ++pc;
             codeBlock.instrStream.instrList.Add(instr);
@@ -6160,7 +6160,7 @@ namespace ProtoAssociative
                         {
                             // Dependency graph top level symbol 
                             graphNode.PushSymbolReference(symbolnode);
-                            EmitDependency(bnode.ExpressionUID, node.isSSAAssignment);
+                            EmitDependency(bnode.ExpressionUID, bnode.isSSAAssignment);
                             functionCallStack.Clear();
                         }
                     }

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -711,7 +711,7 @@ namespace ProtoAssociative
             codeBlock.instrStream.instrList.Add(instr);
         }
 
-        protected void EmitDependency(int exprUID, int modBlkUID, bool isSSAAssign)
+        protected void EmitDependency(int exprUID, bool isSSAAssign)
         {
             SetEntry();
 
@@ -722,7 +722,6 @@ namespace ProtoAssociative
 
             instr.op1 = StackValue.BuildInt(exprUID);
             instr.op2 = StackValue.BuildInt(isSSAAssign ? 1 : 0);
-            instr.op3 = StackValue.BuildInt(modBlkUID);
 
             ++pc;
             codeBlock.instrStream.instrList.Add(instr);
@@ -2432,7 +2431,7 @@ namespace ProtoAssociative
                         nullAssignGraphNode.updateBlock.endpc = pc - 1;
 
                         PushGraphNode(nullAssignGraphNode);
-                        EmitDependency(ProtoCore.DSASM.Constants.kInvalidIndex, ProtoCore.DSASM.Constants.kInvalidIndex, false);
+                        EmitDependency(ProtoCore.DSASM.Constants.kInvalidIndex, false);
                     }
 
                     if (isAllocated)
@@ -5595,7 +5594,7 @@ namespace ProtoAssociative
                 ProtoCore.DSASM.SymbolNode firstSymbol = leftNodeRef.nodeList[0].symbol;
                 if (null != firstSymbol)
                 {
-                    EmitDependency(binaryExpr.ExpressionUID, binaryExpr.modBlkUID, false);
+                    EmitDependency(binaryExpr.ExpressionUID, false);
                 }
 
                 if (core.Options.GenerateSSA)
@@ -6161,7 +6160,7 @@ namespace ProtoAssociative
                         {
                             // Dependency graph top level symbol 
                             graphNode.PushSymbolReference(symbolnode);
-                            EmitDependency(bnode.ExpressionUID, bnode.modBlkUID, bnode.isSSAAssignment);
+                            EmitDependency(bnode.ExpressionUID, node.isSSAAssignment);
                             functionCallStack.Clear();
                         }
                     }
@@ -6218,7 +6217,7 @@ namespace ProtoAssociative
                         {
                             // Dependency graph top level symbol 
                             graphNode.PushSymbolReference(symbolnode);
-                            EmitDependency(bnode.ExpressionUID, bnode.modBlkUID, bnode.isSSAAssignment);
+                            EmitDependency(bnode.ExpressionUID, bnode.isSSAAssignment);
                             functionCallStack.Clear();
                         }
                     }
@@ -6300,7 +6299,7 @@ namespace ProtoAssociative
                             nullAssignGraphNode1.updateBlock.endpc = pc - 1;
 
                             PushGraphNode(nullAssignGraphNode1);
-                            EmitDependency(ProtoCore.DSASM.Constants.kInvalidIndex, ProtoCore.DSASM.Constants.kInvalidIndex, false);
+                            EmitDependency(ProtoCore.DSASM.Constants.kInvalidIndex, false);
 
 
                             //
@@ -6319,7 +6318,7 @@ namespace ProtoAssociative
                             nullAssignGraphNode2.updateBlock.endpc = pc - 1;
 
                             PushGraphNode(nullAssignGraphNode2);
-                            EmitDependency(ProtoCore.DSASM.Constants.kInvalidIndex, ProtoCore.DSASM.Constants.kInvalidIndex, false);
+                            EmitDependency(ProtoCore.DSASM.Constants.kInvalidIndex, false);
                         }
                     }
                     if (isGraphInScope)

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -1309,7 +1309,7 @@ namespace ProtoCore.DSASM
             return isInvalid || isPointerModified || isArrayModified || isDataModified || isDoubleDataModified || isTypeModified;
         }
 
-        private int UpdateGraph(int exprUID, int modBlkId, bool isSSAAssign)
+        private int UpdateGraph(int exprUID, bool isSSAAssign)
         {
             List<AssociativeGraph.GraphNode> reachableGraphNodes = null;
             if (runtimeCore.Options.DirectDependencyExecution)
@@ -4533,14 +4533,11 @@ namespace ProtoCore.DSASM
             // This expression ID of this instruction
             int exprID = (int)instruction.op1.IntegerValue;
             // The SSA assignment flag
-            bool isSSA = (1 == instruction.op2.IntegerValue);
-            int modBlkID = (int)instruction.op3.IntegerValue;
-
+            bool isSSA = instruction.op2.BooleanValue;
 
             // The current function and class scope
             int ci = Constants.kInvalidIndex;
             int fi = Constants.kGlobalScope;
-
 
             int classIndex = Constants.kInvalidIndex;
             int functionIndex = Constants.kGlobalScope;
@@ -4607,7 +4604,7 @@ namespace ProtoCore.DSASM
             }
 
             // Find dependent nodes and mark them dirty
-            UpdateGraph(exprID, modBlkID, isSSA);
+            UpdateGraph(exprID, isSSA);
 
             if (runtimeCore.Options.ApplyUpdate)
             {

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -2109,7 +2109,6 @@ namespace ProtoCore.AST.AssociativeAST
         public int SSAExpressionUID { get; set; }
         public int ExpressionUID { get; set; }
         public int SSASubExpressionID { get; set; }
-        public int modBlkUID { get; set; }
         public Guid guid { get; set; }
         public int OriginalAstID { get; set; }    // The original AST that this Binarynode was derived from
         public bool isSSAAssignment { get; set; }


### PR DESCRIPTION
### Purpose

Cleanup `EditDependency()` and `UpdateGraph()`, remove `modBlkUID` from `BinaryExpressionNode`.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.