### PR TITLE
Fix SchedulerIntegrationTests regressions

### DIFF
--- a/test/DynamoCoreTests/SchedulerTests.cs
+++ b/test/DynamoCoreTests/SchedulerTests.cs
@@ -1245,6 +1245,7 @@ namespace Dynamo.Tests
         private AsyncTask MakeUpdateGraphAsyncTask()
         {
             var t = new FakeUpdateGraphAsyncTask(MakeAsyncTaskData());
+            t.Initialize(dynamoModel.EngineController, dynamoModel.CurrentWorkspace);
             t.InitializeTestData(); // Just to initialize ModifiedNodes
             return t;
         }


### PR DESCRIPTION
### Purpose

This is because the test fixture doesn't call `Initialize()` on  `FakeUpdateGraphAsyncTask`, therefore update graph async task's `TargetWorkspace` is null.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@sharadkjaiswal 
