### PR TITLE
MAGN-9631 Large value range expression crashes on committing the CBN

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -3232,7 +3232,7 @@ namespace ProtoCore.DSASM
             if (svArrayToIterate.IsArray)
             {
                 var array = rmem.Heap.ToHeapObject<DSArray>(svArrayToIterate);
-                if (array.ToDictionary().Any())
+                if (array.Keys.Any())
                 {
                     key = StackValue.BuildArrayKey(svArrayToIterate, 0);
                     key.metaData = svArrayToIterate.metaData;

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -2501,7 +2501,18 @@ namespace ProtoCore.DSASM
                 }
                 else
                 {
-                    StackValue svArray = rmem.Heap.AllocateArray(new StackValue[] {});
+                    StackValue svArray;
+
+                    try
+                    {
+                        svArray = rmem.Heap.AllocateArray(new StackValue[] { });
+                    }
+                    catch (RunOutOfMemoryException)
+                    {
+                        svArray = StackValue.Null;
+                        runtimeCore.RuntimeStatus.LogWarning(WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                    }
+
                     rmem.SetSymbolValue(symbolnode, svArray);
 
                     var array = rmem.Heap.ToHeapObject<DSArray>(svArray);
@@ -3563,8 +3574,16 @@ namespace ProtoCore.DSASM
                 }
                 else
                 {
-                    StackValue svNewProperty = rmem.Heap.AllocatePointer(new [] { svData });
-                    thisObject.SetValueAtIndex(stackIndex, svNewProperty, runtimeCore);
+                    try
+                    {
+                        StackValue svNewProperty = rmem.Heap.AllocatePointer(new[] { svData });
+                        thisObject.SetValueAtIndex(stackIndex, svNewProperty, runtimeCore);
+                    }
+                    catch (RunOutOfMemoryException)
+                    {
+                        runtimeCore.RuntimeStatus.LogWarning(Runtime.WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                        thisObject.SetValueAtIndex(stackIndex, StackValue.Null, runtimeCore);
+                    }
                 }
             }
             else if (svProperty.IsArray && (dimensions > 0))
@@ -3580,8 +3599,16 @@ namespace ProtoCore.DSASM
                 }
                 else
                 {
-                    StackValue svNewProperty = rmem.Heap.AllocatePointer(new [] {svData});
-                    thisObject.SetValueAtIndex(stackIndex, svNewProperty, runtimeCore);
+                    try
+                    {
+                        StackValue svNewProperty = rmem.Heap.AllocatePointer(new[] { svData });
+                        thisObject.SetValueAtIndex(stackIndex, svNewProperty, runtimeCore);
+                    }
+                    catch (RunOutOfMemoryException)
+                    {
+                        runtimeCore.RuntimeStatus.LogWarning(Runtime.WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                        thisObject.SetValueAtIndex(stackIndex, StackValue.Null, runtimeCore);
+                    }
                 }
             }
 
@@ -4026,7 +4053,16 @@ namespace ProtoCore.DSASM
                 StackValue value = rmem.Pop();
                 svs[i] = value;
             }
-            StackValue pointer = rmem.Heap.AllocateArray(svs);
+            StackValue pointer;
+            try
+            {
+                pointer = rmem.Heap.AllocateArray(svs);
+            }
+            catch (RunOutOfMemoryException)
+            {
+                pointer = StackValue.Null;
+                runtimeCore.RuntimeStatus.LogWarning(WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+            }
 
             if (instruction.op2.IsString)
             {

--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using ProtoCore.Utils;
+using ProtoCore.Exceptions;
 
 namespace ProtoCore.DSASM
 {
@@ -123,7 +124,14 @@ namespace ProtoCore.DSASM
 
                     if (size > allocated)
                     {
-                        ReAllocate(size);
+                        try
+                        {
+                            ReAllocate(size);
+                        }
+                        catch (OutOfMemoryException)
+                        {
+                            throw new RunOutOfMemoryException();
+                        }
                     }
 
                     RightShiftElements(shiftSize);
@@ -137,7 +145,14 @@ namespace ProtoCore.DSASM
             }
             else if (index >= allocated)
             {
-                ReAllocate(index + 1);
+                try
+                {
+                    ReAllocate(index + 1);
+                }
+                catch (OutOfMemoryException)
+                {
+                    throw new RunOutOfMemoryException();
+                }
                 Count = index + 1;
             }
 
@@ -314,16 +329,25 @@ namespace ProtoCore.DSASM
 
         /// <summary>
         /// Allocate an array.
+        ///
+        /// Exceptions: ProtoCore.Exceptions.RunOutOfMemoryException
         /// </summary>
         /// <param name="values">Array elements whose indices are integer</param>
         /// <param name="dict">Array elements whose indices are not integer</param>
         /// <returns></returns>
         public StackValue AllocateArray(StackValue[] values)
         {
-            int index = AllocateInternal(values, PrimitiveType.Array);
-            var heapElement = heapElements[index];
-            heapElement.MetaData = new MetaData { type = (int)PrimitiveType.Array };
-            return StackValue.BuildArrayPointer(index);
+            try
+            {
+                int index = AllocateInternal(values, PrimitiveType.Array);
+                var heapElement = heapElements[index];
+                heapElement.MetaData = new MetaData { type = (int)PrimitiveType.Array };
+                return StackValue.BuildArrayPointer(index);
+            }
+            catch (OutOfMemoryException)
+            {
+                throw new RunOutOfMemoryException();
+            }
         }
 
         /// <summary>
@@ -332,7 +356,7 @@ namespace ProtoCore.DSASM
         /// <param name="values">Values of object properties</param>
         /// <param name="metaData">Object type</param>
         /// <returns></returns>
-        public StackValue AllocatePointer(StackValue[] values, MetaData metaData)
+        private StackValue AllocatePointer(StackValue[] values, MetaData metaData)
         {
             int index = AllocateInternal(values, PrimitiveType.Pointer);
             var heapElement = heapElements[index];
@@ -342,26 +366,44 @@ namespace ProtoCore.DSASM
 
         /// <summary>
         /// Allocate an object pointer.
+        ///
+        /// Exceptions: ProtoCore.Exceptions.RunOutOfMemoryException
         /// </summary>
         /// <param name="values">Values of object properties</param>
         /// <returns></returns>
         public StackValue AllocatePointer(StackValue[] values)
         {
-            return AllocatePointer(values, new MetaData { type = (int)PrimitiveType.Pointer });
+            try
+            {
+                return AllocatePointer(values, new MetaData { type = (int)PrimitiveType.Pointer });
+            }
+            catch (OutOfMemoryException)
+            {
+                throw new RunOutOfMemoryException();
+            }
         }
 
         /// <summary>
         /// Allocate an object pointer.
+        ///
+        /// Exceptions: ProtoCore.Exceptions.RunOutOfMemoryException
         /// </summary>
         /// <param name="size">The size of object properties.</param>
         /// <param name="metadata">Object type</param>
         /// <returns></returns>
         public StackValue AllocatePointer(int size, MetaData metadata)
-        {    
-            int index = AllocateInternal(size, PrimitiveType.Pointer);
-            var hpe = heapElements[index];
-            hpe.MetaData = metadata;
-            return StackValue.BuildPointer(index, metadata);
+        {
+            try
+            {
+                int index = AllocateInternal(size, PrimitiveType.Pointer);
+                var hpe = heapElements[index];
+                hpe.MetaData = metadata;
+                return StackValue.BuildPointer(index, metadata);
+            }
+            catch (OutOfMemoryException)
+            {
+                throw new RunOutOfMemoryException();
+            }
         }
 
         /// <summary>
@@ -394,7 +436,14 @@ namespace ProtoCore.DSASM
         /// <returns></returns>
         public StackValue AllocateFixedString(string str)
         {
-            return AllocateStringInternal(str, true);
+            try
+            {
+                return AllocateStringInternal(str, true);
+            }
+            catch (OutOfMemoryException)
+            {
+                throw new RunOutOfMemoryException();
+            }
         }
 
         /// <summary>
@@ -404,7 +453,14 @@ namespace ProtoCore.DSASM
         /// <returns></returns>
         public StackValue AllocateString(string str)
         {
-            return AllocateStringInternal(str, false);
+            try
+            {
+                return AllocateStringInternal(str, false);
+            }
+            catch (OutOfMemoryException)
+            {
+                throw new RunOutOfMemoryException();
+            }
         }
 
         /// <summary>

--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -332,8 +332,7 @@ namespace ProtoCore.DSASM
         /// <param name="values">Values of object properties</param>
         /// <param name="metaData">Object type</param>
         /// <returns></returns>
-        public StackValue AllocatePointer(StackValue[] values, 
-                                          MetaData metaData)
+        public StackValue AllocatePointer(StackValue[] values, MetaData metaData)
         {
             int index = AllocateInternal(values, PrimitiveType.Pointer);
             var heapElement = heapElements[index];
@@ -348,9 +347,7 @@ namespace ProtoCore.DSASM
         /// <returns></returns>
         public StackValue AllocatePointer(StackValue[] values)
         {
-            return AllocatePointer(
-                    values, 
-                    new MetaData { type = (int)PrimitiveType.Pointer });
+            return AllocatePointer(values, new MetaData { type = (int)PrimitiveType.Pointer });
         }
 
         /// <summary>
@@ -365,18 +362,6 @@ namespace ProtoCore.DSASM
             var hpe = heapElements[index];
             hpe.MetaData = metadata;
             return StackValue.BuildPointer(index, metadata);
-        }
-
-        /// <summary>
-        /// Allocate an object pointer.
-        /// </summary>
-        /// <param name="size">The size of object properties.</parame
-        /// <returns></returns>
-        public StackValue AllocatePointer(int size)
-        {
-            return AllocatePointer(
-                    size, 
-                    new MetaData { type = (int)PrimitiveType.Pointer });
         }
 
         /// <summary>

--- a/src/Engine/ProtoCore/DSASM/Heap.cs
+++ b/src/Engine/ProtoCore/DSASM/Heap.cs
@@ -622,13 +622,9 @@ namespace ProtoCore.DSASM
                     var array = ToHeapObject<DSArray>(value);
                     releaseSize += array.MemorySize;
 
-                    foreach (var pair in array.ToDictionary())
+                    foreach (var ele in array.GetReferenceElements())
                     {
-                        if (pair.Key.IsReferenceType)
-                            ptrs.Enqueue(pair.Key);
-
-                        if (pair.Value.IsReferenceType)
-                            ptrs.Enqueue(pair.Value);
+                        ptrs.Enqueue(ele);
                     }
                 }
                 else if (value.IsPointer)
@@ -878,8 +874,7 @@ namespace ProtoCore.DSASM
                     if (pointer.IsArray)
                     {
                         var array = ToHeapObject<DSArray>(pointer);
-                        var dict = array.ToDictionary();
-                        subElements = subElements.Concat(dict.Keys).Concat(dict.Values);
+                        subElements = array.GetReferenceElements();
                     }
                     else
                     {

--- a/src/Engine/ProtoCore/DSASM/HeapObjects.cs
+++ b/src/Engine/ProtoCore/DSASM/HeapObjects.cs
@@ -190,20 +190,26 @@ namespace ProtoCore.DSASM
 
 
         /// <summary>
-        /// Get all reference-typed elements in this array.
+        /// Enqueue all reference-typed element.
         /// Note: it is only used by heap manager to do garbage collection.
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<StackValue> GetReferenceElements()
+        public void CollectElementsForGC(Queue<StackValue> gcQueue)
         {
-            return Values.Concat(Dict == null ? Dict.Keys : Enumerable.Empty<StackValue>()).Where(s => s.IsReferenceType);
+            var elements = Values.Concat(Dict == null ? Dict.Keys : Enumerable.Empty<StackValue>());
+            foreach (var item in elements)
+            {
+                if (item.IsReferenceType)
+                {
+                    gcQueue.Enqueue(item);
+                }
+            }
         }
 
         /// <summary>
-
-        /// </summary>
         /// <param name="core"></param>
         /// <returns></returns>
+        /// </summary>
         public StackValue CopyArray(RuntimeCore runtimeCore)
         {
             Type anyType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank);

--- a/src/Engine/ProtoCore/DSASM/HeapObjects.cs
+++ b/src/Engine/ProtoCore/DSASM/HeapObjects.cs
@@ -188,8 +188,19 @@ namespace ProtoCore.DSASM
             return dict;
         }
 
+
         /// <summary>
-        /// Simply copy an array.
+        /// Get all reference-typed elements in this array.
+        /// Note: it is only used by heap manager to do garbage collection.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<StackValue> GetReferenceElements()
+        {
+            return Values.Concat(Dict == null ? Dict.Keys : Enumerable.Empty<StackValue>()).Where(s => s.IsReferenceType);
+        }
+
+        /// <summary>
+
         /// </summary>
         /// <param name="core"></param>
         /// <returns></returns>

--- a/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
+++ b/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
@@ -376,58 +376,6 @@ namespace ProtoCore.DSASM.Mirror
                 }
             }
 
-            if (svArray.IsArray)
-            {
-                var dict = array.ToDictionary().Where(kvp => !kvp.Key.IsInteger);
-
-                int startIndex = (halfArraySize > 0) ? dict.Count() - halfArraySize : 0;
-                int index = -1;
-
-                foreach (var keyValuePair in dict)
-                {
-                    index++;
-                    if (index < startIndex)
-                    {
-                        continue;
-                    }
-
-                    if (arrayElements.Length > 0)
-                    {
-                        if (forPrint)
-                        {
-                            arrayElements.Append(",");
-                        }
-                        else
-                        {
-                            arrayElements.Append(", ");
-                        }
-                    }
-
-                    StackValue key = keyValuePair.Key;
-                    StackValue value = keyValuePair.Value;
-
-                    if (key.IsArray)
-                    {
-                        arrayElements.Append(GetPointerTrace(key, heap, langblock, pointers, forPrint));
-                    }
-                    else
-                    {
-                        arrayElements.Append(GetStringValue(key, heap, langblock, forPrint));
-                    }
-
-                    arrayElements.Append("=");
-
-                    if (value.IsArray)
-                    {
-                        arrayElements.Append(GetPointerTrace(value, heap, langblock, pointers, forPrint));
-                    }
-                    else
-                    {
-                        arrayElements.Append(GetStringValue(value, heap, langblock, forPrint));
-                    }
-                }
-            }
-
             formatParams.RestoreOutputTraceDepth();
             return arrayElements.ToString();
         }

--- a/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
+++ b/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
@@ -1374,8 +1374,15 @@ namespace ProtoCore.DSASM.Mirror
 
                 int size = sv.Length;
 
-                StackValue ptr = heap.AllocateArray(sv);
-                return ptr;
+                try
+                {
+                    StackValue ptr = heap.AllocateArray(sv);
+                    return ptr;
+                }
+                catch (RunOutOfMemoryException)
+                {
+                    return StackValue.Null;
+                }
             }
 
             // For non-arrays, there is nothing to repack so just return the original stackvalue

--- a/src/Engine/ProtoCore/Exceptions/CompileErrorsOccured.cs
+++ b/src/Engine/ProtoCore/Exceptions/CompileErrorsOccured.cs
@@ -15,4 +15,15 @@ namespace ProtoCore.Exceptions
 
         public RuntimeException(string message) : base("Runtime exception occured. " + message) { }
     }
+
+    public class RunOutOfMemoryException : OutOfMemoryException 
+    {
+        public RunOutOfMemoryException(): base("Run out of memory") 
+        {
+        }
+
+        public RunOutOfMemoryException(string message) : base("Run out of memory. " + message)
+        {
+        }
+    }
 }

--- a/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
+++ b/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
@@ -7,6 +7,7 @@ using ProtoCore.DSASM;
 using ProtoCore.Utils;
 using Autodesk.DesignScript.Runtime;
 using ProtoCore.Properties;
+using ProtoCore.Exceptions;
 
 namespace ProtoFFI
 {
@@ -524,12 +525,20 @@ namespace ProtoFFI
                     if (dsObject != null)
                     {
                         int startIndex = dsObject.Count;
-                        dsObject.ExpandBySize(count);
-                        Validity.Assert(dsObject.Count >= referencedParameters.Count);
-
-                        for (int i = 0; i < referencedParameters.Count; i++)
+                        try
                         {
-                            dsObject.SetValueAtIndex(startIndex + i, referencedParameters[i], dsi.runtime.RuntimeCore);
+                            dsObject.ExpandBySize(count);
+                            Validity.Assert(dsObject.Count >= referencedParameters.Count);
+
+                            for (int i = 0; i < referencedParameters.Count; i++)
+                            {
+                                dsObject.SetValueAtIndex(startIndex + i, referencedParameters[i], dsi.runtime.RuntimeCore);
+                            }
+                        }
+                        catch (RunOutOfMemoryException)
+                        {
+                            dsi.runtime.RuntimeCore.RuntimeStatus.LogWarning(ProtoCore.Runtime.WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                            return StackValue.Null;
                         }
                     }
                 } 

--- a/src/Engine/ProtoCore/FFI/PInvokeFFI.cs
+++ b/src/Engine/ProtoCore/FFI/PInvokeFFI.cs
@@ -7,6 +7,7 @@ using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using ProtoCore.DSASM;
 using FFICppFunction = ProtoCore.Lang.FFICppFunction2;
+using ProtoCore.Exceptions;
 
 namespace ProtoFFI
 {
@@ -181,13 +182,21 @@ namespace ProtoFFI
 
         private object ConvertCSArrayToDSArray(double[] csArray, ProtoCore.DSASM.Interpreter dsi)
         {
-           
             var runtimeCore = dsi.runtime.RuntimeCore;
             object retVal = null;
 
             var values = csArray.Select(x => StackValue.BuildDouble(x)).ToArray();
-            retVal = runtimeCore.RuntimeMemory.Heap.AllocateArray(values);
-            return retVal;
+
+            try
+            {
+                retVal = runtimeCore.RuntimeMemory.Heap.AllocateArray(values);
+                return retVal;
+            }
+            catch (RunOutOfMemoryException)
+            {
+                dsi.runtime.RuntimeCore.RuntimeStatus.LogWarning(ProtoCore.Runtime.WarningID.RunOutOfMemory, ProtoCore.Properties.Resources.RunOutOfMemory);
+                return StackValue.Null;
+            }
         }
 
         #endregion

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1618,8 +1618,16 @@ namespace ProtoCore
                     retTrace.NestedData[i] = cleanRetTrace;
                 }
 
-                StackValue ret = runtimeCore.RuntimeMemory.Heap.AllocateArray(retSVs);
-                return ret;
+                try
+                {
+                    StackValue ret = runtimeCore.RuntimeMemory.Heap.AllocateArray(retSVs);
+                    return ret;
+                }
+                catch (RunOutOfMemoryException)
+                {
+                    runtimeCore.RuntimeStatus.LogWarning(WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                    return StackValue.Null;
+                }
             }
             else
             {
@@ -1721,9 +1729,16 @@ namespace ProtoCore
                     retTrace.NestedData[i] = cleanRetTrace;
                 }
 
-
-                StackValue ret = runtimeCore.RuntimeMemory.Heap.AllocateArray(retSVs);
-                return ret;
+                try
+                {
+                    StackValue ret = runtimeCore.RuntimeMemory.Heap.AllocateArray(retSVs);
+                    return ret;
+                }
+                catch (RunOutOfMemoryException)
+                {
+                    runtimeCore.RuntimeStatus.LogWarning(WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                    return StackValue.Null;
+                }
             }
         }
 
@@ -1873,8 +1888,16 @@ namespace ProtoCore
                 
                 for (int p = 0; p < promotionsRequired; p++)
                 {
-                    StackValue newSV = runtimeCore.RuntimeMemory.Heap.AllocateArray(new StackValue[1] { oldSv });
-                    oldSv = newSV;
+                    try
+                    {
+                        StackValue newSV = runtimeCore.RuntimeMemory.Heap.AllocateArray(new StackValue[1] { oldSv });
+                        oldSv = newSV;
+                    }
+                    catch (RunOutOfMemoryException)
+                    {
+                        runtimeCore.RuntimeStatus.LogWarning(WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                        oldSv = StackValue.Null;
+                    }
                 }
 
                 newArgs[i] = oldSv;

--- a/src/Engine/ProtoCore/Lang/FunctionPointerEvaluator.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionPointerEvaluator.cs
@@ -7,6 +7,7 @@ using ProtoCore.DSASM;
 using ProtoCore.Runtime;
 using ProtoCore.Utils;
 using ProtoCore.Properties;
+using ProtoCore.Exceptions;
 
 namespace ProtoCore.Lang
 {
@@ -68,8 +69,16 @@ namespace ProtoCore.Lang
                 var varParams = args.GetRange(paramCount - 1, varParamCount).ToArray();
                 args.RemoveRange(paramCount - 1, varParamCount);
 
-                var packedParams = interpreter.runtime.rmem.Heap.AllocateArray(varParams);
-                args.Add(packedParams);
+                try
+                {
+                    var packedParams = interpreter.runtime.rmem.Heap.AllocateArray(varParams);
+                    args.Add(packedParams);
+                }
+                catch (RunOutOfMemoryException)
+                {
+                    interpreter.runtime.RuntimeCore.RuntimeStatus.LogWarning(WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                    return StackValue.Null;
+                }
             }
 
             bool isCallingMemberFunciton = procNode.ClassID != Constants.kInvalidIndex 

--- a/src/Engine/ProtoCore/Lang/Replication/ArgumentAtLevel.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/ArgumentAtLevel.cs
@@ -1,4 +1,5 @@
 ﻿using ProtoCore.DSASM;
+using ProtoCore.Exceptions;
 using ProtoCore.Properties;
 using System;
 using System.Collections.Generic;
@@ -130,7 +131,15 @@ namespace ProtoCore.Lang.Replication
             // Promote the array
             while (nestedLevel < 0)
             {
-                argument = runtimeCore.RuntimeMemory.Heap.AllocateArray(new StackValue[1] { argument });
+                try
+                {
+                    argument = runtimeCore.RuntimeMemory.Heap.AllocateArray(new StackValue[1] { argument });
+                }
+                catch (RunOutOfMemoryException)
+                {
+                    runtimeCore.RuntimeStatus.LogWarning(Runtime.WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                    return null;
+                }
                 nestedLevel++;
             }
 
@@ -141,7 +150,15 @@ namespace ProtoCore.Lang.Replication
             else
             {
                 var elements = GetElementsAtLevel(argument, nestedLevel, new List<int>(), atLevel.IsDominant, runtimeCore);
-                argument = runtimeCore.RuntimeMemory.Heap.AllocateArray(elements.Select(e => e.Element).ToArray());
+                try
+                {
+                    argument = runtimeCore.RuntimeMemory.Heap.AllocateArray(elements.Select(e => e.Element).ToArray());
+                }
+                catch (RunOutOfMemoryException)
+                {
+                    runtimeCore.RuntimeStatus.LogWarning(Runtime.WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                    return null;
+                }
                 var indices = elements.Select(e => e.Indices).ToList();
                 return new ArgumentAtLevel(argument, indices, atLevel.IsDominant);
             }
@@ -240,7 +257,16 @@ namespace ProtoCore.Lang.Replication
             }
 
             // Allocate an empty array to hold the value
-            var newRet = runtimeCore.RuntimeMemory.Heap.AllocateArray(new StackValue[] { });
+            StackValue newRet;
+            try
+            {
+                newRet = runtimeCore.RuntimeMemory.Heap.AllocateArray(new StackValue[] { });
+            }
+            catch (RunOutOfMemoryException)
+            {
+                runtimeCore.RuntimeStatus.LogWarning(Runtime.WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                return StackValue.Null;
+            }
             var array = runtimeCore.Heap.ToHeapObject<DSArray>(newRet);
 
             // Write the result back

--- a/src/Engine/ProtoCore/Lang/Type.cs
+++ b/src/Engine/ProtoCore/Lang/Type.cs
@@ -7,6 +7,7 @@ using ProtoCore.Utils;
 using ProtoCore.Properties;
 using System.Linq;
 using System.Text;
+using ProtoCore.Exceptions;
 
 namespace ProtoCore
 {
@@ -440,8 +441,16 @@ namespace ProtoCore
 
                     //Upcast once
                     StackValue coercedValue = Coerce(sv, newTargetType, runtimeCore);
-                    StackValue newSv = rmem.Heap.AllocateArray(new StackValue[] { coercedValue });
-                    return newSv;
+                    try
+                    {
+                        StackValue newSv = rmem.Heap.AllocateArray(new StackValue[] { coercedValue });
+                        return newSv;
+                    }
+                    catch (RunOutOfMemoryException)
+                    {
+                        runtimeCore.RuntimeStatus.LogWarning(Runtime.WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                        return StackValue.Null;
+                    }
                 }
                 else
                 {
@@ -454,8 +463,16 @@ namespace ProtoCore
 
                     //Upcast once
                     StackValue coercedValue = Coerce(sv, newTargetType, runtimeCore);
-                    StackValue newSv = rmem.Heap.AllocateArray(new StackValue[] { coercedValue });
-                    return newSv;
+                    try
+                    {
+                        StackValue newSv = rmem.Heap.AllocateArray(new StackValue[] { coercedValue });
+                        return newSv;
+                    }
+                    catch (RunOutOfMemoryException)
+                    {
+                        runtimeCore.RuntimeStatus.LogWarning(Runtime.WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                        return StackValue.Null;
+                    }
                 }
             }
 

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -2259,7 +2259,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is not enough memory to allocate object..
+        ///   Looks up a localized string similar to There is not enough memory to finish the operation..
         /// </summary>
         public static string RunOutOfMemory {
             get {

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -2259,6 +2259,15 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There is not enough memory to allocate object..
+        /// </summary>
+        public static string RunOutOfMemory {
+            get {
+                return ResourceManager.GetString("RunOutOfMemory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;;&apos; is expected.
         /// </summary>
         public static string SemiColonExpected {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -909,6 +909,6 @@ Parameter name: {0}</value>
     <value>No item exists at specified index address</value>
   </data>
   <data name="RunOutOfMemory" xml:space="preserve">
-    <value>There is not enough memory to allocate object.</value>
+    <value>There is not enough memory to finish the operation.</value>
   </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -908,4 +908,7 @@ Parameter name: {0}</value>
   <data name="IndexIntoNonArrayObject" xml:space="preserve">
     <value>No item exists at specified index address</value>
   </data>
+  <data name="RunOutOfMemory" xml:space="preserve">
+    <value>There is not enough memory to allocate object.</value>
+  </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -909,6 +909,6 @@ Parameter name: {0}</value>
     <value>No item exists at specified index address</value>
   </data>
   <data name="RunOutOfMemory" xml:space="preserve">
-    <value>There is not enough memory to allocate object.</value>
+    <value>There is not enough memory to finish the operation.</value>
   </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -908,4 +908,7 @@ Parameter name: {0}</value>
   <data name="IndexIntoNonArrayObject" xml:space="preserve">
     <value>No item exists at specified index address</value>
   </data>
+  <data name="RunOutOfMemory" xml:space="preserve">
+    <value>There is not enough memory to allocate object.</value>
+  </data>
 </root>

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -36,7 +36,8 @@ namespace ProtoCore
             ModuloByZero,
             InvalidType,
             RangeExpressionOutOfMemory,
-            MoreThanOneDominantList
+            MoreThanOneDominantList,
+            RunOutOfMemory,
         }
 
         public struct WarningEntry

--- a/test/Engine/ProtoTest/DSASM/HeapMarkSweepTests.cs
+++ b/test/Engine/ProtoTest/DSASM/HeapMarkSweepTests.cs
@@ -55,7 +55,7 @@ namespace ProtoTest.DSASM
             var array = heap.AllocateArray(values);
             var str = heap.AllocateString("hello world");
 
-            heap.GCMarkAndSweep(new List<StackValue>(), testExecutive);
+            heap.FullGC(new List<StackValue>(), testExecutive);
             Assert.IsNull(heap.ToHeapObject<DSArray>(array));
             Assert.IsNull(heap.ToHeapObject<DSArray>(str));
         }
@@ -72,7 +72,7 @@ namespace ProtoTest.DSASM
             var array2 = heap.AllocateArray(new StackValue[] { array1 });
             var array3 = heap.AllocateArray(new StackValue[] { array2 });
 
-            heap.GCMarkAndSweep(new List<StackValue>() {}, testExecutive);
+            heap.FullGC(new List<StackValue>() {}, testExecutive);
 
             Assert.IsNull(heap.ToHeapObject<DSArray>(array1));
             Assert.IsNull(heap.ToHeapObject<DSArray>(array2));
@@ -94,7 +94,7 @@ namespace ProtoTest.DSASM
 
             var array = heap.AllocateArray(new StackValue[] { });
 
-            heap.GCMarkAndSweep(new List<StackValue>() {}, testExecutive);
+            heap.FullGC(new List<StackValue>() {}, testExecutive);
 
             Assert.IsNull(heap.ToHeapObject<DSArray>(val));
             Assert.IsNull(heap.ToHeapObject<DSArray>(array));
@@ -112,7 +112,7 @@ namespace ProtoTest.DSASM
             // self reference
             array.SetValueForIndex(0, svArray, null);
 
-            heap.GCMarkAndSweep(new List<StackValue>() {}, testExecutive);
+            heap.FullGC(new List<StackValue>() {}, testExecutive);
             Assert.IsNull(heap.ToHeapObject<DSArray>(svArray));
         }
 
@@ -129,7 +129,7 @@ namespace ProtoTest.DSASM
             // self reference
             array1.SetValueForIndex(0, svArray2, null);
 
-            heap.GCMarkAndSweep(new List<StackValue>() { }, testExecutive);
+            heap.FullGC(new List<StackValue>() { }, testExecutive);
             Assert.IsNull(heap.ToHeapObject<DSArray>(svArray1));
             Assert.IsNull(heap.ToHeapObject<DSArray>(svArray2));
         }

--- a/test/Engine/ProtoTest/DSASM/MemorySafetyTest.cs
+++ b/test/Engine/ProtoTest/DSASM/MemorySafetyTest.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+
+namespace ProtoTest.DSASM
+{
+    [TestFixture]
+    class MemorySafetyTest : ProtoTestBase
+    {
+        [Test]
+        public void TestMemoryAllocation()
+        {
+            string code = @"
+x = {};
+x[1000000000] = 21;
+";
+            thisTest.RunAndVerifyRuntimeWarning(code, ProtoCore.Runtime.WarningID.RunOutOfMemory);
+        }
+    }
+}

--- a/test/Engine/ProtoTest/ProtoTest.csproj
+++ b/test/Engine/ProtoTest/ProtoTest.csproj
@@ -132,6 +132,7 @@
     <Compile Include="DebugTests\SetValueTests.cs" />
     <Compile Include="DSASM\ExecutionMirrorTests.cs" />
     <Compile Include="DSASM\HeapMarkSweepTests.cs" />
+    <Compile Include="DSASM\MemorySafetyTest.cs" />
     <Compile Include="DSASM\StackOverflowTests.cs" />
     <Compile Include="FFITests\ArgumentMarshalingTests.cs" />
     <Compile Include="FFITests\ContextInjectionTests.cs" />


### PR DESCRIPTION
### Purpose

This PR is to fix [MAGN-9631 Large value range expression crashes on committing the CBN](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9631).

The root cause is the engine doesn't handle CLR memory exception properly. For example, for array assignment `x[10000000000] = 21`, internally the engine will expand the size of array and consequentially a `OutOfMemoryException` will be thrown out.

There are two places where memory allocation will happen in the engine. One is allocating objects, for example, `Heap.AllocatePointer()`, `Heap.AllocateArray()` and `Heap.AllocateString()`. The other one is expanding the size of array by array assignment. The PR captures `OutOfMemoryException` in these two cases and logs runtime warnings. 

![msg1](https://cloud.githubusercontent.com/assets/2600379/14268041/331f3578-fb09-11e5-9018-a50f11127cc4.png)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.