### PR TITLE
Resolve relative path using workspace path

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Filename.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Filename.cs
@@ -1,6 +1,8 @@
 ﻿using System.Windows;
 using System.Windows.Forms;
 using CoreNodeModels.Input;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Wpf;
 
 namespace DSCore.File
@@ -8,11 +10,13 @@ namespace DSCore.File
     public class FilenameNodeViewCustomization : FileSystemBrowserNodeViewCustomization, INodeViewCustomization<Filename>
     {
         private Filename model;
+        protected WorkspaceModel workspaceModel;
 
         public void CustomizeView(Filename nodeModel, Dynamo.Controls.NodeView nodeView)
         {
             base.CustomizeView(nodeModel, nodeView);
             this.model = nodeModel;
+            workspaceModel = nodeView.ViewModel.WorkspaceViewModel.Model;
         }
 
         protected override void readFileButton_Click(object sender, RoutedEventArgs e)
@@ -24,7 +28,18 @@ namespace DSCore.File
 
             if (openDialog.ShowDialog() == DialogResult.OK)
             {
-                model.Value = openDialog.FileName;
+                var filepath = openDialog.FileName;
+                model.HintPath = filepath; //Update the hint path as full path.
+
+                //Evaluate relative path to store as model.Value
+                if (workspaceModel != null && !string.IsNullOrEmpty(workspaceModel.FileName))
+                {
+                    if (filepath == workspaceModel.FileName)
+                        filepath = System.IO.Path.GetFileName(filepath);
+                    else
+                        filepath = Utilities.MakeRelativePath(workspaceModel.FileName, filepath);
+                }
+                model.Value = filepath; //This assignment will mark the node dirty and trigger evaluation.
             }
         }
     }

--- a/src/NodeServices/ExecutionEvents.cs
+++ b/src/NodeServices/ExecutionEvents.cs
@@ -20,10 +20,17 @@ namespace Dynamo.Events
         public static event ExecutionStateHandler GraphPostExecution;
 
         /// <summary>
+        /// Gets active session for the execution, when Graph is executing. 
+        /// This property is set to null if graph is not executing.
+        /// </summary>
+        public static IExecutionSession ActiveSession { get; private set; }
+
+        /// <summary>
         /// Notify observers that the graph is about to evaluate
         /// </summary>
         internal static void OnGraphPreExecution(IExecutionSession session)
         {
+            ActiveSession = session;
             if (GraphPreExecution != null)
                 GraphPreExecution(session);
         }
@@ -33,6 +40,7 @@ namespace Dynamo.Events
         /// </summary>
         internal static void OnGraphPostExecution(IExecutionSession session)
         {
+            ActiveSession = null;
             if (GraphPostExecution != null)
                 GraphPostExecution(session);
         }

--- a/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
+++ b/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
@@ -45,6 +45,10 @@
       <HintPath>..\..\extern\prism\Microsoft.Practices.Prism.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\src\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>$(NunitPath)\nunit.framework.dll</HintPath>
       <Private>False</Private>


### PR DESCRIPTION
### Purpose

This PR supports relative path for File Path node and other nodes that uses file path.

- File Path node is enhanced to store hint path as last resolved full path and the "Value" property keeps relative path. The node view customization of File Path node sets the relative path as "Value" and full path as "HintPath" property when a file is selected using browse button.

- File.AbsolutePath(relativepath, hintpath) is implemented to resolve the relative path to an absolute path.

- ExecutionEvents.ActiveSession is implemented to access active session object when Dynamo is executing. This object is null when Dynamo is not executing.

- There is no impact on old DYN files if it contains full path. The new DYN files with `File Path` node will now save `relative path` as well as `hint path`.

- Now relative path can be passed to file specific nodes.
![image](https://cloud.githubusercontent.com/assets/1754137/14269458/805de4ac-fb17-11e5-87dc-791577a2d0a5.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @ke-yu 
- [ ] @Benglin 

### FYIs

@riteshchandawar, @monikaprabhu, @jnealb 
