### PR TITLE
Fixing test failures, used wrong relative path

### DIFF
--- a/test/UI/WatchUINodes.dyn
+++ b/test/UI/WatchUINodes.dyn
@@ -11,7 +11,7 @@
     <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="84509ca2-09bc-4294-82a0-3844021c1a65" nickname="Code Block" x="315.286051157114" y="250.671976518046" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="Point.ByCoordinates(0,0);" ShouldFocus="false" />
     <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="b4fc5d9a-4c5a-4dba-b7a0-b2e1d8876d33" nickname="Code Block" x="351.230088057328" y="57.2879899363054" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{1,2,3};" ShouldFocus="false" />
     <DSCore.File.Filename type="DSCore.File.Filename" guid="c3543240-7c54-4ed0-aac2-01ccb6d5ce8c" nickname="File Path" x="-59.2302863602432" y="733.729063245387" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
-      <System.String>../../../test/UI/Bricks.PNG</System.String>
+      <System.String>Bricks.PNG</System.String>
     </DSCore.File.Filename>
     <DSCore.File.FileObject type="DSCore.File.FileObject" guid="aea33285-bd50-4311-bac5-91941a5d26d2" nickname="File.FromPath" x="289.421883045283" y="738.907065761311" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
   </Elements>

--- a/test/core/WorkflowTestFiles/01 Dynamo Basics/06 Read from CSV.dyn
+++ b/test/core/WorkflowTestFiles/01 Dynamo Basics/06 Read from CSV.dyn
@@ -12,7 +12,7 @@
       <PortInfo index="1" default="True" />
     </Dynamo.Nodes.DSFunction>
     <DSCore.File.Filename guid="0fb0e8d9-0cf6-4a99-bdf6-ed07a02a8143" type="DSCore.File.Filename" nickname="File Path" x="403.795267243145" y="356.359487851088" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
-      <System.String>..\..\..\test\core\WorkflowTestFiles\01 Dynamo Basics\ecaade.csv</System.String>
+      <System.String>ecaade.csv</System.String>
     </DSCore.File.Filename>
   </Elements>
   <Connectors>


### PR DESCRIPTION
### Purpose

This PR fixes following two test failures, due to wrong usage of relative path.

```
1) Test Failure : DynamoCoreWpfTests.NodeViewCustomizationTests.WatchImageCoreContainsImage
     Expected: greater than 10.0d
  But was:  0.0d

at DynamoCoreWpfTests.NodeViewCustomizationTests.WatchImageCoreContainsImage() in e:\Builds\Dynamo_master\Dynamo\test\DynamoCoreWpfTests\NodeViewCustomizationTests.cs:line 244

2) Test Failure : Dynamo.Tests.ComplexTests.ReadFromCSV
     preview data is not a list
  Expected: True
  But was:  False

at Dynamo.Tests.DSEvaluationUnitTestBase.AssertPreviewCount(String guid, Int32 count)
at Dynamo.Tests.ComplexTests.ReadFromCSV() in e:\Builds\Dynamo_master\Dynamo\test\Libraries\WorkflowTests\ComplexTests.cs:line 164

```

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@riteshchandawar 
