### PR TITLE
MAGN-9717 Package installed does not go into the correct path in Dynamo when path is changed

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -80,8 +80,15 @@ namespace Dynamo.Core
         private readonly HashSet<string> preloadedLibraries;
         private readonly HashSet<string> extensionsDirectories;
         private readonly HashSet<string> viewExtensionsDirectories;
-        
+
         #endregion
+
+        internal IPreferences Preferences { get; set; }
+
+        private IEnumerable<string> RootDirectories
+        {
+            get { return Preferences != null ? Preferences.CustomPackageFolders : rootDirectories; }
+        }
 
         #region IPathManager Interface Implementation
 
@@ -107,12 +114,12 @@ namespace Dynamo.Core
 
         public string DefaultUserDefinitions
         {
-            get { return TransformPath(rootDirectories[0], DefinitionsDirectoryName); }
+            get { return TransformPath(RootDirectories.First(), DefinitionsDirectoryName); }
         }
 
         public IEnumerable<string> DefinitionDirectories
         {
-            get { return rootDirectories.Select(path => TransformPath(path, DefinitionsDirectoryName)); }
+            get { return RootDirectories.Select(path => TransformPath(path, DefinitionsDirectoryName)); }
         }
 
         public string CommonDefinitions
@@ -127,12 +134,12 @@ namespace Dynamo.Core
 
         public string DefaultPackagesDirectory
         {
-            get { return TransformPath(rootDirectories[0], PackagesDirectoryName); }
+            get { return TransformPath(RootDirectories.First(), PackagesDirectoryName); }
         }
 
         public IEnumerable<string> PackagesDirectories
         {
-            get { return rootDirectories.Select(path => TransformPath(path, PackagesDirectoryName)); }
+            get { return RootDirectories.Select(path => TransformPath(path, PackagesDirectoryName)); }
         }
 
         public IEnumerable<string> ExtensionsDirectories
@@ -249,7 +256,7 @@ namespace Dynamo.Core
 
                 return PathHelper.IsValidPath(document);
             }
-            catch(Exception)
+            catch
             {
                 return false;
             }
@@ -348,7 +355,7 @@ namespace Dynamo.Core
         /// the target directories cannot be created during this call.</param>
         internal void EnsureDirectoryExistence(List<Exception> exceptions)
         {
-            if (rootDirectories.Count <= 0)
+            if (!RootDirectories.Any())
             {
                 throw new InvalidOperationException(
                     "At least one custom package directory must be specified");
@@ -398,12 +405,6 @@ namespace Dynamo.Core
             }
 
             return Path.Combine(BackupDirectory, fileName);
-        }
-
-        internal void LoadCustomPackageFolders(IEnumerable<string> folders)
-        {
-            rootDirectories.Clear();
-            rootDirectories.AddRange(folders);
         }
 
         #endregion

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -538,7 +538,8 @@ namespace Dynamo.Models
             {
                 PreferenceSettings.CustomPackageFolders.Add(userDataFolder);
             }
-            pathManager.LoadCustomPackageFolders(PreferenceSettings.CustomPackageFolders);
+
+            pathManager.Preferences = PreferenceSettings;
 
 
             SearchModel = new NodeSearchModel();

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1169,7 +1169,6 @@ namespace Dynamo.PackageManager
 
             }
 
-            pathManager.LoadCustomPackageFolders(setting.CustomPackageFolders);
             return folder;
         }
 


### PR DESCRIPTION
### Purpose

Instead of creating events (for CustomPackageFolders is changed) and subscribing on them (`PackagePathViewModel` and `PathManager` do not know about each other), I made `PathManager` reference the same link to package folders, i.e. `PreferenceSettings.CustomPackageFolders`. Existing workflow is quite fragile:
- create `PathManager` and initialize `rootDirectories`;
- validate `rootDirectories`;
- read `PreferenceSettings` (with `CustomPackageFolders`) from a file;
- if Dynamo runs at first time, try read `PreferenceSettings` of an older version of Dynamo with using `PathManager` created in the first step and discard previous step;
- try to add two more folders to `PreferenceSettings.CustomPackageFolders`, one of them is of `PathManager`;
- discard `PathManager.rootDirectories` and override them with `PreferenceSettings.CustomPackageFolders`.

It would be better to initialize and pass `PreferenceSettings` object in `PathManager`constructor, but it's impossible without changing the workflow mentioned above. Any changes to the workflow may result in bugs which are difficult to detect. 
So, using `RootDirectories` as next is a compromise:
```
private List<string> RootDirectories
{
    get { return Preferences != null ? Preferences.CustomPackageFolders : rootDirectories; }
}
```

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI:
![image](https://cloud.githubusercontent.com/assets/7658189/14281736/7917a7ce-fb43-11e5-9558-b73cef26a5da.png)
- [ ] Snapshot of UI changes, if any.

### Reviewers

@aosyatnik @pbidenko 

### Notes

Any better solution is welcome :)
