### PR TITLE
Use GotFocus() event to change code block editor state

### DIFF
--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
@@ -113,7 +113,7 @@ namespace Dynamo.UI.Controls
             stateMachine.Transit(EditorStateMachine.State.Commited);
         }
 
-        protected override void OnFocus(object sender, System.Windows.RoutedEventArgs e)
+        protected override void OnTextAreaGotFocus(object sender, System.Windows.RoutedEventArgs e)
         {
             stateMachine.Transit(EditorStateMachine.State.Editing);
         }

--- a/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
+++ b/src/DynamoCoreWpf/Views/CodeBlocks/CodeBlockEditor.cs
@@ -113,7 +113,7 @@ namespace Dynamo.UI.Controls
             stateMachine.Transit(EditorStateMachine.State.Commited);
         }
 
-        protected override void OnEditorTextChanged()
+        protected override void OnFocus(object sender, System.Windows.RoutedEventArgs e)
         {
             stateMachine.Transit(EditorStateMachine.State.Editing);
         }

--- a/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
@@ -53,10 +53,10 @@ namespace Dynamo.UI.Controls
             this.dynamoViewModel = nodeViewModel.DynamoViewModel;
             this.DataContext = nodeViewModel.NodeModel;
             this.InnerTextEditor.TextChanged += OnTextChanged;
+            this.InnerTextEditor.TextArea.GotFocus+= OnTextAreaGotFocus; 
             this.InnerTextEditor.TextArea.LostFocus += OnTextAreaLostFocus;
             this.InnerTextEditor.TextArea.TextEntering += OnTextAreaTextEntering;
             this.InnerTextEditor.TextArea.TextEntered += OnTextAreaTextEntered;
-            this.InnerTextEditor.TextArea.GotFocus+= OnFocus; 
 
             CodeHighlightingRuleFactory.CreateHighlightingRules(InnerTextEditor, dynamoViewModel.EngineController);
         }
@@ -126,7 +126,7 @@ namespace Dynamo.UI.Controls
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        protected virtual void OnFocus(object sender, RoutedEventArgs e)
+        protected virtual void OnTextAreaGotFocus(object sender, RoutedEventArgs e)
         {
         }
 

--- a/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
+++ b/src/DynamoCoreWpf/Views/CodeCompletion/CodeCompletionEditor.xaml.cs
@@ -56,6 +56,7 @@ namespace Dynamo.UI.Controls
             this.InnerTextEditor.TextArea.LostFocus += OnTextAreaLostFocus;
             this.InnerTextEditor.TextArea.TextEntering += OnTextAreaTextEntering;
             this.InnerTextEditor.TextArea.TextEntered += OnTextAreaTextEntered;
+            this.InnerTextEditor.TextArea.GotFocus+= OnFocus; 
 
             CodeHighlightingRuleFactory.CreateHighlightingRules(InnerTextEditor, dynamoViewModel.EngineController);
         }
@@ -119,13 +120,14 @@ namespace Dynamo.UI.Controls
         protected virtual void OnCommitChange()
         {
         }
-
+        
         /// <summary>
-        /// Derived class overrides this function to handle the text changed event.
+        /// Derived class overrides this function to handle the event of getting focus. 
         /// </summary>
-        protected virtual void OnEditorTextChanged()
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected virtual void OnFocus(object sender, RoutedEventArgs e)
         {
-
         }
 
         /// <summary>
@@ -183,8 +185,6 @@ namespace Dynamo.UI.Controls
         {
             if (WatermarkLabel.Visibility == Visibility.Visible)
                 WatermarkLabel.Visibility = Visibility.Collapsed;
-
-            OnEditorTextChanged();
         }
 
         private void OnTextAreaTextEntering(object sender, TextCompositionEventArgs e)


### PR DESCRIPTION
### Purpose

#6351 introduced a regression when fixing defect [MAGN-9773× Regression Cannot create connection on a CBN after some operations like undo/redo, or moving back from custom workspace](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9773): Copying and pasting a code block node will trigger `OnEditorTextChanged` event which changes the state of code block editor to `Editing`, hence all input and output ports are disabled.

This PR sets the state of code block editor to `Editing` in `GotFocus` event.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 

