### PR TITLE
MAGN-9845 Crash highlighting custom node inpu

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -567,7 +567,7 @@ namespace Dynamo.Controls
 
             bool isInside = IsMouseInsideNodeOrPreview(e.GetPosition(this));
 
-            if (!isInside && previewControl.IsCondensed)
+            if (!isInside && PreviewControl != null && previewControl.IsCondensed)
             {
                 PreviewControl.TransitionToState(PreviewControl.State.Hidden);
             }


### PR DESCRIPTION
### Purpose

To fix crash [MAGN-9845 Crash highlighting custom node input](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9845).

The crash is because of null reference to preview control in `OnNodeViewMouseMove`. Adding null check, because in custom workspace, preview control is null.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers
@aosyatnik 
