### PR TITLE
MAGN-9580 Tou dialog does not pop up if package is published from option in "Manage Packages-> click on the 3 dots on the right of installed package"

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -231,6 +231,8 @@ namespace Dynamo.ViewModels
         private void ExecuteWithTou(Action acceptanceCallback)
         {
             var dModel = dynamoViewModel.Model;
+            // create TermsOfUseHelper object to check asynchronously whether the Terms of Use has 
+            // been accepted, and if so, continue to execute the provided Action.
             var termsOfUseCheck = new TermsOfUseHelper(new TermsOfUseHelperParams
             {
                 PackageManagerClient = dModel.GetPackageManagerExtension().PackageManagerClient,


### PR DESCRIPTION
### Purpose

Display TOU dialog, when publish from Manage Packages/"..." similarly to publishing from Packages menu:
![image](https://cloud.githubusercontent.com/assets/7658189/14346830/b3d028e4-fcbc-11e5-8482-4b9330fd7ed6.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
![image](https://cloud.githubusercontent.com/assets/7658189/14349934/fa722c86-fcce-11e5-9227-7fbd13a7d675.png)
- [ ] Snapshot of UI changes, if any.

### Reviewers

@pbidenko 