### PR TITLE
MAGN-6615: Make IExtensionApplication and related interface internal

### DIFF
--- a/src/NodeServices/Attributes.cs
+++ b/src/NodeServices/Attributes.cs
@@ -47,7 +47,7 @@ namespace Autodesk.DesignScript.Runtime
     /// that implements IExtensionApplication interface.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
-    public sealed class ExtensionApplicationAttribute : Attribute
+    internal sealed class ExtensionApplicationAttribute : Attribute
     {
         public ExtensionApplicationAttribute(Type entryPointType)
         {
@@ -83,7 +83,7 @@ namespace Autodesk.DesignScript.Runtime
     /// that implements IContextDataProvider interface.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
-    public sealed class ContextDataProviderAttribute : Attribute
+    internal sealed class ContextDataProviderAttribute : Attribute
     {
         private Func<bool> mCapturesData = () => true;
 

--- a/src/NodeServices/Interfaces.cs
+++ b/src/NodeServices/Interfaces.cs
@@ -8,7 +8,7 @@ namespace Autodesk.DesignScript.Interfaces
     /// <summary>
     /// Provides application configuration
     /// </summary>
-    public interface IConfiguration
+    internal interface IConfiguration
     {
         /// <summary>
         /// Provides the path of main executing script
@@ -35,7 +35,7 @@ namespace Autodesk.DesignScript.Interfaces
         void SetConfigValue(string config, object value);
     }
 
-    public class ConfigurationKeys
+    internal class ConfigurationKeys
     {
         /// <summary>
         /// This key is used to configure the library filename, which implements 
@@ -127,7 +127,7 @@ namespace Autodesk.DesignScript.Interfaces
     /// <summary>
     /// Represents a session object for current execution.
     /// </summary>
-    public interface IExecutionSession
+    internal interface IExecutionSession
     {
         /// <summary>
         /// Gets the configuration object for this execution session.
@@ -147,7 +147,7 @@ namespace Autodesk.DesignScript.Interfaces
     /// An FFI library can implement this interface to get some notifications
     /// from DesignScript application.
     /// </summary>
-    public interface IExtensionApplication
+    internal interface IExtensionApplication
     {
         /// <summary>
         /// Called when first time this application is loaded.

--- a/src/NodeServices/Properties/AssemblyInfo.cs
+++ b/src/NodeServices/Properties/AssemblyInfo.cs
@@ -11,3 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: Guid("bb5cae3b-3d5a-4a69-91eb-718791cad422")]
 
 [assembly: InternalsVisibleTo("DynamoCore")]
+[assembly: InternalsVisibleTo("ProtoCore")]
+[assembly: InternalsVisibleTo("ProtoGeometry")]
+[assembly: InternalsVisibleTo("LibG.ProtoInterface")]
+[assembly: InternalsVisibleTo("TestServices")]
+[assembly: InternalsVisibleTo("ProtoTestFx")]

--- a/test/Libraries/AnalysisTests/AnalysisTests.cs
+++ b/test/Libraries/AnalysisTests/AnalysisTests.cs
@@ -17,28 +17,8 @@ using NUnit.Framework;
 namespace AnalysisTests
 {
     [TestFixture]
-    public class AnalysisTests
+    public class AnalysisTests : TestServices.GeometricTestBase
     {
-        private TestExecutionSession executionSession;
-        IExtensionApplication application = Application.Instance as IExtensionApplication;
-
-        [TestFixtureSetUp]
-        public void SetUp()
-        {
-            var assemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-
-            executionSession = new TestExecutionSession(assemblyDirectory);
-
-            application.OnBeginExecution(executionSession);
-            HostFactory.Instance.StartUp();
-        }
-
-        [TestFixtureTearDown]
-        public void TearDown()
-        {
-            executionSession = null;
-        }
-
         [Test, Category("UnitTests")]
         public void SurfaceAnalysisDataBySurfacePointsAndResults_ValidArgs()
         {
@@ -195,81 +175,5 @@ namespace AnalysisTests
             var a = new List<Vector> {x,y,z};
             return a;
         } 
-    }
-
-    /// <summary>
-    /// This is a temporary session class which is only used for nodes that are using Geometries.
-    /// When ProtoGeometry is loaded, the static instance GeometryFactory will be constructed which
-    /// requires a session to be present.
-    /// </summary>
-    class TestExecutionSession : IExecutionSession, IConfiguration, IDisposable
-    {
-        private readonly string rootModulePath;
-        private readonly Dictionary<string, object> configValues;
-        private Preloader preloader;
-
-        public TestExecutionSession(string rootModulePath)
-        {
-            configValues = new Dictionary<string, object>();
-            this.rootModulePath = rootModulePath;
-        }
-
-        public IConfiguration Configuration
-        {
-            get { return this; }
-        }
-
-        public string SearchFile(string fileName)
-        {
-            var path = Path.Combine(RootModulePath, fileName);
-            if (File.Exists(path))
-                return path;
-            return fileName;
-        }
-
-        public string RootModulePath
-        {
-            get { return rootModulePath; }
-        }
-
-        public string[] IncludeDirectories
-        {
-            get { return new string[] { RootModulePath }; }
-        }
-
-        public bool IsDebugMode
-        {
-            get { return false; }
-        }
-
-        public object GetConfigValue(string config)
-        {
-            if (string.Compare(ConfigurationKeys.GeometryFactory, config) == 0)
-            {
-                if (preloader == null)
-                {
-                    var exePath = Assembly.GetExecutingAssembly().Location;
-                    preloader = new Preloader(Path.GetDirectoryName(exePath));
-                    preloader.Preload();
-                }
-
-                return preloader.GeometryFactoryPath;
-            }
-
-            if (configValues.ContainsKey(config))
-                return configValues[config];
-
-            return null;
-        }
-
-        public void SetConfigValue(string config, object value)
-        {
-            configValues[config] = value;
-        }
-
-        public void Dispose()
-        {
-            configValues.Clear();
-        }
     }
 }


### PR DESCRIPTION
### Purpose

As a part of ProtoInterface cleanup, IExtensionApplication is made internal and it is advised to use Dynamo.Events.ExecutionEvents to receive notification of pre and post execution. Some of the libraries are still using this interface, so for now, we are making the interface and the related interfaces internal and making the internals visible to the libraries that still use these interfaces. The actual cleanup will be done post 1.0 release so that we have minimal impact on stability.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers
- [ ] @ke-yu 
- [ ] @Randy-Ma 
- [ ] @aparajit-pratap 

