### PR TITLE
1.0 UserData migration

### DIFF
--- a/src/DynamoCore/Configuration/IPathResolver.cs
+++ b/src/DynamoCore/Configuration/IPathResolver.cs
@@ -34,7 +34,7 @@ namespace Dynamo.Interfaces
         /// <summary>
         /// This property represents the root folder where user specific data files 
         /// are stored. If this property returns a null or empty string, then 
-        /// PathManager falls back to using "%ProgramData%\Dynamo". If this property
+        /// PathManager falls back to using "%ProgramData%\Dynamo\Dynamo Core". If this property
         /// returns a string that does not represent an existing folder, PathManager 
         /// will attempt to create a new directory. If the property does not represent
         /// a valid path string, an exception will be thrown by the underlying system 
@@ -47,7 +47,7 @@ namespace Dynamo.Interfaces
         /// This property represents the root folder where application common data 
         /// files (i.e. shared among all users on the same machine) are stored. If 
         /// this property returns a null or empty string, then PathManager falls 
-        /// back to using "%AppData%\Dynamo". If this property returns a string 
+        /// back to using "%AppData%\Dynamo\Dynamo Core". If this property returns a string 
         /// that does not represent an existing folder, PathManager will attempt 
         /// to create a new directory. If the property does not represent a valid 
         /// path string, an exception will be thrown by the underlying system IO 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -507,7 +507,10 @@ namespace Dynamo.Models
 
                 try
                 {
-                    migrator = DynamoMigratorBase.MigrateBetweenDynamoVersions(pathManager, config.PathResolver);
+                    var dynamoLookup = config.UpdateManager != null && config.UpdateManager.Configuration != null 
+                        ? config.UpdateManager.Configuration.DynamoLookUp : null;
+
+                    migrator = DynamoMigratorBase.MigrateBetweenDynamoVersions(pathManager, dynamoLookup);
                 }
                 catch (Exception e)
                 {

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -64,6 +64,13 @@ namespace Dynamo.Updates
         IEnumerable<string> GetDynamoInstallLocations();
 
         /// <summary>
+        /// Gets the full path of user data location of all version of this
+        /// Dynamo product installed on this system.
+        /// </summary>
+        /// <returns></returns>
+        IEnumerable<string> GetDynamoUserDataLocations();
+
+        /// <summary>
         /// Gets the version of latest installed product
         /// </summary>
         BinaryVersion LatestProduct { get; }
@@ -1131,6 +1138,21 @@ namespace Dynamo.Updates
         /// </summary>
         /// <returns>List of Dynamo install path</returns>
         public abstract IEnumerable<string> GetDynamoInstallLocations();
+
+        /// <summary>
+        /// Gets the full path of user data location of all version of this
+        /// Dynamo product installed on this system.
+        /// </summary>
+        /// <returns></returns>
+        public virtual IEnumerable<string> GetDynamoUserDataLocations()
+        {
+            var appdatafolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var dynamoFolder = Path.Combine(appdatafolder, "Dynamo");
+            var coreFolder = Path.Combine(dynamoFolder, "Dynamo Core");
+            var paths = Directory.EnumerateDirectories(coreFolder).ToList();
+            paths.AddRange(Directory.EnumerateDirectories(dynamoFolder));
+            return paths;
+        }
         
         private BinaryVersion GetLatestInstallVersion()
         {

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -64,10 +64,13 @@ namespace Dynamo.Updates
         IEnumerable<string> GetDynamoInstallLocations();
 
         /// <summary>
-        /// Gets the full path of user data location of all version of this
-        /// Dynamo product installed on this system.
+        /// Get a list of user data folders on this system.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// The implementation of this interface method should return a list of user 
+        /// data folders, one for each of Dynamo product installed on the system. When 
+        /// there is no Dynamo product installed, this method returns an empty list.
+        /// </returns>
         IEnumerable<string> GetDynamoUserDataLocations();
 
         /// <summary>
@@ -1141,15 +1144,26 @@ namespace Dynamo.Updates
 
         /// <summary>
         /// Gets the full path of user data location of all version of this
-        /// Dynamo product installed on this system.
+        /// Dynamo product installed on this system. The default implementation
+        /// returns list of all subfolders in %appdata%\Dynamo as well as 
+        /// %appdata%\Dynamo\Dynamo Core\ folders.
         /// </summary>
         /// <returns></returns>
         public virtual IEnumerable<string> GetDynamoUserDataLocations()
         {
-            var appdatafolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var dynamoFolder = Path.Combine(appdatafolder, "Dynamo");
+            var appDatafolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var dynamoFolder = Path.Combine(appDatafolder, "Dynamo");
+            if (!Directory.Exists(dynamoFolder)) return Enumerable.Empty<string>();
+
+            var paths = new List<string>();
             var coreFolder = Path.Combine(dynamoFolder, "Dynamo Core");
-            var paths = Directory.EnumerateDirectories(coreFolder).ToList();
+            //Dynamo Core folder has to be enumerated first to cater migration from
+            //Dynamo 1.0 to Dynamo Core 1.0
+            if (Directory.Exists(coreFolder))
+            {
+                paths.AddRange(Directory.EnumerateDirectories(coreFolder));
+            }
+
             paths.AddRange(Directory.EnumerateDirectories(dynamoFolder));
             return paths;
         }

--- a/test/DynamoCoreTests/UserDataMigrationTests.cs
+++ b/test/DynamoCoreTests/UserDataMigrationTests.cs
@@ -211,6 +211,60 @@ namespace Dynamo
             Assert.AreEqual(TempFolder, versionList[1].UserDataRoot);
         }
 
+        [Test, Category("UnitTests")]
+        public void GetLatestVersionToMigrate()
+        {
+            var mockLookup = new Mock<IDynamoLookUp>();
+            mockLookup.Setup(x => x.GetDynamoUserDataLocations()).Returns(MockUserDirectories);
+
+            var current = new FileVersion(1, 0, Path.Combine(TempFolder, "Test"));
+            var latest = DynamoMigratorBase.GetLatestVersionToMigrate(null, mockLookup.Object, current);
+            Assert.IsTrue(latest.HasValue);
+            Assert.AreEqual(1, latest.Value.MajorPart);
+            Assert.AreEqual(0, latest.Value.MinorPart);
+            Assert.AreEqual(TempFolder, latest.Value.UserDataRoot);
+        }
+
+        [Test, Category("UnitTests")]
+        public void GetLatestVersionToMigrate_10()
+        {
+            var mockLookup = new Mock<IDynamoLookUp>();
+            mockLookup.Setup(x => x.GetDynamoUserDataLocations()).Returns(MockUserDirectories);
+
+            var current = new FileVersion(1, 0, TempFolder);
+            var latest = DynamoMigratorBase.GetLatestVersionToMigrate(null, mockLookup.Object, current);
+            Assert.IsTrue(latest.HasValue);
+            Assert.AreEqual(1, latest.Value.MajorPart);
+            Assert.AreEqual(0, latest.Value.MinorPart);
+            Assert.AreEqual(Path.Combine(TempFolder, "Test"), latest.Value.UserDataRoot);
+        }
+
+
+        [Test, Category("UnitTests")]
+        public void GetLatestVersionToMigrate_PartiallyValidData()
+        {
+            var mockLookup = new Mock<IDynamoLookUp>();
+            mockLookup.Setup(x => x.GetDynamoUserDataLocations()).Returns(MockUserDirectories);
+
+            var current = new FileVersion(0, 9, TempFolder);
+            var latest = DynamoMigratorBase.GetLatestVersionToMigrate(null, mockLookup.Object, current);
+            Assert.IsTrue(latest.HasValue);
+            Assert.AreEqual(0, latest.Value.MajorPart);
+            Assert.AreEqual(8, latest.Value.MinorPart);
+            Assert.AreEqual(TempFolder, latest.Value.UserDataRoot);
+        }
+
+        [Test, Category("UnitTests")]
+        public void GetLatestVersionToMigrate_AllInvalidData()
+        {
+            var mockLookup = new Mock<IDynamoLookUp>();
+            mockLookup.Setup(x => x.GetDynamoUserDataLocations()).Returns(new[] { "x", "y", "z" });
+
+            var current = new FileVersion(1, 0, "a");
+            var latest = DynamoMigratorBase.GetLatestVersionToMigrate(null, mockLookup.Object, current);
+            Assert.IsTrue(!latest.HasValue || latest.Value.UserDataRoot == null);
+        }
+
         private IEnumerable<string> MockUserDirectories()
         {
             yield return Path.Combine(TempFolder, "Test", "1.0");

--- a/test/DynamoCoreTests/UserDataMigrationTests.cs
+++ b/test/DynamoCoreTests/UserDataMigrationTests.cs
@@ -8,6 +8,7 @@ using Dynamo.Configuration;
 using Dynamo.Core;
 using Dynamo.Interfaces;
 using Dynamo.Tests;
+using Dynamo.Updates;
 using Moq;
 using NUnit.Framework;
 
@@ -29,65 +30,67 @@ namespace Dynamo
         [Category("UnitTests")]
         public void FileVersionMajorMinorParts()
         {
-            var fileVersion = new FileVersion(12, 34);
+            var userDataRoot = "test";
+            var fileVersion = new FileVersion(12, 34, userDataRoot);
             Assert.AreEqual(12, fileVersion.MajorPart);
             Assert.AreEqual(34, fileVersion.MinorPart);
+            Assert.AreEqual(userDataRoot, fileVersion.UserDataRoot);
         }
 
         [Test]
         [Category("UnitTests")]
         public void FileVersionCompare_Sorting()
         {
-            var fv1 = new FileVersion(0, 7);
-            var fv2 = new FileVersion(0, 8);
+            var fv1 = new FileVersion(0, 7, "x");
+            var fv2 = new FileVersion(0, 8, "y");
 
             Assert.IsTrue(fv1 < fv2);
             Assert.IsTrue(fv2 > fv1);
 
-            fv1 = new FileVersion(0, 0);
-            fv2 = new FileVersion(0, 0);
+            fv1 = new FileVersion(0, 0, "x");
+            fv2 = new FileVersion(0, 0, "y");
             Assert.IsFalse(fv1 < fv2);
             Assert.IsFalse(fv1 > fv2);
             Assert.IsFalse(fv2 < fv1);
             Assert.IsFalse(fv2 > fv1);
 
-            fv1 = new FileVersion(1, 7);
-            fv2 = new FileVersion(1, 8);
+            fv1 = new FileVersion(1, 7, "x");
+            fv2 = new FileVersion(1, 8, "y");
             Assert.IsTrue(fv1 < fv2);
             Assert.IsTrue(fv2 > fv1);
 
-            fv1 = new FileVersion(1, 9);
-            fv2 = new FileVersion(2, 0);
+            fv1 = new FileVersion(1, 9, "x");
+            fv2 = new FileVersion(2, 0, "y");
             Assert.IsTrue(fv1 < fv2);
             Assert.IsTrue(fv2 > fv1);
 
-            fv1 = new FileVersion(-1, 9);
-            fv2 = new FileVersion(0, 0);
+            fv1 = new FileVersion(-1, 9, "x");
+            fv2 = new FileVersion(0, 0, "y");
             Assert.IsTrue(fv1 < fv2);
             Assert.IsTrue(fv2 > fv1);
 
-            fv1 = new FileVersion(-2, 9);
-            fv2 = new FileVersion(-1, 0);
+            fv1 = new FileVersion(-2, 9, "x");
+            fv2 = new FileVersion(-1, 0, "y");
             Assert.IsTrue(fv1 < fv2);
             Assert.IsTrue(fv2 > fv1);
 
-            fv1 = new FileVersion(2, -9);
-            fv2 = new FileVersion(3, 0);
+            fv1 = new FileVersion(2, -9, "x");
+            fv2 = new FileVersion(3, 0, "y");
             Assert.IsTrue(fv1 < fv2);
             Assert.IsTrue(fv2 > fv1);
 
-            fv1 = new FileVersion(2, -9);
-            fv2 = new FileVersion(2, -8);
+            fv1 = new FileVersion(2, -9, "x");
+            fv2 = new FileVersion(2, -8, "y");
             Assert.IsTrue(fv1 < fv2);
             Assert.IsTrue(fv2 > fv1);
 
-            fv1 = new FileVersion(-2, -9);
-            fv2 = new FileVersion(-2, -8);
+            fv1 = new FileVersion(-2, -9, "x");
+            fv2 = new FileVersion(-2, -8, "y");
             Assert.IsTrue(fv1 < fv2);
             Assert.IsTrue(fv2 > fv1);
 
-            fv1 = new FileVersion(-2, -9);
-            fv2 = new FileVersion(-1, -9);
+            fv1 = new FileVersion(-2, -9, "x");
+            fv2 = new FileVersion(-1, -9, "y");
             Assert.IsTrue(fv1 < fv2);
             Assert.IsTrue(fv2 > fv1);
         }
@@ -98,32 +101,55 @@ namespace Dynamo
         {
             var list = new List<FileVersion>
             {
-                new FileVersion(0, 7),
-                new FileVersion(0, 8),
-                new FileVersion(0, 0),
-                new FileVersion(0, 0),
-                new FileVersion(1, 7),
-                new FileVersion(1, 8),
-                new FileVersion(1, 9),
-                new FileVersion(2, 0),
-                new FileVersion(-1, 9),
-                new FileVersion(0, 0),
-                new FileVersion(-2, 9),
-                new FileVersion(-1, 0),
-                new FileVersion(2, -9),
-                new FileVersion(3, 0),
-                new FileVersion(2, -9),
-                new FileVersion(2, -8),
-                new FileVersion(-2, -9),
-                new FileVersion(-2, -8),
-                new FileVersion(-2, -9),
-                new FileVersion(-1, -9),
+                new FileVersion(0, 7, "a"),
+                new FileVersion(0, 8, "b"),
+                new FileVersion(0, 0, "c"),
+                new FileVersion(0, 0, "d"),
+                new FileVersion(1, 7, "e"),
+                new FileVersion(1, 8, "f"),
+                new FileVersion(1, 9, "g"),
+                new FileVersion(2, 0, "h"),
+                new FileVersion(-1, 9, "x"),
+                new FileVersion(0, 0, "y"),
+                new FileVersion(-2, 9, "z"),
+                new FileVersion(-1, 0, "a"),
+                new FileVersion(2, -9, "b"),
+                new FileVersion(3, 0, "c"),
+                new FileVersion(2, -9, "d"),
+                new FileVersion(2, -8, "e"),
+                new FileVersion(-2, -9, "f"),
+                new FileVersion(-2, -8, "g"),
+                new FileVersion(-2, -9, "h"),
+                new FileVersion(-1, -9, "asdad"),
 
             };
 
             list.Sort();
 
             VerifySortedOrder(list);
+        }
+
+        [Test, Category("UnitTests")]
+        public void TestInstalledVersionFromUserDataFolder()
+        {
+            //Test with valid version string
+            var tempPath = base.TempFolder;
+            var userDataFolder = Path.Combine(tempPath, "1.0");
+            var version = DynamoMigratorBase.GetInstallVersionFromUserDataFolder(userDataFolder);
+            Assert.AreEqual(tempPath, version.UserDataRoot);
+            Assert.AreEqual(1, version.MajorPart);
+            Assert.AreEqual(0, version.MinorPart);
+
+            //Test with -ve version string
+            userDataFolder = Path.Combine(tempPath, "-1.-9");
+            version = DynamoMigratorBase.GetInstallVersionFromUserDataFolder(userDataFolder);
+            Assert.AreEqual(tempPath, version.UserDataRoot);
+            Assert.AreEqual(-1, version.MajorPart);
+            Assert.AreEqual(-9, version.MinorPart);
+
+            //Test with invalid data
+            version = DynamoMigratorBase.GetInstallVersionFromUserDataFolder(tempPath);
+            Assert.AreEqual(default(FileVersion), version);
         }
 
         [Test]
@@ -170,6 +196,27 @@ namespace Dynamo
                 Assert.IsTrue(e.ParamName == "rootFolder");                
             }
             
+        }
+
+        [Test, Category("UnitTests")]
+        public void GetSortedInstallVersion_FromDynamoLookUp()
+        {
+            var mockLookup = new Mock<IDynamoLookUp>();
+            mockLookup.Setup(x=>x.GetDynamoUserDataLocations()).Returns(MockUserDirectories);
+
+            var versionList = DynamoMigratorBase.GetInstalledVersions(null, mockLookup.Object).ToList();
+            VerifySortedOrder(versionList);
+            Assert.AreEqual(4, versionList.Count);
+            Assert.AreEqual(Path.Combine(TempFolder, "Test"), versionList[0].UserDataRoot);
+            Assert.AreEqual(TempFolder, versionList[1].UserDataRoot);
+        }
+
+        private IEnumerable<string> MockUserDirectories()
+        {
+            yield return Path.Combine(TempFolder, "Test", "1.0");
+            yield return Path.Combine(TempFolder, "0.8");
+            yield return Path.Combine(TempFolder, "1.0");
+            yield return Path.Combine(TempFolder, "0.9");
         }
 
         private static void CreateMockPreferenceSettingsFile(string filePath, string packageDir)
@@ -243,16 +290,14 @@ namespace Dynamo
 
             // Create mock objects for IPathManager and IPathResolver
             var mockPathManager = new Mock<IPathManager>();
-            var mockPathResolver = new Mock<IPathResolver>();
-
+            
             var currentVersionDir = Path.Combine(userDataDir, "0.9");
 
-            mockPathResolver.Setup(x => x.UserDataRootFolder).Returns(() => userDataDir);
             mockPathManager.Setup(x => x.UserDataDirectory).Returns(() => currentVersionDir);
 
             // Test MigrateBetweenDynamoVersions
             var targetMigrator = DynamoMigratorBase.MigrateBetweenDynamoVersions(
-                mockPathManager.Object, mockPathResolver.Object);
+                mockPathManager.Object);
 
             // Assert that both 0.8 and 0.9 dirs are the same after migration
             var sourcePackageDir = Path.Combine(sourceVersionDir, "packages");


### PR DESCRIPTION
### Purpose

This PR enhances the `UserData` migration framework so that Dynamo clients can pass additional user data folders for migration.

- `IDynamoLookUp` interface has a new method 
`IEnumberable<string> GetDynamoUserDataLocations()` to return all the user data folders on the system for the client Dynamo application.
- `DynamoMigratorBase` optionally takes `IDynamoLookUp` interface to migrate between Dynamo versions and if a valid `DynamoLookUp` object is passed, it will be used to figure out the migration versions and user data path; otherwise the migration falls back to the default `UserDataDirectory` as returned by the input `IPathManager` interface.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @Benglin 
- [ ] @aparajit-pratap 



