### PR TITLE
Throw SymbolNotFound exception if variable not found

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
+++ b/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
@@ -861,7 +861,15 @@ namespace ProtoCore.DSASM.Mirror
             return MirrorTarget.rmem.Heap.ToHeapObject<DSArray>(obj.DsasmValue).Values.Select(x => Unpack(x)).ToList();
         }
 
-        public StackValue GetGlobalValue(string name, int startBlock = 0)
+        /// <summary>
+        /// Searching variable name starting from specified block.
+        /// Exception:
+        ///     SymbolNotFoundException if variable not found.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="startBlock"></param>
+        /// <returns></returns>
+        public StackValue GetValue(string name, int startBlock = 0)
         {
             ProtoCore.DSASM.Executable exe = MirrorTarget.exe;
 
@@ -877,7 +885,8 @@ namespace ProtoCore.DSASM.Mirror
                     }
                 }
             }
-            return StackValue.Null;
+
+            throw new SymbolNotFoundException(name);
         }
 
         public StackValue GetRawFirstValue(string name, int startBlock = 0, int classcope = Constants.kGlobalScope)

--- a/src/Engine/ProtoCore/Reflection/Mirror.cs
+++ b/src/Engine/ProtoCore/Reflection/Mirror.cs
@@ -66,7 +66,7 @@ namespace ProtoCore
 
                 variableName = varname;
                 blockDeclaration = blockDecl;
-                StackValue svData = deprecateThisMirror.GetGlobalValue(variableName);
+                StackValue svData = deprecateThisMirror.GetValue(variableName);
 
                 mirrorData = new MirrorData(staticCore, this.runtimeCore, svData);
             }

--- a/test/Engine/ProtoTestFx/DebugTestFx.cs
+++ b/test/Engine/ProtoTestFx/DebugTestFx.cs
@@ -209,13 +209,15 @@ namespace ProtoTestFx
 
                     try
                     {
-                        runValue = runExecMirror.GetGlobalValue(symNode.name);
+                        runValue = runExecMirror.GetValue(symNode.name);
                         lookupOk = true;
 
                     }
                     catch (NotImplementedException)
                     {
-
+                    }
+                    catch (SymbolNotFoundException)
+                    {
                     }
                     catch (Exception ex)
                     {
@@ -235,7 +237,7 @@ namespace ProtoTestFx
 
                     if (lookupOk)
                     {
-                        StackValue debugValue = debugExecMirror.GetGlobalValue(symNode.name);
+                        StackValue debugValue = debugExecMirror.GetValue(symNode.name);
                         if (!StackUtils.CompareStackValues(debugValue, runValue, rtcore2, rtcore1))
                         {
                             Assert.Fail(string.Format("\tThe value of variable \"{0}\" doesn't match in run mode and in debug mode.\nTracked by {1}", symNode.name, defectID));


### PR DESCRIPTION
### Purpose

This is to fix Revit regression introduced in #6404. 

`ExecutionMirror.GetValue()` will throw `SymbolNotFound` exception if variable is not found.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

