### PR TITLE
MAGN-9537: Packages/Definitions folders are not created when root folder is not default

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -446,6 +446,9 @@ namespace Dynamo.Core
             if (pathResolver != null && !string.IsNullOrEmpty(pathResolver.UserDataRootFolder))
                 return GetDynamoDataFolder(pathResolver.UserDataRootFolder);
 
+            if (!string.IsNullOrEmpty(userDataDir))
+                return userDataDir; //Return the cached userDataDir if we have one.
+
             var folder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             return GetDynamoDataFolder(Path.Combine(folder, "Dynamo", "Dynamo Core"));
         }


### PR DESCRIPTION
### Purpose

This PR actually fixes [MAGN-9537](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9537), where the packages or definitions folders were not created for Dynamo Studio because Dynamo Studio used a custom root folder and in some cases we relied on the installer to create these folders. [We are going to remove the folder creation from installers so that all scenarios are handled in a similar way](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9888). 

The `DefaultUserDefinitions` and `DefaultPackagesDirectory` properties are not computed properly becuase 'GetUserDataFolder(null)' was not returning the correct path. Fixed to use the cached userDataDir initialized in the constructor of `PathManager`. 


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @Benglin 

### FYIs

@riteshchandawar, @monikaprabhu, @sh4nnongoh 