### PR TITLE
Convert dates to a format suitable for cloudwatch

### DIFF
--- a/src/DynamoCore/Logging/DynamoLogger.cs
+++ b/src/DynamoCore/Logging/DynamoLogger.cs
@@ -169,7 +169,7 @@ namespace Dynamo.Logging
                             try
                             {
                                 ConsoleWriter.AppendLine(string.Format("{0}", message));
-                                FileWriter.WriteLine(string.Format("{0} : {1}", DateTime.Now, message));
+                                FileWriter.WriteLine(string.Format("{0} : {1}", DateTime.UtcNow.ToString("u"), message));
                                 FileWriter.Flush();
                                 RaisePropertyChanged("ConsoleWriter");
                             }
@@ -186,7 +186,7 @@ namespace Dynamo.Logging
                         {
                             try
                             {
-                                FileWriter.WriteLine(string.Format("{0} : {1}", DateTime.Now, message));
+                                FileWriter.WriteLine(string.Format("{0} : {1}", DateTime.UtcNow.ToString("u"), message));
                                 FileWriter.Flush();
                             }
                             catch
@@ -303,13 +303,14 @@ namespace Dynamo.Logging
         {
             lock (this.guardMutex)
             {
-                _logPath = Path.Combine(logDirectory, string.Format("dynamoLog_{0}.txt", Guid.NewGuid().ToString()));
+                _logPath = Path.Combine(logDirectory, string.Format("dynamoLog_{0}.txt", DateTime.UtcNow.ToString("yyyyMMddHHmmss")));
 
+                var date = DateTime.UtcNow.ToString("u");
                 FileWriter = new StreamWriter(_logPath);
-                FileWriter.WriteLine("Dynamo log started " + DateTime.Now.ToString());
+                FileWriter.WriteLine("Dynamo log started " + date);
 
                 ConsoleWriter = new StringBuilder();
-                ConsoleWriter.AppendLine("Dynamo log started " + DateTime.Now.ToString());
+                ConsoleWriter.AppendLine("Dynamo log started " + date);
             }
 
         }


### PR DESCRIPTION
### Purpose

Use UTC dates in a format that is not locale dependent.
Name dynamo logs using the date so the "latest" one can be determined properly.
Both of these are to support sending these logs to AWS CloudWatch

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [n/a] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@ikeough 

### FYIs

$ cat dynamoLog_20160415195612.txt 
Dynamo log started 2016-04-15 19:56:12Z
2016-04-15 19:56:14Z : RequestUpdateVersionInfo
2016-04-15 19:56:14Z : Requesting version update info...
2016-04-15 19:56:14Z : Dynamo -- Build 1.0.0.806
2016-04-15 19:56:14Z : Duplicate migration type registered for SunPathDirection
2016-04-15 19:56:14Z : Dynamo is up to date.
