### PR TITLE
FIX TESTS: Revert to guids for log file names.

### DIFF
--- a/src/DynamoCore/Logging/DynamoLogger.cs
+++ b/src/DynamoCore/Logging/DynamoLogger.cs
@@ -303,7 +303,10 @@ namespace Dynamo.Logging
         {
             lock (this.guardMutex)
             {
-                _logPath = Path.Combine(logDirectory, string.Format("dynamoLog_{0}.txt", DateTime.UtcNow.ToString("yyyyMMddHHmmss")));
+                // We use a guid to uniquely identify the log name. This disambiguates log files
+                // so that parallel testing which needs to access the log files can be done, and
+                // so that services like Cloud Watch can match the dynamoLog_* pattern.
+                _logPath = Path.Combine(logDirectory, string.Format("dynamoLog_{0}.txt", Guid.NewGuid()));
 
                 var date = DateTime.UtcNow.ToString("u");
                 FileWriter = new StreamWriter(_logPath);


### PR DESCRIPTION
### Purpose

In a previous PR, we changed the file names for log files to use a UTC date/time instead of a guid. This caused several test failures as the tests happen in such rapid succession that it was trying to access the same log file. Here, we revert to using a Guid, and add a comment as to why a guid is important.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
  - I've added a comment about why we use Guids in the log file name.
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

Merging immediately to fix the build.

### FYIs

@gregmarr @sharadkjaiswal 

