### PR TITLE
MAGN-9946: Catch Exception while loading binaries and continue with rest

### DIFF
--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -134,7 +134,14 @@ namespace Dynamo.PackageManager
                 {
                     if (assem.IsNodeLibrary)
                     {
-                        OnRequestLoadNodeLibrary(assem.Assembly);
+                        try
+                        {
+                            OnRequestLoadNodeLibrary(assem.Assembly);
+                        }
+                        catch(Dynamo.Exceptions.LibraryLoadFailedException ex)
+                        {
+                            Log(ex.GetType() + ": " + ex.Message);
+                        }
                     }
                 }
 


### PR DESCRIPTION
### Purpose

This PR fixes [MAGN-9946: Mantis Shrimp package does not automatically appear in node library after install](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9946).

#### Background:
Mantis Shrimp contains few binaries as well as many dyf files as a part of the package. The binaries are not to be used as a zero-touch library, rather they are consumed in the custom nodes using python scripts. Dynamo fails to load the binaries as a zero-touch library and throws an exception. Once the exception is thrown, it skips loading the entire package.

Fixed by catching the exception to ignore the failing binary and continue loading the rest of the package. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @ke-yu 
- [ ] @Benglin 

### FYIs
@riteshchandawar, @monikaprabhu, @kronz 