### PR TITLE
Add attribute KeepReferenceThis

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
+++ b/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
@@ -97,6 +97,11 @@ namespace ProtoFFI
         public string Name { get { return Info.Name; } }
 
         private bool? keepReferenceThis;
+        /// <summary>
+        /// If the member has "KeepReferenceThis" attribute, the returned
+        /// DS object will be expanded and be added a reference to "this"
+        /// object.
+        /// </summary>
         public bool KeepReferenceThis
         {
             get

--- a/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
+++ b/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
@@ -568,7 +568,7 @@ namespace ProtoFFI
         /// <summary>
         /// If dsValue is a pointer (object), expand the size of this object and
         /// add references to referencedObjects; if dsValue is an array, then
-        /// recursively do the travelling.
+        /// traverse recursively.
         ///
         /// Exception: ProtoCore.Exception.RunOutOfMemoryException if the engine
         /// fails to expand the size of object.

--- a/src/NodeServices/Attributes.cs
+++ b/src/NodeServices/Attributes.cs
@@ -312,7 +312,8 @@ namespace Autodesk.DesignScript.Runtime
     /// of scope. The life-cycle of parameter will have the same life-cycle as
     /// the return object.
     /// 
-    /// Note the return object should be reference type.
+    /// Note the type of return object should be reference type, either a
+    /// pointer or an array.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class KeepReferenceAttribute : Attribute
@@ -320,9 +321,13 @@ namespace Autodesk.DesignScript.Runtime
     }
 
     /// <summary>
-    /// This attribute indicates the return object should reference to this object.
+    /// This attribute is applied to member function of zero touch libary.
+    /// It indicates the return object should keep a reference to "this"
+    /// object so that even "this" object is out of scope, it will not be
+    /// disposed.
     ///
-    /// Note the return object should be reference type.
+    /// Note the type of return object should be reference type, either a
+    /// pointer or an array.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class KeepReferenceThisAttribute : Attribute

--- a/src/NodeServices/Attributes.cs
+++ b/src/NodeServices/Attributes.cs
@@ -318,4 +318,14 @@ namespace Autodesk.DesignScript.Runtime
     public class KeepReferenceAttribute : Attribute
     {
     }
+
+    /// <summary>
+    /// This attribute indicates the return object should reference to this object.
+    ///
+    /// Note the return object should be reference type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class KeepReferenceThisAttribute : Attribute
+    {
+    }
 }

--- a/test/DynamoCoreTests/AttributeTest.cs
+++ b/test/DynamoCoreTests/AttributeTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using Dynamo.Graph.Connectors;
 using System.IO;
+using Dynamo.Graph.Nodes.ZeroTouch;
 
 namespace Dynamo.Tests
 {
@@ -18,10 +19,14 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void TestAttributeKeepReferenceThis()
+        public void TestKeepReferenceThisAttribute()
         {
             var dynFilePath = Path.Combine(TestDirectory, @"core\dsevaluation\referenceThis.dyn");
             OpenModel(dynFilePath);
+            var node1 = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<Graph.Nodes.CustomNodes.Function>().FirstOrDefault();
+            var node2 = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DSFunction>().FirstOrDefault();
+            ConnectorModel.Make(node1, node2, 0, 0);
+            RunCurrentModel();
             AssertPreviewValue("763c4e98-dbe0-4bb7-b00f-69e5b79b09b0", new object[] { false, false });
         }
     }

--- a/test/DynamoCoreTests/AttributeTest.cs
+++ b/test/DynamoCoreTests/AttributeTest.cs
@@ -21,10 +21,37 @@ namespace Dynamo.Tests
         [Test]
         public void TestKeepReferenceThisAttribute()
         {
+            // Test KeepReferenceThisAttribute could avoid a C# object from
+            // being disposed even it is out function scope. 
+            //
+            // The .dyn file uses ReferenceThis from FFITarget.dll. Note the
+            // return value of GetItems() has reference to "this" object:
+            //
+            // class ReferenceThis {
+            //  ....
+            //  public IEnumerable<ReferenceThisItem> GetItems() {
+            //      return new [] { new ReferenceThisItem(this), ... };
+            //  }
+            // }
+            //
+            // So if we call GetItems() in a function, refThis object will be
+            // disposed and returned object has reference to disposed
+            // ReferenceThis.
+            //
+            // def foo() {
+            //   refThis = ReferenceThis();
+            //   return = refThis.GetItems();
+            // }      
+            //
+            // But if applying KeepReferenceThisAttribute, refThis will be
+            // referenced in the returned object and won't be disposed. This
+            // test case is to verify ReferenceThis.Disposed is false when 
+            // returns from a function.
             var dynFilePath = Path.Combine(TestDirectory, @"core\dsevaluation\referenceThis.dyn");
             OpenModel(dynFilePath);
             var node1 = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<Graph.Nodes.CustomNodes.Function>().FirstOrDefault();
             var node2 = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DSFunction>().FirstOrDefault();
+            // Not connect at the beginning to ensure GC() is invoked.
             ConnectorModel.Make(node1, node2, 0, 0);
             RunCurrentModel();
             AssertPreviewValue("763c4e98-dbe0-4bb7-b00f-69e5b79b09b0", new object[] { false, false });

--- a/test/DynamoCoreTests/AttributeTest.cs
+++ b/test/DynamoCoreTests/AttributeTest.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Dynamo.Graph.Connectors;
+using System.IO;
+
+namespace Dynamo.Tests
+{
+    class AttributeTest : DynamoModelTestBase
+    {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("FFITarget.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        [Test]
+        public void TestAttributeKeepReferenceThis()
+        {
+            var dynFilePath = Path.Combine(TestDirectory, @"core\dsevaluation\referenceThis.dyn");
+            OpenModel(dynFilePath);
+            AssertPreviewValue("763c4e98-dbe0-4bb7-b00f-69e5b79b09b0", new object[] { false, false });
+        }
+    }
+}

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -66,6 +66,7 @@
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
     <Compile Include="AtLevelTest.cs" />
+    <Compile Include="AttributeTest.cs" />
     <Compile Include="MultiOutputNodeTest.cs" />
     <Compile Include="NodeExecutionTest.cs" />
     <Compile Include="AnnotationModelTest.cs" />

--- a/test/Engine/FFITarget/FFITarget.csproj
+++ b/test/Engine/FFITarget/FFITarget.csproj
@@ -59,6 +59,7 @@
     <Compile Include="GlobalClass.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="ReferenceThisTest.cs" />
     <Compile Include="ReplicationTest.cs" />
     <Compile Include="TestCSharpAttribute.cs" />
     <Compile Include="DisposeTracer.cs" />

--- a/test/Engine/FFITarget/ReferenceThisTest.cs
+++ b/test/Engine/FFITarget/ReferenceThisTest.cs
@@ -1,0 +1,49 @@
+﻿using Autodesk.DesignScript.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFITarget
+{
+    public class ReferenceThisItem 
+    {
+        private ReferenceThis refThis;
+
+        public ReferenceThisItem(ReferenceThis refThis)
+        {
+            this.refThis = refThis;
+        }
+
+        public bool IsHostDisposed 
+        {
+            get { return refThis.Disposed; }
+        }
+    }
+
+    public class ReferenceThis : IDisposable 
+    {
+        private bool _disposed = false;
+        public bool Disposed
+        {
+            get { return _disposed; }
+        }
+
+        public ReferenceThis()
+        {
+            _disposed = false; 
+        }
+
+        [KeepReferenceThisAttribute]
+        public IEnumerable<ReferenceThisItem> GetItems()
+        {
+            return new List<ReferenceThisItem> { new ReferenceThisItem(this), new ReferenceThisItem(this) };
+        }
+
+        public void Dispose()
+        {
+            _disposed = true;
+        } 
+    }
+}

--- a/test/core/dsevaluation/referenceThis.dyf
+++ b/test/core/dsevaluation/referenceThis.dyf
@@ -1,0 +1,20 @@
+<Workspace Version="1.0.1.1093" X="0" Y="0" zoom="1" Name="referenceThis" Description="" ID="b68daa55-9a30-4742-8d7a-6cca4ad02ff4" Category="Test">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="ee34c572-0ea2-4263-8449-6dcd089472f6" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="ReferenceThis.ReferenceThis" x="262" y="111" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="FFITarget.dll" function="FFITarget.ReferenceThis.ReferenceThis" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="5dbda6c5-23ec-470f-84fa-8da61d6b2b11" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="ReferenceThis.GetItems" x="565" y="129" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="FFITarget.dll" function="FFITarget.ReferenceThis.GetItems" />
+    <Dynamo.Graph.Nodes.CustomNodes.Output guid="79b973b6-fa10-45c2-8319-9ebdeab6f7d4" type="Dynamo.Graph.Nodes.CustomNodes.Output" nickname="Output" x="929" y="142" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <Symbol value="items" />
+    </Dynamo.Graph.Nodes.CustomNodes.Output>
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="ee34c572-0ea2-4263-8449-6dcd089472f6" start_index="0" end="5dbda6c5-23ec-470f-84fa-8da61d6b2b11" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5dbda6c5-23ec-470f-84fa-8da61d6b2b11" start_index="0" end="79b973b6-fa10-45c2-8319-9ebdeab6f7d4" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>

--- a/test/core/dsevaluation/referenceThis.dyn
+++ b/test/core/dsevaluation/referenceThis.dyn
@@ -1,0 +1,25 @@
+<Workspace Version="1.0.1.1093" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CustomNodes.Function guid="4214577f-db6c-4859-a2fa-3c72b7dec84d" type="Dynamo.Graph.Nodes.CustomNodes.Function" nickname="referenceThis" x="212.5" y="171.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <ID value="b68daa55-9a30-4742-8d7a-6cca4ad02ff4" />
+      <Name value="referenceThis" />
+      <Description value="" />
+      <Inputs />
+      <Outputs>
+        <Output value="items" />
+      </Outputs>
+    </Dynamo.Graph.Nodes.CustomNodes.Function>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e19aef5a-ce08-4798-9a0a-5a37afefd5de" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="ReferenceThisItem.IsHostDisposed" x="466" y="145" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="FFITarget.dll" function="FFITarget.ReferenceThisItem.IsHostDisposed" />
+    <CoreNodeModels.Watch guid="763c4e98-dbe0-4bb7-b00f-69e5b79b09b0" type="CoreNodeModels.Watch" nickname="Watch" x="605" y="443" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="e19aef5a-ce08-4798-9a0a-5a37afefd5de" start_index="0" end="763c4e98-dbe0-4bb7-b00f-69e5b79b09b0" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR is to fix the issue that C# object is disposed improperly. The fix is based on #6314 which was to fix improper dispose issue in the other case. 

The root cause is the same: C# object has been disposed (because its DS wrapper object has been out of scope) but still referenced by other C# objects. Following code shows this scenario:

```
public class ReferenceThisItem 
{
    private ReferenceThis refThis;
    public ReferenceThisItem(ReferenceThis refThis)
    {
        this.refThis = refThis;
    }
}

public class ReferenceThis : IDisposable 
{
    public ReferenceThisItem GetItem()
    {
        return new ReferenceThisItem(this);
    }
}
```
Here `ReferenceThis.GetItem()` returns a `ReferenceThisItem` which internally references to `this` object of this method (`ReferenceThis`). As DesignScript has no idea of the existence of this reference, `ReferenceThis` instance will be disposed when it is out of scope, therefore `ReferenceThisItem` will reference to disposed `ReferenceThis` object.

For example, in the following DesignScript code, `thisItem` will be disposed when it is out of function scope: 
```
def foo()
{
    thisItem = ReferenceThis();
    return = thisItem.GetItem();
}
item = foo();   // now item references to a disposed C# object.
```

This PR adds a new attribute `KeepReferenceThisAttribute`. Just as the hack we did in #6314, we expand the size of returned object and add a reference to `this` object if method has this attribute. 

For example, for C# function:
```
class Foo
{
    [KeepReferenceThis]
    public Bar GetItem([KeepReference]Qux q1, Qux q2);
}
```
Calling `foo.GetItem(q1, q2)` will return an object that has the following memory layout:
```
    +----+
    |    | ----> foo
    +----+
    |    | ----> q1
    +----+
```
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 

### FYIs

@Benglin @ellensi 