### PR TITLE
set camera back to defaults...

### DIFF
--- a/doc/distrib/Samples/en-US/Basics/Basics_Basic01.dyn
+++ b/doc/distrib/Samples/en-US/Basics/Basics_Basic01.dyn
@@ -24,6 +24,6 @@
   <Annotations />
   <Presets />
   <Cameras>
-    <Camera Name="Background Preview" eyeX="-52.9205544635546" eyeY="59.8301006325637" eyeZ="255.782679907181" lookX="52.9205544635546" lookY="-57.3306006688508" lookZ="-255.782679907181" upX="0" upY="1" upZ="0" />
+    <Camera Name="Background Preview" eyeX="-16.9655136013663" eyeY="24.341577725171" eyeZ="50.6494323150915" lookX="12.4441040333119" lookY="-13.0110656299395" lookZ="-58.5449065206009" upX="-0.0812375695793365" upY="0.920504853452448" upZ="0.38219271586380" />
   </Cameras>
 </Workspace>

--- a/doc/distrib/Samples/en-US/Basics/Basics_Basic02.dyn
+++ b/doc/distrib/Samples/en-US/Basics/Basics_Basic02.dyn
@@ -46,8 +46,8 @@
   </Notes>
   <Annotations />
   <Presets />
-  <Cameras>
-    <Camera Name="Background Preview" eyeX="-52.9205544635546" eyeY="59.8301006325637" eyeZ="255.782679907181" lookX="52.9205544635546" lookY="-57.3306006688508" lookZ="-255.782679907181" upX="0" upY="1" upZ="0" />
+ <Cameras>
+    <Camera Name="Background Preview" eyeX="-16.9655136013663" eyeY="24.341577725171" eyeZ="50.6494323150915" lookX="12.4441040333119" lookY="-13.0110656299395" lookZ="-58.5449065206009" upX="-0.0812375695793365" upY="0.920504853452448" upZ="0.38219271586380" />
   </Cameras>
   <SessionTraceData>
     <NodeTraceData NodeId="859b30ae-f9f0-4226-8e08-96b5066e31c7">

--- a/doc/distrib/Samples/en-US/Basics/Basics_Basic03.dyn
+++ b/doc/distrib/Samples/en-US/Basics/Basics_Basic03.dyn
@@ -37,6 +37,6 @@
   <Annotations />
   <Presets />
   <Cameras>
-    <Camera Name="Background Preview" eyeX="-52.9205544635546" eyeY="59.8301006325637" eyeZ="255.782679907181" lookX="52.9205544635546" lookY="-57.3306006688508" lookZ="-255.782679907181" upX="0" upY="1" upZ="0" />
+    <Camera Name="Background Preview" eyeX="-16.9655136013663" eyeY="24.341577725171" eyeZ="50.6494323150915" lookX="12.4441040333119" lookY="-13.0110656299395" lookZ="-58.5449065206009" upX="-0.0812375695793365" upY="0.920504853452448" upZ="0.38219271586380" />
   </Cameras>
 </Workspace>


### PR DESCRIPTION
### Purpose
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9956

These basic samples were created in .7x of Dynamo and did not have a camera element in the .dyn. When they were re-saved in 90 they had a camera element added.

I've simply added a camera element with the same values as the default values of the camera so the camera will be placed in the same position as the older samples.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@QilongTang 

### FYIs

@jnealb 