### PR TITLE
Check if ast list is empty before delta execution

### DIFF
--- a/src/Engine/ProtoCore/AssociativeGraph.cs
+++ b/src/Engine/ProtoCore/AssociativeGraph.cs
@@ -384,7 +384,7 @@ namespace ProtoCore.AssociativeEngine
             {
                 foreach (AssociativeGraph.GraphNode graphNode in graphNodes)
                 {
-                    if (graphNode.isDirty)
+                    if (graphNode.isDirty && graphNode.isActive)
                     {
                         return true;
                     }

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1544,9 +1544,12 @@ namespace ProtoScript.Runners
                 System.Diagnostics.Debug.WriteLine(code);
             }
 
-            ResetForDeltaExecution();
-            CompileAndExecute(dispatchASTList);
-            PostExecution();
+            if (dispatchASTList.Any())
+            {
+                ResetForDeltaExecution();
+                CompileAndExecute(dispatchASTList);
+                PostExecution();
+            }
         }
 
         private List<Guid> PreviewInternal(GraphSyncData syncData)

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1544,12 +1544,9 @@ namespace ProtoScript.Runners
                 System.Diagnostics.Debug.WriteLine(code);
             }
 
-            if (dispatchASTList.Any())
-            {
-                ResetForDeltaExecution();
-                CompileAndExecute(dispatchASTList);
-                PostExecution();
-            }
+            ResetForDeltaExecution();
+            CompileAndExecute(dispatchASTList);
+            PostExecution();
         }
 
         private List<Guid> PreviewInternal(GraphSyncData syncData)
@@ -1578,9 +1575,12 @@ namespace ProtoScript.Runners
             changeSetComputer.UpdateCachedASTFromSubtrees(syncData.ModifiedSubtrees);
 
             // Prior to execution, apply state modifications to the VM given the delta AST's
+            bool anyForcedExecutedNodes = changeSetComputer.csData.ForceExecuteASTList.Any();
             changeSetApplier.Apply(runnerCore, runtimeCore, changeSetComputer.csData);
-
-            CompileAndExecuteForDeltaExecution(finalDeltaAstList);
+            if (finalDeltaAstList.Any() || anyForcedExecutedNodes)
+            {
+                CompileAndExecuteForDeltaExecution(finalDeltaAstList);
+            }
 
             var guids = runtimeCore.ExecutedAstGuids.ToList();
             executedAstGuids[syncData.SessionID] = guids;


### PR DESCRIPTION
### Purpose

This is to fix defect [MAGN-9944 Dynamo crashes when modifying input of custom node](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9944).

The "index out of range" exception is because the engine incorrectly execute instructions
```
push null
retb
```
in `LiveRunner.PostExecution()` in delta execution. `retb` instruction pops a `StackFrame` and `LiveRunner.ApplyUpdate()` tries to pop a `StackFrame` again.

If the dispatch AST list is empty, `LiveRunner.PostExecution()` shouldn't be invoked.s

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 

### FYIs

@riteshchandawar @monikaprabhu 

