### PR TITLE
Clean up ProcedureNode.UpdatedGlobalVariables

### DIFF
--- a/src/Engine/ProtoCore/ProcedureTable.cs
+++ b/src/Engine/ProtoCore/ProcedureTable.cs
@@ -173,10 +173,6 @@ namespace ProtoCore.DSASM
         {
             get; set;
         }
-        public Stack<UpdateNodeRef> UpdatedGlobalVariables
-        {
-            get; set;
-        }
         public Stack<UpdateNodeRef> UpdatedProperties
         {
             get; set;
@@ -207,7 +203,6 @@ namespace ProtoCore.DSASM
             IsActive = true;
             ChildCodeBlocks = new List<int>();
 
-            UpdatedGlobalVariables = new Stack<AssociativeGraph.UpdateNodeRef>();
             UpdatedProperties = new Stack<AssociativeGraph.UpdateNodeRef>();
             UpdatedArgumentProperties = new Dictionary<string, List<AssociativeGraph.UpdateNodeRef>>();
             GraphNodeList = new List<GraphNode>();
@@ -238,7 +233,6 @@ namespace ProtoCore.DSASM
             ChildCodeBlocks = new List<int>(rhs.ChildCodeBlocks);
 
             // Runtime properties are initialized
-            UpdatedGlobalVariables = new Stack<AssociativeGraph.UpdateNodeRef>();
             UpdatedProperties = new Stack<AssociativeGraph.UpdateNodeRef>();
             UpdatedArgumentProperties = new Dictionary<string, List<AssociativeGraph.UpdateNodeRef>>();
             GraphNodeList = new List<GraphNode>();


### PR DESCRIPTION
### Purpose

In https://github.com/DynamoDS/Dynamo/pull/6516 we have make variables in function be local variables, so it not necessary to record all changed global variables in `ProcedureNode`. Remove this field (`ProcedureNode.UpdatedGlobalVariables`).

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@Benglin 