### PR TITLE
MAGN-9903 Change the preview bubble pin icon to a more recognizable icon

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -107,5 +107,5 @@
     <SolidColorBrush x:Key="PinnedIconForegroundColor" Color="#FFFFFF" />
     <SolidColorBrush x:Key="UnpinnedIconBackgroundColor" Color="White" />
     <SolidColorBrush x:Key="PinnedIconBackgroundColor" Color="#FF5E5C5A" />
-    <SolidColorBrush x:Key="PinnedIconHoverBackgroundColor" Color="#E6E6E6" />
+    <SolidColorBrush x:Key="PinnedIconHoverBackgroundColor" Color="#c6c6c6" />
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -220,7 +220,7 @@
                 <Border BorderThickness="0"
                         MouseLeftButtonDown="OnMapPinMouseClick">
                     <fa:ImageAwesome Name="PinnIcon"
-                                     Icon="MapPin"
+                                     Icon="ThumbTack"
                                      Foreground="{Binding RelativeSource={RelativeSource FindAncestor, 
                                                           AncestorType={x:Type uicontrols:PreviewControl}}, 
                                                           Path=StaysOpen,


### PR DESCRIPTION
### Purpose

Change icon, so now it looks as next.
- Pin icon when pinned:

![image](https://cloud.githubusercontent.com/assets/7658189/14818257/d684c8ba-0bc4-11e6-9492-3793de835ada.png)
- Pin icon when pinned and mouse is over the icon (background is darker now, so the white icon is more recognizable):

![image](https://cloud.githubusercontent.com/assets/7658189/14818271/e7dc4976-0bc4-11e6-8a57-89e509841b2a.png)
- Pin icon when unpinned:

![image](https://cloud.githubusercontent.com/assets/7658189/14818122/f3c2930e-0bc3-11e6-8edc-d69683701e97.png)
- Pin icon when unpinned and mouse is over the icon:

![image](https://cloud.githubusercontent.com/assets/7658189/14818174/37995c98-0bc4-11e6-93bb-fdc5393d40a7.png)


### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@pbidenko 

### FYIs

@Racel 