### PR TITLE
MAGN-9890 Preview Bubbles should not appear when user is connecting wires, box-selecting nodes

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -415,11 +415,8 @@ namespace Dynamo.Controls
             // Always set old ZIndex to the last value, even if mouse is not over the node.
             oldZIndex = NodeViewModel.StaticZIndex;
 
-            // Preview is hidden.
-            // Or preview shouldn't be shown for some nodes (e.g. number sliders, watch nodes etc.)
-            // Or node is frozen.
             // There is no need run further.
-            if (!previewEnabled || !ViewModel.IsPreviewInsetVisible || ViewModel.IsFrozen) return; 
+            if (IsPreviewDisabled()) return; 
 
             if (PreviewControl.IsInTransition) // In transition state, come back later.
                 return;
@@ -435,6 +432,18 @@ namespace Dynamo.Controls
             }
 
             Dispatcher.DelayInvoke(previewDelay, BringToFront);
+        }
+
+        private bool IsPreviewDisabled()
+        {
+            // True if a connector is being created now
+            // Or the user is selecting nodes
+            // Or preview is disabled for this node
+            // Or preview shouldn't be shown for some nodes (e.g. number sliders, watch nodes etc.)
+            // Or node is frozen.
+            return ViewModel.WorkspaceViewModel.IsConnecting || 
+                ViewModel.WorkspaceViewModel.IsSelecting || !previewEnabled ||
+                !ViewModel.IsPreviewInsetVisible || ViewModel.IsFrozen;
         }
 
         private void OnNodeViewMouseLeave(object sender, MouseEventArgs e)


### PR DESCRIPTION
### Purpose

No preview bubble appears when user is creating a connector:

![image](https://cloud.githubusercontent.com/assets/7658189/14819233/ca9d7dbc-0bc9-11e6-92ea-cbf2dc61ea4f.png)

And when user is selecting nodes with box:

![image](https://cloud.githubusercontent.com/assets/7658189/14819372/8d69d2dc-0bca-11e6-919a-ed54d34cdadc.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@pbidenko 