### PR TITLE
Throw an exception when a node can't be created by a command.

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -67,7 +67,9 @@ namespace Dynamo.Models
         {
             var node = GetNodeFromCommand(command);
             if (node == null)
-                return;
+            {
+                throw new Exception("Could not create node: " + command.Name);
+            }
 
             node.X = command.X;
             node.Y = command.Y;


### PR DESCRIPTION
### Purpose
This is a continuation of work for [frac-282](https://jira.autodesk.com/browse/FRAC-282). Reach uses Dynamo's `RecordableCommand` types. The `CreateNodeCommand` is used when the client (Flood) wants to construct a workspace on the server (Reach). If the type that corresponds to a `CreateNodeCommand` does not exist on the server, the execution of the command fails silently. In order to surface a message on the client about the failure to create certain nodes, we need to know when those failures occur. Here, I throw an exception when the creation of a node fails. This exception is caught in Reach by the `TolerantCommandVerifier`.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files **n/a**
- [x] All tests pass using the self-service CI. (The excel tests do not pass. @limrzx is this a known issue with the self-service CI?)
- [ ] Snapshot of UI changes, if any. **n/a**

### Reviewers

@mjkkirschner 

@Benglin - I'm not sure if you remember much about the `RecordableCommand` types. But I'm wondering why we don't throw any exceptions when nodes are not created.

