### PR TITLE
Implementing transforms for render packages

### DIFF
--- a/src/DynamoCore/Visualization/DefaultRenderPackageFactory.cs
+++ b/src/DynamoCore/Visualization/DefaultRenderPackageFactory.cs
@@ -191,6 +191,46 @@ namespace Dynamo.Visualization
         }
 
         /// <summary>
+        /// sets the transform that will be applied to all geometry in the renderPackage
+        /// </summary>
+        /// <param name="m11"></param>
+        /// <param name="m12"></param>
+        /// <param name="m13"></param>
+        /// <param name="m14"></param>
+        /// <param name="m21"></param>
+        /// <param name="m22"></param>
+        /// <param name="m23"></param>
+        /// <param name="m24"></param>
+        /// <param name="m31"></param>
+        /// <param name="m32"></param>
+        /// <param name="m33"></param>
+        /// <param name="m34"></param>
+        /// <param name="m41"></param>
+        /// <param name="m42"></param>
+        /// <param name="m43"></param>
+        /// <param name="m44"></param>
+        public void SetTransform(double m11, double m12, double m13, double m14,
+            double m21, double m22, double m23, double m24,
+            double m31, double m32, double m33, double m34,
+            double m41, double m42, double m43, double m44)
+        {
+            this.Transform = new double[] { m11, m12, m13, m14,
+                m21, m22, m23, m24,
+                m31, m32, m33, m34,
+                m41, m42, m43, m44 };
+        }
+
+        /// <summary>
+        /// sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
+        /// </summary>
+        /// <param name="matrix"></param>
+        public void SetTransform(double[] matrix)
+        {
+            this.Transform = matrix;
+        }
+
+
+        /// <summary>
         /// Clear all render data from the render package.
         /// </summary>
         public void Clear()
@@ -215,6 +255,10 @@ namespace Dynamo.Visualization
             IsSelected = false;
             RequiresPerVertexColoration = false;
             DisplayLabels = false;
+            Transform = new double[] {1,0,0,0,
+                                       0,1,0,0,
+                                       0,0,1,0,
+                                       0,0,0,1};
         }
 
         /// <summary>
@@ -268,6 +312,11 @@ namespace Dynamo.Visualization
         {
             get { return meshVertices.Count / 3; }
         }
+
+        /// <summary>
+        /// a 4x4 matrix which is used to transform all geometry in the render packaage
+        /// </summary>
+        public double[] Transform { get; private set; }
 
         /// <summary>
         /// Returns the collection of int values representing how many vertices

--- a/src/DynamoCore/Visualization/DefaultRenderPackageFactory.cs
+++ b/src/DynamoCore/Visualization/DefaultRenderPackageFactory.cs
@@ -189,11 +189,7 @@ namespace Dynamo.Visualization
             this.colors = colors;
             Colors = this.colors;
         }
-
-       
-
-       
-
+        
         /// <summary>
         /// Clear all render data from the render package.
         /// </summary>
@@ -219,7 +215,6 @@ namespace Dynamo.Visualization
             IsSelected = false;
             RequiresPerVertexColoration = false;
             DisplayLabels = false;
-           
         }
 
         /// <summary>

--- a/src/DynamoCore/Visualization/DefaultRenderPackageFactory.cs
+++ b/src/DynamoCore/Visualization/DefaultRenderPackageFactory.cs
@@ -190,45 +190,9 @@ namespace Dynamo.Visualization
             Colors = this.colors;
         }
 
-        /// <summary>
-        /// sets the transform that will be applied to all geometry in the renderPackage
-        /// </summary>
-        /// <param name="m11"></param>
-        /// <param name="m12"></param>
-        /// <param name="m13"></param>
-        /// <param name="m14"></param>
-        /// <param name="m21"></param>
-        /// <param name="m22"></param>
-        /// <param name="m23"></param>
-        /// <param name="m24"></param>
-        /// <param name="m31"></param>
-        /// <param name="m32"></param>
-        /// <param name="m33"></param>
-        /// <param name="m34"></param>
-        /// <param name="m41"></param>
-        /// <param name="m42"></param>
-        /// <param name="m43"></param>
-        /// <param name="m44"></param>
-        public void SetTransform(double m11, double m12, double m13, double m14,
-            double m21, double m22, double m23, double m24,
-            double m31, double m32, double m33, double m34,
-            double m41, double m42, double m43, double m44)
-        {
-            this.Transform = new double[] { m11, m12, m13, m14,
-                m21, m22, m23, m24,
-                m31, m32, m33, m34,
-                m41, m42, m43, m44 };
-        }
+       
 
-        /// <summary>
-        /// sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
-        /// </summary>
-        /// <param name="matrix"></param>
-        public void SetTransform(double[] matrix)
-        {
-            this.Transform = matrix;
-        }
-
+       
 
         /// <summary>
         /// Clear all render data from the render package.
@@ -255,10 +219,7 @@ namespace Dynamo.Visualization
             IsSelected = false;
             RequiresPerVertexColoration = false;
             DisplayLabels = false;
-            Transform = new double[] {1,0,0,0,
-                                       0,1,0,0,
-                                       0,0,1,0,
-                                       0,0,0,1};
+           
         }
 
         /// <summary>
@@ -312,11 +273,6 @@ namespace Dynamo.Visualization
         {
             get { return meshVertices.Count / 3; }
         }
-
-        /// <summary>
-        /// a 4x4 matrix which is used to transform all geometry in the render packaage
-        /// </summary>
-        public double[] Transform { get; private set; }
 
         /// <summary>
         /// Returns the collection of int values representing how many vertices

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -88,9 +88,6 @@
       <HintPath>Y:\Dynamo\extern\ProtoGeometry\ProtoGeometry.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ProtoInterface">
-      <HintPath>..\..\extern\ProtoGeometry\ProtoInterface.dll</HintPath>
-    </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
       <Private>True</Private>

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -83,6 +83,14 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>Y:\Dynamo\extern\ProtoGeometry\ProtoGeometry.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ProtoInterface">
+      <HintPath>..\..\extern\ProtoGeometry\ProtoInterface.dll</HintPath>
+    </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
       <Private>True</Private>

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -66,12 +66,12 @@ namespace Dynamo.Wpf.Rendering
         #region ITransformable implementation
 
         /// <summary>
-        /// A 4x4 matrix which is used to transform all geometry in the render packaage
+        /// A 4x4 matrix that is used to transform all geometry in the render packaage.
         /// </summary>
         public double[] Transform { get; private set; }
 
         /// <summary>
-        /// Sets the transform that will be applied to all geometry in the renderPackage
+        /// Set the transform that is applied to all geometry in the renderPackage.
         /// </summary>
         /// <param name="transform"></param>
         public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
@@ -91,8 +91,8 @@ namespace Dynamo.Wpf.Rendering
         }
 
         /// <summary>
-        /// Sets the transform that will be applied to all geometry in the renderPackage
-        /// by computing the matrix that transforms between from and to
+        /// Set the transform that is applied to all geometry in the renderPackage
+        /// by computing the matrix that transforms between from and to.
         /// </summary>
         /// <param name="from"></param>
         /// <param name="to"></param>
@@ -106,14 +106,14 @@ namespace Dynamo.Wpf.Rendering
 
 
         /// <summary>
-        /// Sets the transform that will be applied to all geometry in the renderPackage
+        /// Set the transform that is applied to all geometry in the renderPackage,
         /// as this is a helix specific implementation it should be noted that the this matrix
         /// should be as follows when converting from a ProtoGeometry/Dynamo CoordinateSystem
         /// [ xaxis.X, xaxis.Z, -xaxis.Y, 0,
         /// zaxis.X, zaxis.Z, -zaxis.Y, 0,
         /// -yaxis.X, -yaxis.Z, yaxis.Y, 0,
         /// org.X, org.Z, -org.Y, 1 ]
-        /// as Helix and Dynamo have their Y and Z axes reversed
+        /// as Helix and Dynamo have their Y and Z axes reversed.
         /// </summary>
         /// <param name="m11"></param>
         /// <param name="m12"></param>
@@ -143,7 +143,7 @@ namespace Dynamo.Wpf.Rendering
         }
 
         /// <summary>
-        /// Sets the transform as a double array, this transform will be applied to all geometry in the renderPackage.
+        /// Set the transform as a double array, this transform is applied to all geometry in the renderPackage.
         /// NOTE: this matrix is assumed to be in row vector form, and will be transformed into the neccesary form
         /// for helix
         /// </summary>

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -36,7 +36,7 @@ namespace Dynamo.Wpf.Rendering
     /// <summary>
     /// A Helix-specifc IRenderPackage implementation.
     /// </summary>
-    public class HelixRenderPackage : IRenderPackage
+    public class HelixRenderPackage : IRenderPackage, Autodesk.DesignScript.Interfaces.ITransformable
     {
         #region private members
 
@@ -62,19 +62,13 @@ namespace Dynamo.Wpf.Rendering
 
         #endregion
 
-        #region IRenderPackage implementation
 
-        public void SetColors(byte[] colors)
-        {
-            this.colors = colors;
-        }
-
-       
+        #region ITransformable implementation
         /// <summary>
         /// sets the transform that will be applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="transform"></param>
-        private void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
+        public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
         {
             var xaxis = transform.XAxis;
             var yaxis = transform.YAxis;
@@ -96,7 +90,7 @@ namespace Dynamo.Wpf.Rendering
         /// </summary>
         /// <param name="from"></param>
         /// <param name="to"></param>
-        private void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem from, Autodesk.DesignScript.Geometry.CoordinateSystem to)
+        public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem from, Autodesk.DesignScript.Geometry.CoordinateSystem to)
         {
             var inverse = from.Inverse();
             var final = inverse.PreMultiplyBy(to);
@@ -131,12 +125,12 @@ namespace Dynamo.Wpf.Rendering
         /// <param name="m42"></param>
         /// <param name="m43"></param>
         /// <param name="m44"></param>
-        private void SetTransform(double m11,double m12, double m13, double m14,
+        public void SetTransform(double m11, double m12, double m13, double m14,
             double m21, double m22, double m23, double m24,
             double m31, double m32, double m33, double m34,
-            double m41, double m42, double m43, double m44 )
+            double m41, double m42, double m43, double m44)
         {
-            this.Transform =  new System.Windows.Media.Media3D.Matrix3D(m11, m12, m13, m14,
+            this.Transform = new System.Windows.Media.Media3D.Matrix3D(m11, m12, m13, m14,
                 m21, m22, m23, m24,
                 m31, m32, m33, m34,
                 m41, m42, m43, m44).ToArray();
@@ -146,9 +140,17 @@ namespace Dynamo.Wpf.Rendering
         /// sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="matrix"></param>
-        private void SetTransform(double[] matrix)
+        public void SetTransform(double[] matrix)
         {
             this.Transform = matrix;
+        }
+        #endregion
+
+        #region IRenderPackage implementation
+
+        public void SetColors(byte[] colors)
+        {
+            this.colors = colors;
         }
 
         public void Clear()
@@ -615,7 +617,7 @@ namespace Dynamo.Wpf.Rendering
         private static Vector3 Vector3ForYUp(double x, double y, double z)
         {
             return new Vector3((float)x, (float)z, (float)-y);
-        } 
+        }
     }
 
     internal static class HelixRenderExtensions

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -46,7 +46,7 @@ namespace Dynamo.Wpf.Rendering
         private bool hasData;
         private List<int> lineStripVertexCounts;
         private byte[] colors;
-        private System.Windows.Media.Media3D.Transform3D transform;
+        private System.Windows.Media.Media3D.Matrix3D transform;
 
         #endregion
 
@@ -58,7 +58,7 @@ namespace Dynamo.Wpf.Rendering
             lines = InitLineGeometry();
             mesh = InitMeshGeometry();
             lineStripVertexCounts = new List<int>();
-            transform = new System.Windows.Media.Media3D.MatrixTransform3D(System.Windows.Media.Media3D.Matrix3D.Identity);
+            transform = System.Windows.Media.Media3D.Matrix3D.Identity;
         }
 
         #endregion
@@ -72,8 +72,16 @@ namespace Dynamo.Wpf.Rendering
 
         public void SetTransform(ICoordinateSystemEntity transform)
         {
-            transform.XAxis
-            transform = new System.Windows.Media.Media3D.Matrix3D().
+            var xaxis = transform.XAxis;
+            var yaxis = transform.YAxis;
+            var zaxis = transform.ZAxis;
+            var org = transform.Origin;
+
+            var csAsMat = new System.Windows.Media.Media3D.Matrix3D(xaxis.X, xaxis.Y, xaxis.Z, org.X,
+                                                                    yaxis.X, yaxis.X, yaxis.Z, org.Y,
+                                                                    zaxis.X, zaxis.Y, zaxis.Z, org.Z,
+                                                                    0, 0, 0, 1);
+            this.transform = csAsMat;
         }
 
         public void Clear()
@@ -345,6 +353,14 @@ namespace Dynamo.Wpf.Rendering
                     lines.Positions.Count > 0 ||
                     mesh.Positions.Count > 0;
                 return hasData;
+            }
+        }
+
+        public System.Windows.Media.Media3D.Matrix3D Transform
+        {
+            get
+            {
+                return transform;
             }
         }
 

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -71,7 +71,7 @@ namespace Dynamo.Wpf.Rendering
         }
 
         /// <summary>
-        /// sets the transform that will applied to all geometry in the renderPackage
+        /// sets the transform that will applied to all geometry in the renderPackage.
         /// </summary>
         /// <param name="transform"></param>
         public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
@@ -89,7 +89,9 @@ namespace Dynamo.Wpf.Rendering
         }
         
         /// <summary>
-        /// 
+        /// computes change of basis matrix between from and to coordinateSystems
+        /// and sets this as the transform that will be applied to all geometery
+        /// in the render package.
         /// </summary>
         /// <param name="from"></param>
         /// <param name="to"></param>

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -46,8 +46,7 @@ namespace Dynamo.Wpf.Rendering
         private bool hasData;
         private List<int> lineStripVertexCounts;
         private byte[] colors;
-        private System.Windows.Media.Media3D.Matrix3D transform;
-
+        
         #endregion
 
         #region constructors
@@ -58,7 +57,7 @@ namespace Dynamo.Wpf.Rendering
             lines = InitLineGeometry();
             mesh = InitMeshGeometry();
             lineStripVertexCounts = new List<int>();
-            transform = System.Windows.Media.Media3D.Matrix3D.Identity;
+            Transform = System.Windows.Media.Media3D.Matrix3D.Identity.ToArray();
         }
 
         #endregion
@@ -88,7 +87,7 @@ namespace Dynamo.Wpf.Rendering
                                                                       org.X, org.Z, -org.Y, 1);
 
 
-            this.transform = csAsMat;
+            this.Transform = csAsMat.ToArray();
         }
 
         /// <summary>
@@ -137,10 +136,19 @@ namespace Dynamo.Wpf.Rendering
             double m31, double m32, double m33, double m34,
             double m41, double m42, double m43, double m44 )
         {
-            this.transform =  new System.Windows.Media.Media3D.Matrix3D(m11, m12, m13, m14,
+            this.Transform =  new System.Windows.Media.Media3D.Matrix3D(m11, m12, m13, m14,
                 m21, m22, m23, m24,
                 m31, m32, m33, m34,
-                m41, m42, m43, m44);
+                m41, m42, m43, m44).ToArray();
+        }
+
+        /// <summary>
+        /// sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
+        /// </summary>
+        /// <param name="matrix"></param>
+        public void SetTransform(double[] matrix)
+        {
+            this.Transform = matrix;
         }
 
         public void Clear()
@@ -156,7 +164,7 @@ namespace Dynamo.Wpf.Rendering
 
             lineStripVertexCounts.Clear();
 
-            transform = System.Windows.Media.Media3D.Matrix3D.Identity;
+            Transform = System.Windows.Media.Media3D.Matrix3D.Identity.ToArray();
 
             IsSelected = false;
             DisplayLabels = false;
@@ -416,16 +424,6 @@ namespace Dynamo.Wpf.Rendering
                 return hasData;
             }
         }
-        /// <summary>
-        /// a 4x4 matrix which is used to transform all geometry in the render packaage
-        /// </summary>
-        public System.Windows.Media.Media3D.Matrix3D Transform
-        {
-            get
-            {
-                return transform;
-            }
-        }
 
         /// <summary>
         /// A flag indicating whether the render package is displaying labels
@@ -461,6 +459,11 @@ namespace Dynamo.Wpf.Rendering
         {
             get { return mesh.Positions.Count; }
         }
+
+        /// <summary>
+        /// a 4x4 matrix which is used to transform all geometry in the render packaage
+        /// </summary>
+        public double[] Transform { get; private set; }
 
         public IEnumerable<int> LineStripVertexCounts
         {
@@ -661,6 +664,26 @@ namespace Dynamo.Wpf.Rendering
             }
 
             return colors;
+        }
+
+        public static double[] ToArray(this System.Windows.Media.Media3D.Matrix3D mat)
+        {
+            return new double[] {mat.M11,mat.M12,mat.M13,mat.M14,
+                mat.M21,mat.M22,mat.M23,mat.M24,
+                mat.M31,mat.M32,mat.M33,mat.M34,
+                mat.OffsetX,mat.OffsetY,mat.OffsetZ,mat.M14,
+            };
+
+        }
+
+        public static System.Windows.Media.Media3D.Matrix3D ToMatrix3D(this double[] matArray)
+        {
+            return new System.Windows.Media.Media3D.Matrix3D(
+                matArray[0], matArray[1], matArray[2], matArray[3],
+                matArray[4], matArray[5], matArray[6], matArray[7],
+                matArray[8], matArray[9], matArray[10], matArray[11],
+                matArray[12], matArray[13], matArray[14], matArray[15]);
+
         }
     }
 }

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -671,7 +671,7 @@ namespace Dynamo.Wpf.Rendering
             return new double[] {mat.M11,mat.M12,mat.M13,mat.M14,
                 mat.M21,mat.M22,mat.M23,mat.M24,
                 mat.M31,mat.M32,mat.M33,mat.M34,
-                mat.OffsetX,mat.OffsetY,mat.OffsetZ,mat.M14,
+                mat.OffsetX,mat.OffsetY,mat.OffsetZ,mat.M44,
             };
 
         }

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -64,8 +64,14 @@ namespace Dynamo.Wpf.Rendering
 
 
         #region ITransformable implementation
+
         /// <summary>
-        /// sets the transform that will be applied to all geometry in the renderPackage
+        /// A 4x4 matrix which is used to transform all geometry in the render packaage
+        /// </summary>
+        public double[] Transform { get; private set; }
+
+        /// <summary>
+        /// Sets the transform that will be applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="transform"></param>
         public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
@@ -85,7 +91,7 @@ namespace Dynamo.Wpf.Rendering
         }
 
         /// <summary>
-        /// sets the transform that will be applied to all geometry in the renderPackage
+        /// Sets the transform that will be applied to all geometry in the renderPackage
         /// by computing the matrix that transforms between from and to
         /// </summary>
         /// <param name="from"></param>
@@ -100,7 +106,7 @@ namespace Dynamo.Wpf.Rendering
 
 
         /// <summary>
-        /// sets the transform that will be applied to all geometry in the renderPackage
+        /// Sets the transform that will be applied to all geometry in the renderPackage
         /// as this is a helix specific implementation it should be noted that the this matrix
         /// should be as follows when converting from a ProtoGeometry/Dynamo CoordinateSystem
         /// [ xaxis.X, xaxis.Z, -xaxis.Y, 0,
@@ -137,7 +143,7 @@ namespace Dynamo.Wpf.Rendering
         }
 
         /// <summary>
-        /// sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
+        /// Sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="matrix"></param>
         public void SetTransform(double[] matrix)
@@ -461,11 +467,6 @@ namespace Dynamo.Wpf.Rendering
         {
             get { return mesh.Positions.Count; }
         }
-
-        /// <summary>
-        /// a 4x4 matrix which is used to transform all geometry in the render packaage
-        /// </summary>
-        public double[] Transform { get; private set; }
 
         public IEnumerable<int> LineStripVertexCounts
         {

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -76,6 +76,73 @@ namespace Dynamo.Wpf.Rendering
         /// <param name="transform"></param>
         public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
         {
+            var worldcs = Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0,0,0);
+            var transformAboutWorldX = transform.Rotate(worldcs.Origin, worldcs.XAxis, -90);
+            var transformYup = transformAboutWorldX.Rotate(transformAboutWorldX.Origin, transformAboutWorldX.XAxis, 90);
+            
+            var xaxis = transformYup.XAxis;
+            var yaxis = transformYup.YAxis;
+            var zaxis = transformYup.ZAxis;
+            var org = transformYup.Origin;
+
+               var csAsMat = new System.Windows.Media.Media3D.Matrix3D( xaxis.X, xaxis.Y, xaxis.Z, 0,
+                                                                        yaxis.X, yaxis.Y, yaxis.Z, 0,
+                                                                        zaxis.X, zaxis.Y, zaxis.Z, 0,
+                                                                        org.X, org.Y,org.Z, 1);
+
+            //   var csAsMat = new System.Windows.Media.Media3D.Matrix3D(-xaxis.X, -xaxis.Z, -xaxis.Y, 0,
+            //                                                        zaxis.X, zaxis.Z, zaxis.Y, 0,
+            //                                                        yaxis.X, yaxis.Z, yaxis.Y, 0,
+            //                                                        org.X, org.Z,-org.Y, 1);
+            this.transform = csAsMat;
+            
+        }
+        
+        public void SetTransformDirect(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
+        {
+            var xaxis = transform.XAxis;
+            var yaxis = transform.YAxis;
+            var zaxis = transform.ZAxis;
+            var org = transform.Origin;
+
+            var csAsMat = new System.Windows.Media.Media3D.Matrix3D(xaxis.X, xaxis.Y, xaxis.Z, 0,
+                                                                         yaxis.X, yaxis.Y, yaxis.Z, 0,
+                                                                         zaxis.X, zaxis.Y, zaxis.Z, 0,
+                                                                         org.X, org.Y, org.Z, 1);
+            csAsMat.Prepend(new System.Windows.Media.Media3D.Matrix3D
+                (1, 0, 0, 0
+                , 0, 0, -1, 0,
+                0, 1, 0, 0,
+                0, 0, 0, 1));
+
+            csAsMat.Append(new System.Windows.Media.Media3D.Matrix3D
+               (1, 0, 0, 0
+               , 0, 0, -1, 0,
+               0, 1, 0, 0,
+               0, 0, 0, 1));
+
+            this.transform = csAsMat;
+
+
+
+            var worldcs = Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0, 0, 0);
+            var transformAboutWorldX = transform.Rotate(worldcs.Origin, worldcs.XAxis, -90);
+            var transformYup = transformAboutWorldX.Rotate(transformAboutWorldX.Origin, transformAboutWorldX.XAxis, 90);
+
+            var xaxis2 = transformYup.XAxis;
+            var yaxis2 = transformYup.YAxis;
+            var zaxis2 = transformYup.ZAxis;
+            var org2 = transformYup.Origin;
+
+            var csAsMat2 = new System.Windows.Media.Media3D.Matrix3D(xaxis2.X, xaxis2.Y, xaxis2.Z, 0,
+                                                                     yaxis2.X, yaxis2.Y, yaxis2.Z, 0,
+                                                                     zaxis2.X, zaxis2.Y, zaxis2.Z, 0,
+                                                                     org2.X, org2.Y, org2.Z, 1);
+
+        }
+
+        public void SetTransformDirect2(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
+        {
             var xaxis = transform.XAxis;
             var yaxis = transform.YAxis;
             var zaxis = transform.ZAxis;
@@ -83,11 +150,13 @@ namespace Dynamo.Wpf.Rendering
 
             var csAsMat = new System.Windows.Media.Media3D.Matrix3D(xaxis.X, xaxis.Z, -xaxis.Y, 0,
                                                                     zaxis.X, zaxis.Z, -zaxis.Y, 0,
-                                                                    yaxis.X, yaxis.Z, -yaxis.Y, 0,
-                                                                    org.X, org.Z,-org.Y, 1);
+                                                                    -yaxis.X, -yaxis.Z, yaxis.Y, 0,
+                                                                      org.X, org.Z, -org.Y, 1);
+
+
             this.transform = csAsMat;
         }
-        
+
         /// <summary>
         /// 
         /// </summary>
@@ -106,10 +175,10 @@ namespace Dynamo.Wpf.Rendering
         /// sets the transform that will be applied to all geometry in the renderPackage
         /// as this is a helix specific implementation it should be noted that the this matrix
         /// should be as follows when converting from a ProtoGeometry/Dynamo CoordinateSystem
-        /// [xaxis.X, xaxis.Z, -xaxis.Y, 0,
-        ///  zaxis.X, zaxis.Z, -zaxis.Y, 0,
-        /// yaxis.X, yaxis.Z, -yaxis.Y, 0,
-        /// org.X, org.Z, -org.Y, 1] 
+        /// [ xaxis.X, xaxis.Z, -xaxis.Y, 0,
+        /// zaxis.X, zaxis.Z, -zaxis.Y, 0,
+        /// -yaxis.X, -yaxis.Z, yaxis.Y, 0,
+        /// org.X, org.Z, -org.Y, 1 ]
         /// as Helix and Dynamo have their Y and Z axes reversed
         /// </summary>
         /// <param name="m11"></param>

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -71,7 +71,7 @@ namespace Dynamo.Wpf.Rendering
         }
 
         /// <summary>
-        /// sets the transform that will applied to all geometry in the renderPackage.
+        /// sets the transform that will applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="transform"></param>
         public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
@@ -89,16 +89,14 @@ namespace Dynamo.Wpf.Rendering
         }
         
         /// <summary>
-        /// computes change of basis matrix between from and to coordinateSystems
-        /// and sets this as the transform that will be applied to all geometery
-        /// in the render package.
+        /// 
         /// </summary>
         /// <param name="from"></param>
         /// <param name="to"></param>
         public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem from, Autodesk.DesignScript.Geometry.CoordinateSystem to)
         {
             var inverse = from.Inverse();
-            var final = inverse.PostMultiplyBy(to);
+            var final = inverse.PreMultiplyBy(to);
 
             this.SetTransform(final);
         }

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -70,18 +70,52 @@ namespace Dynamo.Wpf.Rendering
             this.colors = colors;
         }
 
-        public void SetTransform(ICoordinateSystemEntity transform)
+        /// <summary>
+        /// sets the transform that will applied to all geometry in the renderPackage
+        /// </summary>
+        /// <param name="transform"></param>
+        public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
         {
             var xaxis = transform.XAxis;
             var yaxis = transform.YAxis;
             var zaxis = transform.ZAxis;
             var org = transform.Origin;
 
-            var csAsMat = new System.Windows.Media.Media3D.Matrix3D(xaxis.X, xaxis.Y, xaxis.Z, org.X,
-                                                                    yaxis.X, yaxis.X, yaxis.Z, org.Y,
-                                                                    zaxis.X, zaxis.Y, zaxis.Z, org.Z,
-                                                                    0, 0, 0, 1);
+            var csAsMat = new System.Windows.Media.Media3D.Matrix3D(xaxis.X, xaxis.Z, -xaxis.Y, 0,
+                                                                    zaxis.X, zaxis.Z, -zaxis.Y, 0,
+                                                                    yaxis.X, yaxis.Z, -yaxis.Y, 0,
+                                                                    org.X, org.Z,-org.Y, 1);
             this.transform = csAsMat;
+        }
+
+        /// <summary>
+        /// sets the transform that will be applied to all geometry in the renderPackage
+        /// </summary>
+        /// <param name="m11"></param>
+        /// <param name="m12"></param>
+        /// <param name="m13"></param>
+        /// <param name="m14"></param>
+        /// <param name="m21"></param>
+        /// <param name="m22"></param>
+        /// <param name="m23"></param>
+        /// <param name="m24"></param>
+        /// <param name="m31"></param>
+        /// <param name="m32"></param>
+        /// <param name="m33"></param>
+        /// <param name="m34"></param>
+        /// <param name="m41"></param>
+        /// <param name="m42"></param>
+        /// <param name="m43"></param>
+        /// <param name="m44"></param>
+        public void SetTransform(double m11,double m12, double m13, double m14,
+            double m21, double m22, double m23, double m24,
+            double m31, double m32, double m33, double m34,
+            double m41, double m42, double m43, double m44 )
+        {
+            this.transform =  new System.Windows.Media.Media3D.Matrix3D(m11, m12, m13, m14,
+                m21, m22, m23, m24,
+                m31, m32, m33, m34,
+                m41, m42, m43, m44);
         }
 
         public void Clear()
@@ -96,6 +130,8 @@ namespace Dynamo.Wpf.Rendering
             lines = InitLineGeometry();
 
             lineStripVertexCounts.Clear();
+
+            transform = System.Windows.Media.Media3D.Matrix3D.Identity;
 
             IsSelected = false;
             DisplayLabels = false;
@@ -355,7 +391,9 @@ namespace Dynamo.Wpf.Rendering
                 return hasData;
             }
         }
-
+        /// <summary>
+        /// a 4x4 matrix which is used to transform all geometry in the render packaage
+        /// </summary>
         public System.Windows.Media.Media3D.Matrix3D Transform
         {
             get

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -46,6 +46,7 @@ namespace Dynamo.Wpf.Rendering
         private bool hasData;
         private List<int> lineStripVertexCounts;
         private byte[] colors;
+        private System.Windows.Media.Media3D.Transform3D transform;
 
         #endregion
 
@@ -57,6 +58,7 @@ namespace Dynamo.Wpf.Rendering
             lines = InitLineGeometry();
             mesh = InitMeshGeometry();
             lineStripVertexCounts = new List<int>();
+            transform = new System.Windows.Media.Media3D.MatrixTransform3D(System.Windows.Media.Media3D.Matrix3D.Identity);
         }
 
         #endregion
@@ -66,6 +68,12 @@ namespace Dynamo.Wpf.Rendering
         public void SetColors(byte[] colors)
         {
             this.colors = colors;
+        }
+
+        public void SetTransform(ICoordinateSystemEntity transform)
+        {
+            transform.XAxis
+            transform = new System.Windows.Media.Media3D.Matrix3D().
         }
 
         public void Clear()

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -87,9 +87,30 @@ namespace Dynamo.Wpf.Rendering
                                                                     org.X, org.Z,-org.Y, 1);
             this.transform = csAsMat;
         }
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem from, Autodesk.DesignScript.Geometry.CoordinateSystem to)
+        {
+            var inverse = from.Inverse();
+            var final = inverse.PostMultiplyBy(to);
+
+            this.SetTransform(final);
+        }
+
 
         /// <summary>
         /// sets the transform that will be applied to all geometry in the renderPackage
+        /// as this is a helix specific implementation it should be noted that the this matrix
+        /// should be as follows when converting from a ProtoGeometry/Dynamo CoordinateSystem
+        /// [xaxis.X, xaxis.Z, -xaxis.Y, 0,
+        ///  zaxis.X, zaxis.Z, -zaxis.Y, 0,
+        /// yaxis.X, yaxis.Z, -yaxis.Y, 0,
+        /// org.X, org.Z, -org.Y, 1] 
+        /// as Helix and Dynamo have their Y and Z axes reversed
         /// </summary>
         /// <param name="m11"></param>
         /// <param name="m12"></param>

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -70,78 +70,12 @@ namespace Dynamo.Wpf.Rendering
             this.colors = colors;
         }
 
+       
         /// <summary>
         /// sets the transform that will applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="transform"></param>
         public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
-        {
-            var worldcs = Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0,0,0);
-            var transformAboutWorldX = transform.Rotate(worldcs.Origin, worldcs.XAxis, -90);
-            var transformYup = transformAboutWorldX.Rotate(transformAboutWorldX.Origin, transformAboutWorldX.XAxis, 90);
-            
-            var xaxis = transformYup.XAxis;
-            var yaxis = transformYup.YAxis;
-            var zaxis = transformYup.ZAxis;
-            var org = transformYup.Origin;
-
-               var csAsMat = new System.Windows.Media.Media3D.Matrix3D( xaxis.X, xaxis.Y, xaxis.Z, 0,
-                                                                        yaxis.X, yaxis.Y, yaxis.Z, 0,
-                                                                        zaxis.X, zaxis.Y, zaxis.Z, 0,
-                                                                        org.X, org.Y,org.Z, 1);
-
-            //   var csAsMat = new System.Windows.Media.Media3D.Matrix3D(-xaxis.X, -xaxis.Z, -xaxis.Y, 0,
-            //                                                        zaxis.X, zaxis.Z, zaxis.Y, 0,
-            //                                                        yaxis.X, yaxis.Z, yaxis.Y, 0,
-            //                                                        org.X, org.Z,-org.Y, 1);
-            this.transform = csAsMat;
-            
-        }
-        
-        public void SetTransformDirect(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
-        {
-            var xaxis = transform.XAxis;
-            var yaxis = transform.YAxis;
-            var zaxis = transform.ZAxis;
-            var org = transform.Origin;
-
-            var csAsMat = new System.Windows.Media.Media3D.Matrix3D(xaxis.X, xaxis.Y, xaxis.Z, 0,
-                                                                         yaxis.X, yaxis.Y, yaxis.Z, 0,
-                                                                         zaxis.X, zaxis.Y, zaxis.Z, 0,
-                                                                         org.X, org.Y, org.Z, 1);
-            csAsMat.Prepend(new System.Windows.Media.Media3D.Matrix3D
-                (1, 0, 0, 0
-                , 0, 0, -1, 0,
-                0, 1, 0, 0,
-                0, 0, 0, 1));
-
-            csAsMat.Append(new System.Windows.Media.Media3D.Matrix3D
-               (1, 0, 0, 0
-               , 0, 0, -1, 0,
-               0, 1, 0, 0,
-               0, 0, 0, 1));
-
-            this.transform = csAsMat;
-
-
-
-            var worldcs = Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin(0, 0, 0);
-            var transformAboutWorldX = transform.Rotate(worldcs.Origin, worldcs.XAxis, -90);
-            var transformYup = transformAboutWorldX.Rotate(transformAboutWorldX.Origin, transformAboutWorldX.XAxis, 90);
-
-            var xaxis2 = transformYup.XAxis;
-            var yaxis2 = transformYup.YAxis;
-            var zaxis2 = transformYup.ZAxis;
-            var org2 = transformYup.Origin;
-
-            var csAsMat2 = new System.Windows.Media.Media3D.Matrix3D(xaxis2.X, xaxis2.Y, xaxis2.Z, 0,
-                                                                     yaxis2.X, yaxis2.Y, yaxis2.Z, 0,
-                                                                     zaxis2.X, zaxis2.Y, zaxis2.Z, 0,
-                                                                     org2.X, org2.Y, org2.Z, 1);
-
-        }
-
-        public void SetTransformDirect2(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
         {
             var xaxis = transform.XAxis;
             var yaxis = transform.YAxis;

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -72,7 +72,7 @@ namespace Dynamo.Wpf.Rendering
 
        
         /// <summary>
-        /// sets the transform that will applied to all geometry in the renderPackage
+        /// sets the transform that will be applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="transform"></param>
         public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
@@ -92,7 +92,8 @@ namespace Dynamo.Wpf.Rendering
         }
 
         /// <summary>
-        /// 
+        /// sets the transform that will be applied to all geometry in the renderPackage
+        /// by computing the matrix that transforms between from and to
         /// </summary>
         /// <param name="from"></param>
         /// <param name="to"></param>

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -74,7 +74,7 @@ namespace Dynamo.Wpf.Rendering
         /// sets the transform that will be applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="transform"></param>
-        public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
+        private void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem transform)
         {
             var xaxis = transform.XAxis;
             var yaxis = transform.YAxis;
@@ -96,7 +96,7 @@ namespace Dynamo.Wpf.Rendering
         /// </summary>
         /// <param name="from"></param>
         /// <param name="to"></param>
-        public void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem from, Autodesk.DesignScript.Geometry.CoordinateSystem to)
+        private void SetTransform(Autodesk.DesignScript.Geometry.CoordinateSystem from, Autodesk.DesignScript.Geometry.CoordinateSystem to)
         {
             var inverse = from.Inverse();
             var final = inverse.PreMultiplyBy(to);
@@ -131,7 +131,7 @@ namespace Dynamo.Wpf.Rendering
         /// <param name="m42"></param>
         /// <param name="m43"></param>
         /// <param name="m44"></param>
-        public void SetTransform(double m11,double m12, double m13, double m14,
+        private void SetTransform(double m11,double m12, double m13, double m14,
             double m21, double m22, double m23, double m24,
             double m31, double m32, double m33, double m34,
             double m41, double m42, double m43, double m44 )
@@ -146,7 +146,7 @@ namespace Dynamo.Wpf.Rendering
         /// sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="matrix"></param>
-        public void SetTransform(double[] matrix)
+        private void SetTransform(double[] matrix)
         {
             this.Transform = matrix;
         }

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -267,7 +267,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         public PhongMaterial SelectedMaterial { get; set; }
 
-        public Transform3D StaticTransform
+        public Transform3D BaseTransform
         {
             get
             {
@@ -1079,7 +1079,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             gridModel3D = new DynamoLineGeometryModel3D
             {
                 Geometry = Grid,
-                Transform = StaticTransform,
+                Transform = BaseTransform,
                 Color = Color.White,
                 Thickness = 0.3,
                 IsHitTestVisible = false,
@@ -1096,7 +1096,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var axesModel3D = new DynamoLineGeometryModel3D
             {
                 Geometry = Axes,
-                Transform = StaticTransform,
+                Transform = BaseTransform,
                 Color = Color.White,
                 Thickness = 0.3,
                 IsHitTestVisible = false,
@@ -1501,14 +1501,13 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 labelPlaces[nodeId] = new List<Tuple<string, Vector3>>();
             }
 
-            //if the renderPackage has a transform property use it to transform the text
-            //labels, a HelixRenderPackage created here should always have a transform so
-            //we check the type to make sure before trying to access Transform
-            //TODO(Dynamo 2.0) we can remove this check
+            //if the renderPackage also implements ITransformable then 
+            // use the transform property to transform the text labels
+           
             SharpDX.Vector3 transformedPos = pos;
-            if (rp is HelixRenderPackage)
+            if (rp is HelixRenderPackage && rp is Autodesk.DesignScript.Interfaces.ITransformable)
             {
-                transformedPos = (rp as HelixRenderPackage)
+                transformedPos = (rp as Autodesk.DesignScript.Interfaces.ITransformable)
                    .Transform.ToMatrix3D().Transform((pos).ToPoint3D()).ToVector3();
             }
             

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -37,6 +37,7 @@ using MeshGeometry3D = HelixToolkit.Wpf.SharpDX.MeshGeometry3D;
 using Model3D = HelixToolkit.Wpf.SharpDX.Model3D;
 using PerspectiveCamera = HelixToolkit.Wpf.SharpDX.PerspectiveCamera;
 using TextInfo = HelixToolkit.Wpf.SharpDX.TextInfo;
+using System.Windows.Threading;
 
 namespace Dynamo.Wpf.ViewModels.Watch3D
 {
@@ -1668,14 +1669,20 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         private DynamoGeometryModel3D CreateDynamoGeometryModel3D(HelixRenderPackage rp)
         {
-            var meshGeometry3D = new DynamoGeometryModel3D(renderTechnique)
+            DynamoGeometryModel3D meshGeometry3D = null;
+            Dispatcher.CurrentDispatcher.Invoke(() =>
             {
-                Transform = Model1Transform,
-                Material = WhiteMaterial,
-                IsHitTestVisible = false,
-                RequiresPerVertexColoration = rp.RequiresPerVertexColoration,
-                IsSelected = rp.IsSelected
-            };
+                meshGeometry3D = new DynamoGeometryModel3D(renderTechnique)
+                {
+                    Transform = new System.Windows.Media.Media3D.MatrixTransform3D(rp.Transform),
+                    Material = WhiteMaterial,
+                    IsHitTestVisible = false,
+                    RequiresPerVertexColoration = rp.RequiresPerVertexColoration,
+                    IsSelected = rp.IsSelected
+                };
+            }
+            );
+           
 
             if (rp.Colors != null)
             {

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -266,7 +266,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         public PhongMaterial SelectedMaterial { get; set; }
 
-        public Transform3D BaseTransform
+        /// <summary>
+        /// This is the initial transform applied to 
+        /// elements of the scene, like the grid and world axes.
+        /// </summary>
+        public Transform3D SceneTransform
         {
             get
             {
@@ -1078,7 +1082,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             gridModel3D = new DynamoLineGeometryModel3D
             {
                 Geometry = Grid,
-                Transform = BaseTransform,
+                Transform = SceneTransform,
                 Color = Color.White,
                 Thickness = 0.3,
                 IsHitTestVisible = false,
@@ -1095,7 +1099,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var axesModel3D = new DynamoLineGeometryModel3D
             {
                 Geometry = Axes,
-                Transform = BaseTransform,
+                Transform = SceneTransform,
                 Color = Color.White,
                 Thickness = 0.3,
                 IsHitTestVisible = false,

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1683,8 +1683,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         private DynamoGeometryModel3D CreateDynamoGeometryModel3D(HelixRenderPackage rp)
         {
             DynamoGeometryModel3D meshGeometry3D = null;
-            Dispatcher.CurrentDispatcher.Invoke(() =>
-            {
+           
                 meshGeometry3D = new DynamoGeometryModel3D(renderTechnique)
                 {
                     Transform = new MatrixTransform3D(rp.Transform),
@@ -1693,10 +1692,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     RequiresPerVertexColoration = rp.RequiresPerVertexColoration,
                     IsSelected = rp.IsSelected
                 };
-            }
-            );
-           
-
+            
             if (rp.Colors != null)
             {
                 var pf = PixelFormats.Bgra32;

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1501,10 +1501,17 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 labelPlaces[nodeId] = new List<Tuple<string, Vector3>>();
             }
 
-            //if the renderPackage as a transform use it to transform the text
-            //labels
-            var transformedPos = rp.Transform.ToMatrix3D().Transform(
-                         (pos).ToPoint3D()).ToVector3();
+            //if the renderPackage has a transform property use it to transform the text
+            //labels, a HelixRenderPackage created here should always have a transform so
+            //we check the type to make sure before trying to access Transform
+            //TODO(Dynamo 2.0) we can remove this check
+            SharpDX.Vector3 transformedPos = pos;
+            if (rp is HelixRenderPackage)
+            {
+                transformedPos = (rp as HelixRenderPackage)
+                   .Transform.ToMatrix3D().Transform((pos).ToPoint3D()).ToVector3();
+            }
+            
 
             labelPlaces[nodeId].Add(new Tuple<string, Vector3>(rp.Description, transformedPos));
             if (rp.DisplayLabels)

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -37,7 +37,6 @@ using MeshGeometry3D = HelixToolkit.Wpf.SharpDX.MeshGeometry3D;
 using Model3D = HelixToolkit.Wpf.SharpDX.Model3D;
 using PerspectiveCamera = HelixToolkit.Wpf.SharpDX.PerspectiveCamera;
 using TextInfo = HelixToolkit.Wpf.SharpDX.TextInfo;
-using System.Windows.Threading;
 
 namespace Dynamo.Wpf.ViewModels.Watch3D
 {

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -267,8 +267,13 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         public PhongMaterial SelectedMaterial { get; set; }
 
-        public Transform3D Model1Transform { get; private set; }
-
+        public Transform3D StaticTransform
+        {
+            get
+            {
+                return new TranslateTransform3D(0, -0, 0);
+            }
+        }
         public RenderTechnique RenderTechnique
         {
             get
@@ -1039,8 +1044,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 SpecularShininess = 12.8f,
             };
 
-            Model1Transform = new TranslateTransform3D(0, -0, 0);
-
             // camera setup
             Camera = new PerspectiveCamera();
 
@@ -1076,7 +1079,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             gridModel3D = new DynamoLineGeometryModel3D
             {
                 Geometry = Grid,
-                Transform = Model1Transform,
+                Transform = StaticTransform,
                 Color = Color.White,
                 Thickness = 0.3,
                 IsHitTestVisible = false,
@@ -1093,7 +1096,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var axesModel3D = new DynamoLineGeometryModel3D
             {
                 Geometry = Axes,
-                Transform = Model1Transform,
+                Transform = StaticTransform,
                 Color = Color.White,
                 Thickness = 0.3,
                 IsHitTestVisible = false,
@@ -1674,7 +1677,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             {
                 meshGeometry3D = new DynamoGeometryModel3D(renderTechnique)
                 {
-                    Transform = new System.Windows.Media.Media3D.MatrixTransform3D(rp.Transform),
+                    Transform = new MatrixTransform3D(rp.Transform),
                     Material = WhiteMaterial,
                     IsHitTestVisible = false,
                     RequiresPerVertexColoration = rp.RequiresPerVertexColoration,
@@ -1719,7 +1722,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var lineGeometry3D = new DynamoLineGeometryModel3D()
             {
                 Geometry = HelixRenderPackage.InitLineGeometry(),
-                Transform = Model1Transform,
+                Transform = new MatrixTransform3D(rp.Transform),
                 Color = Color.White,
                 Thickness = thickness,
                 IsHitTestVisible = false,
@@ -1733,7 +1736,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var pointGeometry3D = new DynamoPointGeometryModel3D
             {
                 Geometry = HelixRenderPackage.InitPointGeometry(),
-                Transform = Model1Transform,
+                Transform = new MatrixTransform3D(rp.Transform),
                 Color = Color.White,
                 Figure = PointGeometryModel3D.PointFigure.Ellipse,
                 Size = defaultPointSize,

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1294,7 +1294,12 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     foreach (var id_position in requestedLabelPlaces)
                     {
                         var text = HelixRenderPackage.CleanTag(id_position.Item1);
-                        var textPosition = id_position.Item2 + defaultLabelOffset;
+                        var geom = (GeometryModel3D)Model3DDictionary[key];
+                        
+                        //use the transform of the geometry to transform the text position
+                        var textPosition = geom.Transform.Transform(
+                            id_position.Item2.ToPoint3D()).ToVector3()
+                            + defaultLabelOffset;
                         var textInfo = new TextInfo(text, textPosition);
                         textGeometry.TextInfo.Add(textInfo);
                     }
@@ -1666,8 +1671,13 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 Model3DDictionary.Add(textId, bbText);
             }
             var geom = bbText.Geometry as BillboardText3D;
+            //use the transform of the render package to transform the text position
+            var textPosition = (rp as HelixRenderPackage).Transform.Transform(
+                           (pt).ToPoint3D()).ToVector3()
+                           + defaultLabelOffset;
+
             geom.TextInfo.Add(new TextInfo(HelixRenderPackage.CleanTag(rp.Description),
-                pt + defaultLabelOffset));
+               textPosition));
         }
 
         private DynamoGeometryModel3D CreateDynamoGeometryModel3D(HelixRenderPackage rp)

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1682,9 +1682,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         private DynamoGeometryModel3D CreateDynamoGeometryModel3D(HelixRenderPackage rp)
         {
-            DynamoGeometryModel3D meshGeometry3D = null;
-           
-                meshGeometry3D = new DynamoGeometryModel3D(renderTechnique)
+          
+                var meshGeometry3D = new DynamoGeometryModel3D(renderTechnique)
                 {
                     Transform = new MatrixTransform3D(rp.Transform),
                     Material = WhiteMaterial,

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -48,15 +48,7 @@ namespace Autodesk.DesignScript.Interfaces
         /// The number of mesh vertices in the package.
         /// </summary>
         int MeshVertexCount { get; }
-
-        //TODO(mike) uncomment this code when we decide to add transforms to the public API
-        //and increment our major version number
-        ///// <summary>
-        ///// a 4x4 matrix which is used to transform all geometry in the render packaage
-        ///// </summary>
-        //double[] Transform  { get; } 
-      
-
+        
         /// <summary>
         /// A collection of int values representing how many vertices
         /// comprise each line segment in the package.
@@ -198,9 +190,37 @@ namespace Autodesk.DesignScript.Interfaces
         /// <param name="colors"></param>
         void SetColors(byte[] colors);
 
-        //TODO(mike) uncomment this code when we decide to add transforms to the public API
-        //and increment our major version number
-        /*
+        /// <summary>
+        /// Clear all render data from the render package.
+        /// </summary>
+        void Clear();
+    }
+
+    /// <summary>
+    /// Represents a graphics item object, that can provide tesselated data
+    /// into the given render package.
+    /// </summary>
+    public interface IGraphicItem
+    {
+        /// <summary>
+        /// Gets the graphics/tesselation data in given render package object.
+        /// </summary>
+        /// <param name="package">The render package, where graphics data to be
+        /// pushed.</param>
+        /// <param name="parameters"></param>
+        void Tessellate(IRenderPackage package, TessellationParameters parameters);
+    }
+
+    /// <summary>
+    /// an interface that defines items which have a transform property which is a 4x4 matrix
+    /// </summary>
+    public interface ITransformable
+    {
+        /// <summary>
+        /// a 4x4 matrix which is used to transform all geometry in the render packaage
+        /// </summary>
+        double[] Transform  { get; } 
+        
         /// <summary>
         /// sets the transform as a series of doubles that will be applied to all geometry in the renderPackage
         /// </summary>
@@ -225,35 +245,14 @@ namespace Autodesk.DesignScript.Interfaces
            double m31, double m32, double m33, double m34,
            double m41, double m42, double m43, double m44);
 
-    
-
         /// <summary>
         /// sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="matrix"></param>
         void SetTransform(double[] matrix);
-        */
-
-        /// <summary>
-        /// Clear all render data from the render package.
-        /// </summary>
-        void Clear();
+        
     }
 
-    /// <summary>
-    /// Represents a graphics item object, that can provide tesselated data
-    /// into the given render package.
-    /// </summary>
-    public interface IGraphicItem
-    {
-        /// <summary>
-        /// Gets the graphics/tesselation data in given render package object.
-        /// </summary>
-        /// <param name="package">The render package, where graphics data to be
-        /// pushed.</param>
-        /// <param name="parameters"></param>
-        void Tessellate(IRenderPackage package, TessellationParameters parameters);
-    }
 
     public class TessellationParameters
     {

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -251,9 +251,9 @@ namespace Autodesk.DesignScript.Interfaces
         /// <summary>
         /// Sets the transform as a double array, this transform will be applied to all geometry in the renderPackage.
         /// This matrix should be laid out as follows in row vector order:
-        /// [Xx,Xy,Xz, scalar,
-        ///  Yx, Yy, Yz, scalar,
-        ///  Zx, Zy, Zz, scalar,
+        /// [Xx,Xy,Xz, 0,
+        ///  Yx, Yy, Yz, 0,
+        ///  Zx, Zy, Zz, 0,
         ///  offsetX, offsetY, offsetZ, W]
         /// ]
         ///NOTE: This method should transform the matrix from row vector order to whatever form is needed by the implementation

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -49,10 +49,13 @@ namespace Autodesk.DesignScript.Interfaces
         /// </summary>
         int MeshVertexCount { get; }
 
-        /// <summary>
-        /// a 4x4 matrix which is used to transform all geometry in the render packaage
-        /// </summary>
-        double[] Transform  { get; } 
+        //TODO(mike) uncomment this code when we decide to add transforms to the public API
+        //and increment our major version number
+        ///// <summary>
+        ///// a 4x4 matrix which is used to transform all geometry in the render packaage
+        ///// </summary>
+        //double[] Transform  { get; } 
+      
 
         /// <summary>
         /// A collection of int values representing how many vertices
@@ -195,6 +198,9 @@ namespace Autodesk.DesignScript.Interfaces
         /// <param name="colors"></param>
         void SetColors(byte[] colors);
 
+        //TODO(mike) uncomment this code when we decide to add transforms to the public API
+        //and increment our major version number
+        /*
         /// <summary>
         /// sets the transform as a series of doubles that will be applied to all geometry in the renderPackage
         /// </summary>
@@ -219,11 +225,14 @@ namespace Autodesk.DesignScript.Interfaces
            double m31, double m32, double m33, double m34,
            double m41, double m42, double m43, double m44);
 
+    
+
         /// <summary>
         /// sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="matrix"></param>
         void SetTransform(double[] matrix);
+        */
 
         /// <summary>
         /// Clear all render data from the render package.

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -222,7 +222,10 @@ namespace Autodesk.DesignScript.Interfaces
         double[] Transform  { get; } 
         
         /// <summary>
-        /// Sets the transform as a series of doubles that will be applied to all geometry in the renderPackage
+        /// Sets the transform as a series of doubles that will be applied to all geometry in the renderPackage.
+        /// Following conventional matrix notation, m11 is the value of the first row and first column, and m12
+        /// is the value of the first row and second column.
+        /// NOTE: This method should set the matrix exactly as described by the caller.
         /// </summary>
         /// <param name="m11"></param>
         /// <param name="m12"></param>
@@ -246,7 +249,14 @@ namespace Autodesk.DesignScript.Interfaces
            double m41, double m42, double m43, double m44);
 
         /// <summary>
-        /// Sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
+        /// Sets the transform as a double array, this transform will be applied to all geometry in the renderPackage.
+        /// This matrix should be laid out as follows in row vector order:
+        /// [Xx,Xy,Xz, scalar,
+        ///  Yx, Yy, Yz, scalar,
+        ///  Zx, Zy, Zz, scalar,
+        ///  offsetX, offsetY, offsetZ, W]
+        /// ]
+        ///NOTE: This method should transform the matrix from row vector order to whatever form is needed by the implementation
         /// </summary>
         /// <param name="matrix"></param>
         void SetTransform(double[] matrix);

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -48,7 +48,12 @@ namespace Autodesk.DesignScript.Interfaces
         /// The number of mesh vertices in the package.
         /// </summary>
         int MeshVertexCount { get; }
-        
+
+        /// <summary>
+        /// a 4x4 matrix which is used to transform all geometry in the render packaage
+        /// </summary>
+        double[] Transform  { get; } 
+
         /// <summary>
         /// A collection of int values representing how many vertices
         /// comprise each line segment in the package.
@@ -189,6 +194,36 @@ namespace Autodesk.DesignScript.Interfaces
         /// </summary>
         /// <param name="colors"></param>
         void SetColors(byte[] colors);
+
+        /// <summary>
+        /// sets the transform as a series of doubles that will be applied to all geometry in the renderPackage
+        /// </summary>
+        /// <param name="m11"></param>
+        /// <param name="m12"></param>
+        /// <param name="m13"></param>
+        /// <param name="m14"></param>
+        /// <param name="m21"></param>
+        /// <param name="m22"></param>
+        /// <param name="m23"></param>
+        /// <param name="m24"></param>
+        /// <param name="m31"></param>
+        /// <param name="m32"></param>
+        /// <param name="m33"></param>
+        /// <param name="m34"></param>
+        /// <param name="m41"></param>
+        /// <param name="m42"></param>
+        /// <param name="m43"></param>
+        /// <param name="m44"></param>
+        void SetTransform(double m11, double m12, double m13, double m14,
+           double m21, double m22, double m23, double m24,
+           double m31, double m32, double m33, double m34,
+           double m41, double m42, double m43, double m44);
+
+        /// <summary>
+        /// sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
+        /// </summary>
+        /// <param name="matrix"></param>
+        void SetTransform(double[] matrix);
 
         /// <summary>
         /// Clear all render data from the render package.

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -212,17 +212,17 @@ namespace Autodesk.DesignScript.Interfaces
     }
 
     /// <summary>
-    /// an interface that defines items which have a transform property which is a 4x4 matrix
+    /// An interface that defines items which have a transform property which is a 4x4 matrix
     /// </summary>
     public interface ITransformable
     {
         /// <summary>
-        /// a 4x4 matrix which is used to transform all geometry in the render packaage
+        /// A 4x4 matrix which is used to transform all geometry in the render packaage
         /// </summary>
         double[] Transform  { get; } 
         
         /// <summary>
-        /// sets the transform as a series of doubles that will be applied to all geometry in the renderPackage
+        /// Sets the transform as a series of doubles that will be applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="m11"></param>
         /// <param name="m12"></param>
@@ -246,7 +246,7 @@ namespace Autodesk.DesignScript.Interfaces
            double m41, double m42, double m43, double m44);
 
         /// <summary>
-        /// sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
+        /// Sets the transform as a double array, this transform will be applied to all geometry in the renderPackage
         /// </summary>
         /// <param name="matrix"></param>
         void SetTransform(double[] matrix);

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -212,17 +212,17 @@ namespace Autodesk.DesignScript.Interfaces
     }
 
     /// <summary>
-    /// An interface that defines items which have a transform property which is a 4x4 matrix
+    /// An interface that defines items which have a transform property, which is a 4x4 matrix.
     /// </summary>
     public interface ITransformable
     {
         /// <summary>
-        /// A 4x4 matrix which is used to transform all geometry in the render packaage
+        /// A 4x4 matrix that is used to transform all geometry in the render packaage.
         /// </summary>
         double[] Transform  { get; } 
         
         /// <summary>
-        /// Sets the transform as a series of doubles that will be applied to all geometry in the renderPackage.
+        /// Set the transform using a series of doubles. The resulting transform is applied to all geometry in the renderPackage.
         /// Following conventional matrix notation, m11 is the value of the first row and first column, and m12
         /// is the value of the first row and second column.
         /// NOTE: This method should set the matrix exactly as described by the caller.
@@ -249,14 +249,13 @@ namespace Autodesk.DesignScript.Interfaces
            double m41, double m42, double m43, double m44);
 
         /// <summary>
-        /// Sets the transform as a double array, this transform will be applied to all geometry in the renderPackage.
+        /// Set the transform as a double array, this transform is applied to all geometry in the renderPackage.
         /// This matrix should be laid out as follows in row vector order:
         /// [Xx,Xy,Xz, 0,
         ///  Yx, Yy, Yz, 0,
         ///  Zx, Zy, Zz, 0,
         ///  offsetX, offsetY, offsetZ, W]
-        /// ]
-        ///NOTE: This method should transform the matrix from row vector order to whatever form is needed by the implementation
+        ///NOTE: This method should transform the matrix from row vector order to whatever form is needed by the implementation.
         /// </summary>
         /// <param name="matrix"></param>
         void SetTransform(double[] matrix);


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9347

This PR adds a new interface ITransformable to Autodesk.DesignScript.Interfaces in the DynamoServices project.

using this interface a zero touch node author can supply a transform on their render package during tessellation (for zero touch classes that implement IGraphicItem)  - this transform is used to modify the verticies that are pushed into the render package when used in our helix implementation.

In the future the transform could also be used on flood.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ikeough 

### FYIs
