### PR TITLE
MAGN-9891 User should be able to turn off Preview Bubbles completely

### DIFF
--- a/src/DynamoCore/Configuration/IPreferences.cs
+++ b/src/DynamoCore/Configuration/IPreferences.cs
@@ -22,6 +22,11 @@ namespace Dynamo.Interfaces
         bool ShowConnector { get; set; }
 
         /// <summary>
+        /// Indicates if preview bubbles should be displayed on nodes.
+        /// </summary>
+        bool ShowPreviewBubbles { get; set; }
+
+        /// <summary>
         /// Indicates which type of connector's should be displayed on canvas.
         /// I.e. bezier or polyline
         /// </summary>

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -74,6 +74,11 @@ namespace Dynamo.Configuration
         public int ConsoleHeight { get; set; }
 
         /// <summary>
+        /// Indicates if preview bubbles should be displayed on nodes.
+        /// </summary>
+        public bool ShowPreviewBubbles { get; set; }
+
+        /// <summary>
         /// Should connectors be visible?
         /// </summary>
         public bool ShowConnector { get; set; }
@@ -221,6 +226,7 @@ namespace Dynamo.Configuration
             IsUsageReportingApproved = false;
             LibraryWidth = 304;
             ConsoleHeight = 0;
+            ShowPreviewBubbles = true;
             ShowConnector = true;
             ConnectorType = ConnectorType.BEZIER;
             IsBackgroundPreviewActive = true;

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -1724,11 +1724,29 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hide Preview Bubbles.
+        /// </summary>
+        public static string DynamoViewSettingsMenuHidePreviewBubbles {
+            get {
+                return ResourceManager.GetString("DynamoViewSettingsMenuHidePreviewBubbles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show Edges.
         /// </summary>
         public static string DynamoViewSettingsMenuShowEdges {
             get {
                 return ResourceManager.GetString("DynamoViewSettingsMenuShowEdges", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show Preview Bubbles.
+        /// </summary>
+        public static string DynamoViewSettingsMenuShowPreviewBubbles {
+            get {
+                return ResourceManager.GetString("DynamoViewSettingsMenuShowPreviewBubbles", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1728,6 +1728,14 @@ Do you want to install the latest Dynamo update?</value>
   <data name="DynamoViewSettingsMenuShowEdges" xml:space="preserve">
     <value>Show Edges</value>
   </data>
+  <data name="DynamoViewSettingsMenuHidePreviewBubbles" xml:space="preserve">
+    <value>Hide Preview Bubbles</value>
+    <comment>Settings menu | Hide preview bubbles</comment>
+  </data>
+  <data name="DynamoViewSettingsMenuShowPreviewBubbles" xml:space="preserve">
+    <value>Show Preview Bubbles</value>
+    <comment>Settings menu | Show preview bubbles</comment>
+  </data>
   <data name="DynamoViewSettingsMenuVisualizationSettings" xml:space="preserve">
     <value>Visualization Settings</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1733,6 +1733,14 @@ Do you want to install the latest Dynamo update?</value>
   <data name="DynamoViewSettingsMenuShowEdges" xml:space="preserve">
     <value>Show Edges</value>
   </data>
+  <data name="DynamoViewSettingsMenuHidePreviewBubbles" xml:space="preserve">
+    <value>Hide Preview Bubbles</value>
+    <comment>Settings menu | Hide preview bubbles</comment>
+  </data>
+  <data name="DynamoViewSettingsMenuShowPreviewBubbles" xml:space="preserve">
+    <value>Show Preview Bubbles</value>
+    <comment>Settings menu | Show preview bubbles</comment>
+  </data>
   <data name="DynamoViewSettingsMenuVisualizationSettings" xml:space="preserve">
     <value>Visualization Settings</value>
   </data>

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -971,6 +971,25 @@ namespace Dynamo.Controls
         #endregion
     }
 
+    public class ShowHidePreviewBubblesConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (bool) value
+                ? Resources.DynamoViewSettingsMenuHidePreviewBubbles
+                : Resources.DynamoViewSettingsMenuShowPreviewBubbles;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (string)value == Resources.DynamoViewSettingsMenuHidePreviewBubbles;
+        }
+
+        #endregion
+    }
+
     public class ShowHideFullscreenWatchMenuItemConverter : IValueConverter
     {
         #region IValueConverter Members

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -88,6 +88,7 @@
     <controls:PathToSaveStateConverter x:Key="PathToSaveStateConverter" />
     <controls:InverseBooleanConverter x:Key="InverseBooleanConverter" />
     <controls:ShowHideConsoleMenuItemConverter x:Key="ShowHideConsoleMenuConverter" />
+    <controls:ShowHidePreviewBubblesConverter x:Key="ShowHidePreviewBubblesConverter" />
     <controls:ShowHideFullscreenWatchMenuItemConverter x:Key="ShowHideFullscreenWatchMenuConverter" />
     <controls:PackageSearchStateToStringConverter x:Key="PackageSearchStateToStringConverter" />
     <controls:EmptyStringToCollapsedConverter x:Key="EmptyStringToCollapsedConverter" />

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -241,6 +241,9 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Indicates if preview bubbles should be displayed on nodes.
+        /// </summary>
         public bool ShowPreviewBubbles
         {
             get
@@ -250,7 +253,6 @@ namespace Dynamo.ViewModels
             set
             {
                 model.PreferenceSettings.ShowPreviewBubbles = value;
-
                 RaisePropertyChanged("ShowPreviewBubbles");
             }
         }
@@ -1834,6 +1836,10 @@ namespace Dynamo.ViewModels
             return true;
         }
 
+        /// <summary>
+        /// Toggles Showing Preview Bubbles globally
+        /// </summary>
+        /// <param name="parameter">Command parameter</param>
         public void TogglePreviewBubblesShowing(object parameter)
         {
             ShowPreviewBubbles = !ShowPreviewBubbles;

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -241,6 +241,20 @@ namespace Dynamo.ViewModels
             }
         }
 
+        public bool ShowPreviewBubbles
+        {
+            get
+            {
+                return model.PreferenceSettings.ShowPreviewBubbles;
+            }
+            set
+            {
+                model.PreferenceSettings.ShowPreviewBubbles = value;
+
+                RaisePropertyChanged("ShowPreviewBubbles");
+            }
+        }
+
         public int LibraryWidth
         {
             get
@@ -1818,6 +1832,11 @@ namespace Dynamo.ViewModels
         internal bool CanToggleConsoleShowing(object parameter)
         {
             return true;
+        }
+
+        public void TogglePreviewBubblesShowing(object parameter)
+        {
+            ShowPreviewBubbles = !ShowPreviewBubbles;
         }
 
         public void SelectNeighbors(object parameters)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -46,6 +46,7 @@ namespace Dynamo.ViewModels
             CopyCommand = new DelegateCommand(_ => model.Copy(), CanCopy);
             PasteCommand = new DelegateCommand(Paste, CanPaste);
             ToggleConsoleShowingCommand = new DelegateCommand(ToggleConsoleShowing, CanToggleConsoleShowing);
+            TogglePreviewBubblesShowingCommand = new DelegateCommand(TogglePreviewBubblesShowing);
             ForceRunExpressionCommand = new DelegateCommand(ForceRunExprCmd, RunSettingsViewModel.CanRunExpression);
             MutateTestDelegateCommand = new DelegateCommand(MutateTestCmd, RunSettingsViewModel.CanRunExpression);
             DisplayFunctionCommand = new DelegateCommand(DisplayFunction, CanDisplayFunction);
@@ -120,6 +121,7 @@ namespace Dynamo.ViewModels
         public DelegateCommand SaveImageCommand { get; set; }
         public DelegateCommand ShowSaveImageDialogAndSaveResultCommand { get; set; }
         public DelegateCommand ToggleConsoleShowingCommand { get; set; }
+        public DelegateCommand TogglePreviewBubblesShowingCommand { get; set; }
         public DelegateCommand ShowPackageManagerCommand { get; set; }
         public DelegateCommand ForceRunExpressionCommand { get; set; }
         public DelegateCommand MutateTestDelegateCommand { get; set; }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -696,6 +696,8 @@
                                   IsCheckable="True"
                                   IsChecked="{Binding Path=RenderPackageFactoryViewModel.ShowEdges, Mode=TwoWay}"
                                   Header="{x:Static p:Resources.DynamoViewSettingsMenuShowEdges}"></MenuItem>
+                        <MenuItem Header="{Binding Path=ShowPreviewBubbles, Converter={StaticResource ShowHidePreviewBubblesConverter}}"
+                                  Command="{Binding TogglePreviewBubblesShowingCommand}"/>
                         <MenuItem Focusable="False"
                                   Header="{x:Static p:Resources.DynamoViewSettingMenuManagePackagePath}"
                                   Command="{Binding ManagePackagePathsCommand}"

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -55,11 +55,7 @@ namespace DynamoCoreWpfTests
             var nodeView = NodeViewWithGuid("7828a9dd-88e6-49f4-9ed3-72e355f89bcc");
             nodeView.PreviewControl.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
 
-            View.Dispatcher.Invoke(() =>
-            {
-                nodeView.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0) { RoutedEvent = Mouse.MouseEnterEvent });
-            });
-            DispatcherUtil.DoEvents();
+            RaiseMouseEnterOnNode(nodeView);
 
             Assert.IsTrue(nodeView.PreviewControl.IsCondensed);
         }
@@ -71,11 +67,7 @@ namespace DynamoCoreWpfTests
             var nodeView = NodeViewWithGuid("9ce91e89-c087-49cd-9fd9-540cca086475");
             nodeView.PreviewControl.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
 
-            View.Dispatcher.Invoke(() =>
-            {
-                nodeView.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0) { RoutedEvent = Mouse.MouseEnterEvent });
-            });
-            DispatcherUtil.DoEvents();
+            RaiseMouseEnterOnNode(nodeView);
 
             Assert.IsTrue(nodeView.PreviewControl.IsHidden);
         }
@@ -86,23 +78,12 @@ namespace DynamoCoreWpfTests
             Open(@"core\DetailedPreviewMargin_Test.dyn");
             var nodeView = NodeViewWithGuid("7828a9dd-88e6-49f4-9ed3-72e355f89bcc");
             nodeView.PreviewControl.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
-
-
-            // Raise mouse enter event.
-            View.Dispatcher.Invoke(() =>
-            {
-                nodeView.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0) { RoutedEvent = Mouse.MouseEnterEvent });
-            });
-            DispatcherUtil.DoEvents();
+            
+            RaiseMouseEnterOnNode(nodeView);
 
             Assert.IsTrue(nodeView.PreviewControl.IsCondensed);
 
-            // Raise mouse leave event.
-            View.Dispatcher.Invoke(() =>
-            {
-                nodeView.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0) { RoutedEvent = Mouse.MouseLeaveEvent });
-            });
-            DispatcherUtil.DoEvents();
+            RaiseMouseLeaveNode(nodeView);
 
             Assert.IsTrue(nodeView.PreviewControl.IsHidden);
         }
@@ -115,11 +96,7 @@ namespace DynamoCoreWpfTests
             nodeView.ViewModel.IsFrozen = true;
             nodeView.PreviewControl.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
 
-            View.Dispatcher.Invoke(() =>
-            {
-                nodeView.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0) { RoutedEvent = Mouse.MouseEnterEvent });
-            });
-            DispatcherUtil.DoEvents();
+            RaiseMouseEnterOnNode(nodeView);
 
             Assert.IsTrue(nodeView.PreviewControl.IsHidden);
         }
@@ -301,12 +278,7 @@ namespace DynamoCoreWpfTests
 
             var nodeView = NodeViewWithGuid("456e57f3-d06f-4a53-9771-27188ee9cb40");
 
-            // Raise mouse enter event.
-            View.Dispatcher.Invoke(() =>
-            {
-                nodeView.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0) { RoutedEvent = Mouse.MouseEnterEvent });
-            });
-            DispatcherUtil.DoEvents();
+            RaiseMouseEnterOnNode(nodeView);
 
             Assert.IsTrue(nodeView.PreviewControl.IsHidden);
         }
@@ -344,13 +316,57 @@ namespace DynamoCoreWpfTests
 
             // preview is expanded
             Assert.IsTrue(ElementIsInContainer(nodeView.PreviewControl.HiddenDummy, nodeView));
-        }        
+        }
+
+        [Test]
+        public void PreviewBubble_ToggleShowPreviewBubbles()
+        {
+            Open(@"core\DetailedPreviewMargin_Test.dyn");
+            var nodeView = NodeViewWithGuid("7828a9dd-88e6-49f4-9ed3-72e355f89bcc");
+            Assert.IsTrue(ViewModel.ShowPreviewBubbles, "Preview bubbles are turned off");
+
+            nodeView.PreviewControl.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+            RaiseMouseEnterOnNode(nodeView);
+            Assert.IsTrue(nodeView.PreviewControl.IsCondensed, "Cmpact preview bubble is not shown");
+
+            RaiseMouseLeaveNode(nodeView);
+            Assert.IsTrue(nodeView.PreviewControl.IsHidden, "Preview bubble is not hidden");
+
+            // turn off preview bubbles
+            ViewModel.TogglePreviewBubblesShowingCommand.Execute(null);
+            Assert.IsFalse(ViewModel.ShowPreviewBubbles, "Preview bubbles have not been turned off");
+
+            RaiseMouseEnterOnNode(nodeView);
+
+            Assert.IsTrue(nodeView.PreviewControl.IsHidden, "Preview bubble is not hidden");
+        }
 
         private bool ElementIsInContainer(FrameworkElement element, FrameworkElement container)
         {
             var relativePosition = element.TranslatePoint(new Point(), container);
             
             return (relativePosition.X == 0) && (element.ActualWidth <= container.ActualWidth);
+        }
+
+        private void RaiseMouseEnterOnNode(NodeView nv)
+        {
+            View.Dispatcher.Invoke(() =>
+            {
+                nv.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0) { RoutedEvent = Mouse.MouseEnterEvent });
+            });
+
+            DispatcherUtil.DoEvents();
+        }
+
+        private void RaiseMouseLeaveNode(NodeView nv)
+        {
+            View.Dispatcher.Invoke(() =>
+            {
+                nv.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0) { RoutedEvent = Mouse.MouseLeaveEvent });
+            });
+
+            DispatcherUtil.DoEvents();
         }
     }
 }


### PR DESCRIPTION
### Purpose

An option to turn off/on preview bubbles is added under `Settings` menu:
![image](https://cloud.githubusercontent.com/assets/7658189/14914301/9272c4ac-0e11-11e6-8e1b-a687e83612a4.png)
![image](https://cloud.githubusercontent.com/assets/7658189/14914304/965c961a-0e11-11e6-800f-642c235aca97.png)

The option value is saved in preferences, so that it will persist from session to session.
Appropriate test case is added.

Special case to consider is when a node is located under "Show/Hide Preview Bubbles" menu item, so if the item is clicked, mouse pointer becomes over the node right away:
![image](https://cloud.githubusercontent.com/assets/7658189/14914410/7d88ead4-0e12-11e6-8bbb-99a92d3fb0e8.png)

For some reasons in WPF "Show/Hide Preview Bubbles" value is updated after mouse pointer becomes over the node. As result, preview bubbles are just turned off but preview bubble is shown for the node and v.v.
It is fixed in this PR as well.

### Tests on SelfService

`DynamoCoreWpfTests` has been run on SelfService. With the same changes several times it says that all tests passed, several times not. The changes of the PR don't seem related to the periodic failures at all.

Finally, I created 4 same branches without my changes, just version of master which I branched out, and run `DynamoCoreWpfTests`. The situation is identical (several times tests passed and several times not), so it proves my changes break nothing :)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 