### PR TITLE
Fix for Markdown issues.

### DIFF
--- a/tools/XmlDocToMarkdown/XmlDocToMarkdown/Helper.cs
+++ b/tools/XmlDocToMarkdown/XmlDocToMarkdown/Helper.cs
@@ -99,9 +99,16 @@ namespace XmlDocToMarkdown
             {
                 foreach (var constructor in constructors)
                 {
+                    int pos = 3; //this is the default position of ctor.
                     var text = constructor.Attribute("name").Value;
                     var name = text.Split('.').ToArray();
-                    text = new StringBuilder(text).Replace("#ctor", name[2]).ToString();
+                    //replace the string "ctor" with actual method name
+                    string ctorName =  name.First(x => x.Contains("ctor"));
+                    if (!String.IsNullOrEmpty(ctorName))
+                    {
+                        pos = Array.IndexOf(name, ctorName);
+                    }
+                    text = new StringBuilder(text).Replace("#ctor", name[pos - 1]).ToString();
                     constructor.Attribute("name").Value = text;
                 }
             }

--- a/tools/XmlDocToMarkdown/XmlDocToMarkdown/MarkDownExtensions.cs
+++ b/tools/XmlDocToMarkdown/XmlDocToMarkdown/MarkDownExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -40,7 +41,7 @@ namespace XmlDocToMarkdown
             var elements = new Dictionary<XElement, int>();
             foreach (var node in listOfNodes)
             {
-                var element = (XElement)node;
+                var element =  node as XElement;
                 if (element != null)
                 {
                     if (nodeDictionary.ContainsKey(element.Name.LocalName))
@@ -127,29 +128,32 @@ namespace XmlDocToMarkdown
         public static string MarkDownFormat(this string name, string format)
         {
             var returnString = String.Empty;
-            switch (format)
+            if (!String.IsNullOrEmpty(name))
             {
-                case "Bold" :
-                    //string can be Test or Test | stability.
-                    var splits = name.Split('|');
-                    if (splits.Count() > 1)
-                    {
-                        returnString = "**" + splits[0].Trim() + "**";
-                        returnString = returnString + " | " + splits[1];
-                    }
-                    else
-                    {
-                        returnString = "**" + name + "**";
-                    }
-                    break;
+                switch (format)
+                {
+                    case "Bold":
+                        //string can be Test or Test | stability.
+                        var splits = name.Split('|');
+                        if (splits.Count() > 1)
+                        {
+                            returnString = "**" + splits[0].Trim() + "**";
+                            returnString = returnString + " | " + splits[1];
+                        }
+                        else
+                        {
+                            returnString = "**" + name + "**";
+                        }
+                        break;
 
-                case "Italic":
-                    if(name!= null || name.Length > 0)
-                    {
-                        returnString = "*" + name.Trim() + "*";
-                    }
-                    break;
+                    case "Italic":
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            returnString = "*" + name.Trim() + "*";
+                        }
+                        break;
 
+                }
             }
 
             return returnString;

--- a/tools/XmlDocToMarkdown/XmlDocToMarkdown/MarkDownLibrary.cs
+++ b/tools/XmlDocToMarkdown/XmlDocToMarkdown/MarkDownLibrary.cs
@@ -48,7 +48,8 @@ namespace XmlDocToMarkdown
             }
             else
             {
-                sb.Append(GetMarkdownForType(members, t.FullName));
+                string fullName = t.FullName.Replace("+", ".");
+                sb.Append(GetMarkdownForType(members, fullName));
                 sb.AppendLine("---");
             }
 
@@ -103,7 +104,8 @@ namespace XmlDocToMarkdown
                methodName + "(" + string.Join(",", methodParams.Select(pi => pi.ParameterType.FullName)) + ")" :
                methodName;
 
-                var current = GetMarkdownForMethod(members, t.FullName + fullMethodName);
+                var fullName = t.FullName.Replace("+", ".");
+                var current = GetMarkdownForMethod(members, fullName + fullMethodName);
                 if (current != "" && !foundType) foundType = true;
                 sb.Append(current);
                 sb.AppendLine();
@@ -153,7 +155,8 @@ namespace XmlDocToMarkdown
 
                 Debug.WriteLine(t.FullName + "." + fullMethodName);
 
-                var current = GetMarkdownForMethod(members, t.FullName + "." + fullMethodName);
+                var fullName = t.FullName.Replace("+", ".");
+                var current = GetMarkdownForMethod(members, fullName + "." + fullMethodName);
                 if (current != "" && !foundType) foundType = true;
                 sb.Append(current);
                 sb.AppendLine();
@@ -195,7 +198,8 @@ namespace XmlDocToMarkdown
                  {
                      XmlToMarkdown.PropertySetType  = "get;set;";
                  }
-                var propertyNameSpace = ConvertGenericParameterName(t.FullName);
+                var fullName = t.FullName.Replace("+", ".");
+                var propertyNameSpace = ConvertGenericParameterName(fullName);
                 var current = GetMarkdownForProperty(members, propertyNameSpace + "." + property.Name);
                 if (current != "" && !foundType) foundType = true;
                 sb.Append(current);
@@ -228,7 +232,8 @@ namespace XmlDocToMarkdown
             foreach (var e in t.GetEvents())
             {
                 XmlToMarkdown.ReturnType = string.Empty;
-                var eventNameSpace = ConvertGenericParameterName(t.FullName);
+                var fullName = t.FullName.Replace("+", ".");
+                var eventNameSpace = ConvertGenericParameterName(fullName);
                 var current = GetMarkdownForEvent(members, eventNameSpace + "." + e.Name);
                 if (current != "" && !foundType) foundType = true;
                 sb.Append(current);

--- a/tools/XmlDocToMarkdown/XmlDocToMarkdown/Program.cs
+++ b/tools/XmlDocToMarkdown/XmlDocToMarkdown/Program.cs
@@ -17,7 +17,11 @@ using XmlDocToMarkdown;
 namespace Dynamo.Docs
 {
     class Program
-    {                    
+    {
+        /// <summary>
+        /// Construct the markdown files
+        /// </summary>
+        /// <param name="args">The arguments.</param>
         static void Main(string[] args)
         {
             var asm = Assembly.LoadFrom(args[0]);
@@ -31,7 +35,6 @@ namespace Dynamo.Docs
 
                 Helper.HandleConstructors(xml);
                 Helper.HandleGenerics(xml);
-
                 foreach (var ns in namespaces)
                 {
                     var cleanNamespace = ns.Replace('.', '_');
@@ -40,8 +43,8 @@ namespace Dynamo.Docs
                     {
                         Directory.CreateDirectory(outputDir);
                     }
-                    var publicTypes = asm.GetTypes().Where(t => t.Namespace == ns).Where(t => t.IsPublic);
-                   
+                    var publicTypes = asm.GetTypes().Where(t => t.Namespace == ns).Where(t => t.IsPublic || t.IsNestedPublic);
+
                     foreach (var t in publicTypes)
                     {
                         MarkDownLibrary.GenerateMarkdownDocumentForType(t, outputDir, xml);


### PR DESCRIPTION
This PR fixes the issues with XML markdown. 

1. The Recordable commands are not dispalyed in the documentation. This is because the assembly.gettype() returns a "+" in the string. Now it is replaced with ".".
2. Event names have a **. This is fixed.

@QilongTang 