### PR TITLE
add a new flag to ITransformable so that we can mark if custom transf…

### DIFF
--- a/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
@@ -177,6 +177,14 @@ namespace Dynamo.Scheduler
                         package.RequiresPerVertexColoration = true;
                     }
 
+                    //If the package has a transform that is not the identity matrix
+                    //then set requiresCustomTransform to true.
+                    if (package is ITransformable && (package as ITransformable).Transform.SequenceEqual(
+                        new double[] { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 }) == false)
+                    {
+                        (package as ITransformable).RequiresCustomTransform = true;
+                    }
+
                     if (factory.TessellationParameters.ShowEdges)
                     {
                         var surf = graphicItem as Surface;

--- a/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
@@ -167,6 +167,7 @@ namespace Dynamo.Scheduler
                 }
 
                 var package = factory.CreateRenderPackage();
+                var packageWithTransform = package as ITransformable;
                 package.Description = tag;
 
                 try
@@ -179,10 +180,10 @@ namespace Dynamo.Scheduler
 
                     //If the package has a transform that is not the identity matrix
                     //then set requiresCustomTransform to true.
-                    if (package is ITransformable && (package as ITransformable).Transform.SequenceEqual(
+                    if (packageWithTransform != null && packageWithTransform.Transform.SequenceEqual(
                         new double[] { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 }) == false)
                     {
-                        (package as ITransformable).RequiresCustomTransform = true;
+                        (packageWithTransform).RequiresCustomTransform = true;
                     }
 
                     if (factory.TessellationParameters.ShowEdges)

--- a/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
+++ b/src/DynamoCoreWpf/Rendering/HelixRenderPackage.cs
@@ -66,6 +66,11 @@ namespace Dynamo.Wpf.Rendering
         #region ITransformable implementation
 
         /// <summary>
+        /// A flag indicating whether the render package has had its Transform property set
+        /// explicitly.
+        /// </summary>
+        public bool RequiresCustomTransform { get; set; }
+        /// <summary>
         /// A 4x4 matrix that is used to transform all geometry in the render packaage.
         /// </summary>
         public double[] Transform { get; private set; }

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1363,7 +1363,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     var p = rp.Points;
                     if (p.Positions.Any())
                     {
-                        id = baseId + PointsKey;
+                        //if we require a custom transform then we need to create a new Geometry3d object.
+                        id = ((rp.RequiresCustomTransform) ? rp.Description : baseId) + PointsKey;
 
                         PointGeometryModel3D pointGeometry3D;
 
@@ -1402,7 +1403,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     var l = rp.Lines;
                     if (l.Positions.Any())
                     {
-                        id = baseId + LinesKey;
+                        //if we require a custom transform then we need to create a new Geometry3d object.
+                        id = ((rp.RequiresCustomTransform) ? rp.Description : baseId) + LinesKey;
 
                         LineGeometryModel3D lineGeometry3D;
 
@@ -1445,7 +1447,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     var m = rp.Mesh;
                     if (!m.Positions.Any()) continue;
 
-                    id = ((rp.RequiresPerVertexColoration || rp.Colors != null) ? rp.Description : baseId) + MeshKey;
+                    //if we require a custom transform or vertex coloration then we need to create a new Geometry3d object.
+                    id = ((rp.RequiresPerVertexColoration || rp.Colors != null || rp.RequiresCustomTransform) ? rp.Description : baseId) + MeshKey;
 
                     DynamoGeometryModel3D meshGeometry3D;
 

--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -217,6 +217,12 @@ namespace Autodesk.DesignScript.Interfaces
     public interface ITransformable
     {
         /// <summary>
+        /// A flag indicating whether the render package has had its Transform property set
+        /// explicitly.
+        /// </summary>
+        bool RequiresCustomTransform { get; set; }
+
+        /// <summary>
         /// A 4x4 matrix that is used to transform all geometry in the render packaage.
         /// </summary>
         double[] Transform  { get; } 


### PR DESCRIPTION
### Purpose

related to this task: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9347

 in initial testing before passing this on to @jnealb I found some bugs with this code- namely that it does not work for lines or points after recent changes to HelixWatch3dViewModel - that made it so we only created one Geometry3d object of type each. IE. we now only create 1 line object, 1 point object and push multiple lines into this object. We create multiple mesh objects so the transform interface continued to work there.

This PR adds a flag to the ITransformableInterface (`RequiresCustomTransform`) - similar to `RequresPerVertexColors`. If this flag is true then we create a new Geometry3d Object and assign the transform.

This flag is made true automatically during `UpdateGraphRenderAsyncTask` if the Transform of a renderPackage is not the same as the identity transform so that ZT authors don't need to set it manually.

here is a sample usage:

```
public class TransformableThing : IGraphicItem
    {
        public Geometry geo { get; private set; }
        public CoordinateSystem transform { get; private set; }

        public static TransformableThing byThingGeoCS(Geometry geo, CoordinateSystem cs)
        {
            var tt = new TransformableThing();
            tt.geo = geo;
            tt.transform = cs;
            return tt;
        }


        public void Tessellate(IRenderPackage package, TessellationParameters parameters)
        {
            geo.Tessellate(package, parameters);

            var method = package.GetType().
                GetMethod("SetTransform", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance, null, new[]
                { typeof(Autodesk.DesignScript.Geometry.CoordinateSystem) }, null);
           if (method != null)
            {
                 method.Invoke(package, new object[] { this.transform });
            }
               
        }

    }

}
```
##### just an aside:
I've tried to find to a way get rid of the use of reflection for ZT authors but cannot yet find one, as adding another interface to ZT classes like `ITransformAbleGraphicItem` that calls a method on the ZT class if it implements the interface stops the ZT node from loading in older Dynamo where the interface is not defined... :( 


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ramramps 
@ikeough (if you have bandwidth as you've been reviewing the whole set)

### FYIs
@sharadkjaiswal 
@jnealb 