### PR TITLE
Custom node debugging

### DIFF
--- a/src/DynamoCore/Core/CustomNodeDefinition.cs
+++ b/src/DynamoCore/Core/CustomNodeDefinition.cs
@@ -38,7 +38,7 @@ namespace Dynamo
 
             // Find output elements for the node
 
-            var outputs = nodeModels.OfType<Output>().ToList();
+            OutputNodes = nodeModels.OfType<Output>().ToList();
 
             var topMost = new List<Tuple<int, NodeModel>>();
 
@@ -47,11 +47,11 @@ namespace Dynamo
 
             // if we found output nodes, add select their inputs
             // these will serve as the function output
-            if (outputs.Any())
+            if (OutputNodes.Any())
             {
                 topMost.AddRange(
-                    outputs.Where(x => x.HasInput(0)).Select(x => Tuple.Create(0, x as NodeModel)));
-                returns = outputs.Select(x => x.Return).ToList();
+                    OutputNodes.Where(x => x.HasInput(0)).Select(x => Tuple.Create(0, x as NodeModel)));
+                returns = OutputNodes.Select(x => x.Return).ToList();
             }
             else
             {
@@ -122,14 +122,14 @@ namespace Dynamo
             #region Find inputs
 
             //Find function entry point, and then compile
-            var inputNodes = nodeModels.OfType<Symbol>().ToList();
-            var parameters = inputNodes.Select(x => new TypedParameter(
+            InputNodes = nodeModels.OfType<Symbol>().ToList();
+            var parameters = InputNodes.Select(x => new TypedParameter(
                                                    x.GetAstIdentifierForOutputIndex(0).Value,
                                                    x.Parameter.Type, 
                                                    x.Parameter.DefaultValue,
                                                    null,
                                                    x.Parameter.Summary));
-            var displayParameters = inputNodes.Select(x => x.Parameter.Name);
+            var displayParameters = InputNodes.Select(x => x.Parameter.Name);
 
             #endregion
 
@@ -139,7 +139,7 @@ namespace Dynamo
             Parameters = parameters;
             ReturnKeys = returnKeys;
             DisplayParameters = displayParameters;
-            OutputNodes = topMost.Select(x => x.Item2.GetAstIdentifierForOutputIndex(x.Item1));
+            OutputIdentifiers = topMost.Select(x => x.Item2.GetAstIdentifierForOutputIndex(x.Item1));
             DirectDependencies = nodeModels
                 .OfType<Function>()
                 .Select(node => node.Definition)
@@ -198,8 +198,18 @@ namespace Dynamo
         /// <summary>
         ///     Identifiers associated with the outputs of the custom node.
         /// </summary>
-        public IEnumerable<AssociativeNode> OutputNodes { get; private set; }
+        public IEnumerable<AssociativeNode> OutputIdentifiers { get; private set; }
         
+        /// <summary>
+        ///     Input nodes.
+        /// </summary>
+        public IEnumerable<Symbol> InputNodes { get; private set; }
+
+        /// <summary>
+        ///     Output nodes.
+        /// </summary>
+        public IEnumerable<Output> OutputNodes { get; private set; }
+
         /// <summary>
         ///     User friendly name on UI.
         /// </summary>

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -726,6 +726,788 @@ namespace Dynamo.Core
         }
 
         /// <summary>
+        /// Expand custom node instance and put all nodes in custom node annotation 
+        /// which is in sync with custom node definition.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="targetWorkspace"></param>
+        /// <param name="dynamoModel"></param>
+        public void Expand(Function instance, WorkspaceModel targetWorkspace, DynamoModel dynamoModel)
+        {
+            ExpandInternal(instance, targetWorkspace, dynamoModel, false);
+        }
+
+        /// <summary>
+        /// Expand custom node instance and put all nodes in an annotation.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="targetWorkspace"></param>
+        /// <param name="dynamoModel"></param>
+        public void ExpandToGroup(Function instance, WorkspaceModel targetWorkspace, DynamoModel dynamoModel)
+        {
+            ExpandInternal(instance, targetWorkspace, dynamoModel, true);
+        }
+
+        private void ExpandInternal(Function instance, WorkspaceModel targetWorkspace, DynamoModel dynamoModel, bool expandToGroup)
+        {
+            CustomNodeWorkspaceModel customNodeWorkspace;
+            if (!TryGetFunctionWorkspace(instance.Definition.FunctionId, false, out customNodeWorkspace))
+            {
+                return;
+            }
+
+            #region Copy nodes and notes from custom node workspace to target workspace
+            //make a lookup table to store the guids of the
+            //old models and the guids of their pasted versions
+            var modelLookup = new Dictionary<Guid, NodeModel>();
+
+            var newNodeModels = new List<NodeModel>();
+            var nodes = customNodeWorkspace.Nodes.OfType<NodeModel>().Where(n => !(n is Symbol || n is Output)).ToList();
+            foreach (var node in nodes)
+            {
+                var newNode = dynamoModel.NodeFactory.CopyNode(node, targetWorkspace);
+                modelLookup.Add(node.GUID, newNode);
+                newNodeModels.Add(newNode);
+                targetWorkspace.AddAndRegisterNode(newNode, false);
+            }
+
+            var newNoteModels = new List<NoteModel>();
+            foreach (var note in customNodeWorkspace.Notes)
+            {
+                var noteModel = new NoteModel(note.X, note.Y, note.Text, Guid.NewGuid());
+                newNoteModels.Add(noteModel);
+                targetWorkspace.AddNote(noteModel, false);
+            }
+
+            var createdModels = newNodeModels.Concat<ModelBase>(newNoteModels).ToList();
+            var shiftX = instance.X - createdModels.Min(item => item.X);
+            var shiftY = instance.Y - createdModels.Min(item => item.Y);
+            foreach (var model in createdModels)
+            {
+                model.X = model.X + shiftX;
+                model.Y = model.Y + shiftY;
+            }
+            #endregion
+
+            #region restore connectors among nodes from custom node workspace
+            var connectors = customNodeWorkspace.Connectors.Where(c => nodes.Contains(c.Start.Owner) && nodes.Contains(c.End.Owner));
+            foreach (var connector in connectors)
+            {
+                NodeModel start = null, end = null;
+                modelLookup.TryGetValue(connector.Start.Owner.GUID, out start);
+                modelLookup.TryGetValue(connector.End.Owner.GUID, out end);
+
+                if (start != null && end != null)
+                {
+                    var newConnector = ConnectorModel.Make(start, end, connector.Start.Index, connector.End.Index);
+                    createdModels.Add(newConnector);
+                }
+            }
+            #endregion
+
+            #region restore connectors to input
+            var inputConnectors = targetWorkspace.Connectors.Where(c => c.End.Owner == instance).ToList();
+            var inputs = instance.Definition.InputNodes.ToList();
+
+            foreach (var connector in inputConnectors)
+            {
+                var inputNode = inputs[connector.End.Index];
+
+                HashSet<Tuple<int, NodeModel>> outputSet;
+                if (!inputNode.OutputNodes.TryGetValue(0, out outputSet))
+                {
+                    continue;
+                }
+
+                foreach (var outputTuple in outputSet)
+                {
+                    NodeModel newNode;
+                    if (modelLookup.TryGetValue(outputTuple.Item2.GUID, out newNode))
+                    {
+                        var newConnector = ConnectorModel.Make(connector.Start.Owner, newNode, connector.Start.Index, outputTuple.Item1);
+                        createdModels.Add(newConnector);
+                    }
+                }
+            }
+            #endregion
+
+            #region restore connectors to output
+            var outputConnectors = targetWorkspace.Connectors.Where(c => c.Start.Owner == instance).ToList();
+            var outputs = instance.Definition.OutputNodes.ToList();
+
+            foreach (var connector in outputConnectors)
+            {
+                var outputNode = outputs[connector.Start.Index];
+
+                Tuple<int, NodeModel> inputTuple;
+                if (!outputNode.InputNodes.TryGetValue(0, out inputTuple))
+                {
+                    continue;
+                }
+
+                NodeModel newNode;
+                if (modelLookup.TryGetValue(inputTuple.Item2.GUID, out newNode))
+                {
+                    var newConnector = ConnectorModel.Make(newNode, connector.End.Owner, inputTuple.Item1, connector.End.Index);
+                    createdModels.Add(newConnector);
+                }
+            }
+            #endregion
+
+            #region put all nodes in a group
+            AnnotationModel annotationModel = null;
+            if (expandToGroup)
+            {
+                annotationModel = new AnnotationModel(modelLookup.Values, Enumerable.Empty<NoteModel>())
+                {
+                    GUID = Guid.NewGuid(),
+                    AnnotationText = instance.Definition.DisplayName
+                };
+            }
+            else
+            {
+                annotationModel = new CustomNodeAnnotationModel(instance.Definition.FunctionId, modelLookup.Values, newNoteModels)
+                {
+                    GUID = Guid.NewGuid(),
+                    AnnotationText = instance.Definition.DisplayName
+                };
+
+            }
+            targetWorkspace.AddAnnotation(annotationModel);
+            createdModels.Add(annotationModel);
+            #endregion
+
+            #region record all changes for undo
+            UndoRedoRecorder undoRecorder = targetWorkspace.UndoRecorder;
+            using (undoRecorder.BeginActionGroup())
+            {
+                foreach (var model in createdModels)
+                {
+                    undoRecorder.RecordCreationForUndo(model);
+                }
+
+                foreach (var connector in inputConnectors.Concat(outputConnectors))
+                {
+                    undoRecorder.RecordDeletionForUndo(connector);
+                    connector.Delete(); 
+                }
+
+                undoRecorder.RecordCreationForUndo(annotationModel);
+
+                undoRecorder.RecordDeletionForUndo(instance);
+                targetWorkspace.RemoveNode(instance);
+            };
+            #endregion
+        }
+
+        /// <summary>
+        /// Get the upstream nodes of nodes. Return Tuple in the following format.
+        /// 
+        /// inputNode, output port, <input port, node1>
+        ///                         <input port, node2>
+        //
+        /// </summary>
+        /// <param name="selectedNodeSet"></param>
+        /// <returns></returns>
+        private HashSet<Tuple<NodeModel, int, Tuple<int, NodeModel>>> GetInputNodes(IEnumerable<NodeModel> selectedNodeSet)
+        {
+            return new HashSet<Tuple<NodeModel, int, Tuple<int, NodeModel>>>(
+                   selectedNodeSet.SelectMany(
+                       node =>
+                           Enumerable.Range(0, node.InPorts.Count)
+                           .Where(node.HasConnectedInput)
+                           .Select(data => Tuple.Create(node, data, node.InputNodes[data]))
+                           .Where(input => !selectedNodeSet.Contains(input.Item3.Item2))));
+        }
+
+        /// <summary>
+        /// Get the downstream nodes of nodes. Return Tuple in the following format.
+        ///
+        /// outputNode, output port, <input port, node1>
+        ///                          <input port, node2>
+        /// </summary>
+        /// <param name="selectedNodeSet"></param>
+        /// <returns></returns>
+        private HashSet<Tuple<NodeModel, int, Tuple<int, NodeModel>>> GetOutputNodes(IEnumerable<NodeModel> selectedNodeSet)
+        {
+            return new HashSet<Tuple<NodeModel, int, Tuple<int, NodeModel>>>(
+                    selectedNodeSet.SelectMany(
+                        node =>
+                            Enumerable.Range(0, node.OutPorts.Count)
+                            .Where(node.HasOutput)
+                            .SelectMany(
+                                data =>
+                                    node.OutputNodes[data].Where(
+                                        output => !selectedNodeSet.Contains(output.Item2))
+                                    .Select(output => Tuple.Create(node, data, output)))));
+        }
+
+        /// <summary>
+        /// Copy all nodes in CustomNodeAnnotationModel to custom workspace.
+        /// </summary>
+        /// <param name="model"></param>
+        /// <param name="currentWorkspace"></param>
+        /// <param name="dynamoModel"></param>
+        internal void UpdateCustomNode(CustomNodeAnnotationModel model, WorkspaceModel currentWorkspace, DynamoModel dynamoModel)
+        {
+            CustomNodeWorkspaceModel customNodeWorkspace;
+            if (!TryGetFunctionWorkspace(model.FunctionID, false, out customNodeWorkspace))
+            {
+                return;
+            }
+            customNodeWorkspace.Clear();
+
+            var selectedNodes = model.SelectedModels.Where(s => s is NodeModel).Cast<NodeModel>();
+            var selectedNodeSet = new HashSet<NodeModel>(selectedNodes);
+
+            #region Determine Inputs and Outputs
+
+            // Determine which nodes will be inputs to the new node
+            var inputs = GetInputNodes(selectedNodeSet);
+            var outputs = GetOutputNodes(selectedNodeSet);
+
+            #endregion
+
+            #region UI Positioning Calculations
+
+            double leftMost = selectedNodeSet.Min(node => node.X);
+            double topMost = selectedNodeSet.Min(node => node.Y);
+            double rightMost = selectedNodeSet.Max(node => node.X + node.Width);
+            double leftShift = leftMost - 250;
+
+            #endregion
+
+            #region Recreate nodes and connectors in custom workspace 
+
+            var modelLookup = new Dictionary<Guid, NodeModel>();
+            var createdModels = new List<ModelBase>();
+
+            // Move all nodes and notes to new workspace remove from old
+            foreach (var node in selectedNodeSet)
+            {
+                var newNode = dynamoModel.NodeFactory.CopyNode(node, customNodeWorkspace);
+                createdModels.Add(newNode);
+                modelLookup.Add(node.GUID, newNode);
+                customNodeWorkspace.AddAndRegisterNode(newNode);
+            }
+
+            foreach (var note in model.SelectedModels.OfType<NoteModel>())
+            {
+                var newNote = new NoteModel(note.X - leftShift, note.Y - topMost, note.Text, Guid.NewGuid());
+                customNodeWorkspace.AddNote(newNote, false);
+                createdModels.Add(newNote);
+            }
+
+            var connectors = currentWorkspace.Connectors.Where(c => selectedNodeSet.Contains(c.Start.Owner) && selectedNodeSet.Contains(c.End.Owner));
+            foreach (var connector in connectors)
+            {
+                NodeModel start = null, end = null;
+                modelLookup.TryGetValue(connector.Start.Owner.GUID, out start);
+                modelLookup.TryGetValue(connector.End.Owner.GUID, out end);
+
+                if (start != null && end != null)
+                {
+                    var newConnector = ConnectorModel.Make(start, end, connector.Start.Index, connector.End.Index);
+                    createdModels.Add(newConnector);
+                }
+            }
+            #endregion
+
+            var uniqueInputSenders = new Dictionary<Tuple<NodeModel, int>, Symbol>();
+            // insert variables 
+            foreach (var input in Enumerable.Range(0, inputs.Count).Zip(inputs, Tuple.Create))
+            {
+                int inputIndex = input.Item1;
+
+                NodeModel inputReceiverNode = modelLookup[input.Item2.Item1.GUID];
+                int inputReceiverData = input.Item2.Item2;
+
+                NodeModel inputNode = input.Item2.Item3.Item2;
+                int inputData = input.Item2.Item3.Item1;
+
+                Symbol node;
+
+                var key = Tuple.Create(inputNode, inputData);
+                if (uniqueInputSenders.ContainsKey(key))
+                {
+                    node = uniqueInputSenders[key];
+                }
+                else
+                {
+                    node = new Symbol
+                    {
+                        InputSymbol = inputReceiverNode.InPorts[inputReceiverData].PortName,
+                        X = 0
+                    };
+
+                    // Try to figure out the type of input of custom node 
+                    // from the type of input of selected node. There are
+                    // two kinds of nodes whose input type are available:
+                    // function node and custom node. 
+                    List<Library.TypedParameter> parameters = null;
+
+                    if (inputReceiverNode is Function)
+                    {
+                        var func = inputReceiverNode as Function;
+                        parameters = func.Controller.Definition.Parameters.ToList();
+                    }
+                    else if (inputReceiverNode is DSFunctionBase)
+                    {
+                        var dsFunc = inputReceiverNode as DSFunctionBase;
+                        var funcDesc = dsFunc.Controller.Definition;
+                        parameters = funcDesc.Parameters.ToList();
+
+                        if (funcDesc.Type == Engine.FunctionType.InstanceMethod ||
+                            funcDesc.Type == Engine.FunctionType.InstanceProperty)
+                        {
+                            var dummyType = new ProtoCore.Type() { Name = funcDesc.ClassName };
+                            var instanceParam = new TypedParameter(funcDesc.ClassName, dummyType);
+                            parameters.Insert(0, instanceParam);
+                        }
+                    }
+
+                    // so the input of custom node has format 
+                    //    input_var_name : type
+                    if (parameters != null && parameters.Count() > inputReceiverData)
+                    {
+                        var typeName = parameters[inputReceiverData].DisplayTypeName;
+                        if (!string.IsNullOrEmpty(typeName))
+                        {
+                            node.InputSymbol += " : " + typeName;
+                        }
+                    }
+
+                    node.SetNickNameFromAttribute();
+                    node.Y = inputIndex * (50 + node.Height);
+
+                    uniqueInputSenders[key] = node;
+
+                    customNodeWorkspace.AddAndRegisterNode(node);
+                    createdModels.Add(node);
+                }
+
+                var connector = ConnectorModel.Make(node, inputReceiverNode, 0, inputReceiverData);
+                createdModels.Add(connector);
+            }
+
+            #region Process outputs
+
+            //List of all inner nodes to connect an output. Unique.
+            var outportList = new List<Tuple<NodeModel, int>>();
+
+            var outConnectors = new List<Tuple<NodeModel, int, int>>();
+
+            int i = 0;
+            if (outputs.Any())
+            {
+                foreach (var output in outputs)
+                {
+                    if (outportList.All(x => !(x.Item1 == modelLookup[output.Item1.GUID] && x.Item2 == output.Item2)))
+                    {
+                        NodeModel outputSenderNode = modelLookup[output.Item1.GUID];
+                        int outputSenderData = output.Item2;
+
+                        outportList.Add(Tuple.Create(outputSenderNode, outputSenderData));
+
+                        //Create Symbol Node
+                        var node = new Output
+                        {
+                            Symbol = outputSenderNode.OutPorts[outputSenderData].PortName,
+                            X = rightMost + 75 - leftShift
+                        };
+
+                        node.Y = i * (50 + node.Height);
+
+                        node.SetNickNameFromAttribute();
+
+                        customNodeWorkspace.AddAndRegisterNode(node);
+                        createdModels.Add(node);
+                        var connector = ConnectorModel.Make(outputSenderNode, node, outputSenderData, 0);
+                        createdModels.Add(connector);
+
+                        i++;
+                    }
+                }
+
+                //Connect outputs to new node
+                outConnectors.AddRange(
+                    from output in outputs
+                    let outputSenderNode = output.Item1
+                    let outputSenderData = output.Item2
+                    let outputReceiverData = output.Item3.Item1
+                    let outputReceiverNode = output.Item3.Item2
+                    select
+                        Tuple.Create(
+                            outputReceiverNode,
+                            outportList.FindIndex(
+                                x => x.Item1 == outputSenderNode && x.Item2 == outputSenderData),
+                            outputReceiverData));
+            }
+            else
+            {
+                foreach (var hanging in
+                    selectedNodeSet.SelectMany(
+                        node =>
+                            Enumerable.Range(0, node.OutPortData.Count)
+                            .Where(port => !node.HasOutput(port))
+                            .Select(port => new { node, port })).Distinct())
+                {
+                    var hangingNode = modelLookup[hanging.node.GUID];
+
+                    //Create Symbol Node
+                    var node = new Output
+                    {
+                        Symbol = hangingNode.OutPortData[hanging.port].NickName,
+                        X = rightMost + 75 - leftShift
+                    };
+                    node.Y = i * (50 + node.Height);
+                    node.SetNickNameFromAttribute();
+
+                    createdModels.Add(node);
+                    customNodeWorkspace.AddAndRegisterNode(node);
+                    ConnectorModel.Make(hangingNode, node, hanging.port, 0);
+
+                    i++;
+                }
+            }
+
+            #endregion
+
+            #region record all changes for undo
+            UndoRedoRecorder undoRecorder = customNodeWorkspace.UndoRecorder;
+            using (undoRecorder.BeginActionGroup())
+            {
+                foreach (var newModel in createdModels)
+                {
+                    undoRecorder.RecordCreationForUndo(newModel);
+                }
+            };
+            #endregion
+        }
+
+        internal void RestoreCustomNodeInstance(CustomNodeAnnotationModel model, WorkspaceModel currentWorkspace)
+        {
+            CustomNodeWorkspaceModel customNodeWorkspace;
+            if (!TryGetFunctionWorkspace(model.FunctionID, false, out customNodeWorkspace))
+            {
+                return;
+            }
+
+            UndoRedoRecorder undoRecorder = currentWorkspace.UndoRecorder;
+            using (undoRecorder.BeginActionGroup())
+            {
+                #region Determine Inputs and Outputs
+
+                var selectedNodes = model.SelectedModels.OfType<NodeModel>().ToList();
+                var inputs = GetInputNodes(selectedNodes);
+                var outputs = GetOutputNodes(selectedNodes);
+
+                #endregion
+
+                #region UI Positioning Calculations
+                double avgX = selectedNodes.Average(node => node.X);
+                double avgY = selectedNodes.Average(node => node.Y);
+                #endregion
+
+                #region Handle connectors
+                foreach (var group in DynamoSelection.Instance.Selection.OfType<AnnotationModel>())
+                {
+                    undoRecorder.RecordDeletionForUndo(group);
+                    currentWorkspace.RemoveGroup(group);
+                }
+
+                var connectors = currentWorkspace.Connectors.Where(c =>
+                    selectedNodes.Contains(c.Start.Owner) || selectedNodes.Contains(c.End.Owner)).ToList();
+                foreach (var connector in connectors)
+                {
+                    undoRecorder.RecordDeletionForUndo(connector);
+                    connector.Delete();
+                }
+                #endregion
+
+                #region Remove all nodes and notes in the group
+                foreach (var node in selectedNodes)
+                {
+                    undoRecorder.RecordDeletionForUndo(node);
+                    currentWorkspace.RemoveNode(node);
+                }
+
+                foreach (var note in model.SelectedModels.OfType<NoteModel>())
+                {
+                    undoRecorder.RecordDeletionForUndo(note);
+                    currentWorkspace.RemoveNote(note);
+                }
+
+                #endregion
+
+                #region Process inputs
+
+                var inConnectors = new List<Tuple<NodeModel, int>>();
+                foreach (var input in inputs)
+                {
+                    if (!inConnectors.Any(x => x.Item1 == input.Item3.Item2 && x.Item2 == input.Item3.Item1))
+                    {
+                        inConnectors.Add(Tuple.Create(input.Item3.Item2, input.Item3.Item1));
+                    }
+                }
+
+                #endregion
+
+                #region Process outputs
+
+                //List of all inner nodes to connect an output. Unique.
+                var outportList = new List<Tuple<NodeModel, int>>();
+                var outConnectors = new List<Tuple<NodeModel, int, int>>();
+                foreach (var output in outputs)
+                {
+                    if (outportList.All(x => !(x.Item1 == output.Item1 && x.Item2 == output.Item2)))
+                    {
+                        outportList.Add(Tuple.Create(output.Item1, output.Item2));
+                    }
+                }
+
+                //Connect outputs to new node
+                outConnectors.AddRange(
+                    from output in outputs
+                    let outputSenderNode = output.Item1
+                    let outputSenderData = output.Item2
+                    let outputReceiverData = output.Item3.Item1
+                    let outputReceiverNode = output.Item3.Item2
+                    select Tuple.Create(outputReceiverNode,
+                            outportList.FindIndex(x => x.Item1 == outputSenderNode && x.Item2 == outputSenderData),
+                            outputReceiverData));
+
+                #endregion
+
+                var collapsedNode = CreateCustomNodeInstance(model.FunctionID, isTestMode: false);
+                collapsedNode.X = avgX;
+                collapsedNode.Y = avgY;
+                currentWorkspace.AddAndRegisterNode(collapsedNode, centered: false);
+                undoRecorder.RecordCreationForUndo(collapsedNode);
+
+                for (int idx = 0; idx < inConnectors.Count; idx++)
+                {
+                    var connector = ConnectorModel.Make(inConnectors[idx].Item1, collapsedNode, inConnectors[idx].Item2, idx); 
+                    undoRecorder.RecordCreationForUndo(connector);
+                }
+
+                foreach (var outConnector in outConnectors)
+                {
+                    var connector = ConnectorModel.Make(collapsedNode, outConnector.Item1, outConnector.Item2, outConnector.Item3);
+                    undoRecorder.RecordCreationForUndo(connector);
+                }
+            }
+        }
+
+        internal void UpdateCustomNodeAnnotationModel(CustomNodeAnnotationModel model, WorkspaceModel currentWorkspace, DynamoModel dynamoModel)
+        {
+            CustomNodeWorkspaceModel customNodeWorkspace;
+            if (!TryGetFunctionWorkspace(model.FunctionID, false, out customNodeWorkspace))
+            {
+                return;
+            }
+
+            CustomNodeDefinition defintion;
+            if (!TryGetFunctionDefinition(model.FunctionID, false, out defintion))
+            {
+                return;
+            }
+
+            #region get a list of input and output nodes, we'll restore connectors later on
+            var selectedNodes = model.SelectedModels.OfType<NodeModel>().ToList();
+            var inputs = GetInputNodes(selectedNodes);
+            var inConnectors = new List<Tuple<NodeModel, int>>();
+            foreach (var input in inputs)
+            {
+                if (!inConnectors.Any(x => x.Item1 == input.Item3.Item2 && x.Item2 == input.Item3.Item1))
+                {
+                    inConnectors.Add(Tuple.Create(input.Item3.Item2, input.Item3.Item1));
+                }
+            }
+
+            var outputs = GetOutputNodes(selectedNodes);
+            var outportList = new List<Tuple<NodeModel, int>>();
+            foreach (var output in outputs)
+            {
+                if (!outportList.Any(x => x.Item1 == output.Item1 && x.Item2 == output.Item2))
+                {
+                    outportList.Add(Tuple.Create(output.Item1, output.Item2));
+                }
+            }
+            var outConnector = outputs.Select(output => 
+                Tuple.Create(output.Item3.Item2,
+                        outportList.FindIndex(x => x.Item1 == output.Item1 && x.Item2 == output.Item2),
+                        output.Item3.Item1)).ToList();
+            #endregion
+
+            UndoRedoRecorder undoRecorder = currentWorkspace.UndoRecorder;
+            using (undoRecorder.BeginActionGroup())
+            {
+                #region Remove all nods/notes/connectors in custom node annotation
+                var title = string.Empty;
+                var background = string.Empty;
+                foreach (var group in DynamoSelection.Instance.Selection.OfType<AnnotationModel>())
+                {
+                    title = group.AnnotationText;
+                    background = group.Background;
+                    undoRecorder.RecordDeletionForUndo(group);
+                    currentWorkspace.RemoveGroup(group);
+                }
+
+                var connectors = currentWorkspace.Connectors.Where(c =>
+                    selectedNodes.Contains(c.Start.Owner) || selectedNodes.Contains(c.End.Owner)).ToList();
+                foreach (var connector in connectors)
+                {
+                    undoRecorder.RecordDeletionForUndo(connector);
+                    connector.Delete();
+                }
+
+                foreach (var node in selectedNodes)
+                {
+                    undoRecorder.RecordDeletionForUndo(node);
+                    currentWorkspace.RemoveNode(node);
+                }
+
+                foreach (var note in model.SelectedModels.OfType<NoteModel>())
+                {
+                    undoRecorder.RecordDeletionForUndo(note);
+                    currentWorkspace.RemoveNote(note);
+                }
+
+                #endregion
+
+                #region copy nodes/notes/connectors from custom node to workspace
+                // Create the new NodeModel's
+                var newNodeModels = new List<NodeModel>();
+
+                //make a lookup table to store the guids of the
+                //old models and the guids of their pasted versions
+                var modelLookup = new Dictionary<Guid, NodeModel>();
+
+                var nodes = customNodeWorkspace.Nodes.OfType<NodeModel>().Where(n => !(n is Symbol || n is Output)).ToList();
+                foreach (var node in nodes)
+                {
+                    var newNode = dynamoModel.NodeFactory.CopyNode(node, currentWorkspace);
+                    modelLookup.Add(node.GUID, newNode);
+                    newNodeModels.Add(newNode);
+                }
+
+                var newNoteModels = new List<NoteModel>();
+                foreach (var note in customNodeWorkspace.Notes)
+                {
+                    var noteModel = new NoteModel(note.X, note.Y, note.Text, Guid.NewGuid());
+                    newNoteModels.Add(noteModel);
+                }
+
+                var newItems = newNodeModels.Concat<ModelBase>(newNoteModels);
+                var shiftX = model.X - newItems.Min(item => item.X);
+                var shiftY = model.Y - newItems.Min(item => item.Y);
+                foreach (var m in newItems)
+                {
+                    m.X = m.X + shiftX;
+                    m.Y = m.Y + shiftY;
+                }
+
+                //make a list of all newly created models so that their
+                //creations can be recorded in the undo recorder.
+                var createdModels = new List<ModelBase>();
+                foreach (var newNode in newNodeModels)
+                {
+                    currentWorkspace.AddAndRegisterNode(newNode, false);
+                    createdModels.Add(newNode);
+                }
+
+                foreach (var newNote in newNoteModels)
+                {
+                    currentWorkspace.AddNote(newNote, false);
+                    createdModels.Add(newNote);
+                }
+
+                var newConnectors = customNodeWorkspace.Connectors.Where(
+                    c => nodes.Contains(c.Start.Owner) && nodes.Contains(c.End.Owner));
+                foreach (var connector in newConnectors)
+                {
+                    NodeModel start = null, end = null;
+                    modelLookup.TryGetValue(connector.Start.Owner.GUID, out start);
+                    modelLookup.TryGetValue(connector.End.Owner.GUID, out end);
+
+                    if (start != null && end != null)
+                    {
+                        var newConnector = ConnectorModel.Make(start, end, connector.Start.Index, connector.End.Index);
+                        createdModels.Add(newConnector);
+                    }
+                }
+                #endregion
+
+                #region restore input and output connectors
+
+                var customInputNodes = defintion.InputNodes.ToList();
+                for (int idx = 0; idx < inConnectors.Count; idx++)
+                {
+                    var inputNode = customInputNodes[idx];
+                    var inputTuple = inConnectors[idx];
+
+                    HashSet<Tuple<int, NodeModel>> outputSet;
+                    if (!inputNode.OutputNodes.TryGetValue(0, out outputSet))
+                    {
+                        continue;
+                    }
+
+                    foreach (var outputTuple in outputSet)
+                    {
+                        NodeModel newNode;
+                        if (modelLookup.TryGetValue(outputTuple.Item2.GUID, out newNode))
+                        {
+                            var newConnector = ConnectorModel.Make(inputTuple.Item1, newNode, inputTuple.Item2, outputTuple.Item1);
+                            createdModels.Add(newConnector);
+                        }
+                    }
+                }
+
+                var customOutputNodes = defintion.OutputNodes.ToList();
+                for (int idx = 0; idx < outConnector.Count; idx++)
+                {
+                    var outputTuple = outConnector[idx];
+                    var outputNode = customOutputNodes[outputTuple.Item2];
+
+                    Tuple<int, NodeModel> inputTuple;
+                    if (!outputNode.InputNodes.TryGetValue(0, out inputTuple))
+                    {
+                        continue;
+                    }
+
+                    NodeModel newNode;
+                    if (modelLookup.TryGetValue(inputTuple.Item2.GUID, out newNode))
+                    {
+                        var newConnector = ConnectorModel.Make(newNode, outputTuple.Item1, inputTuple.Item1, outputTuple.Item3);
+                        createdModels.Add(newConnector);
+                    }
+                }
+                #endregion
+
+                #region put all nodes in a group
+                var annotationModel = new CustomNodeAnnotationModel(model.FunctionID, modelLookup.Values, newNoteModels)
+                {
+                    GUID = Guid.NewGuid(),
+                    AnnotationText = title,
+                    Background = background
+                };
+                currentWorkspace.AddAnnotation(annotationModel);
+                createdModels.Add(annotationModel);
+                #endregion
+
+                #region record all changes for undo
+                foreach (var m in createdModels)
+                {
+                    undoRecorder.RecordCreationForUndo(m);
+                }
+
+                undoRecorder.RecordCreationForUndo(annotationModel);
+                #endregion
+            }
+        }
+
+        /// <summary>
         ///     Collapse a set of nodes in a given workspace.
         /// </summary>
         /// <param name="selectedNodes"> The function definition for the user-defined node </param>
@@ -762,27 +1544,8 @@ namespace Dynamo.Core
                 #region Determine Inputs and Outputs
 
                 //Step 1: determine which nodes will be inputs to the new node
-                var inputs =
-                    new HashSet<Tuple<NodeModel, int, Tuple<int, NodeModel>>>(
-                        selectedNodeSet.SelectMany(
-                            node =>
-                                Enumerable.Range(0, node.InPorts.Count)
-                                .Where(node.HasConnectedInput)
-                                .Select(data => Tuple.Create(node, data, node.InputNodes[data]))
-                                .Where(input => !selectedNodeSet.Contains(input.Item3.Item2))));
-
-                var outputs =
-                    new HashSet<Tuple<NodeModel, int, Tuple<int, NodeModel>>>(
-                        selectedNodeSet.SelectMany(
-                            node =>
-                                Enumerable.Range(0, node.OutPorts.Count)
-                                .Where(node.HasOutput)
-                                .SelectMany(
-                                    data =>
-                                        node.OutputNodes[data].Where(
-                                            output => !selectedNodeSet.Contains(output.Item2))
-                                        .Select(output => Tuple.Create(node, data, output)))));
-
+                var inputs = GetInputNodes(selectedNodeSet);
+                var outputs = GetOutputNodes(selectedNodeSet);
                 #endregion
 
                 #region Detect 1-node holes (higher-order function extraction)
@@ -819,7 +1582,7 @@ namespace Dynamo.Core
                 //                            .ToList();
 
                 //                    var nodeInputs =
-                //                        outputs.Where(output => output.Item3.Item2 == outerNode)
+                //                        outputs.Where(output => output.I.tem3.Item2 == outerNode)
                 //                            .Select(
                 //                                output =>
                 //                                    new

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -115,6 +115,7 @@ limitations under the License.
     <Compile Include="Configuration\Context.cs" />
     <Compile Include="Core\DynamoMigrator.cs" />
     <Compile Include="Exceptions\LibraryLoadFailedException.cs" />
+    <Compile Include="Graph\Annotations\CustomNodeAnnotationModel.cs" />
     <Compile Include="Scheduler\Disposable.cs" />
     <Compile Include="Engine\LinkedListOfList.cs" />
     <Compile Include="Extensions\EnumExtension.cs" />

--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -351,7 +351,7 @@ namespace Dynamo.Engine
                     definition.ReturnKeys,
                     definition.FunctionName,
                     definition.FunctionBody,
-                    definition.OutputNodes,
+                    definition.OutputIdentifiers,
                     definition.Parameters,
                     verboseLogging);
 

--- a/src/DynamoCore/Graph/Annotations/CustomNodeAnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/CustomNodeAnnotationModel.cs
@@ -1,0 +1,50 @@
+﻿using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Notes;
+using Dynamo.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Dynamo.Graph.Annotations
+{
+    /// <summary>
+    /// Annotation for expanded custom node.
+    /// </summary>
+    public class CustomNodeAnnotationModel: AnnotationModel
+    {
+        /// <summary>
+        /// Construct CustomNodeAnnotationModel with custom node definition and nodes
+        /// </summary>
+        /// <param name="functionID"></param>
+        /// <param name="nodes"></param>
+        public CustomNodeAnnotationModel(Guid functionID, IEnumerable<NodeModel> nodes, IEnumerable<NoteModel> notes):
+            base(nodes, notes)
+        {
+            FunctionID = functionID; 
+        }
+        
+        /// <summary>
+        /// Function ID of custom node definition
+        /// </summary>
+        public Guid FunctionID 
+        {
+            get; private set;
+        }
+
+        protected override void SerializeCore(XmlElement element, SaveContext context)
+        {
+            XmlElementHelper helper = new XmlElementHelper(element);
+            helper.SetAttribute("functionID", this.FunctionID);
+            base.SerializeCore(element, context);
+        }
+
+        protected override void DeserializeCore(XmlElement element, SaveContext context)
+        {
+            XmlElementHelper helper = new XmlElementHelper(element);
+            base.DeserializeCore(element, context);
+        }
+    }
+}

--- a/src/DynamoCore/Graph/NodeGraph.cs
+++ b/src/DynamoCore/Graph/NodeGraph.cs
@@ -145,7 +145,17 @@ namespace Dynamo.Graph
 
         internal static AnnotationModel LoadAnnotationFromXml(XmlNode annotation, IEnumerable<NodeModel> nodes, IEnumerable<NoteModel> notes)
         {
-            var instance = new AnnotationModel(nodes,notes);             
+            AnnotationModel instance = null;
+            var idAttr = annotation.Attributes["functionID"];
+            Guid functionID;
+            if (idAttr == null || string.IsNullOrEmpty(idAttr.Value) || !Guid.TryParse(idAttr.Value, out functionID))
+            {
+                instance = new AnnotationModel(nodes, notes);
+            }
+            else
+            {
+                instance = new CustomNodeAnnotationModel(functionID, nodes, notes);
+            }
             instance.Deserialize(annotation as XmlElement, SaveContext.File);
             return instance;
         }

--- a/src/DynamoCore/Graph/Nodes/NodeLoaders/NodeFactory.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeLoaders/NodeFactory.cs
@@ -5,6 +5,7 @@ using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Logging;
 using Dynamo.Utilities;
 using ProtoCore.Namespace;
+using Dynamo.Graph.Workspaces;
 
 namespace Dynamo.Graph.Nodes.NodeLoaders
 {
@@ -354,6 +355,34 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
 
             node = null;
             return false;
+        }
+
+        /// <summary>
+        /// Copy a node.
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="workspace"></param>
+        /// <returns></returns>
+        internal NodeModel CopyNode(NodeModel node, WorkspaceModel workspace)
+        {
+            NodeModel newNode;
+
+            var xmlDoc = new XmlDocument();
+            var dynEl = node.Serialize(xmlDoc, SaveContext.Copy);
+            newNode = CreateNodeFromXml(dynEl, SaveContext.Copy, workspace.ElementResolver);
+
+            var lacing = node.ArgumentLacing.ToString();
+            newNode.UpdateValue(new UpdateValueParams("ArgumentLacing", lacing));
+            if (!string.IsNullOrEmpty(node.NickName) && !(node is CustomNodes.Symbol) && !(node is Output))
+            {
+                newNode.NickName = node.NickName;
+            }
+
+            newNode.X = node.X;
+            newNode.Y = node.Y;
+            newNode.Width = node.Width;
+            newNode.Height = node.Height;
+            return newNode;
         }
     }
 }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -2414,13 +2414,27 @@ namespace Dynamo.Graph.Workspaces
                 var selectedNodes = this.Nodes == null ? null : this.Nodes.Where(s => s.IsSelected);
                 var selectedNotes = this.Notes == null ? null : this.Notes.Where(s => s.IsSelected);
 
-                var annotationModel = new AnnotationModel(selectedNodes, selectedNotes);
+                AnnotationModel annotationModel = null;
+                if (typeName.Contains("CustomNodeAnnotationModel"))
+                {
+                    string guid = helper.ReadString("functionID");
+                    Guid functionID;
+                    if (!string.IsNullOrEmpty(guid) && Guid.TryParse(guid, out functionID))
+                    {
+                        annotationModel = new CustomNodeAnnotationModel(functionID, selectedNodes, selectedNotes);
+                    }
+                }
+
+                if (annotationModel == null)
+                {
+                    annotationModel = new AnnotationModel(selectedNodes, selectedNotes);
+                }
+
                 annotationModel.ModelBaseRequested += annotationModel_GetModelBase;
                 annotationModel.Disposed += (_) => annotationModel.ModelBaseRequested -= annotationModel_GetModelBase;
                 annotationModel.Deserialize(modelData, SaveContext.Undo);
                 AddNewAnnotation(annotationModel);
             }
-
             else if (typeName.Contains("PresetModel"))
             {
                 var preset = new PresetModel(this.Nodes);

--- a/src/DynamoCoreWpf/Commands/NodeCommands.cs
+++ b/src/DynamoCoreWpf/Commands/NodeCommands.cs
@@ -23,6 +23,8 @@ namespace Dynamo.ViewModels
         private DelegateCommand _ungroupCommand;
         private DelegateCommand _addToGroupCommand;
         private DelegateCommand _computeRunStateOfTheNodeCommand;
+        private DelegateCommand _expandCommand;
+        private DelegateCommand _expandToWorkspaceCommand;
 
         public DelegateCommand RenameCommand
         {
@@ -159,6 +161,27 @@ namespace Dynamo.ViewModels
                 if (_gotoWorkspaceCommand == null)
                     _gotoWorkspaceCommand = new DelegateCommand(GotoWorkspace, CanGotoWorkspace);
                 return _gotoWorkspaceCommand;
+            }
+        }
+
+        public DelegateCommand ExpandCommand
+        {
+            get
+            {
+                if (_expandCommand == null)
+                    _expandCommand = new DelegateCommand(Expand, CanExpand);
+                return _expandCommand;
+            }
+        }
+
+
+        public DelegateCommand ExpandToWorkspaceCommand
+        {
+            get
+            {
+                if (_expandToWorkspaceCommand == null)
+                    _expandToWorkspaceCommand = new DelegateCommand(ExpandToWorkspace, CanExpandToWorkspace);
+                return _expandToWorkspaceCommand;
             }
         }
 

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -287,6 +287,7 @@
     <Compile Include="ViewModels\Core\AnnotationExtension.cs" />
     <Compile Include="ViewModels\Core\AnnotationViewModel.cs" />
     <Compile Include="Utilities\ResourceUtilities.cs" />
+    <Compile Include="ViewModels\Core\CustomNodeAnnotationViewModel.cs" />
     <Compile Include="ViewModels\Core\DynamoViewModelBranding.cs" />
     <Compile Include="ViewModels\Core\GalleryViewModel.cs" />
     <Compile Include="ViewModels\Core\HomeWorkspaceViewModel.cs" />
@@ -311,6 +312,9 @@
       <DependentUpon>AboutWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\CodeBlocks\CodeBlockEditor.cs" />
+    <Compile Include="Views\Core\CustomNodeAnnotationView.xaml.cs">
+      <DependentUpon>CustomNodeAnnotationView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\Core\DynamoOpenFileDialog.cs" />
     <Compile Include="Views\Gallery\GalleryView.xaml.cs">
       <DependentUpon>GalleryView.xaml</DependentUpon>
@@ -1085,6 +1089,10 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Views\Core\CustomNodeAnnotationView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\Gallery\GalleryView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -20,6 +20,23 @@ namespace Dynamo.Wpf
             dynamoViewModel = nodeView.ViewModel.DynamoViewModel;
 
             nodeView.MainContextMenu.Items.Add(new Separator());
+            var expandCustomNode = new MenuItem
+            {
+                Header = Resources.ContextMenuExpandCustomNode,
+                IsCheckable = false
+            };
+            nodeView.MainContextMenu.Items.Add(expandCustomNode);
+            expandCustomNode.Click += (sender, args) => Expand(nodeView.ViewModel);
+
+            var expandCustomNodeToWorkspace = new MenuItem
+            {
+                Header = Resources.ContextMenuExpandCustomNodeToGroup,
+                IsCheckable = false
+            };
+            nodeView.MainContextMenu.Items.Add(expandCustomNodeToWorkspace);
+            expandCustomNodeToWorkspace.Click += (sender, args) => ExpandToWorkspace(nodeView.ViewModel);
+
+            nodeView.MainContextMenu.Items.Add(new Separator());
 
             // edit contents
             var editItem = new MenuItem
@@ -100,6 +117,23 @@ namespace Dynamo.Wpf
             if (viewModel.GotoWorkspaceCommand.CanExecute(null))
             {
                 viewModel.GotoWorkspaceCommand.Execute(null);
+            }
+        }
+
+
+        private static void Expand(NodeViewModel viewModel)
+        {
+            if (viewModel != null && viewModel.ExpandCommand.CanExecute(null))
+            {
+                viewModel.ExpandCommand.Execute(null);
+            }
+        }
+
+        private static void ExpandToWorkspace(NodeViewModel viewModel)
+        {
+            if (viewModel != null && viewModel.ExpandToWorkspaceCommand.CanExecute(null))
+            {
+                viewModel.ExpandToWorkspaceCommand.Execute(null);
             }
         }
 

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -377,6 +377,24 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Expand Custom Node.
+        /// </summary>
+        public static string ContextMenuExpandCustomNode {
+            get {
+                return ResourceManager.GetString("ContextMenuExpandCustomNode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expand Custom Node to Group.
+        /// </summary>
+        public static string ContextMenuExpandCustomNodeToGroup {
+            get {
+                return ResourceManager.GetString("ContextMenuExpandCustomNodeToGroup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Fit to Screen.
         /// </summary>
         public static string ContextMenuFitToScreen {
@@ -530,6 +548,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Restore to Custom Node Instance.
+        /// </summary>
+        public static string ContextMenuRestoreToCustomNodeInstance {
+            get {
+                return ResourceManager.GetString("ContextMenuRestoreToCustomNodeInstance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show all geometry preview.
         /// </summary>
         public static string ContextMenuShowAllGeometry {
@@ -553,6 +580,24 @@ namespace Dynamo.Wpf.Properties {
         public static string ContextMenuShowUpstreamPreview {
             get {
                 return ResourceManager.GetString("ContextMenuShowUpstreamPreview", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sync with Custom Node.
+        /// </summary>
+        public static string ContextMenuSyncWithCustomNodeDefinition {
+            get {
+                return ResourceManager.GetString("ContextMenuSyncWithCustomNodeDefinition", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update Custom Node.
+        /// </summary>
+        public static string ContextMenuUpdateCustomNodeDefintion {
+            get {
+                return ResourceManager.GetString("ContextMenuUpdateCustomNodeDefintion", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2001,4 +2001,19 @@ Next assemblies were loaded several times:
     <value>Failed to add file: {0}</value>
     <comment>Message box content</comment>
   </data>
+  <data name="ContextMenuExpandCustomNode" xml:space="preserve">
+    <value>Expand Custom Node</value>
+  </data>
+  <data name="ContextMenuExpandCustomNodeToGroup" xml:space="preserve">
+    <value>Expand Custom Node to Group</value>
+  </data>
+  <data name="ContextMenuUpdateCustomNodeDefintion" xml:space="preserve">
+    <value>Update Custom Node</value>
+  </data>
+  <data name="ContextMenuRestoreToCustomNodeInstance" xml:space="preserve">
+    <value>Restore to Custom Node Instance</value>
+  </data>
+  <data name="ContextMenuSyncWithCustomNodeDefinition" xml:space="preserve">
+    <value>Sync with Custom Node</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2003,4 +2003,19 @@ Next assemblies were loaded several times:
     <value>Failed to add file: {0}</value>
     <comment>Message box content</comment>
   </data>
+  <data name="ContextMenuExpandCustomNode" xml:space="preserve">
+    <value>Expand Custom Node</value>
+  </data>
+  <data name="ContextMenuUpdateCustomNodeDefintion" xml:space="preserve">
+    <value>Update Custom Node</value>
+  </data>
+  <data name="ContextMenuExpandCustomNodeToGroup" xml:space="preserve">
+    <value>Expand Custom Node to Group</value>
+  </data>
+  <data name="ContextMenuRestoreToCustomNodeInstance" xml:space="preserve">
+    <value>Restore to Custom Node Instance</value>
+  </data>
+  <data name="ContextMenuSyncWithCustomNodeDefinition" xml:space="preserve">
+    <value>Sync with Custom Node</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DataTemplates.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DataTemplates.xaml
@@ -27,4 +27,7 @@
         <nodes:AnnotationView></nodes:AnnotationView>
     </DataTemplate>
 
+    <DataTemplate DataType="{x:Type viewModels:CustomNodeAnnotationViewModel}">
+        <nodes:CustomNodeAnnotationView></nodes:CustomNodeAnnotationView>
+    </DataTemplate>
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/ViewModels/Core/CustomNodeAnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/CustomNodeAnnotationViewModel.cs
@@ -1,0 +1,152 @@
+﻿using Dynamo.Graph.Annotations;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Workspaces;
+using Dynamo.Selection;
+using Dynamo.UI.Commands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dynamo.ViewModels
+{
+    public class CustomNodeAnnotationViewModel : AnnotationViewModel
+    {
+        private CustomNodeAnnotationModel annotationModel;
+
+        public CustomNodeAnnotationViewModel(WorkspaceViewModel workspaceViewModel, CustomNodeAnnotationModel model)
+            : base(workspaceViewModel, model)
+        {
+            annotationModel = model;
+            annotationModel.PropertyChanged += OnPropertyChanged;
+        }
+
+
+        private DelegateCommand _updateCustomNodeDefinitionCommand;
+        public DelegateCommand UpdateCustomNodeDefinitionCommand
+        {
+            get
+            {
+                if (_updateCustomNodeDefinitionCommand == null)
+                    _updateCustomNodeDefinitionCommand =
+                        new DelegateCommand(UpdateCustomNodeDefintion, CanUpdateCustomNodeDefinition);
+
+                return _updateCustomNodeDefinitionCommand;
+            }
+        }
+
+        private bool CanUpdateCustomNodeDefinition(object obj)
+        {
+            return annotationModel.IsSelected;
+        }
+
+        private void UpdateCustomNodeDefintion(object obj)
+        {
+            if (annotationModel.IsSelected)
+            {
+                this.WorkspaceViewModel.DynamoViewModel.UpdateCustomNodeDefinition(annotationModel);
+            }
+        }
+
+        private DelegateCommand _restoreCustomNodeInstanceCommand;
+        public DelegateCommand RestoreCustomNodeInstanceCommand
+        {
+            get
+            {
+                if (_restoreCustomNodeInstanceCommand == null)
+                    _restoreCustomNodeInstanceCommand =
+                        new DelegateCommand(RestoreCustomNodeInstance, CanRestoreCustomNodeInstance);
+
+                return _restoreCustomNodeInstanceCommand;
+            }
+        }
+
+        private DelegateCommand _syncWithCustomNodeDefinitionCommand;
+        public DelegateCommand SyncWithCustomNodeDefinitionCommand
+        {
+            get
+            {
+                if (_syncWithCustomNodeDefinitionCommand == null)
+                    _syncWithCustomNodeDefinitionCommand =
+                        new DelegateCommand(SyncWithCustomNodeDefinition, CanRestoreCustomNodeInstance);
+
+                return _syncWithCustomNodeDefinitionCommand;
+            }
+        }
+
+        private DelegateCommand _editCustomNodeCommand;
+        public DelegateCommand EditCustomNodeCommand
+        {
+            get
+            {
+                if (_editCustomNodeCommand == null)
+                {
+                    _editCustomNodeCommand = new DelegateCommand(EditCustomNode, CanEditCustomNode);
+                }
+
+                return _editCustomNodeCommand;
+            }
+        }
+
+        private bool CanRestoreCustomNodeInstance(object obj)
+        {
+            return annotationModel.IsSelected;
+        }
+
+        private void RestoreCustomNodeInstance(object obj)
+        {
+            if (annotationModel.IsSelected)
+            {
+                this.WorkspaceViewModel.DynamoViewModel.RestoreCustomNodeInstance(annotationModel);
+            }
+        }
+
+        private bool CanSyncWithCustomNodeDefinition(object obj)
+        {
+            return annotationModel.IsSelected;
+        }
+
+        private void SyncWithCustomNodeDefinition(object obj)
+        {
+            if (annotationModel.IsSelected)
+            {
+                this.WorkspaceViewModel.DynamoViewModel.SyncWithCustomNodeDefinition(annotationModel);
+            }
+        }
+
+        private bool CanEditCustomNode(object obj)
+        {
+            return this.annotationModel.FunctionID != Guid.Empty;
+        }
+
+        private void EditCustomNode(object obj)
+        {
+            if (annotationModel.IsSelected)
+            {
+                WorkspaceViewModel.DynamoViewModel.GoToWorkspace(this.annotationModel.FunctionID);
+            }
+        }
+
+        private void OnPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case "Background":
+                    RegenerateRenderPackages();
+                    break;
+            }
+        }
+
+        private void RegenerateRenderPackages()
+        {
+            var backGroundPreivew = WorkspaceViewModel.DynamoViewModel.Watch3DViewModels.FirstOrDefault();
+            var isInCustomNode = WorkspaceViewModel.DynamoViewModel.Model.CurrentWorkspace is CustomNodeWorkspaceModel;
+            if (!isInCustomNode && backGroundPreivew != null)
+            {
+                var nodes = SelectedModels.OfType<NodeModel>();
+                backGroundPreivew.RegeneratePackagesForNode(nodes);
+            }
+        }
+    }
+}

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1474,6 +1474,54 @@ namespace Dynamo.ViewModels
             return DynamoSelection.Instance.Selection.OfType<NodeModel>().Any();
         }
 
+        public void UpdateCustomNodeDefinition(object parameter)
+        {
+            if (parameter == null)
+            {
+                return;
+            }
+
+            CustomNodeAnnotationModel model = parameter as CustomNodeAnnotationModel;
+            if (model == null)
+            {
+                return;
+            }
+
+            Model.CustomNodeManager.UpdateCustomNode(model, this.currentWorkspaceViewModel.Model, this.Model);
+        }
+
+        public void RestoreCustomNodeInstance(object parameter)
+        {
+            if (parameter == null)
+            {
+                return;
+            }
+
+            CustomNodeAnnotationModel model = parameter as CustomNodeAnnotationModel;
+            if (model == null)
+            {
+                return;
+            }
+
+            Model.CustomNodeManager.RestoreCustomNodeInstance(model, this.currentWorkspaceViewModel.Model);
+        }
+
+        public void SyncWithCustomNodeDefinition(object parameter)
+        {
+            if (parameter == null)
+            {
+                return;
+            }
+
+            CustomNodeAnnotationModel model = parameter as CustomNodeAnnotationModel;
+            if (model == null)
+            {
+                return;
+            }
+
+            Model.CustomNodeManager.UpdateCustomNodeAnnotationModel(model, this.currentWorkspaceViewModel.Model, this.Model);
+        }
+
         /// <summary>
         /// Returns the selected nodes that are "input" nodes, and makes an 
         /// exception for CodeBlockNodes as these are marked false so they 

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1013,6 +1013,20 @@ namespace Dynamo.ViewModels
             DynamoViewModel.GoToWorkspace((NodeLogic as Function).Definition.FunctionId);
         }
 
+        private void Expand(object parameters)
+        {
+            var function = nodeLogic as Function;
+            var workspaceModel = DynamoViewModel.CurrentSpaceViewModel.Model;
+            DynamoViewModel.Model.CustomNodeManager.Expand(function, workspaceModel, DynamoViewModel.Model);
+        }
+
+        private void ExpandToWorkspace(object parameters)
+        {
+            var function = nodeLogic as Function;
+            var workspaceModel = DynamoViewModel.CurrentSpaceViewModel.Model;
+            DynamoViewModel.Model.CustomNodeManager.ExpandToGroup(function, workspaceModel, DynamoViewModel.Model);
+        }
+
         private bool CanGotoWorkspace(object parameters)
         {
             if (NodeLogic is Function)
@@ -1021,6 +1035,16 @@ namespace Dynamo.ViewModels
             }
 
             return false;
+        }
+
+        private bool CanExpand(object parameters)
+        {
+            return NodeLogic is Function;
+        }
+
+        private bool CanExpandToWorkspace(object parameters)
+        {
+            return NodeLogic is Function;
         }
 
         private void CreateGroup(object parameters)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -369,7 +369,9 @@ namespace Dynamo.ViewModels
 
         private void Model_AnnotationAdded(AnnotationModel annotation)
         {
-            var viewModel = new AnnotationViewModel(this, annotation);
+            var viewModel = annotation is CustomNodeAnnotationModel ? 
+                new CustomNodeAnnotationViewModel(this, annotation as CustomNodeAnnotationModel) :
+                new AnnotationViewModel(this, annotation);
             _annotations.Add(viewModel);
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -394,6 +394,19 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
         }
 
+        /// <summary>
+        /// Forces a regeneration of the render packages for nodes.
+        /// </summary>
+        /// <param name="nodes"></param>
+        public void RegeneratePackagesForNode(IEnumerable<NodeModel> nodes)
+        {
+            foreach (var node in nodes)
+            {
+                node.RequestVisualUpdateAsync(scheduler, engineManager.EngineController,
+                        renderPackageFactory, true);
+            }
+        }
+
         protected virtual void OnWorkspaceCleared(WorkspaceModel workspace)
         {
             OnClear();

--- a/src/DynamoCoreWpf/Views/Core/CustomNodeAnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/CustomNodeAnnotationView.xaml
@@ -1,0 +1,323 @@
+﻿<UserControl Name="Group"
+             x:Class="Dynamo.Nodes.CustomNodeAnnotationView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:System="clr-namespace:System;assembly=mscorlib"
+             xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
+             xmlns:controls="clr-namespace:Dynamo.Controls"
+             xmlns:views="clr-namespace:Dynamo.Views"
+             mc:Ignorable="d"                          
+             Height="Auto" Width="Auto" Visibility="Visible"             
+             MouseLeftButtonDown="AnnotationView_OnMouseLeftButtonDown"                                                  
+             MouseRightButtonDown="AnnotationView_OnMouseRightButtonDown"                 
+             Canvas.Left="{Binding Left, Mode=TwoWay}" 
+             Canvas.Top="{Binding Top, Mode=TwoWay}">
+
+    <UserControl.Resources>
+        <Style x:Key="ColorSelectorListBox"
+           TargetType="ListBox">
+            <Setter Property="SnapsToDevicePixels"
+                Value="true" />
+            <Setter Property="OverridesDefaultStyle"
+                Value="true" />
+            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+                Value="Disabled" />
+            <Setter Property="ScrollViewer.VerticalScrollBarVisibility"
+                Value="Hidden" />
+            <Setter Property="ScrollViewer.CanContentScroll"
+                Value="true" />
+            <Setter Property="Width"
+                Value="152" />
+            <Setter Property="Height"
+                Value="54" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListBox">
+                        <Grid Margin="4,8,4,8">
+                            <ScrollViewer Margin="0"
+                                      Focusable="false">
+                                <WrapPanel IsItemsHost="True" />
+                            </ScrollViewer>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="ColorSelectorListBoxItem"
+           TargetType="ListBoxItem">
+            <Setter Property="SnapsToDevicePixels"
+                Value="true" />
+            <Setter Property="OverridesDefaultStyle"
+                Value="true" />
+            <Setter Property="Width"
+                Value="18" />
+            <Setter Property="Height"
+                Value="20" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListBoxItem">
+                        <Grid Margin="3,4,3,4"
+                          SnapsToDevicePixels="true">
+                            <Grid.Background>
+                                <SolidColorBrush Color="Transparent" />
+                            </Grid.Background>
+                            <VisualStateManager.VisualStateGroups>
+                                <VisualStateGroup x:Name="CommonStates">
+                                    <VisualState x:Name="Normal" />
+                                    <VisualState x:Name="MouseOver">
+                                        <Storyboard>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Border"
+                                                                       Storyboard.TargetProperty="Opacity">
+                                                <EasingDoubleKeyFrame KeyTime="0"
+                                                                  Value="1.0" />
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualState>
+                                </VisualStateGroup>
+                                <VisualStateGroup x:Name="SelectionStates">
+                                    <VisualState x:Name="Unselected" />
+                                    <VisualState x:Name="Selected">
+                                        <Storyboard>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Border"
+                                                                       Storyboard.TargetProperty="Opacity">
+                                                <EasingDoubleKeyFrame KeyTime="0"
+                                                                  Value="1.0" />
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualState>
+                                    <VisualState x:Name="SelectedUnfocused" />
+                                </VisualStateGroup>
+                            </VisualStateManager.VisualStateGroups>
+                            <ContentPresenter />
+                            <Border x:Name="Border"
+                                Opacity="0.25"
+                                BorderThickness="1"
+                                BorderBrush="Black"
+                                Background="Transparent" />
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+    <UserControl.Triggers>
+        <EventTrigger  SourceName="Group" RoutedEvent="UserControl.MouseDoubleClick">
+            <BeginStoryboard>
+                <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Duration="0"  
+                                                               Storyboard.TargetName="GroupTextBlock"
+                                                               Storyboard.TargetProperty="(TextBlock.Visibility)">
+                        <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding ElementName=TextBlockGrid, Path=Visibility,
+                            Converter={StaticResource GroupTitleVisibilityConverter },ConverterParameter=FlipTextblock}">
+                        </DiscreteObjectKeyFrame>
+                    </ObjectAnimationUsingKeyFrames>
+                    <ObjectAnimationUsingKeyFrames Duration="0"  
+                                                               Storyboard.TargetName="GroupTextBox"
+                                                               Storyboard.TargetProperty="(TextBox.Visibility)">
+                        <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding ElementName=TextBlockGrid, Path=Visibility,
+                            Converter={StaticResource GroupTitleVisibilityConverter },ConverterParameter=FlipTextbox}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <BooleanAnimationUsingKeyFrames
+                                    Storyboard.TargetName="GroupTextBox"
+                                    Storyboard.TargetProperty="(TextBox.Focusable)">
+                        <DiscreteBooleanKeyFrame
+                                            KeyTime="0"
+                                            Value="True" />
+                    </BooleanAnimationUsingKeyFrames>
+                </Storyboard>
+            </BeginStoryboard>
+        </EventTrigger>
+    </UserControl.Triggers>
+    <Grid Name="AnnotationGrid" Height="Auto">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"></RowDefinition>
+        </Grid.RowDefinitions>
+        <Grid.ContextMenu>
+            <ContextMenu>
+                <MenuItem  Header="{x:Static p:Resources.GroupContextMenuDeleteGroup}"
+                               Name="DeleteAnnotation"
+                           Click="OnDeleteAnnotation"/>
+                <MenuItem  Header="{x:Static p:Resources.GroupContextMenuUngroup}"
+                               Name="UngroupAnnotation"
+                           Click="OnUngroupAnnotation"/>
+                <MenuItem  Header="{x:Static p:Resources.GroupContextMenuGraphLayout}"
+                               Name="GraphLayoutAnnotation"
+                           Click="OnGraphLayoutAnnotation"/>
+                <MenuItem  Header="{x:Static p:Resources.GroupContextMenuFont}"
+                               Name="ChangeSize">
+                    <MenuItem Header ="14" Name="FontSize0" Command="{Binding ChangeFontSize}" CommandParameter="14"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=14}"></MenuItem>
+                    <MenuItem Header ="18" Name="FontSize1" Command="{Binding ChangeFontSize}" CommandParameter="18"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=18}"></MenuItem>
+                    <MenuItem Header ="24" Name="FontSize2" Command="{Binding ChangeFontSize}" CommandParameter="24"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=24}"></MenuItem>
+                    <MenuItem Header ="30" Name="FontSize3" Command="{Binding ChangeFontSize}" CommandParameter="30"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=30}"></MenuItem>
+                    <MenuItem Header ="36" Name="FontSize4" Command="{Binding ChangeFontSize}" CommandParameter="36"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=36}"></MenuItem>
+                    <MenuItem Header ="48" Name="FontSize5" Command="{Binding ChangeFontSize}" CommandParameter="48"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=48}"></MenuItem>
+                    <MenuItem Header ="60" Name="FontSize6" Command="{Binding ChangeFontSize}" CommandParameter="60"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=60}"></MenuItem>
+                    <MenuItem Header ="72" Name="FontSize7" Command="{Binding ChangeFontSize}" CommandParameter="72"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=72}"></MenuItem>
+                    <MenuItem Header ="96" Name="FontSize8" Command="{Binding ChangeFontSize}" CommandParameter="96"
+                              IsChecked="{Binding Path=FontSize,Converter={StaticResource MenuItemCheckConverter},ConverterParameter=96}"></MenuItem>
+                </MenuItem>
+                <ListBox Style="{StaticResource ColorSelectorListBox}"
+                         ItemContainerStyle="{StaticResource ColorSelectorListBoxItem}"
+                          SelectionChanged="OnNodeColorSelectionChanged">
+                    <ListBox.Items>
+                        <Rectangle Fill="#d4b6db" />
+                        <Rectangle Fill="#ffb8d8" />
+                        <Rectangle Fill="#ffc999" />
+                        <Rectangle Fill="#e8f7ad" />
+                        <Rectangle Fill="#b9f9e1" />
+                        <Rectangle Fill="#a4e1ff" />
+                        <Rectangle Fill="#b5b5b5" />
+                        <Rectangle Fill="#FFFFFF" />
+                        <Rectangle Fill="#bb87c6" />
+                        <Rectangle Fill="#ff7bac" />
+                        <Rectangle Fill="#ffaa45" />
+                        <Rectangle Fill="#c1d676" />
+                        <Rectangle Fill="#71c6a8" />
+                        <Rectangle Fill="#48b9ff" />
+                        <Rectangle Fill="#848484" />
+                        <Rectangle Fill="#d8d8d8" />
+                    </ListBox.Items>
+                </ListBox>
+                <Separator/>
+                <MenuItem Header="{x:Static p:Resources.ContextMenuEditCustomNode}"
+                          Name="EditCustomNode"
+                          Command="{Binding Path=EditCustomNodeCommand}"/>
+                <Separator/>
+                <MenuItem Header="{x:Static p:Resources.ContextMenuUpdateCustomNodeDefintion}"
+                          Name="UpdateCustomNode"
+                          Command="{Binding Path=UpdateCustomNodeDefinitionCommand}"/>
+                <MenuItem Header="{x:Static p:Resources.ContextMenuRestoreToCustomNodeInstance}"
+                          Name="RestoreCustomNodeInstance"
+                          Command="{Binding Path=RestoreCustomNodeInstanceCommand}"/>
+                <MenuItem Header="{x:Static p:Resources.ContextMenuSyncWithCustomNodeDefinition}"
+                          Name="SyncWithCustomNodeDefinition"
+                          Command="{Binding Path=SyncWithCustomNodeDefinitionCommand}"/>
+            </ContextMenu>
+        </Grid.ContextMenu>
+        <Rectangle Name="hightlightBorder"                  
+                   Fill="Transparent"
+                   Width="{Binding Width}" 
+                   Height= "{Binding Height}"  
+                   Stroke="Firebrick"
+                   StrokeThickness="5"
+                   StrokeDashArray="1 1"
+                   SnapsToDevicePixels="True"
+                   Canvas.ZIndex="41"
+                   Margin="-1">
+       </Rectangle>
+        <Rectangle Name="selectionBorder"                  
+                   Fill="Transparent"
+                   Width="{Binding Width}" 
+                   Height= "{Binding Height}"  
+                   Stroke="{Binding PreviewState, Converter={StaticResource ConnectionStateToBrushConverter}}"
+                   StrokeThickness="2"
+                   IsHitTestVisible="False"
+                   Canvas.ZIndex="41"
+                   Margin="-1">
+            <Rectangle.Visibility>
+                <Binding Path="PreviewState"
+                         UpdateSourceTrigger="PropertyChanged"
+                         Mode="OneWay"
+                         Converter="{StaticResource ConnectionStateToVisibilityCollapsedConverter}">
+                </Binding>
+            </Rectangle.Visibility>
+        </Rectangle>
+        <Rectangle  Name="AnnotationRectangle"                     
+                    Width="{Binding Width}" 
+                    Height= "{Binding Height}"                   
+                    IsHitTestVisible="True"
+                    Opacity="0.5"                     
+                    >
+            <Rectangle.Fill>
+                <SolidColorBrush Color="{Binding Background}"></SolidColorBrush>
+            </Rectangle.Fill>
+        </Rectangle>
+        <Grid x:Name="TextBlockGrid" Grid.Row="0" Height="auto" MaxWidth="{Binding Width}" 
+              Margin="5,0,5,0"
+              VerticalAlignment="Top">
+            <TextBlock x:Name="GroupTextBlock"                                     
+                    Text ="{Binding AnnotationText, Converter={StaticResource AnnotationTextConverter}}"                        
+                    MaxWidth="{Binding Width}"  
+                    MinHeight="20"   
+                    FontFamily="Trebuchet" 
+                    FontSize="{Binding FontSize}"                   
+                    LineStackingStrategy="BlockLineHeight"                    
+                    TextWrapping="Wrap"
+                    Visibility="Visible">
+            </TextBlock>
+            <TextBox 
+                    Name="GroupTextBox" 
+                    Visibility="Collapsed"
+                    Text ="{Binding AnnotationText,Converter={StaticResource AnnotationTextConverter}}"                                                    
+                    TextWrapping="Wrap"            
+                    MaxWidth="{Binding Width}" 
+                    MinHeight="20"  
+                    FontFamily="Trebuchet" 
+                    FontSize="{Binding FontSize}"                                 
+                    IsVisibleChanged="GroupTextBox_OnIsVisibleChanged"
+                    GotFocus="GroupTextBox_OnGotFocus"                   
+                    TextChanged="GroupTextBox_OnTextChanged"   
+                    AcceptsReturn="True"
+                    AcceptsTab="True">
+            </TextBox>
+            <Grid.Style>
+                <Style TargetType="{x:Type Grid}">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Value="True">
+                                    <Condition.Binding>
+                                        <MultiBinding Converter="{StaticResource GroupFontSizeToEditorEnabledConverter }">
+                                            <Binding Path ="DataContext.Zoom" FallbackValue="1.0" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type views:WorkspaceView}}"></Binding>
+                                            <Binding ElementName="GroupTextBlock" Path="FontSize"/>
+                                            <Binding ElementName="GroupTextBlock" Path="Visibility"/>
+                                        </MultiBinding>
+                                    </Condition.Binding>
+                                </Condition>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Visibility" Value="Visible"></Setter>
+                        </MultiDataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Grid.Style>
+            <Grid.Triggers>
+                <EventTrigger  SourceName="GroupTextBox" RoutedEvent="TextBox.LostKeyboardFocus">
+                    <BeginStoryboard>
+                        <Storyboard>
+                            <ObjectAnimationUsingKeyFrames Duration="0"  
+                                                               Storyboard.TargetName="GroupTextBlock"
+                                                               Storyboard.TargetProperty="(TextBlock.Visibility)">
+                                <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                            </ObjectAnimationUsingKeyFrames>
+                            <ObjectAnimationUsingKeyFrames Duration="0"  
+                                                               Storyboard.TargetName="GroupTextBox"
+                                                               Storyboard.TargetProperty="(TextBox.Visibility)">
+                                <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Collapsed}" />
+                            </ObjectAnimationUsingKeyFrames>
+                            <BooleanAnimationUsingKeyFrames
+                                    Storyboard.TargetName="GroupTextBox"
+                                    Storyboard.TargetProperty="(TextBox.Focusable)">
+                                <DiscreteBooleanKeyFrame
+                                            KeyTime="0"
+                                            Value="True" />
+                            </BooleanAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </BeginStoryboard>
+                </EventTrigger>
+            </Grid.Triggers>
+        </Grid>
+    </Grid>
+
+</UserControl>

--- a/src/DynamoCoreWpf/Views/Core/CustomNodeAnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/CustomNodeAnnotationView.xaml.cs
@@ -1,0 +1,243 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using Dynamo.UI;
+using Dynamo.Utilities;
+using Dynamo.ViewModels;
+using DynCmd = Dynamo.Models.DynamoModel;
+using Dynamo.Selection;
+using Dynamo.UI.Prompts;
+using TextBox = System.Windows.Controls.TextBox;
+
+namespace Dynamo.Nodes
+{
+    /// <summary>
+    /// Interaction logic for AnnotationView.xaml
+    /// </summary>
+    public partial class CustomNodeAnnotationView : IViewModelView<CustomNodeAnnotationViewModel>
+    {
+        public CustomNodeAnnotationViewModel ViewModel { get; private set; }
+        public static DependencyProperty SelectAllTextOnFocus;
+        public CustomNodeAnnotationView()
+        {
+            Resources.MergedDictionaries.Add(SharedDictionaryManager.DynamoModernDictionary);
+            Resources.MergedDictionaries.Add(SharedDictionaryManager.DynamoColorsAndBrushesDictionary);
+            Resources.MergedDictionaries.Add(SharedDictionaryManager.DataTemplatesDictionary);
+            Resources.MergedDictionaries.Add(SharedDictionaryManager.DynamoConvertersDictionary);
+            Resources.MergedDictionaries.Add(SharedDictionaryManager.PortsDictionary);
+
+            InitializeComponent();
+            Loaded += AnnotationView_Loaded;
+            this.GroupTextBlock.SizeChanged += GroupTextBlock_SizeChanged;
+        }
+
+        private void AnnotationView_Loaded(object sender, RoutedEventArgs e)
+        {
+            ViewModel = this.DataContext as CustomNodeAnnotationViewModel;
+            if (ViewModel != null)
+            {
+                //Set the height of Textblock based on the content.
+                if (!ViewModel.AnnotationModel.loadFromXML)
+                {
+                    ViewModel.AnnotationModel.TextBlockHeight = this.GroupTextBlock.ActualHeight;
+                }
+            }
+        }
+
+        private void OnNodeColorSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (e.AddedItems == null || (e.AddedItems.Count <= 0))
+                return;
+
+            //store the old one
+            if (e.RemovedItems != null || e.RemovedItems.Count > 0)
+            {
+                var orectangle = e.AddedItems[0] as Rectangle;
+                if (orectangle != null)
+                {
+                    var brush = orectangle.Fill as SolidColorBrush;
+                    if (brush != null)
+                    {
+                        ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
+                         new DynCmd.UpdateModelValueCommand(
+                         System.Guid.Empty, ViewModel.AnnotationModel.GUID, "Background", brush.Color.ToString()));
+                    }
+
+                }
+            }
+
+            var rectangle = e.AddedItems[0] as Rectangle;
+            if (rectangle != null)
+            {
+                var brush = rectangle.Fill as SolidColorBrush;
+                if (brush != null)
+                    ViewModel.Background = brush.Color;
+            }
+        }
+
+        private void OnUngroupAnnotation(object sender, RoutedEventArgs e)
+        {
+            if (ViewModel != null)
+            {
+                ViewModel.WorkspaceViewModel.DynamoViewModel.DeleteCommand.Execute(null);
+            }
+        }
+
+        /// <summary>
+        /// Handles the OnMouseLeftButtonDown event of the AnnotationView control.
+        /// Selects the models inside the group
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="MouseButtonEventArgs"/> instance containing the event data.</param>
+        private void AnnotationView_OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (GroupTextBlock.IsVisible ||
+                (!GroupTextBlock.IsVisible && !GroupTextBox.IsVisible))
+            {
+                ViewModel.Select();
+            }
+
+            //When Textbox is visible,clear the selection. That way, models will not be added to
+            //dragged nodes one more time. Ref: MAGN-7321
+            if (GroupTextBlock.IsVisible && e.ClickCount >= 2)
+            {
+                DynamoSelection.Instance.ClearSelection();
+                //Set the panning mode to false if a group is in editing mode.
+                if (ViewModel.WorkspaceViewModel.IsPanning)
+                {
+                    ViewModel.WorkspaceViewModel.DynamoViewModel.BackgroundPreviewViewModel.TogglePan(null);
+                }
+                e.Handled = true;
+            }
+
+            //When the Zoom * Fontsized factor is less than 7, then
+            //show the edit window
+            if (!GroupTextBlock.IsVisible && e.ClickCount >= 2)
+            {
+                var editWindow = new EditWindow(ViewModel.WorkspaceViewModel.DynamoViewModel, true)
+                {
+                    Title = Dynamo.Wpf.Properties.Resources.EditAnnotationTitle
+                };
+                editWindow.BindToProperty(DataContext, new Binding("AnnotationText")
+                {
+                    Mode = BindingMode.TwoWay,
+                    Source = (DataContext as AnnotationViewModel),
+                    UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+                });
+
+                editWindow.ShowDialog();
+                e.Handled = true;
+            }
+        }
+
+        private void AnnotationView_OnMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            DynamoSelection.Instance.ClearSelection();
+            System.Guid annotationGuid = this.ViewModel.AnnotationModel.GUID;
+            ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
+               new DynCmd.SelectModelCommand(annotationGuid, Keyboard.Modifiers.AsDynamoType()));
+        }
+
+        /// <summary>
+        /// Handles the OnTextChanged event of the GroupTextBox control.
+        /// Calculates the height of a Group based on the height of textblock
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="TextChangedEventArgs"/> instance containing the event data.</param>
+        private void GroupTextBox_OnTextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (ViewModel != null)
+            {
+                ViewModel.AnnotationModel.TextBlockHeight = GroupTextBox.ActualHeight;
+                ViewModel.WorkspaceViewModel.HasUnsavedChanges = true;
+            }
+        }
+
+
+        /// <summary>
+        /// Handles the SizeChanged event of the GroupTextBlock control.
+        /// This function calculates the height of a group based on font size
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="SizeChangedEventArgs"/> instance containing the event data.</param>
+        private void GroupTextBlock_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (ViewModel != null && (e.HeightChanged || e.WidthChanged))
+            {
+                //Use the DesiredSize and not the Actual height. Because when Textblock is collapsed,
+                //Actual height is same as previous size. used when the Font size changed during zoom
+                ViewModel.AnnotationModel.TextBlockHeight = GroupTextBlock.DesiredSize.Height;
+            }
+        }
+
+
+        /// <summary>
+        /// Select the text in textbox
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.</param>
+        private void GroupTextBox_OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            var textbox = sender as TextBox;
+            if (textbox == null || textbox.Visibility != Visibility.Visible) return;
+
+            //Record the value here, this is useful when title is popped from stack during undo
+            ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
+                new DynCmd.UpdateModelValueCommand(
+                    Guid.Empty, ViewModel.AnnotationModel.GUID, "TextBlockText",
+                    GroupTextBox.Text));
+
+            ViewModel.WorkspaceViewModel.DynamoViewModel.RaiseCanExecuteUndoRedo();
+
+            textbox.Focus();
+            if (textbox.Text.Equals(Properties.Resources.GroupDefaultText))
+            {
+                textbox.SelectAll();
+            }
+        }
+
+        /// <summary>
+        /// Set the Mouse caret at the end
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
+        private void GroupTextBox_OnGotFocus(object sender, RoutedEventArgs e)
+        {
+            this.GroupTextBox.CaretIndex = Int32.MaxValue;
+        }
+
+        /// <summary>
+        /// This function will delete the group with modes
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
+        private void OnDeleteAnnotation(object sender, RoutedEventArgs e)
+        {
+            //Select the group and the models within that group
+            if (ViewModel != null)
+            {
+                ViewModel.Select();
+                ViewModel.WorkspaceViewModel.DynamoViewModel.DeleteCommand.Execute(null);
+            }
+        }
+
+        /// <summary>
+        /// This function will run graph layout algorithm to the nodes inside the selected group.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
+        private void OnGraphLayoutAnnotation(object sender, RoutedEventArgs e)
+        {
+            if (ViewModel != null)
+            {
+                ViewModel.Select();
+                ViewModel.WorkspaceViewModel.DynamoViewModel.GraphAutoLayoutCommand.Execute(null);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### Purpose

Merge recharge project: custom node debugging.

Two context menu items are added to custom node instance:
  * Expand Custom Node: expand custom node instance to a custom node group
  * Expand Custom Node to Group: expand custom node instance to a normal group
![untitled](https://cloud.githubusercontent.com/assets/2600379/15134807/1adde2c0-16a2-11e6-9cd0-fc1e32b327fb.png)

For a custom node group, there are three options available:
  * Update Custom Node: apply the change in the group to custom node definition
  * Restore to Custom Node Instance: remove group and restore to custom node instance
  * Sync with Custom Node: apply the latest change in the custom node definition back to the group
![untitled2](https://cloud.githubusercontent.com/assets/2600379/15134811/1f4a2cb0-16a2-11e6-94f8-ee03a4178102.png)

The color of geometries that generated from custom node group will be the same as the group's background color:
![untitled3](https://cloud.githubusercontent.com/assets/2600379/15134825/3165dfb6-16a2-11e6-9271-4dc41237b709.png)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
