### PR TITLE
MAGN-8944 Update the layout and content for the Compact Preview Bubble

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Extensions\ViewLoadedParams.cs" />
     <Compile Include="Extensions\ViewExtensionDefinition.cs" />
     <Compile Include="Extensions\ViewStartupParams.cs" />
+    <Compile Include="Utilities\CompactBubbleHandler.cs" />
     <Compile Include="Interfaces\IShellCom.cs" />
     <Compile Include="Rendering\HelixRenderPackage.cs" />
     <Compile Include="Interfaces\IBrandingResourceProvider.cs" />
@@ -291,6 +292,7 @@
     <Compile Include="ViewModels\Core\GalleryViewModel.cs" />
     <Compile Include="ViewModels\Core\HomeWorkspaceViewModel.cs" />
     <Compile Include="ViewModels\PackageManager\PackagePathViewModel.cs" />
+    <Compile Include="ViewModels\Preview\CompactBubbleViewModel.cs" />
     <Compile Include="ViewModels\RunSettingsViewModel.cs" />
     <Compile Include="ViewModels\Search\BrowserInternalElementViewModel.cs" />
     <Compile Include="ViewModels\Search\BrowserItemViewModel.cs" />
@@ -330,6 +332,9 @@
     <Compile Include="ViewModels\Watch3D\DynamoEffectsManager.cs" />
     <Compile Include="ViewModels\Watch3D\DynamoRenderTechniquesManager.cs" />
     <Compile Include="Views\Preview\CameraExtensions.cs" />
+    <Compile Include="Views\Preview\PreviewCompactView.xaml.cs">
+      <DependentUpon>PreviewCompactView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\Preview\Watch3DSettingsControl.xaml.cs">
       <DependentUpon>Watch3DSettingsControl.xaml</DependentUpon>
     </Compile>
@@ -1098,6 +1103,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\PackageManager\TermsOfUseView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\Preview\PreviewCompactView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
+++ b/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
@@ -9,6 +9,7 @@ using ProtoCore.DSASM;
 using ProtoCore.Mirror;
 using ProtoCore.Utils;
 using Dynamo.Extensions;
+using Dynamo.Wpf.Properties;
 
 namespace Dynamo.Interfaces
 {
@@ -37,8 +38,6 @@ namespace Dynamo.Interfaces
 
     public class DefaultWatchHandler : IWatchHandler
     {
-        public const string NULL_STRING = "null";
-
         // Formats double value into string. E.g. 1054.32179 => "1054.32179"
         // For more info: https://msdn.microsoft.com/en-us/library/kfsatb94(v=vs.110).aspx
         private const string numberFormat = "g";
@@ -146,7 +145,7 @@ namespace Dynamo.Interfaces
                 // representation instead of casting it as dynamic (that leads to 
                 // a crash).
                 if (data.IsNull)
-                    return new WatchViewModel(NULL_STRING, tag, RequestSelectGeometry);
+                    return new WatchViewModel(Resources.NullString, tag, RequestSelectGeometry);
                 
                 //If the input data is an instance of a class, create a watch node
                 //with the class name and let WatchHandler process the underlying CLR data
@@ -165,14 +164,14 @@ namespace Dynamo.Interfaces
         private static string ToString(object obj)
         {
             return ReferenceEquals(obj, null)
-                ? NULL_STRING
+                ? Resources.NullString
                 : (obj is bool ? obj.ToString().ToLower() : obj.ToString());
         }
 
         public WatchViewModel Process(dynamic value, ProtoCore.RuntimeCore runtimeCore, string tag, bool showRawData, WatchHandlerCallback callback)
         {
             return Object.ReferenceEquals(value, null)
-                ? new WatchViewModel(NULL_STRING, tag, RequestSelectGeometry)
+                ? new WatchViewModel(Resources.NullString, tag, RequestSelectGeometry)
                 : ProcessThing(value, runtimeCore, tag, showRawData, callback);
         }
 

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3229,6 +3229,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to null.
+        /// </summary>
+        public static string NullString {
+            get {
+                return ResourceManager.GetString("NullString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to OK.
         /// </summary>
         public static string OKButton {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1989,6 +1989,9 @@ Do you want to install the latest Dynamo update?</value>
   <data name="PreviewListLabel" xml:space="preserve">
     <value>List</value>
   </data>
+  <data name="NullString" xml:space="preserve">
+    <value>null</value>
+  </data>
   <data name="InvalidTimeZoneMessage" xml:space="preserve">
     <value>Could not sign in at this moment. Check the date, time and time zone settings and try to sign in again.</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1991,6 +1991,9 @@ Do you want to install the latest Dynamo update?</value>
   <data name="PreviewListLabel" xml:space="preserve">
     <value>List</value>
   </data>
+  <data name="NullString" xml:space="preserve">
+    <value>null</value>
+  </data>
   <data name="InvalidTimeZoneMessage" xml:space="preserve">
     <value>Could not sign in at this moment. Check the date, time and time zone settings and try to sign in again.</value>
   </data>

--- a/src/DynamoCoreWpf/Utilities/CompactBubbleHandler.cs
+++ b/src/DynamoCoreWpf/Utilities/CompactBubbleHandler.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Dynamo.Extensions;
+using Dynamo.ViewModels;
+using Dynamo.Wpf.Properties;
+using ProtoCore.Mirror;
+
+namespace Dynamo.Wpf.Utilities
+{
+    public class CompactBubbleHandler
+    {
+        private static int levels;
+        private static int items;
+
+        public static CompactBubbleViewModel Process(dynamic value)
+        {
+            levels = -1;
+            items = 0;
+            return Object.ReferenceEquals(value, null)
+                ? new CompactBubbleViewModel(Resources.NullString, 0, 0)
+                : ProcessThing(value);
+        }        
+
+        private static CompactBubbleViewModel ProcessThing(MirrorData mirrorData)
+        {
+            var viewModel = new CompactBubbleViewModel();            
+
+            if (mirrorData != null)
+            {
+                if (mirrorData.IsCollection)
+                {
+                    viewModel = ProcessCollection(mirrorData);
+                    levels--;
+                }
+                else if (mirrorData.Data == null && !mirrorData.IsNull && mirrorData.Class != null)
+                {
+                    viewModel.NodeLabel = mirrorData.Class.ClassName;
+                    items++;
+                }
+                else if (mirrorData.Data is Enum)
+                {
+                    viewModel.NodeLabel = ((Enum)mirrorData.Data).GetDescription();
+                    items++;
+                }
+                else
+                {
+                    items++;
+                    if (String.IsNullOrEmpty(mirrorData.StringData))
+                    {
+                        viewModel.NodeLabel = String.Empty;
+                    }
+                    else
+                    {
+
+                        int index = mirrorData.StringData.IndexOf('(');
+                        viewModel.NodeLabel = index != -1 ? mirrorData.StringData.Substring(0, index) : mirrorData.StringData;
+                    }
+                }
+            }
+
+            viewModel.NumberOfItems = items;
+            viewModel.NumberOfLevels = levels;
+            return viewModel;
+        }
+
+        private static CompactBubbleViewModel ProcessCollection(MirrorData mirrorData)
+        {
+            var viewModel = new CompactBubbleViewModel();
+
+            var list = mirrorData.GetElements();
+
+            viewModel.NodeLabel = list.Count == 0 ? "Empty List" : "List";
+            foreach (var item in list)
+            {
+                ProcessThing(item);
+            }
+
+            return viewModel;
+        }
+    }
+}

--- a/src/DynamoCoreWpf/Utilities/CompactBubbleHandler.cs
+++ b/src/DynamoCoreWpf/Utilities/CompactBubbleHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Dynamo.Extensions;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Properties;
@@ -71,7 +72,7 @@ namespace Dynamo.Wpf.Utilities
 
             return new CompactBubbleViewModel
             {
-                NodeLabel = list.Count == 0 ? "Empty List" : "List",
+                NodeLabel = list.Any() ? "List" : "Empty List",
                 IsCollection = true
             };
         }

--- a/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
@@ -1,0 +1,65 @@
+﻿
+
+namespace Dynamo.ViewModels
+{
+    public class CompactBubbleViewModel : ViewModelBase
+    {
+        #region Properties
+
+        private string nodeLabel;
+        public string NodeLabel
+        {
+            get { return nodeLabel; }
+            set
+            {
+                nodeLabel = value;
+                RaisePropertyChanged("NodeLabel");
+            }
+        }
+
+        private int numberOfLevels;
+        public int NumberOfLevels
+        {
+            get { return numberOfLevels; }
+            set
+            {
+                numberOfLevels = value;
+                RaisePropertyChanged("NumberOfLevels");
+            }
+        }
+
+        private int numberOfItems;
+        public int NumberOfItems
+        {
+            get { return numberOfItems; }
+            set
+            {
+                numberOfItems = value;
+                RaisePropertyChanged("NumberOfItems");
+                RaisePropertyChanged("ShowNumberOfItems");
+            }
+        }
+
+        public bool ShowNumberOfItems
+        {
+            get { return NumberOfItems > 1; }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public CompactBubbleViewModel()
+        {
+        }
+
+        public CompactBubbleViewModel(string nodeLabel, int levels, int items)
+        {
+            NodeLabel = nodeLabel;
+            NumberOfLevels = levels;
+            NumberOfItems = items;
+        }
+
+        #endregion
+    }
+}

--- a/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
@@ -42,7 +42,7 @@ namespace Dynamo.ViewModels
 
         public bool ShowNumberOfItems
         {
-            get { return NumberOfItems > 1; }
+            get { return NumberOfItems >= 1 && NumberOfLevels < -1; }
         }
 
         #endregion

--- a/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
@@ -1,12 +1,16 @@
-﻿
-
-namespace Dynamo.ViewModels
+﻿namespace Dynamo.ViewModels
 {
+    /// <summary>
+    /// Class containing data to display in compact preview bubble
+    /// </summary>
     public class CompactBubbleViewModel : ViewModelBase
     {
         #region Properties
 
         private string nodeLabel;
+        /// <summary>
+        /// Represents type of node output
+        /// </summary>
         public string NodeLabel
         {
             get { return nodeLabel; }
@@ -17,18 +21,10 @@ namespace Dynamo.ViewModels
             }
         }
 
-        private int numberOfLevels;
-        public int NumberOfLevels
-        {
-            get { return numberOfLevels; }
-            set
-            {
-                numberOfLevels = value;
-                RaisePropertyChanged("NumberOfLevels");
-            }
-        }
-
         private int numberOfItems;
+        /// <summary>
+        /// Number of items in the overall list if node output is a list
+        /// </summary>
         public int NumberOfItems
         {
             get { return numberOfItems; }
@@ -40,23 +36,36 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Indicates if number of list items is shown
+        /// </summary>
         public bool ShowNumberOfItems
         {
-            get { return NumberOfItems >= 1 && NumberOfLevels < -1; }
+            get { return NumberOfItems > 0 && IsCollection; }
         }
+
+        /// <summary>
+        /// Indicates if number of list items is shown
+        /// </summary>
+        public bool IsCollection { get; set; }
 
         #endregion
 
         #region Public Methods
 
-        public CompactBubbleViewModel()
-        {
-        }
+        /// <summary>
+        /// Creates an instance of <cref name="CompactBubbleViewModel"/> class with empty data
+        /// </summary>
+        public CompactBubbleViewModel() { }
 
-        public CompactBubbleViewModel(string nodeLabel, int levels, int items)
+        /// <summary>
+        /// Creates an instance of <cref name="CompactBubbleViewModel"/> class with specified data
+        /// </summary>
+        /// <param name="nodeLabel">Text representing type of node output</param>
+        /// <param name="items">Number of items in the overall list if node output is a list</param>
+        public CompactBubbleViewModel(string nodeLabel, int items)
         {
             NodeLabel = nodeLabel;
-            NumberOfLevels = levels;
             NumberOfItems = items;
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/CompactBubbleViewModel.cs
@@ -47,7 +47,7 @@
         /// <summary>
         /// Indicates if number of list items is shown
         /// </summary>
-        public bool IsCollection { get; set; }
+        internal bool IsCollection { get; private set; }
 
         #endregion
 
@@ -56,7 +56,10 @@
         /// <summary>
         /// Creates an instance of <cref name="CompactBubbleViewModel"/> class with empty data
         /// </summary>
-        public CompactBubbleViewModel() { }
+        public CompactBubbleViewModel(bool isCollection)
+        {
+            IsCollection = isCollection;
+        }
 
         /// <summary>
         /// Creates an instance of <cref name="CompactBubbleViewModel"/> class with specified data

--- a/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
@@ -1,0 +1,53 @@
+﻿<UserControl x:Class="Dynamo.UI.Controls.PreviewCompactView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ui="clr-namespace:Dynamo.UI"
+             mc:Ignorable="d">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoConvertersDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="15" />
+        </Grid.ColumnDefinitions>
+        <TextBlock Name="label"
+                   Grid.Column="0"
+                   Margin="5,5,0,5"
+                   FontFamily="Consolas"
+                   Text="{Binding Path=NodeLabel}" />
+        <TextBlock Name="levels"
+                   Grid.Column="1"
+                   Margin="0,3,0,7"
+                   Foreground="Gray"
+                   FontStyle="Italic"
+                   Visibility="{Binding ShowNumberOfItems,Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"><Run Text="@" /><Run Text="{Binding NumberOfLevels}" />
+        </TextBlock>
+
+        <TextBlock Name="items"
+                   Grid.Column="3"
+                   Margin="0,3,0,7"
+                   Foreground="Gray"
+                   FontStyle="Italic"
+                   Visibility="{Binding ShowNumberOfItems,Converter={StaticResource BooleanToVisibilityCollapsedConverter},ConverterParameter=''}"><Run Text="{}{" /><Run Foreground="DarkRed" Text="{Binding NumberOfItems}" /><Run Text="{}}" />
+        </TextBlock>
+
+
+        <Image x:Name="ExpandIcon"
+               Grid.Column="4"
+               Source="/DynamoCoreWpf;component/UI/Images/bubble-arrow.png"
+               VerticalAlignment="Bottom"
+               Height="6"
+               Width="6"
+               Margin="0,5,5,5" />
+    </Grid>
+</UserControl>

--- a/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml
@@ -15,39 +15,18 @@
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="15" />
         </Grid.ColumnDefinitions>
-        <TextBlock Name="label"
-                   Grid.Column="0"
-                   Margin="5,5,0,5"
-                   FontFamily="Consolas"
-                   Text="{Binding Path=NodeLabel}" />
-        <TextBlock Name="levels"
-                   Grid.Column="1"
-                   Margin="0,3,0,7"
-                   Foreground="Gray"
-                   FontStyle="Italic"
-                   Visibility="{Binding ShowNumberOfItems,Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"><Run Text="@" /><Run Text="{Binding NumberOfLevels}" />
+        <TextBlock Name="Label" Grid.Column="0" Margin="5,5,0,5" FontFamily="Consolas" Text="{Binding Path=NodeLabel}" />
+
+        <TextBlock Name="Items" Grid.Column="2" Margin="0,3,0,7" Foreground="Gray" FontStyle="Italic"
+                   Visibility="{Binding ShowNumberOfItems, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+            {<Run Foreground="DarkRed" Text="{Binding NumberOfItems}" />}
         </TextBlock>
 
-        <TextBlock Name="items"
-                   Grid.Column="3"
-                   Margin="0,3,0,7"
-                   Foreground="Gray"
-                   FontStyle="Italic"
-                   Visibility="{Binding ShowNumberOfItems,Converter={StaticResource BooleanToVisibilityCollapsedConverter},ConverterParameter=''}"><Run Text="{}{" /><Run Foreground="DarkRed" Text="{Binding NumberOfItems}" /><Run Text="{}}" />
-        </TextBlock>
-
-
-        <Image x:Name="ExpandIcon"
-               Grid.Column="4"
-               Source="/DynamoCoreWpf;component/UI/Images/bubble-arrow.png"
-               VerticalAlignment="Bottom"
-               Height="6"
-               Width="6"
-               Margin="0,5,5,5" />
+        <Image x:Name="ExpandIcon" Grid.Column="3" VerticalAlignment="Bottom" Height="6" Width="6" Margin="0,5,5,5"
+               Source="/DynamoCoreWpf;component/UI/Images/bubble-arrow.png"/>
     </Grid>
 </UserControl>

--- a/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml.cs
@@ -1,0 +1,16 @@
+﻿using System.Windows.Controls;
+
+
+namespace Dynamo.UI.Controls
+{
+    /// <summary>
+    /// Interaction logic for PreviewCompactView.xaml
+    /// </summary>
+    public partial class PreviewCompactView : UserControl
+    {
+        public PreviewCompactView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewCompactView.xaml.cs
@@ -1,12 +1,9 @@
-﻿using System.Windows.Controls;
-
-
-namespace Dynamo.UI.Controls
+﻿namespace Dynamo.UI.Controls
 {
     /// <summary>
     /// Interaction logic for PreviewCompactView.xaml
     /// </summary>
-    public partial class PreviewCompactView : UserControl
+    public partial class PreviewCompactView
     {
         public PreviewCompactView()
         {

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -174,22 +174,7 @@
                   MinWidth="{Binding RelativeSource={RelativeSource FindAncestor, 
                              AncestorType={x:Type controls:NodeView}}, 
                              Path=ActualWidth}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="15" />
-                </Grid.ColumnDefinitions>
-                <TextBlock Margin="{StaticResource PreviewContentMargin}"
-                           Grid.Column="0"
-                           FontFamily="Consolas">null</TextBlock>
-
-                <Image x:Name="ExpandIcon"
-                       Grid.Column="1"
-                       Source="/DynamoCoreWpf;component/UI/Images/bubble-arrow.png"
-                       VerticalAlignment="Bottom"
-                       Height="6"
-                       Width="6"
-                       Margin="0,5,5,5" />
-
+                <uicontrols:PreviewCompactView />
             </Grid>
 
             <Grid Name="largeContentGrid"


### PR DESCRIPTION
### Purpose

Compact Preview Bubble now has number of items in the overall list if node output is a list:
![image](https://cloud.githubusercontent.com/assets/7658189/15151813/779ce176-16db-11e6-9215-ad950ca927d7.png)

Note that this number does not include subitems of list type.

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 

### FYIs

@Racel 