### PR TITLE
Touch screen enhancements for workspace canvas

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -42,6 +42,17 @@ namespace Dynamo.ViewModels
             get { return activeConnector; }
         }
 
+        internal bool HandleTouchDrag(object sender, ManipulationDeltaEventArgs e)
+        {
+            return stateMachine.HandleTouchDrag(sender, e);
+        }
+
+        internal bool HandleTouchRelease(object sender, ManipulationCompletedEventArgs e)
+        {
+            return stateMachine.HandleTouchRelease(sender, e);
+        }
+
+
         internal bool HandleLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             return stateMachine.HandleLeftButtonDown(sender, e);
@@ -484,6 +495,31 @@ namespace Dynamo.ViewModels
             #endregion
 
             #region User Input Event Handlers
+
+            internal bool HandleTouchDrag(object sender, ManipulationDeltaEventArgs e)
+            {
+                var touchPos = e.Manipulators.First().GetPosition(sender as IInputElement);
+                var mousePos = new Point(
+                    (touchPos.X - owningWorkspace.Model.X) / owningWorkspace.Zoom,
+                    (touchPos.Y - owningWorkspace.Model.Y) / owningWorkspace.Zoom);
+
+                var selected = GetSelectableFromPoint(mousePos);
+                if (null != selected)
+                {
+                    e.Cancel();
+                    return true;
+                }
+
+                return false;
+            }
+
+            internal bool HandleTouchRelease(object sender, ManipulationCompletedEventArgs e)
+            {
+                if (this.currentState == State.DragSetup)
+                    SetCurrentState(State.None);
+
+                return false;
+            }
 
             internal bool HandleLeftButtonDown(object sender, MouseButtonEventArgs e)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -46,6 +46,7 @@ namespace Dynamo.ViewModels
         public event WorkspaceModel.ZoomEventHandler RequestZoomToViewportCenter;
         public event WorkspaceModel.ZoomEventHandler RequestZoomToViewportPoint;
         public event WorkspaceModel.ZoomEventHandler RequestZoomToFitView;
+        public event WorkspaceModel.ZoomEventHandler RequestZoomPinch;
 
         public event NodeEventHandler RequestCenterViewOnElement;
 
@@ -96,6 +97,19 @@ namespace Dynamo.ViewModels
             if (RequestZoomToFitView != null)
             {
                 RequestZoomToFitView(this, e);
+            }
+        }
+
+        /// <summary>
+        /// For requesting to change zoom level by touch screen pinch
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        internal void OnRequestZoomPinch(object sender, ZoomEventArgs e)
+        {
+            if (RequestZoomPinch != null)
+            {
+                RequestZoomPinch(this, e);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -8,6 +8,7 @@
              Height="Auto"
              Width="Auto"
              Name="topControl"
+             TouchDown="topControl_TouchDown"
              MouseLeftButtonDown="topControl_MouseLeftButtonDown"
              MouseRightButtonDown="topControl_MouseRightButtonDown"
              MouseEnter="OnNodeViewMouseEnter"

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -363,6 +363,19 @@ namespace Dynamo.Controls
             }
         }
 
+        private void topControl_TouchDown(object sender, TouchEventArgs e)
+        {
+            if (ViewModel == null || Keyboard.Modifiers == System.Windows.Input.ModifierKeys.Control) return;
+
+            var view = WpfUtilities.FindUpVisualTree<DynamoView>(this);
+            ViewModel.DynamoViewModel.OnRequestReturnFocusToView();
+            view.mainGrid.Focus();
+
+            Guid nodeGuid = ViewModel.NodeModel.GUID;
+            ViewModel.DynamoViewModel.ExecuteCommand(
+                new DynCmd.SelectModelCommand(nodeGuid, Keyboard.Modifiers.AsDynamoType()));
+        }
+
         private void topControl_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             if (ViewModel == null || Keyboard.Modifiers == System.Windows.Input.ModifierKeys.Control) return;

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
@@ -27,6 +27,7 @@ namespace Dynamo.Nodes
                         ViewModel.UpdateSizeFromView(noteText.ActualWidth, noteText.ActualHeight);
                 };
             noteText.PreviewMouseDown += OnNoteTextPreviewMouseDown;
+            noteText.TouchDown += OnNoteTextPreviewTouchDown;
 
             Loaded += OnNoteViewLoaded;
             Unloaded += OnNoteViewUnloaded;
@@ -73,6 +74,13 @@ namespace Dynamo.Nodes
         }
 
         void OnNoteTextPreviewMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            System.Guid noteGuid = this.ViewModel.Model.GUID;
+            ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
+                new DynCmd.SelectModelCommand(noteGuid, Keyboard.Modifiers.AsDynamoType()));
+        }
+
+        void OnNoteTextPreviewTouchDown(object sender, TouchEventArgs e)
         {
             System.Guid noteGuid = this.ViewModel.Model.GUID;
             ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -219,6 +219,7 @@ namespace Dynamo.Views
                 oldViewModel.RequestZoomToViewportCenter -= vm_ZoomAtViewportCenter;
                 oldViewModel.RequestZoomToViewportPoint -= vm_ZoomAtViewportPoint;
                 oldViewModel.RequestZoomToFitView -= vm_ZoomToFitView;
+                oldViewModel.RequestZoomPinch -= vm_ZoomPinch;
                 oldViewModel.RequestCenterViewOnElement -= CenterViewOnElement;
                 oldViewModel.Model.RequestNodeCentered -= vm_RequestNodeCentered;
                 oldViewModel.RequestAddViewToOuterCanvas -= vm_RequestAddViewToOuterCanvas;
@@ -233,6 +234,7 @@ namespace Dynamo.Views
                 ViewModel.Model.ZoomChanged +=vm_ZoomChanged;
                 ViewModel.RequestZoomToViewportCenter += vm_ZoomAtViewportCenter;
                 ViewModel.RequestZoomToViewportPoint += vm_ZoomAtViewportPoint;
+                ViewModel.RequestZoomPinch += vm_ZoomPinch;
                 ViewModel.RequestZoomToFitView += vm_ZoomToFitView;
                 ViewModel.RequestCenterViewOnElement += CenterViewOnElement;
                 ViewModel.Model.RequestNodeCentered += vm_RequestNodeCentered;
@@ -417,6 +419,37 @@ namespace Dynamo.Views
             var adjustedZoom = (lowerLimit + (ViewModel.Model.Zoom / WorkspaceModel.ZOOM_MAXIMUM) * (upperLimit - lowerLimit)) * zoom;
 
             return adjustedZoom;
+        }
+
+        void vm_ZoomPinch(object sender, EventArgs e)
+        {
+            double resultZoom = (e as ZoomEventArgs).Zoom;
+            Point2D point = (e as ZoomEventArgs).Point;
+
+            ZoomPinch(resultZoom, point);
+        }
+
+        private void ZoomPinch(double resultZoom, Point2D relative)
+        {
+            // Limit zoom
+            if (resultZoom < WorkspaceModel.ZOOM_MINIMUM)
+                resultZoom = WorkspaceModel.ZOOM_MINIMUM;
+            else if (resultZoom > WorkspaceModel.ZOOM_MAXIMUM)
+                resultZoom = WorkspaceModel.ZOOM_MAXIMUM;
+
+            double absoluteX, absoluteY;
+            absoluteX = relative.X * ViewModel.Model.Zoom + ViewModel.Model.X;
+            absoluteY = relative.Y * ViewModel.Model.Zoom + ViewModel.Model.Y;
+            var resultOffset = new Point2D();
+            resultOffset.X = absoluteX - (relative.X * resultZoom);
+            resultOffset.Y = absoluteY - (relative.Y * resultZoom);
+
+            ViewModel.Model.Zoom = resultZoom;
+            ViewModel.Model.X = resultOffset.X;
+            ViewModel.Model.Y = resultOffset.Y;
+
+            vm_CurrentOffsetChanged(this, new PointEventArgs(resultOffset));
+            vm_ZoomChanged(this, new ZoomEventArgs(resultZoom));
         }
 
         void vm_ZoomAtViewportPoint(object sender, EventArgs e)


### PR DESCRIPTION
[Recharge Project 3]
### Purpose

A few enhancements are being added in order to support more intuitive touch screen workflow in the Dynamo workspace.
#### One touch point
- If one finger touches and drags from an empty space on the canvas, the canvas will be panned.
- If one finger touches and drags from a node/note on the canvas, the node/note will be moved/repositioned according to the finger.
- If one finger taps on any control items, it will call the mouse click action. Node connection, double-click (double-tap) on items, and other functionalities should work normally.
- The Helix background preview already supports intuitive single-touch interactions (rotate).
#### Multiple touch points
- Two (or more) fingers can be used to zoom in/out the canvas.
- The Helix background preview already supports intuitive multi-touch interactions (zoom, pan).
#### Limitations and further enhancements
- Because one finger drag has been reserved for canvas pan, therefore window selection is currently not supported for touch screen. Further improvement might be addressed in the upcoming user experience design discussions.
- More intuitive workflow needs to be added not only for the canvas, e.g. to implement finger scrolling on library sidebar, etc.
### Hands-on preview video

Click on the image to open the video

[![image](https://cloud.githubusercontent.com/assets/6386550/15167619/f44f1d98-175c-11e6-9c05-30a7e142f018.png)](https://dl.dropboxusercontent.com/u/34227689/20160501_021915.mp4)
