### PR TITLE
fixed multi-line issue for editWindow

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml
@@ -16,6 +16,7 @@
         </StackPanel.Background>
 
         <TextBox 
+                PreviewKeyDown="OnEditWindowPreviewKeyDown"
                 Margin="10"
                 x:FieldModifier="private" 
                 Style="{DynamicResource ResourceKey=SDarkTextBox}"

--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
@@ -8,6 +8,7 @@ using Dynamo.Models;
 using Dynamo.Nodes;
 using Dynamo.ViewModels;
 using DynCmd = Dynamo.Models.DynamoModel;
+using System.Windows.Input;
 
 namespace Dynamo.UI.Prompts
 {
@@ -29,7 +30,7 @@ namespace Dynamo.UI.Prompts
             
             // do not accept value if user closes 
             this.Closing += (sender, args) => this.DialogResult = false;
-
+            PreviewKeyDown += OnEditWindowPreviewKeyDown;
             if (false != updateSourceOnTextChange)
             {
                 this.editText.TextChanged += delegate
@@ -38,6 +39,15 @@ namespace Dynamo.UI.Prompts
                     if (expr != null)
                         expr.UpdateSource();
                 };
+            }
+        }
+        private void OnEditWindowPreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if(e.Key == Key.Return ||e.Key == Key.Enter)
+            {
+                UpdateNodeName();
+                e.Handled = true;
+                
             }
         }
 
@@ -52,6 +62,10 @@ namespace Dynamo.UI.Prompts
 
         private void OkClick(object sender, RoutedEventArgs e)
         {
+            UpdateNodeName();
+        }
+        private void UpdateNodeName()
+        {
             var expr = editText.GetBindingExpression(TextBox.TextProperty);
             if (expr != null)
             {
@@ -62,7 +76,7 @@ namespace Dynamo.UI.Prompts
                     new DynCmd.UpdateModelValueCommand(
                         System.Guid.Empty, model.GUID, propName, editText.Text));
             }
-           
+
             this.DialogResult = true;
         }
 

--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
@@ -30,7 +30,6 @@ namespace Dynamo.UI.Prompts
             
             // do not accept value if user closes 
             this.Closing += (sender, args) => this.DialogResult = false;
-            PreviewKeyDown += OnEditWindowPreviewKeyDown;
             if (false != updateSourceOnTextChange)
             {
                 this.editText.TextChanged += delegate


### PR DESCRIPTION
### Purpose
References: https://github.com/DynamoDS/Dynamo/issues/6604
This PR is to fix the issue of multi-line text in edit window for node names.
Enter key should result in the edit window to update the node name and close the window.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@aparajit-pratap 
