### PR TITLE
MAGN-9889 Preview Bubble should only appear when user intentionally hovers over a node

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -9,11 +9,11 @@ using System.Text.RegularExpressions;
 using Dynamo.Configuration;
 using Dynamo.Engine.CodeGeneration;
 using Dynamo.Models;
-using System.Windows; 
+using System.Windows;
 using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
-using Dynamo.Graph.Workspaces; 
+using Dynamo.Graph.Workspaces;
 using Dynamo.Selection;
 using Dynamo.Wpf.ViewModels.Core;
 using DynCmd = Dynamo.ViewModels.DynamoViewModel;
@@ -36,6 +36,8 @@ namespace Dynamo.ViewModels
         #region events
         public event SnapInputEventHandler SnapInputEvent;
         #endregion
+
+        public Action OnMouseLeave;
 
         #region private members
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -59,6 +59,11 @@ namespace Dynamo.Controls
             private set
             {
                 viewModel = value;
+                this.MouseLeave += (s, e) =>
+                {
+                    if (viewModel.OnMouseLeave != null)
+                        viewModel.OnMouseLeave();
+                };
                 if (viewModel.PreviewPinned)
                 {
                     CreatePreview(viewModel);
@@ -531,7 +536,6 @@ namespace Dynamo.Controls
                     }
             };
         }
-
         /// <summary>
         /// If mouse is over node or preview control, then preview control is expanded.
         /// </summary>

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Media.Animation;
 using Dynamo.Configuration;
 using Dynamo.Extensions;
 using Dynamo.Models;
+using System.Threading.Tasks;
 
 namespace Dynamo.UI.Controls
 {
@@ -560,11 +561,24 @@ namespace Dynamo.UI.Controls
 
         #region Private Class Methods - Transition Helpers
 
-        private void BeginFadeInTransition()
+        private async void BeginFadeInTransition()
         {
             if (this.IsHidden == false)
                 throw new InvalidOperationException();
 
+            var delayTimer = new DispatcherTimer(DispatcherPriority.Normal);
+            delayTimer.Interval = TimeSpan.FromMilliseconds(1000);
+            this.nodeViewModel.OnMouseLeave += () => delayTimer.Stop();
+            delayTimer.Tick += (obj, e) =>
+            {
+                 Dispatcher.Invoke(() => ProcessFadeIn());
+                delayTimer.Stop();
+            };
+            await Task.Run(() => delayTimer.Start());
+        }
+
+        private void ProcessFadeIn()
+        {
             // To prevent another transition from being started and
             // indicate a new transition is about to be started
             SetCurrentStateAndNotify(State.PreTransition);


### PR DESCRIPTION
### Purpose

Preview Bubble appears when user intentionally hovers over a node.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ramramps 