### PR TITLE
MAGN-9889 Preview Bubble should only appear when user intentionally hovers over a node

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -1213,6 +1213,7 @@
     <ProjectReference Include="..\DynamoUtilities\DynamoUtilities.csproj">
       <Project>{b5f435cb-0d8a-40b1-a4f7-5ecb3ce792a9}</Project>
       <Name>DynamoUtilities</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Engine\GraphLayout\GraphLayout.csproj">
       <Project>{c2595b04-856d-40ae-8b99-4804c7a70708}</Project>

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -9,11 +9,11 @@ using System.Text.RegularExpressions;
 using Dynamo.Configuration;
 using Dynamo.Engine.CodeGeneration;
 using Dynamo.Models;
-using System.Windows; 
+using System.Windows;
 using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
-using Dynamo.Graph.Workspaces; 
+using Dynamo.Graph.Workspaces;
 using Dynamo.Selection;
 using Dynamo.Wpf.ViewModels.Core;
 using DynCmd = Dynamo.ViewModels.DynamoViewModel;
@@ -36,6 +36,8 @@ namespace Dynamo.ViewModels
         #region events
         public event SnapInputEventHandler SnapInputEvent;
         #endregion
+
+        public Action OnMouseLeave;
 
         #region private members
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -59,16 +59,17 @@ namespace Dynamo.Controls
             private set
             {
                 viewModel = value;
-                this.MouseLeave += (s, e) =>
-                {
-                    if (viewModel.OnMouseLeave != null)
-                        viewModel.OnMouseLeave();
-                };
                 if (viewModel.PreviewPinned)
                 {
                     CreatePreview(viewModel);
                 }                
             }
+        }
+
+        private void NodeView_MouseLeave(object sender, MouseEventArgs e)
+        {
+            if (viewModel!=null && viewModel.OnMouseLeave != null)
+                viewModel.OnMouseLeave();
         }
 
         internal PreviewControl PreviewControl
@@ -122,6 +123,7 @@ namespace Dynamo.Controls
             ViewModel.RequestShowNodeRename -= ViewModel_RequestShowNodeRename;
             ViewModel.RequestsSelection -= ViewModel_RequestsSelection;
             ViewModel.NodeLogic.PropertyChanged -= NodeLogic_PropertyChanged;
+            MouseLeave -= NodeView_MouseLeave;
 
             if (previewControl != null)
             {
@@ -194,6 +196,7 @@ namespace Dynamo.Controls
             ViewModel.RequestShowNodeRename += ViewModel_RequestShowNodeRename;
             ViewModel.RequestsSelection += ViewModel_RequestsSelection;
             ViewModel.NodeLogic.PropertyChanged += NodeLogic_PropertyChanged;
+            MouseLeave += NodeView_MouseLeave;
         }
 
         void NodeLogic_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -59,6 +59,11 @@ namespace Dynamo.Controls
             private set
             {
                 viewModel = value;
+                this.MouseLeave += (s, e) =>
+                {
+                    if (viewModel.OnMouseLeave != null)
+                        viewModel.OnMouseLeave();
+                };
                 if (viewModel.PreviewPinned)
                 {
                     CreatePreview(viewModel);
@@ -531,7 +536,6 @@ namespace Dynamo.Controls
                     }
             };
         }
-
         /// <summary>
         /// If mouse is over node or preview control, then preview control is expanded.
         /// </summary>

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -584,7 +584,6 @@ namespace Dynamo.Controls
             }
         }
 
-
         private void OnNodeViewMouseMove(object sender, MouseEventArgs e)
         {
             if (Mouse.Captured == null) return;

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -509,6 +509,15 @@ namespace Dynamo.Views
             {
                 ViewModel.HandleLeftButtonDown(workBench, e);
             }
+
+            if (!ViewModel.IsDragging) return;
+
+            var nodesToHidePreview = this.ChildrenOfType<NodeView>()
+                .Where(view => !view.PreviewControl.IsHidden && !view.PreviewControl.StaysOpen);
+            foreach (var node in nodesToHidePreview)
+            {
+                node.PreviewControl.HidePreviewBubble();
+            }
         }
 
         private void OnCanvasMouseDown(object sender, MouseButtonEventArgs e)

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -11,7 +11,7 @@
              xmlns:ui="clr-namespace:Dynamo.UI"
              xmlns:fa="http://schemas.fontawesome.io/icons/"
              xmlns:uicontrols="clr-namespace:Dynamo.UI.Controls"
-             mc:Ignorable="d">
+             mc:Ignorable="d" Canvas.Top="-20">
 
     <UserControl.Resources>
         <ResourceDictionary>
@@ -27,104 +27,7 @@
             <fwk:Thickness x:Key="PreviewContentMargin">12,5,5,5</fwk:Thickness>
             <clr:Double x:Key="MaxContentGridWidth">488.0</clr:Double>
             <clr:Double x:Key="MaxContentGridHeight">288</clr:Double>
-
-            <clr:Double x:Key="PhasedOutPosition">-52.0</clr:Double>
-            <clr:Double x:Key="PhasedInPosition">-20.0</clr:Double>
-            <clr:TimeSpan x:Key="ResizeBeginTime">0:0:0.2</clr:TimeSpan>
-            <sys:Duration x:Key="AnimationDuration">0:0:0.2</sys:Duration>
-
-            <Storyboard x:Key="phaseInStoryboard"
-                        Completed="OnPreviewControlPhasedIn">
-                <DoubleAnimation Name="phaseInWidthAnimator"
-                                 Storyboard.TargetName="centralizedGrid"
-                                 Storyboard.TargetProperty="Width"
-                                 Duration="{StaticResource AnimationDuration}" />
-                <DoubleAnimation Name="phaseInHeightAnimator"
-                                 Storyboard.TargetName="centralizedGrid"
-                                 Storyboard.TargetProperty="Height"
-                                 Duration="{StaticResource AnimationDuration}" />
-                <DoubleAnimation Storyboard.TargetName="centralizedGrid"
-                                 Storyboard.TargetProperty="Opacity"
-                                 From="0.0"
-                                 To="1.0"
-                                 Duration="{StaticResource AnimationDuration}" />
-                <DoubleAnimation Storyboard.TargetName="thisPreviewControl"
-                                 Storyboard.TargetProperty="(Canvas.Top)"
-                                 From="{StaticResource PhasedOutPosition}"
-                                 To="{StaticResource PhasedInPosition}"
-                                 Duration="{StaticResource AnimationDuration}" />
-            </Storyboard>
-
-            <Storyboard x:Key="expandStoryboard"
-                        Completed="OnPreviewControlExpanded">
-                <DoubleAnimation Name="expandWidthAnimator"
-                                 Storyboard.TargetName="centralizedGrid"
-                                 Storyboard.TargetProperty="Width"
-                                 Duration="{StaticResource AnimationDuration}" />
-                <DoubleAnimation Name="expandHeightAnimator"
-                                 Storyboard.TargetName="centralizedGrid"
-                                 Storyboard.TargetProperty="Height"
-                                 Duration="{StaticResource AnimationDuration}" />
-                <DoubleAnimation Storyboard.TargetName="smallContentGrid"
-                                 Storyboard.TargetProperty="Opacity"
-                                 To="0.0"
-                                 Duration="{StaticResource AnimationDuration}" />
-                <DoubleAnimation Storyboard.TargetName="largeContentGrid"
-                                 Storyboard.TargetProperty="Opacity"
-                                 To="1.0"
-                                 Duration="{StaticResource AnimationDuration}"
-                                 BeginTime="{StaticResource ResizeBeginTime}" />
-            </Storyboard>
-
-            <Storyboard x:Key="condenseStoryboard"
-                        Completed="OnPreviewControlCondensed">
-                <DoubleAnimation Storyboard.TargetName="largeContentGrid"
-                                 Storyboard.TargetProperty="Opacity"
-                                 To="0.0"
-                                 Duration="{StaticResource AnimationDuration}" />
-                <DoubleAnimation Name="condenseWidthAnimator"
-                                 Storyboard.TargetName="centralizedGrid"
-                                 Storyboard.TargetProperty="Width"
-                                 To="{StaticResource MinPreviewControlWidth}"
-                                 Duration="{StaticResource AnimationDuration}"
-                                 BeginTime="{StaticResource ResizeBeginTime}" />
-                <DoubleAnimation Name="condenseHeightAnimator"
-                                 Storyboard.TargetName="centralizedGrid"
-                                 Storyboard.TargetProperty="Height"
-                                 To="{StaticResource MinPreviewControlHeight}"
-                                 Duration="{StaticResource AnimationDuration}"
-                                 BeginTime="{StaticResource ResizeBeginTime}" />
-                <DoubleAnimation Storyboard.TargetName="smallContentGrid"
-                                 Storyboard.TargetProperty="Opacity"
-                                 To="1.0"
-                                 Duration="{StaticResource AnimationDuration}"
-                                 BeginTime="{StaticResource ResizeBeginTime}" />
-            </Storyboard>
-
-            <Storyboard x:Key="phaseOutStoryboard"
-                        Completed="OnPreviewControlPhasedOut">
-                <DoubleAnimation Storyboard.TargetName="centralizedGrid"
-                                 Storyboard.TargetProperty="Opacity"
-                                 From="1.0"
-                                 To="0.0"
-                                 Duration="{StaticResource AnimationDuration}" />
-                <DoubleAnimation Storyboard.TargetName="thisPreviewControl"
-                                 Storyboard.TargetProperty="(Canvas.Top)"
-                                 From="{StaticResource PhasedInPosition}"
-                                 To="{StaticResource PhasedOutPosition}"
-                                 Duration="{StaticResource AnimationDuration}" />
-            </Storyboard>
-
-            <Storyboard x:Key="resizingStoryboard">
-                <DoubleAnimation Name="gridWidthAnimator"
-                                 Storyboard.TargetName="centralizedGrid"
-                                 Storyboard.TargetProperty="Width"
-                                 Duration="{StaticResource AnimationDuration}" />
-                <DoubleAnimation Name="gridHeightAnimator"
-                                 Storyboard.TargetName="centralizedGrid"
-                                 Storyboard.TargetProperty="Height"
-                                 Duration="{StaticResource AnimationDuration}" />
-            </Storyboard>
+            
         </ResourceDictionary>
 
     </UserControl.Resources>
@@ -160,10 +63,8 @@
         <Grid Grid.Column="0"
               Grid.Row="1"
               Name="centralizedGrid"
-              Width="{StaticResource MinPreviewControlWidth}"
-              Height="{StaticResource MinPreviewControlHeight}"
-              VerticalAlignment="Top"
-              Visibility="Hidden">
+              Visibility="Hidden"
+              VerticalAlignment="Top">
             <Border Background="White"
                     BorderThickness="1"
                     BorderBrush="{StaticResource BubblePreviewBorderColor}" />

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -324,7 +324,9 @@ namespace Dynamo.UI.Controls
                 () =>
                 {
                     var mirrorData = nodeViewModel.NodeModel.CachedValue;
-                    newContent = CompactBubbleHandler.Process(mirrorData);                },                (m) =>
+                    newContent = CompactBubbleHandler.Process(mirrorData);
+                },
+                (m) =>
                 {
                     cachedSmallContent = newContent;
                     var smallContentView = smallContentGrid.Children[0] as PreviewCompactView;
@@ -508,6 +510,15 @@ namespace Dynamo.UI.Controls
         {
             if (!IsHidden) throw new InvalidOperationException();
 
+            // do not use delay in tests
+            if (DynamoModel.IsTestMode)
+            {
+                ProcessFadeIn();
+                return;
+            }
+
+            // show preview bubble only if mouse stays over node longer than delay time
+            // so that during quick mouse moving preview bubbles won't be shown
             var delayTimer = new DispatcherTimer(DispatcherPriority.Normal)
             {
                 Interval = TimeSpan.FromMilliseconds(500)

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -17,6 +17,7 @@ using System.Windows.Media.Animation;
 using Dynamo.Configuration;
 using Dynamo.Extensions;
 using Dynamo.Models;
+using System.Threading.Tasks;
 
 namespace Dynamo.UI.Controls
 {
@@ -535,11 +536,24 @@ namespace Dynamo.UI.Controls
 
         #region Private Class Methods - Transition Helpers
 
-        private void BeginFadeInTransition()
+        private async void BeginFadeInTransition()
         {
             if (this.IsHidden == false)
                 throw new InvalidOperationException();
 
+            var delayTimer = new DispatcherTimer(DispatcherPriority.Normal);
+            delayTimer.Interval = TimeSpan.FromMilliseconds(1000);
+            this.nodeViewModel.OnMouseLeave += () => delayTimer.Stop();
+            delayTimer.Tick += (obj, e) =>
+            {
+                 Dispatcher.Invoke(() => ProcessFadeIn());
+                delayTimer.Stop();
+            };
+            await Task.Run(() => delayTimer.Start());
+        }
+
+        private void ProcessFadeIn()
+        {
             // To prevent another transition from being started and
             // indicate a new transition is about to be started
             SetCurrentStateAndNotify(State.PreTransition);

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -162,6 +162,24 @@ namespace Dynamo.UI.Controls
         }
 
         /// <summary>
+        /// Hides preview bubble if it is not pinned
+        /// </summary>
+        internal void HidePreviewBubble()
+        {
+            if (StaysOpen) return;
+
+            if (IsExpanded)
+            {
+                TransitionToState(State.Condensed);
+            }
+
+            if (IsCondensed)
+            {
+                TransitionToState(State.Hidden);
+            }
+        }
+
+        /// <summary>
         /// It is possible for a run to complete while the preview display is
         /// in transition.  In these situations, we can store the MirrorData and
         /// set a flag to refresh the display.

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -23,10 +23,9 @@ using System.Threading.Tasks;
 namespace Dynamo.UI.Controls
 {
     /// <summary>
-    /// Event to be sent when PreviewControl goes into a stable 
-    /// state (e.g. when all on-going storyboards have been completed).
+    /// Event to be sent when state of PreviewControl is changed
     /// </summary>
-    /// <param name="sender"><cref name="PreviewControl"/> instance which state has changed</param>
+    /// <param name="sender"><cref name="PreviewControl"/> instance whose state has changed</param>
     /// <param name="e">The event data</param>
     public delegate void StateChangedEventHandler(object sender, EventArgs e);
 
@@ -81,7 +80,7 @@ namespace Dynamo.UI.Controls
             this.scheduler = nodeViewModel.DynamoViewModel.Model.Scheduler;
             this.nodeViewModel = nodeViewModel;
             InitializeComponent();
-            Loaded += (s, e) => BeginNextTransition();
+            Loaded += PreviewControl_Loaded;
             if (this.nodeViewModel.PreviewPinned)
             {
                 StaysOpen = true;
@@ -524,10 +523,12 @@ namespace Dynamo.UI.Controls
                 Interval = TimeSpan.FromMilliseconds(500)
             };
 
-            nodeViewModel.OnMouseLeave += delayTimer.Stop;
+            var onMouseLeave = new Action(delayTimer.Stop);
+            nodeViewModel.OnMouseLeave += onMouseLeave;
             delayTimer.Tick += (obj, e) =>
             {
                 Dispatcher.Invoke(ProcessFadeIn);
+                nodeViewModel.OnMouseLeave -= onMouseLeave;
                 delayTimer.Stop();
             };
 
@@ -627,6 +628,12 @@ namespace Dynamo.UI.Controls
         #endregion
 
         #region Private Event Handlers
+
+        private void PreviewControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            BeginNextTransition();
+            Loaded -= PreviewControl_Loaded;
+        }
 
         private void OnMapPinMouseClick(object sender, MouseButtonEventArgs e)
         {

--- a/src/DynamoSandbox/DynamoSandbox.csproj
+++ b/src/DynamoSandbox/DynamoSandbox.csproj
@@ -98,6 +98,7 @@
     <ProjectReference Include="..\DynamoUtilities\DynamoUtilities.csproj">
       <Project>{B5F435CB-0D8A-40B1-A4F7-5ECB3CE792A9}</Project>
       <Name>DynamoUtilities</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Tools\DynamoInstallDetective\DynamoInstallDetective.csproj">
       <Project>{98692887-b389-4f73-a71a-9fc516738dab}</Project>

--- a/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
+++ b/src/Libraries/GeometryUIWpf/GeometryUIWpf.csproj
@@ -93,6 +93,7 @@
     <ProjectReference Include="..\..\DynamoUtilities\DynamoUtilities.csproj">
       <Project>{b5f435cb-0d8a-40b1-a4f7-5ecb3ce792a9}</Project>
       <Name>DynamoUtilities</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\NodeServices\DynamoServices.csproj">
       <Project>{ef879a10-041d-4c68-83e7-3192685f1bae}</Project>

--- a/test/Libraries/AnalysisTests/AnalysisTests.csproj
+++ b/test/Libraries/AnalysisTests/AnalysisTests.csproj
@@ -63,6 +63,7 @@
     <ProjectReference Include="..\..\..\src\DynamoUtilities\DynamoUtilities.csproj">
       <Project>{b5f435cb-0d8a-40b1-a4f7-5ecb3ce792a9}</Project>
       <Name>DynamoUtilities</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\..\src\Libraries\Analysis\Analysis.csproj">
       <Project>{76686ed6-e759-4772-81c2-768740be13fa}</Project>


### PR DESCRIPTION
### Purpose

- Preview bubble is shown if mouse stays on node longer than specified delay;
- Animations are removed;
- Preview bubble collapses when dragging is started;
- Code is enhanced;
- Tests passed.

### Task link

[MAGN-9889 Preview Bubble should only appear when user intentionally hovers over a node](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9889)

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any - *the PR changes behavior of UI rather than appearence, so there is no way to show it in snapshot*

### Reviewers

@mjkkirschner 