### PR TITLE
MAGN-9591 It is hard to pin the new preview bubble

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -1284,6 +1284,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Resource Include="UI\Images\bubble-arrow.png" />
+    <Resource Include="UI\Images\icon-whats-new-small.png" />
     <Content Include="ViewModels\Watch3D\Shaders\BillboardText.fx" />
     <Content Include="ViewModels\Watch3D\Shaders\Common.fx" />
     <Content Include="ViewModels\Watch3D\Shaders\Custom.fx" />

--- a/src/DynamoCoreWpf/Services/LoginService.cs
+++ b/src/DynamoCoreWpf/Services/LoginService.cs
@@ -26,7 +26,7 @@ namespace Dynamo.Wpf.Authentication
             // URL shouldn't be empty.
             // URL can be empty, if user's local date is incorrect.
             // This a known bug, described here: https://github.com/DynamoDS/Dynamo/pull/6112
-            if ((o as string).Length == 0)
+            if (o.ToString().Length == 0)
             {
                 MessageBox.Show(Resources.InvalidTimeZoneMessage,
                                 Resources.InvalidLoginUrl,

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -538,6 +538,7 @@ namespace Dynamo.Controls
                     }
             };
         }
+
         /// <summary>
         /// Sets ZIndex of node the maximum value.
         /// </summary>

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -68,6 +68,7 @@
             <Border Background="White"
                     BorderThickness="1"
                     BorderBrush="{StaticResource BubblePreviewBorderColor}" />
+            <!--bubbleTools is a pin icon which expands large preview bubble on mouse hover -->
             <Border Name="bubbleTools"
                     VerticalAlignment="Top"
                     HorizontalAlignment="Right"

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -31,13 +31,31 @@
         </ResourceDictionary>
 
     </UserControl.Resources>
-
+    <UserControl.Triggers>
+        <EventTrigger RoutedEvent="MouseEnter">
+            <BeginStoryboard>
+                <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Duration="0" Storyboard.TargetName="bubbleTools" Storyboard.TargetProperty="Visibility">
+                        <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                    </ObjectAnimationUsingKeyFrames>
+                </Storyboard>
+            </BeginStoryboard>
+        </EventTrigger>
+        <EventTrigger RoutedEvent="MouseLeave">
+            <BeginStoryboard>
+                <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Duration="0" Storyboard.TargetName="bubbleTools" Storyboard.TargetProperty="Visibility">
+                        <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Collapsed}" />
+                    </ObjectAnimationUsingKeyFrames>
+                </Storyboard>
+            </BeginStoryboard>
+        </EventTrigger>
+    </UserControl.Triggers>
     <Grid Name="outerContainer"
           HorizontalAlignment="Left"
           VerticalAlignment="Top">
 
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
@@ -68,7 +86,52 @@
             <Border Background="White"
                     BorderThickness="1"
                     BorderBrush="{StaticResource BubblePreviewBorderColor}" />
-
+            <Border Name="bubbleTools"
+                    VerticalAlignment="Top"
+                    HorizontalAlignment="Right"
+                    Padding="3"
+                    Visibility="Collapsed"
+                    Panel.ZIndex="1">
+                <Border BorderThickness="1"
+                            CornerRadius="4"
+                            BorderBrush="{StaticResource BubblePreviewBorderColor}"
+                            MouseLeftButtonDown="OnMapPinMouseClick">
+                    <StackPanel Orientation="Horizontal">
+                        <StackPanel.Resources>
+                            <Style TargetType="fa:ImageAwesome">
+                                <Setter Value="{Binding RelativeSource={RelativeSource FindAncestor, 
+                                            AncestorType={x:Type uicontrols:PreviewControl}}, 
+                                            Path=StaysOpen,
+                                            Converter={StaticResource PinIconForegroundConverter}}" Property="Foreground"/>
+                            </Style>
+                        </StackPanel.Resources>
+                        <fa:ImageAwesome Icon="EllipsisHorizontal" 
+                                             VerticalAlignment="Bottom" Margin="4,0,0,7" Width="9"/>
+                        <fa:ImageAwesome Name="PinnIcon" Icon="ThumbTack" Height="12" Width="9" Margin="4" />
+                    </StackPanel>
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Style.Triggers>
+                                <DataTrigger Value="True" Binding="{Binding RelativeSource={RelativeSource FindAncestor, 
+                                                          AncestorType={x:Type uicontrols:PreviewControl}}, 
+                                                          Path=StaysOpen}">
+                                    <Setter Property="Background" Value="{StaticResource PinnedIconBackgroundColor}" />
+                                </DataTrigger>
+                                <DataTrigger Value="False" Binding="{Binding Path=StaysOpen, 
+                                                            RelativeSource={RelativeSource FindAncestor, 
+                                                            AncestorType={x:Type uicontrols:PreviewControl}}}">
+                                    <Setter Property="Background"
+                                            Value="{StaticResource UnpinnedIconBackgroundColor}" />
+                                </DataTrigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Background"
+                                            Value="{StaticResource PinnedIconHoverBackgroundColor}" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
+                </Border>
+            </Border>
             <Grid Name="smallContentGrid"
                   HorizontalAlignment="Left"
                   VerticalAlignment="Center"
@@ -87,68 +150,5 @@
                   Visibility="Collapsed">
             </Grid>
         </Grid>
-
-        <Border Grid.Column="1"
-                Grid.Row="1"
-                Name="bubbleTools"
-                Background="White"
-                BorderThickness="0,1,1,1"
-                BorderBrush="{StaticResource BubblePreviewBorderColor}"
-                VerticalAlignment="Top"
-                Visibility="Collapsed">
-            <StackPanel Orientation="Vertical">
-                <!--<fa:ImageAwesome Name="SearchIcon"
-                                 Icon="search"
-                                 Height="10"
-                                 Width="10"
-                                 Margin="5,5,5,5"
-                                 Foreground="{StaticResource BubblePreviewIconColor}" />-->
-                <Border BorderThickness="0"
-                        MouseLeftButtonDown="OnMapPinMouseClick">
-                    <fa:ImageAwesome Name="PinnIcon"
-                                     Icon="ThumbTack"
-                                     Foreground="{Binding RelativeSource={RelativeSource FindAncestor, 
-                                                          AncestorType={x:Type uicontrols:PreviewControl}}, 
-                                                          Path=StaysOpen,
-                                                          Converter={StaticResource PinIconForegroundConverter}}"
-                                     Height="16"
-                                     Width="12"
-                                     Margin="6,6,6,6" />
-                    <Border.Style>
-                        <Style TargetType="Border">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, 
-                                                          AncestorType={x:Type uicontrols:PreviewControl}}, 
-                                                          Path=StaysOpen}"
-                                             Value="True">
-                                    <Setter Property="Background"
-                                            Value="{StaticResource PinnedIconBackgroundColor}" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, 
-                                                          AncestorType={x:Type uicontrols:PreviewControl}}, 
-                                                          Path=StaysOpen}"
-                                             Value="False">
-                                    <Setter Property="Background"
-                                            Value="{StaticResource UnpinnedIconBackgroundColor}" />
-                                </DataTrigger>
-                                <Trigger Property="IsMouseOver"
-                                         Value="True">
-                                    <Setter Property="Background"
-                                            Value="{StaticResource PinnedIconHoverBackgroundColor}" />
-                                </Trigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Border.Style>
-                </Border>
-                <!--<fa:ImageAwesome Name="ArrowIcon"
-                                 Icon="ArrowCircleRight"
-                                 Height="10"
-                                 Width="10"
-                                 Margin="5,5,5,5"
-                                 Foreground="{StaticResource BubblePreviewIconColor}" />-->
-            </StackPanel>
-        </Border>
-
     </Grid>
-
 </UserControl>

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -97,17 +97,17 @@
                             BorderBrush="{StaticResource BubblePreviewBorderColor}"
                             MouseLeftButtonDown="OnMapPinMouseClick">
                     <StackPanel Orientation="Horizontal">
-                        <StackPanel.Resources>
-                            <Style TargetType="fa:ImageAwesome">
-                                <Setter Value="{Binding RelativeSource={RelativeSource FindAncestor, 
-                                            AncestorType={x:Type uicontrols:PreviewControl}}, 
-                                            Path=StaysOpen,
-                                            Converter={StaticResource PinIconForegroundConverter}}" Property="Foreground"/>
-                            </Style>
-                        </StackPanel.Resources>
-                        <fa:ImageAwesome Icon="EllipsisHorizontal" 
-                                             VerticalAlignment="Bottom" Margin="4,0,0,7" Width="9"/>
-                        <fa:ImageAwesome Name="PinnIcon" Icon="ThumbTack" Height="12" Width="9" Margin="4" />
+                        <TextBlock VerticalAlignment="Bottom" Margin="4,0,0,4" Text="..."
+                            Foreground="{Binding RelativeSource={RelativeSource FindAncestor, 
+                                                 AncestorType={x:Type uicontrols:PreviewControl}}, 
+                                                 Path=StaysOpen,
+                                                 Converter={StaticResource PinIconForegroundConverter}}"/>
+
+                        <fa:ImageAwesome Name="PinnIcon" Icon="ThumbTack" Height="12" Width="9" Margin="4" 
+                            Foreground="{Binding RelativeSource={RelativeSource FindAncestor, 
+                                                 AncestorType={x:Type uicontrols:PreviewControl}}, 
+                                                 Path=StaysOpen,
+                                                 Converter={StaticResource PinIconForegroundConverter}}"/>
                     </StackPanel>
                     <Border.Style>
                         <Style TargetType="Border">

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -11,7 +11,9 @@
              xmlns:ui="clr-namespace:Dynamo.UI"
              xmlns:fa="http://schemas.fontawesome.io/icons/"
              xmlns:uicontrols="clr-namespace:Dynamo.UI.Controls"
-             mc:Ignorable="d" Canvas.Top="-20">
+             mc:Ignorable="d"  Canvas.Top="-20"
+             MouseEnter="PreviewControl_MouseEnter"
+             MouseLeave="PreviewControl_MouseLeave">
 
     <UserControl.Resources>
         <ResourceDictionary>
@@ -31,26 +33,6 @@
         </ResourceDictionary>
 
     </UserControl.Resources>
-    <UserControl.Triggers>
-        <EventTrigger RoutedEvent="MouseEnter">
-            <BeginStoryboard>
-                <Storyboard>
-                    <ObjectAnimationUsingKeyFrames Duration="0" Storyboard.TargetName="bubbleTools" Storyboard.TargetProperty="Visibility">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
-                    </ObjectAnimationUsingKeyFrames>
-                </Storyboard>
-            </BeginStoryboard>
-        </EventTrigger>
-        <EventTrigger RoutedEvent="MouseLeave">
-            <BeginStoryboard>
-                <Storyboard>
-                    <ObjectAnimationUsingKeyFrames Duration="0" Storyboard.TargetName="bubbleTools" Storyboard.TargetProperty="Visibility">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Collapsed}" />
-                    </ObjectAnimationUsingKeyFrames>
-                </Storyboard>
-            </BeginStoryboard>
-        </EventTrigger>
-    </UserControl.Triggers>
     <Grid Name="outerContainer"
           HorizontalAlignment="Left"
           VerticalAlignment="Top">

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -659,6 +659,16 @@ namespace Dynamo.UI.Controls
             e.Handled = true;
         }
 
+        private void PreviewControl_MouseEnter(object sender, MouseEventArgs e)
+        {
+            bubbleTools.Visibility = Visibility.Visible;
+        }
+
+        private void PreviewControl_MouseLeave(object sender, MouseEventArgs e)
+        {
+            bubbleTools.Visibility = Visibility.Collapsed;
+        }
+
         #endregion
     }
 }

--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -81,6 +81,7 @@ namespace Dynamo.UI.Controls
             this.nodeViewModel = nodeViewModel;
             InitializeComponent();
             Loaded += PreviewControl_Loaded;
+            SizeChanged += (s, e) => UpdateMargin();
             if (this.nodeViewModel.PreviewPinned)
             {
                 StaysOpen = true;
@@ -92,6 +93,18 @@ namespace Dynamo.UI.Controls
             {
                 StaysOpen = false;
             }
+        }
+
+        private void UpdateMargin()
+        {
+            var nodeWidth = smallContentGrid.MinWidth;
+            var previewWidth = Math.Max(centralizedGrid.ActualWidth, nodeWidth);
+            var margin = (previewWidth - nodeWidth)/2;
+            Margin = new System.Windows.Thickness {Left = -margin };
+            bubbleTools.Margin = new System.Windows.Thickness
+            {
+                Right = margin
+            };
         }
 
         /// <summary>
@@ -262,6 +275,8 @@ namespace Dynamo.UI.Controls
             {
                 StateChanged(this, EventArgs.Empty);
             }
+
+            UpdateMargin();
         }
 
         private void ResetContentViews()
@@ -566,8 +581,6 @@ namespace Dynamo.UI.Controls
             if (StaysOpen) return;
             if (!IsCondensed) throw new InvalidOperationException();
 
-            bubbleTools.Visibility = Visibility.Collapsed;
-
             SetCurrentStateAndNotify(State.InTransition);
 
             thisPreviewControl.Visibility = Visibility.Collapsed;
@@ -584,9 +597,8 @@ namespace Dynamo.UI.Controls
             SetCurrentStateAndNotify(State.PreTransition);
 
             RefreshCondensedDisplay(() =>
-            {
-                smallContentGrid.Visibility = Visibility.Visible;
-                bubbleTools.Visibility = Visibility.Collapsed;
+                {
+                    smallContentGrid.Visibility = Visibility.Visible;
 
                 // The real transition starts
                 SetCurrentStateAndNotify(State.InTransition);
@@ -614,7 +626,6 @@ namespace Dynamo.UI.Controls
         {
             smallContentGrid.Visibility = Visibility.Collapsed;
             largeContentGrid.Visibility = Visibility.Visible;
-            bubbleTools.Visibility = Visibility.Visible;
 
             // The real transition starts
             SetCurrentStateAndNotify(State.InTransition);

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -329,7 +329,7 @@ namespace DynamoCoreWpfTests
             nodeView.PreviewControl.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
 
             RaiseMouseEnterOnNode(nodeView);
-            Assert.IsTrue(nodeView.PreviewControl.IsCondensed, "Cmpact preview bubble is not shown");
+            Assert.IsTrue(nodeView.PreviewControl.IsCondensed, "Compact preview bubble is not shown");
 
             RaiseMouseLeaveNode(nodeView);
             Assert.IsTrue(nodeView.PreviewControl.IsHidden, "Preview bubble is not hidden");
@@ -341,6 +341,30 @@ namespace DynamoCoreWpfTests
             RaiseMouseEnterOnNode(nodeView);
 
             Assert.IsTrue(nodeView.PreviewControl.IsHidden, "Preview bubble is not hidden");
+        }
+
+        [Test]
+        public void PreviewBubble_ShowExpandedPreviewOnPinIconHover()
+        {
+            Open(@"core\DetailedPreviewMargin_Test.dyn");
+            var nodeView = NodeViewWithGuid("7828a9dd-88e6-49f4-9ed3-72e355f89bcc");
+
+            var previewBubble = nodeView.PreviewControl;
+            previewBubble.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+            previewBubble.bubbleTools.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+            // open preview bubble
+            RaiseMouseEnterOnNode(nodeView);
+            Assert.IsTrue(previewBubble.IsCondensed, "Compact preview bubble should be shown");
+            Assert.AreEqual(Visibility.Collapsed, previewBubble.bubbleTools.Visibility, "Pin icon should not be shown");
+
+            // hover preview bubble to see pin icon
+            RaiseMouseEnterOnNode(previewBubble);
+            Assert.AreEqual(Visibility.Visible, previewBubble.bubbleTools.Visibility, "Pin icon should be shown");
+
+            // expand preview bubble
+            RaiseMouseEnterOnNode(previewBubble.bubbleTools);
+            Assert.IsTrue(previewBubble.IsExpanded, "Expanded preview bubble should be shown");
         }
 
         [Test]
@@ -364,7 +388,7 @@ namespace DynamoCoreWpfTests
             return (relativePosition.X == 0) && (element.ActualWidth <= container.ActualWidth);
         }
 
-        private void RaiseMouseEnterOnNode(NodeView nv)
+        private void RaiseMouseEnterOnNode(IInputElement nv)
         {
             View.Dispatcher.Invoke(() =>
             {
@@ -374,7 +398,7 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
         }
 
-        private void RaiseMouseLeaveNode(NodeView nv)
+        private void RaiseMouseLeaveNode(IInputElement nv)
         {
             View.Dispatcher.Invoke(() =>
             {


### PR DESCRIPTION
### Purpose

- When node is hovered, only small preview bubble is shown:
![image](https://cloud.githubusercontent.com/assets/7658189/15289145/d37ce33c-1b78-11e6-862f-864fd09cd704.png)

- When preview bubble is hovered, still only small preview bubble is shown and pin icon appears in new place:
![image](https://cloud.githubusercontent.com/assets/7658189/15289155/e2ac9730-1b78-11e6-9ee9-5e9b798cac3a.png)

- Large preview bubble appears only when pin icon is hovered:
![image](https://cloud.githubusercontent.com/assets/7658189/15289186/20708d88-1b79-11e6-966d-0a9223dcba3d.png)
or preview is pinned:
![image](https://cloud.githubusercontent.com/assets/7658189/15289213/4f9aabde-1b79-11e6-801d-2b8778ea75b7.png)

See the video attached in [the task](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9591) to see new preview bubble behavior

Note that three dots is used instead of `fa-ellipsis-h` icon, because dots on the icon are too close to each other, so it looks not so prettily in our small pin icon

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 

### FYIs

@Racel 