### PR TITLE
To remove unwated libraries from coverage analysis to improve coverage

### DIFF
--- a/src/Config.xml
+++ b/src/Config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AnalyseParams>
 	<Executable><!-- Required.   -->C:\Program Files (x86)\NUnit 2.6.2\bin\nunit-console.exe</Executable>
-	<Arguments> AnalysisTests.dll DataBridgeTests.dll DynamoCoreWpfTests.dll DSCoreNodesTests.dll DynamoServicesTests.dll DynamoPythonTests.dll DynamoMSOfficeTests.dll DynamoCoreTests.dll DynamoUtilitiesTests.dll IntegrationTests.dll   ProtoTest.dll WorkflowTests.dll CommandLineTests.dll --labels=On /noshadow /exclude:Failure /xml=nunit-result.xml</Arguments> 
+	<Arguments>DataBridgeTests.dll DynamoCoreWpfTests.dll DSCoreNodesTests.dll DynamoServicesTests.dll DynamoPythonTests.dll DynamoMSOfficeTests.dll DynamoCoreTests.dll DynamoUtilitiesTests.dll IntegrationTests.dll   ProtoTest.dll WorkflowTests.dll CommandLineTests.dll --labels=On /noshadow /exclude:Failure /xml=nunit-result.xml</Arguments> 
 	<WorkingDir>..\bin\AnyCPU\Release\</WorkingDir>
 	<Output>Coverage.html</Output> <!-- Change the value to html-->
 	<ReportType>html</ReportType><!-- Change the value to html -->
@@ -12,6 +12,12 @@
 </FilterEntry>
 <FilterEntry>
 <ModuleMask>*FFITarget*</ModuleMask>
+</FilterEntry>
+<FilterEntry>
+<ModuleMask>*Helix*</ModuleMask>
+</FilterEntry>
+<FilterEntry>
+<ModuleMask>*resources*</ModuleMask>
 </FilterEntry>
 </ExcludeFilters>
 </Filters>


### PR DESCRIPTION
-  PR to improve coverage

Remove AnalysisTests.dll as those tests require to be run through Revittestsuite.
To remove unwanted libraries from coverage analysis to improve coverage.
 - This includes Helix and SharpDX code from coverage tests, as they are third party library.
 -  Remove *.resource.dll from coverage tests to eliminate resources required for localization.

@aparajit-pratap  - please review this.
