### PR TITLE
MAGN-9757 Turning off "Revit Background Preview" causes Dynamo "Background Preview" on relaunch of Dynamo.

### DIFF
--- a/src/DynamoCore/Configuration/IPreferences.cs
+++ b/src/DynamoCore/Configuration/IPreferences.cs
@@ -33,9 +33,23 @@ namespace Dynamo.Interfaces
         ConnectorType ConnectorType { get; set; }
 
         /// <summary>
-        /// Indicates whether background preview is active or not.
+        /// Collection of pairs [BackgroundPreviewName;isActive]
         /// </summary>
-        bool IsBackgroundPreviewActive { get; set; }
+        List<BackgroundPreviewActiveState> BackgroundPreviews { get; set; }
+
+        /// <summary>
+        /// Returns active state of specified background preview 
+        /// </summary>
+        /// <param name="name">Background preview name</param>
+        /// <returns>The active state</returns>
+        bool GetIsBackgroundPreviewActive(string name);
+
+        /// <summary>
+        /// Sets active state of specified background preview 
+        /// </summary>
+        /// <param name="name">Background preview name</param>
+        /// <param name="value">Active state to set</param>
+        void SetIsBackgroundPreviewActive(string name, bool value);
 
         /// <summary>
         /// Indicates whether background grid is visible or not.
@@ -123,5 +137,30 @@ namespace Dynamo.Interfaces
         /// <returns>Returns true if the serialization is successful, or false 
         /// otherwise.</returns>
         bool Save(string filePath);
+    }
+
+    /// <summary>
+    /// Represents data about active state of preview background
+    /// </summary>
+    public class BackgroundPreviewActiveState
+    {
+        /// <summary>
+        /// Name of background preview 
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Flag which indicates if background preview is active
+        /// </summary>
+        public bool IsActive { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of <c name="BackgroundPreviewActiveState"/> class
+        /// </summary>
+        public BackgroundPreviewActiveState()
+        {
+            // Default value
+            IsActive = true;
+        }
     }
 }

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -89,9 +89,46 @@ namespace Dynamo.Configuration
         public ConnectorType ConnectorType { get; set; }
 
         /// <summary>
-        /// Should the background 3D preview be shown?
+        /// Collection of pairs [BackgroundPreviewName;isActive]
         /// </summary>
-        public bool IsBackgroundPreviewActive { get; set; }
+        public List<BackgroundPreviewActiveState> BackgroundPreviews { get; set; }
+
+        /// <summary>
+         /// Returns active state of specified background preview 
+         /// </summary>
+         /// <param name="name">Background preview name</param>
+         /// <returns>The active state</returns>
+        public bool GetIsBackgroundPreviewActive(string name)
+        {
+            var pair = GetBackgroundPreviewData(name);
+
+            return pair.IsActive;
+        }
+
+        /// <summary>
+        /// Sets active state of specified background preview 
+        /// </summary>
+        /// <param name="name">Background preview name</param>
+        /// <param name="value">Active state</param>
+        public void SetIsBackgroundPreviewActive(string name, bool value)
+        {
+            var pair = GetBackgroundPreviewData(name);
+
+            pair.IsActive = value;
+        }
+
+        private BackgroundPreviewActiveState GetBackgroundPreviewData(string name)
+        {
+            // find or create BackgroundPreviewActiveState instance in list by name
+            var pair = BackgroundPreviews.FirstOrDefault(p => p.Name == name)
+                ?? new BackgroundPreviewActiveState { Name = name };
+            if (!BackgroundPreviews.Contains(pair))
+            {
+                BackgroundPreviews.Add(pair);
+            }
+
+            return pair;
+        }
 
         /// <summary>
         /// Should the background grid be shown?
@@ -220,6 +257,7 @@ namespace Dynamo.Configuration
             WindowW = 1024;
             WindowY = 0.0;
             WindowX = 0.0;
+            BackgroundPreviews = new List<BackgroundPreviewActiveState>();
 
             // Default Settings
             IsFirstRun = true;
@@ -229,7 +267,6 @@ namespace Dynamo.Configuration
             ShowPreviewBubbles = true;
             ShowConnector = true;
             ConnectorType = ConnectorType.BEZIER;
-            IsBackgroundPreviewActive = true;
             IsBackgroundGridVisible = true;
             PackageDirectoriesToUninstall = new List<string>();
             NumberFormat = "f3";

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -528,6 +528,8 @@ namespace Dynamo.ViewModels
         {
             watch3DViewModel.Setup(this, factory);
             watch3DViewModels.Add(watch3DViewModel);
+            watch3DViewModel.Active = PreferenceSettings
+                .GetIsBackgroundPreviewActive(watch3DViewModel.PreferenceWatchName);
             RaisePropertyChanged("Watch3DViewModels");
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -67,7 +67,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         protected List<NodeModel> recentlyAddedNodes = new List<NodeModel>();
         protected bool active;
         protected bool isGridVisible;
-        private readonly List<IRenderPackage> currentTaggedPackages = new List<IRenderPackage>();
+
+        /// <summary>
+        /// Represents the name of current Watch3DViewModel which will be saved in preference settings
+        /// </summary>
+        public virtual string PreferenceWatchName { get { return "IsBackgroundPreviewActive"; } }
 
         /// <summary>
         /// A flag which indicates whether this Watch3DView should process
@@ -85,8 +89,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 }
 
                 active = value;
-                preferences.IsBackgroundPreviewActive = active;
-
+                preferences.SetIsBackgroundPreviewActive(PreferenceWatchName, value);
                 RaisePropertyChanged("Active");
 
                 OnActiveStateChanged();
@@ -217,7 +220,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             engineManager = parameters.EngineControllerManager;
 
             Name = Resources.BackgroundPreviewDefaultName;
-            Active = parameters.Preferences.IsBackgroundPreviewActive;
             isGridVisible = parameters.Preferences.IsBackgroundGridVisible;
             logger = parameters.Logger;
 
@@ -257,8 +259,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         protected virtual void OnActiveStateChanged()
         {
-            preferences.IsBackgroundPreviewActive = active;
-
             UnregisterEventHandlers();
             OnClear();
         }

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -149,8 +149,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         protected override void OnActiveStateChanged()
         {
-            preferences.IsBackgroundPreviewActive = active;
-
             if (!active && CanNavigateBackground)
             {
                 CanNavigateBackground = false;

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/IWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/IWatch3DViewModel.cs
@@ -61,6 +61,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         IRay GetClickRay(MouseEventArgs args);
 
         /// <summary>
+        /// Represents the name of current IWatch3DViewModel which will be saved in preference settings
+        /// </summary>
+        string PreferenceWatchName { get; }
+
+        /// <summary>
         /// Returns the current camera position of the 3D background preview
         /// Note: GetCameraInformation returns the camera position but without the correct
         /// transformation to model coordinates. This function takes care of that transformation

--- a/src/VisualizationTests/Watch3DViewModelTests.cs
+++ b/src/VisualizationTests/Watch3DViewModelTests.cs
@@ -9,13 +9,15 @@ namespace WpfVisualizationTests
         [Test]
         public void Watch3DViewModel_Active_InSyncWithPreferences()
         {
-            Assert.AreEqual(ViewModel.BackgroundPreviewViewModel.Active,ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive);
+            var backgroundPreviewName = ViewModel.BackgroundPreviewViewModel.PreferenceWatchName;
+            Assert.AreEqual(ViewModel.BackgroundPreviewViewModel.Active,
+                ViewModel.Model.PreferenceSettings.GetIsBackgroundPreviewActive(backgroundPreviewName));
 
             ViewModel.BackgroundPreviewViewModel.Active = false;
-            Assert.False(ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive);
+            Assert.False(ViewModel.Model.PreferenceSettings.GetIsBackgroundPreviewActive(backgroundPreviewName));
 
             ViewModel.BackgroundPreviewViewModel.Active = true;
-            Assert.True(ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive);
+            Assert.True(ViewModel.Model.PreferenceSettings.GetIsBackgroundPreviewActive(backgroundPreviewName));
         }
     }
 }

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -445,13 +445,15 @@ namespace DynamoCoreWpfTests
             // Test Case to ensure that the link for these persistent variable
             // between DynamoViewModel, Model is not broken or replaced.
             #region BackgroundPreviewActive
-            bool expectedValue = !ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive;
-            ViewModel.ToggleFullscreenWatchShowing(null);
-            Assert.AreEqual(expectedValue, ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive);
 
-            expectedValue = !ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive;
+            var backgroundPreviewName = ViewModel.BackgroundPreviewViewModel.PreferenceWatchName;
+            bool expectedValue = !ViewModel.Model.PreferenceSettings.GetIsBackgroundPreviewActive(backgroundPreviewName);
             ViewModel.ToggleFullscreenWatchShowing(null);
-            Assert.AreEqual(expectedValue, ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive);
+            Assert.AreEqual(expectedValue, ViewModel.Model.PreferenceSettings.GetIsBackgroundPreviewActive(backgroundPreviewName));
+
+            expectedValue = !ViewModel.Model.PreferenceSettings.GetIsBackgroundPreviewActive(backgroundPreviewName);
+            ViewModel.ToggleFullscreenWatchShowing(null);
+            Assert.AreEqual(expectedValue, ViewModel.Model.PreferenceSettings.GetIsBackgroundPreviewActive(backgroundPreviewName));
             #endregion
 
             #region ConsoleHeight
@@ -511,12 +513,13 @@ namespace DynamoCoreWpfTests
 
             initalSetting.ConnectorType = ConnectorType.BEZIER;
             initalSetting.ConsoleHeight = 100;
-            initalSetting.IsBackgroundPreviewActive = true;
+            initalSetting.SetIsBackgroundPreviewActive(backgroundPreviewName, true);
 
             initalSetting.Save(tempPath);
             resultSetting = PreferenceSettings.Load(tempPath);
 
-            Assert.AreEqual(resultSetting.IsBackgroundPreviewActive, initalSetting.IsBackgroundPreviewActive);
+            Assert.AreEqual(resultSetting.GetIsBackgroundPreviewActive(backgroundPreviewName),
+                initalSetting.GetIsBackgroundPreviewActive(backgroundPreviewName));
             Assert.AreEqual(resultSetting.ConnectorType, initalSetting.ConnectorType);
             Assert.AreEqual(resultSetting.ConsoleHeight, initalSetting.ConsoleHeight);
             #endregion
@@ -524,12 +527,13 @@ namespace DynamoCoreWpfTests
             #region Second Test
             initalSetting.ConnectorType = ConnectorType.POLYLINE;
             initalSetting.ConsoleHeight = 0;
-            initalSetting.IsBackgroundPreviewActive = false;
+            initalSetting.SetIsBackgroundPreviewActive(backgroundPreviewName, false);
 
             initalSetting.Save(tempPath);
             resultSetting = PreferenceSettings.Load(tempPath);
 
-            Assert.AreEqual(resultSetting.IsBackgroundPreviewActive, initalSetting.IsBackgroundPreviewActive);
+            Assert.AreEqual(resultSetting.GetIsBackgroundPreviewActive(backgroundPreviewName),
+                initalSetting.GetIsBackgroundPreviewActive(backgroundPreviewName));
             Assert.AreEqual(resultSetting.ConnectorType, initalSetting.ConnectorType);
             Assert.AreEqual(resultSetting.ConsoleHeight, initalSetting.ConsoleHeight);
             #endregion


### PR DESCRIPTION
### Purpose

The issue is that each `Watch3DViewModel` updates the same member of preference settings - `IsBackgroundPreviewActive` that leads to the bug when there are more than one preview.

The solution is to store `Active` value for each `Watch3DViewModel` in preferences separately by name. So, each preview should just override `PreferenceWatchName` property, otherwise its `Active` value will be saved with default name (as `HelixWatch3DViewModel` does):
![image](https://cloud.githubusercontent.com/assets/7658189/15400196/5619c3d8-1df3-11e6-8d8e-0b8e4a4ccaa8.png)

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 