### PR TITLE
Enable starting Dynamo model from tests

### DIFF
--- a/test/DynamoCoreTests/DynamoModelTestBase.cs
+++ b/test/DynamoCoreTests/DynamoModelTestBase.cs
@@ -20,7 +20,7 @@ namespace Dynamo
 {
     public class DynamoModelTestBase : DSEvaluationUnitTestBase
     {
-        protected DynamoModel CurrentDynamoModel { get; private set; }
+        protected DynamoModel CurrentDynamoModel { get; set; }
 
         protected Preloader preloader;
         protected TestPathResolver pathResolver;


### PR DESCRIPTION
### Purpose

*Reference:* [MAGN-9854](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9854)

This modification is to support tests that extend `DynamoModelTestBase` and has its own implementation for `StartDynamo(IPreferences settings)` for preloading libraries and additional node directories.

### Declarations

- [x] All tests pass using the self-service CI.

### Reviewers

@aparajit-pratap