### PR TITLE
Magn 10004

### DIFF
--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -124,7 +124,7 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Default width of tab
         /// </summary>
-        public static readonly int TabDefaultWidth = 200;
+        public static readonly int TabDefaultWidth = 250;
         #endregion
 
         #region Information Bubble

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Xml;
-using Dynamo.Core;
+﻿using Dynamo.Core;
 using Dynamo.Engine;
 using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Nodes;
@@ -15,6 +9,12 @@ using Dynamo.Models;
 using Dynamo.Scheduler;
 using ProtoCore;
 using ProtoCore.Namespace;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Xml;
 
 namespace Dynamo.Graph.Workspaces
 {

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -79,6 +79,7 @@ namespace Dynamo.Graph.Workspaces
         private string author = "None provided";
         private string description;
         private bool hasUnsavedChanges;
+        private bool isReadOnly;
         private readonly List<NodeModel> nodes;
         private readonly List<NoteModel> notes;
         private readonly List<AnnotationModel> annotations;
@@ -427,6 +428,18 @@ namespace Dynamo.Graph.Workspaces
         }
 
         /// <summary>
+        /// Returns if current workspace is readonly.
+        /// </summary>
+        public bool IsReadOnly
+        {
+            get { return isReadOnly; }
+            set
+            {
+                isReadOnly = value;
+            }
+        }
+
+        /// <summary>
         ///     All of the nodes currently in the workspace.
         /// </summary>
         public IEnumerable<NodeModel> Nodes
@@ -722,6 +735,7 @@ namespace Dynamo.Graph.Workspaces
             Zoom = info.Zoom;
 
             HasUnsavedChanges = false;
+            IsReadOnly = DynamoUtilities.PathHelper.IsReadOnlyPath(fileName);
             LastSaved = DateTime.Now;
 
             WorkspaceVersion = AssemblyHelper.GetDynamoVersion();

--- a/src/DynamoCore/Migration/Migration.cs
+++ b/src/DynamoCore/Migration/Migration.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
-using System.Reflection;
-using System.Xml;
-using Dynamo.Models;
-using Dynamo.Utilities;
-using Dynamo.Logging;
-using System.Collections.Generic;
-using System.IO;
-using Dynamo.Configuration;
-using Dynamo.Graph;
+﻿using Dynamo.Configuration;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.NodeLoaders;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Logging;
+using Dynamo.Models;
+using Dynamo.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
 
 namespace Dynamo.Migration
 {
@@ -374,12 +373,11 @@ namespace Dynamo.Migration
                 backupPath = destFileName;
                 return true;
             }
-            catch (IOException)
-            {
-                // If we caught an IO exception, fall through and let the rest handle this 
-                // (by saving to other locations). Any other exception will be thrown to the 
-                // caller for handling.
-            }
+            // If we caught an IO exception or UnauthorizedAccessException, fall through and let the rest handle this 
+            // (by saving to other locations). Any other exception will be thrown to the 
+            // caller for handling.
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
 
             try
             {
@@ -421,7 +419,7 @@ namespace Dynamo.Migration
         /// already exist).
         /// </summary>
         /// <param name="baseFolder">This is a directory inside which a new 
-        /// backup sub-directory will be created. If this paramter does not 
+        /// backup sub-directory will be created. If this parameter does not 
         /// represent a valid directory name, an exception will be thrown.
         /// </param>
         /// <param name="create">Set this parameter to false if the creation of 
@@ -447,7 +445,6 @@ namespace Dynamo.Migration
             var subFolder = Path.Combine(baseFolder, backupFolderName);
             if (create && (Directory.Exists(subFolder) == false))
                 Directory.CreateDirectory(subFolder);
-
             return subFolder;
         }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1,17 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.Serialization;
-using System.Threading;
-using System.Xml;
 using Dynamo.Configuration;
 using Dynamo.Core;
 using Dynamo.Engine;
+using Dynamo.Events;
 using Dynamo.Extensions;
 using Dynamo.Graph;
 using Dynamo.Graph.Annotations;
@@ -23,6 +13,7 @@ using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Notes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
+using Dynamo.Logging;
 using Dynamo.Migration;
 using Dynamo.Properties;
 using Dynamo.Scheduler;
@@ -31,20 +22,27 @@ using Dynamo.Search.SearchElements;
 using Dynamo.Selection;
 using Dynamo.Updates;
 using Dynamo.Utilities;
-using Dynamo.Logging;
-
 using DynamoServices;
 using DynamoUnits;
 using Greg;
 using ProtoCore;
 using ProtoCore.Runtime;
-
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Xml;
 using Compiler = ProtoAssociative.Compiler;
 // Dynamo package manager
-using Utils = Dynamo.Graph.Nodes.Utilities;
 using DefaultUpdateManager = Dynamo.Updates.UpdateManager;
 using FunctionGroup = Dynamo.Engine.FunctionGroup;
-using Dynamo.Events;
+using Utils = Dynamo.Graph.Nodes.Utilities;
 
 namespace Dynamo.Models
 {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2758,6 +2758,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to We can&apos;t save &quot;{0}&quot; because the file is read only. To keep your changes, you&apos;ll need to save it with a new name or in a different location..
+        /// </summary>
+        public static string MessageConfirmToSaveReadOnlyCustomNode {
+            get {
+                return ResourceManager.GetString("MessageConfirmToSaveReadOnlyCustomNode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to uninstall {0} ?  This will delete the packages root directory.
         ///
         ///You can always redownload the package..

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4563,6 +4563,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [Read-Only] .
+        /// </summary>
+        public static string TabFileNameReadOnlyPrefix {
+            get {
+                return ResourceManager.GetString("TabFileNameReadOnlyPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to I Accept.
         /// </summary>
         public static string TermsOfUseAcceptButton {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -865,6 +865,7 @@ It does not contain your graph or any personal data</value>
     <value>You have unsaved changes to custom node workspace: "{0}".
 
 Would you like to save your changes?</value>
+    <comment>Message box content</comment>
   </data>
   <data name="MessageConfirmToSaveHomeWorkSpace" xml:space="preserve">
     <value>You have unsaved changes to the Home workspace.
@@ -2002,6 +2003,10 @@ Next assemblies were loaded several times:
   </data>
   <data name="MessageFailedToAddFile" xml:space="preserve">
     <value>Failed to add file: {0}</value>
+    <comment>Message box content</comment>
+  </data>
+  <data name="MessageConfirmToSaveReadOnlyCustomNode" xml:space="preserve">
+    <value>We can't save "{0}" because the file is read only. To keep your changes, you'll need to save it with a new name or in a different location.</value>
     <comment>Message box content</comment>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2009,4 +2009,7 @@ Next assemblies were loaded several times:
     <value>We can't save "{0}" because the file is read only. To keep your changes, you'll need to save it with a new name or in a different location.</value>
     <comment>Message box content</comment>
   </data>
+  <data name="TabFileNameReadOnlyPrefix" xml:space="preserve">
+    <value>[Read-Only] </value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -869,6 +869,7 @@ It does not contain your graph or any personal data</value>
     <value>You have unsaved changes to custom node workspace: "{0}".
 
 Would you like to save your changes?</value>
+    <comment>Message box content</comment>
   </data>
   <data name="MessageConfirmToSaveHomeWorkSpace" xml:space="preserve">
     <value>You have unsaved changes to the Home workspace.
@@ -2004,6 +2005,10 @@ Next assemblies were loaded several times:
   </data>
   <data name="MessageFailedToAddFile" xml:space="preserve">
     <value>Failed to add file: {0}</value>
+    <comment>Message box content</comment>
+  </data>
+  <data name="MessageConfirmToSaveReadOnlyCustomNode" xml:space="preserve">
+    <value>We can't save "{0}" because the file is read only. To keep your changes, you'll need to save it with a new name or in a different location.</value>
     <comment>Message box content</comment>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2011,4 +2011,7 @@ Next assemblies were loaded several times:
     <value>We can't save "{0}" because the file is read only. To keep your changes, you'll need to save it with a new name or in a different location.</value>
     <comment>Message box content</comment>
   </data>
+  <data name="TabFileNameReadOnlyPrefix" xml:space="preserve">
+    <value>[Read-Only] </value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -401,8 +401,11 @@ namespace Dynamo.Controls
         {
             if (value is string && !string.IsNullOrEmpty(value as string))
             {
-                // convert to path, get file name
-                return Path.GetFileName((string)value);
+                // Convert to path, get file name. If read-only file, append [Read-Only].
+                if (DynamoUtilities.PathHelper.IsReadOnlyPath((string)value))
+                    return "[Read-Only] "+ Path.GetFileName((string)value);
+                else
+                    return Path.GetFileName((string)value);
             }
 
             return "Unsaved";

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -403,7 +403,7 @@ namespace Dynamo.Controls
             {
                 // Convert to path, get file name. If read-only file, append [Read-Only].
                 if (DynamoUtilities.PathHelper.IsReadOnlyPath((string)value))
-                    return "[Read-Only] "+ Path.GetFileName((string)value);
+                    return Resources.TabFileNameReadOnlyPrefix + Path.GetFileName((string)value);
                 else
                     return Path.GetFileName((string)value);
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1247,7 +1247,7 @@ namespace Dynamo.ViewModels
             if (!String.IsNullOrEmpty(Model.CurrentWorkspace.FileName))
             {
                 // For read-only file, re-direct save to save-as
-                if (this.CurrentSpace.IsReadOnly)//DynamoUtilities.PathHelper.IsReadOnlyPath(this.CurrentSpace.FileName))
+                if (this.CurrentSpace.IsReadOnly)
                     ShowSaveDialogAndSaveResult(parameter);
                 else
                     SaveAs(Model.CurrentWorkspace.FileName);      

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1147,8 +1147,8 @@ namespace Dynamo.ViewModels
             {
                 if (!DynamoModel.IsTestMode)
                 {
-                    // Catch all the IO exceptions here. The message provided by .Net is clear enough to indicate the problem in this case.
-                    if (e is IOException)
+                    // Catch all the IO exceptions and file access here. The message provided by .Net is clear enough to indicate the problem in this case.
+                    if (e is IOException || e is System.UnauthorizedAccessException)
                     {
                         System.Windows.MessageBox.Show(String.Format(e.Message, xmlFilePath));
                     }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1178,7 +1178,7 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Present the open dialogue and open the workspace that is selected.
+        /// Present the open dialog and open the workspace that is selected.
         /// </summary>
         /// <param name="parameter"></param>
         private void ShowOpenDialogAndOpenResult(object parameter)
@@ -1245,7 +1245,14 @@ namespace Dynamo.ViewModels
         private void Save(object parameter)
         {
             if (!String.IsNullOrEmpty(Model.CurrentWorkspace.FileName))
-                SaveAs(Model.CurrentWorkspace.FileName);
+            {
+                // For read-only file, re-direct save to save-as
+                if (this.CurrentSpace.IsReadOnly)//DynamoUtilities.PathHelper.IsReadOnlyPath(this.CurrentSpace.FileName))
+                    ShowSaveDialogAndSaveResult(parameter);
+                else
+                    SaveAs(Model.CurrentWorkspace.FileName);      
+            }
+                
         }
 
         private bool CanSave(object parameter)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -746,19 +746,27 @@ namespace Dynamo.Controls
         void DynamoViewModelRequestUserSaveWorkflow(object sender, WorkspaceSaveEventArgs e)
         {
             var dialogText = "";
-            if (e.Workspace is CustomNodeWorkspaceModel)
+            // If the file is read only, display a different message.
+            if (e.Workspace.IsReadOnly)
             {
-                dialogText = String.Format(Dynamo.Wpf.Properties.Resources.MessageConfirmToSaveCustomNode, e.Workspace.Name);
+                dialogText = String.Format(Dynamo.Wpf.Properties.Resources.MessageConfirmToSaveReadOnlyCustomNode, e.Workspace.FileName);
             }
-            else // homeworkspace
+            else
             {
-                if (string.IsNullOrEmpty(e.Workspace.FileName))
+                if (e.Workspace is CustomNodeWorkspaceModel)
                 {
-                    dialogText = Dynamo.Wpf.Properties.Resources.MessageConfirmToSaveHomeWorkSpace;
+                    dialogText = String.Format(Dynamo.Wpf.Properties.Resources.MessageConfirmToSaveCustomNode, e.Workspace.Name);
                 }
-                else
+                else // home workspace
                 {
-                    dialogText = String.Format(Dynamo.Wpf.Properties.Resources.MessageConfirmToSaveNamedHomeWorkSpace, Path.GetFileName(e.Workspace.FileName));
+                    if (string.IsNullOrEmpty(e.Workspace.FileName))
+                    {
+                        dialogText = Dynamo.Wpf.Properties.Resources.MessageConfirmToSaveHomeWorkSpace;
+                    }
+                    else
+                    {
+                        dialogText = String.Format(Dynamo.Wpf.Properties.Resources.MessageConfirmToSaveNamedHomeWorkSpace, Path.GetFileName(e.Workspace.FileName));
+                    }
                 }
             }
 
@@ -769,7 +777,11 @@ namespace Dynamo.Controls
 
             if (result == MessageBoxResult.Yes)
             {
-                e.Success = dynamoViewModel.ShowSaveDialogIfNeededAndSave(e.Workspace);
+                // If the file is read-only, redirect yes to save-as.
+                if (e.Workspace.IsReadOnly)
+                    dynamoViewModel.ShowSaveDialogAndSaveResult(e.Workspace);
+                else
+                    e.Success = dynamoViewModel.ShowSaveDialogIfNeededAndSave(e.Workspace);
             }
             else if (result == MessageBoxResult.Cancel)
             {

--- a/src/DynamoPackages/PackageManagerClient.cs
+++ b/src/DynamoPackages/PackageManagerClient.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Dynamo.Core;
-using Dynamo.Utilities;
-using Greg;
-using Greg.AuthProviders;
+﻿using Greg;
 using Greg.Requests;
 using Greg.Responses;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Dynamo.PackageManager
 {

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -26,27 +26,27 @@ namespace DynamoUtilities
         /// <summary>
         /// Checks if the file path string is valid and file exist.
         /// </summary>
-        /// <param name="folderPath"></param>
+        /// <param name="filePath">File path</param>
         /// <returns></returns>
-        public static bool IsValidPath(string folderPath)
+        public static bool IsValidPath(string filePath)
         {
-            return (!string.IsNullOrEmpty(folderPath) && (File.Exists(folderPath)));
+            return (!string.IsNullOrEmpty(filePath) && (File.Exists(filePath)));
         }
 
         /// <summary>
         /// Check if user has readonly privilege to the folder path.
         /// </summary>
-        /// <param name="folderPath">Folder path</param>
+        /// <param name="filePath">File path</param>
         /// <returns></returns>
-        public static bool IsReadOnlyPath(string folderPath)
+        public static bool IsReadOnlyPath(string filePath)
         {
-            if (IsValidPath(folderPath))
+            if (IsValidPath(filePath))
             {
-                FileInfo Finfo = new FileInfo(folderPath);
+                FileInfo Finfo = new FileInfo(filePath);
                 // We mark the path read only when
                 // 1. file read-only
                 // 2. user does not have write access to the folder
-                return Finfo.IsReadOnly || !HasWritePermissionOnDir(folderPath);
+                return Finfo.IsReadOnly || !HasWritePermissionOnDir(Finfo.Directory.ToString());
             }
             else
                 return false;
@@ -71,6 +71,7 @@ namespace DynamoUtilities
 
             foreach (FileSystemAccessRule rule in accessRules)
             {
+                // When current rule does not contain setting related to WRITE, skip.
                 if ((FileSystemRights.Write & rule.FileSystemRights) != FileSystemRights.Write)
                     continue;
 

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -31,5 +31,21 @@ namespace DynamoUtilities
         {
             return (!string.IsNullOrEmpty(folderPath) && (File.Exists(folderPath)));
         }
+
+        /// <summary>
+        /// Check if the file path string is readonly privilege.
+        /// </summary>
+        /// <param name="folderPath"></param>
+        /// <returns></returns>
+        public static bool IsReadOnlyPath(string folderPath)
+        {
+            if (IsValidPath(folderPath))
+            {
+                FileInfo Finfo = new FileInfo(folderPath);
+                return Finfo.IsReadOnly;
+            }
+            else
+                return false;
+        }
     }
 }

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.IO;
+using System.Security.AccessControl;
 
 namespace DynamoUtilities
 {
     public class PathHelper
     {
         // This return an exception if any operation failed and the folder
-        // wasn't created. It's the resposibility of the caller of this function
+        // wasn't created. It's the responsibility of the caller of this function
         // to check whether the folder creation is successful or not.
         public static Exception CreateFolderIfNotExist(string folderPath)
         {
@@ -33,19 +34,53 @@ namespace DynamoUtilities
         }
 
         /// <summary>
-        /// Check if the file path string is readonly privilege.
+        /// Check if user has readonly privilege to the folder path.
         /// </summary>
-        /// <param name="folderPath"></param>
+        /// <param name="folderPath">Folder path</param>
         /// <returns></returns>
         public static bool IsReadOnlyPath(string folderPath)
         {
             if (IsValidPath(folderPath))
             {
                 FileInfo Finfo = new FileInfo(folderPath);
-                return Finfo.IsReadOnly;
+                // We mark the path read only when
+                // 1. file read-only
+                // 2. user does not have write access to the folder
+                return Finfo.IsReadOnly || !HasWritePermissionOnDir(folderPath);
             }
             else
                 return false;
+        }
+
+        /// <summary>
+        /// Returns whether current user has write access to the folder path.
+        /// </summary>
+        /// <param name="folderPath">Folder path</param>
+        /// <returns></returns>
+        public static bool HasWritePermissionOnDir(string folderPath)
+        {
+            var writeAllow = false;
+            var writeDeny = false;
+            var accessControlList = Directory.GetAccessControl(folderPath);
+            if (accessControlList == null)
+                return false;
+            var accessRules = accessControlList.GetAccessRules(true, true,
+                                        typeof(System.Security.Principal.SecurityIdentifier));
+            if (accessRules == null)
+                return false;
+
+            foreach (FileSystemAccessRule rule in accessRules)
+            {
+                if ((FileSystemRights.Write & rule.FileSystemRights) != FileSystemRights.Write)
+                    continue;
+
+                if (rule.AccessControlType == AccessControlType.Allow)
+                    writeAllow = true;
+                else if (rule.AccessControlType == AccessControlType.Deny)
+                    writeDeny = true;
+            }
+
+            return writeAllow && !writeDeny;
         }
     }
 }

--- a/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
+++ b/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
@@ -42,10 +42,10 @@ namespace Dynamo.Tests
         {
             // Open a read-only custom node
             OpenTestFile(@"core\CustomNodes", "add_Read_only.dyf");
-            var funcNode = (CurrentDynamoModel.CurrentWorkspace as HomeWorkspaceModel).Nodes.OfType<Function>().First();
-            Assert.IsFalse(funcNode.Definition.IsProxy);
+            var nodeWorkspace = CurrentDynamoModel.Workspaces.FirstOrDefault(x => x is CustomNodeWorkspaceModel);
+            Assert.IsNotNull(nodeWorkspace);
 
-            // a file with a missing custom node definition is opened
+            // a file with a read-only custom node definition is opened
             OpenTestFile(@"core\CustomNodes", "TestAdd.dyn");
             var homeWorkspace = CurrentDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
             Assert.NotNull(homeWorkspace);

--- a/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
+++ b/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
@@ -38,6 +38,21 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void CanLoadReadOnlyNode()
+        {
+            // Open a read-only custom node
+            OpenTestFile(@"core\CustomNodes", "add_Read_only.dyf");
+            var funcNode = (CurrentDynamoModel.CurrentWorkspace as HomeWorkspaceModel).Nodes.OfType<Function>().First();
+            Assert.IsFalse(funcNode.Definition.IsProxy);
+
+            // a file with a missing custom node definition is opened
+            OpenTestFile(@"core\CustomNodes", "TestAdd.dyn");
+            var homeWorkspace = CurrentDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
+            Assert.NotNull(homeWorkspace);
+            homeWorkspace.Run();
+        }
+
+        [Test]
         public void CanOpenCustomNodeWorkspace()
         {
             OpenTestFile(@"core\combine", "Sequence2.dyf");

--- a/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
+++ b/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
@@ -41,6 +41,8 @@ namespace Dynamo.Tests
         public void CanLoadReadOnlyNode()
         {
             // Open a read-only custom node
+            Assert.IsFalse(DynamoUtilities.PathHelper.IsReadOnlyPath(@"core\CustomNodes\add_Read_only.dyf"));
+
             OpenTestFile(@"core\CustomNodes", "add_Read_only.dyf");
             var nodeWorkspace = CurrentDynamoModel.Workspaces.FirstOrDefault(x => x is CustomNodeWorkspaceModel);
             Assert.IsNotNull(nodeWorkspace);
@@ -50,6 +52,9 @@ namespace Dynamo.Tests
             var homeWorkspace = CurrentDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
             Assert.NotNull(homeWorkspace);
             homeWorkspace.Run();
+
+            var funcNode = homeWorkspace.Nodes.OfType<Function>().First();
+            Assert.IsTrue(funcNode.Definition.IsProxy);
         }
 
         [Test]

--- a/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
+++ b/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
@@ -54,7 +54,7 @@ namespace Dynamo.Tests
             homeWorkspace.Run();
 
             var funcNode = homeWorkspace.Nodes.OfType<Function>().First();
-            Assert.IsTrue(funcNode.Definition.IsProxy);
+            Assert.AreEqual(2.0, GetPreviewValue(funcNode.GUID));
         }
 
         [Test]

--- a/test/Libraries/DynamoUtilitiesTests/DynamoUtilitiesTests.csproj
+++ b/test/Libraries/DynamoUtilitiesTests/DynamoUtilitiesTests.csproj
@@ -73,6 +73,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/Libraries/DynamoUtilitiesTests/DynamoUtilitiesTests.csproj
+++ b/test/Libraries/DynamoUtilitiesTests/DynamoUtilitiesTests.csproj
@@ -73,9 +73,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/core/CustomNodes/TestAdd.dyn
+++ b/test/core/CustomNodes/TestAdd.dyn
@@ -1,0 +1,35 @@
+<Workspace Version="1.0.0.1180" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CustomNodes.Function guid="fb872c7c-21af-4074-8011-818874738dc7" type="Dynamo.Graph.Nodes.CustomNodes.Function" nickname="add" x="384.5" y="149.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <ID value="98566e0d-3a11-4327-b688-713f6892a5bf" />
+      <Name value="add" />
+      <Description value="" />
+      <Inputs>
+        <Input value="x" />
+        <Input value="y" />
+      </Inputs>
+      <Outputs>
+        <Output value="var[]..[]" />
+      </Outputs>
+    </Dynamo.Graph.Nodes.CustomNodes.Function>
+    <CoreNodeModels.Input.IntegerSlider guid="65995606-72c2-4167-a9d2-abd90b86ffc9" type="CoreNodeModels.Input.IntegerSlider" nickname="Integer Slider" x="25.5" y="222.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <System.Int32>1</System.Int32>
+      <Range min="0" max="100" step="1" />
+    </CoreNodeModels.Input.IntegerSlider>
+    <CoreNodeModels.Input.IntegerSlider guid="b3383a2c-3150-4687-8983-59c59c1e3207" type="CoreNodeModels.Input.IntegerSlider" nickname="Integer Slider" x="14.5" y="134.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <System.Int32>1</System.Int32>
+      <Range min="0" max="100" step="1" />
+    </CoreNodeModels.Input.IntegerSlider>
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="65995606-72c2-4167-a9d2-abd90b86ffc9" start_index="0" end="fb872c7c-21af-4074-8011-818874738dc7" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b3383a2c-3150-4687-8983-59c59c1e3207" start_index="0" end="fb872c7c-21af-4074-8011-818874738dc7" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>

--- a/test/core/CustomNodes/add_Read_only.dyf
+++ b/test/core/CustomNodes/add_Read_only.dyf
@@ -1,0 +1,16 @@
+<Workspace Version="0.7.6.3485" X="0" Y="0" zoom="1" Description="" Category="Test" Name="add" ID="98566e0d-3a11-4327-b688-713f6892a5bf">
+  <Elements>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="5b21b2bd-221a-4030-99ef-7dc1d112ee42" nickname="Input" x="235.6" y="151.2" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="x : int" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.Symbol type="Dynamo.Nodes.Symbol" guid="fb4519fa-476a-4916-9f60-1f6ae2ac6089" nickname="Input" x="236.4" y="256.8" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+      <Symbol value="y : int" />
+    </Dynamo.Nodes.Symbol>
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="e448524b-913d-40c1-9aed-390f5b475882" nickname="+" x="384.4" y="168" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="+@," />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="5b21b2bd-221a-4030-99ef-7dc1d112ee42" start_index="0" end="e448524b-913d-40c1-9aed-390f5b475882" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="fb4519fa-476a-4916-9f60-1f6ae2ac6089" start_index="0" end="e448524b-913d-40c1-9aed-390f5b475882" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
### Purpose

MAGN-10004 Read only nodes cannot be loaded
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10004

This PR adds:
1) **isReadOnly** preperty to WorkSpaceModel, the property will be only initialized once when workspace constructed, assuming the write access will not be changing all the time
2) **[Read-Only]** prefix on tab of file that current user does not have write access name 
3) Re-direct **save** to **save as** when the currentWorkSpace is read-only
4) New dialog messgae when user made changes to workspace and close, see attached image
5) handle unauthorized exception so read only custom node could be loaded correctly

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
![image](https://cloud.githubusercontent.com/assets/3942418/15430104/d1312150-1e71-11e6-820d-ac6a9c5f0845.png)

![image](https://cloud.githubusercontent.com/assets/3942418/15430120/e5ac913c-1e71-11e6-894d-8b73c6e9a6f2.png)

### Reviewers

@mjkkirschner 

### FYIs

@jnealb @Racel @ramramps @sm6srw 