### PR TITLE
when we need to recompute and rebind the expanded display we should a…

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -156,7 +156,7 @@ namespace Dynamo.UI.Controls
             }
             else if (IsExpanded)
             {
-                RefreshExpandedDisplay(null);
+                RefreshExpandedDisplay(RefreshExpandedDisplayAction);
             }
 
             IsDataBound = true;


### PR DESCRIPTION
### Purpose

When an expanded preview bubble's owner node's cached value is modified we already update the expanded preview binding, but we do not recompute the size - I just hooked up the handler we use when first computing it instead of passing a null callback.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ramramps 

### FYIs

@jnealb @Racel 
