### PR TITLE
Fix unit test

### DIFF
--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -982,7 +982,10 @@ namespace Dynamo.Tests
             var def = dynamoModel.CustomNodeManager.CreateCustomNode(nodeName, catName, "");
 
             var tempPath1 = Path.Combine(TempFolder, nodeName + ".dyf");
-            var tempPath2 = Path.Combine(TempFolder, nodeName + "_v1.dyf");
+            
+            // Create the folder first incase it does not exist
+            Directory.CreateDirectory(Path.Combine(TempFolder, nodeName, nodeName));
+            var tempPath2 = Path.Combine(TempFolder, nodeName, nodeName + ".dyf");
 
             var res = def.SaveAs(tempPath1, ViewModel.Model.EngineController.LiveRunnerRuntimeCore);
             Assert.IsTrue(res);

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -982,7 +982,7 @@ namespace Dynamo.Tests
             var def = dynamoModel.CustomNodeManager.CreateCustomNode(nodeName, catName, "");
 
             var tempPath1 = Path.Combine(TempFolder, nodeName + ".dyf");
-            var tempPath2 = Path.Combine(TempFolder, nodeName, nodeName + ".dyf");
+            var tempPath2 = Path.Combine(TempFolder, nodeName + "_v1.dyf");
 
             var res = def.SaveAs(tempPath1, ViewModel.Model.EngineController.LiveRunnerRuntimeCore);
             Assert.IsTrue(res);


### PR DESCRIPTION
### Purpose

Fix unit test CustomNodeWorkspaceSavedToSamePlaceNotCausingDuplicatedLibraryItems.

This test used to test if saving a custom node in different folder would display duplicate items in LibraryView. But since SaveAs used to fail silently in this test, it is never testing the real case. We should create the directory first in this case.

### Declarations

Unit test fix after exposing exception at SaveAs

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers



### FYIs


