### PR TITLE
Fix lag when clicking on group model in a large graph

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -94,6 +94,11 @@ namespace Dynamo.Controls
             }
         }
 
+        /// <summary>
+        /// Returns a boolean value of whether this node view already has its PreviewControl field
+        /// constructed (not null), in order to avoid calling the PreviewControl constructor
+        /// whenever the accessor property is queried.
+        /// </summary>
         internal bool HasPreviewControl
         {
             get

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -94,6 +94,14 @@ namespace Dynamo.Controls
             }
         }
 
+        internal bool HasPreviewControl
+        {
+            get
+            {
+                return previewControl != null;
+            }
+        }
+
         #region constructors
 
         public NodeView()

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -512,8 +512,9 @@ namespace Dynamo.Views
 
             if (!ViewModel.IsDragging) return;
 
-            var nodesToHidePreview = this.ChildrenOfType<NodeView>()
-                .Where(view => !view.PreviewControl.IsHidden && !view.PreviewControl.StaysOpen);
+            var nodesToHidePreview = this.ChildrenOfType<NodeView>().Where(view =>
+                view.HasPreviewControl && !view.PreviewControl.IsHidden && !view.PreviewControl.StaysOpen);
+
             foreach (var node in nodesToHidePreview)
             {
                 node.PreviewControl.HidePreviewBubble();


### PR DESCRIPTION
### Purpose

This fixes [MAGN-10145](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10145): Lag when clicking on group model in a large graph.

After PR #6627 and [MAGN-9889](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9889), the Preview Bubble should collapse and be disabled when a user is dragging a node if it is unpinned.

Unexpectedly in the mentioned pull request, the call to query and hide the `PreviewControl`s of all nodes in the workspace caused the `PreviewControl` getting constructed when a group is dragged (`OnMouseLeftButtonDown`). Hence, a bunch of `PreviewControl` XAML views were getting generated but hidden immediately. This caused the UI thread of Dynamo to be occupied for 3-5 seconds for a considerably large graph with large groups (refer to the YouTrack issue for a sample graph).

This PR adds checking whether the `PreviewControl` has existed, and only hide them if they exist.

### Declarations

- [x] All tests pass using the self-service CI.

### Reviewers

@mjkkirschner

### FYIs

@riteshchandawar