### PR TITLE
Add configuration to create Dotcover snapshots.

### DIFF
--- a/src/finalConfig.xml
+++ b/src/finalConfig.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+	<TargetExecutable><!-- Required.   -->C:\Program Files (x86)\NUnit 2.6.2\bin\nunit-console.exe</TargetExecutable>
+	<TargetArguments>DataBridgeTests.dll DynamoCoreWpfTests.dll DSCoreNodesTests.dll DynamoServicesTests.dll DynamoPythonTests.dll DynamoMSOfficeTests.dll DynamoCoreTests.dll DynamoUtilitiesTests.dll IntegrationTests.dll   ProtoTest.dll WorkflowTests.dll CommandLineTests.dll --labels=On /noshadow /exclude:Failure /xml=nunit-result.xml</TargetArguments> 
+	<TargetWorkingDir>..\bin\AnyCPU\Release\</TargetWorkingDir>
+	<Output>Snapshot.dcvr</Output> 
+</CoverageParams>


### PR DESCRIPTION
### Add configuration to create Dotcover snapshots.
Currently Dotcover is configured to generate html reports.
We need both html and xml reports required.
• html - > So we have all the details of which code  is covered and not.  
• xml -> so we can create diff and attach on the emails to report regression in coverage percentage

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10150 