### PR TITLE
MAGN-10063: Fix crash in Directory or File Path node due to version mismatch of RestSharp

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -31,6 +31,7 @@ using HorizontalAlignment = System.Windows.HorizontalAlignment;
 using Point = System.Windows.Point;
 using TabControl = System.Windows.Controls.TabControl;
 using Thickness = System.Windows.Thickness;
+using System.Net;
 
 namespace Dynamo.Controls
 {
@@ -1603,7 +1604,7 @@ namespace Dynamo.Controls
             if (value == null)
                 return Resources.FilePathConverterNoFileSelected;
 
-            var str = HttpUtility.UrlDecode(value.ToString());
+            var str = WebUtility.UrlDecode(value.ToString());
 
             if (string.IsNullOrEmpty(str))
                 return Resources.FilePathConverterNoFileSelected;
@@ -1658,7 +1659,7 @@ namespace Dynamo.Controls
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return HttpUtility.UrlEncode(value.ToString());
+            return WebUtility.UrlEncode(value.ToString());
         }
     }
 

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -14,6 +14,7 @@ using Dynamo.Utilities;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM;
 using CoreNodeModels.Properties;
+using System.Net;
 
 namespace CoreNodeModels.Input
 {
@@ -100,7 +101,7 @@ namespace CoreNodeModels.Input
                         select attr;
 
             foreach (XmlAttribute attr in query)
-                attr.Value = HttpUtility.UrlDecode(attr.Value);
+                attr.Value = WebUtility.UrlDecode(attr.Value);
 
             migrationData.AppendNode(newNode as XmlElement);
             return migrationData;


### PR DESCRIPTION
### Purpose

This PR fixes the crash in File Path or Directory node while browsing the file/folder due to an older than required version of RestSharp assembly for Dynamo, loaded by the Revit from another plug-in.

**Diagnosis**
The File Path and Directory node UI uses FilePathDisplayConverter to convert the selected path to text, which internally used HttpUtility.UrlDecode() method from RestSharp.dll and hence it crashed because an older version of RestSharp is already loaded and Dynamo required a higher version of RestSharp.

**Solution**
Use WebUtility.UrlDecode() from System.Net to avoid dependency on RestSharp from File Path node. This will fix this particular issue but we can't remove the dependency of RestSharp from Dynamo project so some other features such as package manager is still impacted with this issue.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @ikeough 
- [ ] @mjkkirschner 

### FYIs
@Benglin 
