### PR TITLE
fix memory leak in viewExtension

### DIFF
--- a/src/Notifications/NotificationsMenuItem.xaml.cs
+++ b/src/Notifications/NotificationsMenuItem.xaml.cs
@@ -21,40 +21,41 @@ namespace Dynamo.Notifications
     public partial class NotificationsMenuItem : UserControl
     {
         NotificationsViewExtension notificationsModel;
-
+        public System.Collections.Specialized.NotifyCollectionChangedEventHandler NotificationsChangeHandler;
         public NotificationsMenuItem(Notifications.NotificationsViewExtension notificationsExtension)
         {
             this.notificationsModel = notificationsExtension;
             InitializeComponent();
 
-            var showItem = new MenuItem();
-            showItem.Header = Properties.Resources.Display;
-            showItem.Click += (o, e) =>
-            {
-                //create a window to display the list of notificationsModels
-                var window = new NotificationsView(notificationsExtension);
-                window.Show();
-            };
+              var showItem = new MenuItem();
+              showItem.Header = Properties.Resources.Display;
+              showItem.Click += (o, e) =>
+              {
+                  //create a window to display the list of notificationsModels
+                  var window = new NotificationsView(notificationsExtension);
+                  window.Show();
+              };
 
-            var dismissItem = new MenuItem();
-            dismissItem.Header = Properties.Resources.Dismiss;
-            dismissItem.Click += (o, e) => { this.notificationsModel.Notifications.Clear(); };
+              var dismissItem = new MenuItem();
+              dismissItem.Header = Properties.Resources.Dismiss;
+              dismissItem.Click += (o, e) => { this.notificationsModel.Notifications.Clear(); };
 
-            //set some defaults
-            dismissItem.IsEnabled = false;
-            showItem.IsEnabled = false;
-            BadgeGrid.Visibility = Visibility.Hidden;
+              //set some defaults
+              dismissItem.IsEnabled = false;
+              showItem.IsEnabled = false;
+              BadgeGrid.Visibility = Visibility.Hidden;
 
-            this.MenuItem.Items.Add(showItem);
-            this.MenuItem.Items.Add(dismissItem);
+              this.MenuItem.Items.Add(showItem);
+              this.MenuItem.Items.Add(dismissItem);
 
-            //create our icon
-            var color = new SolidColorBrush(Colors.LightGray);
-            this.imageicon.Source = FontAwesome.WPF.ImageAwesome.CreateImageSource(FontAwesome.WPF.FontAwesomeIcon.ExclamationCircle, color);
-
+              //create our icon
+                var color = new SolidColorBrush(Colors.LightGray);
+                this.imageicon.Source = FontAwesome.WPF.ImageAwesome.CreateImageSource(FontAwesome.WPF.FontAwesomeIcon.ExclamationCircle, color);
+          
             //create some bindings
             //attach the visibility of the badge and menuItems enabledState to the number of notifications without a binding...
-            this.notificationsModel.Notifications.CollectionChanged += (o, e) => {
+
+            NotificationsChangeHandler = (o, e) => {
                 if (this.notificationsModel.Notifications.Count > 0)
                 {
                     BadgeGrid.Visibility = Visibility.Visible;
@@ -68,6 +69,8 @@ namespace Dynamo.Notifications
                     showItem.IsEnabled = false;
                 }
             };
+
+            this.notificationsModel.Notifications.CollectionChanged += NotificationsChangeHandler;
 
             // create a binding between the label and the count of notifications
             var binding = new Binding();


### PR DESCRIPTION
followup for memory leak in view extension.

reduced memory usage in DynamoCoreWPF tests from 8 back to ~ 3.7

on dispose we now unsubscribe to some handlers but the main change is manually removing the menuItem from the DynamoMenu and nulling out the original user control that was created. These two changes seem to fix the issue.

It's odd that they are necessary though. 