### PR TITLE
memory profiling to get tests running.

### DIFF
--- a/src/Notifications/NotificationsViewExtension.cs
+++ b/src/Notifications/NotificationsViewExtension.cs
@@ -47,6 +47,7 @@ namespace Dynamo.Notifications
            UnregisterEventHandlers();
             //for some reason the menuItem was not being gc'd in tests without manually removing it
             viewLoadedParams.dynamoMenu.Items.Remove(notificationsMenuItem.MenuItem);
+            BindingOperations.ClearAllBindings(notificationsMenuItem.CountLabel);
             notificationsMenuItem = null;
         }
 


### PR DESCRIPTION
using dot memory I found that the binding between the label and notifications count is preventing garbage collection, after this change we can see there is still work to do, but I would like to get a build before tackling anything else.


after a few tests we can see that there are now 3 notificationsViewExtension still around :(
<img width="1037" alt="screen shot 2016-06-05 at 10 11 54 pm" src="https://cloud.githubusercontent.com/assets/508936/15810608/60a2c7fe-2b6e-11e6-8629-cc1aca5c0cf4.png">

after this change and after lots more tests the extension is being freed, and we can see we are leaking custom node models, apparently they are not cleaning up after subscribing to a static event (just like @ke-yu said). @ke-yu do you think fixing this leak would improve Dynamo in general with regards to custom nodes or just in the context of testing? Do custom node workspace models live for the application lifetime?

<img width="1279" alt="screen shot 2016-06-05 at 10 35 19 pm" src="https://cloud.githubusercontent.com/assets/508936/15810607/6096f2da-2b6e-11e6-83f6-b2efda286448.png">