### PR TITLE
Short Cuts alignment for undo/redo

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -378,12 +378,12 @@
                                   Header="{x:Static p:Resources.DynamoViewEditMenuUndo}"
                                   Command="{Binding UndoCommand}"
                                   Name="undo"
-                                  InputGestureText="Ctrl+Z" />
+                                  InputGestureText="Ctrl + Z" />
                         <MenuItem Focusable="False"
                                   Header="{x:Static p:Resources.DynamoViewEditMenuRedo}"
                                   Command="{Binding RedoCommand}"
                                   Name="redo"
-                                  InputGestureText="Ctrl+Y" />
+                                  InputGestureText="Ctrl + Y" />
                         <Separator />
                         <MenuItem Focusable="False"
                                   Header="{x:Static p:Resources.DynamoViewEditMenuCopy}"


### PR DESCRIPTION
### Purpose

Small text alignment change.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.


Before:
![short-cuts do not align in 9_2](https://cloud.githubusercontent.com/assets/3942418/13974658/1a9fdac8-f084-11e5-8ca1-ee32c0982cc4.png)


After:
![new edit menu](https://cloud.githubusercontent.com/assets/3942418/13974579/54cd646e-f083-11e5-86bc-8995155253da.png)

### Reviewers



### FYIs

@Racel @jnealb 

