### PR TITLE
Revert failure category change

### DIFF
--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1348,7 +1348,6 @@ namespace Dynamo.Tests
         }
 
         [Test, TestCaseSource("GetFilesForMutation")]
-        [Category("Failure")]
         public void TestMutation(string fileName)
         {
             MutationTest(fileName);

--- a/test/DynamoCoreTests/PeriodicEvaluationTests.cs
+++ b/test/DynamoCoreTests/PeriodicEvaluationTests.cs
@@ -120,7 +120,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [Category("Failure")]  //LC: I don't understand how this test isn't incredibly sensitive to execution timing
+        //LC: I don't understand how this test isn't incredibly sensitive to execution timing
         public void StartPeriodicEvaluation_CompletesFewerRunsWhenRunTimeIsGreaterThanEvaluationTime()
         {
             Workspace.RunSettings.RunType = RunType.Periodic;

--- a/test/Engine/ProtoTest/LiveRunnerTests/MemoryConsumptionTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MemoryConsumptionTests.cs
@@ -36,7 +36,6 @@ namespace ProtoTest.LiveRunner
 
 
         [Test]
-        [Category("Failure")]
         public void TestInstructionStreamMemory_SimpleWorkflow01()
         {
             List<string> codes = new List<string>() 
@@ -74,7 +73,6 @@ namespace ProtoTest.LiveRunner
 
 
         [Test]
-        [Category("Failure")]
         public void TestPeriodicUpdate01()
         {
             int rhs = 0;
@@ -114,7 +112,6 @@ namespace ProtoTest.LiveRunner
         }
 
         [Test]
-        [Category("Failure")]
         public void TestInstructionStreamMemory_FunctionRedefinition01()
         {
             List<string> codes = new List<string>() 

--- a/test/Libraries/WorkflowTests/DynamoSamples.cs
+++ b/test/Libraries/WorkflowTests/DynamoSamples.cs
@@ -553,7 +553,6 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        [Category("Failure")]
             //Todo Ritesh: Locally passing but failing on CI.
             //After fixing issue with this test case add Smoke Test Category.
         public void ImportExport_Excel_to_Dynamo()


### PR DESCRIPTION
### Purpose

Remove Failure Categories for tests that start to pass.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers



### FYIs

@riteshchandawar 

