### PR TITLE
Add a headless flag to disable update checks

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -422,6 +422,7 @@ namespace Dynamo.Models
             IAuthProvider AuthProvider { get; set; }
             IEnumerable<IExtension> Extensions { get; set; }
             TaskProcessMode ProcessMode { get; set; }
+            bool HeadlessMode { get; set; }
         }
 
       
@@ -442,6 +443,7 @@ namespace Dynamo.Models
             public IAuthProvider AuthProvider { get; set; }
             public IEnumerable<IExtension> Extensions { get; set; }
             public TaskProcessMode ProcessMode { get; set; }
+            public bool HeadlessMode { get; set; }
         }
 
         /// <summary>
@@ -597,7 +599,7 @@ namespace Dynamo.Models
 
             UpdateManager = config.UpdateManager ?? new DefaultUpdateManager(null);
             UpdateManager.Log += UpdateManager_Log;
-            if (!IsTestMode)
+            if (!IsTestMode && !config.HeadlessMode)
             {
                 DefaultUpdateManager.CheckForProductUpdate(UpdateManager);
             }


### PR DESCRIPTION
### Purpose

Allow startup code to indicate that Dynamo is running headless and it shouldn't do update checks.
In the Fractal environment, Reach is occasionally crashing on startup, and the stack trace indicates that it's in the code that checks for updates.
There will be a separate PR in Reach to set this flag.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [n/a] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [n/a] Snapshot of UI changes, if any.

### Reviewers

@ramramps 
@ikeough 

### FYIs
