### PR TITLE
Flatten a single value should return that single value

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -1430,7 +1430,7 @@ namespace ProtoCore.Lang
         internal static StackValue Flatten(StackValue sv, ProtoCore.DSASM.Interpreter runtime)
         {
             if (!sv.IsArray)
-                return DSASM.StackValue.Null;
+                return sv;
 
             List<StackValue> newElements = new List<DSASM.StackValue>();
             GetFlattenedArrayElements(sv, runtime, ref newElements);

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -200,7 +200,7 @@ namespace ProtoCore.Lang
 
                 new BuiltInMethod
                 {
-                    ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 1),
+                    ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank),
                     Parameters = new List<KeyValuePair<string, ProtoCore.Type>>
                     {
                     new KeyValuePair<string, ProtoCore.Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank))

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -2223,7 +2223,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Returns the flattened 1D list of the multi-dimensional input list.
+        ///   Looks up a localized string similar to Returns the flattened 1D list of the multi-dimensional input list. If the input is a single value, returns that value..
         /// </summary>
         public static string ReturnsTheFlattened1DList {
             get {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -442,7 +442,7 @@
     <value>Returns the deepest depth of the list</value>
   </data>
   <data name="ReturnsTheFlattened1DList" xml:space="preserve">
-    <value>Returns the flattened 1D list of the multi-dimensional input list</value>
+    <value>Returns the flattened 1D list of the multi-dimensional input list. If the input is a single value, returns that value.</value>
   </data>
   <data name="ReturnsTheIndex" xml:space="preserve">
     <value>Returns the index of the member in the list</value>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -445,7 +445,7 @@
     <value>Returns the deepest depth of the list</value>
   </data>
   <data name="ReturnsTheFlattened1DList" xml:space="preserve">
-    <value>Returns the flattened 1D list of the multi-dimensional input list</value>
+    <value>Returns the flattened 1D list of the multi-dimensional input list. If the input is a single value, returns that value.</value>
   </data>
   <data name="ReturnsTheIndex" xml:space="preserve">
     <value>Returns the index of the member in the list</value>

--- a/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
@@ -4016,9 +4016,9 @@ x8 = Flatten({null}) ;
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("x1", null);
-            thisTest.Verify("x2", null);
-            thisTest.Verify("x3", null);
-            thisTest.Verify("x4", null);
+            thisTest.Verify("x2", 3);
+            thisTest.Verify("x3", 3.5);
+            thisTest.Verify("x4", true);
             thisTest.Verify("x6", null);
             thisTest.Verify("x8", new Object[] { null });
         }
@@ -4044,7 +4044,7 @@ test =
 }
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
-            thisTest.Verify("test", new Object[] { null, null, null, null, null, new Object[] { null } });
+            thisTest.Verify("test", new Object[] { null, 3, 3.5, true, null, new Object[] { null } });
         }
 
         [Test]
@@ -4070,7 +4070,7 @@ def foo ()
 }
 ";
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
-            thisTest.Verify("test", new Object[] { null, null, null, null, null, new Object[] { null } });
+            thisTest.Verify("test", new Object[] { null, 3, 3.5, true, null, new Object[] { null } });
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

If the input is a single value, `Flatten()` should return that value, instead of returning null.

As `Flatten()` could return a single value, its return type is changed from `var[]` to `var[]..[]` in this PR. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 

