### PR TITLE
Reorder() function should not crash for negative index

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -2231,11 +2231,6 @@ namespace ProtoCore.Lang
                 }
 
                 var index = element.IntegerValue;
-                if (index < 0)
-                {
-                    index += length1;
-                }
-
                 if (index >=length1 || index < 0)
                 {
                     return DSASM.StackValue.Null;

--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -2222,21 +2222,29 @@ namespace ProtoCore.Lang
             StackValue[] svArray = heap.ToHeapObject<DSArray>(sv1).Values.ToArray();
             StackValue[] svIdxArray = heap.ToHeapObject<DSArray>(sv2).Values.ToArray();
             List<StackValue> svList = new List<StackValue>();
-            foreach (StackValue idx in svIdxArray)
+            foreach (StackValue element in svIdxArray)
             {
-                if (!idx.IsInteger)
+                if (!element.IsInteger)
                 {
                     return DSASM.StackValue.Null;
                     //Type Error: Argument(1) must be filled with integers!
-                } 
-                if (idx.IntegerValue >=length1)
+                }
+
+                var index = element.IntegerValue;
+                if (index < 0)
+                {
+                    index += length1;
+                }
+
+                if (index >=length1 || index < 0)
                 {
                     return DSASM.StackValue.Null;
                     //Type Error: Out of array index bound!
                 }
-                svList.Add(svArray[idx.IntegerValue]);
+                svList.Add(svArray[index]);
             }
-            if (svList.Count >= 0)
+
+            if (svList.Any())
             {
                 try
                 {

--- a/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
+++ b/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
@@ -411,6 +411,19 @@ r = c[2];
         }
 
         [Test]
+        public void Reorder2()
+        {
+            String code =
+@"
+x = {1, 2, 3};
+y = {-1, -2, -3};
+z = Reorder(x,y);
+";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("z", new[] { 3, 2, 1 });
+        }
+
+        [Test]
         //Test "IsUniformDepth"
         public void BIM19_IsUniformDepth()
         {

--- a/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
+++ b/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
@@ -416,11 +416,11 @@ r = c[2];
             String code =
 @"
 x = {1, 2, 3};
-y = {-1, -2, -3};
+y = {-1};
 z = Reorder(x,y);
 ";
             thisTest.RunScriptSource(code);
-            thisTest.Verify("z", new[] { 3, 2, 1 });
+            thisTest.Verify("z", null);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

This PR is fix issue https://github.com/DynamoDS/Dynamo/issues/6663. Reorder() function shouldn't crash for negative index. Returns null instead. 

Note although negative index could be used in array indexing, I don't think it is a correct behavior. Functions like `IndexOf` and `List.FirstIndexOf` return negative value if target item not in the list, so negative index should represent an invalid case, instead of an valid index. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers
@sharadkjaiswal 

### FYIs
@riteshchandawar @monikaprabhu 