### PR TITLE
Not to create output port for identfier list

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -431,6 +431,9 @@ namespace Dynamo.Graph.Nodes
                 return null;
 
             var identNode = binExprNode.LeftNode as IdentifierNode;
+            if (identNode == null)
+                return null;
+
             var mappedIdent = NodeUtils.Clone(identNode);
 
             if (!forRawName)
@@ -1239,9 +1242,7 @@ namespace Dynamo.Graph.Nodes
                 return new IdentifierNode(leftNode as IdentifierNode);
             if (leftNode is IdentifierNode)
                 return leftNode as IdentifierNode;
-            else if (leftNode is IdentifierListNode)
-                return GetDefinedIdentifier((leftNode as IdentifierListNode).LeftNode);
-            else if (leftNode is FunctionCallNode)
+            else if (leftNode is IdentifierListNode || leftNode is FunctionCallNode)
                 return null;
             else
                 throw new ArgumentException("Left node type incorrect");


### PR DESCRIPTION
### Purpose

If the left hand side of binary expression is identifier list, not to create output port. For example, 

```
a = 1;
a.x = 2;
```

Previously an output port `a` will be created on line 2, instead of on line 1. It also causes crash (Issue https://github.com/DynamoDS/Dynamo/issues/6709).

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@riteshchandawar 
