### PR TITLE
remove changes to IPreferences and IWatchViewModel

### DIFF
--- a/src/DynamoCore/Configuration/IPreferences.cs
+++ b/src/DynamoCore/Configuration/IPreferences.cs
@@ -7,31 +7,24 @@ using Dynamo.Models;
 namespace Dynamo.Interfaces
 {
     /// <summary>
-    /// An interface which defines preference settings.
+    /// interface that defines settings previewBubble preferences,
+    /// this interface should be merged with IPreferences at Dynamo 2.0
     /// </summary>
-    public interface IPreferences
+    public interface IPreviewBubblePreference
     {
-        /// <summary>
-        /// Returns height of console
-        /// </summary>
-        int ConsoleHeight { get; set; }
-
-        /// <summary>
-        /// Indicates whether connector should be displayed on canvas or not.
-        /// </summary>
-        bool ShowConnector { get; set; }
-
         /// <summary>
         /// Indicates if preview bubbles should be displayed on nodes.
         /// </summary>
         bool ShowPreviewBubbles { get; set; }
 
-        /// <summary>
-        /// Indicates which type of connector's should be displayed on canvas.
-        /// I.e. bezier or polyline
-        /// </summary>
-        ConnectorType ConnectorType { get; set; }
+    }
 
+    /// <summary>
+    /// interface that defines settings backgroundPreview preferences,
+    /// this interface should be merged with IPreferences at Dynamo 2.0
+    /// </summary>
+    public interface IBackgroundPreviewPreference
+    {
         /// <summary>
         /// Collection of pairs [BackgroundPreviewName;isActive]
         /// </summary>
@@ -51,10 +44,39 @@ namespace Dynamo.Interfaces
         /// <param name="value">Active state to set</param>
         void SetIsBackgroundPreviewActive(string name, bool value);
 
+    }
+
+    /// <summary>
+    /// An interface which defines preference settings.
+    /// </summary>
+    public interface IPreferences
+    {
+        /// <summary>
+        /// Returns height of console
+        /// </summary>
+        int ConsoleHeight { get; set; }
+
+        /// <summary>
+        /// Indicates whether connector should be displayed on canvas or not.
+        /// </summary>
+        bool ShowConnector { get; set; }
+
+        /// <summary>
+        /// Indicates which type of connector's should be displayed on canvas.
+        /// I.e. bezier or polyline
+        /// </summary>
+        ConnectorType ConnectorType { get; set; }
+
         /// <summary>
         /// Indicates whether background grid is visible or not.
         /// </summary>
         bool IsBackgroundGridVisible { get; set; }
+
+        /// <summary>
+        /// Indicates whether background preview is active or not.
+        /// </summary>
+        [Obsolete("Property will be deprecated in Dynamo 2.0, please use BackgroundPreviews")]
+        bool IsBackgroundPreviewActive { get; set; }
 
         /// <summary>
         /// Returns the decimal precision used to display numbers.

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -17,7 +17,7 @@ namespace Dynamo.Configuration
     /// from a XML file from DYNAMO_SETTINGS_FILE.
     /// When GUI is closed, the settings into the XML file.
     /// </summary>
-    public class PreferenceSettings : NotificationObject, IPreferences
+    public class PreferenceSettings : NotificationObject, IPreferences, IPreviewBubblePreference, IBackgroundPreviewPreference
     {
         private string numberFormat;
         private string lastUpdateDownloadPath;
@@ -134,6 +134,20 @@ namespace Dynamo.Configuration
         /// Should the background grid be shown?
         /// </summary>
         public bool IsBackgroundGridVisible { get; set; }
+
+        /// <summary>
+        /// Indicates whether background preview is active or not.
+        /// </summary>
+        [Obsolete("Property will be deprecated in Dynamo 2.0, please use BackgroundPreviews")]
+        public bool IsBackgroundPreviewActive { get
+            {
+                return GetIsBackgroundPreviewActive("IsBackgroundPreviewActive");
+            }
+            set
+            {
+                SetIsBackgroundPreviewActive("IsBackgroundPreviewActive", value);
+            }
+        }
 
         /// <summary>
         /// The decimal precision used to display numbers.

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -54,7 +54,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// rendering by various render targets. The base class handles the registration
     /// of all necessary event handlers on models, workspaces, and nodes.
     /// </summary>
-    public class DefaultWatch3DViewModel : NotificationObject, IWatch3DViewModel, IDisposable
+    public class DefaultWatch3DViewModel : NotificationObject, IWatch3DViewModel, IDisposable, IWatchPreferenceProperties
     {
         protected readonly IDynamoModel model;
         protected readonly IScheduler scheduler;
@@ -89,7 +89,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 }
 
                 active = value;
-                preferences.SetIsBackgroundPreviewActive(PreferenceWatchName, value);
+                if(preferences is IBackgroundPreviewPreference)
+                {
+                   (preferences as IBackgroundPreviewPreference).SetIsBackgroundPreviewActive(PreferenceWatchName, value);
+                }
+               
                 RaisePropertyChanged("Active");
 
                 OnActiveStateChanged();

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/IWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/IWatch3DViewModel.cs
@@ -45,7 +45,18 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// </summary>
         public const string ManipulatorPlane  = "E75B2B0E31F1";
     }
-
+    /// <summary>
+    /// interface that defines properties of the Watch3dView required for preference serialization.
+    /// this interface should be merged with IWatch3dViewModel at Dynamo 2.0
+    /// </summary>
+    public interface IWatchPreferenceProperties
+    {
+        /// <summary>
+        /// Represents the name of current IWatch3DViewModel which will be saved in preference settings
+        /// </summary>
+        string PreferenceWatchName { get; }
+    }
+    
     /// <summary>
     /// An interface to expose API's on the Watch UI Viewmodel to extensions
     /// </summary>
@@ -60,11 +71,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// <returns></returns>
         IRay GetClickRay(MouseEventArgs args);
 
-        /// <summary>
-        /// Represents the name of current IWatch3DViewModel which will be saved in preference settings
-        /// </summary>
-        string PreferenceWatchName { get; }
-
+       
         /// <summary>
         /// Returns the current camera position of the 3D background preview
         /// Note: GetCameraInformation returns the camera position but without the correct

--- a/src/VisualizationTests/Watch3DViewModelTests.cs
+++ b/src/VisualizationTests/Watch3DViewModelTests.cs
@@ -19,5 +19,16 @@ namespace WpfVisualizationTests
             ViewModel.BackgroundPreviewViewModel.Active = true;
             Assert.True(ViewModel.Model.PreferenceSettings.GetIsBackgroundPreviewActive(backgroundPreviewName));
         }
+        [Test]
+        public void Watch3DViewModel_Active_InSyncWithPreferencesUsing1_0API()
+        {
+            Assert.AreEqual(ViewModel.BackgroundPreviewViewModel.Active, ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive);
+
+            ViewModel.BackgroundPreviewViewModel.Active = false;
+            Assert.False(ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive);
+
+            ViewModel.BackgroundPreviewViewModel.Active = true;
+            Assert.True(ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive);
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -437,6 +437,47 @@ namespace DynamoCoreWpfTests
 
         #endregion
 
+        [Test,RequiresSTA]
+        [Category("DynamoUI")]
+        public void PreferenceSetting_BackgroundPreview_1_0API()
+        {
+            bool expectedValue = !ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive;
+            ViewModel.ToggleFullscreenWatchShowing(null);
+            Assert.AreEqual(expectedValue, ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive);
+          
+
+            expectedValue = !ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive;
+            ViewModel.ToggleFullscreenWatchShowing(null);
+            Assert.AreEqual(expectedValue, ViewModel.Model.PreferenceSettings.IsBackgroundPreviewActive);
+
+            #region Save And Load of PreferenceSettings
+
+            // Test if variable can be serialize and deserialize without any issue
+            string tempPath = System.IO.Path.GetTempPath();
+            tempPath = Path.Combine(tempPath, "userPreference.xml");
+
+            // Force inital state
+            PreferenceSettings initalSetting = new PreferenceSettings();
+            PreferenceSettings resultSetting;
+
+            initalSetting.IsBackgroundPreviewActive = true;
+
+            initalSetting.Save(tempPath);
+            resultSetting = PreferenceSettings.Load(tempPath);
+
+            Assert.AreEqual(resultSetting.IsBackgroundPreviewActive, initalSetting.IsBackgroundPreviewActive);
+            #endregion
+
+            #region Second Test
+            initalSetting.IsBackgroundPreviewActive = false;
+
+            initalSetting.Save(tempPath);
+            resultSetting = PreferenceSettings.Load(tempPath);
+
+            Assert.AreEqual(resultSetting.IsBackgroundPreviewActive, initalSetting.IsBackgroundPreviewActive);
+            #endregion
+        }
+
         #region PreferenceSettings
         [Test, RequiresSTA]
         [Category("DynamoUI")]


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10147

This PR moves changes that were made to `IPreferences` and `IWatchViewModel` after 1.0 to separate interfaces that the concrete types implement in addition to those original interfaces.

For example `PreferenceSettings` now implements `IPreferences` in addition to `IBackgroundPreferences` and `IPreviewBubblePreferences` - these other interfaces should most likely be fused with IPreferences when we can break the API.

I've obsoleted the removed property `IsBackgroundPreviewActive` and it now calls the new API methods and searches for the default background preview name.

I've also added two tests using the 1.0 API since we are re-adding it.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 
@QilongTang 

### FYIs

@Benglin 
@kronz 
@jnealb 