### PR TITLE
Add tests for Dynamo.Extensions

### DIFF
--- a/test/DynamoCoreTests/ExtensionTests.cs
+++ b/test/DynamoCoreTests/ExtensionTests.cs
@@ -14,12 +14,17 @@ namespace Dynamo.Tests
         string extensionsPath;
         Mock<IExtension> extMock;
         DynamoModel model;
+        ICommandExecutive executive;
+        int cmdExecutionState = -1;
+        private  Logging.NotificationMessage message;
 
         [SetUp]
         public void Init()
         {
             extensionsPath = Path.Combine(Directory.GetCurrentDirectory(), "extensions");
             extMock = new Mock<IExtension>();
+            extMock.Setup(ext => ext.Ready(It.IsAny<ReadyParams>())).Callback((ReadyParams r) => ExtensionReadyCallback(r));
+            cmdExecutionState = -1;
 
             model = DynamoModel.Start(
                 new DynamoModel.DefaultStartConfiguration()
@@ -28,6 +33,18 @@ namespace Dynamo.Tests
                     Extensions = new List<IExtension> { extMock.Object },
                     ProcessMode = TaskProcessMode.Synchronous
                 });
+            model.ExtensionManager.ExtensionAdded += OnExtensionAdded;
+            model.ExtensionManager.ExtensionRemoved += OnExtensionRemoved;
+        }
+
+        void OnExtensionRemoved(IExtension obj)
+        {
+            Assert.AreEqual(extMock.Object, obj);
+        }
+
+        void OnExtensionAdded(IExtension obj)
+        {
+            Assert.AreEqual(extMock.Object, obj);
         }
 
         [Test]
@@ -49,9 +66,77 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void CannotAddSameExtensionTwice()
+        {
+            Assert.AreEqual(1, model.ExtensionManager.Extensions.Count());
+            model.ExtensionManager.Add(extMock.Object);
+            Assert.AreEqual(1, model.ExtensionManager.Extensions.Count());
+        }
+
+        [Test]
         public void ExtensionIsReady()
         {
             extMock.Verify(ext => ext.Ready(It.IsAny<ReadyParams>()));
+        }
+
+        private void ExtensionReadyCallback(ReadyParams ready)
+        {
+            executive = ready.CommandExecutive;
+            Assert.IsTrue(ready.WorkspaceModels.Any());
+            Assert.IsNotNull(ready.CurrentWorkspaceModel);
+            ready.NotificationRecieved += (Logging.NotificationMessage obj) => message = obj;
+        }
+
+        [Test]
+        public void CanExecuteCommand()
+        {
+            Assert.IsNotNull(executive);
+            model.CommandStarting += OnCommandStarting;
+            model.CommandCompleted += OnCommandCompleted;
+            
+            var cmd = new Mock<DynamoModel.RecordableCommand>();
+            Assert.AreEqual(-1, cmdExecutionState);
+            Assert.DoesNotThrow(() => executive.ExecuteCommand(cmd.Object, "TestRecordable", "ExtensionTests"));
+            Assert.AreEqual(0, cmdExecutionState);
+            
+            model.CommandStarting -= OnCommandStarting;
+            model.CommandCompleted -= OnCommandCompleted;
+        }
+
+        [Test]
+        public void ExecuteCommandDoesnotThrowException()
+        {
+            Assert.IsNotNull(executive);
+            var cmd = new ThrowExceptionCommand();
+            Assert.Throws<System.NotImplementedException>(() => cmd.Execute(model));
+            Assert.DoesNotThrow(() => executive.ExecuteCommand(cmd, "TestRecordable", "ExtensionTests"));
+            Assert.AreEqual(Logging.WarningLevel.Error, model.Logger.WarningLevel);
+        }
+
+        void OnCommandCompleted(DynamoModel.RecordableCommand command)
+        {
+            cmdExecutionState--;
+        }
+
+        void OnCommandStarting(DynamoModel.RecordableCommand command)
+        {
+            cmdExecutionState = 1;
+        }
+
+        [Test]
+        public void NotificationHandler()
+        {
+            var sender = "ExecutionTests";
+            var title = "NotificationTitle";
+            var shortMessage = "Short Message";
+            var detailedMessage = "Detailed Notification message";
+            Assert.IsNull(message);
+            model.Logger.LogNotification(sender, title, shortMessage, detailedMessage);
+            Assert.IsNotNull(message);
+            Assert.AreEqual(sender, message.Sender);
+            Assert.AreEqual(title, message.Title);
+            Assert.AreEqual(shortMessage, message.ShortMessage);
+            Assert.AreEqual(detailedMessage, message.DetailedMessage);
         }
 
         [Test]
@@ -61,4 +146,17 @@ namespace Dynamo.Tests
             extMock.Verify(ext => ext.Dispose());
         }
     }
+
+    class ThrowExceptionCommand : DynamoModel.RecordableCommand
+    {
+        protected override void ExecuteCore(DynamoModel dynamoModel)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        protected override void SerializeCore(System.Xml.XmlElement element)
+        {
+        }
+    }
+
 }

--- a/test/DynamoCoreTests/XmlDocumentationTests.cs
+++ b/test/DynamoCoreTests/XmlDocumentationTests.cs
@@ -9,6 +9,7 @@ using Dynamo.Library;
 
 using NUnit.Framework;
 using ProtoCore;
+using Dynamo.Extensions;
 
 namespace Dynamo.Tests
 {
@@ -170,5 +171,21 @@ namespace Dynamo.Tests
             Assert.AreEqual(0.2, weights.Last());
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void EnumDescriptionTest()
+        {
+            Assert.AreEqual(Dynamo.Properties.Resources.HeaderCreate, LibraryHeaders.TestCreate.GetDescription());
+            Assert.AreEqual(Dynamo.Properties.Resources.HeaderAction, LibraryHeaders.TestAction.GetDescription());
+            Assert.AreEqual(LibraryHeaders.TestQuery.ToString(), LibraryHeaders.TestQuery.GetDescription());
+        }
+
+    }
+
+    enum LibraryHeaders
+    {
+        [EnumDescription("HeaderCreate", typeof(Dynamo.Properties.Resources))] TestCreate,
+        [EnumDescription("HeaderAction", typeof(Dynamo.Properties.Resources))] TestAction,
+        TestQuery,
     }
 }


### PR DESCRIPTION
### Purpose

Added few tests to increase the test coverage of Dynamo.Extensions namespace.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

### FYIs
@monikaprabhu, @Benglin 
