### PR TITLE
Some random coverage improvements for DynamoCore assembly

### DIFF
--- a/src/DynamoCore/Graph/Presets/PresetModel.cs
+++ b/src/DynamoCore/Graph/Presets/PresetModel.cs
@@ -95,18 +95,6 @@ namespace Dynamo.Graph.Presets
         }
 
         /// <summary>
-        /// this overload is used for loading
-        /// </summary>
-        private PresetModel(string name, string description, List<NodeModel> nodes, List<XmlElement> serializedNodes, Guid id)
-        {
-            Name = name;
-            Description = description;
-            this.nodes = nodes;
-            this.serializedNodes = serializedNodes;
-            GUID = id;
-        }
-
-        /// <summary>
         /// this overload is used for loading with deserializeCore, we must pass the nodesInTheGraph to the instance of the Preset so that
         /// we can detect missing nodes
         /// </summary>

--- a/test/DynamoCoreTests/SearchModelTests.cs
+++ b/test/DynamoCoreTests/SearchModelTests.cs
@@ -187,6 +187,9 @@ namespace Dynamo.Tests
             var categorized = SearchCategoryUtil.CategorizeSearchEntries(search.SearchEntries, x => x.Categories);
             Assert.AreEqual(1, categorized.SubCategories.Count());
 
+            var allCategories = SearchCategoryUtil.GetAllCategoryNames(categorized);
+            Assert.AreEqual(5, allCategories.Count());
+
             categorized = categorized.SubCategories.First();
             Assert.AreEqual("Category", categorized.Name);
             Assert.AreEqual(1, categorized.SubCategories.Count());

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -797,6 +797,32 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(currentWs.WorkspaceLacingMenu.IsSubmenuOpen);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void TestDumpLibraryToXml()
+        {
+            ViewModel.DumpLibraryToXmlCommand.Execute(null);
+
+            // Look for library dump files aged within 10 seconds from the current time
+            var time = System.DateTime.Now;
+            var attempts = 10;
+
+            for (var attempt = 0; attempt < attempts; ++attempt)
+            {
+                string fileName = string.Format("LibrarySnapshot_{0}.xml", time.ToString("yyyyMMddHmmss"));
+                string fullFileName = Path.Combine(Model.PathManager.LogDirectory, fileName);
+                Console.WriteLine("Looking for library dump file at " + fullFileName);
+                if (File.Exists(fullFileName))
+                {
+                    File.Delete(fullFileName);
+                    Console.WriteLine("Library dump file has been found and deleted.");
+                    Assert.Pass();
+                }
+                time = time.AddSeconds(-1);
+            }
+            Assert.Fail("Library dump file aged within 10 seconds is not found.");
+        }
+
         private void RightClick(IInputElement element)
         {
             element.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Right)


### PR DESCRIPTION
### Purpose
- Modified a test case to cover `Dynamo.Search.SearchCategoryUtil.GetAllCategoryNames()`
- Removed a private constructor `Dynamo.Graph.Presets.PresetModel(string, string, List<NodeModel>, List<XmlElement>, Guid)`. This constructor was once used for the deserialization method, which by now had been changed to have its own implementation for this purpose.
- Added a test case that covers `Dynamo.Search.NodeSearchModel.DumpLibraryToXml(string, string)`, `Dynamo.Models.DynamoModel.DumpLibraryToXml()` and `Dynamo.Models.DynamoModel.CanDumpLibraryToXml()`
### Declarations
- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] All tests pass using the self-service CI.
### Reviewers

@monikaprabhu
