### PR TITLE
Optionally load T-Spline nodes in the node library

### DIFF
--- a/extern/ProtoGeometry/ProtoGeometry_DynamoCustomization.xml
+++ b/extern/ProtoGeometry/ProtoGeometry_DynamoCustomization.xml
@@ -7,6 +7,9 @@
         <namespace name="Autodesk.DesignScript.Geometry">
             <category>Geometry</category>
         </namespace>
+        <namespace name="Autodesk.DesignScript.Geometry.TSpline">
+            <category>Geometry.TSpline</category>
+        </namespace>
     </namespaces>
     <classes>
         <class name="Autodesk.DesignScript.Geometry.Arc" shortname="arc"/>

--- a/src/DynamoCore/Configuration/IPreferences.cs
+++ b/src/DynamoCore/Configuration/IPreferences.cs
@@ -128,6 +128,8 @@ namespace Dynamo.Interfaces
         /// </summary>
         bool ShowEdges { get; set; }
 
+        List<string> NamespacesToExcludeFromLibrary { get; set; }
+
         /// <summary>
         /// Call this method to serialize PreferenceSettings given the output 
         /// file path.

--- a/src/DynamoCore/Configuration/IPreferences.cs
+++ b/src/DynamoCore/Configuration/IPreferences.cs
@@ -128,8 +128,6 @@ namespace Dynamo.Interfaces
         /// </summary>
         bool ShowEdges { get; set; }
 
-        List<string> NamespacesToExcludeFromLibrary { get; set; }
-
         /// <summary>
         /// Call this method to serialize PreferenceSettings given the output 
         /// file path.

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -246,6 +246,11 @@ namespace Dynamo.Configuration
         /// checkbox in OpenFileDialog
         /// </summary>
         public bool OpenFileInManualExecutionMode { get; set; }
+        
+        public List<string> NamespacesToExcludeFromLibrary { get; set; }
+
+        [XmlIgnore]
+        public bool NamespacesToExcludeFromLibrarySpecified { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PreferenceSettings"/> class.
@@ -276,6 +281,7 @@ namespace Dynamo.Configuration
             ShowEdges = false;
             OpenFileInManualExecutionMode = false;
             ShowDetailedLayout = true;
+            NamespacesToExcludeFromLibrary = new List<string>();
 
             BackupInterval = 60000; // 1 minute
             BackupFilesCount = 1;
@@ -351,6 +357,7 @@ namespace Dynamo.Configuration
                 using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read))
                 {
                     settings = serializer.Deserialize(fs) as PreferenceSettings;
+                    settings.InitializeNamespacesToExcludeFromLibrary();
                     fs.Close(); // Release file lock
                 }
             }
@@ -359,6 +366,17 @@ namespace Dynamo.Configuration
             settings.CustomPackageFolders = settings.CustomPackageFolders.Distinct().ToList();
 
             return settings;
+		}
+
+        private void InitializeNamespacesToExcludeFromLibrary()
+        {
+            if (!NamespacesToExcludeFromLibrarySpecified)
+            {
+                NamespacesToExcludeFromLibrary.Add(
+                    "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline"
+                );
+                NamespacesToExcludeFromLibrarySpecified = true;
+            }
         }
     }
 }

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -246,9 +246,16 @@ namespace Dynamo.Configuration
         /// checkbox in OpenFileDialog
         /// </summary>
         public bool OpenFileInManualExecutionMode { get; set; }
-        
+
+        /// <summary>
+        /// Indicates (if any) which namespaces should not be displayed in the Dynamo node library.
+        /// String format: "[library name]:[fully qualified namespace]"
+        /// </summary>
         public List<string> NamespacesToExcludeFromLibrary { get; set; }
 
+        /// <summary>
+        /// True if the NamespacesToExcludeFromLibrary element is found in DynamoSettings.xml.
+        /// </summary>
         [XmlIgnore]
         public bool NamespacesToExcludeFromLibrarySpecified { get; set; }
 
@@ -357,7 +364,6 @@ namespace Dynamo.Configuration
                 using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read))
                 {
                     settings = serializer.Deserialize(fs) as PreferenceSettings;
-                    settings.InitializeNamespacesToExcludeFromLibrary();
                     fs.Close(); // Release file lock
                 }
             }
@@ -368,7 +374,7 @@ namespace Dynamo.Configuration
             return settings;
 		}
 
-        private void InitializeNamespacesToExcludeFromLibrary()
+        internal void InitializeNamespacesToExcludeFromLibrary()
         {
             if (!NamespacesToExcludeFromLibrarySpecified)
             {

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -42,6 +42,7 @@ namespace Dynamo.Engine
         private readonly List<string> packagedLibraries = new List<string>();
 
         private readonly IPathManager pathManager;
+        private readonly IPreferences preferenceSettings;
 
         /// <summary>
         /// Returns core which is used for parsing code and loading libraries
@@ -92,10 +93,12 @@ namespace Dynamo.Engine
         /// </summary>
         /// <param name="libraryManagementCore">Core which is used for parsing code and loading libraries</param>
         /// <param name="pathManager">Instance of IPathManager containing neccessary Dynamo paths</param>
-        public LibraryServices(ProtoCore.Core libraryManagementCore, IPathManager pathManager)
+        /// <param name="preferences">The preference settings of the Dynamo instance</param>
+        public LibraryServices(ProtoCore.Core libraryManagementCore, IPathManager pathManager, IPreferences preferences)
         {
             LibraryManagementCore = libraryManagementCore;
             this.pathManager = pathManager;
+            preferenceSettings = preferences;
 
             PreloadLibraries(pathManager.PreloadedLibraries);
             PopulateBuiltIns();
@@ -327,13 +330,23 @@ namespace Dynamo.Engine
                 throw new ArgumentNullException();
 
             Dictionary<string, FunctionGroup> functionGroups;
-            if (importedFunctionGroups.TryGetValue(library, out functionGroups))
-                return functionGroups.Values;
+            if (!importedFunctionGroups.TryGetValue(library, out functionGroups))
+            {
+                // Return an empty list instead of 'null' as some of the caller may
+                // not have the opportunity to check against 'null' enumerator (for
+                // example, an inner iterator in a nested LINQ statement).
+                return new List<FunctionGroup>();
+            }
 
-            // Return an empty list instead of 'null' as some of the caller may
-            // not have the opportunity to check against 'null' enumerator (for
-            // example, an inner iterator in a nested LINQ statement).
-            return new List<FunctionGroup>();
+            IEnumerable<FunctionGroup> result = functionGroups.Values;
+
+            // Skip namespaces specified in the preference settings
+            foreach (var nsp in preferenceSettings.NamespacesToExcludeFromLibrary
+                .Where(x => x.StartsWith(library + ':')).Select(x => x.Split(':').LastOrDefault()))
+            {
+                result = result.Where(funcGroup => !funcGroup.QualifiedName.StartsWith(nsp));
+            }
+            return result;
         }
 
         /// <summary>

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -20,6 +20,7 @@ using Operator = ProtoCore.DSASM.Operator;
 using ProtoCore;
 using ProtoCore.Namespace;
 using Dynamo.Exceptions;
+using Dynamo.Configuration;
 
 namespace Dynamo.Engine
 {
@@ -341,10 +342,14 @@ namespace Dynamo.Engine
             IEnumerable<FunctionGroup> result = functionGroups.Values;
 
             // Skip namespaces specified in the preference settings
-            foreach (var nsp in preferenceSettings.NamespacesToExcludeFromLibrary
-                .Where(x => x.StartsWith(library + ':')).Select(x => x.Split(':').LastOrDefault()))
+            var settings = preferenceSettings as PreferenceSettings;
+            if (settings != null)
             {
-                result = result.Where(funcGroup => !funcGroup.QualifiedName.StartsWith(nsp));
+                foreach (var nsp in settings.NamespacesToExcludeFromLibrary
+                    .Where(x => x.StartsWith(library + ':')).Select(x => x.Split(':').LastOrDefault()))
+                {
+                    result = result.Where(funcGroup => !funcGroup.QualifiedName.StartsWith(nsp));
+                }
             }
             return result;
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1055,6 +1055,12 @@ namespace Dynamo.Models
         private static void InitializePreferences(IPreferences preferences)
         {
             BaseUnit.NumberFormat = preferences.NumberFormat;
+
+            var settings = preferences as PreferenceSettings;
+            if (settings != null)
+            {
+                settings.InitializeNamespacesToExcludeFromLibrary();
+            }
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -585,7 +585,7 @@ namespace Dynamo.Models
             libraryCore.Compilers.Add(Language.Imperative, new ProtoImperative.Compiler(libraryCore));
             libraryCore.ParsingMode = ParseMode.AllowNonAssignment;
 
-            LibraryServices = new LibraryServices(libraryCore, pathManager);
+            LibraryServices = new LibraryServices(libraryCore, pathManager, preferences);
             LibraryServices.MessageLogged += LogMessage;
             LibraryServices.LibraryLoaded += LibraryLoaded;
 
@@ -1896,6 +1896,34 @@ namespace Dynamo.Models
             }
 
             SearchModel.Add(new NodeModelSearchElement(typeLoadData));
+        }
+
+        /// <summary>
+        /// This method updates the node search library to either hide or unhide nodes that belong
+        /// to a specified assembly name and namespace. These nodes will be hidden from the node
+        /// library sidebar and from the node search.
+        /// </summary>
+        /// <param name="hide">Set to true to hide, set to false to unhide.</param>
+        /// <param name="library">The assembly name of the library.</param>
+        /// <param name="namespc">The namespace of the nodes to be hidden.</param>
+        internal void HideUnhideNamespace(bool hide, string library, string namespc)
+        {
+            var str = library + ':' + namespc;
+            var namespaces = PreferenceSettings.NamespacesToExcludeFromLibrary;
+
+            if (hide)
+            {
+                if (!namespaces.Contains(str))
+                {
+                    namespaces.Add(str);
+                }
+                SearchModel.RemoveNamespace(library, namespc);
+            }
+            else // unhide
+            {
+                namespaces.Remove(str);
+                AddZeroTouchNodesToSearch(LibraryServices.GetFunctionGroups(library));
+            }
         }
 
         private void AddZeroTouchNodesToSearch(IEnumerable<FunctionGroup> functionGroups)

--- a/src/DynamoCore/Search/NodeSearchModel.cs
+++ b/src/DynamoCore/Search/NodeSearchModel.cs
@@ -24,6 +24,11 @@ namespace Dynamo.Search
             base.Add(entry);
         }
 
+        internal void RemoveNamespace(string library, string namespc)
+        {
+            Remove(x => x.Assembly.Equals(library) && x.CreationName.StartsWith(namespc));
+        }
+
         /// <summary>
         ///     Dumps the contents of search into an Xml file.
         /// </summary>

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -1396,6 +1396,24 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable T-Spline nodes.
+        /// </summary>
+        public static string DynamoViewSettingEnableTSplineNodes {
+            get {
+                return ResourceManager.GetString("DynamoViewSettingEnableTSplineNodes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Experimental.
+        /// </summary>
+        public static string DynamoViewSettingExperimental {
+            get {
+                return ResourceManager.GetString("DynamoViewSettingExperimental", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Settings.
         /// </summary>
         public static string DynamoViewSettingMenu {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -559,6 +559,14 @@ It does not contain your graph or any personal data</value>
     <value>Volume Display Units</value>
     <comment>Setting menu | Volume unit display</comment>
   </data>
+  <data name="DynamoViewSettingExperimental" xml:space="preserve">
+    <value>Experimental</value>
+    <comment>Setting menu | Experimental</comment>
+  </data>
+  <data name="DynamoViewSettingEnableTSplineNodes" xml:space="preserve">
+    <value>Enable T-Spline nodes</value>
+    <comment>Setting menu | Experimental | Enable T-Spline nodes</comment>
+  </data>
   <data name="DynamoViewToolbarExportButtonTooltip" xml:space="preserve">
     <value>Export Workspace As Image</value>
     <comment>Toolbar export button tooltip</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -559,6 +559,14 @@ It does not contain your graph or any personal data</value>
     <value>Volume Display Units</value>
     <comment>Setting menu | Volume unit display</comment>
   </data>
+  <data name="DynamoViewSettingExperimental" xml:space="preserve">
+    <value>Experimental</value>
+    <comment>Setting menu | Experimental</comment>
+  </data>
+  <data name="DynamoViewSettingEnableTSplineNodes" xml:space="preserve">
+    <value>Enable T-Spline nodes</value>
+    <comment>Setting menu | Experimental | Enable T-Spline nodes</comment>
+  </data>
   <data name="DynamoViewToolbarExportButtonTooltip" xml:space="preserve">
     <value>Export Workspace As Image</value>
     <comment>Toolbar export button tooltip</comment>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -257,6 +257,24 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Indicates whether to make T-Spline nodes (under ProtoGeometry.dll) discoverable
+        /// in the node search library.
+        /// </summary>
+        public bool EnableTSpline
+        {
+            get
+            {
+                return !PreferenceSettings.NamespacesToExcludeFromLibrary.Contains(
+                    "ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline");
+            }
+            set
+            {
+                model.HideUnhideNamespace(!value,
+                    "ProtoGeometry.dll", "Autodesk.DesignScript.Geometry.TSpline");
+            }
+        }
+
         public int LibraryWidth
         {
             get

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -702,6 +702,14 @@
                                   Header="{x:Static p:Resources.DynamoViewSettingMenuManagePackagePath}"
                                   Command="{Binding ManagePackagePathsCommand}"
                                   Name="managePackagePaths" />
+                        <Separator />
+                        <MenuItem Focusable="False"
+                                  Header="{x:Static p:Resources.DynamoViewSettingExperimental}">
+                            <MenuItem Name="EnableTSpline"
+                                  IsCheckable="True"
+                                  IsChecked="{Binding EnableTSpline}"
+                                  Header="{x:Static p:Resources.DynamoViewSettingEnableTSplineNodes}" />
+                        </MenuItem>
                     </MenuItem>
 
                     <MenuItem Header="{x:Static p:Resources.DynamoViewHelpMenu}"

--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using ProtoCore;
 using TestServices;
 using System.Xml;
+using Dynamo.Configuration;
 
 namespace Dynamo.Tests
 {
@@ -37,7 +38,9 @@ namespace Dynamo.Tests
                 PathResolver = pathResolver
             });
 
-            libraryServices = new LibraryServices(libraryCore, pathManager);
+            var settings = new PreferenceSettings();
+
+            libraryServices = new LibraryServices(libraryCore, pathManager, settings);
 
             RegisterEvents();
         }

--- a/test/DynamoCoreWpfTests/LibraryTests.cs
+++ b/test/DynamoCoreWpfTests/LibraryTests.cs
@@ -1,4 +1,5 @@
 ﻿using Dynamo;
+using Dynamo.Configuration;
 using Dynamo.Core;
 using Dynamo.Engine;
 using Dynamo.Search;
@@ -37,7 +38,9 @@ namespace DynamoCoreWpfTests
                 PathResolver = pathResolver
             });
 
-            libraryServices = new LibraryServices(libraryCore, pathManager);
+            var settings = new PreferenceSettings();
+
+            libraryServices = new LibraryServices(libraryCore, pathManager, settings);
 
             RegisterEvents();
         }


### PR DESCRIPTION
### Purpose

*Reference:* [MAGN-10206](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10206) As an advanced user I would like to access T-Spline nodes and optionally turn them off from the UI so that they don't interfere in search results when I don't need them

A new menu has been added: `Settings` > `Experimental` > `Enable T-Spline nodes`
This menu enables user to optionally load T-Spline nodes in the node library. The option is unchecked by default. The effect of checking/unchecking the option will be reflected immediately in the node library and node search. This does not require restart, as an implementation to remove nodes has been added.

The state of this option will be saved in `DynamoSettings.xml` in the APPDATA folder. A new element `<NamespacesToExcludeFromLibrary>` is added. On the first run, or if the element is not found in the XML file, the element with default value will be added:
```xml
<NamespacesToExcludeFromLibrary>
  <string>ProtoGeometry.dll:Autodesk.DesignScript.Geometry.TSpline</string>
</NamespacesToExcludeFromLibrary>
```
If T-Spline nodes are to be loaded (the user checked the option), the XML element will be updated into an empty element:
```xml
<NamespacesToExcludeFromLibrary />
```

This design is intended to be extensible for multiple different namespaces in future implementation.

*Note:* The T-Spline nodes will only be available after ProtoGeometry and LibG binaries update.

#### Screenshots

*To be added*

### Declarations

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate - *To be added ([MAGN-10277](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10277))*
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.

### Reviewers

@aparajit-pratap