### PR TITLE
Added new command to Wix prebuild process: Copy README file to instal…

### DIFF
--- a/src/DynamoInstall/DynamoInstall.wixproj
+++ b/src/DynamoInstall/DynamoInstall.wixproj
@@ -77,6 +77,10 @@
     <Exec Command="robocopy $(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration) $(DYNAMO_HARVEST_PATH) -XF %2aTest%2a.dll %2a.pdb TestResult.xml -e -XD int -XD Revit_2015 -XD Revit_2016 -XD Revit_2017 -XD samples -XD gallery -XD 0.8" IgnoreExitCode="true" />
     <Exec Command="$(DYNAMO_BASE_PATH)\tools\install\Extra\InstallerSpec.exe $(DYNAMO_HARVEST_PATH) $(DYNAMO_HARVEST_PATH)\InstallSpec.xml" IgnoreExitCode="true" />
     <Exec Condition="Exists('$(MSBuildProjectDirectory)\Digital_Sign.bat')" Command="$(MSBuildProjectDirectory)\Digital_Sign.bat $(DYNAMO_HARVEST_PATH)\binariestosign.txt" IgnoreExitCode="true" />
+    
+    <!-- Copy README file to install folder -->
+    <Exec Command="copy $(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration)\README.txt $(DYNAMO_BASE_PATH)\tools\install\Installers" IgnoreExitCode="true" />
+    
     <HeatDirectory  Directory="$(DYNAMO_HARVEST_PATH)" 
                     PreprocessorVariable="var.harvest" 
                     OutputFile="$(ProjectDir)Release-autogen.wxs" 


### PR DESCRIPTION
### Purpose [MAGN-10246](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10246)

**Problem**:
Running DynamoRevit.exe in silent will still show the README as it is being executed as a post-install process.

**Solution**:
Do not execute README as a post-install process.
The file needs to be referenced from a common location, and this is set as the install folder.

This PR links with DynamoForRevit [PR](https://git.autodesk.com/Dynamo/DynamoForRevit/pull/32).

### Reviewers

@sharadkjaiswal 