### PR TITLE
MAGN-10265 Clicking Enter while editing the Notes will accept the changes in dialog rather than adding new line.

### DIFF
--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
@@ -18,10 +18,13 @@ namespace Dynamo.UI.Prompts
     public partial class EditWindow
     {
         private readonly DynamoViewModel dynamoViewModel;
+        private bool commitChangesOnReturn;
 
         public EditWindow(DynamoViewModel dynamoViewModel,
-            bool updateSourceOnTextChange = false)
+            bool updateSourceOnTextChange = false, bool commitChangesOnReturn = false)
         {
+            this.commitChangesOnReturn = commitChangesOnReturn;
+
             InitializeComponent();
             this.dynamoViewModel = dynamoViewModel;
 
@@ -42,18 +45,11 @@ namespace Dynamo.UI.Prompts
         }
         private void OnEditWindowPreviewKeyDown(object sender, KeyEventArgs e)
         {
-            var expr = editText.GetBindingExpression(TextBox.TextProperty);
-            if(expr != null)
-            {
-                if (expr.DataItem is NodeViewModel ||expr.DataItem is NodeModel)
-                {
-                    if (e.Key == Key.Return || e.Key == Key.Enter)
-                    {
-                        UpdateNodeName();
-                        e.Handled = true;
-                    }
-                }
-            }
+           if(commitChangesOnReturn && (e.Key == Key.Return || e.Key == Key.Enter))
+           {
+               UpdateNodeName();
+               e.Handled = true;
+           }
         }
         public void BindToProperty(object dataContext, System.Windows.Data.Binding binding)
         {

--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
@@ -42,14 +42,19 @@ namespace Dynamo.UI.Prompts
         }
         private void OnEditWindowPreviewKeyDown(object sender, KeyEventArgs e)
         {
-            if(e.Key == Key.Return ||e.Key == Key.Enter)
+            var dataItem = editText.GetBindingExpression(TextBox.TextProperty);
+            if(dataItem != null)
             {
-                UpdateNodeName();
-                e.Handled = true;
-                
+                if (!(dataItem.DataItem is NoteViewModel || dataItem.DataItem is NoteView))
+                {
+                    if (e.Key == Key.Return || e.Key == Key.Enter)
+                    {
+                        UpdateNodeName();
+                        e.Handled = true;
+                    }
+                }
             }
         }
-
         public void BindToProperty(object dataContext, System.Windows.Data.Binding binding)
         {
             if (null != dataContext)

--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
@@ -45,7 +45,7 @@ namespace Dynamo.UI.Prompts
             var dataItem = editText.GetBindingExpression(TextBox.TextProperty);
             if(dataItem != null)
             {
-                if (!(dataItem.DataItem is NoteViewModel || dataItem.DataItem is NoteView))
+                if (dataItem.DataItem is NodeViewModel || dataItem.DataItem is NodeModel)
                 {
                     if (e.Key == Key.Return || e.Key == Key.Enter)
                     {

--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
@@ -42,10 +42,10 @@ namespace Dynamo.UI.Prompts
         }
         private void OnEditWindowPreviewKeyDown(object sender, KeyEventArgs e)
         {
-            var dataItem = editText.GetBindingExpression(TextBox.TextProperty);
-            if(dataItem != null)
+            var expr = editText.GetBindingExpression(TextBox.TextProperty);
+            if(expr != null)
             {
-                if (dataItem.DataItem is NodeViewModel || dataItem.DataItem is NodeModel)
+                if (expr.DataItem is NodeViewModel ||expr.DataItem is NodeModel)
                 {
                     if (e.Key == Key.Return || e.Key == Key.Enter)
                     {

--- a/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/EditWindow.xaml.cs
@@ -18,12 +18,12 @@ namespace Dynamo.UI.Prompts
     public partial class EditWindow
     {
         private readonly DynamoViewModel dynamoViewModel;
-        private bool commitChangesOnReturn;
+        private bool CommitChangesOnReturn { get; set; }
 
         public EditWindow(DynamoViewModel dynamoViewModel,
             bool updateSourceOnTextChange = false, bool commitChangesOnReturn = false)
         {
-            this.commitChangesOnReturn = commitChangesOnReturn;
+            this.CommitChangesOnReturn = commitChangesOnReturn;
 
             InitializeComponent();
             this.dynamoViewModel = dynamoViewModel;
@@ -45,7 +45,7 @@ namespace Dynamo.UI.Prompts
         }
         private void OnEditWindowPreviewKeyDown(object sender, KeyEventArgs e)
         {
-           if(commitChangesOnReturn && (e.Key == Key.Return || e.Key == Key.Enter))
+           if(CommitChangesOnReturn && (e.Key == Key.Return || e.Key == Key.Enter))
            {
                UpdateNodeName();
                e.Handled = true;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -287,7 +287,7 @@ namespace Dynamo.Controls
 
             e.Handled = true;
 
-            var editWindow = new EditWindow(viewModel.DynamoViewModel)
+            var editWindow = new EditWindow(viewModel.DynamoViewModel, false, true)
             {
                 DataContext = ViewModel,
                 Title = Dynamo.Wpf.Properties.Resources.EditNodeWindowTitle


### PR DESCRIPTION
### Purpose
Reference: [MAGN-10265](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10265)
This PR is to fix the issue of notes being saved when user clicks the enter key, thus being unable to create multi-line notes.
The original functionality of updating the node's name when clicking enter will still remain.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 
