### PR TITLE
Add Cancel button to "Cannot download package" dialog

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3022,9 +3022,9 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {2} has dependencies. To uninstall {2}, {0} needs to first uninstall the following dependent packages: {1}. Restart {0} to complete the uninstall, then try and download {2} again.
+        ///   Looks up a localized string similar to {2} has dependencies. To install {2}, {0} needs to first uninstall the following dependent packages: {1}. Restart {0} to complete the uninstall, then try and download {2} again.
         ///
-        ///Uninstall {1}?.
+        ///Uninstall the following dependent packages: {1}?.
         /// </summary>
         public static string MessageUninstallToContinue2 {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3022,7 +3022,9 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} needs to uninstall {1} to continue but it contains binaries already loaded into Dynamo.  It&apos;s now marked for removal, but you&apos;ll need to first restart {0}..
+        ///   Looks up a localized string similar to {2} has dependencies. To uninstall {2}, {0} needs to first uninstall the following dependent packages: {1}. Restart {0} to complete the uninstall, then try and download {2} again.
+        ///
+        ///Uninstall {1}?.
         /// </summary>
         public static string MessageUninstallToContinue2 {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -951,9 +951,9 @@ You can always re-deprecate the package.</value>
     <value>{0} needs to uninstall {1} to continue, but cannot as one of its types appears to be in use.  Try restarting {0}.</value>
   </data>
   <data name="MessageUninstallToContinue2" xml:space="preserve">
-    <value>{2} has dependencies. To uninstall {2}, {0} needs to first uninstall the following dependent packages: {1}. Restart {0} to complete the uninstall, then try and download {2} again.
+    <value>{2} has dependencies. To install {2}, {0} needs to first uninstall the following dependent packages: {1}. Restart {0} to complete the uninstall, then try and download {2} again.
 
-Uninstall {1}?</value>
+Uninstall the following dependent packages: {1}?</value>
   </data>
   <data name="OKButton" xml:space="preserve">
     <value>OK</value>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -951,7 +951,9 @@ You can always re-deprecate the package.</value>
     <value>{0} needs to uninstall {1} to continue, but cannot as one of its types appears to be in use.  Try restarting {0}.</value>
   </data>
   <data name="MessageUninstallToContinue2" xml:space="preserve">
-    <value>{0} needs to uninstall {1} to continue but it contains binaries already loaded into Dynamo. Do you want to remove them? You'll need to restart {0} and re-install the package.</value>
+    <value>You must first uninstall dependent packages {1} to continue installing {2} package. Do you want to uninstall? 
+
+After the uninstall, you must restart {0} and try to install {2} package again.</value>
   </data>
   <data name="OKButton" xml:space="preserve">
     <value>OK</value>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -951,7 +951,7 @@ You can always re-deprecate the package.</value>
     <value>{0} needs to uninstall {1} to continue, but cannot as one of its types appears to be in use.  Try restarting {0}.</value>
   </data>
   <data name="MessageUninstallToContinue2" xml:space="preserve">
-    <value>{0} needs to uninstall {1} to continue but it contains binaries already loaded into Dynamo.  It's now marked for removal, but you'll need to first restart {0}.</value>
+    <value>{0} needs to uninstall {1} to continue but it contains binaries already loaded into Dynamo. Do you want to remove them? You'll need to restart {0} and re-install the package.</value>
   </data>
   <data name="OKButton" xml:space="preserve">
     <value>OK</value>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -951,9 +951,9 @@ You can always re-deprecate the package.</value>
     <value>{0} needs to uninstall {1} to continue, but cannot as one of its types appears to be in use.  Try restarting {0}.</value>
   </data>
   <data name="MessageUninstallToContinue2" xml:space="preserve">
-    <value>You must first uninstall dependent packages {1} to continue installing {2} package. Do you want to uninstall? 
+    <value>{2} has dependencies. To uninstall {2}, {0} needs to first uninstall the following dependent packages: {1}. Restart {0} to complete the uninstall, then try and download {2} again.
 
-After the uninstall, you must restart {0} and try to install {2} package again.</value>
+Uninstall {1}?</value>
   </data>
   <data name="OKButton" xml:space="preserve">
     <value>OK</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -955,7 +955,9 @@ You can always re-deprecate the package.</value>
     <value>{0} needs to uninstall {1} to continue, but cannot as one of its types appears to be in use.  Try restarting {0}.</value>
   </data>
   <data name="MessageUninstallToContinue2" xml:space="preserve">
-    <value>{0} needs to uninstall {1} to continue but it contains binaries already loaded into Dynamo.  It's now marked for removal, but you'll need to first restart {0}.</value>
+    <value>{2} has dependencies. To uninstall {2}, {0} needs to first uninstall the following dependent packages: {1}. Restart {0} to complete the uninstall, then try and download {2} again.
+
+Uninstall {1}?</value>
   </data>
   <data name="OKButton" xml:space="preserve">
     <value>OK</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -955,9 +955,9 @@ You can always re-deprecate the package.</value>
     <value>{0} needs to uninstall {1} to continue, but cannot as one of its types appears to be in use.  Try restarting {0}.</value>
   </data>
   <data name="MessageUninstallToContinue2" xml:space="preserve">
-    <value>{2} has dependencies. To uninstall {2}, {0} needs to first uninstall the following dependent packages: {1}. Restart {0} to complete the uninstall, then try and download {2} again.
+    <value>{2} has dependencies. To install {2}, {0} needs to first uninstall the following dependent packages: {1}. Restart {0} to complete the uninstall, then try and download {2} again.
 
-Uninstall {1}?</value>
+Uninstall the following dependent packages: {1}?</value>
   </data>
   <data name="OKButton" xml:space="preserve">
     <value>OK</value>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -551,15 +551,18 @@ namespace Dynamo.PackageManager
 
                 if (uninstallsRequiringRestart.Any())
                 {
-                    // mark for uninstallation
-                    uninstallsRequiringRestart.ForEach(
-                        x => x.MarkForUninstall(settings));
-
-                    MessageBox.Show(String.Format(Resources.MessageUninstallToContinue2,
-                        PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName, 
-                        JoinPackageNames(uninstallsRequiringRestart)), 
+                    var message = string.Format(Resources.MessageUninstallToContinue2,
+                        PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName,
+                        JoinPackageNames(uninstallsRequiringRestart));
+                    var dialogResult = MessageBox.Show(message, 
                         Resources.CannotDownloadPackageMessageBoxTitle,
-                        MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBoxButton.OKCancel, MessageBoxImage.Error);
+
+                    if (dialogResult == MessageBoxResult.OK)
+                    {
+                        // mark for uninstallation
+                        uninstallsRequiringRestart.ForEach(x => x.MarkForUninstall(settings));
+                    }
                     return;
                 }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -553,7 +553,8 @@ namespace Dynamo.PackageManager
                 {
                     var message = string.Format(Resources.MessageUninstallToContinue2,
                         PackageManagerClientViewModel.DynamoViewModel.BrandingResourceProvider.ProductName,
-                        JoinPackageNames(uninstallsRequiringRestart));
+                        JoinPackageNames(uninstallsRequiringRestart),
+                        element.Name + " " + version.version);
                     var dialogResult = MessageBox.Show(message, 
                         Resources.CannotDownloadPackageMessageBoxTitle,
                         MessageBoxButton.OKCancel, MessageBoxImage.Error);

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -557,9 +557,9 @@ namespace Dynamo.PackageManager
                         element.Name + " " + version.version);
                     var dialogResult = MessageBox.Show(message, 
                         Resources.CannotDownloadPackageMessageBoxTitle,
-                        MessageBoxButton.OKCancel, MessageBoxImage.Error);
+                        MessageBoxButton.YesNo, MessageBoxImage.Error);
 
-                    if (dialogResult == MessageBoxResult.OK)
+                    if (dialogResult == MessageBoxResult.Yes)
                     {
                         // mark for uninstallation
                         uninstallsRequiringRestart.ForEach(x => x.MarkForUninstall(settings));


### PR DESCRIPTION
### Purpose

When installing a package which has some dependencies, Dynamo will firstly try to remove all those dependencies, and requires user to restart Dynamo (and user needs to re-install the package):

![image](https://cloud.githubusercontent.com/assets/2600379/16257317/5ea4e9a4-388a-11e6-8181-e64ce93a2c69.png)

But there is no option to *cancel* the removal of those dependencies. This PR adds a "Cancel" button to this dialog. If user clicks "Cancel", those dependencies won't be removed. The message of this dialog is changed accordingly:

![untitled](https://cloud.githubusercontent.com/assets/2600379/16257366/a81bac76-388a-11e6-91ff-d8170dcfc3a6.png)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@riteshchandawar @Racel : do you think the message on this dialog is OK? 
