### PR TITLE
MAGN-10013 Packages should get loaded once the new path is set for Packages, without relaunching the Dynamo.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
@@ -59,15 +59,11 @@ namespace Dynamo.ViewModels
         public DelegateCommand MovePathDownCommand { get; private set; }
         public DelegateCommand UpdatePathCommand { get; private set; }
         public DelegateCommand SaveSettingCommand { get; private set; }
-        private CustomNodeManager customNodeManager;
-        private PackageLoader pl;
 
-        public PackagePathViewModel(IPreferences setting, CustomNodeManager manager, PackageLoader packageloader)
+        public PackagePathViewModel(LoadAllParams loadAllParams)
         {
-            customNodeManager = manager;
-            pl = packageloader;
             RootLocations = new ObservableCollection<string>(setting.CustomPackageFolders);
-            this.setting = setting;
+            this.setting = loadAllParams.Preferences;
 
             AddPathCommand = new DelegateCommand(p => InsertPath());
             DeletePathCommand = new DelegateCommand(p => RemovePathAt((int) p), CanDelete);
@@ -169,7 +165,8 @@ namespace Dynamo.ViewModels
              {
                  customNodeManager.AddUninitializedCustomNodesInPath(pkg, false, false);
              }*/
-            pl.LoadAll(setting);
+            //pl.LoadAll(setting);
+            
         }
 
     }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
@@ -50,7 +50,10 @@ namespace Dynamo.ViewModels
             }
         }
 
-        private readonly IPreferences setting;
+        private IPreferences setting
+        {
+            get { return loadPackageParams.Preferences; }
+        }
         private readonly PackageLoader packageLoader;
         private readonly LoadPackageParams loadPackageParams;
         private readonly CustomNodeManager customNodeManager;
@@ -64,7 +67,6 @@ namespace Dynamo.ViewModels
 
         public PackagePathViewModel(PackageLoader loader, LoadPackageParams loadParams, CustomNodeManager customNodeManager)
         {
-            this.setting = loadParams.Preferences;
             this.packageLoader = loader;
             this.loadPackageParams = loadParams;
             this.customNodeManager = customNodeManager;

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
@@ -51,7 +51,9 @@ namespace Dynamo.ViewModels
         }
 
         private readonly IPreferences setting;
-
+        private readonly PackageLoader packageLoader;
+        private readonly LoadPackageParams loadPackageParams;
+        private readonly CustomNodeManager customNodeManager;
 
         public DelegateCommand AddPathCommand { get; private set; }
         public DelegateCommand DeletePathCommand { get; private set; }
@@ -60,10 +62,13 @@ namespace Dynamo.ViewModels
         public DelegateCommand UpdatePathCommand { get; private set; }
         public DelegateCommand SaveSettingCommand { get; private set; }
 
-        public PackagePathViewModel(LoadAllParams loadAllParams)
+        public PackagePathViewModel(PackageLoader loader, LoadPackageParams loadParams, CustomNodeManager customNodeManager)
         {
+            this.setting = loadParams.Preferences;
+            this.packageLoader = loader;
+            this.loadPackageParams = loadParams;
+            this.customNodeManager = customNodeManager;
             RootLocations = new ObservableCollection<string>(setting.CustomPackageFolders);
-            this.setting = loadAllParams.Preferences;
 
             AddPathCommand = new DelegateCommand(p => InsertPath());
             DeletePathCommand = new DelegateCommand(p => RemovePathAt((int) p), CanDelete);
@@ -161,12 +166,7 @@ namespace Dynamo.ViewModels
         private void CommitChanges(object param)
         {
             setting.CustomPackageFolders = new List<string>(RootLocations);
-            /* foreach(var pkg in setting.CustomPackageFolders)
-             {
-                 customNodeManager.AddUninitializedCustomNodesInPath(pkg, false, false);
-             }*/
-            //pl.LoadAll(setting);
-            
+            this.packageLoader.LoadCustomNodesAndPackages(loadPackageParams,customNodeManager);
         }
 
     }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
@@ -5,7 +5,8 @@ using System.Linq;
 using System.Text;
 using Dynamo.Interfaces;
 using DelegateCommand = Dynamo.UI.Commands.DelegateCommand;
-
+using Dynamo.Core;
+using Dynamo.PackageManager;
 
 namespace Dynamo.ViewModels
 {
@@ -58,9 +59,13 @@ namespace Dynamo.ViewModels
         public DelegateCommand MovePathDownCommand { get; private set; }
         public DelegateCommand UpdatePathCommand { get; private set; }
         public DelegateCommand SaveSettingCommand { get; private set; }
+        private CustomNodeManager customNodeManager;
+        private PackageLoader pl;
 
-        public PackagePathViewModel(IPreferences setting)
+        public PackagePathViewModel(IPreferences setting, CustomNodeManager manager, PackageLoader packageloader)
         {
+            customNodeManager = manager;
+            pl = packageloader;
             RootLocations = new ObservableCollection<string>(setting.CustomPackageFolders);
             this.setting = setting;
 
@@ -160,6 +165,11 @@ namespace Dynamo.ViewModels
         private void CommitChanges(object param)
         {
             setting.CustomPackageFolders = new List<string>(RootLocations);
+            /* foreach(var pkg in setting.CustomPackageFolders)
+             {
+                 customNodeManager.AddUninitializedCustomNodesInPath(pkg, false, false);
+             }*/
+            pl.LoadAll(setting);
         }
 
     }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -711,7 +711,7 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestPackagePaths(object sender, EventArgs e)
         {
-            var viewModel = new PackagePathViewModel(dynamoViewModel.PreferenceSettings);
+            var viewModel = new PackagePathViewModel(dynamoViewModel.PreferenceSettings,dynamoViewModel.Model.CustomNodeManager,dynamoViewModel.Model.GetPackageManagerExtension().PackageLoader);
             var view = new PackagePathView(viewModel) { Owner = this };
             view.ShowDialog();
         }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -711,7 +711,12 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestPackagePaths(object sender, EventArgs e)
         {
-            var viewModel = new PackagePathViewModel(dynamoViewModel.PreferenceSettings,dynamoViewModel.Model.CustomNodeManager,dynamoViewModel.Model.GetPackageManagerExtension().PackageLoader);
+            var loadAllParams = new LoadAllParams{
+                Preferences = dynamoViewModel.PreferenceSettings,
+                PathManager = dynamoViewModel.Model.PathManager,
+                CustomNodeManager = dynamoViewModel.Model.CustomNodeManager
+            };
+            var viewModel = new PackagePathViewModel(loadAllParams);
             var view = new PackagePathView(viewModel) { Owner = this };
             view.ShowDialog();
         }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -711,12 +711,13 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestPackagePaths(object sender, EventArgs e)
         {
-            var loadAllParams = new LoadAllParams{
+            var loadPackagesParams = new LoadPackageParams {
                 Preferences = dynamoViewModel.PreferenceSettings,
                 PathManager = dynamoViewModel.Model.PathManager,
-                CustomNodeManager = dynamoViewModel.Model.CustomNodeManager
             };
-            var viewModel = new PackagePathViewModel(loadAllParams);
+            var customNodeManager = dynamoViewModel.Model.CustomNodeManager;
+            var packageLoader = dynamoViewModel.Model.GetPackageManagerExtension().PackageLoader;
+            var viewModel = new PackagePathViewModel(packageLoader,loadPackagesParams,customNodeManager);
             var view = new PackagePathView(viewModel) { Owner = this };
             view.ShowDialog();
         }

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -8,6 +8,7 @@ using Dynamo.Logging;
 using Dynamo.Utilities;
 using DynamoPackages.Properties;
 using DynamoUtilities;
+using Dynamo.Core;
 
 namespace Dynamo.PackageManager
 {
@@ -15,6 +16,12 @@ namespace Dynamo.PackageManager
     {
         public IPreferences Preferences { get; set; }
         public IPathManager PathManager { get; set; }
+    }
+    public struct LoadAllParams
+    {
+        public IPreferences Preferences { get; set; }
+        public IPathManager PathManager { get; set; }
+        public CustomNodeManager CustomNodeManager { get; set; }
     }
 
     public enum AssemblyLoadingState
@@ -178,6 +185,17 @@ namespace Dynamo.PackageManager
             foreach (var pkg in LocalPackages)
             {
                 Load(pkg);
+            }
+        }
+        public void LoadCustomNodesAndPackages(LoadAllParams loadAllParams)
+        {
+            LoadAll(new LoadPackageParams
+            {
+                Preferences = loadAllParams.Preferences,
+                PathManager = loadAllParams.PathManager
+            });
+            foreach(var path in loadAllParams.Preferences.CustomPackageFolders){
+                loadAllParams.CustomNodeManager.AddUninitializedCustomNodesInPath(path, false, false);
             }
         }
 

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -17,12 +17,6 @@ namespace Dynamo.PackageManager
         public IPreferences Preferences { get; set; }
         public IPathManager PathManager { get; set; }
     }
-    public struct LoadAllParams
-    {
-        public IPreferences Preferences { get; set; }
-        public IPathManager PathManager { get; set; }
-        public CustomNodeManager CustomNodeManager { get; set; }
-    }
 
     public enum AssemblyLoadingState
     {
@@ -187,16 +181,16 @@ namespace Dynamo.PackageManager
                 Load(pkg);
             }
         }
-        public void LoadCustomNodesAndPackages(LoadAllParams loadAllParams)
+        public void LoadCustomNodesAndPackages(LoadPackageParams loadPackageParams, CustomNodeManager customNodeManager)
         {
-            LoadAll(new LoadPackageParams
-            {
-                Preferences = loadAllParams.Preferences,
-                PathManager = loadAllParams.PathManager
-            });
-            foreach(var path in loadAllParams.Preferences.CustomPackageFolders){
-                loadAllParams.CustomNodeManager.AddUninitializedCustomNodesInPath(path, false, false);
+            foreach(var path in loadPackageParams.Preferences.CustomPackageFolders){
+                customNodeManager.AddUninitializedCustomNodesInPath(path, false, false);
+                if (!this.packagesDirectories.Contains(path))
+                {
+                    this.packagesDirectories.Add(path);
+                }
             }
+            LoadAll(loadPackageParams);
         }
 
         private void ScanAllPackageDirectories(IPreferences preferences)

--- a/test/DynamoCoreWpfTests/PackagePathTests.cs
+++ b/test/DynamoCoreWpfTests/PackagePathTests.cs
@@ -10,6 +10,9 @@ using Dynamo.ViewModels;
 using NUnit.Framework;
 using Dynamo.PackageManager;
 using Dynamo.Core;
+using System.IO;
+using System.Reflection;
+using Dynamo.Models;
 
 namespace DynamoCoreWpfTests
 {
@@ -99,6 +102,27 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, vm.SelectedIndex);
             Assert.AreEqual(@"C:\", vm.RootLocations[0]);
             Assert.AreEqual(@"D:\", vm.RootLocations[1]);
+        }
+        [Test]
+        public void AddPackagePathsTest()
+        {
+            var setting = new PreferenceSettings()
+            {
+                CustomPackageFolders = { @"Z:\" }
+            };
+
+            var vm = CreatePackagePathViewModel(setting);
+
+            var path = string.Empty;
+            vm.RequestShowFileDialog += (sender, args) => { args.Path = path; };
+
+            var testDir = GetTestDirectory(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+            path = Path.Combine(testDir, @"core\packagePathTest");
+            var dynFilePath = Path.Combine(path, @"dynFile\Number1.dyn");
+            vm.AddPathCommand.Execute(null);
+            vm.SaveSettingCommand.Execute(null);
+            Model.ExecuteCommand(new DynamoModel.OpenFileCommand(dynFilePath));
+            Assert.AreEqual(1,GetPreviewValue("07d62dd8-b2f3-40a8-a761-013d93300444"));
         }
 
         #endregion

--- a/test/DynamoCoreWpfTests/PackagePathTests.cs
+++ b/test/DynamoCoreWpfTests/PackagePathTests.cs
@@ -8,7 +8,8 @@ using Dynamo;
 using Dynamo.Configuration;
 using Dynamo.ViewModels;
 using NUnit.Framework;
-
+using Dynamo.PackageManager;
+using Dynamo.Core;
 
 namespace DynamoCoreWpfTests
 {
@@ -22,7 +23,9 @@ namespace DynamoCoreWpfTests
             {
                 CustomPackageFolders = { @"C:\" }
             };
-            var vm = new PackagePathViewModel(setting);
+
+
+            var vm = CreatePackagePathViewModel(setting);
 
             Assert.AreEqual(1, vm.RootLocations.Count);
             Assert.IsFalse(vm.DeletePathCommand.CanExecute(null));
@@ -36,7 +39,7 @@ namespace DynamoCoreWpfTests
                 CustomPackageFolders = { @"C:\", @"D:\", @"E:\" }
             };
 
-            var vm = new PackagePathViewModel(setting);
+            var vm = CreatePackagePathViewModel(setting);
 
             Assert.AreEqual(0, vm.SelectedIndex);
             Assert.IsTrue(vm.MovePathDownCommand.CanExecute(null));
@@ -76,7 +79,7 @@ namespace DynamoCoreWpfTests
                 CustomPackageFolders = { @"Z:\" }
             };
 
-            var vm = new PackagePathViewModel(setting);
+            var vm = CreatePackagePathViewModel(setting);
 
             var path = string.Empty;
             vm.RequestShowFileDialog += (sender, args) => { args.Path = path; };
@@ -97,6 +100,21 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(@"C:\", vm.RootLocations[0]);
             Assert.AreEqual(@"D:\", vm.RootLocations[1]);
         }
+
+        #endregion
+        #region Setup methods
+        private PackagePathViewModel CreatePackagePathViewModel(PreferenceSettings setting)
+        {
+            PackageLoader loader = new PackageLoader(setting.CustomPackageFolders);
+            LoadPackageParams loadParams = new LoadPackageParams
+            {
+                Preferences = setting,
+                PathManager = Model.PathManager
+            };
+            CustomNodeManager customNodeManager = Model.CustomNodeManager;
+            return new PackagePathViewModel(loader, loadParams, customNodeManager);
+        }
+
         #endregion
     }
 }

--- a/test/core/packagePathTest/Number1.dyf
+++ b/test/core/packagePathTest/Number1.dyf
@@ -1,0 +1,18 @@
+<Workspace Version="1.0.1.1732" X="0" Y="0" zoom="1" Name="Number1" Description="" ID="bdc7628c-cbd5-48e9-8ad0-9aad539ed4d2" Category="Number1">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="97322176-242b-4af4-875b-a706b0048cae" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="250" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="1;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CustomNodes.Output guid="a454fcbe-5a16-4db5-b073-61fd19bf5416" type="Dynamo.Graph.Nodes.CustomNodes.Output" nickname="Output" x="404" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <Symbol value="" />
+    </Dynamo.Graph.Nodes.CustomNodes.Output>
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="97322176-242b-4af4-875b-a706b0048cae" start_index="0" end="a454fcbe-5a16-4db5-b073-61fd19bf5416" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>

--- a/test/core/packagePathTest/dynFile/Number1.dyn
+++ b/test/core/packagePathTest/dynFile/Number1.dyn
@@ -1,0 +1,21 @@
+<Workspace Version="1.0.1.1732" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CustomNodes.Function guid="07d62dd8-b2f3-40a8-a761-013d93300444" type="Dynamo.Graph.Nodes.CustomNodes.Function" nickname="Number1" x="231" y="192" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <ID value="bdc7628c-cbd5-48e9-8ad0-9aad539ed4d2" />
+      <Name value="Number1" />
+      <Description value="" />
+      <Inputs />
+      <Outputs>
+        <Output value="" />
+      </Outputs>
+    </Dynamo.Graph.Nodes.CustomNodes.Function>
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose
Reference: [MAGN-10013](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10013)
This PR is to fix the issue of packages and customNodes not being imported when a new path is added.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 
