### PR TITLE
Resolve to a higher version of Dynamo Core

### DIFF
--- a/src/Tools/DynamoInstallDetective/ProductLookUp.cs
+++ b/src/Tools/DynamoInstallDetective/ProductLookUp.cs
@@ -319,6 +319,18 @@ namespace DynamoInstallDetective
             this.debugPath = debugPath;
         }
 
+        public static string GetDynamoPath(Version version, string debugPath = null)
+        {
+            var installs = FindDynamoInstallations(debugPath);
+            if (installs == null) return string.Empty;
+
+            return installs.Products
+                .Where(p => p.VersionInfo.Item1 == version.Major)
+                .Where(p => p.VersionInfo.Item2 >= version.Minor)
+                .Select(p => p.InstallLocation)
+                .LastOrDefault();
+        }
+
         public static DynamoProducts FindDynamoInstallations(string debugPath = null, IProductLookUp lookUp = null)
         {
             var products = new DynamoProducts(debugPath);


### PR DESCRIPTION
### Purpose

- A portion of code to resolve Dynamo Core and determine a matching version was duplicated between Dynamo Sandbox, Dynamo Revit, and Dynamo Studio. Now it is refactored to be inside *DynamoInstallDetective.dll*

- *DynamoSandbox.exe* inside Dynamo Revit folder should be able to resolve the installation of Dynamo Core **minor**-versioned equal to or higher than the *.exe* itself. If it is not able to resolve, display a message. It should not crash or just disappear.

- Any suggestions for better/concise message text is more than welcome - since the current wording does not really convey clearly about the major/minor version numbers.

### Declarations

- [ ] User facing strings, if any, are extracted into `*.resx` files - *The strings which indicate "Dynamo Core is not resolved" are not put into* `.resx` *files because the resources file will not be accessible without resolving Dynamo Core.*

### Screenshot

The following dialog will appear when opening *DynamoSandbox.exe* inside `%PROGRAMFILES%\Dynamo\Dynamo Revit\1.0` but without an existing Dynamo Core installation in `%PROGRAMFILES%\Dynamo\Dynamo Core\1.0`.

![image](https://cloud.githubusercontent.com/assets/6386550/16269009/3c595c8e-38c3-11e6-8264-c8d95f421567.png)

### Reviewers

@sharadkjaiswal

### FYIs

@riteshchandawar @sh4nnongoh