### PR TITLE
Fix for MAGN-10250

### DIFF
--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -402,6 +402,21 @@ namespace Dynamo.Engine
             return importedFunctionGroups.ContainsKey(library);
         }
 
+        /// <summary>
+        /// Checks if a given function is in the builtinFunctionGroups so we do not necessarily look for it's library.
+        /// </summary>
+        /// <param name="library">assembly name</param>
+        /// <param name="nickname">nick name, used for searching as key with default value ""</param>
+        /// <returns></returns>
+        internal bool IsFunctionBuiltIn(string library, string nickname = "")
+        {
+            // For Nodes with Assembly 
+            if (library == "BuiltIn" || library == "Operators")
+                return builtinFunctionGroups.ContainsKey(nickname);
+            else
+                return false;
+        }
+
         private static bool CanbeResolvedTo(ICollection<string> partialName, ICollection<string> fullName)
         {
             return null != partialName && null != fullName && partialName.Count <= fullName.Count

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -412,9 +412,13 @@ namespace Dynamo.Engine
         {
             // For Nodes with not .dll specific Assembly tag
             if (library == Categories.BuiltIn || library == Categories.Operators)
+            {
                 return builtinFunctionGroups.ContainsKey(nickname);
+            }
             else
+            {
                 return false;
+            }
         }
 
         private static bool CanbeResolvedTo(ICollection<string> partialName, ICollection<string> fullName)

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -725,11 +725,11 @@ namespace Dynamo.Engine
                                                                 IsVisibleInLibrary = visibleInLibrary,
                                                                 IsBuiltIn = true,
                                                                 IsPackageMember = false,
-                                                                Assembly = "BuiltIn"
+                                                                Assembly = Categories.BuiltIn
                                                             });
 
             AddBuiltinFunctions(functions);
-            LoadLibraryMigrations("BuiltIn");
+            LoadLibraryMigrations(Categories.BuiltIn);
         }
 
         private static IEnumerable<TypedParameter> GetBinaryFuncArgs()

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -1000,7 +1000,7 @@ namespace Dynamo.Engine
 
         public static class Categories
         {
-            public const string BuiltIn = "BUiltIn";
+            public const string BuiltIn = "BuiltIn";
             public const string BuiltIns = "Builtin Functions";
             public const string Operators = "Operators";
             public const string Constructors = "Create";

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -411,7 +411,7 @@ namespace Dynamo.Engine
         internal bool IsFunctionBuiltIn(string library, string nickname = "")
         {
             // For Nodes with Assembly 
-            if (library == "BuiltIn" || library == "Operators")
+            if (library == Categories.BuiltIn || library == Categories.Operators)
                 return builtinFunctionGroups.ContainsKey(nickname);
             else
                 return false;
@@ -768,7 +768,7 @@ namespace Dynamo.Engine
                     FunctionType = FunctionType.GenericFunction,
                     IsBuiltIn = true,
                     IsPackageMember = false,
-                    Assembly = "Operators"
+                    Assembly = Categories.Operators
                 }))
                 .Concat(new FunctionDescriptor(new FunctionDescriptorParams
                 {
@@ -778,7 +778,7 @@ namespace Dynamo.Engine
                     FunctionType = FunctionType.GenericFunction,
                     IsBuiltIn = true,
                     IsPackageMember = false,
-                    Assembly = "Operators"
+                    Assembly = Categories.Operators
                 }).AsSingleton());
 
             AddBuiltinFunctions(functions);
@@ -1000,6 +1000,7 @@ namespace Dynamo.Engine
 
         public static class Categories
         {
+            public const string BuiltIn = "BUiltIn";
             public const string BuiltIns = "Builtin Functions";
             public const string Operators = "Operators";
             public const string Constructors = "Create";

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -403,14 +403,14 @@ namespace Dynamo.Engine
         }
 
         /// <summary>
-        /// Checks if a given function is in the builtinFunctionGroups so we do not necessarily look for it's library.
+        /// Checks if a given function is in the builtinFunctionGroups so we do not necessarily look for it's library based on its Assembly tag
         /// </summary>
         /// <param name="library">assembly name</param>
         /// <param name="nickname">nick name, used for searching as key with default value ""</param>
         /// <returns></returns>
         internal bool IsFunctionBuiltIn(string library, string nickname = "")
         {
-            // For Nodes with Assembly 
+            // For Nodes with not .dll specific Assembly tag
             if (library == Categories.BuiltIn || library == Categories.Operators)
                 return builtinFunctionGroups.ContainsKey(nickname);
             else

--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -262,19 +262,19 @@ namespace Dynamo.Tests
         {
             string nickName, categoryName;
 
-            nickName = "/"; categoryName = "Operators";
+            nickName = "/"; categoryName = LibraryServices.Categories.Operators;
             Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
 
-            nickName = "*"; categoryName = "Operators";
+            nickName = "*"; categoryName = LibraryServices.Categories.Operators;
             Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
 
             nickName = "=="; categoryName = "";
             Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
 
-            nickName = "AllFalse"; categoryName = "BuiltIn";
+            nickName = "AllFalse"; categoryName = LibraryServices.Categories.BuiltIn;
             Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
 
-            nickName = "SetUnion"; categoryName = "BuiltIn";
+            nickName = "SetUnion"; categoryName = LibraryServices.Categories.BuiltIn;
             Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
 
             nickName = "Reorder"; categoryName = "";
@@ -283,7 +283,7 @@ namespace Dynamo.Tests
             nickName = ""; categoryName = "";
             Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
 
-            nickName = ""; categoryName = "BuiltIn";
+            nickName = ""; categoryName = LibraryServices.Categories.BuiltIn;
             Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
 
         }

--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -256,6 +256,38 @@ namespace Dynamo.Tests
             }
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void TestBuiltInFunctionRecognition()
+        {
+            string nickName, categoryName;
+
+            nickName = "/"; categoryName = "Operators";
+            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+
+            nickName = "*"; categoryName = "Operators";
+            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+
+            nickName = "=="; categoryName = "";
+            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+
+            nickName = "AllFalse"; categoryName = "BuiltIn";
+            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+
+            nickName = "SetUnion"; categoryName = "BuiltIn";
+            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+
+            nickName = "Reorder"; categoryName = "";
+            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+
+            nickName = ""; categoryName = "";
+            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+
+            nickName = ""; categoryName = "BuiltIn";
+            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10250
MAGN-10250 Opening dyn with builtIn nodes give "Failed to load: Builtin" and "Operators" console exceptions

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 

### FYIs

@jnealb @sm6srw @ramramps 

1. Re-order the ZerotouchLibraryLoad Code for easier understanding
2. Added one function in LibraryServices.cs to check if one function is
in BuiltInFunctionGroup