### PR TITLE
Add dotcover commands for report creation

### DIFF
--- a/src/htmlreport.xml
+++ b/src/htmlreport.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReportParams>
+  <Source>Snapshot.dcvr</Source>
+  <Output>CoverageReport.html</Output>
+  <ReportType>html</ReportType>
+</ReportParams>

--- a/src/xmlreport.xml
+++ b/src/xmlreport.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReportParams>
+<WorkingDir>..\bin\AnyCPU\Release\</WorkingDir>
+  <Source>Snapshot.dcvr</Source>
+  <Output>CoverageReport.xml</Output>
+  <ReportType>xml</ReportType>
+</ReportParams>


### PR DESCRIPTION
### To create xml and html report from the dotcover snapshot

1) Xml reports are required for email diff
2) html reports are required to analyze the code that is not covered by tests.

