### PR TITLE
Enable geometry view for watch3d node

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -225,6 +225,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
             Name = Resources.BackgroundPreviewDefaultName;
             isGridVisible = parameters.Preferences.IsBackgroundGridVisible;
+            active = parameters.Preferences.IsBackgroundPreviewActive;
             logger = parameters.Logger;
 
             RegisterEventHandlers();


### PR DESCRIPTION
### Purpose

This is to fix github issue #6685 that watch 3D node is not working. 

Need to initialize Active state of watch 3D node.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@riteshchandawar 

