### PR TITLE
New note should always be on the top of all nodes/notes

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -491,6 +491,7 @@ namespace Dynamo.ViewModels
             IsNodeAddedRecently = true;
             DynamoSelection.Instance.Selection.CollectionChanged += SelectionOnCollectionChanged;
             ZIndex = ++StaticZIndex;
+            ++NoteViewModel.StaticZIndex;
         }
  
         public NodeViewModel(WorkspaceViewModel workspaceViewModel, NodeModel logic, Size preferredSize)

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -71,9 +71,9 @@ namespace Dynamo.ViewModels
         /// </summary>
         public int ZIndex
          {
-                get { return zIndex; }
+
+            get { return zIndex; }
             set { zIndex = value; RaisePropertyChanged("ZIndex"); }
-            //set { zIndex = value; }
         }
 
         public string Text

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -29,6 +29,7 @@ namespace Dynamo.ViewModels
         private NoteModel _model;
         public readonly WorkspaceViewModel WorkspaceViewModel;
         private int zIndex = Configurations.NodeStartZIndex; // initialize the start Z-Index of a note to the same as that of a node
+        internal static int StaticZIndex = Configurations.NodeStartZIndex; 
 
         public NoteModel Model
         {

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -96,8 +96,6 @@ namespace Dynamo.ViewModels
             _model = model;
             model.PropertyChanged += note_PropertyChanged;
             DynamoSelection.Instance.Selection.CollectionChanged += SelectionOnCollectionChanged;
-
-            StaticZIndex = NodeViewModel.StaticZIndex;
             ZIndex = ++StaticZIndex; // places the note on top of all nodes/notes
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -97,7 +97,8 @@ namespace Dynamo.ViewModels
             model.PropertyChanged += note_PropertyChanged;
             DynamoSelection.Instance.Selection.CollectionChanged += SelectionOnCollectionChanged;
 
-            ZIndex = ++NodeViewModel.StaticZIndex; // places the note on top of all nodes/notes
+            StaticZIndex = NodeViewModel.StaticZIndex;
+            ZIndex = ++StaticZIndex; // places the note on top of all nodes/notes
         }
 
         private void SelectionOnCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -5,6 +5,7 @@ using Dynamo.Graph.Notes;
 using Dynamo.Models;
 using Dynamo.Selection;
 using Dynamo.Wpf.ViewModels.Core;
+using Dynamo.Configuration;
 
 namespace Dynamo.ViewModels
 {
@@ -27,6 +28,7 @@ namespace Dynamo.ViewModels
 
         private NoteModel _model;
         public readonly WorkspaceViewModel WorkspaceViewModel;
+        private int zIndex = Configurations.NodeStartZIndex; // initialize the start Z-Index of a note to the same as that of a node
 
         public NoteModel Model
         {
@@ -64,9 +66,24 @@ namespace Dynamo.ViewModels
             }
         }
 
-        public double ZIndex
-        {
-            get { return 3; }
+        /// <summary>
+        /// ZIndex is used to order nodes, when some node is clicked.
+        /// This selected node should be moved above others.
+        /// Start value of zIndex is 3, because 1 is for groups and 2 is for connectors.
+        /// Nodes should be always at the top.
+        /// 
+        /// Static is used because every node should know what is the highest z-index right now.
+        /// </summary>
+        internal static int StaticZIndex = Configurations.NodeStartZIndex;
+ 
+ 
+        /// <summary>
+        /// ZIndex represents the order on the z-plane in which the notes and other objects appear. 
+        /// </summary>
+        public int ZIndex
+         {
+                get { return zIndex; }
+                set { zIndex = value; RaisePropertyChanged("ZIndex"); }
         }
 
         public string Text
@@ -88,6 +105,8 @@ namespace Dynamo.ViewModels
             _model = model;
             model.PropertyChanged += note_PropertyChanged;
             DynamoSelection.Instance.Selection.CollectionChanged += SelectionOnCollectionChanged;
+
+            ZIndex = ++NodeViewModel.StaticZIndex; // places the note on top of all nodes/notes
         }
 
         private void SelectionOnCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -67,23 +67,13 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// ZIndex is used to order nodes, when some node is clicked.
-        /// This selected node should be moved above others.
-        /// Start value of zIndex is 3, because 1 is for groups and 2 is for connectors.
-        /// Nodes should be always at the top.
-        /// 
-        /// Static is used because every node should know what is the highest z-index right now.
-        /// </summary>
-        internal static int StaticZIndex = Configurations.NodeStartZIndex;
- 
- 
-        /// <summary>
         /// ZIndex represents the order on the z-plane in which the notes and other objects appear. 
         /// </summary>
         public int ZIndex
          {
                 get { return zIndex; }
-                set { zIndex = value; RaisePropertyChanged("ZIndex"); }
+            set { zIndex = value; RaisePropertyChanged("ZIndex"); }
+            //set { zIndex = value; }
         }
 
         public string Text

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -572,7 +572,7 @@ namespace Dynamo.Controls
             if (parent == null) return;
             NoteViewModel.StaticZIndex = index + 1;
 
-            foreach (var child in parent.ChildrenOfType<NoteView>())
+            foreach (var child in parent.ChildrenOfType<NodeView>())
             {
                 child.ViewModel.ZIndex = NoteViewModel.StaticZIndex;
             }

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -127,6 +127,7 @@ namespace Dynamo.Controls
             nodeBorder.SizeChanged += OnSizeChanged;
             DataContextChanged += OnDataContextChanged;
 
+
             Panel.SetZIndex(this, 1);
         }
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -565,6 +565,7 @@ namespace Dynamo.Controls
             }
 
             var index = ++NodeViewModel.StaticZIndex;
+            ++NoteViewModel.StaticZIndex; // increment the NoteViewModel ZIndex - how will the current Notes be updated?
 
             oldZIndex = nodeWasClicked ? index : ViewModel.ZIndex;
             ViewModel.ZIndex = index;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -19,6 +19,7 @@ using System.Windows.Threading;
 using DynCmd = Dynamo.Models.DynamoModel;
 
 using Dynamo.UI.Controls;
+using Dynamo.Nodes;
 
 namespace Dynamo.Controls
 {
@@ -565,7 +566,16 @@ namespace Dynamo.Controls
             }
 
             var index = ++NodeViewModel.StaticZIndex;
-            ++NoteViewModel.StaticZIndex; // increment the NoteViewModel ZIndex - how will the current Notes be updated?
+
+            // increment all Notes to ensure that they are always above any Node
+            var parent = TemplatedParent as ContentPresenter;
+            if (parent == null) return;
+            NoteViewModel.StaticZIndex = index + 1;
+
+            foreach (var child in parent.ChildrenOfType<NoteView>())
+            {
+                child.ViewModel.ZIndex = NoteViewModel.StaticZIndex;
+            }
 
             oldZIndex = nodeWasClicked ? index : ViewModel.ZIndex;
             ViewModel.ZIndex = index;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -568,13 +568,11 @@ namespace Dynamo.Controls
             var index = ++NodeViewModel.StaticZIndex;
 
             // increment all Notes to ensure that they are always above any Node
-            var parent = TemplatedParent as ContentPresenter;
-            if (parent == null) return;
             NoteViewModel.StaticZIndex = index + 1;
 
-            foreach (var child in parent.ChildrenOfType<NodeView>())
+            foreach (var note in ViewModel.WorkspaceViewModel.Notes)
             {
-                child.ViewModel.ZIndex = NoteViewModel.StaticZIndex;
+                note.ZIndex = NoteViewModel.StaticZIndex;
             }
 
             oldZIndex = nodeWasClicked ? index : ViewModel.ZIndex;

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -443,7 +443,7 @@ namespace Dynamo.Controls
             nodeWasClicked = false;
 
             // Always set old ZIndex to the last value, even if mouse is not over the node.
-            //oldZIndex = NodeViewModel.StaticZIndex;
+            oldZIndex = NodeViewModel.StaticZIndex;
 
             // There is no need run further.
             if (IsPreviewDisabled()) return;
@@ -459,7 +459,7 @@ namespace Dynamo.Controls
                 PreviewControl.TransitionToState(PreviewControl.State.Condensed);
             }
 
-            //Dispatcher.DelayInvoke(previewDelay, BringToFront);
+            Dispatcher.DelayInvoke(previewDelay, BringToFront);
         }
 
         private bool IsPreviewDisabled()
@@ -478,7 +478,7 @@ namespace Dynamo.Controls
 
         private void OnNodeViewMouseLeave(object sender, MouseEventArgs e)
         {
-           // ViewModel.ZIndex = oldZIndex;
+            ViewModel.ZIndex = oldZIndex;
 
             // If mouse in over node/preview control or preview control is pined, we can not hide preview control.
             if (IsMouseOver || PreviewControl.IsMouseOver || PreviewControl.StaysOpen ||

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -443,7 +443,7 @@ namespace Dynamo.Controls
             nodeWasClicked = false;
 
             // Always set old ZIndex to the last value, even if mouse is not over the node.
-            oldZIndex = NodeViewModel.StaticZIndex;
+            //oldZIndex = NodeViewModel.StaticZIndex;
 
             // There is no need run further.
             if (IsPreviewDisabled()) return;
@@ -459,7 +459,7 @@ namespace Dynamo.Controls
                 PreviewControl.TransitionToState(PreviewControl.State.Condensed);
             }
 
-            Dispatcher.DelayInvoke(previewDelay, BringToFront);
+            //Dispatcher.DelayInvoke(previewDelay, BringToFront);
         }
 
         private bool IsPreviewDisabled()
@@ -478,7 +478,7 @@ namespace Dynamo.Controls
 
         private void OnNodeViewMouseLeave(object sender, MouseEventArgs e)
         {
-            ViewModel.ZIndex = oldZIndex;
+           // ViewModel.ZIndex = oldZIndex;
 
             // If mouse in over node/preview control or preview control is pined, we can not hide preview control.
             if (IsMouseOver || PreviewControl.IsMouseOver || PreviewControl.StaysOpen ||

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
@@ -142,6 +142,11 @@ namespace Dynamo.Nodes
             {
                 child.ViewModel.ZIndex = Configurations.NodeStartZIndex;
             }
+
+            foreach(var child in parent.ChildrenOfType<Controls.NodeView>())
+            {
+                child.ViewModel.ZIndex = Configurations.NodeStartZIndex;
+            }
         }
    }
 }

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
@@ -138,11 +138,13 @@ namespace Dynamo.Nodes
             var parent = TemplatedParent as ContentPresenter;
             if (parent == null) return;
 
+            // reset the ZIndex for all Notes
             foreach (var child in parent.ChildrenOfType<NoteView>())
             {
                 child.ViewModel.ZIndex = Configurations.NodeStartZIndex;
             }
-
+            
+            // reset the ZIndex for all Nodes
             foreach(var child in parent.ChildrenOfType<Controls.NodeView>())
             {
                 child.ViewModel.ZIndex = Configurations.NodeStartZIndex;

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
@@ -9,6 +9,8 @@ using Dynamo.UI.Prompts;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using DynCmd = Dynamo.Models.DynamoModel;
+using Dynamo.Configuration;
+using System.Windows.Controls;
 
 namespace Dynamo.Nodes
 {
@@ -77,6 +79,8 @@ namespace Dynamo.Nodes
             System.Guid noteGuid = this.ViewModel.Model.GUID;
             ViewModel.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(
                 new DynCmd.SelectModelCommand(noteGuid, Keyboard.Modifiers.AsDynamoType()));
+            BringToFront();
+           
         }
 
         private void OnEditItemClick(object sender, RoutedEventArgs e)
@@ -108,5 +112,36 @@ namespace Dynamo.Nodes
                 e.Handled = true;
             }
         }
-    }
+
+        /// <summary>
+        /// Sets ZIndex of the particular note to be the highest in the workspace
+        /// This brings the note to the forefront of the workspace when clicked
+        /// </summary>
+        private void BringToFront()
+        {
+            if (NodeViewModel.StaticZIndex == int.MaxValue)
+            {
+                PrepareZIndex();
+            }
+            
+            ViewModel.ZIndex = ++NodeViewModel.StaticZIndex;
+        }
+
+
+        /// <summary>
+        /// If ZIndex is more then max value of int, it should be set back to 0 for all elements.
+        /// </summary>
+        private void PrepareZIndex()
+        {
+            NodeViewModel.StaticZIndex = Configurations.NodeStartZIndex;
+
+            var parent = TemplatedParent as ContentPresenter;
+            if (parent == null) return;
+
+            foreach (var child in parent.ChildrenOfType<NoteView>())
+            {
+                child.ViewModel.ZIndex = Configurations.NodeStartZIndex;
+            }
+        }
+   }
 }

--- a/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NoteView.xaml.cs
@@ -119,12 +119,12 @@ namespace Dynamo.Nodes
         /// </summary>
         private void BringToFront()
         {
-            if (NodeViewModel.StaticZIndex == int.MaxValue)
+            if (NoteViewModel.StaticZIndex == int.MaxValue)
             {
                 PrepareZIndex();
             }
             
-            ViewModel.ZIndex = ++NodeViewModel.StaticZIndex;
+            ViewModel.ZIndex = ++NoteViewModel.StaticZIndex;
         }
 
 
@@ -133,7 +133,7 @@ namespace Dynamo.Nodes
         /// </summary>
         private void PrepareZIndex()
         {
-            NodeViewModel.StaticZIndex = Configurations.NodeStartZIndex;
+            NoteViewModel.StaticZIndex = Configurations.NodeStartZIndex;
 
             var parent = TemplatedParent as ContentPresenter;
             if (parent == null) return;

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="..\..\src\AssemblySharedInfoGenerator\AssemblySharedInfo.cs">
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
+    <Compile Include="NoteViewTests.cs" />
     <Compile Include="NodeViewTests.cs" />
     <Compile Include="NodeExecutionUITest.cs" />
     <Compile Include="CustomNodeTests.cs" />

--- a/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
+++ b/test/DynamoCoreWpfTests/DynamoTestUIBase.cs
@@ -10,6 +10,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.Scheduler;
 using Dynamo.ViewModels;
+using Dynamo.Nodes;
 using DynamoCoreWpfTests.Utility;
 using DynamoShapeManager;
 using NUnit.Framework;
@@ -198,6 +199,15 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, nodeViewsOfType.Count(), "Expected a single NodeView with guid: " + guid);
 
             return nodeViewsOfType.First();
+        }
+
+        public NoteView NoteViewWithGuid(string guid)
+        {
+            var noteViews = View.NoteViewsInFirstWorkspace();
+            var noteViewsOfType = noteViews.Where(x => x.ViewModel.Model.GUID.ToString() == guid);
+            Assert.AreEqual(1, noteViewsOfType.Count(), "Expected a single NoteView with guid: " + guid);
+
+            return noteViewsOfType.First();
         }
 
         #endregion

--- a/test/DynamoCoreWpfTests/NoteViewTests.cs
+++ b/test/DynamoCoreWpfTests/NoteViewTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Linq;
+using Dynamo.Selection;
+using DynamoCoreWpfTests.Utility;
+using NUnit.Framework;
+using System.Windows.Input;
+using Dynamo.Nodes;
+using System.Windows.Controls;
+
+namespace DynamoCoreWpfTests
+{
+    public class NoteViewTests : DynamoTestUIBase
+    {
+        // adapted from NodeViewTests.cs
+
+        public override void Open(string path)
+        {
+            base.Open(path);
+
+            DispatcherUtil.DoEvents();
+        }
+
+        public override void Run()
+        {
+            base.Run();
+
+            DispatcherUtil.DoEvents();
+        }
+
+        [Test]
+        public void T01_ZIndex_Test_MouseDown()
+        {
+            // Reset zindex to start value.
+            Dynamo.ViewModels.NoteViewModel.StaticZIndex = 3;
+            Open(@"UI\UINotes.dyn");
+
+            var noteView = NoteViewWithGuid("4677e999-d5f5-4bb2-9706-a97bf3a86711");
+
+            // Index of first note == 5.
+            Assert.AreEqual(5, noteView.ViewModel.ZIndex);
+            Assert.AreEqual(3 + ViewModel.HomeSpace.Notes.Count() + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NoteViewModel.StaticZIndex);
+
+            noteView.noteText.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Mouse.PreviewMouseDownEvent,
+                Source = this,
+            });
+            Assert.AreEqual(noteView.ViewModel.ZIndex, Dynamo.ViewModels.NoteViewModel.StaticZIndex);
+        }
+
+        [Test]
+        public void T02_ZIndex_Test_NoteGreaterThanNode()
+        {
+            //Reset ZIndex to start value for both NoteViewModel and NodeViewModel
+            Dynamo.ViewModels.NoteViewModel.StaticZIndex = 3;
+            Dynamo.ViewModels.NodeViewModel.StaticZIndex = 3;
+
+            Open(@"UI\UINotes.dyn");
+            var noteView = NoteViewWithGuid("4677e999-d5f5-4bb2-9706-a97bf3a86711");
+
+            // Index of First Note (initially) == 5
+            Assert.AreEqual(5, noteView.ViewModel.ZIndex);
+            Assert.AreEqual(3 + ViewModel.HomeSpace.Notes.Count() + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NoteViewModel.StaticZIndex);
+
+            // Index of First Node (initally) == 4
+            var nodeView = NodeViewWithGuid("bbc16882-75c2-4a50-a4e4-5e50e191af8f");
+            Assert.AreEqual(4, nodeView.ViewModel.ZIndex);
+            Assert.AreEqual(3 + ViewModel.HomeSpace.Nodes.Count(), Dynamo.ViewModels.NodeViewModel.StaticZIndex);
+
+
+            Assert.Greater(Dynamo.ViewModels.NoteViewModel.StaticZIndex, Dynamo.ViewModels.NodeViewModel.StaticZIndex);
+        }
+
+        [Test]
+        public void T03_Mousedown_NoteGreaterThanNode()
+        {
+            //Reset ZIndex to start value for both NoteViewModel and NodeViewModel
+            Dynamo.ViewModels.NoteViewModel.StaticZIndex = 3;
+            Dynamo.ViewModels.NodeViewModel.StaticZIndex = 3;
+
+            Open(@"UI\UINotes.dyn");
+            var noteView = NoteViewWithGuid("4677e999-d5f5-4bb2-9706-a97bf3a86711");
+            var nodeView = NodeViewWithGuid("bbc16882-75c2-4a50-a4e4-5e50e191af8f");
+
+            // Click on First Node
+            nodeView.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Mouse.PreviewMouseDownEvent,
+                Source = this,
+            });
+            Assert.AreEqual(5, nodeView.ViewModel.ZIndex);
+
+            // Check if First Note's ZIndex is greater than First Node after click
+            Assert.Greater(noteView.ViewModel.ZIndex, nodeView.ViewModel.ZIndex);
+        }
+    }
+}

--- a/test/DynamoCoreWpfTests/Utility/ViewExtensions.cs
+++ b/test/DynamoCoreWpfTests/Utility/ViewExtensions.cs
@@ -6,6 +6,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.Utilities;
 using Dynamo.Views;
+using Dynamo.Nodes;
 
 namespace DynamoCoreWpfTests.Utility
 {
@@ -24,6 +25,16 @@ namespace DynamoCoreWpfTests.Utility
         public static IEnumerable<NodeView> NodeViewsInFirstWorkspace(this DynamoView dynamoView)
         {
             return dynamoView.WorkspaceTabs.ChildrenOfType<WorkspaceView>().First().ChildNodeViews();
+        }
+
+        public static IEnumerable<NoteView> ChildNoteViews(this WorkspaceView noteViews)
+        {
+            return noteViews.ChildrenOfType<NoteView>();
+        }
+
+        public static IEnumerable<NoteView> NoteViewsInFirstWorkspace(this DynamoView dynamoView)
+        {
+            return dynamoView.WorkspaceTabs.ChildrenOfType<WorkspaceView>().First().ChildNoteViews();
         }
     }
 }

--- a/test/UI/UINotes.dyn
+++ b/test/UI/UINotes.dyn
@@ -1,0 +1,17 @@
+<Workspace Version="1.0.1.1823" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <CoreNodeModels.Input.DoubleInput guid="bbc16882-75c2-4a50-a4e4-5e50e191af8f" type="CoreNodeModels.Input.DoubleInput" nickname="Number" x="584.5" y="397.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <System.Double value="0" />
+    </CoreNodeModels.Input.DoubleInput>
+  </Elements>
+  <Connectors />
+  <Notes>
+    <Dynamo.Graph.Notes.NoteModel guid="4677e999-d5f5-4bb2-9706-a97bf3a86711" text="New Note" x="140.5" y="193.5" />
+  </Notes>
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

1. When adding a new note, the note will now appear on the top of the graph (i.e. not buried under everything else). 

2. Additional Bonus: When selecting a note, the note will be brought to the front, in front of all other objects.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

### FYIs

@monikaprabhu 

