### PR TITLE
Update LibraryTests: not using Options.RootCustomPropertyFilterPathName

### DIFF
--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -24,7 +24,7 @@ namespace Dynamo.Tests
         {
             base.Setup();
 
-            libraryCore = new ProtoCore.Core(new Options { RootCustomPropertyFilterPathName = string.Empty });
+            libraryCore = new ProtoCore.Core(new Options());
             libraryCore.Compilers.Add(Language.Associative, new ProtoAssociative.Compiler(libraryCore));
             libraryCore.Compilers.Add(Language.Imperative, new ProtoImperative.Compiler(libraryCore));
             libraryCore.ParsingMode = ParseMode.AllowNonAssignment;

--- a/test/DynamoCoreWpfTests/LibraryTests.cs
+++ b/test/DynamoCoreWpfTests/LibraryTests.cs
@@ -28,7 +28,7 @@ namespace DynamoCoreWpfTests
         {
             base.Setup();
 
-            libraryCore = new ProtoCore.Core(new Options { RootCustomPropertyFilterPathName = string.Empty });
+            libraryCore = new ProtoCore.Core(new Options());
             libraryCore.Compilers.Add(Language.Associative, new ProtoAssociative.Compiler(libraryCore));
             libraryCore.Compilers.Add(Language.Imperative, new ProtoImperative.Compiler(libraryCore));
             libraryCore.ParsingMode = ParseMode.AllowNonAssignment;


### PR DESCRIPTION
### Purpose

LibraryTests fail because they try to initialize `ProtoCore.Options.RootCustomPropertyFilterPathName`, but this property has been removed. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 

