### PR TITLE
Remove error code from engine's error message

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1118,11 +1118,10 @@ namespace ProtoCore
                 //If this has failed, we have multiple feps, which can't be distiquished by class hiearchy. Emit a warning and select one
                 StringBuilder possibleFuncs = new StringBuilder();
                 possibleFuncs.Append(Resources.MultipleFunctionsFound);
+                possibleFuncs.AppendLine();
+                possibleFuncs.AppendLine();
                 foreach (FunctionEndPoint fep in feps)
-                    possibleFuncs.AppendLine("\t" + fep.ToString());
-
-
-                possibleFuncs.AppendLine(string.Format(Resources.ErrorCode, "{DCE486C0-0975-49F9-BE2C-2E7D8CCD17DD}"));
+                    possibleFuncs.AppendLine("    " + fep.ToString());
 
                 runtimeCore.RuntimeStatus.LogWarning(WarningID.AmbiguousMethodDispatch, possibleFuncs.ToString());
             }

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -386,15 +386,6 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error code: {0}.
-        /// </summary>
-        public static string ErrorCode {
-            get {
-                return ResourceManager.GetString("ErrorCode", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Null value cannot be cast to {0}.
         /// </summary>
         public static string FailedToCastFromNull {

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -971,7 +971,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Internal error, please report: Function could not be found on final dispatch (e5235508).
+        ///   Looks up a localized string similar to Internal error, please report: Function could not be found on final dispatch..
         /// </summary>
         public static string kAmbigousMethodDispatch {
             get {
@@ -1106,7 +1106,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Internal error, please report: Dereferencing a non-pointer. (3f47aacd).
+        ///   Looks up a localized string similar to Internal error, please report: Dereferencing a non-pointer..
         /// </summary>
         public static string kDeferencingNonPointer {
             get {
@@ -1259,7 +1259,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Internal error, please report: Statement break causes function to abnormally return null. (6ced82a9).
+        ///   Looks up a localized string similar to Internal error, please report: Statement break causes function to abnormally return null..
         /// </summary>
         public static string kInvalidBreakForFunction {
             get {
@@ -1268,7 +1268,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Internal error, please report: Statement continue cause function to abnormally return null. (fd67aaee).
+        ///   Looks up a localized string similar to Internal error, please report: Statement continue cause function to abnormally return null..
         /// </summary>
         public static string kInvalidContinueForFunction {
             get {
@@ -1322,7 +1322,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Internal error, please report: Method &apos;{0}()&apos; is invoked on an invalid object. (fa006d2b).
+        ///   Looks up a localized string similar to Internal error, please report: Method &apos;{0}()&apos; is invoked on an invalid object..
         /// </summary>
         public static string kInvokeMethodOnInvalidObject {
             get {
@@ -1367,7 +1367,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Internal error, please report: Method resolution failure on: {0}() - (8bc0db87).
+        ///   Looks up a localized string similar to Internal error, please report: Method resolution failure on: {0}().
         /// </summary>
         public static string kMethodResolutionFailure {
             get {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -849,9 +849,6 @@
   <data name="ArrayWithNotSupported" xml:space="preserve">
     <value>Array with no common superclass not yet supported: {0}</value>
   </data>
-  <data name="ErrorCode" xml:space="preserve">
-    <value>Error code: {0}</value>
-  </data>
   <data name="FailedToResolveSortingFunction" xml:space="preserve">
     <value>Failed to resolve the comparison function for sorting, expected def sorter : int(x,y)</value>
   </data>

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -193,7 +193,7 @@
     <value>File : '{0}' is already imported</value>
   </data>
   <data name="kAmbigousMethodDispatch" xml:space="preserve">
-    <value>Internal error, please report: Function could not be found on final dispatch (e5235508)</value>
+    <value>Internal error, please report: Function could not be found on final dispatch.</value>
   </data>
   <data name="kArgumentTypeUndefined" xml:space="preserve">
     <value>Type '{0}' of argument '{1}' is not defined</value>
@@ -238,7 +238,7 @@
     <value>A cyclic dependency exists between two varaibles</value>
   </data>
   <data name="kDeferencingNonPointer" xml:space="preserve">
-    <value>Internal error, please report: Dereferencing a non-pointer. (3f47aacd)</value>
+    <value>Internal error, please report: Dereferencing a non-pointer.</value>
   </data>
   <data name="kExceptionTypeUndefined" xml:space="preserve">
     <value>The exception type '{0}' is not defined</value>
@@ -289,10 +289,10 @@
     <value>The value used in a range expression must be a number or a letter</value>
   </data>
   <data name="kInvalidBreakForFunction" xml:space="preserve">
-    <value>Internal error, please report: Statement break causes function to abnormally return null. (6ced82a9)</value>
+    <value>Internal error, please report: Statement break causes function to abnormally return null.</value>
   </data>
   <data name="kInvalidContinueForFunction" xml:space="preserve">
-    <value>Internal error, please report: Statement continue cause function to abnormally return null. (fd67aaee)</value>
+    <value>Internal error, please report: Statement continue cause function to abnormally return null.</value>
   </data>
   <data name="kInvalidStaticCyclicDependency" xml:space="preserve">
     <value>A cyclic dependency exists between two variables</value>
@@ -301,7 +301,7 @@
     <value>'this' can only be used in methods that are members of a class</value>
   </data>
   <data name="kInvokeMethodOnInvalidObject" xml:space="preserve">
-    <value>Internal error, please report: Method '{0}()' is invoked on an invalid object. (fa006d2b)</value>
+    <value>Internal error, please report: Method '{0}()' is invoked on an invalid object.</value>
   </data>
   <data name="kMethodAlreadyDefined" xml:space="preserve">
     <value>Method '{0}()' is already defined</value>
@@ -316,7 +316,7 @@
     <value>Method '{0}()' not found</value>
   </data>
   <data name="kMethodResolutionFailure" xml:space="preserve">
-    <value>Internal error, please report: Method resolution failure on: {0}() - (8bc0db87)</value>
+    <value>Internal error, please report: Method resolution failure on: {0}().</value>
   </data>
   <data name="kMethodResolutionFailureForOperator" xml:space="preserve">
     <value>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'</value>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -196,7 +196,7 @@
     <value>File : '{0}' is already imported</value>
   </data>
   <data name="kAmbigousMethodDispatch" xml:space="preserve">
-    <value>Internal error, please report: Function could not be found on final dispatch (e5235508)</value>
+    <value>Internal error, please report: Function could not be found on final dispatch.</value>
   </data>
   <data name="kArgumentTypeUndefined" xml:space="preserve">
     <value>Type '{0}' of argument '{1}' is not defined</value>
@@ -241,7 +241,7 @@
     <value>A cyclic dependency exists between two variables</value>
   </data>
   <data name="kDeferencingNonPointer" xml:space="preserve">
-    <value>Internal error, please report: Dereferencing a non-pointer. (3f47aacd)</value>
+    <value>Internal error, please report: Dereferencing a non-pointer.</value>
   </data>
   <data name="kExceptionTypeUndefined" xml:space="preserve">
     <value>The exception type '{0}' is not defined</value>
@@ -292,10 +292,10 @@
     <value>The value used in a range expression must be a number or a letter</value>
   </data>
   <data name="kInvalidBreakForFunction" xml:space="preserve">
-    <value>Internal error, please report: Statement break causes function to abnormally return null. (6ced82a9)</value>
+    <value>Internal error, please report: Statement break causes function to abnormally return null.</value>
   </data>
   <data name="kInvalidContinueForFunction" xml:space="preserve">
-    <value>Internal error, please report: Statement continue cause function to abnormally return null. (fd67aaee)</value>
+    <value>Internal error, please report: Statement continue cause function to abnormally return null.</value>
   </data>
   <data name="kInvalidStaticCyclicDependency" xml:space="preserve">
     <value>A cyclic dependency exists between two variables</value>
@@ -304,7 +304,7 @@
     <value>'this' can only be used in methods that are members of a class</value>
   </data>
   <data name="kInvokeMethodOnInvalidObject" xml:space="preserve">
-    <value>Internal error, please report: Method '{0}()' is invoked on an invalid object. (fa006d2b)</value>
+    <value>Internal error, please report: Method '{0}()' is invoked on an invalid object.</value>
   </data>
   <data name="kMethodAlreadyDefined" xml:space="preserve">
     <value>Method '{0}()' is already defined</value>
@@ -319,7 +319,7 @@
     <value>Method '{0}()' not found</value>
   </data>
   <data name="kMethodResolutionFailure" xml:space="preserve">
-    <value>Internal error, please report: Method resolution failure on: {0}() - (8bc0db87)</value>
+    <value>Internal error, please report: Method resolution failure on: {0}()</value>
   </data>
   <data name="kMethodResolutionFailureForOperator" xml:space="preserve">
     <value>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}'</value>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -852,9 +852,6 @@
   <data name="ArrayWithNotSupported" xml:space="preserve">
     <value>Array with no common superclass not yet supported: {0}</value>
   </data>
-  <data name="ErrorCode" xml:space="preserve">
-    <value>Error code: {0}</value>
-  </data>
   <data name="FailedToResolveSortingFunction" xml:space="preserve">
     <value>Failed to resolve the comparison function for sorting, expected def sorter : int(x,y)</value>
   </data>


### PR DESCRIPTION
### Purpose

Some engine's error messages contain error codes. These error codes are for debugging purpose and shouldn't be in the error messages.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@monikaprabhu 
