### PR TITLE
Fixed issues with screen capture functionality

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -815,78 +815,8 @@ namespace Dynamo.Controls
 
         void DynamoViewModelRequestSaveImage(object sender, ImageSaveEventArgs e)
         {
-            if (string.IsNullOrEmpty(e.Path))
-                return;
-
-            var workspace = dynamoViewModel.Model.CurrentWorkspace;
-            if (workspace == null)
-                return;
-
-            if (!workspace.Nodes.Any() && (!workspace.Notes.Any()))
-                return; // An empty graph.
-
-            var initialized = false;
-            var bounds = new Rect();
-
-            var dragCanvas = WpfUtilities.ChildOfType<DragCanvas>(this);
-            var childrenCount = VisualTreeHelper.GetChildrenCount(dragCanvas);
-            for (int index = 0; index < childrenCount; ++index)
-            {
-                var child = VisualTreeHelper.GetChild(dragCanvas, index);
-                var firstChild = VisualTreeHelper.GetChild(child, 0);
-                if ((!(firstChild is NodeView)) && (!(firstChild is NoteView)))
-                    continue;
-
-                var childBounds = VisualTreeHelper.GetDescendantBounds(child as Visual);
-                childBounds.X = (double)(child as Visual).GetValue(Canvas.LeftProperty);
-                childBounds.Y = (double)(child as Visual).GetValue(Canvas.TopProperty);
-
-                if (initialized)
-                    bounds.Union(childBounds);
-                else
-                {
-                    initialized = true;
-                    bounds = childBounds;
-                }
-            }
-
-            // Add padding to the edge and make them multiples of two.
-            bounds.Width = (((int)Math.Ceiling(bounds.Width)) + 1) & ~0x01;
-            bounds.Height = (((int)Math.Ceiling(bounds.Height)) + 1) & ~0x01;
-
-            var drawingVisual = new DrawingVisual();
-            using (var drawingContext = drawingVisual.RenderOpen())
-            {
-                var targetRect = new Rect(0, 0, bounds.Width, bounds.Height);
-                var visualBrush = new VisualBrush(dragCanvas);
-                drawingContext.DrawRectangle(visualBrush, null, targetRect);
-
-                // drawingContext.DrawRectangle(null, new Pen(Brushes.Blue, 1.0), childBounds);
-            }
-
-            // var m = PresentationSource.FromVisual(this).CompositionTarget.TransformToDevice;
-            // region.Scale(m.M11, m.M22);
-
-            var rtb = new RenderTargetBitmap(((int)bounds.Width),
-                ((int)bounds.Height), 96, 96, PixelFormats.Default);
-
-            rtb.Render(drawingVisual);
-
-            //endcode as PNG
-            var pngEncoder = new PngBitmapEncoder();
-            pngEncoder.Frames.Add(BitmapFrame.Create(rtb));
-
-            try
-            {
-                using (var stm = File.Create(e.Path))
-                {
-                    pngEncoder.Save(stm);
-                }
-            }
-            catch
-            {
-                dynamoViewModel.Model.Logger.Log(Wpf.Properties.Resources.MessageFailedToSaveAsImage);
-            }
+            var workspace = this.ChildOfType<WorkspaceView>();
+            workspace.SaveWorkspaceAsImage(e.Path);
         }
 
         void DynamoViewModelRequestClose(object sender, EventArgs e)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -203,13 +203,18 @@ namespace Dynamo.Views
                 childBounds.Y = (double)(child as Visual).GetValue(Canvas.TopProperty);
 
                 if (initialized)
+                {
                     bounds.Union(childBounds);
+                }
                 else
                 {
                     initialized = true;
                     bounds = childBounds;
                 }
             }
+
+            // Nothing found in the canvas, bail out.
+            if (!initialized) return;
 
             // Add padding to the edge and make them multiples of two (pad 10px on each side).
             bounds.Width = 20 + ((((int)Math.Ceiling(bounds.Width)) + 1) & ~0x01);


### PR DESCRIPTION
### Purpose

Just as my life predictably slumps into irrelevance, I had an eureka moment just last night. Though good for many people I did not leap out of the bathroom naked, what comes up next can potentially change the lives of few people. Exaggerating, yes, but not by much.

The fundamental flaw in *Screen Capture* functionality is now resolved, which allows us to capture Dynamo graph contents in native resolution, such as the following. Quick facts about this fix:

1. The screen grab covers **nodes**, **notes**, **groups**, and **preview bubbles**
2. There are at least `10-pixel` padding in the resulting image, which means the content does not touch the edge of the PNG file
3. The resulting PNG contains alpha channel that allows the PNG to be overlaid on any background
4. Large graphs no longer affect the output PNG clarity, it is always displayed at **100% scale** without distortion
5. If a graph is zoomed way out that node contents are hidden, they will not show up in the final PNG, even though the nodes are captured at 100% scale (so always make sure proper zooming before capturing so node contents are not hidden).

![capture](https://cloud.githubusercontent.com/assets/5086849/16361329/80185d0e-3bbf-11e6-9d7a-0878f367ba95.png)

The following graph is courtesy [Md Lingkon](https://www.facebook.com/lingkonn), which resulted in PNG of dimension `13816 x 4050 px` (measuring **2.58MB**, and most hand-held devices will choose to not open this file so it might not be visible here).

![b334e507-f0b7-42ef-be5f-9cb69c51f764](https://cloud.githubusercontent.com/assets/5086849/16361335/9ed8a38e-3bbf-11e6-88ff-b80208a8b52f.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal @ke-yu 

### FYIs

@riteshchandawar @monikaprabhu 
