### PR TITLE
Retire the const string Categoreis.BuiltIns

### DIFF
--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -540,7 +540,7 @@ namespace Dynamo.Engine
             {
                 return CoreUtils.IsInternalMethod(FunctionName)
                     ? LibraryServices.Categories.Operators
-                    : LibraryServices.Categories.BuiltIns;
+                    : LibraryServices.Categories.BuiltIn;
             }
 
             LibraryCustomization cust = LibraryCustomizationServices.GetForAssembly(Assembly, pathManager);

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -1005,7 +1005,6 @@ namespace Dynamo.Engine
         public static class Categories
         {
             public const string BuiltIn = "BuiltIn";
-            public const string BuiltIns = "Builtin Functions";
             public const string Operators = "Operators";
             public const string Constructors = "Create";
             public const string MemberFunctions = "Actions";


### PR DESCRIPTION
### Purpose

A follow-up PR to https://github.com/DynamoDS/Dynamo/pull/6772 after build machines issue is fixed. I've run all unit test to make sure nothing would break after retiring and replacing **Categories.BuiltIns**

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers



### FYIs

@mjkkirschner 

