### PR TITLE
Magn 10272

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
@@ -20,8 +20,15 @@ namespace Dynamo.Graph.Nodes
         /// 
         internal static string NormalizeLineBreaks(string text)
         {
-            text = text.Replace("\r\n", "\n");
-            return text.Replace("\r", "\n");
+            //text = text.Replace("\r\n", "\n");
+            //return text.Replace("\r", "\n");
+
+            //if (text.Contains("\\n"))
+              //  return text;
+
+            //text = text.Replace("\\r\\n", Environment.NewLine); /r/n works but Environment.Newline doesnt??
+            text = text.Replace("\\r", Environment.NewLine);
+            return text.Replace("\\n", Environment.NewLine);
         }
 
         /// <summary>
@@ -158,6 +165,9 @@ namespace Dynamo.Graph.Nodes
         /// 
         internal static string FormatUserText(string inputCode)
         {
+
+            // inputCode;
+
             if (inputCode == null)
                 return string.Empty;
 
@@ -165,6 +175,9 @@ namespace Dynamo.Graph.Nodes
             var charsToTrim = new char[] { '\n', '\t', ' ' };
             inputCode = NormalizeLineBreaks(inputCode);
             inputCode = inputCode.Trim(charsToTrim);
+
+            //if (inputCode.Contains("\\r\\n"))
+              //  return inputCode;
 
             List<string> statements = new List<string>();
             var splitOption = StringSplitOptions.RemoveEmptyEntries;

--- a/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
@@ -20,8 +20,8 @@ namespace Dynamo.Graph.Nodes
         /// 
         internal static string NormalizeLineBreaks(string text)
         {
-            text = text.Replace("\\r\\n", "\n");
-            return text.Replace("\\r", "\n");
+            text = text.Replace("\r\n", "\n");
+            return text.Replace("\r", "\n");
         }
 
         /// <summary>
@@ -227,7 +227,6 @@ namespace Dynamo.Graph.Nodes
                     inputCode = inputCode + ";";
             }
 
-            inputCode = NormalizeLineBreaks(inputCode);
             return inputCode;
         }
 

--- a/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockUtils.cs
@@ -20,15 +20,8 @@ namespace Dynamo.Graph.Nodes
         /// 
         internal static string NormalizeLineBreaks(string text)
         {
-            //text = text.Replace("\r\n", "\n");
-            //return text.Replace("\r", "\n");
-
-            //if (text.Contains("\\n"))
-              //  return text;
-
-            //text = text.Replace("\\r\\n", Environment.NewLine); /r/n works but Environment.Newline doesnt??
-            text = text.Replace("\\r", Environment.NewLine);
-            return text.Replace("\\n", Environment.NewLine);
+            text = text.Replace("\\r\\n", "\n");
+            return text.Replace("\\r", "\n");
         }
 
         /// <summary>
@@ -176,9 +169,6 @@ namespace Dynamo.Graph.Nodes
             inputCode = NormalizeLineBreaks(inputCode);
             inputCode = inputCode.Trim(charsToTrim);
 
-            //if (inputCode.Contains("\\r\\n"))
-              //  return inputCode;
-
             List<string> statements = new List<string>();
             var splitOption = StringSplitOptions.RemoveEmptyEntries;
 
@@ -237,6 +227,7 @@ namespace Dynamo.Graph.Nodes
                     inputCode = inputCode + ";";
             }
 
+            inputCode = NormalizeLineBreaks(inputCode);
             return inputCode;
         }
 

--- a/src/Libraries/CoreNodes/String.cs
+++ b/src/Libraries/CoreNodes/String.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Autodesk.DesignScript.Runtime;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
+using System.Text.RegularExpressions;
 
 namespace DSCore
 {
@@ -75,10 +76,8 @@ namespace DSCore
         public static string[] Split(string str, params string[] separaters)
         {
             separaters = separaters.Select(s => s == "\n" ? Environment.NewLine : s).ToArray(); // converts all \n in separater array to Environment Newline (i.e. \r\n)
-               
-            if (str.Contains("\n") && !str.Contains(Environment.NewLine)) // converts all \n in string to Environment Newline to ensure that all CBN strings are able to be parsed in the same way as a String node.
-                str = str.Replace("\n", Environment.NewLine);
-
+            str = Regex.Replace(str, "(?<!\r)\n", Environment.NewLine); // converts all \n in String str to Environment.NewLine (i.e. '\r\n')
+            
             return separaters.Contains("")
                 ? str.ToCharArray().Select(char.ToString).ToArray()
                 : str.Split(separaters, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Libraries/CoreNodes/String.cs
+++ b/src/Libraries/CoreNodes/String.cs
@@ -74,7 +74,10 @@ namespace DSCore
         /// <search>divide,separaters,delimiter,cut,csv,comma,</search>
         public static string[] Split(string str, params string[] separaters)
         {
-            separaters = separaters.Select(s => s == "\n" ? Environment.NewLine : s).ToArray(); // converts all \n in separater array to Environment Newline (i.e. /r/n)
+            separaters = separaters.Select(s => s == "\n" ? Environment.NewLine : s).ToArray(); // converts all \n in separater array to Environment Newline (i.e. \r\n)
+               
+            if (str.Contains("\n") && !str.Contains(Environment.NewLine)) // converts all \n in string to Environment Newline to ensure that all CBN strings are able to be parsed in the same way as a String node.
+                str = str.Replace("\n", Environment.NewLine);
 
             return separaters.Contains("")
                 ? str.ToCharArray().Select(char.ToString).ToArray()

--- a/src/Libraries/CoreNodes/String.cs
+++ b/src/Libraries/CoreNodes/String.cs
@@ -74,6 +74,9 @@ namespace DSCore
         /// <search>divide,separaters,delimiter,cut,csv,comma,</search>
         public static string[] Split(string str, params string[] separaters)
         {
+            if (separaters.Contains(Environment.NewLine))
+                return str.Split(separaters, StringSplitOptions.RemoveEmptyEntries);
+
             return separaters.Contains("")
                 ? str.ToCharArray().Select(char.ToString).ToArray()
                 : str.Split(separaters, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Libraries/CoreNodes/String.cs
+++ b/src/Libraries/CoreNodes/String.cs
@@ -74,8 +74,7 @@ namespace DSCore
         /// <search>divide,separaters,delimiter,cut,csv,comma,</search>
         public static string[] Split(string str, params string[] separaters)
         {
-            if (separaters.Contains(Environment.NewLine))
-                return str.Split(separaters, StringSplitOptions.RemoveEmptyEntries);
+            separaters = separaters.Select(s => s == "\n" ? Environment.NewLine : s).ToArray(); // converts all \n in separater array to Environment Newline (i.e. /r/n)
 
             return separaters.Contains("")
                 ? str.ToCharArray().Select(char.ToString).ToArray()

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -1238,6 +1238,13 @@ namespace Dynamo.Tests
             // Test String Newline value
             AssertPreviewValue("6713ee10-a5e7-4049-b514-4388c7e09105", new int[] { 1, 2, 3, 4, 5, 6 });
             AssertSamePreviewValues("07658815-d706-42b4-bb29-b0a65986c58d", "6713ee10-a5e7-4049-b514-4388c7e09105");
+
+            // Test case when CBN has a string - using both CBN and Strings as separators
+            AssertPreviewValue("803d08aa-ca57-41ba-85a9-50fc47104427", new int[] { 1, 2, 3, 4, 5, 6 });
+            AssertSamePreviewValues("07658815-d706-42b4-bb29-b0a65986c58d", "803d08aa-ca57-41ba-85a9-50fc47104427");
+
+            AssertPreviewValue("39447de2-f20c-4482-8f08-50c5001ed971", new int[] { 1, 2, 3, 4, 5, 6 });
+            AssertSamePreviewValues("07658815-d706-42b4-bb29-b0a65986c58d", "39447de2-f20c-4482-8f08-50c5001ed971");
         }
     }
 }

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -1224,5 +1224,20 @@ namespace Dynamo.Tests
             RunModel(@"core\dsevaluation\githubissue_6729.dyn");
             AssertPreviewValue("a1a9e8a5-a791-4924-82e1-0dc6dd2215ed", new int[] { 4, 5 });
         }
+
+        [Test]
+        //String.split yields different results with linebreak separator
+        public void Issue3446()
+        {   
+            
+            RunModel(@"core\dsevaluation\githubissue_3446.dyn");
+
+            // Test CBN '"\n";' value
+            AssertPreviewValue("07658815-d706-42b4-bb29-b0a65986c58d", new int[] { 1, 2, 3, 4, 5, 6 });
+
+            // Test String Newline value
+            AssertPreviewValue("6713ee10-a5e7-4049-b514-4388c7e09105", new int[] { 1, 2, 3, 4, 5, 6 });
+            AssertSamePreviewValues("07658815-d706-42b4-bb29-b0a65986c58d", "6713ee10-a5e7-4049-b514-4388c7e09105");
+        }
     }
 }

--- a/test/core/dsevaluation/githubissue_3446.dyn
+++ b/test/core/dsevaluation/githubissue_3446.dyn
@@ -1,15 +1,15 @@
-<Workspace Version="1.0.1.1791" X="83.9216116346539" Y="95.8783865146474" zoom="0.878530757378055" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+<Workspace Version="0.9.1.4062" X="83.9216116346539" Y="95.8783865146474" zoom="0.878530757378055" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="b7b86334-a9b1-45ed-b709-2c6bdc949fcc" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="182" y="68" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="&quot;&#xA;&quot;;" ShouldFocus="false" />
-    <CoreNodeModels.Input.StringInput guid="f9e6153f-84df-4167-b6b1-871bbd7e3b0b" type="CoreNodeModels.Input.StringInput" nickname="String" x="186.120201981498" y="446.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="b7b86334-a9b1-45ed-b709-2c6bdc949fcc" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="182" y="68" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="&quot;&#xA;&quot;;" ShouldFocus="false" />
+    <CoreNodeModels.Input.StringInput guid="f9e6153f-84df-4167-b6b1-871bbd7e3b0b" type="CoreNodeModels.Input.StringInput" nickname="String" x="186.120201981498" y="446.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
       <System.String>
 </System.String>
       <System.String value="&#xD;&#xA;" />
     </CoreNodeModels.Input.StringInput>
-    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="81fded5b-0c76-4afd-bd9d-079a9f3e8584" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="String.Split" x="598.120201981498" y="187.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.String.Split@string,string[]" inputcount="2" />
-    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="ea828ac6-4cdd-41fa-b8cf-55359cc07ac7" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="String.Split" x="597.120201981498" y="397.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.String.Split@string,string[]" inputcount="2" />
-    <CoreNodeModels.Input.StringInput guid="d891d6a2-25f6-48c3-8d7c-ccab4cfde5c8" type="CoreNodeModels.Input.StringInput" nickname="String" x="186.120201981498" y="255.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="81fded5b-0c76-4afd-bd9d-079a9f3e8584" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="String.Split" x="598.120201981498" y="187.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.String.Split@string,string[]" inputcount="2" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="ea828ac6-4cdd-41fa-b8cf-55359cc07ac7" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="String.Split" x="597.120201981498" y="397.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.String.Split@string,string[]" inputcount="2" />
+    <CoreNodeModels.Input.StringInput guid="d891d6a2-25f6-48c3-8d7c-ccab4cfde5c8" type="CoreNodeModels.Input.StringInput" nickname="String" x="186.120201981498" y="255.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
       <System.String>1
 2
 3
@@ -18,16 +18,27 @@
 6</System.String>
       <System.String value="1&#xD;&#xA;2&#xD;&#xA;3&#xD;&#xA;4&#xD;&#xA;5&#xD;&#xA;6" />
     </CoreNodeModels.Input.StringInput>
-    <CoreNodeModels.Watch guid="6713ee10-a5e7-4049-b514-4388c7e09105" type="CoreNodeModels.Watch" nickname="Watch" x="1107.97876096645" y="344.014582815352" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
-    <CoreNodeModels.Watch guid="07658815-d706-42b4-bb29-b0a65986c58d" type="CoreNodeModels.Watch" nickname="Watch" x="923.655363951064" y="36.3837024683819" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+    <CoreNodeModels.Watch guid="6713ee10-a5e7-4049-b514-4388c7e09105" type="CoreNodeModels.Watch" nickname="Watch" x="1107.97876096645" y="344.014582815352" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" />
+    <CoreNodeModels.Watch guid="07658815-d706-42b4-bb29-b0a65986c58d" type="CoreNodeModels.Watch" nickname="Watch" x="1333.43043098959" y="170.69886333101" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="feec5ea0-04ef-46ba-b6b2-8f0b3eb5fb60" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="String.Split" x="594.062252912877" y="608.400527864645" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.String.Split@string,string[]" inputcount="2" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="2d147fac-77d2-46b3-b03e-f6a48d4f0e8a" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="124" y="589" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="&quot;1&#xA;2&#xA;3&#xA;4&#xA;5&#xA;6&quot;;" ShouldFocus="false" />
+    <CoreNodeModels.Watch guid="803d08aa-ca57-41ba-85a9-50fc47104427" type="CoreNodeModels.Watch" nickname="Watch" x="1092.55748750297" y="584.59343671015" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="3e8ba23e-c5ea-4a2a-a905-340770dbbc31" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="String.Split" x="577.994645666152" y="-12.9308997725325" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.String.Split@string,string[]" inputcount="2" />
+    <CoreNodeModels.Watch guid="39447de2-f20c-4482-8f08-50c5001ed971" type="CoreNodeModels.Watch" nickname="Watch" x="1026.04941779483" y="-76.0884802038465" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" />
   </Elements>
   <Connectors>
     <Dynamo.Graph.Connectors.ConnectorModel start="b7b86334-a9b1-45ed-b709-2c6bdc949fcc" start_index="0" end="81fded5b-0c76-4afd-bd9d-079a9f3e8584" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b7b86334-a9b1-45ed-b709-2c6bdc949fcc" start_index="0" end="3e8ba23e-c5ea-4a2a-a905-340770dbbc31" end_index="1" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="f9e6153f-84df-4167-b6b1-871bbd7e3b0b" start_index="0" end="ea828ac6-4cdd-41fa-b8cf-55359cc07ac7" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f9e6153f-84df-4167-b6b1-871bbd7e3b0b" start_index="0" end="feec5ea0-04ef-46ba-b6b2-8f0b3eb5fb60" end_index="1" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="81fded5b-0c76-4afd-bd9d-079a9f3e8584" start_index="0" end="07658815-d706-42b4-bb29-b0a65986c58d" end_index="0" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="ea828ac6-4cdd-41fa-b8cf-55359cc07ac7" start_index="0" end="6713ee10-a5e7-4049-b514-4388c7e09105" end_index="0" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="d891d6a2-25f6-48c3-8d7c-ccab4cfde5c8" start_index="0" end="81fded5b-0c76-4afd-bd9d-079a9f3e8584" end_index="0" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="d891d6a2-25f6-48c3-8d7c-ccab4cfde5c8" start_index="0" end="ea828ac6-4cdd-41fa-b8cf-55359cc07ac7" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="feec5ea0-04ef-46ba-b6b2-8f0b3eb5fb60" start_index="0" end="803d08aa-ca57-41ba-85a9-50fc47104427" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="2d147fac-77d2-46b3-b03e-f6a48d4f0e8a" start_index="0" end="feec5ea0-04ef-46ba-b6b2-8f0b3eb5fb60" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="2d147fac-77d2-46b3-b03e-f6a48d4f0e8a" start_index="0" end="3e8ba23e-c5ea-4a2a-a905-340770dbbc31" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="3e8ba23e-c5ea-4a2a-a905-340770dbbc31" start_index="0" end="39447de2-f20c-4482-8f08-50c5001ed971" end_index="0" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />

--- a/test/core/dsevaluation/githubissue_3446.dyn
+++ b/test/core/dsevaluation/githubissue_3446.dyn
@@ -1,0 +1,38 @@
+<Workspace Version="1.0.1.1791" X="83.9216116346539" Y="95.8783865146474" zoom="0.878530757378055" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="b7b86334-a9b1-45ed-b709-2c6bdc949fcc" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="182" y="68" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="&quot;&#xA;&quot;;" ShouldFocus="false" />
+    <CoreNodeModels.Input.StringInput guid="f9e6153f-84df-4167-b6b1-871bbd7e3b0b" type="CoreNodeModels.Input.StringInput" nickname="String" x="186.120201981498" y="446.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <System.String>
+</System.String>
+      <System.String value="&#xD;&#xA;" />
+    </CoreNodeModels.Input.StringInput>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="81fded5b-0c76-4afd-bd9d-079a9f3e8584" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="String.Split" x="598.120201981498" y="187.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.String.Split@string,string[]" inputcount="2" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="ea828ac6-4cdd-41fa-b8cf-55359cc07ac7" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="String.Split" x="597.120201981498" y="397.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.String.Split@string,string[]" inputcount="2" />
+    <CoreNodeModels.Input.StringInput guid="d891d6a2-25f6-48c3-8d7c-ccab4cfde5c8" type="CoreNodeModels.Input.StringInput" nickname="String" x="186.120201981498" y="255.172163246666" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <System.String>1
+2
+3
+4
+5
+6</System.String>
+      <System.String value="1&#xD;&#xA;2&#xD;&#xA;3&#xD;&#xA;4&#xD;&#xA;5&#xD;&#xA;6" />
+    </CoreNodeModels.Input.StringInput>
+    <CoreNodeModels.Watch guid="6713ee10-a5e7-4049-b514-4388c7e09105" type="CoreNodeModels.Watch" nickname="Watch" x="1107.97876096645" y="344.014582815352" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+    <CoreNodeModels.Watch guid="07658815-d706-42b4-bb29-b0a65986c58d" type="CoreNodeModels.Watch" nickname="Watch" x="923.655363951064" y="36.3837024683819" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="b7b86334-a9b1-45ed-b709-2c6bdc949fcc" start_index="0" end="81fded5b-0c76-4afd-bd9d-079a9f3e8584" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f9e6153f-84df-4167-b6b1-871bbd7e3b0b" start_index="0" end="ea828ac6-4cdd-41fa-b8cf-55359cc07ac7" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="81fded5b-0c76-4afd-bd9d-079a9f3e8584" start_index="0" end="07658815-d706-42b4-bb29-b0a65986c58d" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="ea828ac6-4cdd-41fa-b8cf-55359cc07ac7" start_index="0" end="6713ee10-a5e7-4049-b514-4388c7e09105" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="d891d6a2-25f6-48c3-8d7c-ccab4cfde5c8" start_index="0" end="81fded5b-0c76-4afd-bd9d-079a9f3e8584" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="d891d6a2-25f6-48c3-8d7c-ccab4cfde5c8" start_index="0" end="ea828ac6-4cdd-41fa-b8cf-55359cc07ac7" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

1. Resolves github issue - https://github.com/DynamoDS/Dynamo/issues/3446. Now, the String.Split node will interpret and resolve the newline separater for both CBNs and Strings in the same manner.

![linebreakseparator](https://cloud.githubusercontent.com/assets/16283396/16370783/04882ac8-3c75-11e6-8343-5391fbab501b.PNG)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

### FYIs

@monikaprabhu 
