### PR TITLE
MAGN-9963 "Getting Started" does not popup on first time load in Dynamo4Revit

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -188,12 +188,21 @@ namespace Dynamo.Configuration
             }
         }
 
-        public Version GetPrevDynamoVersion()
+        /// <summary>
+        /// Indicates if the Gallery should be shown
+        /// </summary>
+        public bool ShowGallery()
         {
+           
             if (string.IsNullOrWhiteSpace(PrevDynamoVersion))
-                return new Version();
+                return true;
             else
-                return new Version(PrevDynamoVersion);
+            {
+                var prevVersion = new Version(PrevDynamoVersion);
+                return new Version(prevVersion.Major, prevVersion.Minor, prevVersion.Build, 0)
+                            < AssemblyHelper.GetDynamoVersion(includeRevisionNumber: false);
+            }
+            
         }
 
         /// <summary>
@@ -322,7 +331,7 @@ namespace Dynamo.Configuration
         {
             try
             {
-                PrevDynamoVersion = AssemblyHelper.GetDynamoVersion(includeRevisionNumber: false).ToString();
+                PrevDynamoVersion = AssemblyHelper.GetDynamoVersion(includeRevisionNumber: true).ToString();
 
                 var serializer = new XmlSerializer(typeof(PreferenceSettings));
                 using (var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write))

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -191,7 +191,7 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Indicates if the Gallery should be shown
         /// </summary>
-        public bool ShowGallery()
+        public bool CanShowGallery()
         {
            
             if (string.IsNullOrWhiteSpace(PrevDynamoVersion))

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -8,6 +8,7 @@ using Dynamo.Graph;
 using Dynamo.Graph.Connectors;
 using Dynamo.Interfaces;
 using Dynamo.Models;
+using Dynamo.Utilities;
 
 namespace Dynamo.Configuration
 {
@@ -51,6 +52,11 @@ namespace Dynamo.Configuration
         /// Indicates first run
         /// </summary>
         public bool IsFirstRun { get; set; }
+
+        /// <summary>
+        /// Indicates version of Dynamo before this run
+        /// </summary>
+        public string PrevDynamoVersion { get; set; }
 
         /// <summary>
         /// Indicates whether usage reporting is approved or not.
@@ -182,6 +188,14 @@ namespace Dynamo.Configuration
             }
         }
 
+        public Version GetPrevDynamoVersion()
+        {
+            if (string.IsNullOrWhiteSpace(PrevDynamoVersion))
+                return new Version();
+            else
+                return new Version(PrevDynamoVersion);
+        }
+
         /// <summary>
         /// A list of recently opened file paths.
         /// </summary>
@@ -308,6 +322,8 @@ namespace Dynamo.Configuration
         {
             try
             {
+                PrevDynamoVersion = AssemblyHelper.GetDynamoVersion(includeRevisionNumber: false).ToString();
+
                 var serializer = new XmlSerializer(typeof(PreferenceSettings));
                 using (var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write))
                 {

--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -113,12 +113,12 @@ namespace Dynamo.UI.Controls
         ObservableCollection<StartPageListItem> recentFiles = null;
         ObservableCollection<StartPageListItem> backupFiles = null;
         internal readonly DynamoViewModel DynamoViewModel;
-        private readonly bool isFirstRun;
+        private readonly bool showGallery;
 
-        internal StartPageViewModel(DynamoViewModel dynamoViewModel, bool isFirstRun)
+        internal StartPageViewModel(DynamoViewModel dynamoViewModel, bool showGallery)
         {
             this.DynamoViewModel = dynamoViewModel;
-            this.isFirstRun = isFirstRun;
+            this.showGallery = showGallery;
 
             this.recentFiles = new ObservableCollection<StartPageListItem>();
             sampleFiles = new ObservableCollection<SampleFileEntry>();
@@ -274,7 +274,7 @@ namespace Dynamo.UI.Controls
             }
         }
 
-        public bool IsFirstRun { get { return isFirstRun; } }
+        public bool ShowGallery { get { return showGallery; } }
 
         public string SampleFolderPath
         {
@@ -465,7 +465,7 @@ namespace Dynamo.UI.Controls
             var id = Wpf.Interfaces.ResourceNames.StartPage.Image;
             StartPageLogo.Source = dynamoViewModel.BrandingResourceProvider.GetImageSource(id);
 
-            if (startPageViewModel.IsFirstRun)
+            if (startPageViewModel.ShowGallery)
             {
                 dynamoViewModel.ShowGalleryCommand.Execute(null);
             }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -424,7 +424,7 @@ namespace Dynamo.Controls
         /// Indicates if it is the first time new Dynamo version runs.
         /// It is used to decide whether the Gallery need to be shown on the StartPage.
         /// </param>
-        private void InitializeStartPage(bool isFirstRun)
+        private void InitializeStartPage(bool showGallery)
         {
             if (DynamoModel.IsTestMode) // No start screen in unit testing.
                 return;
@@ -437,7 +437,7 @@ namespace Dynamo.Controls
                     throw new InvalidOperationException(message);
                 }
 
-                startPage = new StartPageViewModel(dynamoViewModel, isFirstRun);
+                startPage = new StartPageViewModel(dynamoViewModel, showGallery);
                 startPageItemsControl.Items.Add(startPage);
             }
         }
@@ -480,8 +480,9 @@ namespace Dynamo.Controls
             // Do an initial load of the cursor collection
             CursorLibrary.GetCursor(CursorSet.ArcSelect);
 
-            //Backing up IsFirstRun to determine whether to show Gallery
-            var isFirstRun = dynamoViewModel.Model.PreferenceSettings.IsFirstRun;
+            var prevDynamoVersion = dynamoViewModel.Model.PreferenceSettings.GetPrevDynamoVersion();
+            var showGallery = prevDynamoVersion < AssemblyHelper.GetDynamoVersion(includeRevisionNumber: false) ? true : false;
+
             // If first run, Collect Info Prompt will appear
             UsageReportingManager.Instance.CheckIsFirstRun(this, dynamoViewModel.BrandingResourceProvider);
 
@@ -496,7 +497,8 @@ namespace Dynamo.Controls
                                                                      _timer.Elapsed, dynamoViewModel.BrandingResourceProvider.ProductName));
             InitializeLogin();
             InitializeShortcutBar();
-            InitializeStartPage(isFirstRun);
+
+            InitializeStartPage(showGallery);
 
 #if !__NO_SAMPLES_MENU
             LoadSamplesMenu();

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -495,7 +495,7 @@ namespace Dynamo.Controls
             InitializeLogin();
             InitializeShortcutBar();
 
-            InitializeStartPage(dynamoViewModel.Model.PreferenceSettings.ShowGallery());
+            InitializeStartPage(dynamoViewModel.Model.PreferenceSettings.CanShowGallery());
 
 #if !__NO_SAMPLES_MENU
             LoadSamplesMenu();

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -480,9 +480,6 @@ namespace Dynamo.Controls
             // Do an initial load of the cursor collection
             CursorLibrary.GetCursor(CursorSet.ArcSelect);
 
-            var prevDynamoVersion = dynamoViewModel.Model.PreferenceSettings.GetPrevDynamoVersion();
-            var showGallery = prevDynamoVersion < AssemblyHelper.GetDynamoVersion(includeRevisionNumber: false) ? true : false;
-
             // If first run, Collect Info Prompt will appear
             UsageReportingManager.Instance.CheckIsFirstRun(this, dynamoViewModel.BrandingResourceProvider);
 
@@ -498,7 +495,7 @@ namespace Dynamo.Controls
             InitializeLogin();
             InitializeShortcutBar();
 
-            InitializeStartPage(showGallery);
+            InitializeStartPage(dynamoViewModel.Model.PreferenceSettings.ShowGallery());
 
 #if !__NO_SAMPLES_MENU
             LoadSamplesMenu();


### PR DESCRIPTION
### Purpose
References: [MAGN-9963](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9963#)
This PR is to fix the issue of the "Gettting Started" page not showing up when user upgrades Dynamo Revit.
We fix this issue by comparing the previous version and deciding if we should show the gallery.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 
