### PR TITLE
Magn 10274

### DIFF
--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -369,28 +369,18 @@ namespace Dynamo.UI.Controls
             foreach (var filePath in filePaths)
             {
                 var extension = Path.GetExtension(filePath).ToUpper();
+                // If not extension specified and code reach here, this means this is still a valid file 
+                // only without file type. Otherwise, simply take extension substring skipping the 'dot'.
+                var subScript = extension.IndexOf(".") == 0 ? extension.Substring(1) : "";
                 var caption = Path.GetFileNameWithoutExtension(filePath);
-                if (extension.IndexOf(".") == 0)
+
+                files.Add(new StartPageListItem(caption)
                 {
-                    files.Add(new StartPageListItem(caption)
-                    {
-                        ContextData = filePath,
-                        ToolTip = filePath,
-                        SubScript = extension.Substring(1), // Skipping the 'dot'
-                        ClickAction = StartPageListItem.Action.FilePath
-                    });
-                }
-                else
-                {
-                    // If not extension specified and code reach here, this means this is still a valid file only without file type.
-                    files.Add(new StartPageListItem(caption)
-                    {
-                        ContextData = filePath,
-                        ToolTip = filePath,
-                        SubScript = "",
-                        ClickAction = StartPageListItem.Action.FilePath
-                    });
-                }
+                    ContextData = filePath,
+                    ToolTip = filePath,
+                    SubScript = subScript,
+                    ClickAction = StartPageListItem.Action.FilePath
+                });
             }
         }
 

--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -370,11 +370,24 @@ namespace Dynamo.UI.Controls
             {
                 var extension = Path.GetExtension(filePath).ToUpper();
                 var caption = Path.GetFileNameWithoutExtension(filePath);
+                if (extension.IndexOf(".") == 0)
                 {
                     files.Add(new StartPageListItem(caption)
                     {
                         ContextData = filePath,
                         ToolTip = filePath,
+                        SubScript = extension.Substring(1), // Skipping the 'dot'
+                        ClickAction = StartPageListItem.Action.FilePath
+                    });
+                }
+                else
+                {
+                    // If not extension specified and code reach here, this means this is still a valid file only without file type.
+                    files.Add(new StartPageListItem(caption)
+                    {
+                        ContextData = filePath,
+                        ToolTip = filePath,
+                        SubScript = "",
                         ClickAction = StartPageListItem.Action.FilePath
                     });
                 }

--- a/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/StartPage.xaml.cs
@@ -370,13 +370,14 @@ namespace Dynamo.UI.Controls
             {
                 var extension = Path.GetExtension(filePath).ToUpper();
                 var caption = Path.GetFileNameWithoutExtension(filePath);
-                files.Add(new StartPageListItem(caption)
                 {
-                    ContextData = filePath,
-                    ToolTip = filePath,
-                    SubScript = extension.Substring(1), // Skipping the 'dot'
-                    ClickAction = StartPageListItem.Action.FilePath
-                });
+                    files.Add(new StartPageListItem(caption)
+                    {
+                        ContextData = filePath,
+                        ToolTip = filePath,
+                        ClickAction = StartPageListItem.Action.FilePath
+                    });
+                }
             }
         }
 

--- a/test/DynamoCoreTests/CoreDynTests.cs
+++ b/test/DynamoCoreTests/CoreDynTests.cs
@@ -401,6 +401,15 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void CanOpenGoodFileWithoutExtension()
+        {
+            var examplePath = Path.Combine(TestDirectory, @"core\files");
+            string openPath = Path.Combine(examplePath, "Sphere");
+            OpenModel(openPath);
+            BeginRun();
+        }
+
+        [Test]
         public void TestExportToCSVFile()
         {
             var examplePath = Path.Combine(TestDirectory, @"core\files");

--- a/test/core/files/Sphere
+++ b/test/core/files/Sphere
@@ -1,0 +1,19 @@
+<Workspace Version="1.0.1.1733" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="4b1fb285-ce03-4d04-b807-1c083e118070" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Sphere.ByCenterPointRadius" x="384" y="445.6" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="93a2e0f1-3238-4494-b809-ae9897a049fb" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="92" y="425" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="3.14;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="93a2e0f1-3238-4494-b809-ae9897a049fb" start_index="0" end="4b1fb285-ce03-4d04-b807-1c083e118070" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10274
MAGN-10274 Opening dyn file whose dyn extension is missing corrupts Dynamo

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

I propose we going this approach for now:
For file without extension but good to load, they should be treated just as good .txt files which is not among the default file types we support but we load it anyway. So loading it and running it would be the same with normal files while in recent files list, we would not display its file type since it's unknown.
The baseline is: loading file with error should not be sticky or crashing Dynamo in the future.


Example:
![image](https://cloud.githubusercontent.com/assets/3942418/16392187/9b65f6c0-3c78-11e6-873b-158712e8c7e1.png)


### Reviewers

@ramramps 

### FYIs

@jnealb @mjkkirschner @Racel @sm6srw 
