### PR TITLE
Fixed Magn-10270

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -942,6 +942,8 @@ namespace Dynamo.ViewModels
                 var notes = _notes.Select(x => x.Model);
                 var models = nodes.Concat<ModelBase>(notes);
 
+                if (!models.Any()) return;
+
                 // initialize to the first model (either note or node) on the list 
 
                 var firstModel = models.First();

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -939,15 +939,25 @@ namespace Dynamo.ViewModels
             {   // no selection, fitview all nodes and notes
                 if (!_nodes.Any()) return;
 
-                List<NodeModel> nodes = _nodes.Select(x => x.NodeModel).Where(x => x != null).ToList();
-                List<NoteModel> notes = _notes.Select(x => x.Model).Where(x => x != null).ToList();
+                List<NodeModel> nodes = _nodes.Select(x => x.NodeModel).ToList();
+                List<NoteModel> notes = _notes.Select(x => x.Model).ToList();
+                List<ModelBase> models = nodes.Concat<ModelBase>(notes).ToList();
+                
+                // initialize to the first model (either note or node) on the list 
+                minX = models[0].X;
+                maxX = models[0].X;
+                minY = models[0].Y;
+                maxY = models[0].Y;
 
-                //calculates the min and max positions of both x and y coords of all nodes and notes
-
-                minX = Math.Min(nodes.Select(x => x.X).Min(), notes.Select(x => x.X).Min());
-                maxX = Math.Max(nodes.Select(x => x.X + x.Width).Max(), notes.Select(x => x.X + x.Width).Max());
-                minY = Math.Min(nodes.Select(y => y.Y).Min(), notes.Select(y => y.Y).Min());
-                maxY = Math.Max(nodes.Select(y => y.Y + y.Height).Max(), notes.Select(y => y.Y + y.Height).Max());
+                foreach (var model in models)
+                {
+                    //calculates the min and max positions of both x and y coords of all nodes and notes
+                    minX = Math.Min(model.X, minX);
+                    maxX = Math.Max(model.X + model.Width, maxX);
+                    minY = Math.Min(model.Y, minY);
+                    maxY = Math.Max(model.Y + model.Height, maxY);
+                }
+                
             }
 
             var offset = new Point2D(minX, minY);

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -936,14 +936,18 @@ namespace Dynamo.ViewModels
                 maxY = GetSelectionMaxY();
             }
             else
-            {   // no selection, fitview all nodes
+            {   // no selection, fitview all nodes and notes
                 if (!_nodes.Any()) return;
 
                 List<NodeModel> nodes = _nodes.Select(x => x.NodeModel).Where(x => x != null).ToList();
-                minX = nodes.Select(x => x.X).Min();
-                maxX = nodes.Select(x => x.X + x.Width).Max();
-                minY = nodes.Select(y => y.Y).Min();
-                maxY = nodes.Select(y => y.Y + y.Height).Max();
+                List<NoteModel> notes = _notes.Select(x => x.Model).Where(x => x != null).ToList();
+
+                //calculates the min and max positions of both x and y coords of all nodes and notes
+
+                minX = Math.Min(nodes.Select(x => x.X).Min(), notes.Select(x => x.X).Min());
+                maxX = Math.Max(nodes.Select(x => x.X + x.Width).Max(), notes.Select(x => x.X + x.Width).Max());
+                minY = Math.Min(nodes.Select(y => y.Y).Min(), notes.Select(y => y.Y).Min());
+                maxY = Math.Max(nodes.Select(y => y.Y + y.Height).Max(), notes.Select(y => y.Y + y.Height).Max());
             }
 
             var offset = new Point2D(minX, minY);

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -936,18 +936,19 @@ namespace Dynamo.ViewModels
                 maxY = GetSelectionMaxY();
             }
             else
-            {   // no selection, fitview all nodes and notes
-                if (!_nodes.Any()) return;
+            {   
+                // no selection, fitview all nodes and notes
+                var nodes = _nodes.Select(x => x.NodeModel);
+                var notes = _notes.Select(x => x.Model);
+                var models = nodes.Concat<ModelBase>(notes);
 
-                List<NodeModel> nodes = _nodes.Select(x => x.NodeModel).ToList();
-                List<NoteModel> notes = _notes.Select(x => x.Model).ToList();
-                List<ModelBase> models = nodes.Concat<ModelBase>(notes).ToList();
-                
                 // initialize to the first model (either note or node) on the list 
-                minX = models[0].X;
-                maxX = models[0].X;
-                minY = models[0].Y;
-                maxY = models[0].Y;
+
+                var firstModel = models.First();
+                minX = firstModel.X;
+                maxX = firstModel.X;
+                minY = firstModel.Y;
+                maxY = firstModel.Y;
 
                 foreach (var model in models)
                 {


### PR DESCRIPTION
### Purpose

Fixed Magn 10270/https://github.com/DynamoDS/Dynamo/issues/6068 where zoom.extents did not include all elements. Now, zoom.extents includes all elements, including notes. 

![zoomextents](https://cloud.githubusercontent.com/assets/16283396/16402430/02107692-3d1f-11e6-9c25-d546751bbb69.png)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

### FYIs

@monikaprabhu 

