### PR TITLE
MAGN-10171

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -486,6 +486,9 @@ namespace Dynamo.UI.Controls
 
             var largeContentGridSize = largeContentGrid.DesiredSize;
 
+            // Add two times width of scroll bar (5) and right margin(5), refer to infoBubbleView.xaml
+            largeContentGridSize.Width += 20;
+
             // Don't make it smaller then min width.
             largeContentGridSize.Width = largeContentGridSize.Width < largeContentGrid.MinWidth
                 ? largeContentGrid.MinWidth


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10171
MAGN-10171 Preview Bubble pin covers scrollbar
Add extra width to preview bubble so scroll bar could always show

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

Now with minimum length of data in the list, the scroll bar would be displayed besides the pin button (also known as bubble tools). Expanded preview bubble width is added by 20 (2 times scroll bar width and right margin).

![image](https://cloud.githubusercontent.com/assets/3942418/16404924/36dc8148-3cd1-11e6-9948-256b5be0fb92.png)

### Reviewers

Timeboxed this one, let me know if it is what you want. @Racel @ramramps 

### FYIs

@jnealb 

