### PR TITLE
Add tooltip for WPF view buttons

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2318,6 +2318,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Zoom to Fit (Ctrl + 0).
+        /// </summary>
+        public static string InCanvasFitViewButtonToolTip {
+            get {
+                return ResourceManager.GetString("InCanvasFitViewButtonToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enable background 3D preview navigation (Ctrl + B).
         /// </summary>
         public static string InCanvasGeomButtonToolTip {
@@ -2332,6 +2341,42 @@ namespace Dynamo.Wpf.Properties {
         public static string InCanvasNodeButtonToolTip {
             get {
                 return ResourceManager.GetString("InCanvasNodeButtonToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Orbit.
+        /// </summary>
+        public static string InCanvasOrbitButtonToolTip {
+            get {
+                return ResourceManager.GetString("InCanvasOrbitButtonToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pan.
+        /// </summary>
+        public static string InCanvasPanButtonToolTip {
+            get {
+                return ResourceManager.GetString("InCanvasPanButtonToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Zoom In (Ctrl + =).
+        /// </summary>
+        public static string InCanvasZoomInButtonToolTip {
+            get {
+                return ResourceManager.GetString("InCanvasZoomInButtonToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Zoom Out (Ctrl + -).
+        /// </summary>
+        public static string InCanvasZoomOutButtonToolTip {
+            get {
+                return ResourceManager.GetString("InCanvasZoomOutButtonToolTip", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2318,7 +2318,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Zoom to Fit (Ctrl + 0).
+        ///   Looks up a localized string similar to Zoom to Fit.
         /// </summary>
         public static string InCanvasFitViewButtonToolTip {
             get {
@@ -2363,7 +2363,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Zoom In (Ctrl + =).
+        ///   Looks up a localized string similar to Zoom In.
         /// </summary>
         public static string InCanvasZoomInButtonToolTip {
             get {
@@ -2372,7 +2372,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Zoom Out (Ctrl + -).
+        ///   Looks up a localized string similar to Zoom Out.
         /// </summary>
         public static string InCanvasZoomOutButtonToolTip {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2023,7 +2023,7 @@ Next assemblies were loaded several times:
     <value>[Read-Only] </value>
   </data>
   <data name="InCanvasFitViewButtonToolTip" xml:space="preserve">
-    <value>Zoom to Fit (Ctrl + 0)</value>
+    <value>Zoom to Fit</value>
     <comment>Zoom to Fit</comment>
   </data>
   <data name="InCanvasOrbitButtonToolTip" xml:space="preserve">
@@ -2035,11 +2035,11 @@ Next assemblies were loaded several times:
     <comment>Pan</comment>
   </data>
   <data name="InCanvasZoomInButtonToolTip" xml:space="preserve">
-    <value>Zoom In (Ctrl + =)</value>
+    <value>Zoom In</value>
     <comment>Zoom In</comment>
   </data>
   <data name="InCanvasZoomOutButtonToolTip" xml:space="preserve">
-    <value>Zoom Out (Ctrl + -)</value>
+    <value>Zoom Out</value>
     <comment>Zoom Out</comment>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2022,4 +2022,24 @@ Next assemblies were loaded several times:
   <data name="TabFileNameReadOnlyPrefix" xml:space="preserve">
     <value>[Read-Only] </value>
   </data>
+  <data name="InCanvasFitViewButtonToolTip" xml:space="preserve">
+    <value>Zoom to Fit (Ctrl + 0)</value>
+    <comment>Zoom to Fit</comment>
+  </data>
+  <data name="InCanvasOrbitButtonToolTip" xml:space="preserve">
+    <value>Orbit</value>
+    <comment>Orbit</comment>
+  </data>
+  <data name="InCanvasPanButtonToolTip" xml:space="preserve">
+    <value>Pan</value>
+    <comment>Pan</comment>
+  </data>
+  <data name="InCanvasZoomInButtonToolTip" xml:space="preserve">
+    <value>Zoom In (Ctrl + =)</value>
+    <comment>Zoom In</comment>
+  </data>
+  <data name="InCanvasZoomOutButtonToolTip" xml:space="preserve">
+    <value>Zoom Out (Ctrl + -)</value>
+    <comment>Zoom Out</comment>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2024,4 +2024,24 @@ Next assemblies were loaded several times:
   <data name="TabFileNameReadOnlyPrefix" xml:space="preserve">
     <value>[Read-Only] </value>
   </data>
+  <data name="InCanvasFitViewButtonToolTip" xml:space="preserve">
+    <value>Zoom to Fit (Ctrl + 0)</value>
+    <comment>Zoom to Fit</comment>
+  </data>
+  <data name="InCanvasOrbitButtonToolTip" xml:space="preserve">
+    <value>Orbit</value>
+    <comment>Orbit</comment>
+  </data>
+  <data name="InCanvasPanButtonToolTip" xml:space="preserve">
+    <value>Pan</value>
+    <comment>Pan</comment>
+  </data>
+  <data name="InCanvasZoomInButtonToolTip" xml:space="preserve">
+    <value>Zoom In (Ctrl + =)</value>
+    <comment>Zoom In</comment>
+  </data>
+  <data name="InCanvasZoomOutButtonToolTip" xml:space="preserve">
+    <value>Zoom Out (Ctrl + -)</value>
+    <comment>Zoom Out</comment>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2025,7 +2025,7 @@ Next assemblies were loaded several times:
     <value>[Read-Only] </value>
   </data>
   <data name="InCanvasFitViewButtonToolTip" xml:space="preserve">
-    <value>Zoom to Fit (Ctrl + 0)</value>
+    <value>Zoom to Fit</value>
     <comment>Zoom to Fit</comment>
   </data>
   <data name="InCanvasOrbitButtonToolTip" xml:space="preserve">
@@ -2037,11 +2037,11 @@ Next assemblies were loaded several times:
     <comment>Pan</comment>
   </data>
   <data name="InCanvasZoomInButtonToolTip" xml:space="preserve">
-    <value>Zoom In (Ctrl + =)</value>
+    <value>Zoom In</value>
     <comment>Zoom In</comment>
   </data>
   <data name="InCanvasZoomOutButtonToolTip" xml:space="preserve">
-    <value>Zoom Out (Ctrl + -)</value>
+    <value>Zoom Out</value>
     <comment>Zoom Out</comment>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -147,6 +147,12 @@
         <KeyBinding Key="OemMinus"
                     Modifiers="Ctrl"
                     Command="{Binding Path=DataContext.ZoomOutCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+        <KeyBinding Key="Add"
+                    Modifiers="Ctrl"
+                    Command="{Binding Path=DataContext.ZoomInCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
+        <KeyBinding Key="Subtract"
+                    Modifiers="Ctrl"
+                    Command="{Binding Path=DataContext.ZoomOutCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />
         <KeyBinding Key="D0"
                     Modifiers="Ctrl"
                     Command="{Binding Path=DataContext.FitViewCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}}" />

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -256,7 +256,8 @@
             <ui:ImageButton Width="30"
                             Height="28"
                             HorizontalAlignment="Right"
-                            StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-fit-view-states.png">
+                            StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-fit-view-states.png"
+                            ToolTip="{x:Static p:Resources.InCanvasFitViewButtonToolTip}">
                 <ui:ImageButton.Command>
                     <Binding Path="DataContext.FitViewCommand"
                              RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
@@ -266,7 +267,8 @@
             <ui:ImageRepeatButton Width="30"
                                   Height="24"
                                   HorizontalAlignment="Right"
-                                  StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-zoom-in-states.png">
+                                  StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-zoom-in-states.png"
+                                  ToolTip="{x:Static p:Resources.InCanvasZoomInButtonToolTip}">
                 <ui:ImageRepeatButton.Command>
                     <Binding Path="DataContext.ZoomInCommand"
                              RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
@@ -276,7 +278,8 @@
             <ui:ImageRepeatButton Width="30"
                                   Height="28"
                                   HorizontalAlignment="Right"
-                                  StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-zoom-out-states.png">
+                                  StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-zoom-out-states.png"
+                                  ToolTip="{x:Static p:Resources.InCanvasZoomOutButtonToolTip}">
                 <ui:ImageRepeatButton.Command>
                     <Binding Path="DataContext.ZoomOutCommand"
                              RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
@@ -287,7 +290,8 @@
                               Height="30"
                               HorizontalAlignment="Right"
                               StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-pan-states.png"
-                              CheckImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-pan-check.png">
+                              CheckImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-pan-check.png"
+                              ToolTip="{x:Static p:Resources.InCanvasPanButtonToolTip}">
                 <ui:ImageCheckBox.Command>
                     <Binding Path="DataContext.BackgroundPreviewViewModel.TogglePanCommand"
                              RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />
@@ -303,7 +307,8 @@
                               Height="30"
                               HorizontalAlignment="Right"
                               StateImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-orbit-states.png"
-                              CheckImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-orbit-check.png">
+                              CheckImage="/DynamoCoreWpf;component/UI/Images/Canvas/canvas-button-orbit-check.png"
+                              ToolTip="{x:Static p:Resources.InCanvasOrbitButtonToolTip}">
                 <ui:ImageCheckBox.Command>
                     <Binding Path="DataContext.BackgroundPreviewViewModel.ToggleOrbitCommand"
                              RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type controls:DynamoView}}" />


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9917
MAGN-9917 Zoom to Fit, Zoom Up/Down and Pan controls do not have tooltips

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

Added Tooltips for the Zoom Extents, Zoom In, Zoom Out, Pan, and Orbit Buttons in DynamoCoreWPF.  The strings live in Resources.resx & Resources.en-US.resx.  
**UPDATE**: Shortcut keys for the Zoom Extents, Zoom In, & Zoom Out are removed.

English Tooltip strings are as follows:
- "Zoom to Fit"
- "Zoom In"
- "Zoom Out" 
-"Pan"
-"Orbit"

Examples:
![tool3](https://cloud.githubusercontent.com/assets/2145751/16502424/5b7903f2-3edc-11e6-99c7-0e69e9fed267.png)

**UPDATE**: added in the key bindings for the + & - on the numeric keypad for zoom in and zoom out respectively. 

### Reviewers

@QilongTang @Racel 

### FYIs

@jnealb @ramramps @sm6srw 
