### PR TITLE
Fix contains

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -1997,27 +1997,21 @@ namespace ProtoCore.Lang
                 return true;
             }
 
-            bool contains = false;
             var svArray = runtimeCore.Heap.ToHeapObject<DSArray>(sv1).Values;
             foreach (StackValue op in svArray)
             {
-                if (!op.IsArray)
+                if (op.IsArray)
                 {
-                    if (op.Equals(sv2))
+                    if (Contains(op, sv2, runtime))
                         return true;
                 }
                 else
                 {
-                    contains = Contains(op, sv2, runtime);
+                    if (StackUtils.CompareStackValues(op, sv2, runtime.runtime.RuntimeCore))
+                        return true;
                 }
-
-                if (contains) 
-                {
-                    return true;
-                }
-
             }
-            return contains;
+            return false;
         }
         internal static bool ContainsArray(StackValue sv1, StackValue sv2, ProtoCore.DSASM.Interpreter runtime)
         {

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -1054,6 +1054,16 @@ namespace Dynamo.Tests
             OpenModel(dynFilePath);
             AssertPreviewValue("25a90516-9e46-4268-a745-266524844158", 6);
         }
+
+        [Test]
+        public void TestContainsUsingEqualityTest()
+        {
+            // Verify the function with default argument works.
+            var dynFilePath = Path.Combine(TestDirectory, @"core\dsfunction\contains.dyn");
+            OpenModel(dynFilePath);
+            AssertPreviewValue("a612292b-6c72-41f7-bf91-753925f7a776", true);
+            AssertPreviewValue("ad5b2297-537c-4445-b8db-9eca720787ec", true);
+        }
     }
 
     [Category("DSCustomNode")]

--- a/test/core/dsfunction/contains.dyn
+++ b/test/core/dsfunction/contains.dyn
@@ -1,0 +1,40 @@
+<Workspace Version="1.1.1.1921" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="928ae9e8-26a8-4f5c-87c1-170688896ab1" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="375" y="103" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="50a282fa-6888-4a41-9d30-7bf9cb2982c0" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="355" y="293" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="60653d4d-32da-47da-8734-cf97157cd458" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="159" y="235" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="1;&#xA;2;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="395cf7a9-0527-43b4-95c1-448842a8bb20" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="629" y="146" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{pts};" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="38ef82fd-1112-4139-9624-02306010ac22" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Contains" x="859" y="178" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="BuiltIn" function="Contains@var[]..[],var" />
+    <CoreNodeModels.Watch guid="a612292b-6c72-41f7-bf91-753925f7a776" type="CoreNodeModels.Watch" nickname="Watch" x="1107" y="136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="1e5277f4-7392-47eb-b1d4-34688cf426bf" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Contains" x="860" y="320" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="BuiltIn" function="Contains@var[]..[],var" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="51c94c8f-f680-4f8d-afdb-88cfbfaf65be" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="614" y="341" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{pts};" ShouldFocus="false" />
+    <CoreNodeModels.Watch guid="ad5b2297-537c-4445-b8db-9eca720787ec" type="CoreNodeModels.Watch" nickname="Watch" x="1106" y="332" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="928ae9e8-26a8-4f5c-87c1-170688896ab1" start_index="0" end="395cf7a9-0527-43b4-95c1-448842a8bb20" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="928ae9e8-26a8-4f5c-87c1-170688896ab1" start_index="0" end="51c94c8f-f680-4f8d-afdb-88cfbfaf65be" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="928ae9e8-26a8-4f5c-87c1-170688896ab1" start_index="0" end="1e5277f4-7392-47eb-b1d4-34688cf426bf" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="50a282fa-6888-4a41-9d30-7bf9cb2982c0" start_index="0" end="38ef82fd-1112-4139-9624-02306010ac22" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="60653d4d-32da-47da-8734-cf97157cd458" start_index="0" end="928ae9e8-26a8-4f5c-87c1-170688896ab1" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="60653d4d-32da-47da-8734-cf97157cd458" start_index="0" end="50a282fa-6888-4a41-9d30-7bf9cb2982c0" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="60653d4d-32da-47da-8734-cf97157cd458" start_index="1" end="928ae9e8-26a8-4f5c-87c1-170688896ab1" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="60653d4d-32da-47da-8734-cf97157cd458" start_index="1" end="50a282fa-6888-4a41-9d30-7bf9cb2982c0" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="395cf7a9-0527-43b4-95c1-448842a8bb20" start_index="0" end="38ef82fd-1112-4139-9624-02306010ac22" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="38ef82fd-1112-4139-9624-02306010ac22" start_index="0" end="a612292b-6c72-41f7-bf91-753925f7a776" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="1e5277f4-7392-47eb-b1d4-34688cf426bf" start_index="0" end="ad5b2297-537c-4445-b8db-9eca720787ec" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="51c94c8f-f680-4f8d-afdb-88cfbfaf65be" start_index="0" end="1e5277f4-7392-47eb-b1d4-34688cf426bf" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

`Contains` node should use equality testing instead of reference equality testing. For example, the following code should return `true`:
```
pt1 = Point.ByCoordinates(1, 2);
pt2 = Point.ByCoordinates(1, 2);  // pt1 equals pt2
pts = {pt1};
r = Contains(pts, pt1); // r should be true
```

This PR is to fix issue #6824 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@monikaprabhu 
