### PR TITLE
Refactor Contains() and ContainsArray()

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -203,13 +203,8 @@ namespace ProtoCore.Lang
                     ret = ArrayUtilsForBuiltIns.Equals(formalParameters[0], formalParameters[1], interpreter, c);
                     break;
                 case ProtoCore.Lang.BuiltInMethods.MethodID.Contains:
-                    {
-                        if (formalParameters[1].IsArray)
-                            ret = ProtoCore.DSASM.StackValue.BuildBoolean(ArrayUtilsForBuiltIns.ContainsArray(formalParameters[0], formalParameters[1], interpreter));
-                        else
-                            ret = ProtoCore.DSASM.StackValue.BuildBoolean(ArrayUtilsForBuiltIns.Contains(formalParameters[0], formalParameters[1], interpreter));
-                        break;
-                    }
+                    ret = ProtoCore.DSASM.StackValue.BuildBoolean(ArrayUtilsForBuiltIns.Contains(formalParameters[0], formalParameters[1], interpreter));
+                    break;
                 case ProtoCore.Lang.BuiltInMethods.MethodID.IndexOf:
                     {
                         if (formalParameters[0].IsArray)
@@ -1996,67 +1991,13 @@ namespace ProtoCore.Lang
             {
                 return true;
             }
-
-            var svArray = runtimeCore.Heap.ToHeapObject<DSArray>(sv1).Values;
-            foreach (StackValue op in svArray)
+            else
             {
-                if (op.IsArray)
-                {
-                    if (Contains(op, sv2, runtime))
-                        return true;
-                }
-                else
-                {
-                    if (StackUtils.CompareStackValues(op, sv2, runtime.runtime.RuntimeCore))
-                        return true;
-                }
+                var svArray = runtimeCore.Heap.ToHeapObject<DSArray>(sv1).Values;
+                return svArray.Any(v => StackUtils.CompareStackValues(v, sv2, runtimeCore) || (v.IsArray && Contains(v, sv2, runtime)));
             }
-            return false;
         }
-        internal static bool ContainsArray(StackValue sv1, StackValue sv2, ProtoCore.DSASM.Interpreter runtime)
-        {
-            RuntimeCore runtimeCore = runtime.runtime.RuntimeCore;
-            if (!sv1.IsArray)
-            {
-                // Type mismatch.
-                runtimeCore.RuntimeStatus.LogWarning(Runtime.WarningID.InvalidArguments, Resources.kInvalidArguments);
-                return false;
-            }
-            bool contains = false;
-            if (StackUtils.CompareStackValues(sv1, sv2, runtime.runtime.RuntimeCore)) 
-                return true;
 
-            var array = runtimeCore.Heap.ToHeapObject<DSArray>(sv1);
-            foreach (var op in array.Values)
-            {
-                if (!sv2.IsArray)
-                {
-                    if (!op.IsArray)
-                    {
-                        if (op.Equals(sv2))
-                            return true;
-                    }
-                    else
-                    {
-                        contains = ContainsArray(op, sv2, runtime);
-                    }
-                    if (contains) return contains;
-                }
-                else
-                {
-                    if (op.IsArray)
-                    {
-                        contains = StackUtils.CompareStackValues(op, sv2, runtime.runtime.RuntimeCore);
-                        if (!contains)
-                        {
-                            contains = ContainsArray(op, sv2, runtime);
-                        }
-                        if (contains) return contains;
-                    }
-                }
-            }
-            return contains;
-        }
         //IndexOf & IOndexOfArray::: sv2 is index of sv1
         internal static int IndexOf(StackValue sv1, StackValue sv2, ProtoCore.DSASM.Interpreter runtime)
         {

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -490,18 +490,6 @@ namespace ProtoCore.Lang
 
                 new BuiltInMethod
                 {
-                    ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Bool, 0),
-                    Parameters = new List<KeyValuePair<string, ProtoCore.Type>>
-                    {
-                        new KeyValuePair<string, ProtoCore.Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank)),
-                        new KeyValuePair<string, ProtoCore.Type>("element", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0))
-                    },
-                    ID = BuiltInMethods.MethodID.Contains,
-                    MethodAttributes = new MethodAttributes(){Description  = Resources.ChecksIfListContainsTheElement}
-                },
-
-                new BuiltInMethod
-                {
                     ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Integer, 0),
                     Parameters = new List<KeyValuePair<string, ProtoCore.Type>>
                     {

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -1064,6 +1064,17 @@ namespace Dynamo.Tests
             AssertPreviewValue("a612292b-6c72-41f7-bf91-753925f7a776", true);
             AssertPreviewValue("ad5b2297-537c-4445-b8db-9eca720787ec", true);
         }
+
+        [Test]
+        public void TestContainsArray()
+        {
+            // Verify the function with default argument works.
+            var dynFilePath = Path.Combine(TestDirectory, @"core\dsfunction\contains2.dyn");
+            OpenModel(dynFilePath);
+            AssertPreviewValue("863e8d06-0175-42ec-8613-305e9efa95d0", true);
+            AssertPreviewValue("b0d7b844-93a9-43fa-b8f1-15cbb7469a84", true);
+            AssertPreviewValue("d1942e84-355f-4083-bb1c-6b7203ee192c", true);
+        }
     }
 
     [Category("DSCustomNode")]

--- a/test/core/dsfunction/contains2.dyn
+++ b/test/core/dsfunction/contains2.dyn
@@ -1,0 +1,55 @@
+<Workspace Version="1.1.1.1921" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="c477caeb-d40c-4830-9163-962938b10bd1" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="205" y="79" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{{1,2,3}, {4, 5, 6}};&#xA;&#xA;{4, 5, 6};" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="8761c157-0b85-4f03-b75e-adb720afce67" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Contains" x="732" y="129" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="BuiltIn" function="Contains@var[]..[],var[]..[]" />
+    <CoreNodeModels.Watch guid="863e8d06-0175-42ec-8613-305e9efa95d0" type="CoreNodeModels.Watch" nickname="Watch" x="1066" y="147" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="b33f01d0-3631-4673-a7b1-e08e3b74bb6b" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="273" y="241" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="9d0531e4-ee5d-4efe-b593-a7266fbb5ee2" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="279" y="374" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="2720d7f4-eb15-46ac-8d7c-7129ecb47dc2" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="83" y="361" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="1;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="68cce7e7-6c6d-4d06-a083-f1051ac5a403" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="280" y="524" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="c0cafbd6-cca1-4008-9ff4-dbed0c2cd7c2" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="84" y="511" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="1;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="908a95dc-4799-42c9-8664-4bb2f1c2dbef" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Contains" x="953" y="334" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="BuiltIn" function="Contains@var[]..[],var[]..[]" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="92a06253-1a79-40ce-8cb1-06c3b09ee66a" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="665" y="315" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{pt1, pt2};" ShouldFocus="false" />
+    <CoreNodeModels.Watch guid="b0d7b844-93a9-43fa-b8f1-15cbb7469a84" type="CoreNodeModels.Watch" nickname="Watch" x="1277" y="338" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="5a17fa46-e576-45a4-9b28-ab4dca508dbf" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="668" y="638" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{pt2};" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="094d5299-3928-4bb9-ad89-645112cdc437" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Contains" x="955" y="513" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="BuiltIn" function="Contains@var[]..[],var[]..[]" />
+    <CoreNodeModels.Watch guid="d1942e84-355f-4083-bb1c-6b7203ee192c" type="CoreNodeModels.Watch" nickname="Watch" x="1285" y="516" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="8829271c-93ce-446a-a801-55e3ee2e8902" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="658" y="507" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{pt1, {pt2}};" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="c477caeb-d40c-4830-9163-962938b10bd1" start_index="0" end="8761c157-0b85-4f03-b75e-adb720afce67" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="c477caeb-d40c-4830-9163-962938b10bd1" start_index="1" end="8761c157-0b85-4f03-b75e-adb720afce67" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="8761c157-0b85-4f03-b75e-adb720afce67" start_index="0" end="863e8d06-0175-42ec-8613-305e9efa95d0" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b33f01d0-3631-4673-a7b1-e08e3b74bb6b" start_index="0" end="92a06253-1a79-40ce-8cb1-06c3b09ee66a" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b33f01d0-3631-4673-a7b1-e08e3b74bb6b" start_index="0" end="8829271c-93ce-446a-a801-55e3ee2e8902" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="9d0531e4-ee5d-4efe-b593-a7266fbb5ee2" start_index="0" end="92a06253-1a79-40ce-8cb1-06c3b09ee66a" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="9d0531e4-ee5d-4efe-b593-a7266fbb5ee2" start_index="0" end="8829271c-93ce-446a-a801-55e3ee2e8902" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="2720d7f4-eb15-46ac-8d7c-7129ecb47dc2" start_index="0" end="9d0531e4-ee5d-4efe-b593-a7266fbb5ee2" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="2720d7f4-eb15-46ac-8d7c-7129ecb47dc2" start_index="0" end="9d0531e4-ee5d-4efe-b593-a7266fbb5ee2" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="68cce7e7-6c6d-4d06-a083-f1051ac5a403" start_index="0" end="908a95dc-4799-42c9-8664-4bb2f1c2dbef" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="68cce7e7-6c6d-4d06-a083-f1051ac5a403" start_index="0" end="5a17fa46-e576-45a4-9b28-ab4dca508dbf" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="c0cafbd6-cca1-4008-9ff4-dbed0c2cd7c2" start_index="0" end="68cce7e7-6c6d-4d06-a083-f1051ac5a403" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="c0cafbd6-cca1-4008-9ff4-dbed0c2cd7c2" start_index="0" end="68cce7e7-6c6d-4d06-a083-f1051ac5a403" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="908a95dc-4799-42c9-8664-4bb2f1c2dbef" start_index="0" end="b0d7b844-93a9-43fa-b8f1-15cbb7469a84" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="92a06253-1a79-40ce-8cb1-06c3b09ee66a" start_index="0" end="908a95dc-4799-42c9-8664-4bb2f1c2dbef" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5a17fa46-e576-45a4-9b28-ab4dca508dbf" start_index="0" end="094d5299-3928-4bb9-ad89-645112cdc437" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="094d5299-3928-4bb9-ad89-645112cdc437" start_index="0" end="d1942e84-355f-4083-bb1c-6b7203ee192c" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="8829271c-93ce-446a-a801-55e3ee2e8902" start_index="0" end="094d5299-3928-4bb9-ad89-645112cdc437" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

Code duplication. Remove one of them.

Also remove overloaded `Contains()`, this is to fix issue #6849 . Now is only one `Contains` (the next one is `String.Contains`):

![untitled](https://cloud.githubusercontent.com/assets/2600379/16720020/6b699f98-4764-11e6-86a8-5d98e52211bd.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@monikaprabhu , @riteshchandawar 
