### PR TITLE
Fix InvalidOperationException while calling Aggregate on Empty list.

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -598,8 +598,8 @@ namespace Dynamo.Controls
             if(pkgExtension != null)
             {
                 packages = pkgExtension.PackageLoader.LocalPackages
-                    .Select(p => p.Name)
-                    .Aggregate((x, y) => string.Format("{0}, {1}", x, y));
+                    .Select(p => string.Format("{0} {1}", p.Name, p.VersionName))
+                    .Aggregate(String.Empty, (x, y) => string.Format("{0}, {1}", x, y));
             }
             Analytics.TrackTimedEvent(Categories.Performance, "ViewStartup", dynamoViewModel.Model.stopwatch.Elapsed, packages);
         }


### PR DESCRIPTION
### Purpose

- Enumerable.Aggregate() throws InvalidOperationException on an empty list. Fixed by passing a seed value for aggregate.
- Capture package version number together with package name for startup analytics.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

