### PR TITLE
Fix in deserialization of trace data for element binding regressions

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("1.1.1.1813")]
+[assembly: AssemblyVersion("1.1.1.1953")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.1.1.1813")]
+[assembly: AssemblyFileVersion("1.1.1.1953")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("1.1.1.1953")]
+[assembly: AssemblyVersion("1.1.1.1813")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.1.1.1953")]
+[assembly: AssemblyFileVersion("1.1.1.1813")]

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -225,10 +225,20 @@ namespace ProtoCore
 
             public override System.Type BindToType(string assemblyName, string typeName)
             {
-                var result = AppDomain.CurrentDomain.GetAssemblies()
-                    .Where(a => !a.IsDynamic)
-                    .SelectMany(a => a.GetTypes())
-                    .FirstOrDefault(t => t.FullName == typeName);
+                var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic);
+                var types = new List<System.Type>();
+                foreach (var a in assemblies)
+                {
+                    try
+                    {
+                        types.AddRange(a.GetTypes());
+                    }
+                    catch (ReflectionTypeLoadException)
+                    {
+                        // We ignore assembly loading exceptions that are thrown here when their dependencies cannot be found
+                    }
+                }
+                var result = types.FirstOrDefault(t => t.FullName == typeName);
 
                 return result;
             }


### PR DESCRIPTION
### Purpose

This fix addresses [MAGN-10351] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10351).

There were regressions in element binding behaviour after upgrading the Revit2017 version. This was because trace data serialized for Revit elements in a previously saved document was not found in a subsequent execution of the graph. The error lied in deserialization of the trace data, which was throwing exceptions in the callsite. The deserialization logic relies on finding assemblies necessary for the deserialization where the one used in the serialization is not known. See the implementation of `TraceBinder`. In the case of Revit2017 it happens that a number of the assemblies cannot load and throw an exception as a result when queried for their types. The fix is to ignore these exceptions and proceed with finding the types of only those that are able to load.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 

### FYIs

@Randy-Ma 
@riteshchandawar 
