### PR TITLE
LibraryServices backward compatibility

### DIFF
--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -95,7 +95,7 @@ namespace Dynamo.Engine
         /// <param name="libraryManagementCore">Core which is used for parsing code and loading libraries</param>
         /// <param name="pathManager">Instance of IPathManager containing neccessary Dynamo paths</param>
         /// <param name="preferences">The preference settings of the Dynamo instance</param>
-        public LibraryServices(ProtoCore.Core libraryManagementCore, IPathManager pathManager, IPreferences preferences)
+        public LibraryServices(ProtoCore.Core libraryManagementCore, IPathManager pathManager, IPreferences preferences = null)
         {
             LibraryManagementCore = libraryManagementCore;
             this.pathManager = pathManager;


### PR DESCRIPTION
### Purpose

To fix backward compatibility failure caused by PR #6738: Optionally load T-Spline nodes in the node library.

### Declarations

- [x] All tests pass using the self-service CI.

### FYI

@aparajit-pratap