### PR TITLE
Fix test failures

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModelExtensions.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModelExtensions.cs
@@ -99,6 +99,8 @@ namespace Dynamo.Graph.Nodes
 
         internal static string GetOriginalName(this NodeModel node)
         {
+            if (node == null) return string.Empty;
+
             var function = node as DSFunctionBase;
             if (function != null)
                 return function.Controller.Definition.DisplayName;

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -94,8 +94,16 @@ namespace Dynamo.Engine
         /// </summary>
         /// <param name="libraryManagementCore">Core which is used for parsing code and loading libraries</param>
         /// <param name="pathManager">Instance of IPathManager containing neccessary Dynamo paths</param>
+        public LibraryServices(ProtoCore.Core libraryManagementCore, IPathManager pathManager)
+            : this(libraryManagementCore, pathManager, null) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibraryServices"/> class.
+        /// </summary>
+        /// <param name="libraryManagementCore">Core which is used for parsing code and loading libraries</param>
+        /// <param name="pathManager">Instance of IPathManager containing neccessary Dynamo paths</param>
         /// <param name="preferences">The preference settings of the Dynamo instance</param>
-        public LibraryServices(ProtoCore.Core libraryManagementCore, IPathManager pathManager, IPreferences preferences = null)
+        public LibraryServices(ProtoCore.Core libraryManagementCore, IPathManager pathManager, IPreferences preferences)
         {
             LibraryManagementCore = libraryManagementCore;
             this.pathManager = pathManager;

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -802,7 +802,7 @@ namespace Dynamo.Models
                 Dynamo.Logging.Analytics.TrackEvent(
                     Logging.Actions.Create,
                     Logging.Categories.NodeOperations,
-                    Node.GetOriginalName());
+                    (Node != null) ? Node.GetOriginalName() : Name ?? "");
             }
 
             #endregion

--- a/src/DynamoCoreWpf/Commands/AutomationSettings.cs
+++ b/src/DynamoCoreWpf/Commands/AutomationSettings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Windows;
 using System.Windows.Threading;
 using System.Xml;
@@ -462,7 +463,7 @@ namespace Dynamo.ViewModels
             // calls like NUnit test cases can properly display the exception.
             // 
             if (PlaybackException != null)
-                throw PlaybackException;
+                ExceptionDispatchInfo.Capture(PlaybackException).Throw();
         }
 
         private void ChangeStateInternal(State playbackState)

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -149,7 +149,7 @@ namespace Dynamo.ViewModels
                     throw new InvalidOperationException("Unhandled command name");
             }
 
-            if (Dynamo.Logging.Analytics.ReportingAnalytics)
+            if (Dynamo.Logging.Analytics.ReportingAnalytics && !command.IsInPlaybackMode)
             {
                 command.TrackAnalytics();
             }


### PR DESCRIPTION
### Purpose

#### 1. Fix test failures related to RecordableCommand
* Force disable analytics tracking under recorded tests.
* Yet still, never track a `CreateNodeEvent` if by any chance the `Node` is null, by adding null checking inside the recently introduced methods `CreateNodeCommand.TrackAnalytics()` and `NodeModelExtensions.GetOriginalName()`.
* Capture better stack trace for exceptions that are thrown inside a recorded test.

##### Stack trace in NUnit before change:
![image](https://cloud.githubusercontent.com/assets/6386550/16866979/a7603828-4aa1-11e6-9460-d022f3f7727b.png)

##### After change:
![image](https://cloud.githubusercontent.com/assets/6386550/16866969/99e9c114-4aa1-11e6-96e7-468895f5feaf.png)

#### 2. Fix backward compatibility test failures related to LibraryServices
* We now have two constructors that accept 2 arguments and 3 arguments, to ensure binary compatibility.

### Declarations

- [x] The code base is in a better state after this PR
- [x] All tests pass using the self-service CI.

### Reviewers

@Benglin @ke-yu

### FYI

@aparajit-pratap