### PR TITLE
Adjust the path looking logic for two pathes

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -444,7 +444,11 @@ namespace Dynamo.Core
         internal string GetUserDataFolder(IPathResolver pathResolver = null)
         {
             if (pathResolver != null && !string.IsNullOrEmpty(pathResolver.UserDataRootFolder))
-                return GetDynamoDataFolder(pathResolver.UserDataRootFolder);
+            {
+                var versionedPath = GetDynamoDataFolder(pathResolver.UserDataRootFolder);
+                if (Directory.Exists(versionedPath)) return versionedPath;
+                return pathResolver.UserDataRootFolder;
+            }
 
             if (!string.IsNullOrEmpty(userDataDir))
                 return userDataDir; //Return the cached userDataDir if we have one.
@@ -456,7 +460,11 @@ namespace Dynamo.Core
         private string GetCommonDataFolder(IPathResolver pathResolver)
         {
             if (pathResolver != null && !string.IsNullOrEmpty(pathResolver.CommonDataRootFolder))
-                return GetDynamoDataFolder(pathResolver.CommonDataRootFolder);
+            {
+                var versionedPath = GetDynamoDataFolder(pathResolver.CommonDataRootFolder);
+                if (Directory.Exists(versionedPath)) return versionedPath;
+                return pathResolver.CommonDataRootFolder;
+            }
 
             var folder = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
             return GetDynamoDataFolder(Path.Combine(folder, "Dynamo", "Dynamo Core"));


### PR DESCRIPTION
### Purpose

This is to adjust the path looking logic for two pathes. At first we will try to look for the path by appending major.minor(e.g. 0.9, 1.1) to the corresponding root folder, if the folder exists, then return it, otherwise, return the root folder.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 


