### PR TITLE
MAGN-7228 Number from Feet and Inches rounds input text incorrectly and output is confusing

### DIFF
--- a/src/Libraries/DynamoUnits/Units.cs
+++ b/src/Libraries/DynamoUnits/Units.cs
@@ -715,7 +715,8 @@ namespace DynamoUnits
                     return (_value * ToFoot).ToString(NumberFormat, CultureInfo.InvariantCulture) + FEET;
 
                 case LengthUnit.FractionalFoot:
-                    return Utils.ToFeetAndFractionalInches(_value * ToFoot);
+                    //return Utils.ToFeetAndFractionalInches(_value * ToFoot);
+                    return Utils.ToFeetAndDecimalInches(_value * ToFoot);
 
                 default:
                     return _value.ToString(NumberFormat, CultureInfo.InvariantCulture) + METERS;
@@ -1890,6 +1891,40 @@ namespace DynamoUnits
                 return string.Format("{0}{1}\"", sign, inches).Trim();
             }
             return string.Format("{0}{1} {2}\"", sign, inches, fraction).Trim();
+        }
+
+        public static string ToFeetAndDecimalInches(double decimalFeet)
+        {
+            double wholeFeet = 0.0;
+            double partialFeet = 0.0;
+
+            if (decimalFeet < 0)
+            {
+                wholeFeet = Math.Ceiling(decimalFeet);
+                if (wholeFeet == 0)
+                    partialFeet = decimalFeet;
+                else
+                    partialFeet = wholeFeet - decimalFeet;
+            }
+            else
+            {
+                wholeFeet = Math.Floor(decimalFeet);
+                partialFeet = decimalFeet - wholeFeet;
+            }
+
+            string decimalInches = (Math.Round(partialFeet * 12.0, ROUND_DIGITS)).ToString(BaseUnit.NumberFormat, CultureInfo.InvariantCulture);
+
+            string feet = "";
+            if (wholeFeet != 0.0)
+                feet = string.Format("{0}'", wholeFeet);
+
+            if (wholeFeet.AlmostEquals(0.0, EPSILON) && (partialFeet * 12.0).AlmostEquals(0.0, EPSILON))
+                feet = "0'";
+
+            // Adding symbol for inch
+            decimalInches += "\"";
+
+            return string.Format("{0} {1}", feet, decimalInches).Trim();
         }
 
         public static bool ParseLengthInFeetFromString(string value, out double feet, out double numerator, out double denominator)

--- a/src/Libraries/DynamoUnits/Units.cs
+++ b/src/Libraries/DynamoUnits/Units.cs
@@ -1914,6 +1914,18 @@ namespace DynamoUnits
 
             string decimalInches = (Math.Round(partialFeet * 12.0, ROUND_DIGITS)).ToString(BaseUnit.NumberFormat, CultureInfo.InvariantCulture);
 
+            if (partialFeet.AlmostEquals(1.0000, EPSILON))
+            {
+                //add a foot to the whole feet
+                wholeFeet += 1.0;
+                decimalInches = "0.0000";
+            }
+            else if (partialFeet.AlmostEquals(-1.0000, EPSILON))
+            {
+                wholeFeet -= 1.0;
+                decimalInches = "0.0000";
+            }
+
             string feet = "";
             if (wholeFeet != 0.0)
                 feet = string.Format("{0}'", wholeFeet);
@@ -1929,7 +1941,9 @@ namespace DynamoUnits
 
         public static bool ParseLengthInFeetFromString(string value, out double feet, out double numerator, out double denominator)
         {
-            string pattern = @"(\A((?<ft>((\+|-)?\d{0,}([.,]\d{1,})?))( ?)('|ft)?)\Z)|(\A(?<ft>(?<num>(\+|-)?\d+)/(?<den>\d+)*( ?)('|ft)?)\Z)";
+            // This string pattern only handle for the case of input in whole feet without unit symbol 
+            // or fractional feet with/without unit symbol.
+            string pattern = @"(\A((?<ft>((\+|-)?\d{0,}([.,]\d{1,})?))( ?))\Z)|(\A(?<ft>(?<num>(\+|-)?\d+)/(?<den>\d+)*( ?)('|ft)?)\Z)";
 
             feet = 0.0;
             numerator = 0.0;

--- a/src/Libraries/DynamoUnits/Units.cs
+++ b/src/Libraries/DynamoUnits/Units.cs
@@ -628,16 +628,15 @@ namespace DynamoUnits
         [Obsolete("Length.SetValueFromString is obsolete.", false)]
         public override void SetValueFromString(string value)
         {
-            //first try to parse the input as a number
-            //it it's parsable, then just cram it into
-            //whatever the project units are
-            double total = 0.0;
-            double feet, inch, m, cm, mm, numerator, denominator;
             //For input with either unit of feet specified
             //or without any unit being specified.
             //When there is no unit being specified in the input,
             //we take that as unit of feet by default
-            if(Utils.ParseLengthInFeetFromString(value, out feet, out numerator, out denominator))
+
+            double total = 0.0;
+            double feet, inch, m, cm, mm, numerator, denominator;
+
+            if (Utils.ParseLengthInFeetFromString(value, out feet, out numerator, out denominator))
             { 
                 if (feet == 0 && denominator != 0)
                 {
@@ -650,11 +649,7 @@ namespace DynamoUnits
                 _value = total / UiLengthConversion;
                 return;
             }
-            /*if (Double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out total))
-             {
-                 _value = total/UiLengthConversion;
-                 return;
-             }*/
+            
             //For inputs with inches specified.
             double fractionalInch = 0.0;
             Utils.ParseLengthFromString(value, out feet, out inch, out m, out cm, out mm, out numerator, out denominator);
@@ -715,7 +710,6 @@ namespace DynamoUnits
                     return (_value * ToFoot).ToString(NumberFormat, CultureInfo.InvariantCulture) + FEET;
 
                 case LengthUnit.FractionalFoot:
-                    //return Utils.ToFeetAndFractionalInches(_value * ToFoot);
                     return Utils.ToFeetAndDecimalInches(_value * ToFoot);
 
                 default:
@@ -1961,7 +1955,10 @@ namespace DynamoUnits
                                 out denominator);
                 return true;
             }
-            else return false;
+            else
+            {
+                return false;
+            }
         }
 
         public static void ParseLengthFromString(string value, out double feet, 

--- a/src/Libraries/DynamoUnits/Units.cs
+++ b/src/Libraries/DynamoUnits/Units.cs
@@ -63,6 +63,7 @@ namespace DynamoUnits
         private static VolumeUnit _hostApplicationInternalVolumeUnit = DynamoUnits.VolumeUnit.CubicMeter;
 
         private static string _numberFormat = "f4";
+        private static string _generalNumberFormat = "G";
 
         public static double Epsilon
         {
@@ -93,6 +94,11 @@ namespace DynamoUnits
             set { _numberFormat = value; }
         }
 
+        public static string GeneralNumberFormat
+        {
+            get { return _generalNumberFormat; }
+            set { _generalNumberFormat = value; }
+        }
     }
 
     [IsVisibleInDynamoLibrary(false)]
@@ -1905,19 +1911,19 @@ namespace DynamoUnits
                 wholeFeet = Math.Floor(decimalFeet);
                 partialFeet = decimalFeet - wholeFeet;
             }
-
-            string decimalInches = (Math.Round(partialFeet * 12.0, ROUND_DIGITS)).ToString(BaseUnit.NumberFormat, CultureInfo.InvariantCulture);
+           
+            string decimalInches = (Math.Round(partialFeet * 12.0, ROUND_DIGITS)).ToString(BaseUnit.GeneralNumberFormat, CultureInfo.InvariantCulture);
 
             if (partialFeet.AlmostEquals(1.0000, EPSILON))
             {
                 //add a foot to the whole feet
                 wholeFeet += 1.0;
-                decimalInches = "0.0000";
+                decimalInches = "0";
             }
             else if (partialFeet.AlmostEquals(-1.0000, EPSILON))
             {
                 wholeFeet -= 1.0;
-                decimalInches = "0.0000";
+                decimalInches = "0";
             }
 
             string feet = "";

--- a/test/DynamoCoreTests/UnitsOfMeasureTests.cs
+++ b/test/DynamoCoreTests/UnitsOfMeasureTests.cs
@@ -255,20 +255,11 @@ namespace Dynamo.Tests
             length.Value = 0.0;
             Assert.AreEqual("0' 0.0000\"", length.ToString());
 
-            /*length.Value = 0.003175; //1/8"
-            Assert.AreEqual("1/8\"", length.ToString());*/
-
             length.Value = 0.003175; //1/8"
             Assert.AreEqual("0.1250\"", length.ToString());
 
-            /*length.Value = 0.301752; //.99ft
-            Assert.AreEqual("11 7/8\"", length.ToString());*/
-
             length.Value = 0.301752; //.99ft
             Assert.AreEqual("11.8800\"", length.ToString());
-
-            /*length.Value = 0.3044952; //.999ft
-            Assert.AreEqual("11 63/64\"", length.ToString());*/
 
             length.Value = 0.3044952; //.999ft
             Assert.AreEqual("11.9880\"", length.ToString());

--- a/test/DynamoCoreTests/UnitsOfMeasureTests.cs
+++ b/test/DynamoCoreTests/UnitsOfMeasureTests.cs
@@ -237,38 +237,38 @@ namespace Dynamo.Tests
         public void ToFractionalFootRepresentations()
         {
             //test just the fractional case
-            var length = Length.FromDouble(0.0762); //.25"
+            var length = Length.FromDouble(0.0762); //.25'
             length.LengthUnit = LengthUnit.FractionalFoot;
 
-            Assert.AreEqual("3.0000\"", length.ToString());
+            Assert.AreEqual("3\"", length.ToString());
 
             length.Value = -0.0762;
-            Assert.AreEqual("-3.0000\"", length.ToString());
+            Assert.AreEqual("-3\"", length.ToString());
 
             length.Value = 0.3048; //1ft.
-            Assert.AreEqual("1' 0.0000\"", length.ToString());
+            Assert.AreEqual("1' 0\"", length.ToString());
 
             length.Value = -0.3048;
-            Assert.AreEqual("-1' 0.0000\"", length.ToString());
+            Assert.AreEqual("-1' 0\"", length.ToString());
 
             //test some edge cases
             length.Value = 0.0;
-            Assert.AreEqual("0' 0.0000\"", length.ToString());
+            Assert.AreEqual("0' 0\"", length.ToString());
 
             length.Value = 0.003175; //1/8"
-            Assert.AreEqual("0.1250\"", length.ToString());
+            Assert.AreEqual("0.125\"", length.ToString());
 
             length.Value = 0.301752; //.99ft
-            Assert.AreEqual("11.8800\"", length.ToString());
+            Assert.AreEqual("11.88\"", length.ToString());
 
             length.Value = 0.3044952; //.999ft
-            Assert.AreEqual("11.9880\"", length.ToString());
+            Assert.AreEqual("11.988\"", length.ToString());
 
             length.Value = 0.35560000000142239; //1'2"
-            Assert.AreEqual("1' 2.0000\"", length.ToString());
+            Assert.AreEqual("1' 2\"", length.ToString());
 
             length.Value = -0.35560000000142239; //-1'2"
-            Assert.AreEqual("-1' 2.0000\"", length.ToString());
+            Assert.AreEqual("-1' 2\"", length.ToString());
 
         }
 
@@ -588,24 +588,24 @@ namespace Dynamo.Tests
         public void UiRounding()
         {
             var length = Length.FromFeet(1.5, LengthUnit.FractionalFoot);
-            Assert.AreEqual("2' 0.0000\"", ((Length)length.Round()).ToString());
-            Assert.AreEqual("2' 0.0000\"", ((Length)length.Ceiling()).ToString());
-            Assert.AreEqual("1' 0.0000\"", ((Length)length.Floor()).ToString());
+            Assert.AreEqual("2' 0\"", ((Length)length.Round()).ToString());
+            Assert.AreEqual("2' 0\"", ((Length)length.Ceiling()).ToString());
+            Assert.AreEqual("1' 0\"", ((Length)length.Floor()).ToString());
 
             length = Length.FromFeet(1.2, LengthUnit.FractionalFoot);
-            Assert.AreEqual("1' 0.0000\"", ((Length)length.Round()).ToString());
-            Assert.AreEqual("2' 0.0000\"", ((Length)length.Ceiling()).ToString());
-            Assert.AreEqual("1' 0.0000\"", ((Length)length.Floor()).ToString());
+            Assert.AreEqual("1' 0\"", ((Length)length.Round()).ToString());
+            Assert.AreEqual("2' 0\"", ((Length)length.Ceiling()).ToString());
+            Assert.AreEqual("1' 0\"", ((Length)length.Floor()).ToString());
 
             length = Length.FromFeet(-1.5, LengthUnit.FractionalFoot);
-            Assert.AreEqual("-2' 0.0000\"", ((Length)length.Round()).ToString());
-            Assert.AreEqual("-1' 0.0000\"", ((Length)length.Ceiling()).ToString());
-            Assert.AreEqual("-2' 0.0000\"", ((Length)length.Floor()).ToString());
+            Assert.AreEqual("-2' 0\"", ((Length)length.Round()).ToString());
+            Assert.AreEqual("-1' 0\"", ((Length)length.Ceiling()).ToString());
+            Assert.AreEqual("-2' 0\"", ((Length)length.Floor()).ToString());
 
             length = Length.FromFeet(-1.2, LengthUnit.FractionalFoot);
-            Assert.AreEqual("-1' 0.0000\"", ((Length)length.Round()).ToString());
-            Assert.AreEqual("-1' 0.0000\"", ((Length)length.Ceiling()).ToString());
-            Assert.AreEqual("-2' 0.0000\"", ((Length)length.Floor()).ToString());
+            Assert.AreEqual("-1' 0\"", ((Length)length.Round()).ToString());
+            Assert.AreEqual("-1' 0\"", ((Length)length.Ceiling()).ToString());
+            Assert.AreEqual("-2' 0\"", ((Length)length.Floor()).ToString());
 
             //this fails as explained here:
             //http://msdn.microsoft.com/en-us/library/wyk4d9cy(v=vs.110).aspx

--- a/test/DynamoCoreTests/UnitsOfMeasureTests.cs
+++ b/test/DynamoCoreTests/UnitsOfMeasureTests.cs
@@ -240,35 +240,45 @@ namespace Dynamo.Tests
             var length = Length.FromDouble(0.0762); //.25"
             length.LengthUnit = LengthUnit.FractionalFoot;
 
-            Assert.AreEqual("3\"", length.ToString());
+            Assert.AreEqual("3.0000\"", length.ToString());
 
             length.Value = -0.0762;
-            Assert.AreEqual("-3\"", length.ToString());
+            Assert.AreEqual("-3.0000\"", length.ToString());
 
             length.Value = 0.3048; //1ft.
-            Assert.AreEqual("1' 0\"", length.ToString());
+            Assert.AreEqual("1' 0.0000\"", length.ToString());
 
             length.Value = -0.3048;
-            Assert.AreEqual("-1' 0\"", length.ToString());
+            Assert.AreEqual("-1' 0.0000\"", length.ToString());
 
             //test some edge cases
             length.Value = 0.0;
-            Assert.AreEqual("0' 0\"", length.ToString());
+            Assert.AreEqual("0' 0.0000\"", length.ToString());
+
+            /*length.Value = 0.003175; //1/8"
+            Assert.AreEqual("1/8\"", length.ToString());*/
 
             length.Value = 0.003175; //1/8"
-            Assert.AreEqual("1/8\"", length.ToString());
+            Assert.AreEqual("0.1250\"", length.ToString());
+
+            /*length.Value = 0.301752; //.99ft
+            Assert.AreEqual("11 7/8\"", length.ToString());*/
 
             length.Value = 0.301752; //.99ft
-            Assert.AreEqual("11 7/8\"", length.ToString());
+            Assert.AreEqual("11.8800\"", length.ToString());
+
+            /*length.Value = 0.3044952; //.999ft
+            Assert.AreEqual("11 63/64\"", length.ToString());*/
 
             length.Value = 0.3044952; //.999ft
-            Assert.AreEqual("11 63/64\"", length.ToString());
+            Assert.AreEqual("11.9880\"", length.ToString());
 
             length.Value = 0.35560000000142239; //1'2"
-            Assert.AreEqual("1' 2\"", length.ToString());
+            Assert.AreEqual("1' 2.0000\"", length.ToString());
 
             length.Value = -0.35560000000142239; //-1'2"
-            Assert.AreEqual("-1' 2\"", length.ToString());
+            Assert.AreEqual("-1' 2.0000\"", length.ToString());
+
         }
 
         [Test]
@@ -390,6 +400,36 @@ namespace Dynamo.Tests
             Utils.ParseLengthFromString(length, out feet, out inch, out m, out cm, out mm, out numerator,
                                         out denominator);
             Assert.AreEqual(1, inch);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void ParseLengthInFeetFromString()
+        {
+            double feet = 0;
+            double numeratorInFeet = 0;
+            double denominatorInFeet = 0;
+
+            string length = "1/32";
+            Utils.ParseLengthInFeetFromString(length, out feet, out numeratorInFeet,
+                                        out denominatorInFeet);
+            Assert.AreEqual(0, feet);
+            Assert.AreEqual(1, numeratorInFeet);
+            Assert.AreEqual(32, denominatorInFeet);
+
+            length = "1/128\'";
+            Utils.ParseLengthInFeetFromString(length, out feet, out numeratorInFeet,
+                                        out denominatorInFeet);
+            Assert.AreEqual(0, feet);
+            Assert.AreEqual(1, numeratorInFeet);
+            Assert.AreEqual(128, denominatorInFeet);
+
+            length = "8.25";
+            Utils.ParseLengthInFeetFromString(length, out feet, out numeratorInFeet,
+                                        out denominatorInFeet);
+            Assert.AreEqual(8.25, feet);
+            Assert.AreEqual(0, numeratorInFeet);
+            Assert.AreEqual(0, denominatorInFeet);
         }
 
         [Test]
@@ -557,29 +597,29 @@ namespace Dynamo.Tests
         public void UiRounding()
         {
             var length = Length.FromFeet(1.5, LengthUnit.FractionalFoot);
-            Assert.AreEqual("2' 0\"", ((Length)length.Round()).ToString());
-            Assert.AreEqual("2' 0\"", ((Length)length.Ceiling()).ToString());
-            Assert.AreEqual("1' 0\"", ((Length)length.Floor()).ToString());
+            Assert.AreEqual("2' 0.0000\"", ((Length)length.Round()).ToString());
+            Assert.AreEqual("2' 0.0000\"", ((Length)length.Ceiling()).ToString());
+            Assert.AreEqual("1' 0.0000\"", ((Length)length.Floor()).ToString());
 
             length = Length.FromFeet(1.2, LengthUnit.FractionalFoot);
-            Assert.AreEqual("1' 0\"", ((Length)length.Round()).ToString());
-            Assert.AreEqual("2' 0\"", ((Length)length.Ceiling()).ToString());
-            Assert.AreEqual("1' 0\"", ((Length)length.Floor()).ToString());
+            Assert.AreEqual("1' 0.0000\"", ((Length)length.Round()).ToString());
+            Assert.AreEqual("2' 0.0000\"", ((Length)length.Ceiling()).ToString());
+            Assert.AreEqual("1' 0.0000\"", ((Length)length.Floor()).ToString());
 
             length = Length.FromFeet(-1.5, LengthUnit.FractionalFoot);
-            Assert.AreEqual("-2' 0\"", ((Length)length.Round()).ToString());
-            Assert.AreEqual("-1' 0\"", ((Length)length.Ceiling()).ToString());
-            Assert.AreEqual("-2' 0\"", ((Length)length.Floor()).ToString());
+            Assert.AreEqual("-2' 0.0000\"", ((Length)length.Round()).ToString());
+            Assert.AreEqual("-1' 0.0000\"", ((Length)length.Ceiling()).ToString());
+            Assert.AreEqual("-2' 0.0000\"", ((Length)length.Floor()).ToString());
 
             length = Length.FromFeet(-1.2, LengthUnit.FractionalFoot);
-            Assert.AreEqual("-1' 0\"", ((Length)length.Round()).ToString());
-            Assert.AreEqual("-1' 0\"", ((Length)length.Ceiling()).ToString());
-            Assert.AreEqual("-2' 0\"", ((Length)length.Floor()).ToString());
+            Assert.AreEqual("-1' 0.0000\"", ((Length)length.Round()).ToString());
+            Assert.AreEqual("-1' 0.0000\"", ((Length)length.Ceiling()).ToString());
+            Assert.AreEqual("-2' 0.0000\"", ((Length)length.Floor()).ToString());
 
             //this fails as explained here:
             //http://msdn.microsoft.com/en-us/library/wyk4d9cy(v=vs.110).aspx
             //length = Units.Length.FromFeet(.5);
-            //Assert.AreEqual("1' 0\"", ((Units.Length)length.Round()).ToString(LengthUnit.FractionalFoot));
+            //Assert.AreEqual("1' 0.0000\"", ((Units.Length)length.Round()).ToString(LengthUnit.FractionalFoot));
         }
 
         [Test]


### PR DESCRIPTION
### Purpose
References: [MAGN-7228] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7228)
This PR is to fix the issue of Number From Feet and Inches does not return the correct value when user input is in fractional feet with/without unit symbol. 
This PR also changes the display format in the input box from (feet+fractional inches) to (feet+decimal inches).

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

