### PR TITLE
Magn 10383-Editing custom node description crashes for Read-Only package folder

### DIFF
--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -38,6 +38,15 @@ namespace Dynamo.Wpf
             };
             nodeView.MainContextMenu.Items.Add(editPropertiesItem);
             editPropertiesItem.Click += (sender, args) => EditCustomNodeProperties();
+            CustomNodeWorkspaceModel ws;
+            dynamoViewModel.Model.CustomNodeManager.TryGetFunctionWorkspace(
+                functionNodeModel.Definition.FunctionId,
+                DynamoModel.IsTestMode,
+                out ws);
+            if (ws.IsReadOnly)
+            {
+                editPropertiesItem.IsEnabled = false;
+            }
 
             // publish
             var publishCustomNodeItem = new MenuItem

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -38,12 +38,15 @@ namespace Dynamo.Wpf
             };
             nodeView.MainContextMenu.Items.Add(editPropertiesItem);
             editPropertiesItem.Click += (sender, args) => EditCustomNodeProperties();
+
+            // Check if the workspace is read-only or not, disable editPropertiesItem accordingly
             CustomNodeWorkspaceModel ws;
             dynamoViewModel.Model.CustomNodeManager.TryGetFunctionWorkspace(
                 functionNodeModel.Definition.FunctionId,
                 DynamoModel.IsTestMode,
                 out ws);
-            if (ws.IsReadOnly)
+
+            if (ws != null && ws.IsReadOnly)
             {
                 editPropertiesItem.IsEnabled = false;
             }

--- a/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
+++ b/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
@@ -41,7 +41,9 @@ namespace Dynamo.Tests
         public void CanLoadReadOnlyNode()
         {
             // Open a read-only custom node
-            Assert.IsFalse(DynamoUtilities.PathHelper.IsReadOnlyPath(@"core\CustomNodes\add_Read_only.dyf"));
+            FileInfo fInfo = new FileInfo(@"core\CustomNodes\add_Read_only.dyf");
+            fInfo.IsReadOnly = true;
+            Assert.IsTrue(DynamoUtilities.PathHelper.IsReadOnlyPath(@"core\CustomNodes\add_Read_only.dyf"));
 
             OpenTestFile(@"core\CustomNodes", "add_Read_only.dyf");
             var nodeWorkspace = CurrentDynamoModel.Workspaces.FirstOrDefault(x => x is CustomNodeWorkspaceModel);

--- a/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
+++ b/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
@@ -41,9 +41,11 @@ namespace Dynamo.Tests
         public void CanLoadReadOnlyNode()
         {
             // Open a read-only custom node
-            FileInfo fInfo = new FileInfo(@"core\CustomNodes\add_Read_only.dyf");
+            var pathInTestsDir = @"core\CustomNodes\add_Read_only.dyf";
+            var filePath = Path.Combine(TestDirectory, pathInTestsDir);
+            FileInfo fInfo = new FileInfo(filePath);
             fInfo.IsReadOnly = true;
-            Assert.IsTrue(DynamoUtilities.PathHelper.IsReadOnlyPath(@"core\CustomNodes\add_Read_only.dyf"));
+            Assert.IsTrue(DynamoUtilities.PathHelper.IsReadOnlyPath(filePath));
 
             OpenTestFile(@"core\CustomNodes", "add_Read_only.dyf");
             var nodeWorkspace = CurrentDynamoModel.Workspaces.FirstOrDefault(x => x is CustomNodeWorkspaceModel);

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -414,10 +414,11 @@ namespace DynamoCoreWpfTests
 
             var funcNode = homeWorkspace.Nodes.OfType<Function>().First();
             var customNodeView = NodeViewWithGuid("fb872c7c-21af-4074-8011-818874738dc7");
-            foreach (MenuItem menuItem in customNodeView.MainContextMenu.Items)
+            foreach (var menuItem in customNodeView.MainContextMenu.Items)
             {
-                if(menuItem.Header.ToString() == Dynamo.Wpf.Properties.Resources.ContextMenuEditCustomNodeProperty)
-                    Assert.IsFalse(menuItem.IsEnabled);
+                MenuItem item = menuItem as MenuItem;
+                if(item != null && item.Header.ToString() == Dynamo.Wpf.Properties.Resources.ContextMenuEditCustomNodeProperty)
+                    Assert.IsFalse(item.IsEnabled);
             }
         }
     }

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -413,7 +413,7 @@ namespace DynamoCoreWpfTests
             Assert.NotNull(Model.CurrentWorkspace);
 
             var funcNode = homeWorkspace.Nodes.OfType<Function>().First();
-            var customNodeView = NodeViewWithGuid("98566e0d-3a11-4327-b688-713f6892a5bf");
+            var customNodeView = NodeViewWithGuid("fb872c7c-21af-4074-8011-818874738dc7");
             
             MenuItem menuItem = customNodeView.MainContextMenu.Items.GetItemAt(customNodeView.MainContextMenu.Items.Count - 2) as MenuItem;
             Assert.IsFalse(menuItem.IsEnabled);

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -413,7 +413,7 @@ namespace DynamoCoreWpfTests
             Assert.NotNull(Model.CurrentWorkspace);
 
             var funcNode = homeWorkspace.Nodes.OfType<Function>().First();
-            var customNodeView = NodeViewWithGuid("fb872c7c - 21af - 4074 - 8011 - 818874738dc7");
+            var customNodeView = NodeViewWithGuid("98566e0d-3a11-4327-b688-713f6892a5bf");
             
             MenuItem menuItem = customNodeView.MainContextMenu.Items.GetItemAt(customNodeView.MainContextMenu.Items.Count - 2) as MenuItem;
             Assert.IsFalse(menuItem.IsEnabled);

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -414,9 +414,11 @@ namespace DynamoCoreWpfTests
 
             var funcNode = homeWorkspace.Nodes.OfType<Function>().First();
             var customNodeView = NodeViewWithGuid("fb872c7c-21af-4074-8011-818874738dc7");
-            
-            MenuItem menuItem = customNodeView.MainContextMenu.Items.GetItemAt(customNodeView.MainContextMenu.Items.Count - 2) as MenuItem;
-            Assert.IsFalse(menuItem.IsEnabled);
+            foreach (MenuItem menuItem in customNodeView.MainContextMenu.Items)
+            {
+                if(menuItem.Header.ToString() == Dynamo.Wpf.Properties.Resources.ContextMenuEditCustomNodeProperty)
+                    Assert.IsFalse(menuItem.IsEnabled);
+            }
         }
     }
 }

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -1,16 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using CoreNodeModelsWpf.Controls;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.CustomNodes;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Nodes;
 using Dynamo.Utilities;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
-using CoreNodeModelsWpf.Controls;
 
 namespace DynamoCoreWpfTests
 {
@@ -392,6 +395,28 @@ namespace DynamoCoreWpfTests
 
             DispatcherUtil.DoEvents();
             Assert.AreEqual(8, items.Count());
+        }
+
+        [Test]
+        public void TestEditReadOnlyCustomNodeProperty()
+        {
+            // Open a read-only custom node
+            var pathInTestsDir = @"core\CustomNodes\add_Read_only.dyf";
+            var filePath = Path.Combine(GetTestDirectory(ExecutingDirectory), pathInTestsDir);
+            FileInfo fInfo = new FileInfo(filePath);
+            fInfo.IsReadOnly = true;
+            Assert.IsTrue(DynamoUtilities.PathHelper.IsReadOnlyPath(filePath));
+
+            // a file with a read-only custom node definition is opened
+            Open(@"core\CustomNodes\TestAdd.dyn");
+            var homeWorkspace = Model.CurrentWorkspace as HomeWorkspaceModel;
+            Assert.NotNull(Model.CurrentWorkspace);
+
+            var funcNode = homeWorkspace.Nodes.OfType<Function>().First();
+            var customNodeView = NodeViewWithGuid("fb872c7c - 21af - 4074 - 8011 - 818874738dc7");
+            
+            MenuItem menuItem = customNodeView.MainContextMenu.Items.GetItemAt(customNodeView.MainContextMenu.Items.Count - 2) as MenuItem;
+            Assert.IsFalse(menuItem.IsEnabled);
         }
     }
 }


### PR DESCRIPTION
### Purpose

Editing custom node description crashes for Read-Only package folder

This PR grey out [edit node description..] on the right click menu when custom node is read-only. Enabling loading of read-only node is new, so it is not regressed before. I checked about the regression I added earlier, found that submitted read-only file will not preserve the read-only access, so it needs to be set by code in unit test. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
![image](https://cloud.githubusercontent.com/assets/3942418/16973675/8243db52-4e03-11e6-9ad1-010825940e08.png)

### Reviewers

@mjkkirschner 

### FYIs

@ramramps @saintentropy @jnealb @kronz @Racel 
