### PR TITLE
Adjust the logic to get the samples and the gallery folders

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -490,6 +490,12 @@ namespace Dynamo.Core
 
         private static string GetSamplesFolder(string dataRootDirectory)
         {
+            var versionedDirectory = dataRootDirectory;
+            if (!Directory.Exists(versionedDirectory))
+            {
+                dataRootDirectory = Directory.GetParent(versionedDirectory).FullName;
+            }
+
             var uiCulture = CultureInfo.CurrentUICulture.ToString();
             var sampleDirectory = Path.Combine(dataRootDirectory, "samples", uiCulture);
 
@@ -512,6 +518,12 @@ namespace Dynamo.Core
 
         private static string GetGalleryDirectory(string commonDataDir)
         {
+            var versionedDirectory = commonDataDir;
+            if (!Directory.Exists(versionedDirectory))
+            {
+                commonDataDir = Directory.GetParent(versionedDirectory).FullName;
+            }
+
             var uiCulture = CultureInfo.CurrentUICulture.ToString();
             var galleryDirectory = Path.Combine(commonDataDir, "gallery", uiCulture);
 


### PR DESCRIPTION
### Purpose

This is to adjust the path looking logic for the samples and the gallery folder. If the root folder does not exist, the root folder will be adjusted to its parent folder.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 
@sharadkjaiswal 

### FYIs
@riteshchandawar 