### PR TITLE
Fix File Version so that Tests Could pass

### DIFF
--- a/test/core/dsfunction/contains.dyn
+++ b/test/core/dsfunction/contains.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="1.1.1.1921" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+<Workspace Version="1.1.0.0" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
     <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="928ae9e8-26a8-4f5c-87c1-170688896ab1" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="375" y="103" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">

--- a/test/core/dsfunction/contains2.dyn
+++ b/test/core/dsfunction/contains2.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="1.1.1.1921" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+<Workspace Version="1.1.0.0" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
     <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="c477caeb-d40c-4830-9163-962938b10bd1" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="205" y="79" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{{1,2,3}, {4, 5, 6}};&#xA;&#xA;{4, 5, 6};" ShouldFocus="false" />


### PR DESCRIPTION
### Purpose

Fix the two remaining unit tests in RC1.1.0 branch. Dyns from a future version of Dynamo is cherry picked into release branch, this should be avoided:
1) Test Failure : Dynamo.Tests.DSEvaluationModelTest.TestContainsArray
     Expected: not null
  But was:  null

at Dynamo.Tests.DSEvaluationUnitTestBase.GetVarName(String guid)
at Dynamo.Tests.DSEvaluationModelTest.TestContainsArray()

2) Test Failure : Dynamo.Tests.DSEvaluationModelTest.TestContainsUsingEqualityTest
     Expected: not null
  But was:  null

at Dynamo.Tests.DSEvaluationUnitTestBase.GetVarName(String guid)
at Dynamo.Tests.DSEvaluationModelTest.TestContainsUsingEqualityTest()


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers



### FYIs

@ke-yu @mjkkirschner @jnealb 
