### PR TITLE
Enable/disable t-spline nodes only on relaunch of Dynamo

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1954,12 +1954,12 @@ namespace Dynamo.Models
                 {
                     namespaces.Add(str);
                 }
-                SearchModel.RemoveNamespace(library, namespc);
+                //SearchModel.RemoveNamespace(library, namespc);
             }
             else // unhide
             {
                 namespaces.Remove(str);
-                AddZeroTouchNodesToSearch(LibraryServices.GetFunctionGroups(library));
+                //AddZeroTouchNodesToSearch(LibraryServices.GetFunctionGroups(library));
             }
         }
 

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -1396,7 +1396,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable T-Spline nodes.
+        ///   Looks up a localized string similar to Enable T-Spline nodes (requires relaunch of Dynamo).
         /// </summary>
         public static string DynamoViewSettingEnableTSplineNodes {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -564,7 +564,7 @@ It does not contain your graph or any personal data</value>
     <comment>Setting menu | Experimental</comment>
   </data>
   <data name="DynamoViewSettingEnableTSplineNodes" xml:space="preserve">
-    <value>Enable T-Spline nodes</value>
+    <value>Enable T-Spline nodes (requires relaunch of Dynamo)</value>
     <comment>Setting menu | Experimental | Enable T-Spline nodes</comment>
   </data>
   <data name="DynamoViewToolbarExportButtonTooltip" xml:space="preserve">

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -564,7 +564,7 @@ It does not contain your graph or any personal data</value>
     <comment>Setting menu | Experimental</comment>
   </data>
   <data name="DynamoViewSettingEnableTSplineNodes" xml:space="preserve">
-    <value>Enable T-Spline nodes</value>
+    <value>Enable T-Spline nodes (requires relaunch of Dynamo)</value>
     <comment>Setting menu | Experimental | Enable T-Spline nodes</comment>
   </data>
   <data name="DynamoViewToolbarExportButtonTooltip" xml:space="preserve">


### PR DESCRIPTION
### Purpose

This PR addresses [MAGN-10405] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10405). Due to bugs in library view refresh, enabling and disabling T-Spline nodes does not refresh the library UI properly (see [MAGN-10323] (http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10323)). Therefore for the 1.1 release we have decided to display the nodes only on a relaunch of Dynamo when the menu option is selected. Likewise when the option is unchecked, the T-Splines nodes are hidden again only on a relaunch of Dynamo in a session.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@Benglin 
@kronz 
@Racel 
