### PR TITLE
Rc1.1.0 fix missing methods

### DIFF
--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1576,7 +1576,7 @@ namespace Dynamo.Models
             #region Public Class Methods
 
             [JsonConstructor]
-            public ModelEventCommand(string modelGuid, string eventName, int value = 1)
+            public ModelEventCommand(string modelGuid, string eventName, int value)
                 : base(new[] { Guid.Parse(modelGuid) })
             {
                 EventName = eventName;
@@ -1591,7 +1591,7 @@ namespace Dynamo.Models
                 Value = 1;
             }
 
-            public ModelEventCommand(Guid modelGuid, string eventName, int value = 1)
+            public ModelEventCommand(Guid modelGuid, string eventName, int value)
                 : base(new[] { modelGuid })
             {
                 EventName = eventName;
@@ -1604,7 +1604,7 @@ namespace Dynamo.Models
                 Value = 1;
             }
 
-            public ModelEventCommand(IEnumerable<Guid> modelGuid, string eventName, int value = 1)
+            public ModelEventCommand(IEnumerable<Guid> modelGuid, string eventName, int value)
                 : base(modelGuid)
             {
                 EventName = eventName;

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1583,11 +1583,25 @@ namespace Dynamo.Models
                 Value = value;
             }
 
+            [JsonConstructor]
+            public ModelEventCommand(string modelGuid, string eventName)
+                : base(new[] { Guid.Parse(modelGuid) })
+            {
+                EventName = eventName;
+                Value = 1;
+            }
+
             public ModelEventCommand(Guid modelGuid, string eventName, int value = 1)
                 : base(new[] { modelGuid })
             {
                 EventName = eventName;
                 Value = value;
+            }
+            public ModelEventCommand(Guid modelGuid, string eventName)
+               : base(new[] { modelGuid })
+            {
+                EventName = eventName;
+                Value = 1;
             }
 
             public ModelEventCommand(IEnumerable<Guid> modelGuid, string eventName, int value = 1)
@@ -1595,6 +1609,13 @@ namespace Dynamo.Models
             {
                 EventName = eventName;
                 Value = value;
+            }
+
+            public ModelEventCommand(IEnumerable<Guid> modelGuid, string eventName)
+               : base(modelGuid)
+            {
+                EventName = eventName;
+                Value = 1;
             }
 
             internal static ModelEventCommand DeserializeCore(XmlElement element)

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackagePathViewModel.cs
@@ -81,6 +81,25 @@ namespace Dynamo.ViewModels
 
             SelectedIndex = 0;
         }
+        /// <summary>
+        /// This constructor overload has been added for backwards comptability.
+        /// </summary>
+        /// <param name="setting"></param>
+        public PackagePathViewModel(IPreferences setting)
+        {
+
+            RootLocations = new ObservableCollection<string>(setting.CustomPackageFolders);
+
+            AddPathCommand = new DelegateCommand(p => InsertPath());
+            DeletePathCommand = new DelegateCommand(p => RemovePathAt((int)p), CanDelete);
+            MovePathUpCommand = new DelegateCommand(p => SwapPath((int)p, ((int)p) - 1), CanMoveUp);
+            MovePathDownCommand = new DelegateCommand(p => SwapPath((int)p, ((int)p) + 1), CanMoveDown);
+            UpdatePathCommand = new DelegateCommand(p => UpdatePathAt((int)p));
+            SaveSettingCommand = new DelegateCommand(CommitChanges);
+
+            SelectedIndex = 0;
+        }
+
 
         private void RaiseCanExecuteChanged()
         {
@@ -168,7 +187,10 @@ namespace Dynamo.ViewModels
         private void CommitChanges(object param)
         {
             setting.CustomPackageFolders = new List<string>(RootLocations);
-            this.packageLoader.LoadCustomNodesAndPackages(loadPackageParams,customNodeManager);
+            if (this.packageLoader != null)
+            {
+                this.packageLoader.LoadCustomNodesAndPackages(loadPackageParams, customNodeManager);
+            }
         }
 
     }


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10373
### Declarations

attempts to add missing public constructors to RC1.1 (we can cherry pick these changes to master)
I have not modified the internal method which cannot be found as I do not think it's an issue as it's not part of the public API. We may need to investigate a way to squelch certain failures for these BC break tests.

public Void **ModelEventCommand**..ctor(System.String, System.String)

public Void **Dynamo.ViewModels.PackagePathViewModel**..ctor(Dynamo.Interfaces.IPreferences)

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ellensi 
@QilongTang 
### FYIs

@kronz 