### PR TITLE
Further fix to the logic to get the samples or the gallery folders

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -493,9 +493,19 @@ namespace Dynamo.Core
         private static string GetSamplesFolder(string dataRootDirectory)
         {
             var versionedDirectory = dataRootDirectory;
-            if (!Directory.Exists(versionedDirectory)
-                || !Directory.Exists(Path.Combine(versionedDirectory, SamplesDirectoryName)))
+            if (!Directory.Exists(versionedDirectory))
             {
+                // Try to see if folder "%ProgramData%\{...}\{major}.{minor}" exists, if it
+                // does not, then root directory would be "%ProgramData%\{...}".
+                //
+                dataRootDirectory = Directory.GetParent(versionedDirectory).FullName;
+            }
+            else if (!Directory.Exists(Path.Combine(versionedDirectory, SamplesDirectoryName)))
+            {
+                // If the folder "%ProgramData%\{...}\{major}.{minor}" exists, then try to see
+                // if the folder "%ProgramData%\{...}\{major}.{minor}\samples" exists. If it
+                // doesn't exist, then root directory would be "%ProgramData%\{...}".
+                //
                 dataRootDirectory = Directory.GetParent(versionedDirectory).FullName;
             }
 
@@ -522,9 +532,19 @@ namespace Dynamo.Core
         private static string GetGalleryDirectory(string commonDataDir)
         {
             var versionedDirectory = commonDataDir;
-            if (!Directory.Exists(versionedDirectory)
-                || !Directory.Exists(Path.Combine(versionedDirectory, GalleryDirectoryName)))
+            if (!Directory.Exists(versionedDirectory))
             {
+                // Try to see if folder "%ProgramData%\{...}\{major}.{minor}" exists, if it
+                // does not, then root directory would be "%ProgramData%\{...}".
+                //
+                commonDataDir = Directory.GetParent(versionedDirectory).FullName;
+            }
+            else if (!Directory.Exists(Path.Combine(versionedDirectory, GalleryDirectoryName)))
+            {
+                // If the folder "%ProgramData%\{...}\{major}.{minor}" exists, then try to see
+                // if the folder "%ProgramData%\{...}\{major}.{minor}\gallery" exists. If it
+                // doesn't exist, then root directory would be "%ProgramData%\{...}".
+                //
                 commonDataDir = Directory.GetParent(versionedDirectory).FullName;
             }
 

--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -56,6 +56,8 @@ namespace Dynamo.Core
         public const string ExtensionsDirectoryName = "extensions";
         public const string ViewExtensionsDirectoryName = "viewExtensions";
         public const string DefinitionsDirectoryName = "definitions";
+        public const string SamplesDirectoryName = "samples";
+        public const string GalleryDirectoryName = "gallery";
         public const string BackupDirectoryName = "backup";
         public const string PreferenceSettingsFileName = "DynamoSettings.xml";
         public const string GalleryContentsFileName = "GalleryContents.xml";
@@ -491,13 +493,14 @@ namespace Dynamo.Core
         private static string GetSamplesFolder(string dataRootDirectory)
         {
             var versionedDirectory = dataRootDirectory;
-            if (!Directory.Exists(versionedDirectory))
+            if (!Directory.Exists(versionedDirectory)
+                || !Directory.Exists(Path.Combine(versionedDirectory, SamplesDirectoryName)))
             {
                 dataRootDirectory = Directory.GetParent(versionedDirectory).FullName;
             }
 
             var uiCulture = CultureInfo.CurrentUICulture.ToString();
-            var sampleDirectory = Path.Combine(dataRootDirectory, "samples", uiCulture);
+            var sampleDirectory = Path.Combine(dataRootDirectory, SamplesDirectoryName, uiCulture);
 
             // If the localized samples directory does not exist then fall back 
             // to using the en-US samples folder. Do an additional check to see 
@@ -508,7 +511,7 @@ namespace Dynamo.Core
                 !di.GetDirectories().Any() ||
                 !di.GetFiles("*.dyn", SearchOption.AllDirectories).Any())
             {
-                var neturalCommonSamples = Path.Combine(dataRootDirectory, "samples", "en-US");
+                var neturalCommonSamples = Path.Combine(dataRootDirectory, SamplesDirectoryName, "en-US");
                 if (Directory.Exists(neturalCommonSamples))
                     sampleDirectory = neturalCommonSamples;
             }
@@ -519,13 +522,14 @@ namespace Dynamo.Core
         private static string GetGalleryDirectory(string commonDataDir)
         {
             var versionedDirectory = commonDataDir;
-            if (!Directory.Exists(versionedDirectory))
+            if (!Directory.Exists(versionedDirectory)
+                || !Directory.Exists(Path.Combine(versionedDirectory, GalleryDirectoryName)))
             {
                 commonDataDir = Directory.GetParent(versionedDirectory).FullName;
             }
 
             var uiCulture = CultureInfo.CurrentUICulture.ToString();
-            var galleryDirectory = Path.Combine(commonDataDir, "gallery", uiCulture);
+            var galleryDirectory = Path.Combine(commonDataDir, GalleryDirectoryName, uiCulture);
 
             // If the localized gallery directory does not exist then fall back 
             // to using the en-US gallery folder. Do an additional check to see 
@@ -535,7 +539,7 @@ namespace Dynamo.Core
             if (!Directory.Exists(galleryDirectory) ||
                 !di.GetFiles("*.xml",SearchOption.TopDirectoryOnly).Any())
             {
-                var neutralCommonGallery = Path.Combine(commonDataDir, "gallery", "en-US");
+                var neutralCommonGallery = Path.Combine(commonDataDir, GalleryDirectoryName, "en-US");
                 if (Directory.Exists(neutralCommonGallery))
                     galleryDirectory = neutralCommonGallery;
             }


### PR DESCRIPTION
### Purpose

This is a further fix to MAGN-10283 which has been addressed in https://github.com/DynamoDS/Dynamo/pull/6908.

In this fix, the samples/gallery folders will be checked whether they exist in the old parent folders as well, if not, then the parent folders will be used as the new root folders.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 

### FYIs
@kronz @Racel @sharadkjaiswal 

