### PR TITLE
JSON.net only allows one json constructor attribute per type.

### DIFF
--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1583,7 +1583,7 @@ namespace Dynamo.Models
                 Value = value;
             }
 
-            [JsonConstructor]
+         
             public ModelEventCommand(string modelGuid, string eventName)
                 : base(new[] { Guid.Parse(modelGuid) })
             {


### PR DESCRIPTION
### Purpose
When I added multiple constructors for backwards compatibility I added a second json constructor attribute, JSON.net does not allow this it turns out.
remove the attribute for the constructor with less parameters.



@ramramps 

### FYIs

@gregmarr 
@jnealb 

will cherry pick to 1.1 now.