### PR TITLE
JSON.net only allows one json constructor attribute per type.

### DIFF
--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1583,7 +1583,7 @@ namespace Dynamo.Models
                 Value = value;
             }
 
-            [JsonConstructor]
+         
             public ModelEventCommand(string modelGuid, string eventName)
                 : base(new[] { Guid.Parse(modelGuid) })
             {


### PR DESCRIPTION
### Purpose

cherry pick:
https://github.com/DynamoDS/Dynamo/pull/6939

to 1.1