### PR TITLE
Highligh port view in light blue color if use list structure

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoColorsAndBrushes.xaml
@@ -108,4 +108,8 @@
     <SolidColorBrush x:Key="UnpinnedIconBackgroundColor" Color="White" />
     <SolidColorBrush x:Key="PinnedIconBackgroundColor" Color="#FF5E5C5A" />
     <SolidColorBrush x:Key="PinnedIconHoverBackgroundColor" Color="#c6c6c6" />
+
+    <!-- Port color -->
+    <SolidColorBrush x:Key="KeepListStructureHighlight" Color="#66AAD7"/>
+    <SolidColorBrush x:Key="NotKeepListStructureHighlight" Color="White"/>
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -188,4 +188,8 @@
                                       TrueBrush="{StaticResource PinnedIconForegroundColor}"
                                       FalseBrush="{StaticResource UnpinnedIconForegroundColor}">
     </controls:BooleanToBrushConverter>
+    <controls:BooleanToBrushConverter x:Key="KeepListStructureHighlighColorConverter"
+                                      TrueBrush="{StaticResource KeepListStructureHighlight}"
+                                      FalseBrush="{StaticResource NotKeepListStructureHighlight}">
+    </controls:BooleanToBrushConverter>
 </ResourceDictionary>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -37,15 +37,16 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Grid Name="mainGrid"
-              Grid.Column="0"
-              Background="Transparent"
-              IsHitTestVisible="True"
-              Margin="{Binding Path=MarginThickness}"
-              Height="{Binding Path=Height}"
-              ToolTipService.ShowDuration="60000"
-              IsEnabled="{Binding Path=IsEnabled}"
-             >
+            <Grid
+                Name="mainGrid"
+                Grid.Column="0"
+                Background="Transparent"
+                IsHitTestVisible="True"
+                Margin="{Binding Path=MarginThickness}"
+                Height="{Binding Path=Height}"
+                ToolTipService.ShowDuration="60000"
+                IsEnabled="{Binding Path=IsEnabled}">
+
                 <interactivity:Interaction.Triggers>
                     <views:HandlingEventTrigger EventName="MouseLeftButtonDown">
                         <interactivity:InvokeCommandAction Command="{Binding Path=ConnectCommand}" />
@@ -54,16 +55,16 @@
 
                 <Grid.ContextMenu>
                     <ContextMenu Visibility="{Binding Path=DefaultValueEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <MenuItem Header="{x:Static p:Resources.PortViewContextMenuUserDefaultValue}"
-                              IsCheckable="True"
-                              IsEnabled="{Binding Path=DefaultValueEnabled, Mode=OneWay}"
-                              IsChecked="{Binding Path=UsingDefaultValue, Mode=TwoWay}" />
+                        <MenuItem
+                            Header="{x:Static p:Resources.PortViewContextMenuUserDefaultValue}"
+                            IsCheckable="True"
+                            IsEnabled="{Binding Path=DefaultValueEnabled, Mode=OneWay}"
+                            IsChecked="{Binding Path=UsingDefaultValue, Mode=TwoWay}" />
                     </ContextMenu>
                 </Grid.ContextMenu>
 
                 <Grid.ToolTip>
-                    <dynui:DynamoToolTip AttachmentSide="{Binding Path=PortType, Converter={StaticResource PortToAttachmentConverter}}"
-                         Style="{DynamicResource ResourceKey=SLightToolTip}">
+                    <dynui:DynamoToolTip AttachmentSide="{Binding Path=PortType, Converter={StaticResource PortToAttachmentConverter}}" Style="{DynamicResource ResourceKey=SLightToolTip}">
                         <Grid>
                             <TextBlock Text="{Binding Path=ToolTipContent}"></TextBlock>
                         </Grid>
@@ -83,9 +84,11 @@
                the grid's width, the outside rectangle is shrinked to fit the grid. Port snapping cannot occur in that case 
                as no mouse events are generated.This happens only for codeblock node. 
             -->
-                <Rectangle Fill="Transparent"
-                       SnapsToDevicePixels="True"
-                       IsHitTestVisible="{Binding IsHitTestVisible}">
+                <Rectangle
+                    Fill="Transparent"
+                    SnapsToDevicePixels="True"
+                    IsHitTestVisible="{Binding IsHitTestVisible}">
+
                     <interactivity:Interaction.Triggers>
                         <views:HandlingEventTrigger EventName="MouseEnter">
                             <interactivity:InvokeCommandAction Command="{Binding Path=MouseEnterCommand}" CommandParameter="{Binding}" />
@@ -105,7 +108,7 @@
                     </Rectangle.Margin>
                 </Rectangle>
                 <Rectangle Name="highlightOverlay"
-                       Fill="White"
+                       Fill="{Binding Path=ShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlighColorConverter}}"
                        MinWidth="26"
                        Margin="0,0,0,1"
                        IsHitTestVisible="True">
@@ -154,7 +157,12 @@
                   Height="{Binding Path=Height}"
                   ToolTipService.ShowDuration="60000"
                   Visibility="{Binding Path=UseLevelVisibility}">
-                <Rectangle Name="highlightOverlayForArrow" Fill="White" MinWidth="12" Margin="0,0,0,1" IsHitTestVisible="True">
+                <Rectangle
+                    Name="highlightOverlayForArrow" 
+                    Fill="{Binding Path=ShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlighColorConverter}}"
+                    MinWidth="12"
+                    Margin="0,0,0,1"
+                    IsHitTestVisible="True">
                     <interactivity:Interaction.Triggers>
                         <views:HandlingEventTrigger EventName="MouseLeftButtonDown">
                             <interactivity:InvokeCommandAction Command="{Binding Path=MouseLeftButtonDownOnLevelCommand}" CommandParameter="{Binding}" />


### PR DESCRIPTION
### Purpose

Highlight port view in light blue color if "Keep List Structure" option is selected for the port.

![highligh](https://cloud.githubusercontent.com/assets/2600379/17125257/76e9c17e-5324-11e6-991b-398491a84751.png)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@Racel 

