### PR TITLE
MAGN-10349 & MAGN-7228 Test cases update

### DIFF
--- a/test/DynamoCoreTests/UnitsOfMeasureTests.cs
+++ b/test/DynamoCoreTests/UnitsOfMeasureTests.cs
@@ -237,7 +237,7 @@ namespace Dynamo.Tests
         public void ToFractionalFootRepresentations()
         {
             //test just the fractional case
-            var length = Length.FromDouble(0.0762); //.25"
+            var length = Length.FromDouble(0.0762); //.25'
             length.LengthUnit = LengthUnit.FractionalFoot;
 
             Assert.AreEqual("3\"", length.ToString());
@@ -256,13 +256,13 @@ namespace Dynamo.Tests
             Assert.AreEqual("0' 0\"", length.ToString());
 
             length.Value = 0.003175; //1/8"
-            Assert.AreEqual("1/8\"", length.ToString());
+            Assert.AreEqual("0.125\"", length.ToString());
 
             length.Value = 0.301752; //.99ft
-            Assert.AreEqual("11 7/8\"", length.ToString());
+            Assert.AreEqual("11.88\"", length.ToString());
 
             length.Value = 0.3044952; //.999ft
-            Assert.AreEqual("11 63/64\"", length.ToString());
+            Assert.AreEqual("11.988\"", length.ToString());
 
             length.Value = 0.35560000000142239; //1'2"
             Assert.AreEqual("1' 2\"", length.ToString());

--- a/test/Libraries/CoreNodesTests/StringTests.cs
+++ b/test/Libraries/CoreNodesTests/StringTests.cs
@@ -345,7 +345,7 @@ namespace DSCoreNodesTests
             Assert.AreEqual("a", String.Remove("abcdef", 1));
             Assert.AreEqual("aef", String.Remove("abcdef", 1, 3));
             Assert.AreEqual("aef", String.Remove("abcdef", -5, 3));
-            Assert.AreEqual("aef", String.Remove("abcdef", -2, -3));
+            Assert.AreEqual("abf", String.Remove("abcdef", -2, -3));
         }
     }
 }


### PR DESCRIPTION
### Purpose

Updated test cases for MAGN-10349 (String.Remove anomaly) & MAGN-7228 (Number from Feet and Inches rounds input text incorrectly and output is confusing)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers
@ke-yu 

