### PR TITLE
Magn 10037 - CI Test Update 

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -219,8 +219,11 @@ namespace Dynamo.Controls
         private void NodeModel_ConnectorAdded(Graph.Connectors.ConnectorModel obj)
         {
             // If the mouse does not leave the node after the connnector is added,
-            // try to show the preview bubble without new mouse enter event.   
-            Dispatcher.BeginInvoke(new Action(TryShowPreviewBubbles), DispatcherPriority.Loaded);
+            // try to show the preview bubble without new mouse enter event. 
+            if (IsMouseOver)
+            {
+                Dispatcher.BeginInvoke(new Action(TryShowPreviewBubbles), DispatcherPriority.Loaded);
+            }
         }
 
         void NodeLogic_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)


### PR DESCRIPTION
### Purpose

Re-connecting to a node leaves the Preview Bubble disabled until you hover off the node and back onto it

This PR updates the fix for Magn 10037 to include logic which ignores connection events where the mouse is not over the node.  This was causing failures in CI testing.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ramramps 

### FYIs

@mjkkirschner @QilongTang @jnealb @Racel @kronz 

