### PR TITLE
MAGN-10353 Crash when installing packages to folder

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2210,6 +2210,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Folder Not Found.
+        /// </summary>
+        public static string FolderNotFoundError {
+            get {
+                return ResourceManager.GetString("FolderNotFoundError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You do not have write permission to {0}..
         /// </summary>
         public static string FolderNotWritableError {
@@ -3476,6 +3485,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package folder is not accessible..
+        /// </summary>
+        public static string PackageFolderNotAccessible {
+            get {
+                return ResourceManager.GetString("PackageFolderNotAccessible", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package Manager Website.
         /// </summary>
         public static string PackageManagerWebSiteButton {
@@ -3499,6 +3517,15 @@ namespace Dynamo.Wpf.Properties {
         public static string PackageNeedAtLeastOneFile {
             get {
                 return ResourceManager.GetString("PackageNeedAtLeastOneFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package is not existed..
+        /// </summary>
+        public static string PackageNotExisted {
+            get {
+                return ResourceManager.GetString("PackageNotExisted", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2210,6 +2210,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Access Denied.
+        /// </summary>
+        public static string FolderNotAccessibleError {
+            get {
+                return ResourceManager.GetString("FolderNotAccessibleError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Folder Not Found.
         /// </summary>
         public static string FolderNotFoundError {
@@ -3485,7 +3494,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package folder is not accessible..
+        ///   Looks up a localized string similar to A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to {0} {1}.{2}Please update the permissions and try again..
         /// </summary>
         public static string PackageFolderNotAccessible {
             get {
@@ -3521,7 +3530,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package is not existed..
+        ///   Looks up a localized string similar to The root directory of the package does not exist. Please try and re-install the package..
         /// </summary>
         public static string PackageNotExisted {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -793,6 +793,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Directory Not Found.
+        /// </summary>
+        public static string DirectoryNotFound {
+            get {
+                return ResourceManager.GetString("DirectoryNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Download Warning.
         /// </summary>
         public static string DownloadWarningMessageBoxTitle {
@@ -2210,24 +2219,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Access Denied.
-        /// </summary>
-        public static string FolderNotAccessibleError {
-            get {
-                return ResourceManager.GetString("FolderNotAccessibleError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Folder Not Found.
-        /// </summary>
-        public static string FolderNotFoundError {
-            get {
-                return ResourceManager.GetString("FolderNotFoundError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to You do not have write permission to {0}..
         /// </summary>
         public static string FolderNotWritableError {
@@ -3495,8 +3486,7 @@ namespace Dynamo.Wpf.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to
-        ///{0}
-        ///Please update the permissions and try again..
+        ///{0}.
         /// </summary>
         public static string PackageFolderNotAccessible {
             get {
@@ -4734,6 +4724,15 @@ namespace Dynamo.Wpf.Properties {
         public static string TooltipCurrentIndex {
             get {
                 return ResourceManager.GetString("TooltipCurrentIndex", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable To Access Package Directory.
+        /// </summary>
+        public static string UnableToAccessPackageDirectory {
+            get {
+                return ResourceManager.GetString("UnableToAccessPackageDirectory", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3494,7 +3494,9 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to {0} {1}.{2}Please update the permissions and try again..
+        ///   Looks up a localized string similar to A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to
+        ///{0}
+        ///Please update the permissions and try again..
         /// </summary>
         public static string PackageFolderNotAccessible {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2066,7 +2066,9 @@ Next assemblies were loaded several times:
     <value>Folder Not Found</value>
   </data>
   <data name="PackageFolderNotAccessible" xml:space="preserve">
-    <value>A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to {0} {1}.{2}Please update the permissions and try again.</value>
+    <value>A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to
+{0}
+Please update the permissions and try again.</value>
   </data>
   <data name="PackageNotExisted" xml:space="preserve">
     <value>The root directory of the package does not exist. Please try and re-install the package.</value>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2062,18 +2062,17 @@ Next assemblies were loaded several times:
   <data name="UseLevelPopupMenuItem" xml:space="preserve">
     <value>Use Levels?</value>
   </data>
-  <data name="FolderNotFoundError" xml:space="preserve">
-    <value>Folder Not Found</value>
+  <data name="DirectoryNotFound" xml:space="preserve">
+    <value>Directory Not Found</value>
   </data>
   <data name="PackageFolderNotAccessible" xml:space="preserve">
     <value>A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to
-{0}
-Please update the permissions and try again.</value>
+{0}</value>
   </data>
   <data name="PackageNotExisted" xml:space="preserve">
     <value>The root directory of the package does not exist. Please try and re-install the package.</value>
   </data>
-  <data name="FolderNotAccessibleError" xml:space="preserve">
-    <value>Access Denied</value>
+  <data name="UnableToAccessPackageDirectory" xml:space="preserve">
+    <value>Unable To Access Package Directory</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2066,9 +2066,12 @@ Next assemblies were loaded several times:
     <value>Folder Not Found</value>
   </data>
   <data name="PackageFolderNotAccessible" xml:space="preserve">
-    <value>Package folder is not accessible.</value>
+    <value>A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to {0} {1}.{2}Please update the permissions and try again.</value>
   </data>
   <data name="PackageNotExisted" xml:space="preserve">
-    <value>Package is not existed.</value>
+    <value>The root directory of the package does not exist. Please try and re-install the package.</value>
+  </data>
+  <data name="FolderNotAccessibleError" xml:space="preserve">
+    <value>Access Denied</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2044,7 +2044,7 @@ Next assemblies were loaded several times:
   </data>
   <data name="MessageErrorOpeningFileGeneral" xml:space="preserve">
     <value>Error Opening File</value>
-    <comment>Nofication Center Title</comment>
+    <comment>Notification Center Title</comment>
   </data>
   <data name="ContextMenuLacingAuto" xml:space="preserve">
     <value>Auto</value>
@@ -2061,5 +2061,14 @@ Next assemblies were loaded several times:
   </data>
   <data name="UseLevelPopupMenuItem" xml:space="preserve">
     <value>Use Levels?</value>
+  </data>
+  <data name="FolderNotFoundError" xml:space="preserve">
+    <value>Folder Not Found</value>
+  </data>
+  <data name="PackageFolderNotAccessible" xml:space="preserve">
+    <value>Package folder is not accessible.</value>
+  </data>
+  <data name="PackageNotExisted" xml:space="preserve">
+    <value>Package is not existed.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2068,9 +2068,12 @@ Next assemblies were loaded several times:
     <value>Folder Not Found</value>
   </data>
   <data name="PackageFolderNotAccessible" xml:space="preserve">
-    <value>Package folder is not accessible.</value>
+    <value>A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to {0} {1}.{2}Please update the permissions and try again.</value>
   </data>
   <data name="PackageNotExisted" xml:space="preserve">
-    <value>Package is not existed.</value>
+    <value>The root directory of the package does not exist. Please try and re-install the package.</value>
+  </data>
+  <data name="FolderNotAccessibleError" xml:space="preserve">
+    <value>Access Denied</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2064,18 +2064,17 @@ Next assemblies were loaded several times:
   <data name="UseLevelPopupMenuItem" xml:space="preserve">
     <value>Use Levels?</value>
   </data>
-  <data name="FolderNotFoundError" xml:space="preserve">
-    <value>Folder Not Found</value>
+  <data name="DirectoryNotFound" xml:space="preserve">
+    <value>Directory Not Found</value>
   </data>
   <data name="PackageFolderNotAccessible" xml:space="preserve">
     <value>A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to
-{0}
-Please update the permissions and try again.</value>
+{0}</value>
   </data>
   <data name="PackageNotExisted" xml:space="preserve">
     <value>The root directory of the package does not exist. Please try and re-install the package.</value>
   </data>
-  <data name="FolderNotAccessibleError" xml:space="preserve">
-    <value>Access Denied</value>
+  <data name="UnableToAccessPackageDirectory" xml:space="preserve">
+    <value>Unable To Access Package Directory</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2068,7 +2068,9 @@ Next assemblies were loaded several times:
     <value>Folder Not Found</value>
   </data>
   <data name="PackageFolderNotAccessible" xml:space="preserve">
-    <value>A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to {0} {1}.{2}Please update the permissions and try again.</value>
+    <value>A problem occurred when trying to install the package. Dynamo is unable to obtain read/write access to
+{0}
+Please update the permissions and try again.</value>
   </data>
   <data name="PackageNotExisted" xml:space="preserve">
     <value>The root directory of the package does not exist. Please try and re-install the package.</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2046,7 +2046,7 @@ Next assemblies were loaded several times:
   </data>
   <data name="MessageErrorOpeningFileGeneral" xml:space="preserve">
     <value>Error Opening File</value>
-    <comment>Nofication Center Title</comment>
+    <comment>Notification Center Title</comment>
   </data>
   <data name="ContextMenuLacingAuto" xml:space="preserve">
     <value>Auto</value>
@@ -2063,5 +2063,14 @@ Next assemblies were loaded several times:
   </data>
   <data name="UseLevelPopupMenuItem" xml:space="preserve">
     <value>Use Levels?</value>
+  </data>
+  <data name="FolderNotFoundError" xml:space="preserve">
+    <value>Folder Not Found</value>
+  </data>
+  <data name="PackageFolderNotAccessible" xml:space="preserve">
+    <value>Package folder is not accessible.</value>
+  </data>
+  <data name="PackageNotExisted" xml:space="preserve">
+    <value>Package is not existed.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -8,6 +8,7 @@ using Dynamo.Graph;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.PackageManager;
+using System.IO;
 
 using Microsoft.Practices.Prism.Commands;
 using Microsoft.Practices.Prism.ViewModel;
@@ -167,7 +168,15 @@ namespace Dynamo.ViewModels
 
         private void GoToRootDirectory()
         {
-            Process.Start(Model.RootDirectory);
+            // Check for the existance of RootDirectory
+            if (Directory.Exists(Model.RootDirectory))
+            {
+                Process.Start(Model.RootDirectory);
+            }
+            else
+            {
+                System.Windows.Forms.MessageBox.Show(Wpf.Properties.Resources.PackageNotExisted, Wpf.Properties.Resources.FolderNotFoundError, System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
+            }
         }
 
         private bool CanGoToRootDirectory()

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -175,7 +175,7 @@ namespace Dynamo.ViewModels
             }
             else
             {
-                System.Windows.Forms.MessageBox.Show(Wpf.Properties.Resources.PackageNotExisted, Wpf.Properties.Resources.FolderNotFoundError, System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
+                System.Windows.Forms.MessageBox.Show(Wpf.Properties.Resources.PackageNotExisted, Wpf.Properties.Resources.DirectoryNotFound, System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
@@ -5,6 +5,9 @@ using System.Windows.Controls.Primitives;
 using Dynamo.UI;
 using Dynamo.ViewModels;
 using Dynamo.PackageManager.ViewModels;
+using DynamoUtilities;
+using System.IO;
+using System.Windows.Forms;
 
 namespace Dynamo.PackageManager.UI
 {
@@ -46,7 +49,7 @@ namespace Dynamo.PackageManager.UI
 
         private void OnShowContextMenuFromLeftClicked(object sender, RoutedEventArgs e)
         {
-            var button = (Button)sender;
+            var button = (System.Windows.Controls.Button)sender;
             button.ContextMenu.DataContext = button.DataContext;
             button.ContextMenu.PlacementTarget = button;
             button.ContextMenu.Placement = PlacementMode.Bottom;
@@ -75,17 +78,27 @@ namespace Dynamo.PackageManager.UI
             
             e.Cancel = true;
 
-            var dialog = new DynamoFolderBrowserDialog
+            // Handle for the case, initialPath does not exist.
+            var errorCannotCreateFolder = PathHelper.CreateFolderIfNotExist(initialPath);
+            if (errorCannotCreateFolder == null)
             {
-                // Navigate to initial folder.
-                SelectedPath = initialPath,
-                Owner = this
-            };
+                var dialog = new DynamoFolderBrowserDialog
+                {
+                    // Navigate to initial folder.
+                    SelectedPath = initialPath,
+                    Owner = this
+                };
 
-            if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                {
+                    e.Cancel = false;
+                    e.Path = dialog.SelectedPath;
+                }
+
+            }
+            else
             {
-                e.Cancel = false;
-                e.Path = dialog.SelectedPath;
+                System.Windows.Forms.MessageBox.Show(Wpf.Properties.Resources.PackageFolderNotAccessible, Wpf.Properties.Resources.FolderNotFoundError, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
@@ -99,7 +99,7 @@ namespace Dynamo.PackageManager.UI
             else
             {
                 string errorMessage = string.Format(Wpf.Properties.Resources.PackageFolderNotAccessible, initialPath);
-                System.Windows.Forms.MessageBox.Show(errorMessage, Wpf.Properties.Resources.FolderNotAccessibleError, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                System.Windows.Forms.MessageBox.Show(errorMessage, Wpf.Properties.Resources.UnableToAccessPackageDirectory, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
@@ -98,7 +98,8 @@ namespace Dynamo.PackageManager.UI
             }
             else
             {
-                System.Windows.Forms.MessageBox.Show(Wpf.Properties.Resources.PackageFolderNotAccessible, Wpf.Properties.Resources.FolderNotFoundError, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                string errorMessage = string.Format(Wpf.Properties.Resources.PackageFolderNotAccessible, "\n", initialPath, "\n");
+                System.Windows.Forms.MessageBox.Show(errorMessage, Wpf.Properties.Resources.FolderNotAccessibleError, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml.cs
@@ -98,7 +98,7 @@ namespace Dynamo.PackageManager.UI
             }
             else
             {
-                string errorMessage = string.Format(Wpf.Properties.Resources.PackageFolderNotAccessible, "\n", initialPath, "\n");
+                string errorMessage = string.Format(Wpf.Properties.Resources.PackageFolderNotAccessible, initialPath);
                 System.Windows.Forms.MessageBox.Show(errorMessage, Wpf.Properties.Resources.FolderNotAccessibleError, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }

--- a/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml.cs
@@ -124,7 +124,7 @@ namespace Dynamo.Wpf.Views.PackageManager
             }
             else
             {
-                string errorMessage = string.Format(Wpf.Properties.Resources.PackageFolderNotAccessible, "\n", args.Path, "\n");
+                string errorMessage = string.Format(Wpf.Properties.Resources.PackageFolderNotAccessible, args.Path);
                 System.Windows.Forms.MessageBox.Show(errorMessage, Wpf.Properties.Resources.FolderNotAccessibleError, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }

--- a/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml.cs
@@ -16,6 +16,8 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using Dynamo.UI;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
+using DynamoUtilities;
+using System.IO;
 
 namespace Dynamo.Wpf.Views.PackageManager
 {
@@ -101,17 +103,27 @@ namespace Dynamo.Wpf.Views.PackageManager
             var args = e as PackagePathEventArgs;
             args.Cancel = true;
 
-            var dialog = new DynamoFolderBrowserDialog
+            // Handle for the case, args.Path does not exist.
+            var errorCannotCreateFolder = PathHelper.CreateFolderIfNotExist(args.Path);
+            if (errorCannotCreateFolder == null)
             {
-                // Navigate to initial folder.
-                SelectedPath = args.Path,
-                Owner = this
-            };
+                var dialog = new DynamoFolderBrowserDialog
+                {
+                    // Navigate to initial folder.
+                    SelectedPath = args.Path,
+                    Owner = this
+                };
 
-            if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                {
+                    args.Cancel = false;
+                    args.Path = dialog.SelectedPath;
+                }
+
+            }
+            else
             {
-                args.Cancel = false;
-                args.Path = dialog.SelectedPath;
+                System.Windows.Forms.MessageBox.Show(Wpf.Properties.Resources.PackageFolderNotAccessible, Wpf.Properties.Resources.FolderNotFoundError, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml.cs
@@ -105,7 +105,8 @@ namespace Dynamo.Wpf.Views.PackageManager
 
             // Handle for the case, args.Path does not exist.
             var errorCannotCreateFolder = PathHelper.CreateFolderIfNotExist(args.Path);
-            if (errorCannotCreateFolder == null)
+            // args.Path == null condition is to handle when user want to create new path.
+            if (errorCannotCreateFolder == null || args.Path == null)
             {
                 var dialog = new DynamoFolderBrowserDialog
                 {
@@ -123,7 +124,8 @@ namespace Dynamo.Wpf.Views.PackageManager
             }
             else
             {
-                System.Windows.Forms.MessageBox.Show(Wpf.Properties.Resources.PackageFolderNotAccessible, Wpf.Properties.Resources.FolderNotFoundError, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                string errorMessage = string.Format(Wpf.Properties.Resources.PackageFolderNotAccessible, "\n", args.Path, "\n");
+                System.Windows.Forms.MessageBox.Show(errorMessage, Wpf.Properties.Resources.FolderNotAccessibleError, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackagePathView.xaml.cs
@@ -125,7 +125,7 @@ namespace Dynamo.Wpf.Views.PackageManager
             else
             {
                 string errorMessage = string.Format(Wpf.Properties.Resources.PackageFolderNotAccessible, args.Path);
-                System.Windows.Forms.MessageBox.Show(errorMessage, Wpf.Properties.Resources.FolderNotAccessibleError, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                System.Windows.Forms.MessageBox.Show(errorMessage, Wpf.Properties.Resources.UnableToAccessPackageDirectory, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 


### PR DESCRIPTION
### Purpose

- Fixed Error MAGN-10353 Crash when installing packages to folder
- Need to be reviewed for more meaningful error message to be displayed.

Error scenarios: 
1> Case 1:
- Error 1: After opening dynamo, User delete the package folder in C:\Users\<yourname>\AppData\Roaming\Dynamo\Dynamo Core\1.1\packages
When user, want to install package following this steps: packages -> search pakcages -> install package to folder. 
Dynamo Crashed. 

- Fix 1: Automatically create a new folder when it is not existed and let the user install normally. If the package cannot be created due to some accessibility issues like access denied, the error message will be pop up like the picture bellow. (Unable To Access Package Directory)

2> Case 2: 
- Error 2: 
create folder in C:\Users\<yourname>\AppData\Roaming\Dynamo\Dynamo Core\1.1\
setting -> manage node and package paths -> choose that folder
restart dynamo
delete folder
setting -> manage node and package paths -> click on the 3 dots on the right side of deleted folder path.
Dynamo Crashed.

- Fix 2: If the folder is not existed but the path is still in the manage node and package path, automatically create a new folder according to that path so that when user click to select that folder, no error will be trigger. 
In the case package cannot be created due to some accessibility issues like access denied, the error message will be pop up like the picture bellow. (Unable To Access Package Directory)

3> Case 3: 
- Error 3: 
Go to packages -> search pakcages -> install package to folder. 
Let Dynamo install the chosen package to the selected folder.
After finish installing, delete that folder from C:\Users\<yourname>\AppData\Roaming\Dynamo\Dynamo Core\1.1\
Then, open Package -> Manage Packages. Select the 3 dots beside the installed package and choose "Go To Root Directory"
Dynamo Crashed.

- Fix 3: In the GoToDirectory function, check for the existence of the directory first. If it is not existed, the error message will be shown like below (Directory Not Found). 
In this fix, we are not trying to create a new folder because when the root directory is not existed means that the package installed is not exist and should be re-install. Hence, no need to create an empty folder without any packages in it.

Here are the 2 pictures of the error messages to be display.

Unable To Access Package Directory (For Fix 1 and Fix 2) 
![unabletoaccesspackagedirectory](https://cloud.githubusercontent.com/assets/14092408/17392388/aa68d2b0-5a4f-11e6-8912-e408adff002e.JPG)

Directory Not Found (For Fix 3)
![directorynotfound](https://cloud.githubusercontent.com/assets/14092408/17392406/c95fba8a-5a4f-11e6-990b-8f7e69508e08.JPG)




### Declarations




Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

###FYI
@riteshchandawar 


