### PR TITLE
Always set default attribute for node

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1803,10 +1803,7 @@ namespace Dynamo.Graph.Nodes
             {
                 XmlElement portInfo = element.OwnerDocument.CreateElement("PortInfo");
                 portInfo.SetAttribute("index", t.index.ToString(CultureInfo.InvariantCulture));
-                if (t.port.UsingDefaultValue)
-                {
-                    portInfo.SetAttribute("default", true.ToString());
-                }
+                portInfo.SetAttribute("default", t.port.UsingDefaultValue.ToString());
 
                 if (t.port.UseLevels)
                 {


### PR DESCRIPTION
### Purpose

Because of List@Level UI enhancement, each node will create a `PortInfo` element when it is serialized:
```
<PortInfo index="0" useLevels="True" level="2" shouldKeepListStructure="True" />
```
But for 1.0, `PortInfo` will only be created when the node isn't using default value for some inputs. When it comes across `PortInfo` element, it expects this element would have `default` attribute. To be able to open to open new file on 1.0, we need to always serialize `default` attribute:
```
<PortInfo index="0" default="True" useLevels="True" level="2" shouldKeepListStructure="True" />
```

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs
@monikaprabhu 

