### PR TITLE
Append replication guide to input if "Use Level" is enabled

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -989,12 +989,13 @@ namespace Dynamo.Graph.Nodes
             switch (ArgumentLacing)
             {
                 case LacingStrategy.Shortest:
-                    /*
                     for (int i = 0; i < inputs.Count(); ++i)
                     {
-                        inputs[i] = AstFactory.AddReplicationGuide(inputs[i], new List<int> { 1 }, false);
+                        if (InPorts[i].UseLevels)
+                        {
+                            inputs[i] = AstFactory.AddReplicationGuide(inputs[i], new List<int> { 1 }, false);
+                        }
                     }
-                    */
                     break;
 
                 case LacingStrategy.Longest:

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -203,7 +203,7 @@
                     AllowsTransparency="True"
                     IsOpen="{Binding Path=ShowUseLevelMenu,diag:PresentationTraceSources.TraceLevel=High}"
                     StaysOpen="False">
-                    <Grid Background="Transparent">
+                    <Grid Background="#e5e2de">
                         <Grid.Resources>
                             <ResourceDictionary>
                                 <Style TargetType="CheckBox">
@@ -212,7 +212,7 @@
                                     <Setter Property="FontSize" Value="13"/>
                                     <Style.Triggers>
                                         <Trigger Property="IsEnabled" Value="false">
-                                            <Setter Property="Foreground" Value="#E0E0E0"/>
+                                            <Setter Property="Foreground" Value="#999999"/>
                                         </Trigger>
                                     </Style.Triggers>
                                 </Style>
@@ -232,7 +232,7 @@
                                 <TextBlock 
                                     FontFamily="{StaticResource OpenSansRegular}" 
                                     FontSize="10" 
-                                    Foreground="#E0E0E0" 
+                                    Foreground="#999999" 
                                     Focusable="False" 
                                     Padding="20, 0, 0, 0"
                                     Text="{x:Static p:Resources.UseLevelKeepListStructureHint}"/>


### PR DESCRIPTION
### Purpose

* If "Use Levels" is selected and lacing is set to shortest, then automatically apply <1> to input
* If "Use Levels" is selected and lacing is set to longest, then automatically apply <1L> to input
* If "Use Levels" is selected and lacing is set to cross, then apply the appropriate rep guide based on lacing logic

This is because current Shortest lacing actually is Auto lacing. To support semantic versioning, we can't change it now till 2.0. Instead, we make Shortest lacing be real shortest lacing by appending replication guide "<1>" if "Use Levels" is selected.

Example:

![untitled](https://cloud.githubusercontent.com/assets/2600379/17486463/7c1b66a8-5dc3-11e6-8fa3-bc6caaa87fcc.png)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@Racel 
