### PR TITLE
Documentation load failure reach

### DIFF
--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -67,42 +67,23 @@ namespace Dynamo.Engine
                 baseDir = Path.GetDirectoryName(Path.GetFullPath(assemblyLocation));
             }
 
-            var xmlFileName = assemblyName + ".xml";
-
             var language = System.Threading.Thread.CurrentThread.CurrentUICulture.ToString();
-            var localizedResPath = Path.Combine(baseDir, language);
-            documentationPath = Path.Combine(localizedResPath, xmlFileName);
-
-            if (File.Exists(documentationPath))
-                return true;
-
-            //try with uppercase XML for linux
-            documentationPath = PathHelper.replaceExtension(documentationPath, ".XML");
-            if (File.Exists(documentationPath))
-                return true;
+            //try with the system culture
+            var localizedDocPath = Path.Combine(baseDir, language);
 
             //try with the fallback culture
-            localizedResPath = Path.Combine(baseDir, Configurations.FallbackUiCulture);
-            documentationPath = Path.Combine(localizedResPath, xmlFileName);
-            if (File.Exists(documentationPath))
+            var localizedFallbackDockPath = Path.Combine(baseDir, Configurations.FallbackUiCulture);
+
+            var searchPaths = new List<string>() { localizedDocPath, localizedFallbackDockPath, baseDir };
+            var extension = ".xml";
+
+            documentationPath = PathHelper.FindFileInPaths(assemblyName, extension, searchPaths.ToArray());
+            if(documentationPath != string.Empty)
+            {
                 return true;
-
-            //try with uppercase XML for linux
-            documentationPath = PathHelper.replaceExtension(documentationPath, ".XML");
-            if (File.Exists(documentationPath))
-                return true;
-
-            //try in the base directory
-            documentationPath = Path.Combine(baseDir, xmlFileName);
-            if (File.Exists(documentationPath))
-                return true;
-
-            //try with uppercase XML for linux
-            documentationPath = PathHelper.replaceExtension(documentationPath, ".XML");
-            return File.Exists(documentationPath);
-
+            }
+            return false;
         }
 
     }
-
 }

--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -77,10 +77,10 @@ namespace Dynamo.Engine
                 return true;
 
             //try with uppercase XML for linux
-            documentationPath = Path.Combine(Path.GetDirectoryName(documentationPath),Path.GetFileNameWithoutExtension(documentationPath) + ".XML");
+            documentationPath = PathHelper.replaceExtension(documentationPath, ".XML");
             if (File.Exists(documentationPath))
                 return true;
-              
+
             //try with the fallback culture
             localizedResPath = Path.Combine(baseDir, Configurations.FallbackUiCulture);
             documentationPath = Path.Combine(localizedResPath, xmlFileName);
@@ -88,20 +88,21 @@ namespace Dynamo.Engine
                 return true;
 
             //try with uppercase XML for linux
-            documentationPath = Path.Combine(Path.GetDirectoryName(documentationPath), Path.GetFileNameWithoutExtension(documentationPath) + ".XML");
+            documentationPath = PathHelper.replaceExtension(documentationPath, ".XML");
             if (File.Exists(documentationPath))
                 return true;
-            
+
             //try in the base directory
             documentationPath = Path.Combine(baseDir, xmlFileName);
             if (File.Exists(documentationPath))
                 return true;
 
             //try with uppercase XML for linux
-            documentationPath = Path.Combine(Path.GetDirectoryName(documentationPath), Path.GetFileNameWithoutExtension(documentationPath) + ".XML");
+            documentationPath = PathHelper.replaceExtension(documentationPath, ".XML");
             return File.Exists(documentationPath);
-               
+
         }
+
     }
 
 }

--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -76,13 +76,31 @@ namespace Dynamo.Engine
             if (File.Exists(documentationPath))
                 return true;
 
+            //try with uppercase XML for linux
+            documentationPath = Path.GetFileNameWithoutExtension(documentationPath) + ".XML";
+            if (File.Exists(documentationPath))
+                return true;
+              
+            //try with the fallback culture
             localizedResPath = Path.Combine(baseDir, Configurations.FallbackUiCulture);
             documentationPath = Path.Combine(localizedResPath, xmlFileName);
             if (File.Exists(documentationPath))
                 return true;
 
+            //try with uppercase XML for linux
+            documentationPath = Path.GetFileNameWithoutExtension(documentationPath) + ".XML";
+            if (File.Exists(documentationPath))
+                return true;
+            
+            //try in the base directory
             documentationPath = Path.Combine(baseDir, xmlFileName);
+            if (File.Exists(documentationPath))
+                return true;
+
+            //try with uppercase XML for linux
+            documentationPath = Path.GetFileNameWithoutExtension(documentationPath) + ".XML";
             return File.Exists(documentationPath);
+               
         }
     }
 

--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -77,7 +77,7 @@ namespace Dynamo.Engine
                 return true;
 
             //try with uppercase XML for linux
-            documentationPath = Path.GetFileNameWithoutExtension(documentationPath) + ".XML";
+            documentationPath = Path.Combine(Path.GetDirectoryName(documentationPath),Path.GetFileNameWithoutExtension(documentationPath) + ".XML");
             if (File.Exists(documentationPath))
                 return true;
               
@@ -88,7 +88,7 @@ namespace Dynamo.Engine
                 return true;
 
             //try with uppercase XML for linux
-            documentationPath = Path.GetFileNameWithoutExtension(documentationPath) + ".XML";
+            documentationPath = Path.Combine(Path.GetDirectoryName(documentationPath), Path.GetFileNameWithoutExtension(documentationPath) + ".XML");
             if (File.Exists(documentationPath))
                 return true;
             
@@ -98,7 +98,7 @@ namespace Dynamo.Engine
                 return true;
 
             //try with uppercase XML for linux
-            documentationPath = Path.GetFileNameWithoutExtension(documentationPath) + ".XML";
+            documentationPath = Path.Combine(Path.GetDirectoryName(documentationPath), Path.GetFileNameWithoutExtension(documentationPath) + ".XML");
             return File.Exists(documentationPath);
                
         }

--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -172,7 +172,10 @@ namespace Dynamo.Engine
             var documentNode = GetMemberDocumentNode(function, xml);
 
             if (documentNode == null)
+            {
+                Console.WriteLine("doc node" + function.FunctionName + "was null :(");
                 return String.Empty;
+            }
             if (property.Equals(DocumentElementType.Description) && !documentNode.Parameters.ContainsKey(paramName))
                 return String.Empty;
 
@@ -376,9 +379,11 @@ namespace Dynamo.Engine
                                 break;
                             case XmlTagType.SearchTags:
                                 currentDocNode.SearchTags = reader.Value.CleanUpDocString();
+                                Console.WriteLine("current tag is" + currentDocNode.SearchTags);
                                 break;
                             case XmlTagType.SearchTagWeights:
                                 currentDocNode.SearchTagWeights = reader.Value.CleanUpDocString();
+                                Console.WriteLine("current tag is" + currentDocNode.SearchTagWeights);
                                 break;
                         }
 

--- a/src/DynamoCore/Library/XmlDocumentationExtensions.cs
+++ b/src/DynamoCore/Library/XmlDocumentationExtensions.cs
@@ -172,10 +172,8 @@ namespace Dynamo.Engine
             var documentNode = GetMemberDocumentNode(function, xml);
 
             if (documentNode == null)
-            {
-                Console.WriteLine("doc node" + function.FunctionName + "was null :(");
                 return String.Empty;
-            }
+
             if (property.Equals(DocumentElementType.Description) && !documentNode.Parameters.ContainsKey(paramName))
                 return String.Empty;
 
@@ -379,11 +377,9 @@ namespace Dynamo.Engine
                                 break;
                             case XmlTagType.SearchTags:
                                 currentDocNode.SearchTags = reader.Value.CleanUpDocString();
-                                Console.WriteLine("current tag is" + currentDocNode.SearchTags);
                                 break;
                             case XmlTagType.SearchTagWeights:
                                 currentDocNode.SearchTagWeights = reader.Value.CleanUpDocString();
-                                Console.WriteLine("current tag is" + currentDocNode.SearchTagWeights);
                                 break;
                         }
 

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -83,5 +83,17 @@ namespace DynamoUtilities
 
             return writeAllow && !writeDeny;
         }
+
+        /// <summary>
+        /// returns the original path with the extension replaced with the new extension. 
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="extension"></param>
+        /// <returns></returns>
+        public static string replaceExtension(string path, string extension)
+        {
+            path = Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path) + extension);
+            return path;
+        }
     }
 }

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Security.AccessControl;
 
 namespace DynamoUtilities
@@ -85,15 +86,30 @@ namespace DynamoUtilities
         }
 
         /// <summary>
-        /// returns the original path with the extension replaced with the new extension. 
+        /// searchs for a file with an extension in a list of paths, returns the first match
+        /// where the extension is case insensitive. If no file is found, returns an empty string.
         /// </summary>
-        /// <param name="path"></param>
+        /// <param name="filename"></param>
         /// <param name="extension"></param>
+        /// <param name="searchPaths"></param>
         /// <returns></returns>
-        public static string replaceExtension(string path, string extension)
+        public static string FindFileInPaths(string filename, string extension, string[] searchPaths)
         {
-            path = Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path) + extension);
-            return path;
+            foreach (var path in searchPaths)
+            {
+                if (Directory.Exists(path))
+                {
+                    var files = Directory.GetFiles(path);
+                    var matches = files.ToList().Where(x => x.EndsWith(filename+extension) || x.EndsWith(filename+extension.ToUpper()) || x.EndsWith(filename+extension.ToLower()));
+                    if (matches.Count() > 0)
+                    {
+                        //found a match, return the first one
+                        return matches.First();
+                    }
+
+                }
+            }
+            return string.Empty;
         }
     }
 }

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -100,7 +100,8 @@ namespace DynamoUtilities
                 if (Directory.Exists(path))
                 {
                     var files = Directory.GetFiles(path);
-                    var matches = files.ToList().Where(x => x.EndsWith(filename+extension) || x.EndsWith(filename+extension.ToUpper()) || x.EndsWith(filename+extension.ToLower()));
+                    //matches occur where filename and extension are the same when both are lowercased
+                    var matches = files.ToList().Where(x => String.CompareOrdinal(Path.GetFileName(x).ToLower(), (filename + extension).ToLower()) == 0) ;
                     if (matches.Count() > 0)
                     {
                         //found a match, return the first one

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -102,6 +102,11 @@ namespace DynamoUtilities
                     var files = Directory.GetFiles(path);
                     //matches occur where filename and extension are the same when both are lowercased
                     var matches = files.ToList().Where(x => String.CompareOrdinal(Path.GetFileName(x).ToLower(), (filename + extension).ToLower()) == 0) ;
+                    if (matches.Count() > 1)
+                    {
+                        Console.WriteLine(string.Format("While searching for {0}{1} in {2}, {3} matches were found, the first will be loaded",
+                            filename, extension, path, matches.Count().ToString()));
+                    }
                     if (matches.Count() > 0)
                     {
                         //found a match, return the first one

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -600,12 +600,56 @@ namespace Dynamo.Tests
             }
 
             Assert.AreEqual(filePath, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path }));
-            Assert.AreEqual(filePath, PathHelper.FindFileInPaths("SaveFile", ".TXT", new String[] { path }));
-            Assert.AreEqual(filePath, PathHelper.FindFileInPaths("SaveFile", ".tXt", new String[] { path }));
-
             File.Delete(filePath);
+            filePath = Path.Combine(path, "SaveFile.TXT");
+            using (StreamWriter sw = new StreamWriter(filePath))
+            {
+                sw.Write("test");
+            }
+
+            Assert.AreEqual(filePath, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path }));
+            File.Delete(filePath);
+            filePath = Path.Combine(path, "SaveFile.tXt");
+            using (StreamWriter sw = new StreamWriter(filePath))
+            {
+                sw.Write("test");
+            }
+
+            Assert.AreEqual(filePath, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path }));
+            File.Delete(filePath);
+
+
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void FindFilesRespectsPathOrder()
+        {
+            var path1 = Path.Combine(Path.GetTempPath(),"firstFindFile");
+            var path2 = Path.Combine(Path.GetTempPath(), "secondFindFile");
+
+            Directory.CreateDirectory(path1);
+            Directory.CreateDirectory(path2);
+
+            string filePath1 = Path.Combine(path1, "SaveFile.txt");
+            string filePath2 = Path.Combine(path1, "SaveFile.TXT");
+
+            using (StreamWriter sw = new StreamWriter(filePath1))
+            {
+                sw.Write("test");
+            }
+            using (StreamWriter sw = new StreamWriter(filePath2))
+            {
+                sw.Write("test");
+            }
+
+
+            Assert.AreEqual(filePath1, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path1,path2 }));
+
+
+            Directory.Delete(path1,true);
+            Directory.Delete(path2,true);
+        }
 
         [Test]
         public void WrapTextTest()

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -632,7 +632,7 @@ namespace Dynamo.Tests
             Directory.CreateDirectory(path2);
 
             string filePath1 = Path.Combine(path1, "SaveFile.txt");
-            string filePath2 = Path.Combine(path1, "SaveFile.TXT");
+            string filePath2 = Path.Combine(path2, "SaveFile.TXT");
 
             using (StreamWriter sw = new StreamWriter(filePath1))
             {
@@ -645,7 +645,7 @@ namespace Dynamo.Tests
 
 
             Assert.AreEqual(filePath1, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path1,path2 }));
-
+            Assert.AreEqual(filePath2, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path2, path1 }));
 
             Directory.Delete(path1,true);
             Directory.Delete(path2,true);

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -589,6 +589,25 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        [Category("UnitTests")]
+        public void FindFilesWithcaseinsensitiveFileExtensions()
+        {
+            var path = Path.GetTempPath();
+            string filePath = Path.Combine(path, "SaveFile.txt");
+            using (StreamWriter sw = new StreamWriter(filePath))
+            {
+                sw.Write("test");
+            }
+
+            Assert.AreEqual(filePath, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path }));
+            Assert.AreEqual(filePath, PathHelper.FindFileInPaths("SaveFile", ".TXT", new String[] { path }));
+            Assert.AreEqual(filePath, PathHelper.FindFileInPaths("SaveFile", ".tXt", new String[] { path }));
+
+            File.Delete(filePath);
+        }
+
+
+        [Test]
         public void WrapTextTest()
         {
             string testingSTR = string.Empty;


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10403

This PR adds some extra search paths to locations for documentation .xmls as some of our documentation has  .XML as an extension and this fails to be imported on nix systems. (upperCase)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

These changes return the correct library response on Ubuntu 14.04.

### Reviewers

@QilongTang  - I'd like to see the test results before we get this merged.

### FYIs

@Racel 