### PR TITLE
Add a headless start configuration for testing.

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -459,6 +459,46 @@ namespace Dynamo.Models
         }
 
         /// <summary>
+        /// A start configuration used for testing. 
+        /// 
+        /// This configuration sets both StartInTestMode and IsHeadless to true,
+        /// regardless of the settings in the configuration used to initialize it.
+        /// </summary>
+        public struct HeadlessStartConfiguration : IStartConfiguration2
+        {
+            public string Context { get; set; }
+            public string DynamoCorePath { get; set; }
+            public string DynamoHostPath { get; set; }
+            public IPreferences Preferences { get; set; }
+            public IPathResolver PathResolver { get; set; }
+            public bool StartInTestMode { get; set; }
+            public IUpdateManager UpdateManager { get; set; }
+            public ISchedulerThread SchedulerThread { get; set; }
+            public string GeometryFactoryPath { get; set; }
+            public IAuthProvider AuthProvider { get; set; }
+            public IEnumerable<IExtension> Extensions { get; set; }
+            public TaskProcessMode ProcessMode { get; set; }
+            public bool IsHeadless { get; set; }
+
+            public HeadlessStartConfiguration(DefaultStartConfiguration config)
+            {
+                Context = config.Context;
+                DynamoCorePath = config.DynamoCorePath;
+                DynamoHostPath = config.DynamoHostPath;
+                Preferences = config.Preferences;
+                PathResolver = config.PathResolver;
+                StartInTestMode = true;
+                UpdateManager = config.UpdateManager;
+                SchedulerThread = config.SchedulerThread;
+                GeometryFactoryPath = config.GeometryFactoryPath;
+                AuthProvider = config.AuthProvider;
+                Extensions = config.Extensions;
+                ProcessMode = config.ProcessMode;
+                IsHeadless = true;
+            }
+        }
+
+        /// <summary>
         ///     Start DynamoModel with all default configuration options
         /// </summary>
         /// <returns>The instance of <see cref="DynamoModel"/></returns>


### PR DESCRIPTION
### Purpose

This PR is required for [FRAC-495](https://jira.autodesk.com/browse/FRAC-495). It adds the `HeadlessStartConfiguration` that can be used by Reach during testing. We add the implementation in Dynamo to make it obvious what will need to be merged when the `IStartConfiguration` and `IStartConfiguration2` interfaces are merged for Dynamo 2.0.

See the parent PR at https://github.com/DynamoDS/Reach/pull/226.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR. 
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 

