### PR TITLE
Update the style of Use Level popup menu

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -209,7 +209,7 @@
                                 <Style TargetType="CheckBox">
                                     <Setter Property="FontFamily" Value="{StaticResource OpenSansRegular}"/>
                                     <Setter Property="Foreground" Value="#555555"/>
-                                    <Setter Property="FontSize" Value="13"/>
+                                    <Setter Property="FontSize" Value="11"/>
                                     <Style.Triggers>
                                         <Trigger Property="IsEnabled" Value="false">
                                             <Setter Property="Foreground" Value="#999999"/>
@@ -218,7 +218,7 @@
                                 </Style>
                             </ResourceDictionary>
                         </Grid.Resources>
-                        <Border BorderBrush="#E0E0E0" BorderThickness="1" CornerRadius="5" Padding="5" Background="#CBC6BE">
+                        <Border BorderBrush="#5E5C5A" BorderThickness="1" CornerRadius="5" Padding="5" Background="#CBC6BE">
                             <StackPanel>
                                 <CheckBox 
                                     Content="{x:Static p:Resources.UseLevelPopupMenuItem}"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -203,7 +203,7 @@
                     AllowsTransparency="True"
                     IsOpen="{Binding Path=ShowUseLevelMenu,diag:PresentationTraceSources.TraceLevel=High}"
                     StaysOpen="False">
-                    <Grid Background="#E5E2DE">
+                    <Grid Background="Transparent">
                         <Grid.Resources>
                             <ResourceDictionary>
                                 <Style TargetType="CheckBox">
@@ -218,7 +218,12 @@
                                 </Style>
                             </ResourceDictionary>
                         </Grid.Resources>
-                        <Border BorderBrush="#5E5C5A" BorderThickness="1" CornerRadius="5" Padding="5" Background="#E5E2DE">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="10"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Path Grid.Column="0" Stroke="#5E5C5A" Fill="#E5E2DE" Margin="1,0,0,0" Data="M 0,10 L 12,5 12,15 Z"/>
+                        <Border BorderBrush="#5E5C5A" BorderThickness="1" CornerRadius="2" Padding="2" Background="#E5E2DE" Grid.Column="1">
                             <StackPanel>
                                 <CheckBox 
                                     Content="{x:Static p:Resources.UseLevelPopupMenuItem}"
@@ -238,6 +243,7 @@
                                     Text="{x:Static p:Resources.UseLevelKeepListStructureHint}"/>
                             </StackPanel>
                         </Border>
+                        <Path Grid.Column="1" Stroke="#E5E2DE" Fill="#E5E2DE" Data="M 0,7 L 1,7 L 1,13 L0,13 Z"/>
                     </Grid>
                 </dynui:UseLevelPopup>
             </Grid>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -203,12 +203,12 @@
                     AllowsTransparency="True"
                     IsOpen="{Binding Path=ShowUseLevelMenu,diag:PresentationTraceSources.TraceLevel=High}"
                     StaysOpen="False">
-                    <Grid Background="#e5e2de">
+                    <Grid Background="#E5E2DE">
                         <Grid.Resources>
                             <ResourceDictionary>
                                 <Style TargetType="CheckBox">
                                     <Setter Property="FontFamily" Value="{StaticResource OpenSansRegular}"/>
-                                    <Setter Property="Foreground" Value="#555555"/>
+                                    <Setter Property="Foreground" Value="#5E5C5A"/>
                                     <Setter Property="FontSize" Value="11"/>
                                     <Style.Triggers>
                                         <Trigger Property="IsEnabled" Value="false">
@@ -218,7 +218,7 @@
                                 </Style>
                             </ResourceDictionary>
                         </Grid.Resources>
-                        <Border BorderBrush="#5E5C5A" BorderThickness="1" CornerRadius="5" Padding="5" Background="#CBC6BE">
+                        <Border BorderBrush="#5E5C5A" BorderThickness="1" CornerRadius="5" Padding="5" Background="#E5E2DE">
                             <StackPanel>
                                 <CheckBox 
                                     Content="{x:Static p:Resources.UseLevelPopupMenuItem}"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -243,7 +243,7 @@
                                     Text="{x:Static p:Resources.UseLevelKeepListStructureHint}"/>
                             </StackPanel>
                         </Border>
-                        <Path Grid.Column="1" Stroke="#E5E2DE" Fill="#E5E2DE" Data="M 0,7 L 1,7 L 1,13 L0,13 Z"/>
+                        <Path Grid.Column="1" Stroke="#E5E2DE" Fill="#E5E2DE" Data="M 0,7.5 L 1,7.5 L 1,12.5 L0,12.5 Z"/>
                     </Grid>
                 </dynui:UseLevelPopup>
             </Grid>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -236,7 +236,7 @@
                                     IsEnabled="{Binding ElementName=UseLevel, Path=IsChecked}"/>
                                 <TextBlock 
                                     FontFamily="{StaticResource OpenSansRegular}" 
-                                    FontSize="10" 
+                                    FontSize="9" 
                                     Foreground="#999999" 
                                     Focusable="False" 
                                     Padding="20, 0, 0, 0"


### PR DESCRIPTION
### Purpose

* Change background color to #E5E2DE
* Change stroke to #5E5C5A
* Font size reduced to 10 pt
* Change description text color to #999999
* Add small tab

![untitled](https://cloud.githubusercontent.com/assets/2600379/17577189/6b546536-5fad-11e6-8533-573ad239f4ac.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### FYIs

@Racel, @monikaprabhu 
