### PR TITLE
Update input port padding

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -161,7 +161,7 @@
                 <Rectangle
                     Name="highlightOverlayForArrow" 
                     Fill="{Binding Path=ShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlighColorConverter}}"
-                    MinWidth="12"
+                    MinWidth="8"
                     Margin="0,0,0,1"
                     IsHitTestVisible="True">
                     <interactivity:Interaction.Triggers>
@@ -189,7 +189,7 @@
                                            Height="16"
                                            Level="{Binding Path=Level, Mode=TwoWay}"
                                            KeepListStructure="{Binding Path=ShouldKeepListStructure}"
-                                           Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityConverter}, FallbackValue=Hidden}"/>
+                                           Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, FallbackValue=Collapsed}"/>
                     <fa:FontAwesome Icon="ChevronRight"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Center"


### PR DESCRIPTION
### Purpose

Increase input port padding so that input port could be easily connected to.

* If no input port uses level, all inputs are collapsed
* If one or more input ports use level, inputs are expanded, but padding is added for input port (note input port high light state)

![untitled](https://cloud.githubusercontent.com/assets/2600379/17577943/f23ebb0c-5fb5-11e6-9f0d-cb9d0b2eced0.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### FYIs

@Racel 

