### PR TITLE
Fixed List Label Hover Highlighting and List Label Margins

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2834,7 +2834,7 @@ namespace Dynamo.Controls
         {
             if (value is int)
             {
-                var margin = (int)value == 1 ? new Thickness(3, 0, 0, 0) : new Thickness();
+                var margin = (int)value == 1 ? new Thickness(4, 3, 0, 0) : new Thickness(2,3,0,0);
                 return margin; 
             }
             return new Thickness();

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -325,6 +325,14 @@
                         <Style TargetType="ListViewItem">
                             <Setter Property="Margin" Value="{Binding Path=. , Converter= {StaticResource LeftThicknessConverter} }"></Setter>
                                 <Setter Property="Focusable" Value="False"/>
+                            <Setter Property="Padding" Value="0"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="{x:Type ListViewItem}">
+                                        <ContentPresenter />
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
                         </Style>
                     </ListView.ItemContainerStyle>
 

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -316,7 +316,7 @@
             <!-- Shows list@level labels in List -->
             
             <ListView Name="listLevelsView"
-                      Grid.Column ="0" Margin="7,3,0,7" 
+                      Grid.Column ="0" Margin="6,3,0,7" 
                       Background="Transparent"
                       Visibility="{Binding IsCollection, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
                       BorderThickness="0">


### PR DESCRIPTION
### Purpose

PR to address: [Magn-10525](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10525)

1. Updated margins and padding to ensure consistency across Win7 and Win10 machines.
2. Updated list labels such that when the mouse overs over the labels, there will not be any highlighting of the label (Win10)

Screenshot in Win10:

![listlabelmargins](https://cloud.githubusercontent.com/assets/16283396/17580826/22d54d8a-5fd4-11e6-9a73-ea1648ad62c5.PNG)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

### FYIs