### PR TITLE
Add padding for Use Level popup

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -209,7 +209,7 @@
                                 <Style TargetType="CheckBox">
                                     <Setter Property="FontFamily" Value="{StaticResource OpenSansRegular}"/>
                                     <Setter Property="Foreground" Value="#5E5C5A"/>
-                                    <Setter Property="FontSize" Value="11"/>
+                                    <Setter Property="FontSize" Value="12"/>
                                     <Style.Triggers>
                                         <Trigger Property="IsEnabled" Value="false">
                                             <Setter Property="Foreground" Value="#999999"/>
@@ -226,15 +226,18 @@
                         <Border BorderBrush="#5E5C5A" BorderThickness="1" CornerRadius="2" Padding="2" Background="#E5E2DE" Grid.Column="1">
                             <StackPanel>
                                 <CheckBox 
+                                    Margin="5, 5, 5, 0"
                                     Content="{x:Static p:Resources.UseLevelPopupMenuItem}"
                                     IsChecked="{Binding Path=UseLevels, Mode=TwoWay}"
                                     Name="UseLevel"/>
-                                <Separator/>
+                                <Separator Margin ="5, 5, 5, 0"/>
                                 <CheckBox
+                                    Margin="5, 5, 5, 0"
                                     Content="{x:Static p:Resources.UseLevelKeepListStructurePopupMenuItem}"
                                     IsChecked="{Binding Path=ShouldKeepListStructure, Mode=TwoWay}"
                                     IsEnabled="{Binding ElementName=UseLevel, Path=IsChecked}"/>
                                 <TextBlock 
+                                    Margin="5, 0, 5, 5"
                                     FontFamily="{StaticResource OpenSansRegular}" 
                                     FontSize="9" 
                                     Foreground="#999999" 


### PR DESCRIPTION
### Purpose

Add padding for Use Level popup.

![untitled](https://cloud.githubusercontent.com/assets/2600379/17589628/6d29c346-6008-11e6-9f6b-2d127c31c610.png)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### FYIs
@Racel 

