### PR TITLE
Remove question marks from Use Levels popup

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5027,7 +5027,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Keep list structure?.
+        ///   Looks up a localized string similar to Keep list structure.
         /// </summary>
         public static string UseLevelKeepListStructurePopupMenuItem {
             get {
@@ -5036,7 +5036,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use Levels?.
+        ///   Looks up a localized string similar to Use Levels.
         /// </summary>
         public static string UseLevelPopupMenuItem {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2057,10 +2057,10 @@ Next assemblies were loaded several times:
     <value>Keep 1 input list's nesting</value>
   </data>
   <data name="UseLevelKeepListStructurePopupMenuItem" xml:space="preserve">
-    <value>Keep list structure?</value>
+    <value>Keep list structure</value>
   </data>
   <data name="UseLevelPopupMenuItem" xml:space="preserve">
-    <value>Use Levels?</value>
+    <value>Use Levels</value>
   </data>
   <data name="DirectoryNotFound" xml:space="preserve">
     <value>Directory Not Found</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2059,10 +2059,10 @@ Next assemblies were loaded several times:
     <value>Keep 1 input list's nesting</value>
   </data>
   <data name="UseLevelKeepListStructurePopupMenuItem" xml:space="preserve">
-    <value>Keep list structure?</value>
+    <value>Keep list structure</value>
   </data>
   <data name="UseLevelPopupMenuItem" xml:space="preserve">
-    <value>Use Levels?</value>
+    <value>Use Levels</value>
   </data>
   <data name="DirectoryNotFound" xml:space="preserve">
     <value>Directory Not Found</value>


### PR DESCRIPTION
### Purpose

Remove question marks from two checkboxes in Use Levels popup.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@Racel 

