### PR TITLE
Fix random crash in preview control

### DIFF
--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -191,6 +191,9 @@ namespace CoreNodeModelsWpf.Nodes
             // then update on the ui thread
             t.ThenPost((_) =>
             {
+                //If wvm is not computed successfully then don't post.
+                if (wvm == null) return;
+
                 // store in temp variable to silence binding
                 var temp = rootWatchViewModel.Children;
 


### PR DESCRIPTION
### Purpose

This PR fixes some of the crashes caused by refreshing preview control. It potentially fixes [MAGN-9932](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9932), [MAGN-10531](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10531) and [MAGN-10528](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10528)

- When `GenerateWatchViewModelForData` async task throws any exception newViewModel is not set properly and hence while accessing it in `AsyncTaskCompletedHandler delegate` it throws `NullReferenceException`. Fixed by an early return when the newViewModel is null.
- Sometimes `DivideByZeroException` is thrown from `ComputeLargeContentSize` method while calling `UpdateLayout`. Used Try-catch to catch this exception and set the content size as default condensed content.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

### FYIs

@monikaprabhu 

