### PR TITLE
Revert node right expanding, increase input port highlight area

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -152,7 +152,7 @@
                 <Grid Visibility="{Binding Path=UseLevelVisibility}" HorizontalAlignment="Right"> 
                     <!-- This is is a stub UI element just occupy the space of List@Level spinner
                          so that input port highlight will get wider area if "Use Levels" option is off -->
-                    <TextBlock
+                    <Grid
                         HorizontalAlignment="Right"
                         Width="45"
                         Background="{x:Null}"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -189,7 +189,7 @@
                                            Height="16"
                                            Level="{Binding Path=Level, Mode=TwoWay}"
                                            KeepListStructure="{Binding Path=ShouldKeepListStructure}"
-                                           Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, FallbackValue=Collapsed}"/>
+                                           Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityConverter}, FallbackValue=Hidden}"/>
                     <fa:FontAwesome Icon="ChevronRight"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Center"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -109,7 +109,7 @@
                 </Rectangle>
                 <Rectangle Name="highlightOverlay"
                        Fill="{Binding Path=ShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlighColorConverter}}"
-                       MinWidth="26"
+                       MinWidth="19"
                        Margin="0,0,0,1"
                        IsHitTestVisible="True">
                     <interactivity:Interaction.Triggers>
@@ -134,8 +134,10 @@
                     </Rectangle.Style>
                 </Rectangle>
 
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
                 <TextBlock Name="portNameTb"
                        Width="Auto"
+                       HorizontalAlignment="Stretch"
                        Style="{StaticResource SZoomFadeText}"
                        Text="{Binding Path=PortName, Converter={StaticResource PortNameConverter} }"
                        VerticalAlignment="Center"
@@ -146,22 +148,33 @@
                        Background="{x:Null}"
                        Foreground="#555555">
                 </TextBlock>
+                <!-- We wrap the text block in a grid so that it wont be displayed on output port-->
+                <Grid Visibility="{Binding Path=UseLevelVisibility}" HorizontalAlignment="Right"> 
+                    <!-- This is is a stub UI element just occupy the space of List@Level spinner
+                         so that input port highlight will get wider area if "Use Levels" option is off -->
+                    <TextBlock
+                        HorizontalAlignment="Right"
+                        Width="45"
+                        Background="{x:Null}"
+                        IsHitTestVisible="False"
+                        Visibility="{Binding Path=UseLevels, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}"/>
+                </Grid>
+                </StackPanel>
             </Grid>
 
             <Grid Name="useLevelGrid"
                   Cursor="Hand"
                   Grid.Column="1"
                   Background="Transparent"
-                  HorizontalAlignment="Right"
+                  HorizontalAlignment="Stretch"
                   IsHitTestVisible="True"
                   Margin="{Binding Path=MarginThickness}"
                   Height="{Binding Path=Height}"
-                  ToolTipService.ShowDuration="60000"
                   Visibility="{Binding Path=UseLevelVisibility}">
                 <Rectangle
                     Name="highlightOverlayForArrow" 
                     Fill="{Binding Path=ShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlighColorConverter}}"
-                    MinWidth="8"
+                    MinWidth="10"
                     Margin="0,0,0,1"
                     IsHitTestVisible="True">
                     <interactivity:Interaction.Triggers>
@@ -189,9 +202,10 @@
                                            Height="16"
                                            Level="{Binding Path=Level, Mode=TwoWay}"
                                            KeepListStructure="{Binding Path=ShouldKeepListStructure}"
-                                           Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityConverter}, FallbackValue=Hidden}"/>
+                                           Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, FallbackValue=Collapsed}"/>
                     <fa:FontAwesome Icon="ChevronRight"
-                                    HorizontalAlignment="Right"
+                                    Width="10"
+                                    HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
                                     IsHitTestVisible="False"
                                     Background="{x:Null}"
@@ -252,5 +266,4 @@
             </Grid>
         </Grid>
     </DataTemplate>
-
 </ResourceDictionary>


### PR DESCRIPTION
### Purpose

PR #7020 make input port be smaller if none of input port enables "Use Levels" option, but it also brings an issue that "Use Levels" popup menu may cover List@Level spinner control (because input port will expand to the right), so it is inconvenience to change level values.

This PR revert that change. Also make the highlight area of input port be larger if "Use Levels" option is not enabled:

![hightlight](https://cloud.githubusercontent.com/assets/2600379/17661476/02c42782-6312-11e6-8299-6d78ae2bf4b5.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

### FYIs

@Racel 
