### PR TITLE
move method from dynamoUtilities to DynamoCore as internal method

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("1.1.1.2275")]
+[assembly: AssemblyVersion("1.1.1.1955")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.1.1.2275")]
+[assembly: AssemblyFileVersion("1.1.1.1955")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("1.1.1.1955")]
+[assembly: AssemblyVersion("1.1.1.2275")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.1.1.1955")]
+[assembly: AssemblyFileVersion("1.1.1.2275")]

--- a/src/DynamoCore/Library/DocumentationServices.cs
+++ b/src/DynamoCore/Library/DocumentationServices.cs
@@ -5,6 +5,7 @@ using System.Xml;
 using Dynamo.Configuration;
 using Dynamo.Interfaces;
 using DynamoUtilities;
+using System.Linq;
 
 namespace Dynamo.Engine
 {
@@ -77,12 +78,45 @@ namespace Dynamo.Engine
             var searchPaths = new List<string>() { localizedDocPath, localizedFallbackDockPath, baseDir };
             var extension = ".xml";
 
-            documentationPath = PathHelper.FindFileInPaths(assemblyName, extension, searchPaths.ToArray());
+            documentationPath = FindFileInPaths(assemblyName, extension, searchPaths.ToArray());
             if(documentationPath != string.Empty)
             {
                 return true;
             }
             return false;
+        }
+
+        /// <summary>
+        /// searchs for a file with an extension in a list of paths, returns the first match
+        /// where the extension is case insensitive. If no file is found, returns an empty string.
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <param name="extension"></param>
+        /// <param name="searchPaths"></param>
+        /// <returns></returns>
+        internal static string FindFileInPaths(string filename, string extension, string[] searchPaths)
+        {
+            foreach (var path in searchPaths)
+            {
+                if (Directory.Exists(path))
+                {
+                    var files = Directory.GetFiles(path);
+                    //matches occur where filename and extension are the same when both are lowercased
+                    var matches = files.ToList().Where(x => String.CompareOrdinal(Path.GetFileName(x).ToLower(), (filename + extension).ToLower()) == 0);
+                    if (matches.Count() > 1)
+                    {
+                        Console.WriteLine(string.Format("While searching for {0}{1} in {2}, {3} matches were found, the first will be loaded",
+                            filename, extension, path, matches.Count().ToString()));
+                    }
+                    if (matches.Count() > 0)
+                    {
+                        //found a match, return the first one
+                        return matches.First();
+                    }
+
+                }
+            }
+            return string.Empty;
         }
 
     }

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Security.AccessControl;
 
 namespace DynamoUtilities
@@ -83,39 +82,6 @@ namespace DynamoUtilities
             }
 
             return writeAllow && !writeDeny;
-        }
-
-        /// <summary>
-        /// searchs for a file with an extension in a list of paths, returns the first match
-        /// where the extension is case insensitive. If no file is found, returns an empty string.
-        /// </summary>
-        /// <param name="filename"></param>
-        /// <param name="extension"></param>
-        /// <param name="searchPaths"></param>
-        /// <returns></returns>
-        public static string FindFileInPaths(string filename, string extension, string[] searchPaths)
-        {
-            foreach (var path in searchPaths)
-            {
-                if (Directory.Exists(path))
-                {
-                    var files = Directory.GetFiles(path);
-                    //matches occur where filename and extension are the same when both are lowercased
-                    var matches = files.ToList().Where(x => String.CompareOrdinal(Path.GetFileName(x).ToLower(), (filename + extension).ToLower()) == 0) ;
-                    if (matches.Count() > 1)
-                    {
-                        Console.WriteLine(string.Format("While searching for {0}{1} in {2}, {3} matches were found, the first will be loaded",
-                            filename, extension, path, matches.Count().ToString()));
-                    }
-                    if (matches.Count() > 0)
-                    {
-                        //found a match, return the first one
-                        return matches.First();
-                    }
-
-                }
-            }
-            return string.Empty;
         }
     }
 }

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using Dynamo.Configuration;
 using ProtoCore.AST.AssociativeAST;
 using DynamoUtilities;
+using Dynamo.Engine;
 
 namespace Dynamo.Tests
 {
@@ -599,7 +600,7 @@ namespace Dynamo.Tests
                 sw.Write("test");
             }
 
-            Assert.AreEqual(filePath, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path }));
+            Assert.AreEqual(filePath, DocumentationServices.FindFileInPaths("SaveFile", ".txt", new String[] { path }));
             File.Delete(filePath);
             filePath = Path.Combine(path, "SaveFile.TXT");
             using (StreamWriter sw = new StreamWriter(filePath))
@@ -607,7 +608,7 @@ namespace Dynamo.Tests
                 sw.Write("test");
             }
 
-            Assert.AreEqual(filePath, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path }));
+            Assert.AreEqual(filePath, DocumentationServices.FindFileInPaths("SaveFile", ".txt", new String[] { path }));
             File.Delete(filePath);
             filePath = Path.Combine(path, "SaveFile.tXt");
             using (StreamWriter sw = new StreamWriter(filePath))
@@ -615,7 +616,7 @@ namespace Dynamo.Tests
                 sw.Write("test");
             }
 
-            Assert.AreEqual(filePath, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path }));
+            Assert.AreEqual(filePath, DocumentationServices.FindFileInPaths("SaveFile", ".txt", new String[] { path }));
             File.Delete(filePath);
 
 
@@ -644,8 +645,8 @@ namespace Dynamo.Tests
             }
 
 
-            Assert.AreEqual(filePath1, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path1,path2 }));
-            Assert.AreEqual(filePath2, PathHelper.FindFileInPaths("SaveFile", ".txt", new String[] { path2, path1 }));
+            Assert.AreEqual(filePath1, DocumentationServices.FindFileInPaths("SaveFile", ".txt", new String[] { path1,path2 }));
+            Assert.AreEqual(filePath2, DocumentationServices.FindFileInPaths("SaveFile", ".txt", new String[] { path2, path1 }));
 
             Directory.Delete(path1,true);
             Directory.Delete(path2,true);


### PR DESCRIPTION
### Purpose

This PR moves `PathHelper.FindFileInPaths` from `DynamoUtilities.dll` to `DynamoCore.dll` and makes it an internal method.  This change should fix a BC break due to a deployment of some dlls with studio.

To make sure no further breaks are introduced we must monitor carefully any public changes to DynamoUtilities, DynamoServices and DynamoUnits in particular (any others?)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 

### FYIs

@jnealb @kronz 