### PR TITLE
MAGN-10516 Lacing properties should publish correctly from Studio to Flood/Reach

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2216,11 +2216,11 @@ namespace Dynamo.Graph.Nodes
     public enum LacingStrategy
     {
         Disabled,
-        Auto,
         First,
         Shortest,
         Longest,
-        CrossProduct
+        CrossProduct,
+        Auto
     };
 
     /// <summary>


### PR DESCRIPTION
### Purpose

This fix ensures backward compatibly of Dynamo.Storage with Dynamo Core.  The LacingStrategy enum needed to be re-ordered back to the original sequence to maintain binary-level compatibility without requiring recompilation.  This change will also fix errors in client code that had referenced the LacingStrategy enum prior to the addition of auto.
    
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 

### FYIs

@ramramps @ke-yu @QilongTang 
