### PR TITLE
Updated 'GoogleAnalyticsConsent.rtf' with additional contents

### DIFF
--- a/doc/distrib/GoogleAnalyticsConsent.rtf
+++ b/doc/distrib/GoogleAnalyticsConsent.rtf
@@ -1,17 +1,17 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff37\deff0\stshfdbch0\stshfloch37\stshfhich37\stshfbi37\deflang18441\deflangfe2052\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\f11\fbidi \froman\fcharset128\fprq1{\*\panose 02020609040205080304}MS Mincho{\*\falt ?l?r ??\'81\'66c};}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f39\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0604030504040204}Verdana;}{\f40\fbidi \fmodern\fcharset128\fprq1{\*\panose 02020609040205080304}@MS Mincho;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f39\fbidi \fswiss\fcharset0\fprq2{\*\panose 00000000000000000000}Verdana;}{\f40\fbidi \fmodern\fcharset128\fprq1{\*\panose 02020609040205080304}@MS Mincho;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f54\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\f55\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f57\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f58\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f59\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\f60\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f61\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f62\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f394\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}
-{\f395\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f397\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f398\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f401\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}
-{\f402\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f424\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f425\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f427\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}
-{\f428\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}{\f431\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f432\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\f444\fbidi \fswiss\fcharset238\fprq2 Verdana CE;}
-{\f445\fbidi \fswiss\fcharset204\fprq2 Verdana Cyr;}{\f447\fbidi \fswiss\fcharset161\fprq2 Verdana Greek;}{\f448\fbidi \fswiss\fcharset162\fprq2 Verdana Tur;}{\f451\fbidi \fswiss\fcharset186\fprq2 Verdana Baltic;}
-{\f452\fbidi \fswiss\fcharset163\fprq2 Verdana (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f42\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\f43\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f45\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f46\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f47\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\f48\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f49\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f50\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f382\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}
+{\f383\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f385\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f386\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f389\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}
+{\f390\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f412\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f413\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f415\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}
+{\f416\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}{\f419\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f420\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\f432\fbidi \fswiss\fcharset238\fprq2 Verdana CE;}
+{\f433\fbidi \fswiss\fcharset204\fprq2 Verdana Cyr;}{\f435\fbidi \fswiss\fcharset161\fprq2 Verdana Greek;}{\f436\fbidi \fswiss\fcharset162\fprq2 Verdana Tur;}{\f439\fbidi \fswiss\fcharset186\fprq2 Verdana Baltic;}
+{\f440\fbidi \fswiss\fcharset163\fprq2 Verdana (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
 {\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
 {\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
 {\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fdbmajor\f31521\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
@@ -44,9 +44,9 @@
 \widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af37\afs22\alang1025 \ltrch\fcs0 \f37\fs22\cf17\lang18441\langfe2052\cgrid\langnp18441\langfenp2052 \snext11 \ssemihidden \sunhideused Normal Table;}{\*\cs15 \additive 
 \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\kerning32\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \slocked \spriority9 \styrsid7559448 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \ab\ai\af0\afs28 \ltrch\fcs0 
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \spriority9 \styrsid7559448 Heading 2 Char;}{\*\cs17 \additive \rtlch\fcs1 \ab\af0\afs26 \ltrch\fcs0 \b\fs26\loch\f31502\hich\af31502\dbch\af31501 
-\sbasedon10 \slink3 \slocked \spriority9 \styrsid7559448 Heading 3 Char;}}{\*\rsidtbl \rsid3037294\rsid5012088\rsid6827092\rsid7174336\rsid7559448\rsid9534305\rsid10551617\rsid14831659\rsid15021189}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0
-\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author Limiardi Sancerio}{\operator Ben Goh}{\creatim\yr2015\mo5\dy4\hr12\min55}{\revtim\yr2016\mo7\dy28\hr15\min4}{\version6}{\edmins9}{\nofpages1}{\nofwords182}
-{\nofchars1040}{\*\company Autodesk, Inc.}{\nofcharsws1220}{\vern57441}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\sbasedon10 \slink3 \slocked \spriority9 \styrsid7559448 Heading 3 Char;}}{\*\rsidtbl \rsid3037294\rsid5012088\rsid6827092\rsid7174336\rsid7559448\rsid9534305\rsid10551617\rsid12388035\rsid14831659\rsid15021189}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
+\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author Limiardi Sancerio}{\operator Ben Goh}{\creatim\yr2015\mo5\dy4\hr12\min55}{\revtim\yr2016\mo8\dy16\hr11\min42}{\version7}{\edmins9}{\nofpages1}
+{\nofwords182}{\nofchars1040}{\*\company Autodesk, Inc.}{\nofcharsws1220}{\vern57441}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont1\relyonvml0\donotembedlingdata0\grfdocevents0\validatexml1\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors1\noxlattoyen
 \expshrtn\noultrlspc\dntblnsbdb\nospaceforul\formshade\horzdoc\dgmargin\dghspace180\dgvspace180\dghorigin1440\dgvorigin1440\dghshow1\dgvshow1
 \jexpand\viewkind1\viewscale100\pgbrdrhead\pgbrdrfoot\splytwnine\ftnlytwnine\htmautsp\nolnhtadjtbl\useltbaln\alntblind\lytcalctblwd\lyttblrtgr\lnbrkrule\nobrkwrptbl\snaptogridincell\allowfieldendsel\wrppunct
@@ -58,17 +58,17 @@
 \b\fs20\cf18\lang1033\langfe1041\loch\af39\hich\af39\dbch\af11\langfenp1041\insrsid15021189\charrsid15021189 \hich\af39\dbch\af11\loch\f39 [Google Analytics]}{\rtlch\fcs1 \af0\afs20 \ltrch\fcs0 
 \b\fs20\cf18\lang1033\langfe1041\loch\af39\hich\af39\dbch\af11\langfenp1041\insrsid15021189 
 \par }{\rtlch\fcs1 \af0\afs20 \ltrch\fcs0 \b\fs20\cf18\lang1033\langfe1041\loch\af39\hich\af39\dbch\af11\langfenp1041\insrsid15021189\charrsid15021189 
-\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10551617 {\rtlch\fcs1 \af0\afs20 \ltrch\fcs0 \fs20\cf18\lang1033\langfe1041\loch\af39\hich\af39\dbch\af11\langfenp1041\insrsid10551617\charrsid10551617 
+\par }\pard \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid12388035 {\rtlch\fcs1 \af0\afs20 \ltrch\fcs0 \fs20\cf18\lang1033\langfe1041\loch\af39\hich\af39\dbch\af11\langfenp1041\insrsid12388035\charrsid12388035 
 \hich\af39\dbch\af11\loch\f39 
 Autodesk uses Google Analytics in this product. If you agree to its use, Autodesk will receive non-personal product usage information about this Autodesk software.  We use this information to improve our products and understand how people use them.
 \par 
 \par \hich\af39\dbch\af11\loch\f39 
-This information is limited to Dynamo startup time, name of packages loaded during the startup, evaluation time and name of nodes evaluated, name of Dynamo screens viewed (such as Gallery, StartPage, Nodes, Geometry, PythonEditor, CustomNode, Workspace, e
-\hich\af39\dbch\af11\loch\f39 t\hich\af39\dbch\af11\loch\f39 
-c.), application idle time, number of nodes in Dynamo file and name of unresolved nodes during file open, other Dynamo commands (such as STLExport, SaveImage, Auto Layout, Node creation (including name of nodes created), search term for nodes and packages
+This information is limited to Dynamo startup time, name of packages loaded during the startup, evaluation time and name of nodes evaluated, name of Dynamo screens viewed (such as Gallery, StartPage, Nodes, Geometry, PythonEditor, CustomNode, Workspace et
+\hich\af39\dbch\af11\loch\f39 c\hich\af39\dbch\af11\loch\f39 
+.), application idle time, number of nodes in Dynamo file and name of unresolved nodes during file open, other Dynamo commands [such as STLExport, SaveImage, Auto Layout, Node creation (including name of nodes created)], search term for nodes and packages
 ,\hich\af39\dbch\af11\loch\f39 
- correlation of search term with Node name used by user, your city and country location, and operating system type.  This information is not used to identify or contact you, and we do not track use of standard pull down menu controls (e.g., "file", "edit"
-,\hich\af39\dbch\af11\loch\f39  etc.).  
+ correlation of search term with Node name used by user, your city and country location, and operating system type.  This information is not used to identify or contact you, and we do not track use of standard pull down menu controls (e.g., "file," "edit,
+\hich\af39\dbch\af11\loch\f39 "\hich\af39\dbch\af11\loch\f39  etc.).  
 \par 
 \par \hich\af39\dbch\af11\loch\f39 You can turn data collection off by using the tick box below or later by bringing this dialogue box back up though the Setting menu tool.  Thank you for your consideration.}{\rtlch\fcs1 \af0\afs20 \ltrch\fcs0 
 \fs20\cf18\lang1033\langfe1041\loch\af39\hich\af39\dbch\af11\langfenp1041\insrsid7174336\charrsid3037294 
@@ -190,8 +190,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000703b
-c83b9ee8d101feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000003023
+f93670f7d101feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}


### PR DESCRIPTION
### Purpose

This pull request extends #6951 to further update `GoogleAnalyticsConsent.rtf` file with the following new contents (note the addition of square brackets `[such as STLExport...]` to make the structure clearer as requested):

> This information is limited to Dynamo startup time, name of packages loaded during the startup, evaluation time and name of nodes evaluated, name of Dynamo screens viewed (such as Gallery, StartPage, Nodes, Geometry, PythonEditor, CustomNode, Workspace etc.), application idle time, number of nodes in Dynamo file and name of unresolved nodes during file open, other Dynamo commands [such as STLExport, SaveImage, Auto Layout, Node creation (including name of nodes created)], search term for nodes and packages, correlation of search term with Node name used by user, your city and country location, and operating system type.  This information is not used to identify or contact you, and we do not track use of standard pull down menu controls (e.g., "file," "edit," etc.).  

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

None

### FYIs

None