### PR TITLE
Fix huge memory consumption issue in preview control and watch node

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -67,11 +67,6 @@
                 </Setter>
             </Style>
 
-            <Style TargetType="{x:Type TreeViewItem}">
-                <Setter Property="IsExpanded"
-                        Value="{Binding IsNodeExpanded}" />
-            </Style>
-            
             <!-- Expander Button Style -->
             <Style x:Key="ExpandCollapseToggleStyleWT" TargetType="ToggleButton">
                 <Setter Property="Focusable" Value="False"/>
@@ -244,22 +239,7 @@
             
             <!-- TreeView Control Style-->
             <Style x:Key="TreeView" TargetType="TreeView">
-                <Setter Property="OverridesDefaultStyle" Value="True" />
-                <Setter Property="SnapsToDevicePixels" Value="True" />
                 <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden"/>
-                <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="TreeView">
-                            <Border Name="Border" CornerRadius="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="0" >
-                                <ScrollViewer Focusable="False" CanContentScroll="False" Padding="1">
-                                    <ItemsPresenter/>
-                                </ScrollViewer>
-                            </Border>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
                         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -236,16 +236,6 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-            
-            <!-- TreeView Control Style-->
-            <Style x:Key="TreeView" TargetType="TreeView">
-                <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden"/>
-                <Style.Triggers>
-                    <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
-                    </Trigger>
-                </Style.Triggers>
-            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
@@ -260,14 +250,24 @@
                   Background="White"
                   Opacity=".5"
                   BorderBrush="{x:Null}"
-                  Style="{StaticResource TreeView}"
                   VirtualizingStackPanel.IsVirtualizing="True"
                   VirtualizingStackPanel.VirtualizationMode="Recycling"
                   ItemContainerStyle="{StaticResource WatchTreeViewItem}"
                   SelectedItemChanged="TreeView1_OnSelectedItemChanged">
+
+            <TreeView.Style>
+                <Style TargetType="TreeView">
+                    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden"/>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </TreeView.Style>
+
             <TreeView.ItemsPanel>
                 <ItemsPanelTemplate>
-                                       
                     <VirtualizingStackPanel>
                         <VirtualizingPanel.Style>
                             <Style TargetType="{x:Type VirtualizingPanel}">


### PR DESCRIPTION
### Purpose

This PR is to fix huge memory consumption issue in preview bubble and watch node (preview bubble and watch node share same control `WatchTree`).

The memory consumption of Dynamo is over 3GB once connecting a 200x200 2D list to a watch node or expanding preview bubble:

![untitled](https://cloud.githubusercontent.com/assets/2600379/17761865/88f7edca-653d-11e6-8686-4bc23dda8a97.png)

Problem had to do with this style setting for `ScrollViewer` in `TreeView`: 
```
<Setter Property="Template">
    <Setter.Value>
        <ControlTemplate TargetType="TreeView">
            <Border Name="Border" CornerRadius="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0" >
               <ScrollViewer Focusable="False" CanContentScroll="False" Padding="1">
                          <ItemsPresenter/>
               </ScrollViewer>
            </Border>
        </ControlTemplate>
    </Setter.Value>
</Setter>
```
By targeting the ScrollViewer style template within the TreeView style template, this was an overlap/conflict with the code which defined the ScrollViewer style:

```
<Style TargetType="ScrollViewer">
    <Setter Property="Template">
        <Setter.Value>
            <ControlTemplate TargetType="{x:Type ScrollViewer}">
...
```
This led to slowdown/little memory used - which was negligible with little content displayed in the Preview Control. When there was a large dataset to be displayed, however, I suspect that this duplication of styles led to a rendering issue (or even possibly a duplication of the ItemsPresenter) which may have caused the memleak.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

### FYIs

@mjkkirschner , @sharadkjaiswal 

