### PR TITLE
Fix Level Border

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml
@@ -27,7 +27,6 @@
 
             <!-- MaxContentGrid = (MaxPreviewControl - (2 * Margin)) -->
             <fwk:Thickness x:Key="PreviewContentMargin">12,5,5,5</fwk:Thickness>
-            <clr:Double x:Key="MaxContentGridWidth">488.0</clr:Double>
             <clr:Double x:Key="MaxContentGridHeight">288</clr:Double>
             
         </ResourceDictionary>
@@ -125,7 +124,7 @@
             </Grid>
 
             <Grid Name="largeContentGrid"
-                  MaxWidth="{StaticResource MaxContentGridWidth}"
+                  HorizontalAlignment="Stretch"
                   MaxHeight="{StaticResource MaxContentGridHeight}"
                   MinWidth="{Binding RelativeSource={RelativeSource FindAncestor, 
                              AncestorType={x:Type controls:NodeView}}, 

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -345,7 +345,7 @@
             </TreeView.ItemTemplate>
         </TreeView>
 
-        <Border BorderBrush="#aaaaaa" BorderThickness="1" Grid.Row="1">
+        <Border BorderBrush="#d4d4d4" BorderThickness="1" Grid.Row="1" HorizontalAlignment="Stretch">
 
         <Grid Name ="ListLevelsDisplay" Grid.Row="1">
             <Grid.ColumnDefinitions>


### PR DESCRIPTION
### Purpose

Previously, when faced with a long list in the Code Block Node, the margins for the list level labels will be truncated. This can be seen here: 

![pasted image at 2016_08_16 09_34 am](https://cloud.githubusercontent.com/assets/16283396/17761617/2a686052-653b-11e6-917d-c192df1809e6.png)

On further investigation, this was due to the fact that the entire largeContentGrid (PreviewControl.xaml) had a max width property. The reason for this is unclear (the history goes back beyond before Dynamo was hosted on github). By removing this max width property and setting the horizontal alignment of the largeContentGrid to stretch, this allowed the margins of the label (which were bounded by largeContentGrid) to align with the margins of the preview control. The result is as follows:

![labelborderfix](https://cloud.githubusercontent.com/assets/16283396/17761663/8a136470-653b-11e6-825a-c24fb7e616cc.PNG)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

### FYIs

@Racel 

