### PR TITLE
Creation of ListLevelUI Command framework

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1764,6 +1764,22 @@ namespace Dynamo.Graph.Nodes
                     }
                     return true;
 
+                case "Level":
+                    // The value is defined as such: "portIndex;useLevel;keepListStructure;level"
+                    // portIndex and Level are integers
+                    // useLevel and keepListStructure are boolean values
+                    var levelInfo = value.Split(';');
+                    int portIndex, level;
+                    bool useLevel, keepListStructure;
+                    if (levelInfo.Length == 4 && int.TryParse(levelInfo[0], out portIndex) && bool.TryParse(levelInfo[1], out useLevel)
+      && bool.TryParse(levelInfo[2], out keepListStructure) && int.TryParse(levelInfo[3], out level))
+                    {
+                        InPorts[portIndex].Level = level;
+                        InPorts[portIndex].UseLevels = useLevel;
+                        InPorts[portIndex].ShouldKeepListStructure = keepListStructure;
+                    }
+                    return true;
+
             }
 
             return base.UpdateValueCore(updateValueParams);

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -108,7 +108,7 @@
                     </Rectangle.Margin>
                 </Rectangle>
                 <Rectangle Name="highlightOverlay"
-                       Fill="{Binding Path=ShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlighColorConverter}}"
+                       Fill="{Binding Path=ToggleShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlighColorConverter}}"
                        MinWidth="19"
                        Margin="0,0,0,1"
                        IsHitTestVisible="True">
@@ -157,7 +157,7 @@
                         Width="45"
                         Background="{x:Null}"
                         IsHitTestVisible="False"
-                        Visibility="{Binding Path=UseLevels, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}"/>
+                        Visibility="{Binding Path=ToggleUseLevels, Converter={StaticResource InverseBoolToVisibilityCollapsedConverter}}"/>
                 </Grid>
                 </StackPanel>
             </Grid>
@@ -173,7 +173,7 @@
                   Visibility="{Binding Path=UseLevelVisibility}">
                 <Rectangle
                     Name="highlightOverlayForArrow" 
-                    Fill="{Binding Path=ShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlighColorConverter}}"
+                    Fill="{Binding Path=ToggleShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlighColorConverter}}"
                     MinWidth="10"
                     Margin="0,0,0,1"
                     IsHitTestVisible="True">
@@ -200,9 +200,9 @@
                                            VerticalAlignment="Center"
                                            Width="45"
                                            Height="16"
-                                           Level="{Binding Path=Level, Mode=TwoWay}"
-                                           KeepListStructure="{Binding Path=ShouldKeepListStructure}"
-                                           Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, FallbackValue=Collapsed}"/>
+                                           Level="{Binding Path=ToggleLevel, Mode=TwoWay}"
+                                           KeepListStructure="{Binding Path=ToggleShouldKeepListStructure}"
+                                           Visibility="{Binding Path=ToggleUseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, FallbackValue=Collapsed}"/>
                     <fa:FontAwesome Icon="ChevronRight"
                                     Width="10"
                                     HorizontalAlignment="Center"
@@ -242,13 +242,13 @@
                                 <CheckBox 
                                     Margin="5, 5, 5, 0"
                                     Content="{x:Static p:Resources.UseLevelPopupMenuItem}"
-                                    IsChecked="{Binding Path=UseLevels, Mode=TwoWay}"
+                                    IsChecked="{Binding Path=ToggleUseLevels, Mode=TwoWay}"
                                     Name="UseLevel"/>
                                 <Separator Margin ="5, 5, 5, 0"/>
                                 <CheckBox
                                     Margin="5, 5, 5, 0"
                                     Content="{x:Static p:Resources.UseLevelKeepListStructurePopupMenuItem}"
-                                    IsChecked="{Binding Path=ShouldKeepListStructure, Mode=TwoWay}"
+                                    IsChecked="{Binding Path=ToggleShouldKeepListStructure, Mode=TwoWay}"
                                     IsEnabled="{Binding ElementName=UseLevel, Path=IsChecked}"/>
                                 <TextBlock 
                                     Margin="5, 0, 5, 5"

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -155,35 +155,44 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// If UseLevel is enabled on this port.
         /// </summary>
-        public bool UseLevels
+        public bool ToggleUseLevels
         {
             get { return _port.UseLevels; }
             set
             {
-               _port.UseLevels = value;
-               if (!_port.UseLevels)
-               {
-                   ShouldKeepListStructure = false;
-               }
+                if (!value)
+                {
+                    Levels(value, false, _port.Level);
+                }
+                else
+                {
+                    Levels(value, _port.ShouldKeepListStructure, _port.Level);
+                }
             }
         }
 
         /// <summary>
         /// If should keep list structure on this port.
         /// </summary>
-        public bool ShouldKeepListStructure
+        public bool ToggleShouldKeepListStructure
         {
             get { return _port.ShouldKeepListStructure; }
-            set { _port.ShouldKeepListStructure = value; }
+            set
+            {
+                Levels(_port.UseLevels, value, _port.Level);
+            }
         }
 
         /// <summary>
-        /// Levle of list.
+        /// Level of list.
         /// </summary>
-        public int Level
+        public int ToggleLevel
         {
             get { return _port.Level; }
-            set { _port.Level = value; } 
+            set
+            {
+                Levels(_port.UseLevels, _port.ShouldKeepListStructure, value);
+            }
         }
 
         /// <summary>
@@ -281,13 +290,13 @@ namespace Dynamo.ViewModels
                     RaisePropertyChanged("MarginThickness");
                     break;
                 case "UseLevels":
-                    RaisePropertyChanged("UseLevels");
+                    RaisePropertyChanged("ToggleUseLevels");
                     break;
                 case "Level":
-                    RaisePropertyChanged("Level");
+                    RaisePropertyChanged("ToggleLevel");
                     break;
                 case "ShouldKeepListStructure":
-                    RaisePropertyChanged("ShouldKeepListStructure");
+                    RaisePropertyChanged("ToggleShouldKeepListStructure");
                     break;
             }
             
@@ -298,6 +307,14 @@ namespace Dynamo.ViewModels
             DynamoViewModel dynamoViewModel = this._node.DynamoViewModel;
             WorkspaceViewModel workspaceViewModel = dynamoViewModel.CurrentSpaceViewModel;
             workspaceViewModel.HandlePortClicked(this);
+        }
+
+        private void Levels(bool useLevels, bool keepListStructure, int level)
+        {
+            string levelInfo = PortModel.Index + ";" + useLevels + ";" + keepListStructure + ";" + level.ToString();
+            var command = new DynamoModel.UpdateModelValueCommand(Guid.Empty,
+    PortModel.Owner.GUID, "Level", levelInfo);
+            _node.DynamoViewModel.ExecuteCommand(command);
         }
 
         private bool CanConnect(object parameter)

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1100,6 +1100,25 @@ namespace DynamoCoreWpfTests
             AssertPreviewValue("345cd2d4-5f3b-4eb0-9d5f-5dd90c5a7493", 36.0);
         }
 
+        [Test, RequiresSTA]
+        public void TestLevels()
+        {
+            RunCommandsFromFile("TestLevels.xml");
+            Assert.AreEqual(3, workspace.Nodes.Count());
+            var levels = GetNode("137ba70d-2835-404d-ba51-c7ad8dd201df") as NodeModel;
+
+            // check first index in Port
+            var index1 = levels.InPorts[0];
+            Assert.AreEqual(4, index1.Level);
+            Assert.AreEqual(true, index1.UseLevels);
+            Assert.AreEqual(false, index1.ShouldKeepListStructure);
+
+            // check second index in Port
+            var index2 = levels.InPorts[1];
+            Assert.AreEqual(3, index2.Level);
+            Assert.AreEqual(true, index2.UseLevels);
+            Assert.AreEqual(false, index2.ShouldKeepListStructure);
+        }
         #endregion
     }
 

--- a/test/core/recorded/TestLevels.xml
+++ b/test/core/recorded/TestLevels.xml
@@ -1,0 +1,68 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="464" Y="329" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>0fca922b-47c3-4fb9-89f4-3f7ff1322547</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="0fca922b-47c3-4fb9-89f4-3f7ff1322547" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="372" y="298" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{{1}};" ShouldFocus="false" />
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="{{1}};" WorkspaceGuid="ea37a19a-f791-4c03-ac0e-5483568e53af">
+    <ModelGuid>0fca922b-47c3-4fb9-89f4-3f7ff1322547</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="409" Y="437" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>bc4714fc-b5d4-4d5f-bf82-83e35fa14b2b</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="bc4714fc-b5d4-4d5f-bf82-83e35fa14b2b" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="317" y="406" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="1;" ShouldFocus="false" />
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="1;" WorkspaceGuid="ea37a19a-f791-4c03-ac0e-5483568e53af">
+    <ModelGuid>bc4714fc-b5d4-4d5f-bf82-83e35fa14b2b</ModelGuid>
+  </UpdateModelValueCommand>
+  <CreateNodeCommand X="680" Y="332" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>137ba70d-2835-404d-ba51-c7ad8dd201df</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="137ba70d-2835-404d-ba51-c7ad8dd201df" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.Flatten" x="680" y="332" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="true" assembly="DSCoreNodes.dll" function="DSCore.List.Flatten@var[]..[],int">
+      <PortInfo index="0" default="False" useLevels="True" level="4" shouldKeepListStructure="False" />
+      <PortInfo index="1" default="False" useLevels="True" level="3" shouldKeepListStructure="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </CreateNodeCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>0fca922b-47c3-4fb9-89f4-3f7ff1322547</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>137ba70d-2835-404d-ba51-c7ad8dd201df</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>bc4714fc-b5d4-4d5f-bf82-83e35fa14b2b</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="1">
+    <ModelGuid>137ba70d-2835-404d-ba51-c7ad8dd201df</ModelGuid>
+  </MakeConnectionCommand>
+  <UpdateModelValueCommand Name="Level" Value="0;True;False;2" WorkspaceGuid="00000000-0000-0000-0000-000000000000">
+    <ModelGuid>137ba70d-2835-404d-ba51-c7ad8dd201df</ModelGuid>
+  </UpdateModelValueCommand>
+  <UpdateModelValueCommand Name="Level" Value="1;True;False;2" WorkspaceGuid="00000000-0000-0000-0000-000000000000">
+    <ModelGuid>137ba70d-2835-404d-ba51-c7ad8dd201df</ModelGuid>
+  </UpdateModelValueCommand>
+  <UpdateModelValueCommand Name="Level" Value="1;True;False;3" WorkspaceGuid="00000000-0000-0000-0000-000000000000">
+    <ModelGuid>137ba70d-2835-404d-ba51-c7ad8dd201df</ModelGuid>
+  </UpdateModelValueCommand>
+  <UpdateModelValueCommand Name="PreviewPinned" Value="True" WorkspaceGuid="00000000-0000-0000-0000-000000000000">
+    <ModelGuid>137ba70d-2835-404d-ba51-c7ad8dd201df</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>137ba70d-2835-404d-ba51-c7ad8dd201df</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Level" Value="0;True;False;3" WorkspaceGuid="00000000-0000-0000-0000-000000000000">
+    <ModelGuid>137ba70d-2835-404d-ba51-c7ad8dd201df</ModelGuid>
+  </UpdateModelValueCommand>
+  <UpdateModelValueCommand Name="Level" Value="0;True;False;4" WorkspaceGuid="00000000-0000-0000-0000-000000000000">
+    <ModelGuid>137ba70d-2835-404d-ba51-c7ad8dd201df</ModelGuid>
+  </UpdateModelValueCommand>
+</Commands>


### PR DESCRIPTION
### Purpose
_Fulfills Magn-10519_

In order to automate testing of the list level UI, this command framework was created to allow the list level UI to have recordable commands. These recordable commands can then be passed in as a XML file in order to automate future unit tests.

The UI actions which are recorded are:

1. Use Level
2. Should Keep List Structure
3. Level Change

Using the existing `UpdateModelValueCommand` framework, the results of the following operation (see first screenshot) are logged (see second screenshot).

![leveluidemo](https://cloud.githubusercontent.com/assets/16283396/17764511/68cd043a-6552-11e6-911f-8384c4509f6f.PNG)

![leveluicommanddemo](https://cloud.githubusercontent.com/assets/16283396/17764510/68ca780a-6552-11e6-88fe-79cc40107a6b.PNG)

The `UpdateModelValueCommand` value in the XML document is as follows: "portIndex;useLevel;keepListStructure;level"

Also, I have added a test case in `RecordedTests.cs` and `TestLevel.xml` to test this command framework.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

### FYIs

@monikaprabhu 

