### PR TITLE
Support undo/redo for list@level operations

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1549,21 +1549,7 @@ namespace Dynamo.Graph.Nodes
                 case "UsingDefaultValue":
                 case "Level":
                 case "UseLevels":
-                    OnNodeModified();
-                    break;
-
                 case "ShouldKeepListStructure":
-                    var portModel = sender as PortModel;
-                    if (portModel != null && portModel.ShouldKeepListStructure)
-                    {
-                        foreach (var inport in InPorts)
-                        {
-                            if (inport != portModel && inport.ShouldKeepListStructure)
-                            {
-                                inport.ShouldKeepListStructure = false;  
-                            }
-                        }
-                    }
                     OnNodeModified();
                     break;
 
@@ -1774,6 +1760,31 @@ namespace Dynamo.Graph.Nodes
                             bool.TryParse(parts[1], out useLevels))
                         {
                             inPorts[portIndex].UseLevels = useLevels;
+                        }
+                    }
+                    return true;
+
+                case "KeepListStructure":
+                    var keepListStructureInfos = value.Split(new[] { ':' });
+                    if (keepListStructureInfos != null && keepListStructureInfos.Count() == 2)
+                    {
+                        int portIndex;
+                        bool keepListStructure;
+                        if (int.TryParse(keepListStructureInfos[0], out portIndex) &&
+                            bool.TryParse(keepListStructureInfos[1], out keepListStructure))
+                        {
+                            inPorts[portIndex].ShouldKeepListStructure = keepListStructure;
+                            if (keepListStructure)
+                            {
+                                // Only allow one input port to keep list structure
+                                for (int i = 0; i < inPorts.Count; i++)
+                                {
+                                    if (portIndex != i && inPorts[i].ShouldKeepListStructure)
+                                    {
+                                        inPorts[i].ShouldKeepListStructure = false;
+                                    }
+                                }
+                            }
                         }
                     }
                     return true;

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1788,6 +1788,20 @@ namespace Dynamo.Graph.Nodes
                         }
                     }
                     return true;
+
+                case "ChangeLevel":
+                    var changeLevelInfos = value.Split(new[] { ':' });
+                    if (changeLevelInfos != null && changeLevelInfos.Count() == 2)
+                    {
+                        int portIndex;
+                        int level;
+                        if (int.TryParse(changeLevelInfos[0], out portIndex) &&
+                            int.TryParse(changeLevelInfos[1], out level))
+                        {
+                            inPorts[portIndex].Level = level;
+                        }
+                    }
+                    return true;
             }
 
             return base.UpdateValueCore(updateValueParams);

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1764,6 +1764,19 @@ namespace Dynamo.Graph.Nodes
                     }
                     return true;
 
+                case "UseLevels":
+                    var parts = value.Split(new[] { ':' });
+                    if (parts != null && parts.Count() == 2)
+                    {
+                        int portIndex;
+                        bool useLevels;
+                        if (int.TryParse(parts[0], out portIndex) &&
+                            bool.TryParse(parts[1], out useLevels))
+                        {
+                            inPorts[portIndex].UseLevels = useLevels;
+                        }
+                    }
+                    return true;
             }
 
             return base.UpdateValueCore(updateValueParams);
@@ -1876,20 +1889,20 @@ namespace Dynamo.Graph.Nodes
                         }
 
                         attrValue = subNode.Attributes["useLevels"];
+                        bool useLevels = false;
                         if (attrValue != null)
                         {
-                            bool useLevels = false;
                             bool.TryParse(attrValue.Value, out useLevels);
-                            inPorts[index].UseLevels = useLevels;
                         }
+                        inPorts[index].UseLevels = useLevels;
 
                         attrValue = subNode.Attributes["shouldKeepListStructure"];
+                        bool shouldKeepListStructure = false;
                         if (attrValue != null)
                         {
-                            bool shouldKeepListStructure = false;
                             bool.TryParse(attrValue.Value, out shouldKeepListStructure);
-                            inPorts[index].ShouldKeepListStructure = shouldKeepListStructure;
                         }
+                        inPorts[index].ShouldKeepListStructure = shouldKeepListStructure;
 
                         attrValue = subNode.Attributes["level"];
                         if (attrValue != null)

--- a/src/DynamoCoreWpf/Commands/NodeCommands.cs
+++ b/src/DynamoCoreWpf/Commands/NodeCommands.cs
@@ -210,6 +210,5 @@ namespace Dynamo.ViewModels
                 return _computeRunStateOfTheNodeCommand;
             }
         }
-        
     }
 }

--- a/src/DynamoCoreWpf/Controls/UseLevelSpinner.cs
+++ b/src/DynamoCoreWpf/Controls/UseLevelSpinner.cs
@@ -115,7 +115,7 @@ namespace Dynamo.UI.Controls
             InitializeCommands();
 
             LevelProperty = DependencyProperty.Register("Level", typeof(int), typeof(UseLevelSpinner),
-                new FrameworkPropertyMetadata(2, OnLevelChanged, CoerceValue));
+                new FrameworkPropertyMetadata(2, OnLevelChanged));
 
             KeepListStructureProperty = DependencyProperty.Register("KeepListStructure", typeof(bool), typeof(UseLevelSpinner),
                 new FrameworkPropertyMetadata(false, OnKeepListStructureChanged));

--- a/src/DynamoCoreWpf/Controls/UseLevelSpinner.cs
+++ b/src/DynamoCoreWpf/Controls/UseLevelSpinner.cs
@@ -9,7 +9,7 @@ namespace Dynamo.UI.Controls
     /// <summary>
     /// UseLevelSpinner control 
     /// </summary>
-    [DefaultProperty("Value"), DefaultEvent("ValueChanged")]
+    [DefaultProperty("Level"), DefaultEvent("LevelChanged")]
     public class UseLevelSpinner : Control
     {
         private const int MinimumLevel = 1;
@@ -95,9 +95,9 @@ namespace Dynamo.UI.Controls
         #region Events
 
         /// <summary>
-        /// Occurs when the Value property changes.
+        /// Occurs when the Level property changes.
         /// </summary>
-        public event RoutedPropertyChangedEventHandler<int> ValueChanged
+        public event RoutedPropertyChangedEventHandler<int> LevelChanged
         {
             add { AddHandler(LevelChangedEvent, value); }
 
@@ -286,9 +286,9 @@ namespace Dynamo.UI.Controls
         }
 
         /// <summary>
-        /// Raises the ValueChanged event.
+        /// Raises the LevelChanged event.
         /// </summary>
-        /// <param name="args">Arguments associated with the ValueChanged event.</param>
+        /// <param name="args">Arguments associated with the LevelChanged event.</param>
         protected virtual void OnLevelChanged(RoutedPropertyChangedEventArgs<int> args)
         {
             RaiseEvent(args);

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -50,18 +50,6 @@
     <Reference Include="FontAwesome.WPF">
       <HintPath>..\..\extern\FontAwesome\FontAwesome.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="GalaSoft.MvvmLight, Version=5.3.0.19026, Culture=neutral, PublicKeyToken=e7570ab207bcb616, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="GalaSoft.MvvmLight.Extras, Version=5.3.0.19032, Culture=neutral, PublicKeyToken=669f0b5e8f868abf, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.Extras.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="GalaSoft.MvvmLight.Platform, Version=5.3.0.19032, Culture=neutral, PublicKeyToken=5f873c45e98af8a1, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.Platform.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Greg, Version=1.0.5959.26179, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Greg.1.0.5959.26179\lib\net45\Greg.dll</HintPath>
       <Private>True</Private>
@@ -88,10 +76,6 @@
     </Reference>
     <Reference Include="Microsoft.Practices.Prism">
       <HintPath>..\..\extern\prism\Microsoft.Practices.Prism.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -143,9 +127,8 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Windows.Interactivity">
+      <HintPath>..\..\extern\System.Windows.Interactivity\System.Windows.Interactivity.dll</HintPath>
     </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -50,6 +50,18 @@
     <Reference Include="FontAwesome.WPF">
       <HintPath>..\..\extern\FontAwesome\FontAwesome.WPF.dll</HintPath>
     </Reference>
+    <Reference Include="GalaSoft.MvvmLight, Version=5.3.0.19026, Culture=neutral, PublicKeyToken=e7570ab207bcb616, processorArchitecture=MSIL">
+      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GalaSoft.MvvmLight.Extras, Version=5.3.0.19032, Culture=neutral, PublicKeyToken=669f0b5e8f868abf, processorArchitecture=MSIL">
+      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.Extras.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GalaSoft.MvvmLight.Platform, Version=5.3.0.19032, Culture=neutral, PublicKeyToken=5f873c45e98af8a1, processorArchitecture=MSIL">
+      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.Platform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Greg, Version=1.0.5959.26179, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Greg.1.0.5959.26179\lib\net45\Greg.dll</HintPath>
       <Private>True</Private>
@@ -76,6 +88,10 @@
     </Reference>
     <Reference Include="Microsoft.Practices.Prism">
       <HintPath>..\..\extern\prism\Microsoft.Practices.Prism.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -127,8 +143,9 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Windows.Interactivity">
-      <HintPath>..\..\extern\System.Windows.Interactivity\System.Windows.Interactivity.dll</HintPath>
+    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -205,7 +205,7 @@
                                            KeepListStructure="{Binding Path=ShouldKeepListStructure}"
                                            Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, FallbackValue=Collapsed}">
                     </dynui:UseLevelSpinner>
-                    <fa:FontAwesome Icon="ChevronRight"
+                    <fa:FontAwesome Icon="EllipsisVertical"
                                     Width="10"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -242,7 +242,9 @@
                                 <CheckBox 
                                     Margin="5, 5, 5, 0"
                                     Content="{x:Static p:Resources.UseLevelPopupMenuItem}"
-                                    IsChecked="{Binding Path=UseLevels, Mode=TwoWay}"
+                                    IsChecked="{Binding Path=UseLevels, Mode=OneWay}"
+                                    Command="{Binding Path=UseLevelsCommand}"
+                                    CommandParameter="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}"
                                     Name="UseLevel"/>
                                 <Separator Margin ="5, 5, 5, 0"/>
                                 <CheckBox

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -200,9 +200,16 @@
                                            VerticalAlignment="Center"
                                            Width="45"
                                            Height="16"
-                                           Level="{Binding Path=Level, Mode=TwoWay}"
+                                           Level="{Binding Path=Level, Mode=OneWay}"
                                            KeepListStructure="{Binding Path=ShouldKeepListStructure}"
-                                           Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, FallbackValue=Collapsed}"/>
+                                           Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, FallbackValue=Collapsed}">
+                        <interactivity:Interaction.Triggers>
+                            <interactivity:EventTrigger EventName="LevelChanged">
+                                <command:Event
+                                <interactivity:InvokeCommandAction Command="{Binding ChangeLevelCommand}" CommandParameter="{Binding Path=Level, RelativeSource={RelativeSource AncestorType={x:Type dynui:UseLevelSpinner}}}"/>
+                            </interactivity:EventTrigger>
+                        </interactivity:Interaction.Triggers>
+                    </dynui:UseLevelSpinner>
                     <fa:FontAwesome Icon="ChevronRight"
                                     Width="10"
                                     HorizontalAlignment="Center"
@@ -212,7 +219,7 @@
                                     Foreground="#555555"/>
                 </StackPanel>
                 <dynui:UseLevelPopup
-                    Name="MyPopup"
+                    x:Name="MyPopup"
                     Placement="Right"
                     AllowsTransparency="True"
                     IsOpen="{Binding Path=ShowUseLevelMenu,diag:PresentationTraceSources.TraceLevel=High}"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -8,6 +8,7 @@
                       xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
                       xmlns:fa="http://schemas.fontawesome.io/icons/"
                       xmlns:diag="clr-namespace:System.Diagnostics;assembly=WindowsBase"
+                      xmlns:command="clr-namespace:GalaSoft.MvvmLight.Command;assembly=GalaSoft.MvvmLight.Platform"
                       xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf">
 
     <!-- Templates
@@ -205,8 +206,7 @@
                                            Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, FallbackValue=Collapsed}">
                         <interactivity:Interaction.Triggers>
                             <interactivity:EventTrigger EventName="LevelChanged">
-                                <command:Event
-                                <interactivity:InvokeCommandAction Command="{Binding ChangeLevelCommand}" CommandParameter="{Binding Path=Level, RelativeSource={RelativeSource AncestorType={x:Type dynui:UseLevelSpinner}}}"/>
+                                <command:EventToCommand Command="{Binding ChangeLevelCommand}" PassEventArgsToCommand="True"/>
                             </interactivity:EventTrigger>
                         </interactivity:Interaction.Triggers>
                     </dynui:UseLevelSpinner>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -201,14 +201,9 @@
                                            VerticalAlignment="Center"
                                            Width="45"
                                            Height="16"
-                                           Level="{Binding Path=Level, Mode=OneWay}"
+                                           Level="{Binding Path=Level, Mode=TwoWay}"
                                            KeepListStructure="{Binding Path=ShouldKeepListStructure}"
                                            Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, FallbackValue=Collapsed}">
-                        <interactivity:Interaction.Triggers>
-                            <interactivity:EventTrigger EventName="LevelChanged">
-                                <command:EventToCommand Command="{Binding ChangeLevelCommand}" PassEventArgsToCommand="True"/>
-                            </interactivity:EventTrigger>
-                        </interactivity:Interaction.Triggers>
                     </dynui:UseLevelSpinner>
                     <fa:FontAwesome Icon="ChevronRight"
                                     Width="10"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -251,7 +251,7 @@
                                     Margin="5, 5, 5, 0"
                                     Content="{x:Static p:Resources.UseLevelKeepListStructurePopupMenuItem}"
                                     IsChecked="{Binding Path=ShouldKeepListStructure, Mode=OneWay}"
-                                    Command="{Binding Path=KeeeListStructureCommand}"
+                                    Command="{Binding Path=KeepListStructureCommand}"
                                     CommandParameter="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}"
                                     IsEnabled="{Binding ElementName=UseLevel, Path=IsChecked}"/>
                                 <TextBlock 

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -205,7 +205,7 @@
                                            KeepListStructure="{Binding Path=ShouldKeepListStructure}"
                                            Visibility="{Binding Path=UseLevels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}, FallbackValue=Collapsed}">
                     </dynui:UseLevelSpinner>
-                    <fa:FontAwesome Icon="EllipsisVertical"
+                    <fa:FontAwesome Icon="ChevronRight"
                                     Width="10"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -250,7 +250,9 @@
                                 <CheckBox
                                     Margin="5, 5, 5, 0"
                                     Content="{x:Static p:Resources.UseLevelKeepListStructurePopupMenuItem}"
-                                    IsChecked="{Binding Path=ShouldKeepListStructure, Mode=TwoWay}"
+                                    IsChecked="{Binding Path=ShouldKeepListStructure, Mode=OneWay}"
+                                    Command="{Binding Path=KeeeListStructureCommand}"
+                                    CommandParameter="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}"
                                     IsEnabled="{Binding ElementName=UseLevel, Path=IsChecked}"/>
                                 <TextBlock 
                                     Margin="5, 0, 5, 5"

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1082,45 +1082,6 @@ namespace Dynamo.ViewModels
             return DynamoSelection.Instance.Selection.Count() == 1;
         }
 
-        /// <summary>
-        /// Specify UseLevels on the corresponding input port.
-        /// </summary>
-        /// <param name="portIndex"></param>
-        /// <param name="use"></param>
-        public void UseLevels(int portIndex, bool use)
-        {
-            var command = new DynamoModel.UpdateModelValueCommand(
-                Guid.Empty, NodeModel.GUID, "UseLevels", string.Format("{0}:{1}", portIndex, use));
-
-            DynamoViewModel.ExecuteCommand(command);
-        }
-
-        /// <summary>
-        /// Keep list structure on the corresponding input port.
-        /// </summary>
-        /// <param name="portIndex"></param>
-        /// <param name="keep"></param>
-        public void KeepListStructure(int portIndex, bool keep)
-        {
-            var command = new DynamoModel.UpdateModelValueCommand(
-                Guid.Empty, NodeModel.GUID, "KeepListStructure", string.Format("{0}:{1}", portIndex, keep));
-
-            DynamoViewModel.ExecuteCommand(command);
-        }
-
-        /// <summary>
-        /// Change level on the corresponding input port to specified value.
-        /// </summary>
-        /// <param name="portIndex"></param>
-        /// <param name="value"></param>
-        public void ChangeLevel(int portIndex, int value)
-        {
-            var command = new DynamoModel.UpdateModelValueCommand(
-                Guid.Empty, NodeModel.GUID, "ChangeLevel", string.Format("{0}:{1}", portIndex, value));
-
-            DynamoViewModel.ExecuteCommand(command);
-        }
-
         private void RaiseFrozenPropertyChanged()
         {            
             RaisePropertyChanged("IsFrozen");

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1108,6 +1108,19 @@ namespace Dynamo.ViewModels
             DynamoViewModel.ExecuteCommand(command);
         }
 
+        /// <summary>
+        /// Change level on the corresponding input port to specified value.
+        /// </summary>
+        /// <param name="portIndex"></param>
+        /// <param name="keep"></param>
+        public void ChangeLevel(int portIndex, int value)
+        {
+            var command = new DynamoModel.UpdateModelValueCommand(
+                Guid.Empty, NodeModel.GUID, "ChangeLevel", string.Format("{0}:{1}", portIndex, value));
+
+            DynamoViewModel.ExecuteCommand(command);
+        }
+
         private void RaiseFrozenPropertyChanged()
         {            
             RaisePropertyChanged("IsFrozen");

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1112,7 +1112,7 @@ namespace Dynamo.ViewModels
         /// Change level on the corresponding input port to specified value.
         /// </summary>
         /// <param name="portIndex"></param>
-        /// <param name="keep"></param>
+        /// <param name="value"></param>
         public void ChangeLevel(int portIndex, int value)
         {
             var command = new DynamoModel.UpdateModelValueCommand(

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1059,7 +1059,6 @@ namespace Dynamo.ViewModels
         private void ToggleIsFrozen(object parameters)
         {
             var node = this.nodeLogic;
-
             if (node != null)
             {
                 var oldFrozen = (!node.isFrozenExplicitly).ToString();

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1099,6 +1099,23 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Keep list structure on the corresponding input port.
+        /// </summary>
+        /// <param name="portIndex"></param>
+        /// <param name="keep"></param>
+        public void KeepListStructure(int portIndex, bool keep)
+        {
+            var node = this.nodeLogic;
+            if (node != null)
+            {
+                var command = new DynamoModel.UpdateModelValueCommand(Guid.Empty,
+                    new[] { node.GUID }, "KeepListStructure", string.Format("{0}:{1}", portIndex, keep));
+
+                DynamoViewModel.Model.ExecuteCommand(command);
+            }
+        }
+
         private void RaiseFrozenPropertyChanged()
         {            
             RaisePropertyChanged("IsFrozen");

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1089,14 +1089,10 @@ namespace Dynamo.ViewModels
         /// <param name="use"></param>
         public void UseLevels(int portIndex, bool use)
         {
-            var node = this.nodeLogic;
-            if (node != null)
-            {
-                var command = new DynamoModel.UpdateModelValueCommand(Guid.Empty,
-                    new[] { node.GUID }, "UseLevels", string.Format("{0}:{1}", portIndex, use));
+            var command = new DynamoModel.UpdateModelValueCommand(
+                Guid.Empty, NodeModel.GUID, "UseLevels", string.Format("{0}:{1}", portIndex, use));
 
-                DynamoViewModel.Model.ExecuteCommand(command);
-            }
+            DynamoViewModel.ExecuteCommand(command);
         }
 
         /// <summary>
@@ -1106,14 +1102,10 @@ namespace Dynamo.ViewModels
         /// <param name="keep"></param>
         public void KeepListStructure(int portIndex, bool keep)
         {
-            var node = this.nodeLogic;
-            if (node != null)
-            {
-                var command = new DynamoModel.UpdateModelValueCommand(Guid.Empty,
-                    new[] { node.GUID }, "KeepListStructure", string.Format("{0}:{1}", portIndex, keep));
+            var command = new DynamoModel.UpdateModelValueCommand(
+                Guid.Empty, NodeModel.GUID, "KeepListStructure", string.Format("{0}:{1}", portIndex, keep));
 
-                DynamoViewModel.Model.ExecuteCommand(command);
-            }
+            DynamoViewModel.ExecuteCommand(command);
         }
 
         private void RaiseFrozenPropertyChanged()

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -1059,6 +1059,7 @@ namespace Dynamo.ViewModels
         private void ToggleIsFrozen(object parameters)
         {
             var node = this.nodeLogic;
+
             if (node != null)
             {
                 var oldFrozen = (!node.isFrozenExplicitly).ToString();
@@ -1079,6 +1080,23 @@ namespace Dynamo.ViewModels
         private bool CanToggleIsFrozen(object parameters)
         {
             return DynamoSelection.Instance.Selection.Count() == 1;
+        }
+
+        /// <summary>
+        /// Specify UseLevels on the corresponding input port.
+        /// </summary>
+        /// <param name="portIndex"></param>
+        /// <param name="use"></param>
+        public void UseLevels(int portIndex, bool use)
+        {
+            var node = this.nodeLogic;
+            if (node != null)
+            {
+                var command = new DynamoModel.UpdateModelValueCommand(Guid.Empty,
+                    new[] { node.GUID }, "UseLevels", string.Format("{0}:{1}", portIndex, use));
+
+                DynamoViewModel.Model.ExecuteCommand(command);
+            }
         }
 
         private void RaiseFrozenPropertyChanged()

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -296,12 +296,19 @@ namespace Dynamo.ViewModels
             {
                 if (_useLevelsCommand == null)
                 {
-                    _useLevelsCommand = new DelegateCommand(
-                        parameter => _node.UseLevels(_port.Index, (bool)parameter),
-                        parameter => true);
+                    _useLevelsCommand = new DelegateCommand(UseLevel, p => true);
                 }
                 return _useLevelsCommand;
             }
+        }
+
+        private void UseLevel(object parameter)
+        {
+            var useLevel = (bool)parameter;
+            var command = new DynamoModel.UpdateModelValueCommand(
+                Guid.Empty, _node.NodeLogic.GUID, "UseLevels", string.Format("{0}:{1}", _port.Index, useLevel));
+
+            _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
         }
 
         /// <summary>
@@ -313,32 +320,45 @@ namespace Dynamo.ViewModels
             {
                 if (_keepListStructureCommand == null)
                 {
-                    _keepListStructureCommand = new DelegateCommand(
-                        parameter => _node.KeepListStructure(_port.Index, (bool)parameter),
-                        parameter => true);
+                    _keepListStructureCommand = new DelegateCommand(KeepListStructure, p => true);
                 }
                 return _keepListStructureCommand;
             }
         }
 
+        private void KeepListStructure(object parameter)
+        {
+            bool keepListStructure = (bool)parameter;
+            var command = new DynamoModel.UpdateModelValueCommand(
+                Guid.Empty, _node.NodeLogic.GUID, "KeepListStructure", string.Format("{0}:{1}", _port.Index, keepListStructure));
+
+            _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
+        }
+
+        /// <summary>
+        /// ChangeLevel command
+        /// </summary>
         public DelegateCommand ChangeLevelCommand
         {
             get
             {
                 if (_levelChangedCommand == null)
                 {
-                    _levelChangedCommand = new DelegateCommand(
-                        parameter =>
-                        {
-                            var eventArg = parameter as RoutedPropertyChangedEventArgs<int>;
-                            if (eventArg != null)
-                            {
-                                _node.ChangeLevel(_port.Index, eventArg.NewValue);
-                            }
-                        },
-                        parameter => true);
+                    _levelChangedCommand = new DelegateCommand(ChangeLevel, p => true);
                 }
                 return _levelChangedCommand;
+            }
+        }
+
+        private void ChangeLevel(object parameter)
+        {
+            var eventArg = parameter as RoutedPropertyChangedEventArgs<int>;
+            if (eventArg != null)
+            {
+                var command = new DynamoModel.UpdateModelValueCommand(
+                                Guid.Empty, _node.NodeLogic.GUID, "ChangeLevel", string.Format("{0}:{1}", _port.Index, eventArg.NewValue));
+
+                _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -178,7 +178,6 @@ namespace Dynamo.ViewModels
         public int Level
         {
             get { return _port.Level; }
-            set { _port.Level = value; } 
         }
 
         /// <summary>
@@ -329,7 +328,14 @@ namespace Dynamo.ViewModels
                 if (_levelChangedCommand == null)
                 {
                     _levelChangedCommand = new DelegateCommand(
-                        parameter => _node.ChangeLevel(_port.Index, (int)parameter),
+                        parameter =>
+                        {
+                            var eventArg = parameter as RoutedPropertyChangedEventArgs<int>;
+                            if (eventArg != null)
+                            {
+                                _node.ChangeLevel(_port.Index, eventArg.NewValue);
+                            }
+                        },
                         parameter => true);
                 }
                 return _levelChangedCommand;

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -4,6 +4,7 @@ using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.Utilities;
+using Dynamo.UI.Commands;
 
 namespace Dynamo.ViewModels
 {
@@ -14,6 +15,7 @@ namespace Dynamo.ViewModels
 
         private readonly PortModel _port;
         private readonly NodeViewModel _node;
+        private DelegateCommand _useLevelsCommand;
 
         /// <summary>
         /// Port model.
@@ -158,14 +160,6 @@ namespace Dynamo.ViewModels
         public bool UseLevels
         {
             get { return _port.UseLevels; }
-            set
-            {
-               _port.UseLevels = value;
-               if (!_port.UseLevels)
-               {
-                   ShouldKeepListStructure = false;
-               }
-            }
         }
 
         /// <summary>
@@ -291,6 +285,20 @@ namespace Dynamo.ViewModels
                     break;
             }
             
+        }
+
+        public DelegateCommand UseLevelsCommand 
+        {
+            get
+            {
+                if (_useLevelsCommand == null)
+                {
+                    _useLevelsCommand = new DelegateCommand(
+                        parameter => _node.UseLevels(_port.Index, (bool)parameter),
+                        parameter => true);
+                }
+                return _useLevelsCommand;
+            }
         }
 
         private void Connect(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -17,7 +17,6 @@ namespace Dynamo.ViewModels
         private readonly NodeViewModel _node;
         private DelegateCommand _useLevelsCommand;
         private DelegateCommand _keepListStructureCommand;
-        private DelegateCommand _levelChangedCommand;
 
         /// <summary>
         /// Port model.
@@ -178,6 +177,10 @@ namespace Dynamo.ViewModels
         public int Level
         {
             get { return _port.Level; }
+            set
+            {
+                ChangeLevel(value);
+            }
         }
 
         /// <summary>
@@ -335,31 +338,12 @@ namespace Dynamo.ViewModels
             _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
         }
 
-        /// <summary>
-        /// ChangeLevel command
-        /// </summary>
-        public DelegateCommand ChangeLevelCommand
+        private void ChangeLevel(int level)
         {
-            get
-            {
-                if (_levelChangedCommand == null)
-                {
-                    _levelChangedCommand = new DelegateCommand(ChangeLevel, p => true);
-                }
-                return _levelChangedCommand;
-            }
-        }
+            var command = new DynamoModel.UpdateModelValueCommand(
+                            Guid.Empty, _node.NodeLogic.GUID, "ChangeLevel", string.Format("{0}:{1}", _port.Index, level));
 
-        private void ChangeLevel(object parameter)
-        {
-            var eventArg = parameter as RoutedPropertyChangedEventArgs<int>;
-            if (eventArg != null)
-            {
-                var command = new DynamoModel.UpdateModelValueCommand(
-                                Guid.Empty, _node.NodeLogic.GUID, "ChangeLevel", string.Format("{0}:{1}", _port.Index, eventArg.NewValue));
-
-                _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
-            }
+            _node.WorkspaceViewModel.DynamoViewModel.ExecuteCommand(command);
         }
 
         private void Connect(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -16,6 +16,7 @@ namespace Dynamo.ViewModels
         private readonly PortModel _port;
         private readonly NodeViewModel _node;
         private DelegateCommand _useLevelsCommand;
+        private DelegateCommand _keepListStructureCommand;
 
         /// <summary>
         /// Port model.
@@ -168,7 +169,6 @@ namespace Dynamo.ViewModels
         public bool ShouldKeepListStructure
         {
             get { return _port.ShouldKeepListStructure; }
-            set { _port.ShouldKeepListStructure = value; }
         }
 
         /// <summary>
@@ -287,6 +287,9 @@ namespace Dynamo.ViewModels
             
         }
 
+        /// <summary>
+        /// UseLevels command
+        /// </summary>
         public DelegateCommand UseLevelsCommand 
         {
             get
@@ -298,6 +301,23 @@ namespace Dynamo.ViewModels
                         parameter => true);
                 }
                 return _useLevelsCommand;
+            }
+        }
+
+        /// <summary>
+        /// ShouldKeepListStructure command
+        /// </summary>
+        public DelegateCommand KeeeListStructureCommand
+        {
+            get
+            {
+                if (_keepListStructureCommand == null)
+                {
+                    _keepListStructureCommand = new DelegateCommand(
+                        parameter => _node.KeepListStructure(_port.Index, (bool)parameter),
+                        parameter => true);
+                }
+                return _keepListStructureCommand;
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -307,7 +307,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// ShouldKeepListStructure command
         /// </summary>
-        public DelegateCommand KeeeListStructureCommand
+        public DelegateCommand KeepListStructureCommand
         {
             get
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -17,6 +17,7 @@ namespace Dynamo.ViewModels
         private readonly NodeViewModel _node;
         private DelegateCommand _useLevelsCommand;
         private DelegateCommand _keepListStructureCommand;
+        private DelegateCommand _levelChangedCommand;
 
         /// <summary>
         /// Port model.
@@ -318,6 +319,20 @@ namespace Dynamo.ViewModels
                         parameter => true);
                 }
                 return _keepListStructureCommand;
+            }
+        }
+
+        public DelegateCommand ChangeLevelCommand
+        {
+            get
+            {
+                if (_levelChangedCommand == null)
+                {
+                    _levelChangedCommand = new DelegateCommand(
+                        parameter => _node.ChangeLevel(_port.Index, (int)parameter),
+                        parameter => true);
+                }
+                return _levelChangedCommand;
             }
         }
 

--- a/src/DynamoCoreWpf/packages.config
+++ b/src/DynamoCoreWpf/packages.config
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="Cyotek.Drawing.BitmapFont" version="1.0.2.0" targetFramework="net45" />
   <package id="Greg" version="1.0.5959.26179" targetFramework="net45" />
   <package id="HelixToolkit" version="2015.1.629" targetFramework="net45" />
   <package id="HelixToolkit.Wpf" version="2015.1.629" targetFramework="net45" />
   <package id="HelixToolkit.Wpf.SharpDX" version="2015.1.629" targetFramework="net45" />
+  <package id="MvvmLight" version="5.3.0.0" targetFramework="net45" />
+  <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="RestSharp" version="105.2.3" targetFramework="net45" />
   <package id="SharpDX" version="2.6.3" targetFramework="net45" />

--- a/src/DynamoCoreWpf/packages.config
+++ b/src/DynamoCoreWpf/packages.config
@@ -1,13 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="Cyotek.Drawing.BitmapFont" version="1.0.2.0" targetFramework="net45" />
   <package id="Greg" version="1.0.5959.26179" targetFramework="net45" />
   <package id="HelixToolkit" version="2015.1.629" targetFramework="net45" />
   <package id="HelixToolkit.Wpf" version="2015.1.629" targetFramework="net45" />
   <package id="HelixToolkit.Wpf.SharpDX" version="2015.1.629" targetFramework="net45" />
-  <package id="MvvmLight" version="5.3.0.0" targetFramework="net45" />
-  <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="RestSharp" version="105.2.3" targetFramework="net45" />
   <package id="SharpDX" version="2.6.3" targetFramework="net45" />

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="..\..\src\AssemblySharedInfoGenerator\AssemblySharedInfo.cs">
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
+    <Compile Include="ListAtLevelTest.cs" />
     <Compile Include="NoteViewTests.cs" />
     <Compile Include="NodeViewTests.cs" />
     <Compile Include="NodeExecutionUITest.cs" />

--- a/test/DynamoCoreWpfTests/ListAtLevelTest.cs
+++ b/test/DynamoCoreWpfTests/ListAtLevelTest.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace DynamoCoreWpfTests
+{
+    [TestFixture]
+    public class ListAtLevelTest : RecordedUnitTestBase
+    {
+        [Test, RequiresSTA]
+        public void Test01()
+        {
+            var listNode = "e4988561-5a7c-4936-8ba4-e07fda0dd733";
+
+            RunCommandsFromFile("listatlevel-01.xml", (commandTag) =>
+            {
+                if (commandTag == "UseLevel2")
+                {
+                    AssertPreviewValue(listNode, new string[] { "foo", "qux" });
+                }
+                else if (commandTag == "UseLevel1")
+                {
+                    AssertPreviewValue(listNode, new string[] { "foo", "bar", "qux", "quz" });
+                }
+                else if (commandTag == "UseLevel3")
+                {
+                    AssertPreviewValue(listNode, new object[] { new string[] { "foo", "bar" } });
+
+                }
+                else if (commandTag == "Undo_UseLevel1")
+                {
+                    AssertPreviewValue(listNode, new string[] { "foo", "bar", "qux", "quz" });
+                }
+                else if (commandTag == "Undo_UseLevel2")
+                {
+                    AssertPreviewValue(listNode, new string[] { "foo", "qux" });
+                }
+            });
+        }
+    }
+}

--- a/test/core/recorded/listatlevel-01.xml
+++ b/test/core/recorded/listatlevel-01.xml
@@ -1,0 +1,54 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
+  <CreateNodeCommand X="675" Y="178" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>e4988561-5a7c-4936-8ba4-e07fda0dd733</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e4988561-5a7c-4936-8ba4-e07fda0dd733" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.FirstItem" x="675" y="178" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]">
+      <PortInfo index="0" default="False" useLevels="True" level="2" shouldKeepListStructure="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="310" Y="214" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>c7e8b13e-959e-45fb-9f3d-3c66fd079b2b</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="c7e8b13e-959e-45fb-9f3d-3c66fd079b2b" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="218" y="183" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{{&quot;foo&quot;, &quot;bar&quot;}, {&quot;qux&quot;, &quot;quz&quot;}};" ShouldFocus="false" />
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="{{&quot;foo&quot;, &quot;bar&quot;}, {&quot;qux&quot;, quz&quot;}}" WorkspaceGuid="faaed644-f15d-44ea-a841-097e57fb5232">
+    <ModelGuid>c7e8b13e-959e-45fb-9f3d-3c66fd079b2b</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="{{&quot;foo&quot;, &quot;bar&quot;}, {&quot;qux&quot;, &quot;quz&quot;}}" WorkspaceGuid="faaed644-f15d-44ea-a841-097e57fb5232">
+    <ModelGuid>c7e8b13e-959e-45fb-9f3d-3c66fd079b2b</ModelGuid>
+  </UpdateModelValueCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>c7e8b13e-959e-45fb-9f3d-3c66fd079b2b</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>e4988561-5a7c-4936-8ba4-e07fda0dd733</ModelGuid>
+  </MakeConnectionCommand>
+  <UpdateModelValueCommand Name="UseLevels" Value="0:True" WorkspaceGuid="00000000-0000-0000-0000-000000000000">
+    <ModelGuid>e4988561-5a7c-4936-8ba4-e07fda0dd733</ModelGuid>
+  </UpdateModelValueCommand>
+  <PausePlaybackCommand Tag="UseLevel2" PauseDurationInMs="20" />
+  <UpdateModelValueCommand Name="ChangeLevel" Value="0:1" WorkspaceGuid="00000000-0000-0000-0000-000000000000">
+    <ModelGuid>e4988561-5a7c-4936-8ba4-e07fda0dd733</ModelGuid>
+  </UpdateModelValueCommand>
+  <PausePlaybackCommand Tag="UseLevel1" PauseDurationInMs="20" />
+  <UpdateModelValueCommand Name="ChangeLevel" Value="0:2" WorkspaceGuid="00000000-0000-0000-0000-000000000000">
+    <ModelGuid>e4988561-5a7c-4936-8ba4-e07fda0dd733</ModelGuid>
+  </UpdateModelValueCommand>
+  <UpdateModelValueCommand Name="ChangeLevel" Value="0:3" WorkspaceGuid="00000000-0000-0000-0000-000000000000">
+    <ModelGuid>e4988561-5a7c-4936-8ba4-e07fda0dd733</ModelGuid>
+  </UpdateModelValueCommand>
+  <PausePlaybackCommand Tag="UseLevel3" PauseDurationInMs="20" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <PausePlaybackCommand Tag="Undo_UseLevel1" PauseDurationInMs="20" />
+  <UndoRedoCommand CmdOperation="0" />
+  <PausePlaybackCommand Tag="Undo_UseLevel2" PauseDurationInMs="20" />
+</Commands>


### PR DESCRIPTION
### Purpose

This PR is to support undo/redo for list@level UI operations by using `UpdateModelValueCommands`. As this command is recordable, we are able to do UI automation test for list@level now.

The schema of `Value` that used in `UpdateModelValueCommands` is `portIndex:value`. For example, the following XML elements are recorded commands for "Use Levels" and "Keep List Structure" operations. Note `Value="0:True"` attributes in these two `UpdateModelValueCommand`

```xml
...
<UpdateModelValueCommand WorkspaceGuid="00000000-0000-0000-0000-000000000000" Value="0:True" Name="UseLevels">
    <ModelGuid>9d024830-2529-4250-8c09-6f263a844561</ModelGuid>
</UpdateModelValueCommand>

<UpdateModelValueCommand WorkspaceGuid="00000000-0000-0000-0000-000000000000" Value="0:True" Name="KeepListStructure">
    <ModelGuid>9d024830-2529-4250-8c09-6f263a844561</ModelGuid>
</UpdateModelValueCommand>
```
### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 

### FYIs

@monikaprabhu @Racel 
