### PR TITLE
MAGN-10016 Publishing a package locally twice crashes dynamo

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1038,6 +1038,21 @@ namespace Dynamo.PackageManager
                 var builder = new PackageDirectoryBuilder(new MutatingFileSystem(), remapper);
                 builder.BuildDirectory(Package, publishPath, files);
                 UploadState = PackageUploadHandle.State.Uploaded;
+
+                // Calling back the OnPublishSuccess() function to close the dialog
+                // once the publish finished.
+                // Timer is used to prevent a sudden close of the dialog, 
+                // so that the users are clearly acknowledged about the uploaded state.
+                if (UploadState == PackageUploadHandle.State.Uploaded)
+                {
+                    System.Threading.Timer timer = null;
+                    timer = new System.Threading.Timer((obj) =>
+                        {
+                            OnPublishSuccess();
+                            timer.Dispose();
+                        },
+                        null, 1000, System.Threading.Timeout.Infinite);
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
### Purpose

- Fixed crash when click publish package locally twice by closing the publish package window automatically once the upload is successful. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 



