### PR TITLE
Fix Escape Character Edge Case Issues in CodeBlockNode(#7044)

### DIFF
--- a/src/Engine/ProtoCore/BuildStatus.cs
+++ b/src/Engine/ProtoCore/BuildStatus.cs
@@ -463,6 +463,8 @@ namespace ProtoCore
                     return Properties.Resources.in_expected;
                 case  "??? expected":
                     return Properties.Resources.triquestionmark_expected;
+                case "';' is expected":
+                    return Properties.Resources.SemiColonExpected;
                 case  "invalid Hydrogen":
                     return Properties.Resources.invalid_Hydrogen;
                 case   "this symbol not expected in Import_Statement":

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -148,9 +148,9 @@ public Node root { get; set; }
                 }
             }
             else if (s[i] == '\\' && i == s.Length - 1)
-                {
+            {
                     SynErr(Resources.EOF_expected);
-                }
+            }
             else
             {
                 sb.Append(s[i]);
@@ -613,6 +613,7 @@ public Node root { get; set; }
 		errors.count++;
 		errDist = 0;
 	 }
+
 
 
 	
@@ -1190,7 +1191,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		node = null; 
 		Associative_LogicalExpression(out node);
 		while (la.kind == 53) {
-			Associative_TernaryOp(ref node);
+			AssociativeTernaryOp(ref node);
 		}
 	}
 
@@ -1447,13 +1448,13 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		returnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank);
 		
 		if (la.kind == 47) {
-			Associative_TypeRestriction(out returnType);
+			AssociativeTypeRestriction(out returnType);
 		}
 		Associative_ArgumentSignatureDefinition(out argumentSignature);
 		argumentSign = argumentSignature; 
 	}
 
-	void Associative_TypeRestriction(out ProtoCore.Type type) {
+	void AssociativeTypeRestriction(out ProtoCore.Type type) {
 		Expect(47);
 		Associative_ClassReference(out type);
 		type.rank = 0; 
@@ -1846,7 +1847,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		}
 	}
 
-	void Associative_TernaryOp(ref ProtoCore.AST.AssociativeAST.AssociativeNode node) {
+	void AssociativeTernaryOp(ref ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		ProtoCore.AST.AssociativeAST.InlineConditionalNode inlineConNode = new ProtoCore.AST.AssociativeAST.InlineConditionalNode(); 
 		Expect(53);
 		inlineConNode.ConditionExpression = node; node = null; 
@@ -2032,12 +2033,12 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	}
 
 	void Associative_ArithmeticExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		Associative_Term(out node);
+		AssociativeTerm(out node);
 		while (la.kind == 15 || la.kind == 54) {
 			Operator op; 
 			Associative_AddOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
-			Associative_Term(out expr2);
+			AssociativeTerm(out expr2);
 			node = GenerateBinaryOperatorMethodCallNode(op, node, expr2);
 			
 		}
@@ -2098,7 +2099,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else SynErr(91);
 	}
 
-	void Associative_Term(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
+	void AssociativeTerm(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		#if ENABLE_BIT_OP 
 		Associative_interimfactor(out node);
 		#else             
@@ -2775,7 +2776,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		node = null; 
 		Imperative_binexpr(out node);
 		while (la.kind == 53) {
-			Imperative_TernaryOp(ref node);
+			ImperativeTernaryOp(ref node);
 		}
 	}
 
@@ -2970,7 +2971,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		}
 	}
 
-	void Imperative_TernaryOp(ref ProtoCore.AST.ImperativeAST.ImperativeNode node) {
+	void ImperativeTernaryOp(ref ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		ProtoCore.AST.ImperativeAST.InlineConditionalNode inlineConNode = new ProtoCore.AST.ImperativeAST.InlineConditionalNode(); 
 		Expect(53);
 		inlineConNode.ConditionExpression = node; node = null; 

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -1191,7 +1191,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		node = null; 
 		Associative_LogicalExpression(out node);
 		while (la.kind == 53) {
-			AssociativeTernaryOp(ref node);
+			Associative_TernaryOp(ref node);
 		}
 	}
 
@@ -1448,13 +1448,13 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		returnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank);
 		
 		if (la.kind == 47) {
-			AssociativeTypeRestriction(out returnType);
+			Associative_TypeRestriction(out returnType);
 		}
 		Associative_ArgumentSignatureDefinition(out argumentSignature);
 		argumentSign = argumentSignature; 
 	}
 
-	void AssociativeTypeRestriction(out ProtoCore.Type type) {
+	void Associative_TypeRestriction(out ProtoCore.Type type) {
 		Expect(47);
 		Associative_ClassReference(out type);
 		type.rank = 0; 
@@ -1847,7 +1847,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		}
 	}
 
-	void AssociativeTernaryOp(ref ProtoCore.AST.AssociativeAST.AssociativeNode node) {
+	void Associative_TernaryOp(ref ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		ProtoCore.AST.AssociativeAST.InlineConditionalNode inlineConNode = new ProtoCore.AST.AssociativeAST.InlineConditionalNode(); 
 		Expect(53);
 		inlineConNode.ConditionExpression = node; node = null; 
@@ -2033,12 +2033,12 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	}
 
 	void Associative_ArithmeticExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		AssociativeTerm(out node);
+		Associative_Term(out node);
 		while (la.kind == 15 || la.kind == 54) {
 			Operator op; 
 			Associative_AddOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
-			AssociativeTerm(out expr2);
+			Associative_Term(out expr2);
 			node = GenerateBinaryOperatorMethodCallNode(op, node, expr2);
 			
 		}
@@ -2099,7 +2099,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else SynErr(91);
 	}
 
-	void AssociativeTerm(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
+	void Associative_Term(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		#if ENABLE_BIT_OP 
 		Associative_interimfactor(out node);
 		#else             
@@ -2776,7 +2776,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		node = null; 
 		Imperative_binexpr(out node);
 		while (la.kind == 53) {
-			ImperativeTernaryOp(ref node);
+			Imperative_TernaryOp(ref node);
 		}
 	}
 
@@ -2971,7 +2971,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		}
 	}
 
-	void ImperativeTernaryOp(ref ProtoCore.AST.ImperativeAST.ImperativeNode node) {
+	void Imperative_TernaryOp(ref ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		ProtoCore.AST.ImperativeAST.InlineConditionalNode inlineConNode = new ProtoCore.AST.ImperativeAST.InlineConditionalNode(); 
 		Expect(53);
 		inlineConNode.ConditionExpression = node; node = null; 

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -99,7 +99,7 @@ public Node root { get; set; }
     private int stmtsParsed = 0;
 
 
-    private static string GetEscapedString(string s)
+    private string GetEscapedString(string s)
     {
         System.Text.StringBuilder sb = new System.Text.StringBuilder();
 
@@ -147,6 +147,10 @@ public Node root { get; set; }
                         break;
                 }
             }
+            else if (s[i] == '\\' && i == s.Length - 1)
+                {
+                    SynErr(Resources.EOF_expected);
+                }
             else
             {
                 sb.Append(s[i]);
@@ -609,7 +613,6 @@ public Node root { get; set; }
 		errors.count++;
 		errDist = 0;
 	 }
-
 
 
 	

--- a/src/Engine/ProtoCore/Parser/Scanner.cs
+++ b/src/Engine/ProtoCore/Parser/Scanner.cs
@@ -862,8 +862,9 @@ public class Scanner {
 				else {goto case 0;}
 			case 37:
 				recEnd = pos; recKind = 4;
-				if (ch <= '!' || ch >= '#' && ch <= '[' || ch >= ']' && ch <= 65535) {AddCh(); goto case 7;}
-				else if (ch == '"') {AddCh(); goto case 8;}
+				if (ch <= '!' || ch >= '#' && ch != ';' && ch <= '[' || ch >= ']' && ch <= 65535) {AddCh(); goto case 7;}
+                else if (ch == ';') { goto case 8; }
+                else if (ch == '"') {AddCh(); goto case 8;}
 				else if (ch == 92) {AddCh(); goto case 34;}
 				else {t.kind = 4; break;}
 			case 38:

--- a/src/Engine/ProtoCore/Parser/Scanner.cs
+++ b/src/Engine/ProtoCore/Parser/Scanner.cs
@@ -610,24 +610,24 @@ public class Scanner {
 		start[41] = 17; 
 		start[33] = 31; 
 		start[45] = 18; 
-		start[124] = 52; 
+		start[124] = 51; 
 		start[60] = 32; 
 		start[62] = 33; 
-		start[61] = 53; 
+		start[61] = 52; 
 		start[59] = 23; 
-		start[47] = 54; 
-		start[123] = 39; 
-		start[125] = 40; 
-		start[58] = 41; 
-		start[44] = 42; 
-		start[63] = 43; 
-		start[43] = 44; 
-		start[42] = 45; 
-		start[37] = 46; 
-		start[38] = 55; 
-		start[94] = 47; 
-		start[126] = 50; 
-		start[35] = 51; 
+		start[47] = 53; 
+		start[123] = 38; 
+		start[125] = 39; 
+		start[58] = 40; 
+		start[44] = 41; 
+		start[63] = 42; 
+		start[43] = 43; 
+		start[42] = 44; 
+		start[37] = 45; 
+		start[38] = 54; 
+		start[94] = 46; 
+		start[126] = 49; 
+		start[35] = 50; 
 		start[Buffer.EOF] = -1;
 
 	}
@@ -847,12 +847,10 @@ public class Scanner {
 				if (ch == '=') {AddCh(); goto case 20;}
 				else {t.kind = 18; break;}
 			case 34:
-				if (ch <= '!' || ch >= '#' && ch <= '[' || ch >= ']' && ch <= 65535) {AddCh(); goto case 7;}
-				else if (ch == '"') {AddCh(); goto case 37;}
-				else if (ch == 92) {AddCh(); goto case 34;}
+				if (ch == '"' || ch == 92) {AddCh(); goto case 7;}
 				else {goto case 0;}
 			case 35:
-				if (ch == 39) {AddCh(); goto case 38;}
+				if (ch == 39) {AddCh(); goto case 37;}
 				else if (ch == '"' || ch == '0' || ch == 92 || ch >= 'a' && ch <= 'b' || ch == 'f' || ch == 'n' || ch == 'r' || ch >= 't' && ch <= 'v') {AddCh(); goto case 10;}
 				else {goto case 0;}
 			case 36:
@@ -861,58 +859,51 @@ public class Scanner {
 				else if (ch == '*') {AddCh(); goto case 36;}
 				else {goto case 0;}
 			case 37:
-				recEnd = pos; recKind = 4;
-				if (ch <= '!' || ch >= '#' && ch != ';' && ch <= '[' || ch >= ']' && ch <= 65535) {AddCh(); goto case 7;}
-                else if (ch == ';') { goto case 8; }
-                else if (ch == '"') {AddCh(); goto case 8;}
-				else if (ch == 92) {AddCh(); goto case 34;}
-				else {t.kind = 4; break;}
-			case 38:
 				recEnd = pos; recKind = 5;
 				if (ch == 39) {AddCh(); goto case 11;}
 				else {t.kind = 5; break;}
-			case 39:
+			case 38:
 				{t.kind = 45; break;}
-			case 40:
+			case 39:
 				{t.kind = 46; break;}
-			case 41:
+			case 40:
 				{t.kind = 47; break;}
-			case 42:
+			case 41:
 				{t.kind = 51; break;}
-			case 43:
+			case 42:
 				{t.kind = 53; break;}
-			case 44:
+			case 43:
 				{t.kind = 54; break;}
-			case 45:
+			case 44:
 				{t.kind = 55; break;}
-			case 46:
+			case 45:
 				{t.kind = 57; break;}
-			case 47:
+			case 46:
 				{t.kind = 59; break;}
-			case 48:
+			case 47:
 				{t.kind = 60; break;}
-			case 49:
+			case 48:
 				{t.kind = 61; break;}
-			case 50:
+			case 49:
 				{t.kind = 62; break;}
-			case 51:
+			case 50:
 				{t.kind = 63; break;}
-			case 52:
+			case 51:
 				recEnd = pos; recKind = 16;
-				if (ch == '|') {AddCh(); goto case 49;}
+				if (ch == '|') {AddCh(); goto case 48;}
 				else {t.kind = 16; break;}
-			case 53:
+			case 52:
 				recEnd = pos; recKind = 52;
 				if (ch == '=') {AddCh(); goto case 21;}
 				else {t.kind = 52; break;}
-			case 54:
+			case 53:
 				recEnd = pos; recKind = 56;
 				if (ch == '/') {AddCh(); goto case 25;}
 				else if (ch == '*') {AddCh(); goto case 26;}
 				else {t.kind = 56; break;}
-			case 55:
+			case 54:
 				recEnd = pos; recKind = 58;
-				if (ch == '&') {AddCh(); goto case 48;}
+				if (ch == '&') {AddCh(); goto case 47;}
 				else {t.kind = 58; break;}
 
 		}

--- a/src/Engine/ProtoCore/Parser/atg/Start.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Start.atg
@@ -24,7 +24,7 @@ COMPILER DesignScriptParser
     private int stmtsParsed = 0;
 
 
-    private static string GetEscapedString(string s)
+    private string GetEscapedString(string s)
     {
         System.Text.StringBuilder sb = new System.Text.StringBuilder();
 
@@ -71,6 +71,10 @@ COMPILER DesignScriptParser
                         sb.Append(s[i]);
                         break;
                 }
+            }
+            else if (s[i] == '\\' && i == s.Length - 1)
+            {
+                    SynErr(Resources.EOF_expected);
             }
             else
             {
@@ -544,7 +548,7 @@ CHARACTERS
     cr  = '\r'. 
     lf  = '\n'.
     tab = '\t'.
-    anyButDoubleQuote = ANY - '\"'.
+    anyButDoubleQuote = ANY - '\"' - '\\'.
     anyButQuote = ANY - '\''.
     anychar = ANY.
     other = ANY - '/' - '*'.
@@ -554,8 +558,8 @@ TOKENS
     ident = unicodeIdentifierStart {unicodeIdentifierPart}.
     number = digit {digit} .
     float = digit {digit} '.' digit {digit} [('E' | 'e') ['+'|'-'] digit {digit}].
-    textstring = '"' {anyButDoubleQuote | "\\\""} '"'.
-    char = '\'' (anyButQuote | "\\\'" | "\\\"" | "\\\\" | "\\0" | "\\a" | "\\b" | "\\f" | "\\n" | "\\r" | "\\t" | "\\v" | "\\u") '\''.
+    textstring = '"' {anyButDoubleQuote | "\\\\" | "\\\""} '"'.
+    char = "'" (anyButQuote | "\\\\" | "\\\'" | "\\\"" | "\\0" | "\\a" | "\\b" | "\\f" | "\\n" | "\\r" | "\\t" | "\\v" | "\\u") "'".
     period = '.'.
     postfixed_replicationguide = digit {digit} 'L'.
 


### PR DESCRIPTION
### Purpose

Addressing Github Issue #7044, this PR is meant to provide a fix for the weird behavior exhibited by the escape character `\`. 

Previously, in several edge cases as demonstrated in the following screenshot, the escape character does not exhibit the correct behavior:

![escapesequenceerr](https://cloud.githubusercontent.com/assets/16283396/17846769/e2bd0a1a-687c-11e6-91f0-9623fe6ae7af.PNG)

This meant that there were 3 previously unresolved problems:

1. There was no `SemiColonExpected` error which could be thrown. This resulted in this class of errors simply throwing `Error: error`. 
2. In the scenario where there was an escape character before a close-inverted comma, `\"`, the escape character did not escape the close inverted comma.
3. In the scenario where there were two or more lines in the CodeBlockNode, the double escape character sequence before the close inverted comma `\\"` would result in an error. 

Now, the fix addresses all 3 parts of the problem:

1. Throwing the appropriate `SemiColonExpected` error when a relevant issue arises.
2. Throwing the appropriate `EOF Expected` error when the escape character escapes the close inverted comma.
3. [EDIT] Instead of directly modifying the `Scanner.cs` file, changes were made to `Start.atg` directly to handle the close-inverted comma - semi-colon sequence, preventing the error produced in problem no.3.

The same view nodes are reproduced here to show the changes:

![escapesequence](https://cloud.githubusercontent.com/assets/16283396/17846768/e2750d82-687c-11e6-998b-4cc6edc5c7ca.PNG)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ke-yu 

### FYIs

