### PR TITLE
MAGN-10074 As a User I want to see the background preview state of my node

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -346,6 +346,36 @@
         </Style.Triggers>
     </Style>
 
+    <!--Zoom fade preview-->
+    <Style x:Key="SZoomFadePreview"
+           TargetType="{x:Type Border}">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=DataContext.Zoom, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:WorkspaceView}}, Converter={StaticResource ZoomToBooleanConverter}}"
+                         Value="true">
+                <DataTrigger.EnterActions>
+                    <BeginStoryboard>
+                        <Storyboard>
+                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                             To="0.4"
+                                             Duration="0:0:0.5" />
+                        </Storyboard>
+                    </BeginStoryboard>
+                </DataTrigger.EnterActions>
+                <DataTrigger.ExitActions>
+                    <BeginStoryboard>
+                        <Storyboard>
+                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                             To="0.7"
+                                             Duration="0:0:0.5" />
+                        </Storyboard>
+                    </BeginStoryboard>
+                </DataTrigger.ExitActions>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+
+
     <Style x:Key="SZoomFadeTextBox"
            TargetType="{x:Type TextBox}">
         <Style.Triggers>

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -117,6 +117,28 @@
             </ContextMenu>
         </Grid.ContextMenu>
 
+        <Rectangle Name="frozenBorder"
+                Grid.Row="1"
+                Grid.ColumnSpan="3"
+                Grid.RowSpan="3"
+                Canvas.ZIndex="1"
+                Margin="-5,-5,-5,-5"
+                StrokeDashArray="2"
+                StrokeThickness="3"
+                Opacity=".5"
+                Stroke="#444">
+            <Rectangle.Style>
+                <Style TargetType="{x:Type Rectangle}">
+                    <Setter Property="Visibility" Value="Hidden"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsFrozen}" Value="True">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Rectangle.Style>
+        </Rectangle>
+
         <Border Name="customNodeBorder0"
                 Grid.Row="0"
                 Grid.ColumnSpan="3"
@@ -224,6 +246,25 @@
                 </dynui:DynamoToolTip>
             </Rectangle.ToolTip>
         </Rectangle>
+
+        <Border Name="previewState"
+                Grid.Row="1"
+                Grid.ColumnSpan="3"
+                Grid.RowSpan="3"
+                Canvas.ZIndex="12"
+                Margin="1,1,1,1"
+                Background="#99B8CA"
+                Opacity=".4"
+                Style="{StaticResource SZoomFadePreview}">
+            <Border.Visibility>
+                <Binding Path="IsVisible"
+                         UpdateSourceTrigger="PropertyChanged"
+                         Mode="OneWay"
+                         Converter="{StaticResource InverseBoolToVisibilityConverter}">
+                </Binding>
+            </Border.Visibility>
+        </Border>
+
 
         <TextBlock Name="nickNameBlock"
                    Grid.Row="1"


### PR DESCRIPTION
### Purpose

* This PR proposes a way to provide a visual cue of a nodes preview state for geometry in the background preview.  Similar to freeze (which adjust the transparency of a node) this adds a visual cue on top of the current color states of the nodes which are: Inactive (lighter), Active (default), Warning (yellow hue), and Error (red hue)].  This PR adds a darker hue to the node whose preview is turned off.  The darker hue is applied to all the node states and as well as a node with a frozen state whose preview is turned off. 

![states](https://cloud.githubusercontent.com/assets/2145751/17865583/297be8c4-6871-11e6-9125-a2dda67ce892.png)
States

![image](https://cloud.githubusercontent.com/assets/2145751/17865685/7d40fb34-6871-11e6-9fb1-46a46633ed94.png)
Example

* This PR also proposes an additional affordance for freeze to help clarify the state of nodes in the graph.  Previously changing a nodes state to freeze adjusted its background (and its child nodes) to transparent as well as adjusting its child connection wires to dashed/transparent.  We have added a border with the same dashed/transparent wire style to the frozen nodes.

![image](https://cloud.githubusercontent.com/assets/2145751/17866141/673c3022-6873-11e6-9420-3369e7f8e281.png)
Example
   
### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.

### Reviewers

@ramramps @Racel 

### FYIs

@mjkkirschner @QilongTang @sm6srw 
