### PR TITLE
add a simple test to make sure command actually opens file

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1155,14 +1155,14 @@ namespace Dynamo.ViewModels
                 if (AskUserToSaveWorkspaceOrCancel(HomeSpace))
                 {
                     this.ExecuteCommand(command);
+                    this.ShowStartPage = false;
                 }
             }
             else
             {
                 this.ExecuteCommand(command);
+                this.ShowStartPage = false;
             }
-
-            
         }
 
         /// <summary>

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -462,6 +462,20 @@ namespace Dynamo.Tests
 
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void EnsureOnOpenIfSaveCommandOpensDynFile()
+        {
+            
+            //openPath
+            string openPath = Path.Combine(TestDirectory, (@"UI\GroupTest.dyn"));
+            //send the command
+            ViewModel.OpenIfSavedCommand.Execute(new Dynamo.Models.DynamoModel.OpenFileCommand(openPath));
+
+            Assert.GreaterOrEqual(2, GetModel().CurrentWorkspace.Nodes.ToList().Count());
+
+        }
+
 
         [Test]
         [Category("UnitTests")]


### PR DESCRIPTION
### Purpose

follow up for (https://github.com/DynamoDS/Dynamo/pull/7061)

This PR hides the start page when a file is opened using the command so the graph is actually displayed. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@saintentropy 

### FYIs

@BogdanZavu
@kronz 