### PR TITLE
Fix element binding issue for multiple custom node instances

### DIFF
--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -250,6 +250,7 @@ namespace Dynamo.Configuration
         internal static readonly string NodeTraceDataXmlTag = "NodeTraceData";
         internal static readonly string CallsiteTraceDataXmlTag = "CallsiteTraceData";
         internal static readonly string NodeIdAttribName = "NodeId";
+        internal static readonly string CallSiteID = "CallSiteID";
 
         #endregion
 

--- a/src/DynamoCore/Engine/CodeGeneration/AstBuilder.cs
+++ b/src/DynamoCore/Engine/CodeGeneration/AstBuilder.cs
@@ -331,6 +331,14 @@ namespace Dynamo.Engine.CodeGeneration
                     ? scopedNode.BuildAstInScope(inputAstNodes, verboseLogging, this)
                     : node.BuildAst(inputAstNodes, context);
 
+            foreach (var astNode in astNodes)
+            {
+                if (astNode.Kind == AstKind.BinaryExpression)
+                {
+                    (astNode as BinaryExpressionNode).guid = node.GUID;
+                }
+            }
+
             if (verboseLogging)
             {
                 foreach (var n in astNodes)

--- a/src/DynamoCore/Graph/Nodes/NodeCategories.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeCategories.cs
@@ -7,6 +7,7 @@ using System.Xml;
 using Dynamo.Configuration;
 using Dynamo.Engine;
 using Dynamo.Library;
+using ProtoCore;
 
 namespace Dynamo.Graph.Nodes
 {
@@ -280,7 +281,7 @@ namespace Dynamo.Graph.Nodes
         /// to be saved to the XmlDocument. This parameter cannot be null and 
         /// must represent a non-empty list of node-data-list pairs.</param>
         internal static void SaveTraceDataToXmlDocument(XmlDocument document,
-            IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> nodeTraceDataList)
+            IEnumerable<KeyValuePair<Guid, List<CallSite.RawTraceData>>> nodeTraceDataList)
         {
             #region Parameter Validations
 
@@ -329,9 +330,9 @@ namespace Dynamo.Graph.Nodes
                 {
                     var callsiteXmlElement = document.CreateElement(
                         Configurations.CallsiteTraceDataXmlTag);
-                    callsiteXmlElement.SetAttribute(Configurations.CallSiteID, data.Key);
+                    callsiteXmlElement.SetAttribute(Configurations.CallSiteID, data.ID);
 
-                    callsiteXmlElement.InnerText = data.Value;
+                    callsiteXmlElement.InnerText = data.Data;
                     nodeElement.AppendChild(callsiteXmlElement);
                 }
             }
@@ -347,7 +348,7 @@ namespace Dynamo.Graph.Nodes
         /// data-list pairs are to be deserialized.</param>
         /// <returns>Returns a dictionary of deserialized node-data-list pairs
         /// loaded from the given XmlDocument.</returns>
-        internal static IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>>
+        internal static IEnumerable<KeyValuePair<Guid, List<CallSite.RawTraceData>>>
             LoadTraceDataFromXmlDocument(XmlDocument document)
         {
             if (document == null)
@@ -365,7 +366,7 @@ namespace Dynamo.Graph.Nodes
                         where childNode.Name.Equals(sessionXmlTagName)
                         select childNode;
 
-            var loadedData = new Dictionary<Guid, List<KeyValuePair<string, string>>>();
+            var loadedData = new Dictionary<Guid, List<CallSite.RawTraceData>>();
             if (!query.Any()) // There's no data, return empty dictionary.
                 return loadedData;
 
@@ -373,7 +374,7 @@ namespace Dynamo.Graph.Nodes
             foreach (XmlElement nodeElement in sessionElement.ChildNodes)
             {
                 var guid = Guid.Parse(nodeElement.GetAttribute(Configurations.NodeIdAttribName));
-                List<KeyValuePair<string, string>> callsiteTraceData = new List<KeyValuePair<string, string>>();
+                List<CallSite.RawTraceData> callsiteTraceData = new List<CallSite.RawTraceData>();
                 foreach (var child in nodeElement.ChildNodes.Cast<XmlElement>())
                 {
                     var callsiteId = string.Empty;
@@ -382,7 +383,7 @@ namespace Dynamo.Graph.Nodes
                         callsiteId = child.GetAttribute(Configurations.CallSiteID);
                     }
                     var traceData = child.InnerText;
-                    callsiteTraceData.Add(new KeyValuePair<string, string>(callsiteId, traceData));
+                    callsiteTraceData.Add(new CallSite.RawTraceData(callsiteId, traceData));
                 }
                 loadedData.Add(guid, callsiteTraceData);
             }

--- a/src/DynamoCore/Graph/Nodes/NodeCategories.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeCategories.cs
@@ -280,7 +280,7 @@ namespace Dynamo.Graph.Nodes
         /// to be saved to the XmlDocument. This parameter cannot be null and 
         /// must represent a non-empty list of node-data-list pairs.</param>
         internal static void SaveTraceDataToXmlDocument(XmlDocument document,
-            IEnumerable<KeyValuePair<Guid, List<string>>> nodeTraceDataList)
+            IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> nodeTraceDataList)
         {
             #region Parameter Validations
 
@@ -329,8 +329,9 @@ namespace Dynamo.Graph.Nodes
                 {
                     var callsiteXmlElement = document.CreateElement(
                         Configurations.CallsiteTraceDataXmlTag);
+                    callsiteXmlElement.SetAttribute(Configurations.CallSiteID, data.Key);
 
-                    callsiteXmlElement.InnerText = data;
+                    callsiteXmlElement.InnerText = data.Value;
                     nodeElement.AppendChild(callsiteXmlElement);
                 }
             }

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -29,7 +29,7 @@ namespace Dynamo.Graph.Workspaces
         private PulseMaker pulseMaker;
         private readonly bool verboseLogging;
         private bool graphExecuted;
-        private IEnumerable<KeyValuePair<Guid, List<string>>> historicalTraceData;
+        private IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> historicalTraceData;
 
         /// <summary>
         ///     Returns <see cref="EngineController"/> object assosiated with this home workspace
@@ -78,7 +78,7 @@ namespace Dynamo.Graph.Workspaces
         /// In near future, the file loading mechanism will be completely moved 
         /// into WorkspaceModel, that's the time we removed this property setter below.
         /// </summary>
-        internal IEnumerable<KeyValuePair<Guid, List<string>>> PreloadedTraceData
+        internal IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> PreloadedTraceData
         {
             get
             {
@@ -97,7 +97,7 @@ namespace Dynamo.Graph.Workspaces
             }
         }
 
-        private IEnumerable<KeyValuePair<Guid, List<string>>> preloadedTraceData;
+        private IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> preloadedTraceData;
 
         internal bool IsEvaluationPending
         {
@@ -185,7 +185,7 @@ namespace Dynamo.Graph.Workspaces
             : this(engine,
                 scheduler,
                 factory,
-                Enumerable.Empty<KeyValuePair<Guid, List<string>>>(),
+                Enumerable.Empty<KeyValuePair<Guid, List<KeyValuePair<string, string>>>>(),
                 Enumerable.Empty<NodeModel>(),
                 Enumerable.Empty<NoteModel>(),
                 Enumerable.Empty<AnnotationModel>(),
@@ -216,7 +216,7 @@ namespace Dynamo.Graph.Workspaces
         public HomeWorkspaceModel(EngineController engine, 
             DynamoScheduler scheduler, 
             NodeFactory factory,
-            IEnumerable<KeyValuePair<Guid, List<string>>> traceData, 
+            IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> traceData, 
             IEnumerable<NodeModel> nodes, 
             IEnumerable<NoteModel> notes, 
             IEnumerable<AnnotationModel> annotations,
@@ -252,11 +252,12 @@ namespace Dynamo.Graph.Workspaces
             // nulled, to check for node deletions and reconcile the trace data.
             // We do a deep copy of this data because the PreloadedTraceData is
             // later set to null before the graph update.
-            var copiedData = new List<KeyValuePair<Guid, List<string>>>();
+            var copiedData = new List<KeyValuePair<Guid, List<KeyValuePair<string, string>>>>();
             foreach (var kvp in PreloadedTraceData)
             {
-                var strings = kvp.Value.Select(string.Copy).ToList();
-                copiedData.Add(new KeyValuePair<Guid, List<string>>(kvp.Key, strings));
+                List<KeyValuePair<string, string>> callSiteTraceData = new List<KeyValuePair<string, string>>();
+                callSiteTraceData.AddRange(kvp.Value);
+                copiedData.Add(new KeyValuePair<Guid, List<KeyValuePair<string, string>>>(kvp.Key, callSiteTraceData));
             }
             historicalTraceData = copiedData;
         }

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -29,10 +29,10 @@ namespace Dynamo.Graph.Workspaces
         private PulseMaker pulseMaker;
         private readonly bool verboseLogging;
         private bool graphExecuted;
-        private IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> historicalTraceData;
+        private IEnumerable<KeyValuePair<Guid, List<CallSite.RawTraceData>>> historicalTraceData;
 
         /// <summary>
-        ///     Returns <see cref="EngineController"/> object assosiated with this home workspace
+        ///     Returns <see cref="EngineController"/> object assosiated with thisPreloadedTraceData home workspace
         /// to coordinate the interactions between some DesignScript
         /// sub components like library managment, live runner and so on.
         /// </summary>
@@ -78,7 +78,7 @@ namespace Dynamo.Graph.Workspaces
         /// In near future, the file loading mechanism will be completely moved 
         /// into WorkspaceModel, that's the time we removed this property setter below.
         /// </summary>
-        internal IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> PreloadedTraceData
+        internal IEnumerable<KeyValuePair<Guid, List<CallSite.RawTraceData>>> PreloadedTraceData
         {
             get
             {
@@ -97,7 +97,7 @@ namespace Dynamo.Graph.Workspaces
             }
         }
 
-        private IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> preloadedTraceData;
+        private IEnumerable<KeyValuePair<Guid, List<CallSite.RawTraceData>>> preloadedTraceData;
 
         internal bool IsEvaluationPending
         {
@@ -185,7 +185,7 @@ namespace Dynamo.Graph.Workspaces
             : this(engine,
                 scheduler,
                 factory,
-                Enumerable.Empty<KeyValuePair<Guid, List<KeyValuePair<string, string>>>>(),
+                Enumerable.Empty<KeyValuePair<Guid, List<CallSite.RawTraceData>>>(),
                 Enumerable.Empty<NodeModel>(),
                 Enumerable.Empty<NoteModel>(),
                 Enumerable.Empty<AnnotationModel>(),
@@ -216,7 +216,7 @@ namespace Dynamo.Graph.Workspaces
         public HomeWorkspaceModel(EngineController engine, 
             DynamoScheduler scheduler, 
             NodeFactory factory,
-            IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> traceData, 
+            IEnumerable<KeyValuePair<Guid, List<CallSite.RawTraceData>>> traceData, 
             IEnumerable<NodeModel> nodes, 
             IEnumerable<NoteModel> notes, 
             IEnumerable<AnnotationModel> annotations,
@@ -252,12 +252,12 @@ namespace Dynamo.Graph.Workspaces
             // nulled, to check for node deletions and reconcile the trace data.
             // We do a deep copy of this data because the PreloadedTraceData is
             // later set to null before the graph update.
-            var copiedData = new List<KeyValuePair<Guid, List<KeyValuePair<string, string>>>>();
+            var copiedData = new List<KeyValuePair<Guid, List<CallSite.RawTraceData>>>();
             foreach (var kvp in PreloadedTraceData)
             {
-                List<KeyValuePair<string, string>> callSiteTraceData = new List<KeyValuePair<string, string>>();
+                List<CallSite.RawTraceData> callSiteTraceData = new List<CallSite.RawTraceData>();
                 callSiteTraceData.AddRange(kvp.Value);
-                copiedData.Add(new KeyValuePair<Guid, List<KeyValuePair<string, string>>>(kvp.Key, callSiteTraceData));
+                copiedData.Add(new KeyValuePair<Guid, List<CallSite.RawTraceData>>(kvp.Key, callSiteTraceData));
             }
             historicalTraceData = copiedData;
         }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1902,7 +1902,7 @@ namespace Dynamo.Graph.Workspaces
                 // a DSVarArgFunction or a CodeBlockNodeModel into a list.
                 var nodeGuids =
                     Nodes.Where(
-                        n => n is DSFunction || n is DSVarArgFunction || n is CodeBlockNodeModel)
+                        n => n is DSFunction || n is DSVarArgFunction || n is CodeBlockNodeModel || n is Function)
                         .Select(n => n.GUID);
 
                 var nodeTraceDataList = runtimeCore.RuntimeData.GetTraceDataForNodes(nodeGuids, runtimeCore.DSExecutable);

--- a/src/DynamoCore/Scheduler/SetTraceDataAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/SetTraceDataAsyncTask.cs
@@ -5,13 +5,14 @@ using Dynamo.Engine;
 using Dynamo.Graph;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
+using ProtoCore;
 
 namespace Dynamo.Scheduler
 {
     class SetTraceDataAsyncTask : AsyncTask
     {
         private EngineController engineController;
-        private IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> traceData;
+        private IEnumerable<KeyValuePair<Guid, List<CallSite.RawTraceData>>> traceData;
 
         public override TaskPriority Priority
         {

--- a/src/DynamoCore/Scheduler/SetTraceDataAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/SetTraceDataAsyncTask.cs
@@ -11,7 +11,7 @@ namespace Dynamo.Scheduler
     class SetTraceDataAsyncTask : AsyncTask
     {
         private EngineController engineController;
-        private IEnumerable<KeyValuePair<Guid, List<string>>> traceData;
+        private IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> traceData;
 
         public override TaskPriority Priority
         {

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -728,14 +728,7 @@ namespace ProtoCore.DSASM
             }
 
             // Get the cached callsite, creates a new one for a first-time call
-            CallSite callsite = runtimeCore.RuntimeData.GetCallSite(
-                exe.ExecutingGraphnode, 
-                classIndex, 
-                fNode.Name, 
-                exe,
-                runtimeCore.RunningBlock, 
-                runtimeCore.Options, 
-                runtimeCore.RuntimeStatus);
+            CallSite callsite = runtimeCore.RuntimeData.GetCallSite(classIndex, fNode.Name, exe, runtimeCore);
             Validity.Assert(null != callsite);
 
             List<StackValue> registers = GetRegisters();
@@ -866,10 +859,7 @@ namespace ProtoCore.DSASM
 
             var stackFrame = new StackFrame(thisObject, classIndex, procIndex, pc + 1, 0, runtimeCore.RunningBlock, fepRun ? StackFrameType.Function : StackFrameType.LanguageBlock, StackFrameType.Function, 0, rmem.FramePointer, 0, registers, 0);
 
-            var callsite = runtimeCore.RuntimeData.GetCallSite(exe.ExecutingGraphnode,
-                                            classIndex,
-                                            procNode.Name,
-                                            exe, runtimeCore.RunningBlock, runtimeCore.Options, runtimeCore.RuntimeStatus);
+            var callsite = runtimeCore.RuntimeData.GetCallSite(classIndex, procNode.Name, exe, runtimeCore);
 
             Validity.Assert(null != callsite);
 

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -400,12 +400,12 @@ namespace ProtoCore.DSASM
             pc = (int)rmem.GetAtRelative(StackFrame.FrameIndexReturnAddress).IntegerValue;
         }
 
-        private void PushInterpreterProps(InterpreterProperties properties)
+        public void PushInterpreterProps(InterpreterProperties properties)
         {
             runtimeCore.InterpreterProps.Push(new InterpreterProperties(properties));
         }
 
-        private InterpreterProperties PopInterpreterProps()
+        public InterpreterProperties PopInterpreterProps()
         {
             return runtimeCore.InterpreterProps.Pop();
         }

--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -693,14 +693,7 @@ namespace ProtoCore.Lang
                                                stackFrame.GetRegisters(), 
                                                0);
 
-            ProtoCore.CallSite callsite = runtimeData.GetCallSite(
-                runtime.exe.ExecutingGraphnode, 
-                thisObjectType, 
-                functionName, 
-                runtime.exe,
-                runtimeCore.RunningBlock,
-                runtimeCore.Options, 
-                runtimeCore.RuntimeStatus);
+            ProtoCore.CallSite callsite = runtimeData.GetCallSite( thisObjectType, functionName, runtime.exe, runtimeCore);
             Validity.Assert(null != callsite);
 
             // TODO: Disabling support for stepping into replicated function calls temporarily - pratapa

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -24,6 +24,28 @@ namespace ProtoCore
         #region private classes
 
         /// <summary>
+        /// Trace data for a specific callsite
+        /// </summary>
+        public class RawTraceData
+        {
+            public string ID
+            {
+                get; private set;
+            }
+
+            public string Data
+            {
+                get; private set;
+            }
+           
+            public RawTraceData(string callSiteID, string data)
+            {
+                ID = callSiteID;
+                Data = data;
+            }
+        }
+
+        /// <summary>
         /// Data structure used to carry trace data
         /// </summary>
         public class SingleRunTraceData
@@ -1985,9 +2007,9 @@ namespace ProtoCore
         /// <param name="callSiteData">The serialized representation of a SingleRunTraceData object.</param>
         /// <returns>A flat collection of ISerializable objects.</returns>
         public static IList<ISerializable> GetAllSerializablesFromSingleRunTraceData(
-            KeyValuePair<string, string> callSiteData)
+            RawTraceData callSiteData)
         {
-            var helper = TraceSerialiserHelper.FromCallSiteData(callSiteData.Value);
+            var helper = TraceSerialiserHelper.FromCallSiteData(callSiteData.Data);
             if (helper == null)
             {
                 return new List<ISerializable>();

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1985,9 +1985,9 @@ namespace ProtoCore
         /// <param name="callSiteData">The serialized representation of a SingleRunTraceData object.</param>
         /// <returns>A flat collection of ISerializable objects.</returns>
         public static IList<ISerializable> GetAllSerializablesFromSingleRunTraceData(
-            string callSiteData)
+            KeyValuePair<string, string> callSiteData)
         {
-            var helper = TraceSerialiserHelper.FromCallSiteData(callSiteData);
+            var helper = TraceSerialiserHelper.FromCallSiteData(callSiteData.Value);
             if (helper == null)
             {
                 return new List<ISerializable>();

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -61,6 +61,18 @@ namespace ProtoCore
             CallSite csInstance = null;
             var graphNode = executable.ExecutingGraphnode;
 
+            // If it is a nested function call, append all callsite ids
+            var callsiteID = string.Empty;
+            var runtimeProperties = runtimeCore.InterpreterProps;
+            foreach (var prop in runtimeProperties)
+            {
+                if (prop != null && prop.executingGraphNode != null && graphNode != prop.executingGraphNode)
+                {
+                    callsiteID += ";" + prop.executingGraphNode.CallsiteIdentifier;
+                }
+            }
+            callsiteID += graphNode.CallsiteIdentifier;
+
             // TODO Jun: Currently generates a new callsite for imperative and 
             // internally generated functions.
             // Fix the issues that cause the cache to go out of sync when 
@@ -78,7 +90,7 @@ namespace ProtoCore
                                           executable.FunctionTable,
                                           runtimeCore.Options.ExecutionMode);
             }
-            else if (!CallsiteCache.TryGetValue(graphNode.CallsiteIdentifier, out csInstance))
+            else if (!CallsiteCache.TryGetValue(callsiteID, out csInstance))
             {
                 // Attempt to retrieve a preloaded callsite data (optional).
                 var traceData = GetAndRemoveTraceDataForNode(graphNode.guid);
@@ -89,7 +101,7 @@ namespace ProtoCore
                                           runtimeCore.Options.ExecutionMode,
                                           traceData);
 
-                CallsiteCache[graphNode.CallsiteIdentifier] = csInstance;
+                CallsiteCache[callsiteID] = csInstance;
                 CallSiteToNodeMap[csInstance.CallSiteID] = graphNode.guid;
                 ASTToCallSiteMap[graphNode.AstID] = csInstance;
 

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -31,19 +31,12 @@ namespace ProtoCore
         /// </summary>
         public Dictionary<Guid, Guid> CallSiteToNodeMap { get; private set; }
  		 
-        /// <summary>		
-        /// Map from a AST node's ID to a callsite.		
-        /// </summary>
-        public Dictionary<int, CallSite> ASTToCallSiteMap { get; private set; }
-
-
  #endregion
 
         public RuntimeData()
         {
             CallsiteCache = new Dictionary<string, CallSite>();
             CallSiteToNodeMap = new Dictionary<Guid, Guid>();
-            ASTToCallSiteMap = new Dictionary<int, CallSite>();
         }
 
       
@@ -103,8 +96,6 @@ namespace ProtoCore
 
                 CallsiteCache[callsiteID] = csInstance;
                 CallSiteToNodeMap[csInstance.CallSiteID] = graphNode.guid;
-                ASTToCallSiteMap[graphNode.AstID] = csInstance;
-
             }
 
             if (graphNode != null && !CoreUtils.IsDisposeMethod(methodName))

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -55,17 +55,11 @@ namespace ProtoCore
         /// <param name="core"></param>
         /// <param name="uid"></param>
         /// <returns></returns>
-        public CallSite GetCallSite(GraphNode graphNode,
-                                    int classScope,
-                                    string methodName,
-                                    Executable executable,
-                                    int runningBlock,
-                                    Options options,
-                                    RuntimeStatus runtimeStatus
-             )
+        public CallSite GetCallSite(int classScope, string methodName, Executable executable, RuntimeCore runtimeCore)
         {
             Validity.Assert(null != executable.FunctionTable);
             CallSite csInstance = null;
+            var graphNode = executable.ExecutingGraphnode;
 
             // TODO Jun: Currently generates a new callsite for imperative and 
             // internally generated functions.
@@ -73,7 +67,7 @@ namespace ProtoCore
             // attempting to cache internal functions. This may require a 
             // secondary callsite cache for internal functions so they dont 
             // clash with the graphNode UID key
-            var language = executable.instrStreamList[runningBlock].language;
+            var language = executable.instrStreamList[runtimeCore.RunningBlock].language;
             bool isImperative = language == Language.Imperative;
             bool isInternalFunction = CoreUtils.IsInternalFunction(methodName);
 
@@ -82,7 +76,7 @@ namespace ProtoCore
                 csInstance = new CallSite(classScope,
                                           methodName,
                                           executable.FunctionTable,
-                                          options.ExecutionMode);
+                                          runtimeCore.Options.ExecutionMode);
             }
             else if (!CallsiteCache.TryGetValue(graphNode.CallsiteIdentifier, out csInstance))
             {
@@ -92,7 +86,7 @@ namespace ProtoCore
                 csInstance = new CallSite(classScope,
                                           methodName,
                                           executable.FunctionTable,
-                                          options.ExecutionMode,
+                                          runtimeCore.Options.ExecutionMode,
                                           traceData);
 
                 CallsiteCache[graphNode.CallsiteIdentifier] = csInstance;
@@ -104,9 +98,9 @@ namespace ProtoCore
             if (graphNode != null && !CoreUtils.IsDisposeMethod(methodName))
             {
                 csInstance.UpdateCallSite(classScope, methodName);
-                if (options.IsDeltaExecution)
+                if (runtimeCore.Options.IsDeltaExecution)
                 {
-                    runtimeStatus.ClearWarningForExpression(graphNode.exprUID);
+                    runtimeCore.RuntimeStatus.ClearWarningForExpression(graphNode.exprUID);
                 }
             }
 

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -68,7 +68,10 @@ namespace ProtoCore
                     }
                 }
             }
-            callsiteIdentifiers.Add(graphNode.CallsiteIdentifier);
+            if (graphNode != null)
+            {
+                callsiteIdentifiers.Add(graphNode.CallsiteIdentifier);
+            }
             var callsiteID = string.Join(";", callsiteIdentifiers.ToArray());
 
             // TODO Jun: Currently generates a new callsite for imperative and 

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -321,7 +321,16 @@ namespace ProtoCore
                 }
             }
 
-            return callsiteTraceData;
+            // For backword compatibility: old dyn file doesn't have CallSiteID
+            // attribute, so the call site id will be empty string.
+            if (callsiteTraceData == null && !string.IsNullOrEmpty(callsiteID))
+            {
+                return GetAndRemoveTraceDataForNode(nodeGuid, string.Empty);
+            }
+            else
+            {
+                return callsiteTraceData;
+            }
         }
 
         #endregion // Trace Data Serialization Methods/Members

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1338,6 +1338,8 @@ namespace ProtoScript.Runners
                 StackValue restoreFramePointer = runtimeCore.RuntimeMemory.GetAtRelative(ProtoCore.DSASM.StackFrame.FrameIndexFramePointer);
                 runtimeCore.RuntimeMemory.FramePointer = (int)restoreFramePointer.IntegerValue;
                 runtimeCore.RuntimeMemory.PopFrame(ProtoCore.DSASM.StackFrame.StackFrameSize);
+
+                runtimeCore.CurrentExecutive.CurrentDSASMExec.PopInterpreterProps();
             }
             ForceGC();
         }

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -300,7 +300,7 @@ namespace Dynamo.Tests
         public void SaveTraceDataToXmlDocument00()
         {
             XmlDocument document = new XmlDocument();
-            var data = new Dictionary<Guid, List<KeyValuePair<string, string>>>();
+            var data = new Dictionary<Guid, List<ProtoCore.CallSite.RawTraceData>>();
 
             Assert.Throws<ArgumentNullException>(() =>
             {
@@ -340,22 +340,22 @@ namespace Dynamo.Tests
             var nodeGuid0 = Guid.NewGuid();
             var nodeGuid1 = Guid.NewGuid();
 
-            var nodeData0 = new List<KeyValuePair<string, string>>();
-            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData00"));
-            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData01"));
-            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData02"));
+            var nodeData0 = new List<ProtoCore.CallSite.RawTraceData>();
+            nodeData0.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData00"));
+            nodeData0.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData01"));
+            nodeData0.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData02"));
 
-            var nodeData1 = new List<KeyValuePair<string, string>>();
-            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData10"));
-            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData11"));
-            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData12"));
+            var nodeData1 = new List<ProtoCore.CallSite.RawTraceData>();
+            nodeData0.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData10"));
+            nodeData0.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData11"));
+            nodeData0.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData12"));
 
             // Create sample data.
-            var data = new Dictionary<Guid, List<KeyValuePair<string, string>>>();
+            var data = new Dictionary<Guid, List<ProtoCore.CallSite.RawTraceData>>();
             data.Add(nodeGuid0, nodeData0);
             data.Add(nodeGuid1, nodeData1);
 
-            IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> outputs = null;
+            IEnumerable<KeyValuePair<Guid, List<ProtoCore.CallSite.RawTraceData>>> outputs = null;
 
             Assert.DoesNotThrow(() =>
             {
@@ -376,13 +376,13 @@ namespace Dynamo.Tests
             Assert.AreEqual(3, outputData0.Count);
             Assert.AreEqual(3, outputData1.Count);
 
-            Assert.AreEqual("TraceData00", outputData0[0].Value);
-            Assert.AreEqual("TraceData01", outputData0[1].Value);
-            Assert.AreEqual("TraceData02", outputData0[2].Value);
+            Assert.AreEqual("TraceData00", outputData0[0].Data);
+            Assert.AreEqual("TraceData01", outputData0[1].Data);
+            Assert.AreEqual("TraceData02", outputData0[2].Data);
 
-            Assert.AreEqual("TraceData10", outputData1[0].Value);
-            Assert.AreEqual("TraceData11", outputData1[1].Value);
-            Assert.AreEqual("TraceData12", outputData1[2].Value);
+            Assert.AreEqual("TraceData10", outputData1[0].Data);
+            Assert.AreEqual("TraceData11", outputData1[1].Data);
+            Assert.AreEqual("TraceData12", outputData1[2].Data);
         }
 
         [Test]
@@ -407,7 +407,7 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void LoadTraceDataFromXmlDocument01()
         {
-            IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> outputs = null;
+            IEnumerable<KeyValuePair<Guid, List<ProtoCore.CallSite.RawTraceData>>> outputs = null;
 
             Assert.DoesNotThrow(() =>
             {

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -346,9 +346,9 @@ namespace Dynamo.Tests
             nodeData0.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData02"));
 
             var nodeData1 = new List<ProtoCore.CallSite.RawTraceData>();
-            nodeData0.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData10"));
-            nodeData0.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData11"));
-            nodeData0.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData12"));
+            nodeData1.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData10"));
+            nodeData1.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData11"));
+            nodeData1.Add(new ProtoCore.CallSite.RawTraceData("", "TraceData12"));
 
             // Create sample data.
             var data = new Dictionary<Guid, List<ProtoCore.CallSite.RawTraceData>>();

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -300,7 +300,7 @@ namespace Dynamo.Tests
         public void SaveTraceDataToXmlDocument00()
         {
             XmlDocument document = new XmlDocument();
-            var data = new Dictionary<Guid, List<string>>();
+            var data = new Dictionary<Guid, List<KeyValuePair<string, string>>>();
 
             Assert.Throws<ArgumentNullException>(() =>
             {
@@ -340,18 +340,18 @@ namespace Dynamo.Tests
             var nodeGuid0 = Guid.NewGuid();
             var nodeGuid1 = Guid.NewGuid();
 
-            var nodeData0 = new List<string>()
-            {
-                "TraceData00", "TraceData01", "TraceData02"
-            };
+            var nodeData0 = new List<KeyValuePair<string, string>>();
+            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData00"));
+            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData01"));
+            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData02"));
 
-            var nodeData1 = new List<string>()
-            {
-                "TraceData10", "TraceData11", "TraceData12"
-            };
+            var nodeData1 = new List<KeyValuePair<string, string>>();
+            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData10"));
+            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData11"));
+            nodeData0.Add(new KeyValuePair<string, string>("", "TraceData12"));
 
             // Create sample data.
-            var data = new Dictionary<Guid, List<string>>();
+            var data = new Dictionary<Guid, List<KeyValuePair<string, string>>>();
             data.Add(nodeGuid0, nodeData0);
             data.Add(nodeGuid1, nodeData1);
 

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -355,7 +355,7 @@ namespace Dynamo.Tests
             data.Add(nodeGuid0, nodeData0);
             data.Add(nodeGuid1, nodeData1);
 
-            IEnumerable<KeyValuePair<Guid, List<string>>> outputs = null;
+            IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> outputs = null;
 
             Assert.DoesNotThrow(() =>
             {
@@ -376,13 +376,13 @@ namespace Dynamo.Tests
             Assert.AreEqual(3, outputData0.Count);
             Assert.AreEqual(3, outputData1.Count);
 
-            Assert.AreEqual("TraceData00", outputData0[0]);
-            Assert.AreEqual("TraceData01", outputData0[1]);
-            Assert.AreEqual("TraceData02", outputData0[2]);
+            Assert.AreEqual("TraceData00", outputData0[0].Value);
+            Assert.AreEqual("TraceData01", outputData0[1].Value);
+            Assert.AreEqual("TraceData02", outputData0[2].Value);
 
-            Assert.AreEqual("TraceData10", outputData1[0]);
-            Assert.AreEqual("TraceData11", outputData1[1]);
-            Assert.AreEqual("TraceData12", outputData1[2]);
+            Assert.AreEqual("TraceData10", outputData1[0].Value);
+            Assert.AreEqual("TraceData11", outputData1[1].Value);
+            Assert.AreEqual("TraceData12", outputData1[2].Value);
         }
 
         [Test]
@@ -407,7 +407,7 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void LoadTraceDataFromXmlDocument01()
         {
-            IEnumerable<KeyValuePair<Guid, List<string>>> outputs = null;
+            IEnumerable<KeyValuePair<Guid, List<KeyValuePair<string, string>>>> outputs = null;
 
             Assert.DoesNotThrow(() =>
             {


### PR DESCRIPTION
### Purpose

This PR is to fix defect MAGN-10165 that element binding doesn't work for custom node.

Element binding is to associate elements with node that *directly* generates those elements. In other word, the type of node should be `DSFunction` (function from zero touch library). If node generates some elements, when .dyn file is saved, there is a `<SessionTraceData>` which records node ID and encoded elements' information:

```xml
<SessionTraceData>
    <NodeTraceData NodeId="ccb31126-9527-45be-8ac5-ba34e46ea436">
        <CallsiteTraceData>....</CallsiteTraceData>
    </NodeTraceData>
</SessionTraceData>
```

When this .dyn is re-opened, trace data will be loaded. At runtime, when executing a node (function), instead of creating a new call site each time, same call site will be reused if this node has been executed before and associate the call site with loaded or updated trace data. The runtime maintains two dictionaries:  `CallSiteCache` dictionary maps from node's GUID combined with context information like function scope and class scope to call site instance and `CallSiteToNodeMap` maps call site to node. The latter will be used to get the associated trace data of a node.

Now, if there are two nodes which are custom node instances of a same custom node, and node `C` in this custom node creates elements:
```

    +---+
    | A | -------->  +---Custom Node X--+
    +---+            |                  |
                     |       +---+      |
    +---+            |       | C |      |
    | B | -------->  |       +---+      |    
    +---+            |                  | 
                     +------------------+
```

As we mentioned before, trace data is stored in call site instance. In this case, `A` eventually calls `C`, so the key value pair in `CallSiteCache` would be `{C_GUID + context information, call site instance for C}`, the key value pair in `CallSiteToNodeMap` would be `{call site instance for C, C_GUID }`. When `B` eventually calls `C`, same call site will be reused. So here there are two problems:
  1. Trace data stored in the call site is overwritten by the other call, because call site is re-used.
  2. Trace data is not associated with top level node like `A` and `B', but with node `C` which cannot be serialized.

For the first problem, instead of just using `C`'s GUID, we generate a long call site identifier (used in `CallSiteCache`) encodes the information of the whole function call chain (`A` -> `C` and `B` -> `C`) to ensure the uniqueness. For example, in this case the call site identifier may looks like:
```
    GUID_A + A's context information + GUID_C + C's context information
```

For the second problem, instead of saving trace data to the node that initiates function call, we use top level nodes -- in this case they are `A` and `B` -- and associate call sites with them. When .dyn file is saved, a node may have multiple `CallsiteTraceData`. This PR added an attribute `CallSiteID` to differentiate them:
```xml
<SessionTraceData>
    <NodeTraceData NodeId="GUID_A">
      <CallsiteTraceData CallSiteID="GUID_A_GUID_C">...</CallsiteTraceData>
      <CallsiteTraceData CallSiteID="GUID_A_GUID_D">...</CallsiteTraceData>
    </NodeTraceData>
   <NodeTraceData NodeId="GUID_B">
      <CallsiteTraceData CallSiteID="GUID_B_GUID_C">...</CallsiteTraceData>
    </NodeTraceData>
</SessionTraceData>
```

This solution has some downsides:
  1. Backward compatibility. Old .dyn file doesn't have `CallSiteID` attribute, in this case we use empty string as call site ID. If fails to look up call site instance with some non-empty call site ID, we'll try to use empty string to search.
  2. The size of .dyn file may be bloated, as a custom node instance node will aggregate all elements that generated internally.
  3. Trace data is stored in a flatten list, so searching `CallSiteCache` is not efficient, we probably need a more structural way to represent trace data (at runtime or in .dyn file).

Element binding test case run without regression:
![untitled](https://cloud.githubusercontent.com/assets/2600379/17997274/24d854c4-6ba0-11e6-9762-3b5952e71dc4.png)

Related Revit regression test case: https://github.com/DynamoDS/DynamoRevit/pull/1223

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers
@sharadkjaiswal 
