### PR TITLE
Not to trace binding details for ShowUseLevelMenu

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -217,7 +217,7 @@
                     x:Name="MyPopup"
                     Placement="Right"
                     AllowsTransparency="True"
-                    IsOpen="{Binding Path=ShowUseLevelMenu,diag:PresentationTraceSources.TraceLevel=High}"
+                    IsOpen="{Binding Path=ShowUseLevelMenu}"
                     StaysOpen="False">
                     <Grid Background="Transparent">
                         <Grid.Resources>


### PR DESCRIPTION
### Purpose

Previously I set `PresentationTraceSources.TraceLevel` to `High` to debug binding `ShowUseLevelMenu`, so tons of binding information is printed out during debugging:
```
System.Windows.Data Warning: 60 : BindingExpression (hash=9253841): Default mode resolved to TwoWay
System.Windows.Data Warning: 61 : BindingExpression (hash=9253841): Default update trigger resolved to PropertyChanged
System.Windows.Data Warning: 62 : BindingExpression (hash=9253841): Attach to Dynamo.UI.Controls.UseLevelPopup.IsOpen (hash=43863175)
System.Windows.Data Warning: 67 : BindingExpression (hash=9253841): Resolving source 
System.Windows.Data Warning: 70 : BindingExpression (hash=9253841): Found data context element: UseLevelPopup (hash=43863175) (OK)
System.Windows.Data Warning: 78 : BindingExpression (hash=9253841): Activate with root item PortViewModel (hash=7534692)
System.Windows.Data Warning: 107 : BindingExpression (hash=9253841):   At level 0 using cached accessor for PortViewModel.ShowUseLevelMenu: RuntimePropertyInfo(ShowUseLevelMenu)
System.Windows.Data Warning: 104 : BindingExpression (hash=9253841): Replace item at level 0 with PortViewModel (hash=7534692), using accessor RuntimePropertyInfo(ShowUseLevelMenu)
System.Windows.Data Warning: 101 : BindingExpression (hash=9253841): GetValue at level 0 from PortViewModel (hash=7534692) using RuntimePropertyInfo(ShowUseLevelMenu): 'False'
```
Remove this setting from xaml file.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### FYIs

@ikeough 

