### PR TITLE
Show Preview Bubble check CleanUp

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -1760,15 +1760,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hide Preview Bubbles.
-        /// </summary>
-        public static string DynamoViewSettingsMenuHidePreviewBubbles {
-            get {
-                return ResourceManager.GetString("DynamoViewSettingsMenuHidePreviewBubbles", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Show Edges.
         /// </summary>
         public static string DynamoViewSettingsMenuShowEdges {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1739,10 +1739,6 @@ Do you want to install the latest Dynamo update?</value>
   <data name="DynamoViewSettingsMenuShowEdges" xml:space="preserve">
     <value>Show Edges</value>
   </data>
-  <data name="DynamoViewSettingsMenuHidePreviewBubbles" xml:space="preserve">
-    <value>Hide Preview Bubbles</value>
-    <comment>Settings menu | Hide preview bubbles</comment>
-  </data>
   <data name="DynamoViewSettingsMenuShowPreviewBubbles" xml:space="preserve">
     <value>Show Preview Bubbles</value>
     <comment>Settings menu | Show preview bubbles</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1744,10 +1744,6 @@ Do you want to install the latest Dynamo update?</value>
   <data name="DynamoViewSettingsMenuShowEdges" xml:space="preserve">
     <value>Show Edges</value>
   </data>
-  <data name="DynamoViewSettingsMenuHidePreviewBubbles" xml:space="preserve">
-    <value>Hide Preview Bubbles</value>
-    <comment>Settings menu | Hide preview bubbles</comment>
-  </data>
   <data name="DynamoViewSettingsMenuShowPreviewBubbles" xml:space="preserve">
     <value>Show Preview Bubbles</value>
     <comment>Settings menu | Show preview bubbles</comment>

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -975,25 +975,6 @@ namespace Dynamo.Controls
         #endregion
     }
 
-    public class ShowHidePreviewBubblesConverter : IValueConverter
-    {
-        #region IValueConverter Members
-
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            return (bool) value
-                ? Resources.DynamoViewSettingsMenuHidePreviewBubbles
-                : Resources.DynamoViewSettingsMenuShowPreviewBubbles;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            return (string)value == Resources.DynamoViewSettingsMenuHidePreviewBubbles;
-        }
-
-        #endregion
-    }
-
     public class ShowHideFullscreenWatchMenuItemConverter : IValueConverter
     {
         #region IValueConverter Members

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -88,7 +88,6 @@
     <controls:PathToSaveStateConverter x:Key="PathToSaveStateConverter" />
     <controls:InverseBooleanConverter x:Key="InverseBooleanConverter" />
     <controls:ShowHideConsoleMenuItemConverter x:Key="ShowHideConsoleMenuConverter" />
-    <controls:ShowHidePreviewBubblesConverter x:Key="ShowHidePreviewBubblesConverter" />
     <controls:ShowHideFullscreenWatchMenuItemConverter x:Key="ShowHideFullscreenWatchMenuConverter" />
     <controls:PackageSearchStateToStringConverter x:Key="PackageSearchStateToStringConverter" />
     <controls:EmptyStringToCollapsedConverter x:Key="EmptyStringToCollapsedConverter" />

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1912,15 +1912,6 @@ namespace Dynamo.ViewModels
             return true;
         }
 
-        /// <summary>
-        /// Toggles Showing Preview Bubbles globally
-        /// </summary>
-        /// <param name="parameter">Command parameter</param>
-        public void TogglePreviewBubblesShowing(object parameter)
-        {
-            ShowPreviewBubbles = !ShowPreviewBubbles;
-        }
-
         public void SelectNeighbors(object parameters)
         {
             List<ISelectable> sels = DynamoSelection.Instance.Selection.ToList<ISelectable>();

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -48,7 +48,6 @@ namespace Dynamo.ViewModels
             CopyCommand = new DelegateCommand(_ => model.Copy(), CanCopy);
             PasteCommand = new DelegateCommand(Paste, CanPaste);
             ToggleConsoleShowingCommand = new DelegateCommand(ToggleConsoleShowing, CanToggleConsoleShowing);
-            TogglePreviewBubblesShowingCommand = new DelegateCommand(TogglePreviewBubblesShowing);
             ForceRunExpressionCommand = new DelegateCommand(ForceRunExprCmd, RunSettingsViewModel.CanRunExpression);
             MutateTestDelegateCommand = new DelegateCommand(MutateTestCmd, RunSettingsViewModel.CanRunExpression);
             DisplayFunctionCommand = new DelegateCommand(DisplayFunction, CanDisplayFunction);
@@ -123,7 +122,6 @@ namespace Dynamo.ViewModels
         public DelegateCommand SaveImageCommand { get; set; }
         public DelegateCommand ShowSaveImageDialogAndSaveResultCommand { get; set; }
         public DelegateCommand ToggleConsoleShowingCommand { get; set; }
-        public DelegateCommand TogglePreviewBubblesShowingCommand { get; set; }
         public DelegateCommand ShowPackageManagerCommand { get; set; }
         public DelegateCommand ForceRunExpressionCommand { get; set; }
         public DelegateCommand MutateTestDelegateCommand { get; set; }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -702,9 +702,11 @@
                                   IsCheckable="True"
                                   IsChecked="{Binding Path=RenderPackageFactoryViewModel.ShowEdges, Mode=TwoWay}"
                                   Header="{x:Static p:Resources.DynamoViewSettingsMenuShowEdges}"></MenuItem>
-                        <MenuItem Header="{Binding Path=ShowPreviewBubbles, Converter={StaticResource ShowHidePreviewBubblesConverter}}"
-                                  Command="{Binding TogglePreviewBubblesShowingCommand}"/>
-                        <MenuItem Focusable="False"
+                  <MenuItem Focusable="False"
+                                  IsCheckable="True"
+                                  IsChecked="{Binding ShowPreviewBubbles, Mode=TwoWay}"
+                                  Header="{x:Static p:Resources.DynamoViewSettingsMenuShowPreviewBubbles}"/>
+                  <MenuItem Focusable="False"
                                   Header="{x:Static p:Resources.DynamoViewSettingMenuManagePackagePath}"
                                   Command="{Binding ManagePackagePathsCommand}"
                                   Name="managePackagePaths" />

--- a/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
+++ b/test/DynamoCoreWpfTests/PreviewBubbleTests.cs
@@ -336,7 +336,7 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(nodeView.PreviewControl.IsHidden, "Preview bubble is not hidden");
 
             // turn off preview bubbles
-            ViewModel.TogglePreviewBubblesShowingCommand.Execute(null);
+            ViewModel.ShowPreviewBubbles = false;
             Assert.IsFalse(ViewModel.ShowPreviewBubbles, "Preview bubbles have not been turned off");
 
             RaiseMouseEnterOnNode(nodeView);


### PR DESCRIPTION
### Purpose

[MAGN-10477](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10477) "Show Preview Bubble" check mark is missing in the settings menu, after opted for it (Show/HIde inconsistent with Show Edges)

This PR cleans up code related to show preview bubble selection under Settings menu, so show preview bubble selection has the same behavior like "Show Edges" or "Enable T-Spline Nodes" which utilize the check mark instead of display different content on selection. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

**Old UI**:
Show Preview Bubble State
![image](https://cloud.githubusercontent.com/assets/3942418/18006914/e49ea2ee-6b6f-11e6-8b6d-426957b9670a.png)

Hide Preview Bubble State
![image](https://cloud.githubusercontent.com/assets/3942418/18006872/b9297864-6b6f-11e6-9eb2-19f2d668f192.png)

**New UI**:
Show Preview Bubble State
![image](https://cloud.githubusercontent.com/assets/3942418/18006790/68aa06a6-6b6f-11e6-8a44-ba752e56f6b3.png)

Hide Preview Bubble State
![image](https://cloud.githubusercontent.com/assets/3942418/18006812/857e0d7c-6b6f-11e6-9fbb-08cc10535839.png)

### Reviewers

@ramramps @Racel 

### FYIs

@mjkkirschner @saintentropy 

