### PR TITLE
Magn 10605: Graphs with large vertex counts consume processor when program is idle

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -892,6 +892,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             UpdateSceneItems();
             RaisePropertyChanged("SceneItems");
             OnRequestViewRefresh();
+            //Call update to the clipping plane after the scene items are updated
             UpdateNearClipPlane();
         }
    

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1793,6 +1793,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         internal void UpdateNearClipPlane()
         {
+
+            if (camera == null) return;
+
             var near = camera.NearPlaneDistance;
             var far = camera.FarPlaneDistance;
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -677,11 +677,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         public override void GenerateViewGeometryFromRenderPackagesAndRequestUpdate(IEnumerable<IRenderPackage> taskPackages)
         {
-            foreach (var p in taskPackages)
+            /*foreach (var p in taskPackages)
             {
                 Debug.WriteLine(string.Format("Processing render packages for {0}", p.Description));
             }
-
+            */
             recentlyAddedNodes.Clear();
 
 #if DEBUG

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -892,6 +892,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             UpdateSceneItems();
             RaisePropertyChanged("SceneItems");
             OnRequestViewRefresh();
+            UpdateNearClipPlane();
         }
    
         private KeyValuePair<string, Model3D>[] FindAllGeometryModel3DsForNode(NodeModel node)

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -90,6 +90,7 @@ namespace Dynamo.Controls
             watch_view.MouseUp += (sender, args) =>
             {
                 ViewModel.OnViewMouseUp(sender, args);
+                //Call update on completion of user manipulation of the scene
                 ViewModel.UpdateNearClipPlane();
             };
 
@@ -218,6 +219,8 @@ namespace Dynamo.Controls
 
         private void CompositionTargetRenderingHandler(object sender, EventArgs e)
         {
+            //Do not call the clip plane update on the render loop if the camera is unchanged or
+            //the user is manipulating the view with mouse 
             if (!View.Camera.Position.Equals(prevCamera) && !View.IsMouseCaptured )
             {
                 ViewModel.UpdateNearClipPlane();

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -224,9 +224,9 @@ namespace Dynamo.Controls
             if (!View.Camera.Position.Equals(prevCamera) && !View.IsMouseCaptured )
             {
                 ViewModel.UpdateNearClipPlane();
-                ViewModel.ComputeFrameUpdate();   
             }
-            prevCamera = watch_view.Camera.Position;          
+            ViewModel.ComputeFrameUpdate();
+            prevCamera = View.Camera.Position;          
         }
 
         private void MouseButtonIgnoreHandler(object sender, MouseButtonEventArgs e)

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -25,6 +25,7 @@ namespace Dynamo.Controls
         #region private members
 
         private Point rightMousePoint;
+        private Point3D prevCamera;
 
         #endregion
 
@@ -89,6 +90,7 @@ namespace Dynamo.Controls
             watch_view.MouseUp += (sender, args) =>
             {
                 ViewModel.OnViewMouseUp(sender, args);
+                ViewModel.UpdateNearClipPlane();
             };
 
             watch_view.MouseMove += (sender, args) =>
@@ -216,8 +218,12 @@ namespace Dynamo.Controls
 
         private void CompositionTargetRenderingHandler(object sender, EventArgs e)
         {
-            ViewModel.UpdateNearClipPlane();
-            ViewModel.ComputeFrameUpdate();
+            if (!View.Camera.Position.Equals(prevCamera) && !View.IsMouseCaptured )
+            {
+                ViewModel.UpdateNearClipPlane();
+                ViewModel.ComputeFrameUpdate();   
+            }
+            prevCamera = watch_view.Camera.Position;          
         }
 
         private void MouseButtonIgnoreHandler(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
### Purpose

This PR address some performance issues related the clip plane distance algorithm.  The algorithm runs to ensure the clip plane distance correctly encapsulate the 3D scene.  This method was previously called on the render loop for the background preview and would cause some performance and memory degradation for models with high vertex counts.  This PR introduces some conditions to only call the method when the scene camera changes or when scene elements are updated.  The method is also only called when user interaction such as orbiting is completed to facilitate smoother visualization for models with large vertex counts.

[http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10605](url) 

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@kronz @ramramps @jnealb 