### PR TITLE
API backward compatibility Fix

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -975,6 +975,29 @@ namespace Dynamo.Controls
         #endregion
     }
 
+    /// <summary>
+    /// Obsolete class of ShowHidePreviewBubblesConverter
+    /// Using of this class will produce compile warnings
+    /// TODO: To be removed in Dynamo 2.0
+    /// </summary>
+    [System.Obsolete("This class is obsolete, string converter for Preview Bubble Display Option only returns single value now. ")]
+    public class ShowHidePreviewBubblesConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return Resources.DynamoViewSettingsMenuShowPreviewBubbles;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (string)value == Resources.DynamoViewSettingsMenuShowPreviewBubbles;
+        }
+
+        #endregion
+    }
+
     public class ShowHideFullscreenWatchMenuItemConverter : IValueConverter
     {
         #region IValueConverter Members

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1912,6 +1912,18 @@ namespace Dynamo.ViewModels
             return true;
         }
 
+        /// <summary>
+        /// Obsolete method toggles Showing Preview Bubbles globally
+        /// Using of this class will produce compile warnings
+        /// TODO: To be removed in Dynamo 2.0
+        /// </summary>
+        /// <param name="parameter">Command parameter</param>
+        [System.Obsolete("This method is obsolete, set DynamoViewModel.ShowPreviewBubbles directly instead.")]
+        public void TogglePreviewBubblesShowing(object parameter)
+        {
+            ShowPreviewBubbles = !ShowPreviewBubbles;
+        }
+
         public void SelectNeighbors(object parameters)
         {
             List<ISelectable> sels = DynamoSelection.Instance.Selection.ToList<ISelectable>();

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -122,6 +122,9 @@ namespace Dynamo.ViewModels
         public DelegateCommand SaveImageCommand { get; set; }
         public DelegateCommand ShowSaveImageDialogAndSaveResultCommand { get; set; }
         public DelegateCommand ToggleConsoleShowingCommand { get; set; }
+        // TODO: To be removed in Dynamo 2.0
+        [System.Obsolete("This delegate command is obsolete, set DynamoViewModel.ShowPreviewBubbles directly instead.")]
+        public DelegateCommand TogglePreviewBubblesShowingCommand { get; set; }
         public DelegateCommand ShowPackageManagerCommand { get; set; }
         public DelegateCommand ForceRunExpressionCommand { get; set; }
         public DelegateCommand MutateTestDelegateCommand { get; set; }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelDelegateCommands.cs
@@ -79,8 +79,10 @@ namespace Dynamo.ViewModels
             ShowGalleryCommand = new DelegateCommand(p => OnRequestShowHideGallery(true), o => true);
             CloseGalleryCommand = new DelegateCommand(p => OnRequestShowHideGallery(false), o => true);
             ShowNewPresetsDialogCommand = new DelegateCommand(ShowNewPresetStateDialogAndMakePreset, CanShowNewPresetStateDialog);
-            NodeFromSelectionCommand = new DelegateCommand(CreateNodeFromSelection, CanCreateNodeFromSelection);            
-       }
+            NodeFromSelectionCommand = new DelegateCommand(CreateNodeFromSelection, CanCreateNodeFromSelection);
+            // TODO: To be removed in Dynamo 2.0
+            TogglePreviewBubblesShowingCommand = new DelegateCommand(TogglePreviewBubblesShowing);
+        }
         public DelegateCommand OpenIfSavedCommand { get; set; }
         public DelegateCommand OpenCommand { get; set; }
         public DelegateCommand ShowOpenDialogAndOpenResultCommand { get; set; }


### PR DESCRIPTION
### Purpose

[MAGN-10610](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10610) Fix API BC issue related to "Show Preview Bubble" PR . I deleted some public class or method is the earlier PR https://github.com/DynamoDS/Dynamo/pull/7086 which will break API backward compatibility, this PR adds them back but mark them obsolete.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@mjkkirschner 

### FYIs

@ramramps @saintentropy @sm6srw 

