### PR TITLE
Fix Escape Character Edge Case Issues in CodeBlockNode(#7044)

### DIFF
--- a/src/Engine/ProtoCore/BuildStatus.cs
+++ b/src/Engine/ProtoCore/BuildStatus.cs
@@ -463,6 +463,8 @@ namespace ProtoCore
                     return Properties.Resources.in_expected;
                 case  "??? expected":
                     return Properties.Resources.triquestionmark_expected;
+                case "';' is expected":
+                    return Properties.Resources.SemiColonExpected;
                 case  "invalid Hydrogen":
                     return Properties.Resources.invalid_Hydrogen;
                 case   "this symbol not expected in Import_Statement":

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -99,7 +99,7 @@ public Node root { get; set; }
     private int stmtsParsed = 0;
 
 
-    private static string GetEscapedString(string s)
+    private string GetEscapedString(string s)
     {
         System.Text.StringBuilder sb = new System.Text.StringBuilder();
 
@@ -147,6 +147,9 @@ public Node root { get; set; }
                         break;
                 }
             }
+			else if (s[i] == '\\' && i == s.Length - 1) {
+                 SynErr(Resources.EOF_expected);
+                }
             else
             {
                 sb.Append(s[i]);

--- a/src/Engine/ProtoCore/Parser/atg/Start.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Start.atg
@@ -24,7 +24,7 @@ COMPILER DesignScriptParser
     private int stmtsParsed = 0;
 
 
-    private static string GetEscapedString(string s)
+    private string GetEscapedString(string s)
     {
         System.Text.StringBuilder sb = new System.Text.StringBuilder();
 
@@ -72,6 +72,9 @@ COMPILER DesignScriptParser
                         break;
                 }
             }
+			else if (s[i] == '\\' && i == s.Length - 1) {
+                 SynErr(Resources.EOF_expected);
+                }
             else
             {
                 sb.Append(s[i]);


### PR DESCRIPTION
### Purpose

Addressing Github Issue #7044, this PR is meant to provide a fix for the weird behavior exhibited by the escape character `\`.

Previously, in several edge cases as demonstrated in the following screenshot, the escape character does not exhibit the correct behavior:

![escapesequenceerr](https://cloud.githubusercontent.com/assets/16283396/18079930/c53a5246-6ec5-11e6-9d84-8349cb4a5b46.PNG)

This meant that there were 3 previously unresolved problems:

1. There was no `SemiColonExpected` error which could be thrown. This resulted in this class of errors simply throwing `Error: error`.
2. In the scenario where there was an escape character before a close-inverted comma, `\"`, the escape character did not escape the close inverted comma.
3. In the scenario where there were two or more lines in the CodeBlockNode, the double escape character sequence before the close inverted comma `\\"` would result in an error.

Previously, a fix was made which addressed all 3 problems, but caused Revit to crash (#7068). As such, changes to the code was made and now this fix addresses 2 parts of the issue:

1. Throwing the appropriate `SemiColonExpected` error when a relevant issue arises.
2. Throwing the appropriate `EOF Expected` error when the escape character escapes the close inverted comma.
3. The last problem could not be solved despite multiple attempts to address the issue through Coco/R's EBNF parser. 

As such, the current state of string parsing is shown here:

![backslashissue](https://cloud.githubusercontent.com/assets/16283396/18080097/832cfb8c-6ec6-11e6-85ab-612d462df8a9.PNG)

![backslashissue2](https://cloud.githubusercontent.com/assets/16283396/18080136/b507df82-6ec6-11e6-9484-313d2c15fad5.PNG)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 

### FYIs

