### PR TITLE
DNM: deleting render packages before calculating new ones creates flicker

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2098,15 +2098,15 @@ namespace Dynamo.Graph.Nodes
         private void OnRenderPackageUpdateCompleted(AsyncTask asyncTask)
         {
             var task = asyncTask as UpdateRenderPackageAsyncTask;
+            var packages = new List<IRenderPackage>();
             if (task.RenderPackages.Any())
             {
-                var packages = new List<IRenderPackage>();
-
                 packages.AddRange(task.RenderPackages);
                 packages.AddRange(OnRequestRenderPackages());
 
-                OnRenderPackagesUpdated(packages);
             }
+            OnRenderPackagesUpdated(packages);
+
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -559,7 +559,14 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         protected virtual void OnRenderPackagesUpdated(NodeModel node, IEnumerable<IRenderPackage> packages)
         {
-            AddGeometryForRenderPackages(packages);
+            if (!packages.Any())
+            {
+                RemoveGeometryForNode(node);
+            }
+            else
+            {
+                AddGeometryForRenderPackages(packages);
+            }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -648,7 +648,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             {
                 case "CachedValue":
                     Debug.WriteLine(string.Format("Requesting render packages for {0}", node.GUID));
-                    RemoveGeometryForNode(node);
                     node.RequestVisualUpdateAsync(scheduler, engineManager.EngineController, renderPackageFactory);
                     break;
 
@@ -760,6 +759,13 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var geometryModels = FindAllGeometryModel3DsForNode(identifier);
             DeleteGeometries(geometryModels, requestUpdate); 
         }
+
+        protected override void OnRenderPackagesUpdated(NodeModel node, IEnumerable<IRenderPackage> packages)
+        {
+            RemoveGeometryForNode(node);
+            base.OnRenderPackagesUpdated(node,packages);
+        }
+
 
         protected override void OnModelPropertyChanged(object sender, PropertyChangedEventArgs e)
         {


### PR DESCRIPTION
### Purpose

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10541

On Run Periodic there is a flash/flicker when geometry is updated.

This PR moves the request for removal of old render packages from nodes from the `cachedValue` property change event to the `OnRenderPackagesUpdated` event raised on the completion of the `UpdateRenderPackageAsyncTask `.

The reasoning is that we should have already calculated the new render packages before removing the old ones as the UI thread is doing the removal and the Scheduler thread is calculating render packages, these will be out of sync causing a flicker as the render packages are added sometime after the old ones are removed, by waiting until the new packages are calculated - removing all packages, and then adding the newly updated packages back there is no flicker.

note: I still need to run the tests on self serve CI, but have manually verified this working with run periodic and code block assignment redefinition issue. (9434).

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 
@aparajit-pratap 

### FYIs

@tatlin 