### PR TITLE
Fix sequence of disposing and deleting gizmos

### DIFF
--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -474,8 +474,9 @@ namespace Dynamo.Manipulation
             var gizmos = GetGizmos(false);
             foreach (var item in gizmos)
             {
-                BackgroundPreviewViewModel.DeleteGeometryForIdentifier(item.Name);
+                // Unsubscribe gizmos from camera-change events before updating the scene
                 item.Dispose();
+                BackgroundPreviewViewModel.DeleteGeometryForIdentifier(item.Name);
             }
         }
 


### PR DESCRIPTION
### Purpose

This fixes the crash [MAGN-10619] (https://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10619) that was a result of the change made in #7087. As described by @jnealb the crash is reproduced when a `Point.ByCoordinates` node is selected, its gizmo displays and in the background preview, the user clicks (mouse down) on the point itself (not on the gizmo). 

### Analysis

The following is the sequence of events leading to the crash:
1. Selecting the point in the geometry preview fires a mouse down event in the view that is also handled by `HandleViewClick` in `HelixWatch3DViewModel`.
2. `HandleViewClick` basically does hit testing and returns the geometry that has been selected in the geometry view (in this case the point) and in addition returns the corresponding node for that point.
3. It then clears the collection of all selected nodes in the workspace before selecting just that one node for the point. The `SelectionCollectionChanged` event is handled by the `DynamoManipulationExtension` class to update the deletion and creation of manipulators and deletion and drawing of their gizmo geometries respectively. This implementation basically serves the purpose of making the gizmo appear on point selection.
4. Therefore when the selection collection is cleared that ends up in a call to `UpdateManipulators` which first deletes any existing manipulators before creating new ones.
5. When the manipulator is disposed, its `Origin` is disposed first before its gizmo.
6. Next the gizmo geometry is disposed before the gizmo itself is disposed.
7. However the deletion of the gizmo geometry results in a call to `DeleteGeometries` in `HelixWatch3DViewModel` that in turn calls `OnSceneItemsChanged` and finally `UpdateNearClipPlane`. This is where this chain of calls ties into #7087.
8. Now `UpdateNearClipPlane` updates the near and far clipping plane distances for the view camera AND camera changed events are also subscribed to by the `OnViewCameraChanged` method of the `Gizmo` .
9. `OnViewCameraChanged` method of the gizmo basically redraws it. Why? Because we redraw the gizmo for all camera-change events so that they are always at the same distance from the camera so as to be zoom-invariant. 
10. In the `Redraw` method we try to access the `Origin` property of the manipulator that has already been disposed in step 5 and therefore the CRASH. 

### Resolution

The solution for this is simply to unsubscribe the gizmo from camera-change events (i.e. dispose it) before deleting its geometry in step 6. Therefore the sequence of deletion of gizmo geometry vs. disposing the gizmo has been switched.

### Declarations

- [X] The code base is in a better state after this PR


### Reviewers

@sharadkjaiswal  
@saintentropy 
@QilongTang 
@ramramps 

### FYIs

@jnealb 
@kronz 

