### PR TITLE
Update MAGN-10605

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -892,8 +892,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             UpdateSceneItems();
             RaisePropertyChanged("SceneItems");
             OnRequestViewRefresh();
-            //Call update to the clipping plane after the scene items are updated
-            UpdateNearClipPlane();
         }
    
         private KeyValuePair<string, Model3D>[] FindAllGeometryModel3DsForNode(NodeModel node)

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -223,7 +223,7 @@ namespace Dynamo.Controls
         private void CompositionTargetRenderingHandler(object sender, EventArgs e)
         {
             //Do not call the clip plane update on the render loop if the camera is unchanged or
-            //the user is manipulating the view with mouse.  Do run when queued from by runUpdateClipPlane bool 
+            //the user is manipulating the view with mouse.  Do run when queued by runUpdateClipPlane bool 
             if (runUpdateClipPlane || (!View.Camera.Position.Equals(prevCamera) && !View.IsMouseCaptured) )
             {
                 ViewModel.UpdateNearClipPlane();


### PR DESCRIPTION
### Purpose

This PR modifies the original [(PR 7087)] (https://github.com/DynamoDS/Dynamo/pull/7087) for MAGN-10605 where graphs with large vertex counts consume processor when program is idle.  PR 7087 introduced a crash with its interaction with the gizmo feature.  [PR 7103](https://github.com/DynamoDS/Dynamo/pull/7103) resolves this specific crash issue with a fix to the gizmo code logic.  

This crash however exposed some flaws with how the original PR interacted with the Helix rendering pipeline.  This PR moves all the calls to UpdateNearClipPlane() back to the CompositionTarget.Rendering event rather then triggering them directly by adding some queuing logic.  Since this code matches Dynamo 1.1 code more closely this change should limit additional regressions.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ramramps 
@mjkkirschner 
@QilongTang 

### FYIs

@kronz @aparajit-pratap 