### PR TITLE
Display Dynamo Revit Version alongside with Dynamo Core Version in DynamoRevit

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -198,9 +198,14 @@ namespace Dynamo.Models
             get { return UpdateManager.ProductVersion.ToString(); }
         }
 
-        public string DynamoRevitVersion
+        public string HostVersion
         {
-            get { return UpdateManager.DynamoRevitVersion == null ? null : UpdateManager.DynamoRevitVersion.ToString(); }
+            get { return UpdateManager.HostVersion == null ? null : UpdateManager.HostVersion.ToString(); }
+        }
+
+        public string HostName
+        {
+            get { return UpdateManager.HostName == null ? null : UpdateManager.HostName; }
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -198,20 +198,38 @@ namespace Dynamo.Models
             get { return UpdateManager.ProductVersion.ToString(); }
         }
 
+        /// <summary>
+        /// Current Version of the Host (i.e. DynamoRevit/DynamoStudio)
+        /// </summary>
         public string HostVersion
         {
-            get { return UpdateManager.HostVersion == null ? null : UpdateManager.HostVersion.ToString(); }
+            get {
+                if (HostUpdateManager == null) { return null; }
+                else { return HostUpdateManager.HostVersion == null ? null : HostUpdateManager.HostVersion.ToString(); }
+            }
         }
 
+        /// <summary>
+        /// Name of the Host (i.e. DynamoRevit/DynamoStudio)
+        /// </summary>
         public string HostName
         {
-            get { return UpdateManager.HostName == null ? null : UpdateManager.HostName; }
+            get
+            {
+                if (HostUpdateManager == null) { return null; }
+                else { return HostUpdateManager.HostName == null ? null : HostUpdateManager.HostName; }
+            }
         }
 
         /// <summary>
         /// UpdateManager to handle automatic upgrade to higher version.
         /// </summary>
         public IUpdateManager UpdateManager { get; private set; }
+
+        /// <summary>
+        /// HostUpdateManager to keep track of the latest host version (i.e. DynamoRevit/DynamoStudio)
+        /// </summary>
+        public IHostUpdateManager HostUpdateManager { get; private set; }
 
         /// <summary>
         ///     The path manager that configures path information required for
@@ -624,6 +642,7 @@ namespace Dynamo.Models
             AuthenticationManager = new AuthenticationManager(config.AuthProvider);
 
             UpdateManager = config.UpdateManager ?? new DefaultUpdateManager(null);
+            HostUpdateManager = (IHostUpdateManager) config.UpdateManager ?? new DefaultUpdateManager(null);
             UpdateManager.Log += UpdateManager_Log;
             if (!IsTestMode && !IsHeadless)
             {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -628,9 +628,18 @@ namespace Dynamo.Models
             // config.UpdateManager has to be cast to IHostUpdateManager in order to extract the HostVersion and HostName
             // see IHostUpdateManager summary for more details 
             var hostUpdateManager = (IHostUpdateManager) config.UpdateManager;
-            HostName = hostUpdateManager == null ? string.Empty : hostUpdateManager.HostName; 
-            HostVersion = hostUpdateManager == null ? null : hostUpdateManager.HostVersion == null ? null : hostUpdateManager.HostVersion.ToString();
 
+            if (hostUpdateManager != null)
+            {
+                HostName = hostUpdateManager.HostName;
+                HostVersion = hostUpdateManager.HostVersion == null ? null : hostUpdateManager.HostVersion.ToString();
+            }
+            else
+            {
+                HostName = string.Empty;
+                HostVersion = null;
+            }
+            
             UpdateManager.Log += UpdateManager_Log;
             if (!IsTestMode && !IsHeadless)
             {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -200,7 +200,7 @@ namespace Dynamo.Models
 
         public string DynamoRevitVersion
         {
-            get { return UpdateManager.DynamoRevitVersion.ToString(); }
+            get { return UpdateManager.DynamoRevitVersion == null ? null : UpdateManager.DynamoRevitVersion.ToString(); }
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -198,6 +198,11 @@ namespace Dynamo.Models
             get { return UpdateManager.ProductVersion.ToString(); }
         }
 
+        public string DynamoRevitVersion
+        {
+            get { return UpdateManager.DynamoRevitVersion.ToString(); }
+        }
+
         /// <summary>
         /// UpdateManager to handle automatic upgrade to higher version.
         /// </summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -228,6 +228,9 @@ namespace Dynamo.Models
 
         /// <summary>
         /// HostUpdateManager to keep track of the latest host version (i.e. DynamoRevit/DynamoStudio)
+        /// This additional Interface is created to ensure backward compatibility when Host versions are older than Core versions
+        /// This Interface contains two getter/setter methods to update the Host Version and Name
+        /// This Interface should be removed and merged with UpdateManager in 2.0
         /// </summary>
         public IHostUpdateManager HostUpdateManager { get; private set; }
 
@@ -642,6 +645,9 @@ namespace Dynamo.Models
             AuthenticationManager = new AuthenticationManager(config.AuthProvider);
 
             UpdateManager = config.UpdateManager ?? new DefaultUpdateManager(null);
+
+            // config.UpdateManager has to be cast to IHostUpdateManager in order to extract the HostVersion and HostName
+            // see IHostUpdateManager summary for more details 
             HostUpdateManager = (IHostUpdateManager) config.UpdateManager ?? new DefaultUpdateManager(null);
             UpdateManager.Log += UpdateManager_Log;
             if (!IsTestMode && !IsHeadless)

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -201,38 +201,17 @@ namespace Dynamo.Models
         /// <summary>
         /// Current Version of the Host (i.e. DynamoRevit/DynamoStudio)
         /// </summary>
-        public string HostVersion
-        {
-            get {
-                if (HostUpdateManager == null) { return null; }
-                else { return HostUpdateManager.HostVersion == null ? null : HostUpdateManager.HostVersion.ToString(); }
-            }
-        }
+        public string HostVersion { get; set; }
 
         /// <summary>
         /// Name of the Host (i.e. DynamoRevit/DynamoStudio)
         /// </summary>
-        public string HostName
-        {
-            get
-            {
-                if (HostUpdateManager == null) { return null; }
-                else { return HostUpdateManager.HostName == null ? null : HostUpdateManager.HostName; }
-            }
-        }
+        public string HostName { get; set; }
 
         /// <summary>
         /// UpdateManager to handle automatic upgrade to higher version.
         /// </summary>
         public IUpdateManager UpdateManager { get; private set; }
-
-        /// <summary>
-        /// HostUpdateManager to keep track of the latest host version (i.e. DynamoRevit/DynamoStudio)
-        /// This additional Interface is created to ensure backward compatibility when Host versions are older than Core versions
-        /// This Interface contains two getter/setter methods to update the Host Version and Name
-        /// This Interface should be removed and merged with UpdateManager in 2.0
-        /// </summary>
-        public IHostUpdateManager HostUpdateManager { get; private set; }
 
         /// <summary>
         ///     The path manager that configures path information required for
@@ -648,7 +627,10 @@ namespace Dynamo.Models
 
             // config.UpdateManager has to be cast to IHostUpdateManager in order to extract the HostVersion and HostName
             // see IHostUpdateManager summary for more details 
-            HostUpdateManager = (IHostUpdateManager) config.UpdateManager ?? new DefaultUpdateManager(null);
+            var hostUpdateManager = (IHostUpdateManager) config.UpdateManager;
+            HostName = hostUpdateManager == null ? string.Empty : hostUpdateManager.HostName; 
+            HostVersion = hostUpdateManager == null ? null : hostUpdateManager.HostVersion == null ? null : hostUpdateManager.HostVersion.ToString();
+
             UpdateManager.Log += UpdateManager_Log;
             if (!IsTestMode && !IsHeadless)
             {

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -78,10 +78,6 @@ namespace Dynamo.Updates
         /// </summary>
         BinaryVersion AvailableVersion { get; }
 
-        Version HostVersion { get; set; }
-
-        String HostName { get; set; }
-
         /// <summary>
         /// Returns information, where version can be updated.
         /// </summary>
@@ -158,6 +154,19 @@ namespace Dynamo.Updates
         /// </summary>
         /// <param name="id">int</param>
         void RegisterExternalApplicationProcessId(int id);
+    }
+
+    public interface IHostUpdateManager
+    {
+        /// <summary>
+        /// Get the current version of the Host
+        /// </summary>
+        Version HostVersion { get; set; }
+
+        /// <summary>
+        /// Get the current name of the Host
+        /// </summary>
+        String HostName { get; set; }
     }
 
     /// <summary>
@@ -548,7 +557,7 @@ namespace Dynamo.Updates
     /// <summary>
     /// This class provides services for product update management.
     /// </summary>
-    internal sealed class UpdateManager : NotificationObject, IUpdateManager
+    internal sealed class UpdateManager : NotificationObject, IUpdateManager, IHostUpdateManager
     {
         #region Private Class Data Members
 

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -157,8 +157,10 @@ namespace Dynamo.Updates
     }
 
     /// <summary>
-    /// Additional Interface to ensure backward compatibility for 1.x Host Versions which may be older than the Core version
-    /// Interface should be merged with IUpdateManager in 2.0
+    /// HostUpdateManager to keep track of the latest host version (i.e. DynamoRevit/DynamoStudio)
+    /// This additional Interface is created to ensure backward compatibility when Host versions are older than Core versions
+    /// This Interface contains two getter/setter methods to update the Host Version and Name
+    /// This Interface should be removed and merged with UpdateManager in 2.0
     /// </summary>
     public interface IHostUpdateManager
     {
@@ -758,6 +760,8 @@ namespace Dynamo.Updates
         {
             this.configuration = configuration;
             PropertyChanged += UpdateManager_PropertyChanged;
+            HostVersion = null;
+            HostName = string.Empty;
         }
 
         void UpdateManager_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -619,25 +619,19 @@ namespace Dynamo.Updates
         public string HostName { get; set; }
 
         /// <summary>
-        /// CoreHostVersionComparison is a method which compares the current Dynamo Core Version and the HostVersion 
-        /// (DynamoRevit/DynamoStudio etc.)
-        /// It then returns the BinaryVersion of whichever Version is earlier. 
+        /// BaseVersion is a method which compares the current Dynamo Core Version and the HostVersion
+        /// (DynamoRevit/DynamoStudio etc.) and returns the earlier (lower) Version.
         /// This allows subsequent methods to do a single check and if there is an updated version (to either Core/Host
         /// versions), the subsequent methods will poll the server for an update.
         /// </summary>
-        private BinaryVersion CoreHostVersionComparison()
+        private BinaryVersion BaseVersion()
         {
+            if (HostVersion == null) return ProductVersion;
 
-            var binaryHostVersion = HostVersion == null ? BinaryVersion.FromString("0.0.0.0") : BinaryVersion.FromString(HostVersion.ToString());
+            var binaryHostVersion = BinaryVersion.FromString(HostVersion.ToString());
 
-            if (ProductVersion < binaryHostVersion)
-            {
-                return ProductVersion;
-            }
-            else
-            {
-                return binaryHostVersion != BinaryVersion.FromString("0.0.0.0") ? binaryHostVersion : ProductVersion; 
-            }
+            if (ProductVersion < binaryHostVersion) return ProductVersion;
+            else return binaryHostVersion;
         }
 
         /// <summary>
@@ -651,7 +645,7 @@ namespace Dynamo.Updates
                 // This causes the UI to display the update button only after the download has
                 // completed.
                 return downloadedUpdateInfo == null
-                    ? CoreHostVersionComparison() : updateInfo.Version;
+                    ? BaseVersion() : updateInfo.Version;
             }
         }
 
@@ -708,7 +702,7 @@ namespace Dynamo.Updates
                 if (DownloadedUpdateInfo == null)
                     return false;
 
-                return ForceUpdate || AvailableVersion > CoreHostVersionComparison();
+                return ForceUpdate || AvailableVersion > BaseVersion();
             }
         }
 
@@ -890,7 +884,7 @@ namespace Dynamo.Updates
             {
                 if (useStable) //Check stables
                 {
-                    if (latestBuildVersion > CoreHostVersionComparison())
+                    if (latestBuildVersion > BaseVersion())
                     {
                         SetUpdateInfo(latestBuildVersion, latestBuildDownloadUrl, latestBuildSignatureUrl);
                     }

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -621,13 +621,8 @@ namespace Dynamo.Updates
         /// <summary>
         /// BinaryVersion version of HostVersion
         /// </summary>
-        public BinaryVersion BinaryHostVersion
-        {
-            get
-            {
-                return HostVersion == null ? null : BinaryVersion.FromString(HostVersion.ToString());
-            }
-        }
+        private BinaryVersion BinaryHostVersion() { return HostVersion == null ? BinaryVersion.FromString("0.0.0.0") 
+                : BinaryVersion.FromString(HostVersion.ToString()); }
 
         /// <summary>
         ///     Obtains available update version string 
@@ -699,7 +694,7 @@ namespace Dynamo.Updates
 
                 // checks if a new version is available for either the Host version 
                 // even if the Core version has already been updated
-                bool HostVersionUpdate = HostVersion == null ? false : AvailableVersion > BinaryHostVersion;
+                bool HostVersionUpdate = HostVersion == null ? false : AvailableVersion > BinaryHostVersion();
 
                 return ForceUpdate || AvailableVersion > ProductVersion || HostVersionUpdate;
             }
@@ -883,7 +878,8 @@ namespace Dynamo.Updates
             {
                 if (useStable) //Check stables
                 {
-                    if (latestBuildVersion > ProductVersion || latestBuildVersion > BinaryHostVersion)
+                    if (latestBuildVersion > ProductVersion || BinaryHostVersion() != BinaryVersion.FromString("0.0.0.0") &&
+                        latestBuildVersion > BinaryHostVersion())
                     {
                         SetUpdateInfo(latestBuildVersion, latestBuildDownloadUrl, latestBuildSignatureUrl);
                     }

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -78,6 +78,8 @@ namespace Dynamo.Updates
         /// </summary>
         BinaryVersion AvailableVersion { get; }
 
+        Version DynamoRevitVersion { get; set; }
+
         /// <summary>
         /// Returns information, where version can be updated.
         /// </summary>
@@ -594,6 +596,8 @@ namespace Dynamo.Updates
 
             return productVersion;
         }
+
+        public Version DynamoRevitVersion { get; set; }
 
         /// <summary>
         ///     Obtains available update version string 

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -78,7 +78,9 @@ namespace Dynamo.Updates
         /// </summary>
         BinaryVersion AvailableVersion { get; }
 
-        Version DynamoRevitVersion { get; set; }
+        Version HostVersion { get; set; }
+
+        String HostName { get; set; }
 
         /// <summary>
         /// Returns information, where version can be updated.
@@ -597,7 +599,9 @@ namespace Dynamo.Updates
             return productVersion;
         }
 
-        public Version DynamoRevitVersion { get; set; }
+        public Version HostVersion { get; set; }
+
+        public string HostName { get; set; }
 
         /// <summary>
         ///     Obtains available update version string 

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -616,6 +616,9 @@ namespace Dynamo.Updates
 
         public string HostName { get; set; }
 
+        /// <summary>
+        /// BinaryVersion version of HostVersion
+        /// </summary>
         public BinaryVersion BinaryHostVersion
         {
             get
@@ -692,7 +695,8 @@ namespace Dynamo.Updates
                 if (DownloadedUpdateInfo == null)
                     return false;
 
-                // checks if a new version is available for either the Host or Core version.
+                // checks if a new version is available for either the Host version 
+                // even if the Core version has already been updated
                 bool HostVersionUpdate = HostVersion == null ? false : AvailableVersion > BinaryHostVersion;
 
                 return ForceUpdate || AvailableVersion > ProductVersion || HostVersionUpdate;

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -616,6 +616,14 @@ namespace Dynamo.Updates
 
         public string HostName { get; set; }
 
+        public BinaryVersion BinaryHostVersion
+        {
+            get
+            {
+                return HostVersion == null ? null : BinaryVersion.FromString(HostVersion.ToString());
+            }
+        }
+
         /// <summary>
         ///     Obtains available update version string 
         /// </summary>
@@ -681,10 +689,13 @@ namespace Dynamo.Updates
             get
             {
                 //Update is not available unitl it's downloaded
-                if(DownloadedUpdateInfo==null)
+                if (DownloadedUpdateInfo == null)
                     return false;
 
-                return ForceUpdate || AvailableVersion > ProductVersion;
+                // checks if a new version is available for either the Host or Core version.
+                bool HostVersionUpdate = HostVersion == null ? false : AvailableVersion > BinaryHostVersion;
+
+                return ForceUpdate || AvailableVersion > ProductVersion || HostVersionUpdate;
             }
         }
 
@@ -864,7 +875,7 @@ namespace Dynamo.Updates
             {
                 if (useStable) //Check stables
                 {
-                    if (latestBuildVersion > ProductVersion)
+                    if (latestBuildVersion > ProductVersion || latestBuildVersion > BinaryHostVersion)
                     {
                         SetUpdateInfo(latestBuildVersion, latestBuildDownloadUrl, latestBuildSignatureUrl);
                     }
@@ -1269,7 +1280,7 @@ namespace Dynamo.Updates
         /// update check if a newer version of the product is already installed.
         /// </summary>
         /// <param name="manager">Update manager instance using which product
-        /// update check nees to be done.</param>
+        /// update check needs to be done.</param>
         internal static void CheckForProductUpdate(IUpdateManager manager)
         {
             //If we already have higher version installed, don't look for product update.

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -156,6 +156,10 @@ namespace Dynamo.Updates
         void RegisterExternalApplicationProcessId(int id);
     }
 
+    /// <summary>
+    /// Additional Interface to ensure backward compatibility for 1.x Host Versions which may be older than the Core version
+    /// Interface should be merged with IUpdateManager in 2.0
+    /// </summary>
     public interface IHostUpdateManager
     {
         /// <summary>

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2073,6 +2073,51 @@ namespace Dynamo.Controls
         }
     }
 
+    public class NullValueToHorizontalAlignCenterConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null) return HorizontalAlignment.Center;
+            return HorizontalAlignment.Right;
+        }
+
+        public object ConvertBack(
+            object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class NullValueToGridRow1Converter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null) return 1;
+            return 2;
+        }
+
+        public object ConvertBack(
+            object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class NullValueToMarginConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null) return new Thickness(57,0,0,0);
+            return new Thickness(105,0,0,0);
+        }
+
+        public object ConvertBack(
+            object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     // Depending on the number of points in FullCategoryName margin will be done.
     // E.g. Geometry -> Margin="5,0,0,0"
     // E.g. RootCategory.Namespace1.Namespace2 -> Margin="45,0,20,0"

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2073,20 +2073,6 @@ namespace Dynamo.Controls
         }
     }
 
-    public class NullValueToHorizontalAlignCenterConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value == null) return HorizontalAlignment.Center;
-            return HorizontalAlignment.Right;
-        }
-
-        public object ConvertBack(
-            object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
 
     public class NullValueToGridRow1Converter : IValueConverter
     {
@@ -2094,21 +2080,6 @@ namespace Dynamo.Controls
         {
             if (value == null) return 1;
             return 2;
-        }
-
-        public object ConvertBack(
-            object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    public class NullValueToMarginConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value == null) return new Thickness(57,0,0,0);
-            return new Thickness(105,0,0,0);
         }
 
         public object ConvertBack(

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2073,7 +2073,10 @@ namespace Dynamo.Controls
         }
     }
 
-
+    /// <summary>
+    /// This converter was created for AboutWindow.xaml in order to accomodate the changes required
+    /// for the display for both Core/Host versions. 
+    /// </summary>
     public class NullValueToGridRow1Converter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -141,9 +141,7 @@
     <controls:IntToVisibilityConverter x:Key="IntToVisibilityConverter" />
     <controls:LibraryTreeItemsHostVisibilityConverter x:Key="LibraryTreeItemsHostVisibilityConverter" />
     <controls:NullValueToCollapsedConverter x:Key="NullValueToCollapsedConverter" />
-    <controls:NullValueToHorizontalAlignCenterConverter x:Key="NullValueToHorizontalAlignCenterConverter"/>
     <controls:NullValueToGridRow1Converter x:Key="NullValueToGridRow1Converter"/>
-    <controls:NullValueToMarginConverter x:Key="NullValueToMarginConverter"/>
     <controls:SearchHighlightMarginConverter x:Key="SearchHighlightMarginConverter" />
     <controls:InOutParamTypeConverter x:Key="InOutParamTypeConverter" />
     <controls:NodeTypeToColorConverter x:Key="NodeTypeToColorConverter"

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -141,6 +141,9 @@
     <controls:IntToVisibilityConverter x:Key="IntToVisibilityConverter" />
     <controls:LibraryTreeItemsHostVisibilityConverter x:Key="LibraryTreeItemsHostVisibilityConverter" />
     <controls:NullValueToCollapsedConverter x:Key="NullValueToCollapsedConverter" />
+    <controls:NullValueToHorizontalAlignCenterConverter x:Key="NullValueToHorizontalAlignCenterConverter"/>
+    <controls:NullValueToGridRow1Converter x:Key="NullValueToGridRow1Converter"/>
+    <controls:NullValueToMarginConverter x:Key="NullValueToMarginConverter"/>
     <controls:SearchHighlightMarginConverter x:Key="SearchHighlightMarginConverter" />
     <controls:InOutParamTypeConverter x:Key="InOutParamTypeConverter" />
     <controls:NodeTypeToColorConverter x:Key="NodeTypeToColorConverter"

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -347,6 +347,11 @@ namespace Dynamo.ViewModels
             get { return model.Version; }
         }
 
+        public string DynamoRevitVersion
+        {
+            get { return model.DynamoRevitVersion; }
+        }
+
         public bool IsUpdateAvailable
         {
             get

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -347,9 +347,14 @@ namespace Dynamo.ViewModels
             get { return model.Version; }
         }
 
-        public string DynamoRevitVersion
+        public string HostVersion
         {
-            get { return model.DynamoRevitVersion; }
+            get { return model.HostVersion; }
+        }
+
+        public string HostName
+        {
+            get { return model.HostName; }
         }
 
         public bool IsUpdateAvailable

--- a/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
+++ b/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
@@ -54,14 +54,14 @@
                            Text="Dynamo Core"
                            Margin="12,0,0,0"
                            Background="Transparent" 
-                           Foreground="#888888"
+                           Foreground="#898989"
                            Visibility="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToCollapsedConverter}}"
                            FontSize="14"/>
 
                 <TextBlock Name ="VersionNumber" 
                          Grid.Row="0"
                          Background="Transparent" 
-                         Foreground="#888888" 
+                         Foreground="#bbbbbb" 
                          FontSize="14" 
                          FontFamily="{StaticResource OpenSansRegular}" 
                          Margin="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToMarginConverter}}" 
@@ -71,11 +71,11 @@
                            Grid.Row="1"
                            HorizontalAlignment="Center"
                            Background="Transparent" 
-                           Foreground="#888888" 
+                           Foreground="#898989" 
                            FontSize="14"
                            Margin="0,-10,0,0"
                            Visibility="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToCollapsedConverter}}">
-                           Dynamo Revit   <Run Foreground="Pink" Text= "{Binding DynamoRevitVersion, Mode=OneWay}"/>
+                           Dynamo Revit   <Run Foreground="#bbbbbb" Text= "{Binding DynamoRevitVersion, Mode=OneWay}"/>
                 </TextBlock>
                 <TextBlock x:Name ="UpdateInfo"
                            Grid.Row="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToGridRow1Converter}}"

--- a/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
+++ b/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
@@ -41,31 +41,54 @@
                 <RowDefinition Height="*"></RowDefinition>
                 <RowDefinition Height="40"></RowDefinition>
             </Grid.RowDefinitions>
+
             <Grid Grid.Row="1">
-                <StackPanel VerticalAlignment="Stretch">
-                    <TextBox Name ="VersionNumber" 
-                             Background="Transparent" 
-                             Foreground="#888888" 
-                             BorderThickness="0" 
-                             FontSize="14" 
-                             FontFamily="{StaticResource OpenSansRegular}" 
-                             Margin="0,0,8,0" 
-                             Text="{Binding Version, Mode=OneWay}" 
-                             PreviewMouseDown="OnPreviewMouseDown"
-                             IsReadOnly="True" 
-                             IsReadOnlyCaretVisible="False"
-                             HorizontalAlignment="Center"/>
-                    <TextBlock x:Name ="UpdateInfo" 
-                               FontSize="12" 
-                               FontFamily="{StaticResource OpenSansRegular}" 
-                               Foreground="#00bb00"
-                               PreviewMouseDown="OnPreviewMouseDown"
-                               HorizontalAlignment="Center">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <TextBlock Name="DynamoCoreLabel"
+                           Grid.Row="0"
+                           Text="Dynamo Core"
+                           Margin="12,0,0,0"
+                           Background="Transparent" 
+                           Foreground="#888888"
+                           Visibility="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToCollapsedConverter}}"
+                           FontSize="14"/>
+
+                <TextBlock Name ="VersionNumber" 
+                         Grid.Row="0"
+                         Background="Transparent" 
+                         Foreground="#888888" 
+                         FontSize="14" 
+                         FontFamily="{StaticResource OpenSansRegular}" 
+                         Margin="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToMarginConverter}}" 
+                         Text="{Binding Version, Mode=OneWay}" 
+                         PreviewMouseDown="OnPreviewMouseDown"/>
+                <TextBlock Name="DynamoRevitVersion"
+                           Grid.Row="1"
+                           HorizontalAlignment="Center"
+                           Background="Transparent" 
+                           Foreground="#888888" 
+                           FontSize="14"
+                           Margin="0,-10,0,0"
+                           Visibility="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToCollapsedConverter}}">
+                           Dynamo Revit   <Run Foreground="Pink" Text= "{Binding DynamoRevitVersion, Mode=OneWay}"/>
+                </TextBlock>
+                <TextBlock x:Name ="UpdateInfo"
+                           Grid.Row="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToGridRow1Converter}}"
+                           HorizontalAlignment="Center"
+                           FontSize="12" 
+                           FontFamily="{StaticResource OpenSansRegular}" 
+                           Foreground="#00bb00"
+                           Margin="0,-10,0,0"
+                           PreviewMouseDown="OnPreviewMouseDown">
                         <Run Foreground="{Binding IsUpdateAvailable, Converter={StaticResource IsUpdateAvailableBrushConverter}}" 
                              Text="{Binding Model.UpdateManager, Converter={StaticResource IsUpdateAvailableToTextConverter}, 
                              ConverterParameter=DataContext, Mode=OneWay}"/>
-                    </TextBlock>
-                </StackPanel>
+                </TextBlock>
             </Grid>
             <Button Name="DynamoWebsiteButton" Grid.Row="2" Click="OnClickLink" Style="{StaticResource STextButton}"/>
             <Image Grid.Column="0"

--- a/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
+++ b/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
@@ -55,7 +55,6 @@
                            Margin="12,0,0,0"
                            Background="Transparent" 
                            Foreground="#898989"
-                           Visibility="{Binding HostVersion, Converter={StaticResource NullValueToCollapsedConverter}}"
                            FontSize="14"/>
 
                 <TextBlock Name ="DynamoCoreVersionNumber" 
@@ -64,9 +63,10 @@
                          Foreground="#bbbbbb" 
                          FontSize="14" 
                          FontFamily="{StaticResource OpenSansRegular}" 
-                         Margin="{Binding HostVersion, Converter={StaticResource NullValueToMarginConverter}}" 
+                         Margin="105,0,0,0" 
                          Text="{Binding Version, Mode=OneWay}" 
                          PreviewMouseDown="OnPreviewMouseDown"/>
+
                 <TextBlock Name="GenericHostVersion"
                            Grid.Row="1"
                            HorizontalAlignment="Center"
@@ -79,9 +79,9 @@
                            <Run Foreground="#bbbbbb" Text= "{Binding HostVersion, Mode=OneWay}"/>
                 </TextBlock>
                 <TextBlock x:Name ="UpdateInfo"
-                           Grid.Row="{Binding HostVersion, Converter={StaticResource NullValueToGridRow1Converter}}"
                            HorizontalAlignment="Center"
                            FontSize="12" 
+                           Grid.Row="{Binding HostVersion, Converter={StaticResource NullValueToGridRow1Converter}}"
                            FontFamily="{StaticResource OpenSansRegular}" 
                            Foreground="#00bb00"
                            Margin="0,-10,0,0"

--- a/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
+++ b/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
@@ -55,30 +55,31 @@
                            Margin="12,0,0,0"
                            Background="Transparent" 
                            Foreground="#898989"
-                           Visibility="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToCollapsedConverter}}"
+                           Visibility="{Binding HostVersion, Converter={StaticResource NullValueToCollapsedConverter}}"
                            FontSize="14"/>
 
-                <TextBlock Name ="VersionNumber" 
+                <TextBlock Name ="DynamoCoreVersionNumber" 
                          Grid.Row="0"
                          Background="Transparent" 
                          Foreground="#bbbbbb" 
                          FontSize="14" 
                          FontFamily="{StaticResource OpenSansRegular}" 
-                         Margin="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToMarginConverter}}" 
+                         Margin="{Binding HostVersion, Converter={StaticResource NullValueToMarginConverter}}" 
                          Text="{Binding Version, Mode=OneWay}" 
                          PreviewMouseDown="OnPreviewMouseDown"/>
-                <TextBlock Name="DynamoRevitVersion"
+                <TextBlock Name="GenericHostVersion"
                            Grid.Row="1"
                            HorizontalAlignment="Center"
                            Background="Transparent" 
                            Foreground="#898989" 
                            FontSize="14"
                            Margin="0,-10,0,0"
-                           Visibility="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToCollapsedConverter}}">
-                           Dynamo Revit   <Run Foreground="#bbbbbb" Text= "{Binding DynamoRevitVersion, Mode=OneWay}"/>
+                           Visibility="{Binding HostVersion, Converter={StaticResource NullValueToCollapsedConverter}}">
+                           <Run Text="{Binding HostName, Mode=OneWay}"/>
+                           <Run Foreground="#bbbbbb" Text= "{Binding HostVersion, Mode=OneWay}"/>
                 </TextBlock>
                 <TextBlock x:Name ="UpdateInfo"
-                           Grid.Row="{Binding DynamoRevitVersion, Converter={StaticResource NullValueToGridRow1Converter}}"
+                           Grid.Row="{Binding HostVersion, Converter={StaticResource NullValueToGridRow1Converter}}"
                            HorizontalAlignment="Center"
                            FontSize="12" 
                            FontFamily="{StaticResource OpenSansRegular}" 


### PR DESCRIPTION
### Purpose

This PR address the user story filed in _MAGN-9532_. Previously, in DynamoRevit, whenever users clicked on the 'Help' -> 'About' menu, all they see will be as follows: 

![aboutboxdynamostandalone](https://cloud.githubusercontent.com/assets/16283396/18193983/1f446f78-7115-11e6-90e1-279dee547085.PNG)

This is the same About Box window which users see in DynamoSandbox. The version number reflected here is essentially the version number of DynamoCore. At times, however, DynamoRevit's version will be different from that of DynamoCore. 

As such, in order to improve the visibility of the different versions to the user, this PR (alongside with the one filed in the main Dynamo repo) allows the user to see both versions at the same time in DynamoRevit:

![aboutboxdynamorevit](https://cloud.githubusercontent.com/assets/16283396/18193988/234ed5f4-7115-11e6-9566-de9e3b35f573.PNG)

In DynamoSandbox, however, the single version still remains:

![aboutboxdynamostandalone](https://cloud.githubusercontent.com/assets/16283396/18193994/2704d982-7115-11e6-967d-695c72b502e4.PNG)

Amendments were made in both DynamoRevit.cs as well as in DynamoCore itself. See PR: https://github.com/DynamoDS/DynamoRevit/pull/1263 (Updated PR)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@sharadkjaiswal 

### FYIs

@ke-yu 
