### PR TITLE
Sample memory information directly in ProtoTestConsoleRunner

### DIFF
--- a/test/Engine/ProtoTestConsoleRunner/Program.cs
+++ b/test/Engine/ProtoTestConsoleRunner/Program.cs
@@ -39,6 +39,9 @@ namespace ProtoTestConsoleRunner
                 return;
             }
 
+            var profilingThread = new Thread(new ThreadStart(CollectingMemory));
+            profilingThread.Start();
+
             System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
             sw.Start();
 
@@ -52,10 +55,6 @@ namespace ProtoTestConsoleRunner
             ProtoFFI.DLLFFIHandler.Register(ProtoFFI.FFILanguage.CSharp, new ProtoFFI.CSModuleHelper());
 
             ProtoScriptRunner runner = new ProtoScriptRunner();
-
-            var profilingThread = new Thread(new ThreadStart(CollectingMemory));
-            profilingThread.Start();
-
             runner.LoadAndExecute(filename, core);
             long ms = sw.ElapsedMilliseconds;
             sw.Stop();

--- a/test/performance/bin/run.py
+++ b/test/performance/bin/run.py
@@ -115,7 +115,7 @@ def main():
     args = parser.parse_args()
 
     logfile = args.logfile
-    log(logfile, datetime.datetime.now().isoformat() + ' run performance benchmark')
+    log(logfile, datetime.datetime.now().isoformat() + ' run language performance benchmark')
 
     commits = args.commits
     if commits is None:

--- a/test/performance/bin/run.py
+++ b/test/performance/bin/run.py
@@ -9,13 +9,13 @@ import json
 import shutil
 import urllib2
 
-def run(profiler, hostapp, test_case, test_output):
+def run(hostapp, test_case, test_output):
     # memlog hostapp test.ds
     # 
     # the output of memlog is cputime,managedheap,privateworkingset
     with open(test_output, "wb") as output: 
         for x in range(0, 5):
-            proc = subprocess.Popen([profiler, hostapp, test_case], stdout=output)
+            proc = subprocess.Popen([hostapp, test_case], stdout=output)
             proc.wait()
     
 # harvest test case result from output_path 
@@ -135,11 +135,6 @@ def main():
         log(logfile, 'Error: Performance folder ' + performance_folder + ' does not exists.')
         sys.exit(1)
 
-    profiler = os.path.join(performance_folder, 'bin\\memlog.exe')
-    if not os.path.exists(profiler):
-        log(logfile, 'Error: Profiler path ' + profiler + ' does not exists.')
-        sys.exit(1)
-
     test_case_path = os.path.join(performance_folder, 'testcases') 
     if not os.path.exists(test_case_path):
         log(logfile, 'Error: Test cases path ' + test_case_path + ' does not exists.')
@@ -169,7 +164,7 @@ def main():
         test_case_name = os.path.splitext(test_file)[0]
         test_result_file = os.path.join(test_result_path, test_case_name + '.out')
         try:
-            run(profiler, hostapp, dyn_file_path, test_result_file)
+            run(hostapp, dyn_file_path, test_result_file)
         except:
             log(logfile, 'Error: Failed to run test case ' + test_case_name)
 


### PR DESCRIPTION
### Purpose

For performance benchmark, sample memory information directly in ProtoTestConsoleRunner instead of using memlog.exe

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)