### PR TITLE
White list adsk components

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -228,7 +228,10 @@ namespace Dynamo.Applications
             return sb.ToString();
         }
 
-        public static String[] assemblyNamesToIgnore = { "Newtonsoft.Json" };
+        /// <summary>
+        /// The white list of dependencies to be ignored.
+        /// </summary>
+        private static String[] assemblyNamesToIgnore = { "Newtonsoft.Json" };
 
         /// <summary>
         /// Checks that an assembly does not have any dependencies that have already been loaded into the 

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -228,7 +228,7 @@ namespace Dynamo.Applications
             return sb.ToString();
         }
 
-        public static String[] assemblyNamesToIgnore = { "CollaborateDB", "Autodesk.Bcg.Http", "Autodesk.Bcg.Net ", "Autodesk.C4R.Client"};
+        public static String[] assemblyNamesToIgnore = { "Newtonsoft.Json" };
 
         /// <summary>
         /// Checks that an assembly does not have any dependencies that have already been loaded into the 
@@ -267,7 +267,7 @@ namespace Dynamo.Applications
             {
                 if (loadedAssemblyDict.ContainsKey(currentReferencedAssembly.Name))
                 {
-                    //if the dll is already loadead, then check that our required version is not greater than the currently loaded one.
+                    //if the dll is already loaded, then check that our required version is not greater than the currently loaded one.
                     var loadedAssembly = loadedAssemblyDict[currentReferencedAssembly.Name];
                     if (currentReferencedAssembly.Version.Major > loadedAssembly.Version.Major)
                     {

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -228,6 +228,8 @@ namespace Dynamo.Applications
             return sb.ToString();
         }
 
+        public static String[] assemblyNamesToIgnore = { "CollaborateDB", "Autodesk.Bcg.Http", "Autodesk.Bcg.Net ", "Autodesk.C4R.Client"};
+
         /// <summary>
         /// Checks that an assembly does not have any dependencies that have already been loaded into the 
         /// appDomain with an incompatible to the one Dynamo requires.
@@ -236,21 +238,21 @@ namespace Dynamo.Applications
         /// <returns>returns a list of fileLoad exceptions - if the list is empty no mismatched assemblies were encountered </returns>
         public static List<Exception> CheckAssemblyForVersionMismatches(Assembly assembly)
         {
-            return GetVersionMismatchedReferencesInAppDomain(assembly, new string[] { });
+            return GetVersionMismatchedReferencesInAppDomain(assembly, assemblyNamesToIgnore);
         }
 
         /// <summary>
         /// Handler for an assembly load event into a host's appdomain - we need to make sure
-        /// that another addin or package has not loadead another version of a .dll that we require.
+        /// that another addin or package has not loaded another version of a .dll that we require.
         /// If this happens Dynamo will most likely crash. We should alert the user they
         /// have an incompatible addin/package installed.. this is only called if the host calls or
         /// subscribes to it during AppDomain.AssemblyLoad event.
         /// 
         private static List<Exception> GetVersionMismatchedReferencesInAppDomain(Assembly assembly, String[] assemblyNamesToIgnore)
         {
-            //get all assemblies that are currently loaded into the appdomain.
+            // Get all assemblies that are currently loaded into the appdomain.
             var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
-            // ignore some assemblies(revit assemblies) that we know work and have changed their version number format or do not align
+            // Ignore some assemblies(Revit assemblies) that we know work and have changed their version number format or do not align
             // with semantic versioning.
 
             var loadedAssemblyNames = loadedAssemblies.Select(assem => assem.GetName()).ToList();

--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -1,20 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Dynamo.Interfaces;
-using Dynamo.Scheduler;
-using DynamoShapeManager;
-using System.Reflection;
-using System.IO;
-using Dynamo.Models;
-using Dynamo.Updates;
-using Microsoft.Win32;
 using System.Diagnostics;
-using System.Threading;
 using System.Globalization;
-using NDesk.Options;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using Dynamo.Interfaces;
+using Dynamo.Models;
+using Dynamo.Scheduler;
+using Dynamo.Updates;
 using DynamoApplications.Properties;
+using DynamoShapeManager;
+using Microsoft.Win32;
+using NDesk.Options;
 
 namespace Dynamo.Applications
 {

--- a/src/Notifications/NotificationsViewExtension.cs
+++ b/src/Notifications/NotificationsViewExtension.cs
@@ -1,19 +1,9 @@
-﻿using Dynamo.Models;
-using Dynamo.ViewModels;
-using Dynamo.Wpf.Extensions;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+using Dynamo.Wpf.Extensions;
 
 namespace Dynamo.Notifications
 {
@@ -44,7 +34,7 @@ namespace Dynamo.Notifications
         
         public void Dispose()
         {
-           UnregisterEventHandlers();
+            UnregisterEventHandlers();
             //for some reason the menuItem was not being gc'd in tests without manually removing it
             viewLoadedParams.dynamoMenu.Items.Remove(notificationsMenuItem.MenuItem);
             BindingOperations.ClearAllBindings(notificationsMenuItem.CountLabel);
@@ -64,9 +54,9 @@ namespace Dynamo.Notifications
             Notifications = new ObservableCollection<Logging.NotificationMessage>();
             
             notificationHandler = new Action<Logging.NotificationMessage>((notificationMessage) =>
-           {
-               Notifications.Add(notificationMessage);
-           });
+            {
+                Notifications.Add(notificationMessage);
+            });
 
             p.NotificationRecieved += notificationHandler;
              
@@ -74,9 +64,9 @@ namespace Dynamo.Notifications
             notificationsMenuItem = new NotificationsMenuItem(this);
             //null out the content of the notificationsMenu to get rid of 
             //the parent of the menuItem we created
-           (notificationsMenuItem.MenuItem.Parent as ContentControl).Content = null;
+            (notificationsMenuItem.MenuItem.Parent as ContentControl).Content = null;
             //place the menu into the DynamoMenu
-           p.dynamoMenu.Items.Add(notificationsMenuItem.MenuItem);
+            p.dynamoMenu.Items.Add(notificationsMenuItem.MenuItem);
         }
 
         public void Shutdown()


### PR DESCRIPTION
### Purpose

[MAGN-10615](https://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10615) Notifications are generated for Revit2017 R2 flagging ADSK components

Loading Dynamo ontop of Revit 2017 R2 gives user 2 notifications constantly. This is because whiling loading Greg.dll and dynamopackages.dll, we are referencing a newer version of Newtonsoft.Json than other component of Revit like "Autodesk.Bcg.Http", "Autodesk.Bcg.Net ", "Autodesk.C4R.Client". So we whitelist Newtonsoft.Json for dependency check, this will may require some system test but will avoid confusing users in Revit2017 R2 and Revit2018 Review Release.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)
Only one private static member is introduced.

### Reviewers

@mjkkirschner 

### FYIs

@jnealb 
@kronz 