### PR TITLE
Update to fix setErrorState test issue.

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1115,7 +1115,9 @@ namespace Dynamo.PackageManager
                 // At the same time, as unqualified files existed, 
                 // files returned from BuildPackage() is 0.
                 // This is caused by the package file is not existed or it has already been in a package.
-                if (files == null || unqualifiedFiles.Count() > 0) 
+                // files.Count() is also checking for the exception that was caught in BuildPackage().
+                // The scenario can be user trying to publish unsaved workspace.
+                if (files == null || files.Count() < 1 || unqualifiedFiles.Count() > 0) 
                 {
                     string filesCannotBePublished = null;
                     foreach (var file in unqualifiedFiles)
@@ -1124,7 +1126,16 @@ namespace Dynamo.PackageManager
                     }
                     string FileNotPublishMessage = string.Format(Resources.FileNotPublishMessage, filesCannotBePublished);
                     UploadState = PackageUploadHandle.State.Error;
-                    DialogResult response = System.Windows.Forms.MessageBox.Show(FileNotPublishMessage, Resources.FileNotPublishCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    DialogResult response;
+                    if (DynamoModel.IsTestMode)
+                    {
+                        response = DialogResult.OK;
+                    }
+                    else
+                    {
+                         response = System.Windows.Forms.MessageBox.Show(FileNotPublishMessage, Resources.FileNotPublishCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+
                     if (response == DialogResult.OK)
                     {
                         this.ClearPackageContents();
@@ -1133,6 +1144,7 @@ namespace Dynamo.PackageManager
                     }
                     return;
                 }
+
                 UploadState = PackageUploadHandle.State.Copying;
                 Uploading = true;
                 // begin publishing to local directory
@@ -1146,7 +1158,18 @@ namespace Dynamo.PackageManager
                 // whether user wants to continue uploading another file or not.
                 if (UploadState == PackageUploadHandle.State.Uploaded)
                 {
-                    DialogResult dialogResult = System.Windows.Forms.MessageBox.Show(Resources.PublishPackageMessage, Resources.PublishPackageDialogCaption, MessageBoxButtons.YesNo, MessageBoxIcon.Information);
+                    // For test mode, presume the dialog input to be No and proceed.
+                    DialogResult dialogResult;
+
+                    if (DynamoModel.IsTestMode)
+                    {
+                        dialogResult = DialogResult.No;
+                    }
+                    else
+                    {
+                        dialogResult = System.Windows.Forms.MessageBox.Show(Resources.PublishPackageMessage, Resources.PublishPackageDialogCaption, MessageBoxButtons.YesNo, MessageBoxIcon.Information);
+                    }
+
                     if (dialogResult == DialogResult.Yes)
                     { 
                         this.ClearAllEntries();

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1126,15 +1126,7 @@ namespace Dynamo.PackageManager
                     }
                     string FileNotPublishMessage = string.Format(Resources.FileNotPublishMessage, filesCannotBePublished);
                     UploadState = PackageUploadHandle.State.Error;
-                    DialogResult response;
-                    if (DynamoModel.IsTestMode)
-                    {
-                        response = DialogResult.OK;
-                    }
-                    else
-                    {
-                         response = System.Windows.Forms.MessageBox.Show(FileNotPublishMessage, Resources.FileNotPublishCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    }
+                    DialogResult response = DynamoModel.IsTestMode ? DialogResult.OK : System.Windows.Forms.MessageBox.Show(FileNotPublishMessage, Resources.FileNotPublishCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
                     if (response == DialogResult.OK)
                     {
@@ -1159,16 +1151,7 @@ namespace Dynamo.PackageManager
                 if (UploadState == PackageUploadHandle.State.Uploaded)
                 {
                     // For test mode, presume the dialog input to be No and proceed.
-                    DialogResult dialogResult;
-
-                    if (DynamoModel.IsTestMode)
-                    {
-                        dialogResult = DialogResult.No;
-                    }
-                    else
-                    {
-                        dialogResult = System.Windows.Forms.MessageBox.Show(Resources.PublishPackageMessage, Resources.PublishPackageDialogCaption, MessageBoxButtons.YesNo, MessageBoxIcon.Information);
-                    }
+                    DialogResult dialogResult = DynamoModel.IsTestMode ? DialogResult.No : System.Windows.Forms.MessageBox.Show(Resources.PublishPackageMessage, Resources.PublishPackageDialogCaption, MessageBoxButtons.YesNo, MessageBoxIcon.Information); ;
 
                     if (dialogResult == DialogResult.Yes)
                     { 


### PR DESCRIPTION
### Purpose
This PR is to fix the DynamoCoreWpfTests.PublishPackageViewModelTests.SetsErrorState.
The PR also remove the pop up dialog when it is in test mode.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@aparajit-pratap 

### FYIs

@Benglin 