### PR TITLE
MAGN-10353 Crash when installing packages to folder (Network Path Issue)

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1592,7 +1592,24 @@ namespace Dynamo.ViewModels
             else if (vm.Model.CurrentWorkspace is CustomNodeWorkspaceModel)
             {
                 var pathManager = vm.model.PathManager;
-                _fileDialog.InitialDirectory = pathManager.DefaultUserDefinitions;
+                try
+                {
+                    Directory.EnumerateDirectories(pathManager.DefaultUserDefinitions);
+                    _fileDialog.InitialDirectory = pathManager.DefaultUserDefinitions;
+                }
+                catch(Exception ex)
+                {
+                    // if exception occur on the DefaultUserDefinition
+                    // choose the next path in the list of directory.
+                    foreach(var chosenPath in pathManager.DefinitionDirectories)
+                    {
+                        if(chosenPath != pathManager.DefaultUserDefinitions)
+                        {
+                            _fileDialog.InitialDirectory = chosenPath;
+                            break;
+                        }
+                    }
+                }
             }
 
             if (_fileDialog.ShowDialog() == DialogResult.OK)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1592,24 +1592,7 @@ namespace Dynamo.ViewModels
             else if (vm.Model.CurrentWorkspace is CustomNodeWorkspaceModel)
             {
                 var pathManager = vm.model.PathManager;
-                try
-                {
-                    Directory.EnumerateDirectories(pathManager.DefaultUserDefinitions);
-                    _fileDialog.InitialDirectory = pathManager.DefaultUserDefinitions;
-                }
-                catch(Exception ex)
-                {
-                    // if exception occur on the DefaultUserDefinition
-                    // choose the next path in the list of directory.
-                    foreach(var chosenPath in pathManager.DefinitionDirectories)
-                    {
-                        if(chosenPath != pathManager.DefaultUserDefinitions)
-                        {
-                            _fileDialog.InitialDirectory = chosenPath;
-                            break;
-                        }
-                    }
-                }
+                _fileDialog.InitialDirectory = pathManager.DefaultUserDefinitions;
             }
 
             if (_fileDialog.ShowDialog() == DialogResult.OK)

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -203,19 +203,23 @@ namespace Dynamo.PackageManager
 
         private void ScanPackageDirectories(string root, IPreferences preferences)
         {
-            if (!Directory.Exists(root))
+            try
             {
-                this.Log(string.Format(Resources.InvalidPackageFolderWarning, root));
-                return;
-            }
+                if (!Directory.Exists(root))
+                {
+                    this.Log(string.Format(Resources.InvalidPackageFolderWarning, root));
+                    return;
+                }
 
-            foreach (var dir in
-                Directory.EnumerateDirectories(root, "*", SearchOption.TopDirectoryOnly))
-            {
-                var pkg = ScanPackageDirectory(dir);
-                if (pkg != null && preferences.PackageDirectoriesToUninstall.Contains(dir)) 
-                    pkg.MarkForUninstall(preferences);
+                foreach (var dir in
+                    Directory.EnumerateDirectories(root, "*", SearchOption.TopDirectoryOnly))
+                {
+                    var pkg = ScanPackageDirectory(dir);
+                    if (pkg != null && preferences.PackageDirectoriesToUninstall.Contains(dir))
+                        pkg.MarkForUninstall(preferences);
+                }
             }
+            catch (Exception ex) { }
         }
 
         public Package ScanPackageDirectory(string directory)

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -219,7 +219,9 @@ namespace Dynamo.PackageManager
                         pkg.MarkForUninstall(preferences);
                 }
             }
-            catch (Exception ex) { }
+            catch (UnauthorizedAccessException ex) { }
+            catch (IOException ex) { }
+            catch (ArgumentException ex) { }
         }
 
         public Package ScanPackageDirectory(string directory)

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -13,8 +13,13 @@ namespace DynamoUtilities
         {
             try
             {
+                // When network path is access denied, the Directory.Exits however still 
+                // return true.
+                // EnumerateDirectories operation is additional check
+                // to catch exception for network path.
                 if (!Directory.Exists(folderPath))
                     Directory.CreateDirectory(folderPath);
+                Directory.EnumerateDirectories(folderPath);
             }
             catch (IOException ex) { return ex; }
             catch (ArgumentException ex) { return ex; }


### PR DESCRIPTION
### Purpose
- Solve the problem of inaccessible network path causing hard crash on Dynamo by catching the exception.
- Since the inaccessible network path is still default user directory in the setting, the attempt to save a newly created custom node will show an error dialog indicating that the path is not accessible. However, the dialog is unwanted in this case. Hence, we have decided to automatically choose the next priority path in the Manage Node and Package Path and set it to be the initial path of the file save dialog. 
- In the case of there is only one path in Manage Node and Package Path and that path is not accessible, the initial path of the file save dialog will be anywhere that user recently visit. This behavior is handled by Windows.
- FYI: Here is the old pull request https://github.com/DynamoDS/Dynamo/pull/6973 that fixed the same problem in local directory but not network path. 


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers
@ke-yu 

### FYIs

@Benglin 