### PR TITLE
MAGN-10627 File compatibility dialog shouldn't pop up for the same and minor version changes.

### DIFF
--- a/src/DynamoCore/Migration/Migration.cs
+++ b/src/DynamoCore/Migration/Migration.cs
@@ -150,8 +150,9 @@ namespace Dynamo.Migration
             Version fileVersion = VersionFromString(workspaceInfo.Version);
 
             var currentVersion = AssemblyHelper.GetDynamoVersion(includeRevisionNumber: false);
-
-            if (fileVersion > currentVersion)
+            // Only compare for major version difference. 
+            // For minor versions and build versions, we ignore the differences
+            if (fileVersion.Major > currentVersion.Major)
             {
                 bool resume = displayFutureFileMessage(
                     workspaceInfo.FileName,


### PR DESCRIPTION
### Purpose
- Fixed File compatibility dialog pop up for the minor version or build version changes by only check for the Major version difference specifically.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers
@sharadkjaiswal 
### FYIs
