### PR TITLE
Fix for Range and Sequence Default Lacing

### DIFF
--- a/src/Libraries/CoreNodeModels/Range.cs
+++ b/src/Libraries/CoreNodeModels/Range.cs
@@ -29,7 +29,7 @@ namespace CoreNodeModels
 
             RegisterAllPorts();
 
-            ArgumentLacing = LacingStrategy.Longest;
+            ArgumentLacing = LacingStrategy.Shortest;
         }
 
         public override bool IsConvertible
@@ -102,7 +102,7 @@ namespace CoreNodeModels
 
             RegisterAllPorts();
 
-            ArgumentLacing = LacingStrategy.Longest;
+            ArgumentLacing = LacingStrategy.Shortest;
         }
 
         public override bool IsConvertible


### PR DESCRIPTION
### Purpose

This PR is made to fix the Github issue (https://github.com/DynamoDS/Dynamo/issues/7080). The default Lacing setting for the nodes are `Shortest`. In the Sequence and Range nodes, however, the default setting was set to `Longest`. 

![defaultlacingbug](https://cloud.githubusercontent.com/assets/16283396/18501089/844499ba-7a80-11e6-9f16-1765b04d8c0d.png)

In order to standardize the default Lacing setting, this PR ensures that the Sequence and Range nodes both have `Shortest` Lacing by default.

![fixdefaultlacing](https://cloud.githubusercontent.com/assets/16283396/18501083/7348467a-7a80-11e6-807d-780388242a06.PNG)
 
### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 

### FYIs

@riteshchandawar 

