### PR TITLE
MAGN-10626: Attributes from zero touch dlls in DynamoStudio are not understood by DynamoCore

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -614,10 +614,9 @@ namespace ProtoFFI
                 }
             }
 
-            foreach (var item in atts)
+            foreach (Attribute item in atts)
             {
-                SupressImportIntoVMAttribute supressImport = item as SupressImportIntoVMAttribute;
-                if (null != supressImport)
+                if (item.SupressImportIntoVM())
                     return true;
             }
 
@@ -1214,10 +1213,9 @@ namespace ProtoFFI
             attributes = type.GetCustomAttributes(false).Cast<Attribute>().ToArray();
             foreach (var attr in attributes)
             {
-                if (attr is IsVisibleInDynamoLibraryAttribute)
+                if (attr.HiddenInDynamoLibrary())
                 {
-                    var visibleInLibraryAttr = attr as IsVisibleInDynamoLibraryAttribute;
-                    HiddenInLibrary = (visibleInLibraryAttr.Visible == false);
+                    HiddenInLibrary = true;
                 }
                 else if (attr is ObsoleteAttribute)
                 {
@@ -1293,10 +1291,9 @@ namespace ProtoFFI
                     var multiReturnAttr = (attr as MultiReturnAttribute);
                     returnKeys = multiReturnAttr.ReturnKeys.ToList();
                 }
-                else if (attr is IsVisibleInDynamoLibraryAttribute)
+                else if(attr.HiddenInDynamoLibrary())
                 {
-                    var visibleInLibraryAttr = attr as IsVisibleInDynamoLibraryAttribute;
-                    HiddenInLibrary = (visibleInLibraryAttr.Visible == false);
+                    HiddenInLibrary = true;
                 }
                 else if (attr is IsObsoleteAttribute)
                 {
@@ -1365,6 +1362,51 @@ namespace ProtoFFI
                     AddAttribute("ArbitraryDimensionArrayImportAttribute", true);
                 }
             }
+        }
+    }
+
+    static class AttributeUtils
+    {
+        /// <summary>
+        /// Checks if the given attribute is of type SupressImportIntoVMAttribute
+        /// </summary>
+        /// <param name="attribute">Given attribute</param>
+        /// <returns>True if the given attribute is of type SupressImportIntoVMAttribute</returns>
+        public static bool SupressImportIntoVM(this Attribute attribute)
+        {
+            //TODO@Dynamo 2.0 
+            //Following code is to fix attribute resolution issue due to
+            //presence of DynamoServices.dll in Dynamo Studio folder. The DLL
+            //can be removed in 2.0, once we have removed the dlls we can restore
+            //following code.
+            //return attribute is SupressImportIntoVMAttribute;
+            
+            return null != attribute && attribute.GetType().Name == typeof(SupressImportIntoVMAttribute).Name;
+        }
+
+        /// <summary>
+        /// Checks if the given attribute is of type IsVisibleInDynamoLibraryAttribute
+        /// and has Visible property set to false.
+        /// </summary>
+        /// <param name="attribute">Given attribute</param>
+        /// <returns>True if the given attribute is of 
+        /// IsVisibleInDynamoLibraryAttribute type and has Visible property false.</returns>
+        public static bool HiddenInDynamoLibrary(this Attribute attribute)
+        {
+            var visibleInLibraryAttr = attribute as IsVisibleInDynamoLibraryAttribute;
+            if (visibleInLibraryAttr != null)
+            {
+                return visibleInLibraryAttr.Visible == false;
+            }
+            
+            //TODO@Dynamo 2.0 remove following code in 2.0
+            if (attribute == null || attribute.GetType().Name != typeof(IsVisibleInDynamoLibraryAttribute).Name)
+            {
+                return false;
+            }
+
+            var propInfo = attribute.GetType().GetProperty("Visible");
+            return propInfo != null && (bool)propInfo.GetValue(attribute) == false;
         }
     }
 }


### PR DESCRIPTION
### Purpose

This PR fixes the issue that lot of unwanted methods and classes from Translation.dll are seen in library view on Dynamo Studio.

**Analysis:**
DynamoStudio 1.1 included some duplicate DLLs from DynamoCore in its installation, which can't be removed from the installer to support the minor upgrade patch for DynamoStudio 1.2 onwards. If these DLLs get loaded in DynamoStudio application, might cause some unexpected behaviors one of which is reported above. To mitigate the issue we are preloading those duplicate DLLs at the startup of DynamoStudio. But Translation.dll is loaded using Load From context and hence it loads the local copy of DynamoServices.dll even if a version of it is already loaded from DynamoCore. Due to this, the attribute comparison fails and hence we see the unwanted methods/classes in library view.

**Resolution**
Implemented AttributeUtils extension class to implement extension methods to check the attribute types using name comparison and invoke specific properties using reflection APIs to check for SupressImportIntoVM() and HiddenInDynamoLibrary().
These extension method implementation needs to be corrected in Dynamo 2.0 release.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

- [x] @ke-yu 
- [ ] @ellensi 

### FYIs

@mjkkirschner, @ikeough 
