### PR TITLE
Use a fixed location for the logs when running headless

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -324,9 +324,14 @@ namespace Dynamo.Core
             // Current user specific directories.
             userDataDir = GetUserDataFolder(pathResolver);
 
-            logDirectory = Path.Combine(userDataDir, LogsDirectoryName);
+            // When running as a headless process, put the logs directory in a consistent
+            // location that doesn't change every time the version number changes.
+            var userDataDirNoVersion = Directory.GetParent(userDataDir).FullName;
+            logDirectory = Path.Combine(Dynamo.Models.DynamoModel.IsHeadless ? userDataDirNoVersion : userDataDir,
+                                        LogsDirectoryName);
+
             preferenceFilePath = Path.Combine(userDataDir, PreferenceSettingsFileName);
-            backupDirectory = Path.Combine(Directory.GetParent(userDataDir).FullName, BackupDirectoryName);
+            backupDirectory = Path.Combine(userDataDirNoVersion, BackupDirectoryName);
 
             // Common directories.
             commonDataDir = GetCommonDataFolder(pathResolver);


### PR DESCRIPTION
### Purpose

The current Logs directory location varies based on the Dynamo version number.  This makes extracting the Dynamo log difficult on the Reach servers.  The ECS task volume directory must be updated each time that the Dynamo version number changes.  This change removes the version number from the logs directory path when running headless, without affecting the normal logs directory path.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [n/a] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [n/a] Snapshot of UI changes, if any.
- [x] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ramramps @mjkkirschner 

### FYIs

@ikeough 
