### PR TITLE
UpdateAssemblyVersionNum

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("1.1.1.1955")]
+[assembly: AssemblyVersion("1.2.1.1955")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.1.1.1955")]
+[assembly: AssemblyFileVersion("1.2.1.1955")]


### PR DESCRIPTION
### Purpose

Dynamo Core Version Number will be displayed in Flood UI specifically customizer->Mange/About->About box. As @mjkkirschner Pointed out earlier, that while building reach on a linux machine with mono, the AssemblyVersionNumber in AssemblySharedInfo.cs will not be refreshed thus if we did not update it manually, flood could show confusing DynamoCore Version Num to users. Like currently, flood.Dev is showing dynamoCore1.1.1.1955 but actually it's running latest Core1.2.1.xxxx.

![image](https://cloud.githubusercontent.com/assets/3942418/18522456/23d844ac-7a7e-11e6-8004-c0f02bc621da.png)

I am only updating the minor version number here. But open to better approaches. Maybe it's worth to figure out how to update the number when built with mono.


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers


### FYIs

@mjkkirschner @Benglin 

