### PR TITLE
Build fix: don't copy [Content_Types].xml and nupkg to samples

### DIFF
--- a/tools/install/ExtractResources.bat
+++ b/tools/install/ExtractResources.bat
@@ -22,7 +22,7 @@ echo ---------------------------------------------------------------------------
 rd /s/q %player%
 %nugetroot%\NuGet.exe restore -ConfigFile %cwd%..\..\dynamo-nuget.config -PackagesDirectory %player%
 robocopy "%player%\DynamoPlayer-Revit2017.1.0.2\Revit_2017" "%binroot%\Revit_2017" /e
-robocopy "%player%\DynamoPlayer-SampleScripts-localized-Revit2017.1.0.2" "%binroot%\samples" /e
+robocopy "%player%\DynamoPlayer-SampleScripts-localized-Revit2017.1.0.2" "%binroot%\samples" /e -XF *.nupkg [Content_Types].xml
 
 echo .
 echo -------------------------------------------------------------------------------


### PR DESCRIPTION
### Purpose

Build fix for #7154 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs
@dobriai