### PR TITLE
localized file names are not supported by MSI

### DIFF
--- a/tools/install/ExtractResources.bat
+++ b/tools/install/ExtractResources.bat
@@ -22,7 +22,7 @@ echo ---------------------------------------------------------------------------
 rd /s/q %player%
 %nugetroot%\NuGet.exe restore -ConfigFile %cwd%..\..\dynamo-nuget.config -PackagesDirectory %player%
 robocopy "%player%\DynamoPlayer-Revit2017.1.0.2\Revit_2017" "%binroot%\Revit_2017" /e
-robocopy "%player%\DynamoPlayer-SampleScripts-localized-Revit2017.1.0.2" "%binroot%\samples" /e -XF *.nupkg [Content_Types].xml
+robocopy "%player%\DynamoPlayer-SampleScripts-localized-Revit2017.1.0.2\en-US" "%binroot%\samples\en-US" /e
 
 echo .
 echo -------------------------------------------------------------------------------


### PR DESCRIPTION
### Purpose

Copy only English sample files as localized file names are not supported by MSI. I tried using UTF-8 codepage in wix, but it didn't work. For now, copy only English files so that build proceeds.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@dobriai
