### PR TITLE
fix cast exception in tests

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -627,8 +627,8 @@ namespace Dynamo.Models
 
             // config.UpdateManager has to be cast to IHostUpdateManager in order to extract the HostVersion and HostName
             // see IHostUpdateManager summary for more details 
-            var hostUpdateManager = (IHostUpdateManager) config.UpdateManager;
-
+            var hostUpdateManager = config.UpdateManager as IHostUpdateManager;
+          
             if (hostUpdateManager != null)
             {
                 HostName = hostUpdateManager.HostName;


### PR DESCRIPTION
### Purpose

fix two failing tests which are throwing cast exceptions when attempting to cast a mock update manager to `IHostUpdateManager`

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@QilongTang 

### FYIs

@samuelcwl 

