### PR TITLE
MAGN-10353 Crash when installing packages to folder (Network Path Issue)

### DIFF
--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.IO;
 using System.Security.AccessControl;
 

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.IO;
 using System.Security.AccessControl;
 
@@ -13,12 +14,14 @@ namespace DynamoUtilities
         {
             try
             {
-                // When network path is access denied, the Directory.Exits however still 
-                // return true.
-                // EnumerateDirectories operation is additional check
-                // to catch exception for network path.
                 if (!Directory.Exists(folderPath))
                     Directory.CreateDirectory(folderPath);
+
+                // When network path is access denied, the Directory.Exits however still 
+                // return true.
+                // This means no exception will be caught since Directory.CreateDirectory() is not run.
+                // Hence, EnumerateDirectories operation is additional check
+                // to catch exception for this network path access denied issue. 
                 Directory.EnumerateDirectories(folderPath);
             }
             catch (IOException ex) { return ex; }


### PR DESCRIPTION
### Purpose
- Since Directory.EnumerateDirectories() returns a IEnumerable object, it will not cause dynamo to slowdown.
- In this pull request, I just updated the comments to make the intention of using Directory.EnumerateDirectories() to solve network path accessibility issue to be clearer. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers
@ke-yu 

### FYIs

