### PR TITLE
Fix regressions

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1095,7 +1095,7 @@ namespace ProtoCore
 
             //Walk the class tree structure to find the method
 
-            if (runtimeCore.DSExecutable.classTable.ClassNodes[typeID].Base != Constants.kInvalidIndex)
+            while (runtimeCore.DSExecutable.classTable.ClassNodes[typeID].Base != Constants.kInvalidIndex)
             {
                 typeID = runtimeCore.DSExecutable.classTable.ClassNodes[typeID].Base;
 

--- a/src/Engine/ProtoCore/Reflection/Mirror.cs
+++ b/src/Engine/ProtoCore/Reflection/Mirror.cs
@@ -340,7 +340,7 @@ namespace ProtoCore
                 Validity.Assert(staticCore != null);
 
                 ClassNode cNode = ClassNode;
-                if (cNode.Base != Constants.kInvalidIndex)
+                while (cNode.Base != Constants.kInvalidIndex)
                 {
                     int ci = cNode.Base;
                     baseClasses.Add(new ClassMirror(staticCore, staticCore.ClassTable.ClassNodes[ci], this.libraryMirror));

--- a/src/Engine/ProtoCore/Utils/ClassUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ClassUtils.cs
@@ -23,7 +23,7 @@ namespace ProtoCore.Utils
             ret.Add(runtimeCore.DSExecutable.classTable.ClassNodes.IndexOf(cn));
 
             ClassNode target = cn;
-            if (target.Base != Constants.kInvalidIndex)
+            while (target.Base != Constants.kInvalidIndex)
             {
                 ret.Add(target.Base);
                 target = runtimeCore.DSExecutable.classTable.ClassNodes[target.Base];

--- a/src/Libraries/CoreNodes/Optimize.ds
+++ b/src/Libraries/CoreNodes/Optimize.ds
@@ -1,6 +1,6 @@
 import("FunctionObject.ds");
 
-def NewtonRootFind1DNoDeriv(objFunc: _FunctionObject, start: double, maxIters: int)
+def NewtonRootFind1DNoDeriv(objFunc: Function, start: double, maxIters: int)
 {
 	return = [Imperative]
 	{
@@ -26,7 +26,7 @@ def NewtonRootFind1DNoDeriv(objFunc: _FunctionObject, start: double, maxIters: i
 	}
 }
 
-def NewtonRootFind1DWithDeriv(objFunc: _FunctionObject, derivFunc: _FunctionObject, start: double, maxIters: int)
+def NewtonRootFind1DWithDeriv(objFunc: Function, derivFunc: Function, start: double, maxIters: int)
 {
 	return = [Imperative]
 	{


### PR DESCRIPTION
### Purpose

Fix two regressions.

The first one is because of the removal of `__FunctionObject` class, Optimize.ds should be updated to use `Function` instead.

The second one is because not to go through class inheritance chain when getting base class. or finding member functions.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)
