### PR TITLE
Move DynamoPlayer integration code to DynamoForRevit

### DIFF
--- a/tools/install/ExtractResources.bat
+++ b/tools/install/ExtractResources.bat
@@ -11,18 +11,6 @@ IF /I "%2"=="x86" set OPT_Platform=x86
 
 set binroot=%cwd%..\..\bin\%OPT_Platform%\%OPT_CONFIGURATION%
 set wwlroot=%cwd%..\..\bin\wwl
-set nugetroot=%cwd%..\NuGet
-set player=%cwd%..\..\bin\DynamoPlayer
-
-echo -------------------------------------------------------------------------------
-echo NuGet restore playlist packages
-echo DynamoPlayer folder: %player%
-echo %nugetroot%\NuGet.exe restore -ConfigFile %cwd%..\..\dynamo-nuget.config -PackagesDirectory %player%
-echo -------------------------------------------------------------------------------
-rd /s/q %player%
-%nugetroot%\NuGet.exe restore -ConfigFile %cwd%..\..\dynamo-nuget.config -PackagesDirectory %player%
-robocopy "%player%\DynamoPlayer-Revit2017.1.0.3\Revit_2017" "%binroot%\Revit_2017" /e
-robocopy "%player%\DynamoPlayer-SampleScripts-localized-Revit2017.1.0.2\en-US" "%binroot%\samples\en-US" /e
 
 echo .
 echo -------------------------------------------------------------------------------

--- a/tools/install/packages.config
+++ b/tools/install/packages.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DynamoPlayer-Revit2017" version="1.0.3" targetFramework="net45" />
-  <package id="DynamoPlayer-SampleScripts-localized-Revit2017" version="1.0.2" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
### Purpose

The DynamoPlayer resources don't need to go for localization step because it already contains localized resources. Moving the integration code to DynamoForRevit to better align with Revit project. Refer https://git.autodesk.com/Dynamo/DynamoForRevit/pull/44 for details.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@mjkkirschner 
