### PR TITLE
Support simple heterogeneous array argument in method resolution

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -547,7 +547,7 @@ namespace ProtoCore
                 foreach (List<ReplicationInstruction> replicationOption in replicationTrials)
                 {
                     List<List<StackValue>> reducedParams = Replicator.ComputeAllReducedParams(arguments, replicationOption, runtimeCore);
-                    Dictionary<FunctionEndPoint, int> lookups;
+                    HashSet<FunctionEndPoint> lookups;
                     if (funcGroup.CanGetExactMatchStatics(context, reducedParams, stackFrame, runtimeCore, out lookups))
                     {
                         return true; //Replicates against cluster
@@ -793,11 +793,11 @@ namespace ProtoCore
             #region Case 1a: Replicate only according to the replication guides, but with a sub-typing match
             {
                 List<List<StackValue>> reducedParams = Replicator.ComputeAllReducedParams(arguments, instructions, runtimeCore);
-                Dictionary<FunctionEndPoint, int> lookups; 
+                HashSet<FunctionEndPoint> lookups; 
                 if (funcGroup.CanGetExactMatchStatics( context, reducedParams, stackFrame, runtimeCore, out lookups))
                 {
                     //Otherwise we have a cluster of FEPs that can be used to dispatch the array
-                    resolvesFeps = new List<FunctionEndPoint>(lookups.Keys);
+                    resolvesFeps = new List<FunctionEndPoint>(lookups);
                     replicationInstructions = instructions;
                     return;
                 }
@@ -813,11 +813,11 @@ namespace ProtoCore
                 foreach (List<ReplicationInstruction> repOption in replicationTrials)
                 {
                     List<List<StackValue>> reducedParams = Replicator.ComputeAllReducedParams(arguments, repOption, runtimeCore);
-                    Dictionary<FunctionEndPoint, int> lookups;
+                    HashSet<FunctionEndPoint> lookups;
                     if (funcGroup.CanGetExactMatchStatics(context, reducedParams, stackFrame, runtimeCore, out lookups))
                     {
                         //Otherwise we have a cluster of FEPs that can be used to dispatch the array
-                        resolvesFeps = new List<FunctionEndPoint>(lookups.Keys);
+                        resolvesFeps = new List<FunctionEndPoint>(lookups);
                         replicationInstructions = repOption;
                         return;
                     }

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -969,7 +969,6 @@ namespace ProtoCore
 
             #endregion
 
-
             resolvesFeps = new List<FunctionEndPoint>();
             replicationInstructions = instructions;
         }
@@ -1431,7 +1430,7 @@ namespace ProtoCore
             }
 
             arguments.ForEach(x => runtimeCore.AddCallSiteGCRoot(CallSiteID, x));
-            StackValue ret = Execute(resolvesFeps, context, arguments, replicationInstructions, stackFrame, runtimeCore, funcGroup);
+            StackValue ret = Execute(resolvesFeps, context, arguments, replicationInstructions, stackFrame, runtimeCore);
             if (!ret.IsExplicitCall)
             {
                 ret = AtLevelHandler.RestoreDominantStructure(ret, domintListStructure, replicationInstructions, runtimeCore); 
@@ -1447,8 +1446,7 @@ namespace ProtoCore
             List<StackValue> formalParameters, 
             List<ReplicationInstruction> replicationInstructions, 
             StackFrame stackFrame, 
-            RuntimeCore runtimeCore, 
-            FunctionGroup funcGroup)
+            RuntimeCore runtimeCore)
         {
             SingleRunTraceData singleRunTraceData = (invokeCount < traceData.Count) ? traceData[invokeCount] : new SingleRunTraceData();
             SingleRunTraceData newTraceData = new SingleRunTraceData();
@@ -1457,14 +1455,12 @@ namespace ProtoCore
             if (replicationInstructions.Count == 0)
             {
                 c.IsReplicating = false;
-                ret = ExecWithZeroRI(functionEndPoint, c, formalParameters, stackFrame, runtimeCore, funcGroup,
-                    singleRunTraceData, newTraceData);
+                ret = ExecWithZeroRI(functionEndPoint, c, formalParameters, stackFrame, runtimeCore, singleRunTraceData, newTraceData);
             }
             else //replicated call
             {
                 c.IsReplicating = true;
-                ret = ExecWithRISlowPath(functionEndPoint, c, formalParameters, replicationInstructions, stackFrame,
-                                         runtimeCore, funcGroup, singleRunTraceData, newTraceData);
+                ret = ExecWithRISlowPath(functionEndPoint, c, formalParameters, replicationInstructions, stackFrame, runtimeCore, singleRunTraceData, newTraceData);
             }
 
             //Do a trace save here
@@ -1498,7 +1494,6 @@ namespace ProtoCore
             List<ReplicationInstruction> replicationInstructions, 
             StackFrame stackFrame, 
             RuntimeCore runtimeCore, 
-            FunctionGroup funcGroup, 
             SingleRunTraceData previousTraceData, 
             SingleRunTraceData newTraceData)
         {
@@ -1508,7 +1503,7 @@ namespace ProtoCore
             //Recursion base case
             if (replicationInstructions.Count == 0)
             {
-                return ExecWithZeroRI(functionEndPoint, c, formalParameters, stackFrame, runtimeCore, funcGroup, previousTraceData, newTraceData);
+                return ExecWithZeroRI(functionEndPoint, c, formalParameters, stackFrame, runtimeCore, previousTraceData, newTraceData);
             }
 
             //Get the replication instruction that this call will deal with
@@ -1638,8 +1633,7 @@ namespace ProtoCore
 
                     SingleRunTraceData cleanRetTrace = new SingleRunTraceData();
 
-                    retSVs[i] = ExecWithRISlowPath(functionEndPoint, c, newFormalParams, newRIs, stackFrame, runtimeCore,
-                                                    funcGroup, lastExecTrace, cleanRetTrace);
+                    retSVs[i] = ExecWithRISlowPath(functionEndPoint, c, newFormalParams, newRIs, stackFrame, runtimeCore, lastExecTrace, cleanRetTrace);
 
                     runtimeCore.AddCallSiteGCRoot(CallSiteID, retSVs[i]);
 
@@ -1703,8 +1697,7 @@ namespace ProtoCore
                     List<StackValue> newFormalParams = new List<StackValue>();
                     newFormalParams.AddRange(formalParameters);
 
-                    return ExecWithRISlowPath(functionEndPoint, c, newFormalParams, newRIs, stackFrame, runtimeCore,
-                                                funcGroup, previousTraceData, newTraceData);
+                    return ExecWithRISlowPath(functionEndPoint, c, newFormalParams, newRIs, stackFrame, runtimeCore, previousTraceData, newTraceData);
                 }
 
                 //Now iterate over each of these options
@@ -1749,8 +1742,7 @@ namespace ProtoCore
                     //previousTraceData = lastExecTrace;
                     SingleRunTraceData cleanRetTrace = new SingleRunTraceData();
 
-                    retSVs[i] = ExecWithRISlowPath(functionEndPoint, c, newFormalParams, newRIs, stackFrame, runtimeCore,
-                                                    funcGroup, lastExecTrace, cleanRetTrace);
+                    retSVs[i] = ExecWithRISlowPath(functionEndPoint, c, newFormalParams, newRIs, stackFrame, runtimeCore, lastExecTrace, cleanRetTrace);
 
                     runtimeCore.AddCallSiteGCRoot(CallSiteID, retSVs[i]);
 
@@ -1776,7 +1768,7 @@ namespace ProtoCore
         /// </summary>
         private StackValue ExecWithZeroRI(List<FunctionEndPoint> functionEndPoint, Context c,
                                           List<StackValue> formalParameters, StackFrame stackFrame, RuntimeCore runtimeCore,
-                                          FunctionGroup funcGroup, SingleRunTraceData previousTraceData, SingleRunTraceData newTraceData)
+                                          SingleRunTraceData previousTraceData, SingleRunTraceData newTraceData)
         {
             if (runtimeCore.CancellationPending)
             {

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1402,6 +1402,20 @@ namespace ProtoCore
             //If we got here then the function group got resolved
             log.AppendLine("Function group resolved: " + funcGroup);
 
+            List<FunctionEndPoint> candidatesFeps = new List<FunctionEndPoint>();
+            int argumentNumber = arguments.Count;
+            foreach (var fep in funcGroup.FunctionEndPoints)
+            {
+                int defaultParamNumber = fep.procedureNode.ArgumentInfos.Count(x => x.IsDefault);
+                int parameterNumber = fep.procedureNode.ArgumentTypes.Count;
+
+                if (argumentNumber <= parameterNumber && parameterNumber - argumentNumber <= defaultParamNumber)
+                {
+                    candidatesFeps.Add(fep);
+                }
+            }
+            funcGroup = new FunctionGroup(candidatesFeps);
+
             #endregion
 
             partialReplicationGuides = PerformRepGuideDemotion(arguments, partialReplicationGuides, runtimeCore);

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -781,7 +781,6 @@ namespace ProtoCore
             List<StackValue> arguments,
             FunctionGroup funcGroup,
             List<ReplicationInstruction> instructions, 
-            List<List<ReplicationGuide>> partialReplicationGuides,
             StackFrame stackFrame,
             RuntimeCore runtimeCore,
             out List<FunctionEndPoint> resolvesFeps,
@@ -1431,7 +1430,7 @@ namespace ProtoCore
             List<ReplicationInstruction> replicationInstructions;
 
             arguments = PerformRepGuideForcedPromotion(arguments, partialReplicationGuides, runtimeCore);
-            ComputeFeps(log, context, arguments, funcGroup, partialInstructions, partialReplicationGuides, stackFrame, runtimeCore, out resolvesFeps, out replicationInstructions);
+            ComputeFeps(log, context, arguments, funcGroup, partialInstructions, stackFrame, runtimeCore, out resolvesFeps, out replicationInstructions);
 
             if (resolvesFeps.Count == 0)
             {

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -794,7 +794,7 @@ namespace ProtoCore
             {
                 List<List<StackValue>> reducedParams = Replicator.ComputeAllReducedParams(arguments, instructions, runtimeCore);
                 HashSet<FunctionEndPoint> lookups; 
-                if (funcGroup.CanGetExactMatchStatics( context, reducedParams, stackFrame, runtimeCore, out lookups))
+                if (funcGroup.CanGetExactMatchStatics(context, reducedParams, stackFrame, runtimeCore, out lookups))
                 {
                     //Otherwise we have a cluster of FEPs that can be used to dispatch the array
                     resolvesFeps = new List<FunctionEndPoint>(lookups);
@@ -822,6 +822,7 @@ namespace ProtoCore
                         return;
                     }
                 }
+
             }
 
             #endregion
@@ -1307,6 +1308,7 @@ namespace ProtoCore
             //If we got here then the function group got resolved
             log.AppendLine("Function group resolved: " + funcGroup);
 
+            // Filter function end point
             List<FunctionEndPoint> candidatesFeps = new List<FunctionEndPoint>();
             int argumentNumber = arguments.Count;
             foreach (var fep in funcGroup.FunctionEndPoints)

--- a/src/Engine/ProtoCore/Lang/FunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionEndPoint.cs
@@ -25,16 +25,6 @@ namespace ProtoCore
 			set;
 		}
 		
-		public bool FuncHasOverloads { //If the function has overloads and the type distance has changed, we'll have to do a re-resolution
-			get;
-			internal set;
-		}
-		
-		public bool FuncHasPredicates { //If the function has predicates, we need to retest
-			get;
-			internal set;
-		}
-
         // In which block it is defined?
         public int BlockScope { get; set; }
 

--- a/src/Engine/ProtoCore/Lang/FunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionEndPoint.cs
@@ -97,7 +97,6 @@ namespace ProtoCore
             return true;
         }
 
-
         internal int ComputeCastDistance(List<StackValue> args, ClassTable classTable, RuntimeCore runtimeCore)
         {
             //Compute the cost to migrate a class calls argument types to the coresponding base types
@@ -112,50 +111,44 @@ namespace ProtoCore
             {
                 return 0;
             }
-            else
+
+            int distance = 0;
+            for (int i = 0; i < args.Count; ++i)
             {
-                int distance = 0;
-                // Check if all the types match the current function at 'n'
-                for (int i = 0; i < args.Count; ++i)
+                int rcvdType = args[i].metaData.type;
+
+                // If its a default argumnet, then it wasnt provided by the caller
+                // The rcvdType is the type of the argument signature
+                if (args[i].IsDefaultArgument)
                 {
-                    int rcvdType = args[i].metaData.type;
-
-                    // If its a default argumnet, then it wasnt provided by the caller
-                    // The rcvdType is the type of the argument signature
-                    if (args[i].IsDefaultArgument)
-                    {
-                        rcvdType = FormalParams[i].UID;
-                    }
-
-                    int expectedType = FormalParams[i].UID;
-
-                    if (FormalParams[i].IsIndexable != args[i].IsArray) //Replication code will take care of this
-                    {
-                        continue;
-                    }
-                    else if (FormalParams[i].IsIndexable)  // both are arrays
-                    {
-                        continue;
-                    }
-                    else if (expectedType == rcvdType)
-                    {
-                        continue;
-                    }
-                    else if (rcvdType != Constants.kInvalidIndex && expectedType != Constants.kInvalidIndex)
-                    {
-                        int currentCost = ClassUtils.GetUpcastCountTo(
-                            classTable.ClassNodes[rcvdType], 
-                            classTable.ClassNodes[expectedType], 
-                            runtimeCore);
-                        distance += currentCost;
-                    }
+                    rcvdType = FormalParams[i].UID;
                 }
-                return distance;
+
+                int expectedType = FormalParams[i].UID;
+
+                if (FormalParams[i].IsIndexable != args[i].IsArray) //Replication code will take care of this
+                {
+                    continue;
+                }
+                else if (FormalParams[i].IsIndexable)  // both are arrays
+                {
+                    continue;
+                }
+                else if (expectedType == rcvdType)
+                {
+                    continue;
+                }
+                else if (rcvdType != Constants.kInvalidIndex && expectedType != Constants.kInvalidIndex)
+                {
+                    int currentCost = ClassUtils.GetUpcastCountTo(
+                        classTable.ClassNodes[rcvdType],
+                        classTable.ClassNodes[expectedType],
+                        runtimeCore);
+                    distance += currentCost;
+                }
             }
+            return distance;
         }
-
-
-
 
 	    /// <summary>
         /// Compute the number of type transforms needed to turn the current type into the target type
@@ -165,105 +158,87 @@ namespace ProtoCore
         /// <returns></returns>
         public int ComputeTypeDistance(List<StackValue> args, ProtoCore.DSASM.ClassTable classTable, RuntimeCore runtimeCore, bool allowArrayPromotion = false)
         {
-            //Modified from proc Table, does not use quite the same arguments
-                
-            int distance = (int)ProcedureDistance.MaxDistance;
-
-            if (0 == args.Count && 0 == FormalParams.Length)
+            if (args.Count == 0 && FormalParams.Length == 0)
             {
-                distance = (int)ProcedureDistance.ExactMatchDistance;
+                return (int)ProcedureDistance.ExactMatchDistance;
             }
-            else
+
+            if (args.Count != FormalParams.Length)
             {
-                // Jun Comment:
-                // Default args not provided by the caller would have been pushed by the call instruction as optype = DefaultArs
-                if (FormalParams.Length == args.Count)
+                return (int)ProcedureDistance.MaxDistance;
+            }
+
+            int distance = (int)ProcedureDistance.MaxDistance;
+            // Jun Comment:
+            // Default args not provided by the caller would have been pushed by the call instruction as optype = DefaultArs
+            for (int i = 0; i < args.Count; ++i)
+            {
+                int rcvdType = args[i].metaData.type;
+
+                // If its a default argumnet, then it wasnt provided by the caller
+                // The rcvdType is the type of the argument signature
+                if (args[i].IsDefaultArgument)
                 {
-                    // Check if all the types match the current function at 'n'
-                    for (int i = 0; i < args.Count; ++i)
+                    rcvdType = FormalParams[i].UID;
+                }
+
+                int expectedType = FormalParams[i].UID;
+                int currentScore = (int)ProcedureDistance.NotMatchScore;
+
+                //sv rank > param rank
+                if (allowArrayPromotion)
+                {
+                    //stop array -> single
+                    if (args[i].IsArray && !FormalParams[i].IsIndexable) //Replication code will take care of this
                     {
-                        int rcvdType = args[i].metaData.type;
-
-                        // If its a default argumnet, then it wasnt provided by the caller
-                        // The rcvdType is the type of the argument signature
-                        if (args[i].IsDefaultArgument)
-                        {
-                            rcvdType = FormalParams[i].UID; 
-                        }
-
-                        int expectedType = FormalParams[i].UID;
-                        int currentScore = (int)ProcedureDistance.NotMatchScore;
-
-                        //Fuqiang: For now disable rank check
-                        //if function is expecting array, but non-array or array of lower rank is passed, break.
-                        //if (args[i].rank != -1 && args[i].UID != (int)PrimitiveType.kTypeVar && args[i].rank < argTypeList[i].rank)
-
-                        //Only enable type check, and array and non-array check
-                       /*  SUSPECTED REDUNDANT Luke,Jun
-                        * if (args[i].rank != -1 && args[i].UID != (int)PrimitiveType.kTypeVar && !args[i].IsIndexable && FormalParams[i].IsIndexable)
-                        {
-                            distance = (int)ProcedureDistance.kMaxDistance;
-                            break;
-                        }
-                        else */
-
-                        //sv rank > param rank
-
-                        if (allowArrayPromotion)
-                        {
-                            //stop array -> single
-                            if (args[i].IsArray && !FormalParams[i].IsIndexable) //Replication code will take care of this
-                            {
-                                distance = (int)ProcedureDistance.MaxDistance;
-                                break;
-                            }
-                        }
-                        else
-                        {
-                            //stop array -> single && single -> array
-                            if (args[i].IsArray != FormalParams[i].IsIndexable)
-                            //Replication code will take care of this
-                            {
-                                distance = (int)ProcedureDistance.MaxDistance;
-                                break;
-                            }
-                        }
-                        
-                        if (FormalParams[i].IsIndexable && (FormalParams[i].IsIndexable == args[i].IsArray))
-                        {
-                            //In case of conversion from double to int, add a conversion score.
-                            //There are overloaded methods and the difference is the parameter type between int and double.
-                            //Add this to make it call the correct one. - Randy
-                            bool bContainsDouble = ArrayUtils.ContainsDoubleElement(args[i], runtimeCore);
-                            if (FormalParams[i].UID == (int)PrimitiveType.Integer && bContainsDouble)
-                            {
-                                currentScore = (int)ProcedureDistance.CoerceDoubleToIntScore;
-                            }
-                            else if (FormalParams[i].UID == (int)PrimitiveType.Double && !bContainsDouble)
-                            {
-                                currentScore = (int)ProcedureDistance.CoerceIntToDoubleScore;
-                            }
-                            else
-                            {
-                                currentScore = (int)ProcedureDistance.ExactMatchScore;
-                            }
-                        }
-                        else if (expectedType == rcvdType && (FormalParams[i].IsIndexable == args[i].IsArray))
-                        {
-                            currentScore = (int)ProcedureDistance.ExactMatchScore;
-                        }
-                        else if (rcvdType != ProtoCore.DSASM.Constants.kInvalidIndex)
-                        {
-                            currentScore = classTable.ClassNodes[rcvdType].GetCoercionScore(expectedType);
-                            if (currentScore == (int)ProcedureDistance.NotMatchScore)
-                            {
-                                distance = (int)ProcedureDistance.MaxDistance;
-                                break;
-                            }
-                        }
-                        distance -= currentScore;
+                        distance = (int)ProcedureDistance.MaxDistance;
+                        break;
                     }
                 }
+                else
+                {
+                    //stop array -> single && single -> array
+                    if (args[i].IsArray != FormalParams[i].IsIndexable)
+                    //Replication code will take care of this
+                    {
+                        distance = (int)ProcedureDistance.MaxDistance;
+                        break;
+                    }
+                }
+
+                if (FormalParams[i].IsIndexable && (FormalParams[i].IsIndexable == args[i].IsArray))
+                {
+                    //In case of conversion from double to int, add a conversion score.
+                    //There are overloaded methods and the difference is the parameter type between int and double.
+                    //Add this to make it call the correct one. - Randy
+                    bool bContainsDouble = ArrayUtils.ContainsDoubleElement(args[i], runtimeCore);
+                    if (FormalParams[i].UID == (int)PrimitiveType.Integer && bContainsDouble)
+                    {
+                        currentScore = (int)ProcedureDistance.CoerceDoubleToIntScore;
+                    }
+                    else if (FormalParams[i].UID == (int)PrimitiveType.Double && !bContainsDouble)
+                    {
+                        currentScore = (int)ProcedureDistance.CoerceIntToDoubleScore;
+                    }
+                    else
+                    {
+                        currentScore = (int)ProcedureDistance.ExactMatchScore;
+                    }
+                }
+                else if (expectedType == rcvdType && (FormalParams[i].IsIndexable == args[i].IsArray))
+                {
+                    currentScore = (int)ProcedureDistance.ExactMatchScore;
+                }
+                else if (rcvdType != ProtoCore.DSASM.Constants.kInvalidIndex)
+                {
+                    currentScore = classTable.ClassNodes[rcvdType].GetCoercionScore(expectedType);
+                    if (currentScore == (int)ProcedureDistance.NotMatchScore)
+                    {
+                        distance = (int)ProcedureDistance.MaxDistance;
+                        break;
+                    }
+                }
+                distance -= currentScore;
             }
             return distance;
         }

--- a/src/Engine/ProtoCore/Lang/FunctionGroup.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionGroup.cs
@@ -174,8 +174,8 @@ namespace ProtoCore
         }
 
         /// <summary>
-        /// Returns a dictionary of the function end points that are type loosely compatible
-        /// with the costs of the associated conversions. 
+        /// Returns a dictionary of the function end points that are type compatible
+        /// with any branch of replicated parameters. 
         /// </summary>
         /// <param name="context"></param>
         /// <param name="formalParams"></param>
@@ -183,16 +183,17 @@ namespace ProtoCore
         /// <param name="classTable"></param>
         /// <param name="runtimeCore"></param>
         /// <returns></returns>
-        public Dictionary<FunctionEndPoint, int> GetLooseConversionDistances(Runtime.Context context,
-            List<StackValue> formalParams, List<ReplicationInstruction> replicationInstructions,
-            ClassTable classTable, RuntimeCore runtimeCore)
+        public Dictionary<FunctionEndPoint, int> GetLooseConversionDistances(
+            Runtime.Context context,
+            List<StackValue> formalParams,
+            List<ReplicationInstruction> replicationInstructions,
+            ClassTable classTable,
+            RuntimeCore runtimeCore)
         {
             Dictionary<FunctionEndPoint, int> ret = new Dictionary<FunctionEndPoint, int>();
-
-            List<FunctionEndPoint> feps = FunctionEndPoints;
             var reducedParams = Replicator.ComputeAllReducedParams(formalParams, replicationInstructions, runtimeCore);
 
-            foreach (FunctionEndPoint fep in feps)
+            foreach (FunctionEndPoint fep in FunctionEndPoints)
             {
                 foreach (var reducedParam in reducedParams)
                 {

--- a/src/Engine/ProtoCore/Lang/FunctionGroup.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionGroup.cs
@@ -116,7 +116,7 @@ namespace ProtoCore
             bool isInstance = thisptr.IsPointer && thisptr.Pointer!= Constants.kInvalidIndex;
             bool isGlobal = thisptr.IsPointer && thisptr.Pointer == Constants.kInvalidIndex;
                                   
-            foreach (FunctionEndPoint fep in FunctionEndPoints)
+            foreach (FunctionEndPoint fep in FunctionEndPoints) 
             {
                 var proc = fep.procedureNode;
 
@@ -134,21 +134,14 @@ namespace ProtoCore
                     continue;
                 }
 
-                bool typesOK = true;
-                foreach (List<StackValue> reducedParamSVs in allReducedParamSVs)
+                if (allReducedParamSVs.All(ps => fep.DoesTypeDeepMatch(ps, runtimeCore)))
                 {
-                    if (!fep.DoesTypeDeepMatch(reducedParamSVs, runtimeCore))
-                    {
-                        typesOK = false;
-                        break;
-                    }
-                }
 
-                if (typesOK)
                     ret.Add(fep);
+                }
             }
 
-            return ret;
+            return ret; 
         }
 
         /// <summary>

--- a/src/Engine/ProtoCore/Lang/FunctionGroup.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionGroup.cs
@@ -73,14 +73,17 @@ namespace ProtoCore
         /// <param name="core"></param>
         /// <param name="unresolvable">The number of argument sets that couldn't be resolved</param>
         /// <returns></returns>
-        public Dictionary<FunctionEndPoint, int> GetExactMatchStatistics(
+        public bool CanGetExactMatchStatics(
             Runtime.Context context,
-            List<List<StackValue>> reducedFormalParams, StackFrame stackFrame, RuntimeCore runtimeCore, out int unresolvable)
+            List<List<StackValue>> reducedFormalParams,
+            StackFrame stackFrame,
+            RuntimeCore runtimeCore,
+            out Dictionary<FunctionEndPoint, int> lookup)
         {
             List<ReplicationInstruction> replicationInstructions = new List<ReplicationInstruction>(); //We've already done the reduction before calling this
 
-            unresolvable = 0;
-            Dictionary<FunctionEndPoint, int> ret = new Dictionary<FunctionEndPoint, int>();
+            int unresolvable = 0;
+            lookup = new Dictionary<FunctionEndPoint, int>();
 
             foreach (List<StackValue> formalParamSet in reducedFormalParams)
             {
@@ -95,14 +98,14 @@ namespace ProtoCore
 
                 foreach (FunctionEndPoint fep in feps)
                 {
-                    if (ret.ContainsKey(fep))
-                        ret[fep]++;
+                    if (lookup.ContainsKey(fep))
+                        lookup[fep]++;
                     else
-                        ret.Add(fep, 1);
+                        lookup.Add(fep, 1);
                 }
              }
 
-             return ret;
+             return unresolvable == 0;
         }
 
 

--- a/src/Engine/ProtoCore/Lang/FunctionGroup.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionGroup.cs
@@ -78,34 +78,24 @@ namespace ProtoCore
             List<List<StackValue>> reducedFormalParams,
             StackFrame stackFrame,
             RuntimeCore runtimeCore,
-            out Dictionary<FunctionEndPoint, int> lookup)
+            out HashSet<FunctionEndPoint> lookup)
         {
-            List<ReplicationInstruction> replicationInstructions = new List<ReplicationInstruction>(); //We've already done the reduction before calling this
-
-            int unresolvable = 0;
-            lookup = new Dictionary<FunctionEndPoint, int>();
-
+            lookup = new HashSet<FunctionEndPoint>();
             foreach (List<StackValue> formalParamSet in reducedFormalParams)
             {
-                List<FunctionEndPoint> feps = GetExactTypeMatches(context,
-                                                                  formalParamSet, replicationInstructions, stackFrame,
-                                                                  runtimeCore);
+                List<FunctionEndPoint> feps = GetExactTypeMatches(context, formalParamSet, new List<ReplicationInstruction>(), stackFrame, runtimeCore);
                 if (feps.Count == 0)
                 {
-                    //We have an arugment set that couldn't be resolved
-                    unresolvable++;
+                    return false;
                 }
 
                 foreach (FunctionEndPoint fep in feps)
                 {
-                    if (lookup.ContainsKey(fep))
-                        lookup[fep]++;
-                    else
-                        lookup.Add(fep, 1);
+                    lookup.Add(fep);
                 }
              }
 
-             return unresolvable == 0;
+            return true;
         }
 
 

--- a/src/Engine/ProtoCore/Lang/FunctionGroup.cs
+++ b/src/Engine/ProtoCore/Lang/FunctionGroup.cs
@@ -173,6 +173,40 @@ namespace ProtoCore
             return ret;
         }
 
+        /// <summary>
+        /// Returns a dictionary of the function end points that are type loosely compatible
+        /// with the costs of the associated conversions. 
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="formalParams"></param>
+        /// <param name="replicationInstructions"></param>
+        /// <param name="classTable"></param>
+        /// <param name="runtimeCore"></param>
+        /// <returns></returns>
+        public Dictionary<FunctionEndPoint, int> GetLooseConversionDistances(Runtime.Context context,
+            List<StackValue> formalParams, List<ReplicationInstruction> replicationInstructions,
+            ClassTable classTable, RuntimeCore runtimeCore)
+        {
+            Dictionary<FunctionEndPoint, int> ret = new Dictionary<FunctionEndPoint, int>();
+
+            List<FunctionEndPoint> feps = FunctionEndPoints;
+            var reducedParams = Replicator.ComputeAllReducedParams(formalParams, replicationInstructions, runtimeCore);
+
+            foreach (FunctionEndPoint fep in feps)
+            {
+                foreach (var reducedParam in reducedParams)
+                {
+                    int distance = fep.GetConversionDistance(reducedParam, classTable, true, runtimeCore);
+                    if (distance != (int)ProcedureDistance.InvalidDistance)
+                    {
+                        ret.Add(fep, distance);
+                        break;
+                    } 
+                }
+            }
+
+            return ret;
+        }
 
         public static bool CheckInvalidArrayCoersion(FunctionEndPoint fep, List<StackValue> reducedSVs, ClassTable classTable, RuntimeCore runtimeCore, bool allowArrayPromotion)
         {

--- a/src/Engine/ProtoCore/Utils/ArrayUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ArrayUtils.cs
@@ -122,14 +122,13 @@ namespace ProtoCore.Utils
 
         public static Dictionary<int, StackValue> GetTypeExamplesForLayer(StackValue array, RuntimeCore runtimeCore)
         {
+            Dictionary<int, StackValue> usageFreq = new Dictionary<int, StackValue>();
+
             if (!array.IsArray)
             {
-                Dictionary<int, StackValue> ret = new Dictionary<int, StackValue>();
-                ret.Add(array.metaData.type, array);
-                return ret;
+                usageFreq.Add(array.metaData.type, array);
+                return usageFreq;
             }
-
-            Dictionary<int, StackValue> usageFreq = new Dictionary<int, StackValue>();
 
             //This is the element on the heap that manages the data structure
             var dsArray = runtimeCore.Heap.ToHeapObject<DSArray>(array);

--- a/test/Engine/ProtoTest/Associative/MethodsFocusTeam.cs
+++ b/test/Engine/ProtoTest/Associative/MethodsFocusTeam.cs
@@ -1733,6 +1733,56 @@ r2 = foo(a, {1});
             thisTest.Verify("r1", new object[] {41});
             thisTest.Verify("r2", new object[] {42});
         }
+
+        [Test]
+        public void TestMethodResolutionOnHeterogeneousArray01()
+        {
+            string code = @"
+def foo(x : int)
+{
+    return = x;
+}
+
+r = foo({""foo"", ""bar"", 33.9});
+";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("r", new object[] { null, null, 40 });
+        }
+
+        [Test]
+        public void TestMethodResolutionOnHeterogeneousArray02()
+        {
+            string code = @"
+def foo(x: int, y : string)
+{
+    return = x;
+}
+
+xs = {""foo"", 10, ""bar""};
+ys = { 12, ""ding"", ""dang""};
+r = foo(xs, ys);
+";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("r", new object[] { null, 10, null});
+        }
+
+        [Test]
+        public void TestMethodResolutionOnHeterogeneousArray03()
+        {
+            string code = @"
+def foo(x: int, y : string)
+{
+    return = x;
+}
+
+xs = {""foo"", 10, ""bar""};
+ys = { 12, ""ding"", ""dang""};
+r = foo(xs<1>, ys<1>);
+";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("r", new object[] { null, 10, null });
+        }
+
     }
 }
 

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests.cs
@@ -6220,7 +6220,7 @@ import(""FFITarget.dll"");
             TestFrameWork.Verify(mirror, "v", 3);
             TestFrameWork.Verify(mirror, "w", 3);
             TestFrameWork.Verify(mirror, "x", new object[] { 1, 1 });
-            TestFrameWork.Verify(mirror, "y", 3);
+            TestFrameWork.Verify(mirror, "y", new object[] { new object[] { 1, 1 } });
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Current method resolution is a little bit strict if argument is a heterogeneous array. Suppose we have function
```
def foo(x: int)
{
    return x;
}
```
Then call this function with a heterogeneous array `foo({"bar", 42)`. Method resolution logic will fail to find out a function `foo()` which exactly matches arguments `"bar"` and `42` (after replication). 

So method resolution should be more tolerance so that it is able to handle heterogeneous array to some extend. This is important to fix issue #7153.

This PR adds extra checking to method resolution logic: if all cases fail, then try to find out a method which matches with *any* branch of replicated arguments, and dispatch to that method if it exits. 

Example:
```
def foo(x: int, y : string)
{
    return = x;
}
xs = {"foo", 10, "bar"};
ys = { 12, "ding", "dang"};
r = foo(xs, ys);
```
In this case `foo()` is called with replicated arguments `{"foo", 12}, {10, "ding"} and {"bar", "dang"}`. As the second arguments `{10, "ding"}` match with `foo()`, method resolution succeeds, and the result will be `{null, 10, null}`.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@sharadkjaiswal @Benglin 
