### PR TITLE
Fix MAGN-10067: output port not created if inline condition used in imperative language block

### DIFF
--- a/src/Engine/ProtoCore/Parser/ImperativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/ImperativeAST.cs
@@ -1009,6 +1009,17 @@ namespace ProtoCore.AST.ImperativeAST
         public ImperativeNode TrueExpression { get; set; }
         public ImperativeNode FalseExpression { get; set; }
 
+        public InlineConditionalNode()
+        {
+        }
+
+        public InlineConditionalNode(InlineConditionalNode rhs) : base(rhs)
+        {
+            ConditionExpression = NodeUtils.Clone(rhs.ConditionExpression);
+            TrueExpression = NodeUtils.Clone(rhs.TrueExpression);
+            FalseExpression = NodeUtils.Clone(rhs.FalseExpression);
+        }
+
         public override bool Equals(object other)
         {
             if (null == ConditionExpression || null == TrueExpression || null == FalseExpression)

--- a/src/Engine/ProtoCore/Utils/NodeUtils.cs
+++ b/src/Engine/ProtoCore/Utils/NodeUtils.cs
@@ -236,6 +236,10 @@ namespace ProtoCore.Utils
             {
                 return new ProtoCore.AST.ImperativeAST.UnaryExpressionNode(rhsNode as ProtoCore.AST.ImperativeAST.UnaryExpressionNode);
             }
+            else if (rhsNode is AST.ImperativeAST.InlineConditionalNode)
+            {
+                return new AST.ImperativeAST.InlineConditionalNode(rhsNode as AST.ImperativeAST.InlineConditionalNode);
+            }
 
             Validity.Assert(false);
             return null;


### PR DESCRIPTION
### Purpose

This PR is to fix defect MAGN-10067: input/output port not created if inline condition used in imperative language block. See attached image:

![image](https://cloud.githubusercontent.com/assets/2600379/18700592/b1858a4e-800a-11e6-9381-81c067b62953.png)

This is because an exception thrown out in `NodeUtils.Clone()` for inline conditional node as it is not handled. Add the handling for imperative inline conditional node.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@riteshchandawar 

