### PR TITLE
MAGN-10698 Cannot publish locally a package if the default directory is not accessible

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4525,6 +4525,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Please go to Manage Node and Package Paths in Setting to change your default directory..
+        /// </summary>
+        public static string SolutionToFolderNotWritatbleError {
+            get {
+                return ResourceManager.GetString("SolutionToFolderNotWritatbleError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Advanced Tutorials.
         /// </summary>
         public static string StartPageAdvancedTutorials {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4525,7 +4525,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Please go to Manage Node and Package Paths in Setting to change your default directory..
+        ///   Looks up a localized string similar to Please update the permissions or go to &apos;Settings &gt; Manage Node and Package Paths...&apos; to change your default directory..
         /// </summary>
         public static string SolutionToFolderNotWritatbleError {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2101,4 +2101,7 @@ Failed to publish file(s):
     <value>Package published successfully. 
 Want to publish a different package?</value>
   </data>
+  <data name="SolutionToFolderNotWritatbleError" xml:space="preserve">
+    <value>Please go to Manage Node and Package Paths in Setting to change your default directory.</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2102,6 +2102,6 @@ Failed to publish file(s):
 Want to publish a different package?</value>
   </data>
   <data name="SolutionToFolderNotWritatbleError" xml:space="preserve">
-    <value>Please go to Manage Node and Package Paths in Setting to change your default directory.</value>
+    <value>Please update the permissions or go to 'Settings &gt; Manage Node and Package Paths...' to change your default directory.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2103,4 +2103,7 @@ Failed to publish file(s):
     <value>Package published successfully. 
 Want to publish a different package?</value>
   </data>
+  <data name="SolutionToFolderNotWritatbleError" xml:space="preserve">
+    <value>Please go to Manage Node and Package Paths in Setting to change your default directory.</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2104,6 +2104,6 @@ Failed to publish file(s):
 Want to publish a different package?</value>
   </data>
   <data name="SolutionToFolderNotWritatbleError" xml:space="preserve">
-    <value>Please go to Manage Node and Package Paths in Setting to change your default directory.</value>
+    <value>Please update the permissions or go to 'Settings &gt; Manage Node and Package Paths...' to change your default directory.</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -1268,7 +1268,12 @@ namespace Dynamo.PackageManager
             if (!IsDirectoryWritable(folder))
             {
                 ErrorString = String.Format(Resources.FolderNotWritableError, folder);
-                return string.Empty;
+                var ErrorMessage = ErrorString + "\n" + Resources.SolutionToFolderNotWritatbleError;
+                DialogResult response = DynamoModel.IsTestMode ? DialogResult.OK : System.Windows.Forms.MessageBox.Show(ErrorMessage, Resources.FileNotPublishCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                if (response == DialogResult.OK)
+                {
+                    return string.Empty;
+                }
             }
 
             var pkgSubFolder = Path.Combine(folder, PathManager.PackagesDirectoryName);

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
@@ -54,7 +54,7 @@ namespace Dynamo.PackageManager
                     e.Path = dialog.SelectedPath;
                 }
             }
-            else if (e.Path.CompareTo(string.Empty) != 0)
+            else if (!String.IsNullOrEmpty(e.Path))
             {
                 e.Cancel = false;
             }

--- a/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PublishPackageView.xaml.cs
@@ -54,7 +54,11 @@ namespace Dynamo.PackageManager
                     e.Path = dialog.SelectedPath;
                 }
             }
-           
+            else if (e.Path.CompareTo(string.Empty) != 0)
+            {
+                e.Cancel = false;
+            }
+
         }
     }
 


### PR DESCRIPTION
### Purpose
 - Issue: When user default directory is an inaccessible path, any publish locally package operation will not work.
 - Fix: 
  + In OnRequestShowFolderBrowserDialog() when the PathEventArgs.path is not null but is inaccessible, the PathEventArgs.cancel will still be set to false. This means only when PathEventArgs.path is null, PathEventArgs.cancel is true.
  + This is to prevent the GetPublishFolder() stop at the args.cancel check when the path is not null.

 - Here are a few UI changes: 
    + When the default path is inaccessible, the status of publish package dialog will show an error message.
    + An error dialog also appears to tell user how to change the default path.

![magn 10698](https://cloud.githubusercontent.com/assets/14092408/18699641/2c0a8752-8005-11e6-8c21-30c80e9d622f.JPG)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 