### PR TITLE
Fix some regressions

### DIFF
--- a/test/Libraries/WorkflowTests/ComplexTests.cs
+++ b/test/Libraries/WorkflowTests/ComplexTests.cs
@@ -244,8 +244,8 @@ namespace Dynamo.Tests
             AssertNoDummyNodes();
 
             //check the number of nodes and connectors
-            Assert.AreEqual(44, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
-            Assert.AreEqual(36, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            Assert.AreEqual(45, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
+            Assert.AreEqual(37, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
             //check List.Map
             var map1 = "34986114-3561-4feb-993b-3c53c9ef352f";
@@ -669,8 +669,8 @@ namespace Dynamo.Tests
             AssertNoDummyNodes();
 
             // check the number of nodes and connectors
-            Assert.AreEqual(32, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
-            Assert.AreEqual(26, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            Assert.AreEqual(33, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
+            Assert.AreEqual(27, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
             //check List.Map
             var list = "34986114-3561-4feb-993b-3c53c9ef352f";
@@ -1010,8 +1010,8 @@ namespace Dynamo.Tests
             AssertNoDummyNodes();
 
             //check the number of nodes and connectors
-            Assert.AreEqual(64, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
-            Assert.AreEqual(40, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            Assert.AreEqual(69, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
+            Assert.AreEqual(45, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
 
             //check Surface.Thicken
             var surfaceID = "a7b4e678-3278-4554-8ce2-7c76faca79d7";

--- a/test/System/IntegrationTests/IncrementingTraceTests.cs
+++ b/test/System/IntegrationTests/IncrementingTraceTests.cs
@@ -1593,7 +1593,7 @@ mtcAID = mtcA.ID;";
 
             TestFrameWork.AssertValue("mtcAID", new List<int>() { 0, 1}, astLiveRunner);
 
-            Assert.IsTrue(astLiveRunner.RuntimeCore.RuntimeData.CallsiteCache.Count == 1);
+            Assert.IsTrue(astLiveRunner.RuntimeCore.RuntimeData.CallsiteCache.Count == 2);
 
 
             Console.WriteLine("==============Completed first verification ===================");

--- a/test/core/WorkflowTestFiles/ListManagementMisc/Combine.dyn
+++ b/test/core/WorkflowTestFiles/ListManagementMisc/Combine.dyn
@@ -1,99 +1,178 @@
-<Workspace Version="0.7.5.3327" X="-2025.02068906631" Y="308.830333621592" zoom="0.950984727029984" Description="" Category="" Name="Home">
+<Workspace Version="1.2.1.2644" X="-2018.62068906631" Y="211.230333621592" zoom="0.950984727029984" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="232e3c38-eba5-45ac-a48e-7a28c981978d" nickname="Point.ByCoordinates" x="730.072941681612" y="-97.32248810896" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="00bde5f2-d493-471f-8a96-ccf262f607e6" nickname="Code Block" x="-183.612658408593" y="175.945973110655" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="x = 0..360..24;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" nickname="Math.Sin" x="182.215736905481" y="10.5676743290963" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.Math.Sin@double" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="f80430ef-10e0-4c49-a900-ccd4699665ff" nickname="*" x="182.652052827371" y="-161.71717945736" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="*@," />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="713785ce-66d6-4e4a-9e82-cf6ac94b447b" nickname="Code Block" x="-30.1980407217359" y="-98.2842575755678" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0.2;" ShouldFocus="false" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="555b06f0-2188-4b21-8d78-589ea6c2fd01" nickname="Code Block" x="437.652052827371" y="-57.2171794573603" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" nickname="*" x="554.123694866777" y="30.2212165336962" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="*@," />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="87000fc6-56f9-429d-977b-5150e79bda56" nickname="Code Block" x="364.652052827371" y="115.78282054264" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="4;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="21d31559-fc02-412a-99f5-cdcb766f1bd2" nickname="NurbsCurve.ByPoints" x="939.515624188966" y="-94.6699902690747" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="e8a64668-ee00-4290-868f-1c8e4970d0d2" nickname="+" x="203.245420692425" y="358.900184218226" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="+@," />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="40cbf19c-9182-4536-8530-01442a0c2714" nickname="Code Block" x="25.4815944795993" y="436.748460345878" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="120;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="e014f8bd-0b2d-47b4-ad61-b708e3d63856" nickname="NurbsCurve.ByPoints" x="988.150683632418" y="255.244962094166" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="92b01453-7f63-4040-8664-93ece7aba70b" nickname="Point.ByCoordinates" x="779.947521344488" y="216.825324885123" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="582b03fc-7dc9-413a-b322-432a3f5940a9" nickname="*" x="556.348517976863" y="460.087330485367" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="*@," />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="e1ac034d-ea27-4df3-8049-6099267bbcbf" nickname="Code Block" x="383.471295538765" y="509.923667635792" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="4;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="7468eead-3b06-40a6-8653-3b8b88180f89" nickname="Math.Sin" x="389.20807480723" y="367.901176326504" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.Math.Sin@double" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="acbd24d0-ecaf-487d-9ab1-82431a566b9b" nickname="Code Block" x="562.840302538075" y="341.777566975215" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="20;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="50d2a6e8-35f9-45dc-a858-6d67683c5b68" nickname="Geometry.Translate" x="1233.33479941474" y="53.3631408043654" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.Translate@double,double,double" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="51e63597-d9fd-4602-a2ad-f06f6873d215" nickname="Code Block" x="1052.34778182596" y="87.3662660309333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="50;&#xA;0;" ShouldFocus="false" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="9ab004ca-0917-4858-85bc-57ae681e33e8" nickname="Code Block" x="1500.96856495265" y="15.6255051664936" isVisible="false" isUpstreamVisible="true" lacing="Disabled" CodeText="crves = {a, b, c};" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" nickname="Surface.ByLoft" x="1802.05278726858" y="-45.1868026608493" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" nickname="Surface.PointAtParameter" x="2090.89981769624" y="-38.5589879185765" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.PointAtParameter@double,double">
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="232e3c38-eba5-45ac-a48e-7a28c981978d" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="730.072941681612" y="-97.32248810896" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="00bde5f2-d493-471f-8a96-ccf262f607e6" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-183.612658408593" y="175.945973110655" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="x = 0..360..24;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Sin" x="182.215736905481" y="10.5676743290963" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Sin@double">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="f80430ef-10e0-4c49-a900-ccd4699665ff" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="*" x="182.652052827371" y="-161.71717945736" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="*@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="713785ce-66d6-4e4a-9e82-cf6ac94b447b" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-30.1980407217359" y="-98.2842575755678" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="0.2;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="555b06f0-2188-4b21-8d78-589ea6c2fd01" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="437.652052827371" y="-57.2171794573603" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="0;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="*" x="554.123694866777" y="30.2212165336962" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="*@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="87000fc6-56f9-429d-977b-5150e79bda56" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="364.652052827371" y="115.78282054264" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="4;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="21d31559-fc02-412a-99f5-cdcb766f1bd2" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="NurbsCurve.ByPoints" x="939.515624188966" y="-94.6699902690747" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e8a64668-ee00-4290-868f-1c8e4970d0d2" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="+" x="203.245420692425" y="358.900184218226" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="+@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="40cbf19c-9182-4536-8530-01442a0c2714" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="25.4815944795993" y="436.748460345878" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="120;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e014f8bd-0b2d-47b4-ad61-b708e3d63856" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="NurbsCurve.ByPoints" x="988.150683632418" y="255.244962094166" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="92b01453-7f63-4040-8664-93ece7aba70b" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="779.947521344488" y="216.825324885123" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="582b03fc-7dc9-413a-b322-432a3f5940a9" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="*" x="556.348517976863" y="460.087330485367" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="*@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="e1ac034d-ea27-4df3-8049-6099267bbcbf" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="383.471295538765" y="509.923667635792" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="4;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="7468eead-3b06-40a6-8653-3b8b88180f89" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Sin" x="389.20807480723" y="367.901176326504" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Sin@double">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="acbd24d0-ecaf-487d-9ab1-82431a566b9b" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="562.840302538075" y="341.777566975215" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="20;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="50d2a6e8-35f9-45dc-a858-6d67683c5b68" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Geometry.Translate" x="1233.33479941474" y="53.3631408043654" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.Translate@double,double,double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+      <PortInfo index="3" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="51e63597-d9fd-4602-a2ad-f06f6873d215" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1052.34778182596" y="87.3662660309333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="50;&#xA;0;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="9ab004ca-0917-4858-85bc-57ae681e33e8" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1500.96856495265" y="15.6255051664936" isVisible="false" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="crves = {a, b, c};" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.ByLoft" x="1802.05278726858" y="-45.1868026608493" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.PointAtParameter" x="2090.89981769624" y="-38.5589879185765" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.PointAtParameter@double,double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
       <PortInfo index="2" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="f8382ff0-62e0-4125-89ee-882e3f032833" nickname="Code Block" x="1868" y="157" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0..1..#end;" ShouldFocus="false" />
-    <Dynamo.Nodes.IntegerSlider type="Dynamo.Nodes.IntegerSlider" guid="1eeed0eb-f578-4848-a6ac-dd5e67e28750" nickname="Integer Slider" x="1639.5814867634" y="199.027194750085" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="f8382ff0-62e0-4125-89ee-882e3f032833" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1868" y="157" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="0..1..#end;" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <CoreNodeModels.Input.IntegerSlider guid="1eeed0eb-f578-4848-a6ac-dd5e67e28750" type="CoreNodeModels.Input.IntegerSlider" nickname="Integer Slider" x="1639.5814867634" y="199.027194750085" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Int32>15</System.Int32>
-      <Range min="0" max="100" />
-    </Dynamo.Nodes.IntegerSlider>
-    <DSCore.Map type="DSCore.Map" guid="34986114-3561-4feb-993b-3c53c9ef352f" nickname="List.Map" x="2575.83306513471" y="-0.162593978424098" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="b4d963a6-f9f0-4ca4-b0b1-67c7c23e34fc" nickname="NurbsCurve.ByPoints" x="2295.30597071947" y="121.667840900126" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="3fc5a861-697e-4940-bad9-a8010eef0249" nickname="Curve.Offset" x="3069.8145792622" y="138.77911470906" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.Offset@double">
+      <Range min="0" max="100" step="1" />
+    </CoreNodeModels.Input.IntegerSlider>
+    <CoreNodeModels.HigherOrder.Map guid="34986114-3561-4feb-993b-3c53c9ef352f" type="CoreNodeModels.HigherOrder.Map" nickname="List.Map" x="2575.83306513471" y="-0.162593978424098" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </CoreNodeModels.HigherOrder.Map>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="b4d963a6-f9f0-4ca4-b0b1-67c7c23e34fc" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="NurbsCurve.ByPoints" x="2295.30597071947" y="121.667840900126" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="3fc5a861-697e-4940-bad9-a8010eef0249" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Curve.Offset" x="3069.8145792622" y="138.77911470906" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.Offset@double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="5bb3ad6f-e46e-4351-89ee-b63f5ca43910" nickname="List.FirstItem" x="2237.07109120239" y="365.184089016083" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]" />
-    <DSCore.Map type="DSCore.Map" guid="7ec7b343-6e0c-46ba-b89a-7df17e6a0833" nickname="List.Map" x="2449.39606892253" y="308.995834061842" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="b5ccf380-27e9-4401-a9e0-fa70edd333d6" nickname="*" x="2890.27351630683" y="318.935454320818" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="*@," />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="cce66bb7-6e5b-4dfb-a4b0-427b523e24ec" nickname="Code Block" x="2692" y="426" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0.1;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="cd8135dc-2d29-4466-bc0d-476016f811cb" nickname="Surface.ByLoft" x="3462.7465122179" y="5.83872432532291" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]" />
-    <DSCore.Combine type="DSCore.Combine" guid="ce5a6237-f69b-4a84-9838-245272c8fccf" nickname="List.Combine" x="3273.15533214265" y="-2.68719913883285" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="3" />
-    <DSCoreNodesUI.CreateList type="DSCoreNodesUI.CreateList" guid="f000bb79-9963-4b37-8a01-18200cb0f02a" nickname="List.Create" x="3087.70539331252" y="-65.8470015714951" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="1e71378e-dd9c-4d10-9c3c-471b59f257cf" nickname="List.Transpose" x="2306.98470496255" y="-53.1741748841562" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.Transpose@var[]..[]" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="9c4448aa-0eed-4492-803e-45266957e9cc" nickname="Point.Y" x="2676.48049416823" y="305.515607423468" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Y" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="5bb3ad6f-e46e-4351-89ee-b63f5ca43910" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.FirstItem" x="2237.07109120239" y="365.184089016083" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <CoreNodeModels.HigherOrder.Map guid="7ec7b343-6e0c-46ba-b89a-7df17e6a0833" type="CoreNodeModels.HigherOrder.Map" nickname="List.Map" x="2449.39606892253" y="308.995834061842" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </CoreNodeModels.HigherOrder.Map>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="b5ccf380-27e9-4401-a9e0-fa70edd333d6" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="*" x="2890.27351630683" y="318.935454320818" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="*@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="cce66bb7-6e5b-4dfb-a4b0-427b523e24ec" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="2692" y="426" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="0.1;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="cd8135dc-2d29-4466-bc0d-476016f811cb" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.ByLoft" x="3462.7465122179" y="5.83872432532291" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <CoreNodeModels.HigherOrder.Combine guid="ce5a6237-f69b-4a84-9838-245272c8fccf" type="CoreNodeModels.HigherOrder.Combine" nickname="List.Combine" x="3273.15533214265" y="-2.68719913883285" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="3">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </CoreNodeModels.HigherOrder.Combine>
+    <CoreNodeModels.CreateList guid="f000bb79-9963-4b37-8a01-18200cb0f02a" type="CoreNodeModels.CreateList" nickname="List.Create" x="3087.70539331252" y="-65.8470015714951" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="2">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </CoreNodeModels.CreateList>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="1e71378e-dd9c-4d10-9c3c-471b59f257cf" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.Transpose" x="2352.41130201729" y="-49.8092417689905" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.Transpose@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="9c4448aa-0eed-4492-803e-45266957e9cc" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.Y" x="2676.48049416823" y="305.515607423468" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Y">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="40de7dac-bc68-4730-b8af-bd5955ffd3de" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="2238.31753344242" y="-164.253566066706" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="surface[0];" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </Elements>
   <Connectors>
-    <Dynamo.Models.ConnectorModel start="232e3c38-eba5-45ac-a48e-7a28c981978d" start_index="0" end="21d31559-fc02-412a-99f5-cdcb766f1bd2" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="f80430ef-10e0-4c49-a900-ccd4699665ff" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="e8a64668-ee00-4290-868f-1c8e4970d0d2" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" start_index="0" end="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f80430ef-10e0-4c49-a900-ccd4699665ff" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f80430ef-10e0-4c49-a900-ccd4699665ff" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="713785ce-66d6-4e4a-9e82-cf6ac94b447b" start_index="0" end="f80430ef-10e0-4c49-a900-ccd4699665ff" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="555b06f0-2188-4b21-8d78-589ea6c2fd01" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="87000fc6-56f9-429d-977b-5150e79bda56" start_index="0" end="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="21d31559-fc02-412a-99f5-cdcb766f1bd2" start_index="0" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="21d31559-fc02-412a-99f5-cdcb766f1bd2" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e8a64668-ee00-4290-868f-1c8e4970d0d2" start_index="0" end="7468eead-3b06-40a6-8653-3b8b88180f89" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="40cbf19c-9182-4536-8530-01442a0c2714" start_index="0" end="e8a64668-ee00-4290-868f-1c8e4970d0d2" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e014f8bd-0b2d-47b4-ad61-b708e3d63856" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="92b01453-7f63-4040-8664-93ece7aba70b" start_index="0" end="e014f8bd-0b2d-47b4-ad61-b708e3d63856" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="582b03fc-7dc9-413a-b322-432a3f5940a9" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e1ac034d-ea27-4df3-8049-6099267bbcbf" start_index="0" end="582b03fc-7dc9-413a-b322-432a3f5940a9" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="7468eead-3b06-40a6-8653-3b8b88180f89" start_index="0" end="582b03fc-7dc9-413a-b322-432a3f5940a9" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="acbd24d0-ecaf-487d-9ab1-82431a566b9b" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="50d2a6e8-35f9-45dc-a858-6d67683c5b68" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="0" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="1" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="1" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="3" portType="0" />
-    <Dynamo.Models.ConnectorModel start="9ab004ca-0917-4858-85bc-57ae681e33e8" start_index="0" end="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" start_index="0" end="1e71378e-dd9c-4d10-9c3c-471b59f257cf" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f8382ff0-62e0-4125-89ee-882e3f032833" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f8382ff0-62e0-4125-89ee-882e3f032833" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="1eeed0eb-f578-4848-a6ac-dd5e67e28750" start_index="0" end="f8382ff0-62e0-4125-89ee-882e3f032833" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="34986114-3561-4feb-993b-3c53c9ef352f" start_index="0" end="ce5a6237-f69b-4a84-9838-245272c8fccf" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="34986114-3561-4feb-993b-3c53c9ef352f" start_index="0" end="3fc5a861-697e-4940-bad9-a8010eef0249" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="b4d963a6-f9f0-4ca4-b0b1-67c7c23e34fc" start_index="0" end="34986114-3561-4feb-993b-3c53c9ef352f" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="3fc5a861-697e-4940-bad9-a8010eef0249" start_index="0" end="ce5a6237-f69b-4a84-9838-245272c8fccf" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="5bb3ad6f-e46e-4351-89ee-b63f5ca43910" start_index="0" end="7ec7b343-6e0c-46ba-b89a-7df17e6a0833" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="7ec7b343-6e0c-46ba-b89a-7df17e6a0833" start_index="0" end="9c4448aa-0eed-4492-803e-45266957e9cc" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="b5ccf380-27e9-4401-a9e0-fa70edd333d6" start_index="0" end="3fc5a861-697e-4940-bad9-a8010eef0249" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="cce66bb7-6e5b-4dfb-a4b0-427b523e24ec" start_index="0" end="b5ccf380-27e9-4401-a9e0-fa70edd333d6" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="ce5a6237-f69b-4a84-9838-245272c8fccf" start_index="0" end="cd8135dc-2d29-4466-bc0d-476016f811cb" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f000bb79-9963-4b37-8a01-18200cb0f02a" start_index="0" end="ce5a6237-f69b-4a84-9838-245272c8fccf" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="1e71378e-dd9c-4d10-9c3c-471b59f257cf" start_index="0" end="34986114-3561-4feb-993b-3c53c9ef352f" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="1e71378e-dd9c-4d10-9c3c-471b59f257cf" start_index="0" end="7ec7b343-6e0c-46ba-b89a-7df17e6a0833" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="9c4448aa-0eed-4492-803e-45266957e9cc" start_index="0" end="b5ccf380-27e9-4401-a9e0-fa70edd333d6" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="232e3c38-eba5-45ac-a48e-7a28c981978d" start_index="0" end="21d31559-fc02-412a-99f5-cdcb766f1bd2" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="f80430ef-10e0-4c49-a900-ccd4699665ff" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="e8a64668-ee00-4290-868f-1c8e4970d0d2" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" start_index="0" end="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f80430ef-10e0-4c49-a900-ccd4699665ff" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f80430ef-10e0-4c49-a900-ccd4699665ff" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="713785ce-66d6-4e4a-9e82-cf6ac94b447b" start_index="0" end="f80430ef-10e0-4c49-a900-ccd4699665ff" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="555b06f0-2188-4b21-8d78-589ea6c2fd01" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="87000fc6-56f9-429d-977b-5150e79bda56" start_index="0" end="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="21d31559-fc02-412a-99f5-cdcb766f1bd2" start_index="0" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="21d31559-fc02-412a-99f5-cdcb766f1bd2" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e8a64668-ee00-4290-868f-1c8e4970d0d2" start_index="0" end="7468eead-3b06-40a6-8653-3b8b88180f89" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="40cbf19c-9182-4536-8530-01442a0c2714" start_index="0" end="e8a64668-ee00-4290-868f-1c8e4970d0d2" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e014f8bd-0b2d-47b4-ad61-b708e3d63856" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="92b01453-7f63-4040-8664-93ece7aba70b" start_index="0" end="e014f8bd-0b2d-47b4-ad61-b708e3d63856" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="582b03fc-7dc9-413a-b322-432a3f5940a9" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e1ac034d-ea27-4df3-8049-6099267bbcbf" start_index="0" end="582b03fc-7dc9-413a-b322-432a3f5940a9" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="7468eead-3b06-40a6-8653-3b8b88180f89" start_index="0" end="582b03fc-7dc9-413a-b322-432a3f5940a9" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="acbd24d0-ecaf-487d-9ab1-82431a566b9b" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="50d2a6e8-35f9-45dc-a858-6d67683c5b68" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="0" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="1" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="1" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="3" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="9ab004ca-0917-4858-85bc-57ae681e33e8" start_index="0" end="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" start_index="0" end="40de7dac-bc68-4730-b8af-bd5955ffd3de" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f8382ff0-62e0-4125-89ee-882e3f032833" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f8382ff0-62e0-4125-89ee-882e3f032833" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="1eeed0eb-f578-4848-a6ac-dd5e67e28750" start_index="0" end="f8382ff0-62e0-4125-89ee-882e3f032833" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="34986114-3561-4feb-993b-3c53c9ef352f" start_index="0" end="ce5a6237-f69b-4a84-9838-245272c8fccf" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="34986114-3561-4feb-993b-3c53c9ef352f" start_index="0" end="3fc5a861-697e-4940-bad9-a8010eef0249" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b4d963a6-f9f0-4ca4-b0b1-67c7c23e34fc" start_index="0" end="34986114-3561-4feb-993b-3c53c9ef352f" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="3fc5a861-697e-4940-bad9-a8010eef0249" start_index="0" end="ce5a6237-f69b-4a84-9838-245272c8fccf" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5bb3ad6f-e46e-4351-89ee-b63f5ca43910" start_index="0" end="7ec7b343-6e0c-46ba-b89a-7df17e6a0833" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="7ec7b343-6e0c-46ba-b89a-7df17e6a0833" start_index="0" end="9c4448aa-0eed-4492-803e-45266957e9cc" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b5ccf380-27e9-4401-a9e0-fa70edd333d6" start_index="0" end="3fc5a861-697e-4940-bad9-a8010eef0249" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="cce66bb7-6e5b-4dfb-a4b0-427b523e24ec" start_index="0" end="b5ccf380-27e9-4401-a9e0-fa70edd333d6" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="ce5a6237-f69b-4a84-9838-245272c8fccf" start_index="0" end="cd8135dc-2d29-4466-bc0d-476016f811cb" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f000bb79-9963-4b37-8a01-18200cb0f02a" start_index="0" end="ce5a6237-f69b-4a84-9838-245272c8fccf" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="1e71378e-dd9c-4d10-9c3c-471b59f257cf" start_index="0" end="34986114-3561-4feb-993b-3c53c9ef352f" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="1e71378e-dd9c-4d10-9c3c-471b59f257cf" start_index="0" end="7ec7b343-6e0c-46ba-b89a-7df17e6a0833" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="9c4448aa-0eed-4492-803e-45266957e9cc" start_index="0" end="b5ccf380-27e9-4401-a9e0-fa70edd333d6" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="40de7dac-bc68-4730-b8af-bd5955ffd3de" start_index="0" end="1e71378e-dd9c-4d10-9c3c-471b59f257cf" end_index="0" portType="0" />
   </Connectors>
   <Notes>
-    <Dynamo.Models.NoteModel text="Let's find the Y coordinate of the first point in each of the lists." x="2483.11097384784" y="248.748548112779" />
-    <Dynamo.Models.NoteModel text="Create some offset curves where the offset is a function of the Y coordinate we found in the previous step." x="2941.71206245357" y="69.9484878651686" />
-    <Dynamo.Models.NoteModel text="The Surface.ByLoft expects a list of curves. So we use the List.Create method as the combinator on the List.Combine node, specifying two input ports. This will take our collection of curves on the surface and our collection of offset curves and &quot;zip&quot; them into sublists, each with two curves." x="3113.10273319185" y="-189.795142846867" />
+    <Dynamo.Graph.Notes.NoteModel guid="e4dd7a1f-ef2a-487a-8dac-bdcc081e9190" text="Let's find the Y coordinate of the first point in each of the lists." x="2483.11097384784" y="248.748548112779" />
+    <Dynamo.Graph.Notes.NoteModel guid="a7776094-3daf-4129-8dc4-12b3759ca0ab" text="Create some offset curves where the offset is a function of the Y coordinate we found in the previous step." x="2941.71206245357" y="69.9484878651686" />
+    <Dynamo.Graph.Notes.NoteModel guid="12e5f725-199a-4e1a-a08a-9bfcabe43144" text="The Surface.ByLoft expects a list of curves. So we use the List.Create method as the combinator on the List.Combine node, specifying two input ports. This will take our collection of curves on the surface and our collection of offset curves and &quot;zip&quot; them into sublists, each with two curves." x="3113.10273319185" y="-189.795142846867" />
   </Notes>
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>

--- a/test/core/WorkflowTestFiles/ListManagementMisc/Map.dyn
+++ b/test/core/WorkflowTestFiles/ListManagementMisc/Map.dyn
@@ -1,71 +1,128 @@
-<Workspace Version="0.7.5.3327" X="-1281.1522782121" Y="214.60731589509" zoom="1.0480407454808" Description="" Category="" Name="Home">
+<Workspace Version="1.2.1.2644" X="-1505.1522782121" Y="186.60731589509" zoom="1.0480407454808" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="232e3c38-eba5-45ac-a48e-7a28c981978d" nickname="Point.ByCoordinates" x="730.072941681612" y="-97.32248810896" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="00bde5f2-d493-471f-8a96-ccf262f607e6" nickname="Code Block" x="-183.612658408593" y="175.945973110655" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="x = 0..360..24;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" nickname="Math.Sin" x="182.215736905481" y="10.5676743290963" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.Math.Sin@double" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="f80430ef-10e0-4c49-a900-ccd4699665ff" nickname="*" x="182.652052827371" y="-161.71717945736" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="*@," />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="713785ce-66d6-4e4a-9e82-cf6ac94b447b" nickname="Code Block" x="-30.1980407217359" y="-98.2842575755678" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0.2;" ShouldFocus="false" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="555b06f0-2188-4b21-8d78-589ea6c2fd01" nickname="Code Block" x="437.652052827371" y="-57.2171794573603" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" nickname="*" x="554.123694866777" y="30.2212165336962" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="*@," />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="87000fc6-56f9-429d-977b-5150e79bda56" nickname="Code Block" x="364.652052827371" y="115.78282054264" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="4;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="21d31559-fc02-412a-99f5-cdcb766f1bd2" nickname="NurbsCurve.ByPoints" x="939.515624188966" y="-94.6699902690747" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="e8a64668-ee00-4290-868f-1c8e4970d0d2" nickname="+" x="203.245420692425" y="358.900184218226" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="+@," />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="40cbf19c-9182-4536-8530-01442a0c2714" nickname="Code Block" x="25.4815944795993" y="436.748460345878" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="120;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="e014f8bd-0b2d-47b4-ad61-b708e3d63856" nickname="NurbsCurve.ByPoints" x="988.150683632418" y="255.244962094166" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="92b01453-7f63-4040-8664-93ece7aba70b" nickname="Point.ByCoordinates" x="779.947521344488" y="216.825324885123" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="582b03fc-7dc9-413a-b322-432a3f5940a9" nickname="*" x="556.348517976863" y="460.087330485367" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="*@," />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="e1ac034d-ea27-4df3-8049-6099267bbcbf" nickname="Code Block" x="383.471295538765" y="509.923667635792" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="4;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="7468eead-3b06-40a6-8653-3b8b88180f89" nickname="Math.Sin" x="389.20807480723" y="367.901176326504" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.Math.Sin@double" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="acbd24d0-ecaf-487d-9ab1-82431a566b9b" nickname="Code Block" x="562.840302538075" y="341.777566975215" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="20;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="50d2a6e8-35f9-45dc-a858-6d67683c5b68" nickname="Geometry.Translate" x="1233.33479941474" y="53.3631408043654" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.Translate@double,double,double" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="51e63597-d9fd-4602-a2ad-f06f6873d215" nickname="Code Block" x="1052.34778182596" y="87.3662660309333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="50;&#xA;0;" ShouldFocus="false" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="9ab004ca-0917-4858-85bc-57ae681e33e8" nickname="Code Block" x="1500.96856495265" y="15.6255051664936" isVisible="false" isUpstreamVisible="true" lacing="Disabled" CodeText="crves = {a, b, c};" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" nickname="Surface.ByLoft" x="1802.05278726858" y="-45.1868026608493" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" nickname="Surface.PointAtParameter" x="2090.89981769624" y="-38.5589879185765" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.PointAtParameter@double,double">
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="232e3c38-eba5-45ac-a48e-7a28c981978d" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="730.072941681612" y="-97.32248810896" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="00bde5f2-d493-471f-8a96-ccf262f607e6" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-183.612658408593" y="175.945973110655" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="x = 0..360..24;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Sin" x="182.215736905481" y="10.5676743290963" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Sin@double">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="f80430ef-10e0-4c49-a900-ccd4699665ff" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="*" x="182.652052827371" y="-161.71717945736" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="*@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="713785ce-66d6-4e4a-9e82-cf6ac94b447b" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-30.1980407217359" y="-98.2842575755678" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="0.2;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="555b06f0-2188-4b21-8d78-589ea6c2fd01" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="437.652052827371" y="-57.2171794573603" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="0;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="*" x="554.123694866777" y="30.2212165336962" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="*@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="87000fc6-56f9-429d-977b-5150e79bda56" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="364.652052827371" y="115.78282054264" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="4;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="21d31559-fc02-412a-99f5-cdcb766f1bd2" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="NurbsCurve.ByPoints" x="939.515624188966" y="-94.6699902690747" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e8a64668-ee00-4290-868f-1c8e4970d0d2" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="+" x="203.245420692425" y="358.900184218226" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="+@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="40cbf19c-9182-4536-8530-01442a0c2714" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="25.4815944795993" y="436.748460345878" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="120;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e014f8bd-0b2d-47b4-ad61-b708e3d63856" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="NurbsCurve.ByPoints" x="988.150683632418" y="255.244962094166" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="92b01453-7f63-4040-8664-93ece7aba70b" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="779.947521344488" y="216.825324885123" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="582b03fc-7dc9-413a-b322-432a3f5940a9" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="*" x="556.348517976863" y="460.087330485367" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="*@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="e1ac034d-ea27-4df3-8049-6099267bbcbf" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="383.471295538765" y="509.923667635792" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="4;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="7468eead-3b06-40a6-8653-3b8b88180f89" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Sin" x="389.20807480723" y="367.901176326504" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Sin@double">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="acbd24d0-ecaf-487d-9ab1-82431a566b9b" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="562.840302538075" y="341.777566975215" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="20;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="50d2a6e8-35f9-45dc-a858-6d67683c5b68" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Geometry.Translate" x="1233.33479941474" y="53.3631408043654" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.Translate@double,double,double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+      <PortInfo index="3" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="51e63597-d9fd-4602-a2ad-f06f6873d215" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1052.34778182596" y="87.3662660309333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="50;&#xA;0;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="9ab004ca-0917-4858-85bc-57ae681e33e8" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1500.96856495265" y="15.6255051664936" isVisible="false" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="crves = {a, b, c};" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.ByLoft" x="1802.05278726858" y="-45.1868026608493" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.PointAtParameter" x="2090.89981769624" y="-38.5589879185765" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.PointAtParameter@double,double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
       <PortInfo index="2" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="f8382ff0-62e0-4125-89ee-882e3f032833" nickname="Code Block" x="1868" y="157" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0..1..#end;" ShouldFocus="false" />
-    <Dynamo.Nodes.IntegerSlider type="Dynamo.Nodes.IntegerSlider" guid="1eeed0eb-f578-4848-a6ac-dd5e67e28750" nickname="Integer Slider" x="1639.5814867634" y="199.027194750085" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="f8382ff0-62e0-4125-89ee-882e3f032833" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1868" y="157" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="0..1..#end;" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <CoreNodeModels.Input.IntegerSlider guid="1eeed0eb-f578-4848-a6ac-dd5e67e28750" type="CoreNodeModels.Input.IntegerSlider" nickname="Integer Slider" x="1639.5814867634" y="199.027194750085" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Int32>36</System.Int32>
-      <Range min="0" max="100" />
-    </Dynamo.Nodes.IntegerSlider>
-    <DSCore.Map type="DSCore.Map" guid="34986114-3561-4feb-993b-3c53c9ef352f" nickname="List.Map" x="2434.39791312081" y="157.998255574372" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="b4d963a6-f9f0-4ca4-b0b1-67c7c23e34fc" nickname="NurbsCurve.ByPoints" x="2216.84911935191" y="206.660485759519" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
+      <Range min="0" max="100" step="1" />
+    </CoreNodeModels.Input.IntegerSlider>
+    <CoreNodeModels.HigherOrder.Map guid="34986114-3561-4feb-993b-3c53c9ef352f" type="CoreNodeModels.HigherOrder.Map" nickname="List.Map" x="2544.31730365667" y="129.755078839463" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </CoreNodeModels.HigherOrder.Map>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="b4d963a6-f9f0-4ca4-b0b1-67c7c23e34fc" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="NurbsCurve.ByPoints" x="2216.84911935191" y="206.660485759519" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="52c38121-438f-4c1c-9f49-81f15e581fd0" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.FirstItem" x="2347.57311566488" y="-14.7010657376892" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
   </Elements>
   <Connectors>
-    <Dynamo.Models.ConnectorModel start="232e3c38-eba5-45ac-a48e-7a28c981978d" start_index="0" end="21d31559-fc02-412a-99f5-cdcb766f1bd2" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="f80430ef-10e0-4c49-a900-ccd4699665ff" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="e8a64668-ee00-4290-868f-1c8e4970d0d2" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" start_index="0" end="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f80430ef-10e0-4c49-a900-ccd4699665ff" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f80430ef-10e0-4c49-a900-ccd4699665ff" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="713785ce-66d6-4e4a-9e82-cf6ac94b447b" start_index="0" end="f80430ef-10e0-4c49-a900-ccd4699665ff" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="555b06f0-2188-4b21-8d78-589ea6c2fd01" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="87000fc6-56f9-429d-977b-5150e79bda56" start_index="0" end="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="21d31559-fc02-412a-99f5-cdcb766f1bd2" start_index="0" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="21d31559-fc02-412a-99f5-cdcb766f1bd2" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e8a64668-ee00-4290-868f-1c8e4970d0d2" start_index="0" end="7468eead-3b06-40a6-8653-3b8b88180f89" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="40cbf19c-9182-4536-8530-01442a0c2714" start_index="0" end="e8a64668-ee00-4290-868f-1c8e4970d0d2" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e014f8bd-0b2d-47b4-ad61-b708e3d63856" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="92b01453-7f63-4040-8664-93ece7aba70b" start_index="0" end="e014f8bd-0b2d-47b4-ad61-b708e3d63856" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="582b03fc-7dc9-413a-b322-432a3f5940a9" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e1ac034d-ea27-4df3-8049-6099267bbcbf" start_index="0" end="582b03fc-7dc9-413a-b322-432a3f5940a9" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="7468eead-3b06-40a6-8653-3b8b88180f89" start_index="0" end="582b03fc-7dc9-413a-b322-432a3f5940a9" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="acbd24d0-ecaf-487d-9ab1-82431a566b9b" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="50d2a6e8-35f9-45dc-a858-6d67683c5b68" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="0" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="1" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="1" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="3" portType="0" />
-    <Dynamo.Models.ConnectorModel start="9ab004ca-0917-4858-85bc-57ae681e33e8" start_index="0" end="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" start_index="0" end="34986114-3561-4feb-993b-3c53c9ef352f" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f8382ff0-62e0-4125-89ee-882e3f032833" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f8382ff0-62e0-4125-89ee-882e3f032833" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="1eeed0eb-f578-4848-a6ac-dd5e67e28750" start_index="0" end="f8382ff0-62e0-4125-89ee-882e3f032833" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="b4d963a6-f9f0-4ca4-b0b1-67c7c23e34fc" start_index="0" end="34986114-3561-4feb-993b-3c53c9ef352f" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="232e3c38-eba5-45ac-a48e-7a28c981978d" start_index="0" end="21d31559-fc02-412a-99f5-cdcb766f1bd2" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="f80430ef-10e0-4c49-a900-ccd4699665ff" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="00bde5f2-d493-471f-8a96-ccf262f607e6" start_index="0" end="e8a64668-ee00-4290-868f-1c8e4970d0d2" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="2ea4fa78-a64e-48a6-a2c1-2ca49f7408bd" start_index="0" end="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f80430ef-10e0-4c49-a900-ccd4699665ff" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f80430ef-10e0-4c49-a900-ccd4699665ff" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="713785ce-66d6-4e4a-9e82-cf6ac94b447b" start_index="0" end="f80430ef-10e0-4c49-a900-ccd4699665ff" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="555b06f0-2188-4b21-8d78-589ea6c2fd01" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" start_index="0" end="232e3c38-eba5-45ac-a48e-7a28c981978d" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="87000fc6-56f9-429d-977b-5150e79bda56" start_index="0" end="0d01f0f6-ac29-4657-b21c-cfe10ae8617d" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="21d31559-fc02-412a-99f5-cdcb766f1bd2" start_index="0" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="21d31559-fc02-412a-99f5-cdcb766f1bd2" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e8a64668-ee00-4290-868f-1c8e4970d0d2" start_index="0" end="7468eead-3b06-40a6-8653-3b8b88180f89" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="40cbf19c-9182-4536-8530-01442a0c2714" start_index="0" end="e8a64668-ee00-4290-868f-1c8e4970d0d2" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e014f8bd-0b2d-47b4-ad61-b708e3d63856" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="92b01453-7f63-4040-8664-93ece7aba70b" start_index="0" end="e014f8bd-0b2d-47b4-ad61-b708e3d63856" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="582b03fc-7dc9-413a-b322-432a3f5940a9" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e1ac034d-ea27-4df3-8049-6099267bbcbf" start_index="0" end="582b03fc-7dc9-413a-b322-432a3f5940a9" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="7468eead-3b06-40a6-8653-3b8b88180f89" start_index="0" end="582b03fc-7dc9-413a-b322-432a3f5940a9" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="acbd24d0-ecaf-487d-9ab1-82431a566b9b" start_index="0" end="92b01453-7f63-4040-8664-93ece7aba70b" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="50d2a6e8-35f9-45dc-a858-6d67683c5b68" start_index="0" end="9ab004ca-0917-4858-85bc-57ae681e33e8" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="0" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="1" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="51e63597-d9fd-4602-a2ad-f06f6873d215" start_index="1" end="50d2a6e8-35f9-45dc-a858-6d67683c5b68" end_index="3" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="9ab004ca-0917-4858-85bc-57ae681e33e8" start_index="0" end="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b5cb4be4-d90d-4783-8b0b-c44c6e18b327" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" start_index="0" end="52c38121-438f-4c1c-9f49-81f15e581fd0" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f8382ff0-62e0-4125-89ee-882e3f032833" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f8382ff0-62e0-4125-89ee-882e3f032833" start_index="0" end="8d5c9519-04e4-4274-8a6f-c4e5e03350ff" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="1eeed0eb-f578-4848-a6ac-dd5e67e28750" start_index="0" end="f8382ff0-62e0-4125-89ee-882e3f032833" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b4d963a6-f9f0-4ca4-b0b1-67c7c23e34fc" start_index="0" end="34986114-3561-4feb-993b-3c53c9ef352f" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="52c38121-438f-4c1c-9f49-81f15e581fd0" start_index="0" end="34986114-3561-4feb-993b-3c53c9ef352f" end_index="0" portType="0" />
   </Connectors>
   <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>

--- a/test/core/WorkflowTestFiles/MiscDefinitions/Woven Surface.dyn
+++ b/test/core/WorkflowTestFiles/MiscDefinitions/Woven Surface.dyn
@@ -1,55 +1,90 @@
-<Workspace Version="0.7.6.4256" X="117.28366288407" Y="234.016225633772" zoom="0.272563477774877" Name="Home" RunType="Manually" RunPeriod="100">
-  <NamespaceResolutionMap />
+<Workspace Version="1.2.1.2644" X="-125.828981706737" Y="186.339091258426" zoom="0.56854822359188" Name="Home" Description="" RunType="Manual" RunPeriod="100" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Point" resolvedName="Autodesk.DesignScript.Geometry.Point" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="NurbsCurve" resolvedName="Autodesk.DesignScript.Geometry.NurbsCurve" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="Surface" resolvedName="Autodesk.DesignScript.Geometry.Surface" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="List" resolvedName="DSCore.List" assemblyName="DSCoreNodes.dll" />
+  </NamespaceResolutionMap>
   <Elements>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="9d1d64a6-68fb-459b-bfe2-e766a705dc11" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-137.124904607187" y="-103.322912883599" isVisible="false" isUpstreamVisible="true" lacing="Disabled" CodeText="// Create a surface&#xA;&#xA;pts1 = {Point.ByCoordinates(-15,-5),&#xA;Point.Origin(),&#xA;Point.ByCoordinates(15,5)};&#xA;&#xA;pts2 = {Point.ByCoordinates(-15,-5,10),&#xA;Point.ByCoordinates(0,0,10),&#xA;Point.ByCoordinates(15,-5,15)};&#xA;&#xA;crv1 = NurbsCurve.ByPoints(pts1);&#xA;crv2 = NurbsCurve.ByPoints(pts2);&#xA;&#xA;Surface.ByLoft({crv1,crv2});" ShouldFocus="false" />
-    <DSCoreNodesUI.Input.IntegerSlider guid="1baf1065-d559-4722-8121-2fb86dc8c1a5" type="DSCoreNodesUI.Input.IntegerSlider" nickname="Number of Staves" x="-291.284394858571" y="518.903911009021" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="9d1d64a6-68fb-459b-bfe2-e766a705dc11" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-137.124904607187" y="-103.322912883599" isVisible="false" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="// Create a surface&#xA;&#xA;pts1 = {Point.ByCoordinates(-15,-5),&#xA;Point.Origin(),&#xA;Point.ByCoordinates(15,5)};&#xA;&#xA;pts2 = {Point.ByCoordinates(-15,-5,10),&#xA;Point.ByCoordinates(0,0,10),&#xA;Point.ByCoordinates(15,-5,15)};&#xA;&#xA;crv1 = NurbsCurve.ByPoints(pts1);&#xA;crv2 = NurbsCurve.ByPoints(pts2);&#xA;&#xA;Surface.ByLoft({crv1,crv2});" ShouldFocus="false" />
+    <CoreNodeModels.Input.IntegerSlider guid="1baf1065-d559-4722-8121-2fb86dc8c1a5" type="CoreNodeModels.Input.IntegerSlider" nickname="Number of Staves" x="-291.284394858571" y="518.903911009021" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Int32>5</System.Int32>
       <Range min="0" max="15" step="1" />
-    </DSCoreNodesUI.Input.IntegerSlider>
-    <DSCoreNodesUI.Input.IntegerSlider guid="449f1227-10f6-4302-a0c4-80e90ca1e948" type="DSCoreNodesUI.Input.IntegerSlider" nickname="Number of weaves" x="-293.449558340226" y="404.150246481332" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </CoreNodeModels.Input.IntegerSlider>
+    <CoreNodeModels.Input.IntegerSlider guid="449f1227-10f6-4302-a0c4-80e90ca1e948" type="CoreNodeModels.Input.IntegerSlider" nickname="Number of weaves" x="-293.449558340226" y="404.150246481332" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Int32>4</System.Int32>
       <Range min="0" max="15" step="1" />
-    </DSCoreNodesUI.Input.IntegerSlider>
-    <DSCoreNodesUI.Input.DoubleSlider guid="dbb4d4c2-69c5-473a-bc9c-fbdff375cce2" type="DSCoreNodesUI.Input.DoubleSlider" nickname="Weave Width" x="-287.883568482973" y="638.051080633141" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </CoreNodeModels.Input.IntegerSlider>
+    <CoreNodeModels.Input.DoubleSlider guid="dbb4d4c2-69c5-473a-bc9c-fbdff375cce2" type="CoreNodeModels.Input.DoubleSlider" nickname="Weave Width" x="-287.883568482973" y="638.051080633141" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Double>2.352</System.Double>
       <Range min="0" max="5" step="0.01" />
-    </DSCoreNodesUI.Input.DoubleSlider>
-    <DSCoreNodesUI.Input.DoubleSlider guid="02a23767-c97e-4bc6-b62a-06460d7d0727" type="DSCoreNodesUI.Input.DoubleSlider" nickname="Depth" x="-293.296477187109" y="744.144091234212" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </CoreNodeModels.Input.DoubleSlider>
+    <CoreNodeModels.Input.DoubleSlider guid="02a23767-c97e-4bc6-b62a-06460d7d0727" type="CoreNodeModels.Input.DoubleSlider" nickname="Depth" x="-293.296477187109" y="744.144091234212" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Double>1.352</System.Double>
       <Range min="0" max="5" step="0.01" />
-    </DSCoreNodesUI.Input.DoubleSlider>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="5bdf889e-b676-4ea4-b207-20cd9668b863" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-391.685493359684" y="92.3317945786393" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="def IntervalMidPts(num)&#xA;{&#xA;a = 0..1..#(num+1);&#xA;b = List.RestOfItems(a);&#xA;return = b - (1/(2*num));&#xA;};" ShouldFocus="false" />
-    <Dynamo.Nodes.CodeBlockNodeModel guid="73aa7872-fd75-4542-9270-80daa02de33f" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="121" y="412" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="IntervalMidPts(numStaves);&#xA;IntervalMidPts(numWeaves);" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction guid="2193b896-3aa4-4b34-9563-e1ef8736007a" type="Dynamo.Nodes.DSFunction" nickname="Surface.PointAtParameter" x="564.738668983194" y="197.04349030307" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.PointAtParameter@double,double">
+    </CoreNodeModels.Input.DoubleSlider>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="5bdf889e-b676-4ea4-b207-20cd9668b863" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-391.685493359684" y="92.3317945786393" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="def IntervalMidPts(num)&#xA;{&#xA;a = 0..1..#(num+1);&#xA;b = List.RestOfItems(a);&#xA;return = b - (1/(2*num));&#xA;};" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="73aa7872-fd75-4542-9270-80daa02de33f" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="121" y="412" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="IntervalMidPts(numStaves);&#xA;IntervalMidPts(numWeaves);" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="2193b896-3aa4-4b34-9563-e1ef8736007a" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.PointAtParameter" x="564.738668983194" y="197.04349030307" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.PointAtParameter@double,double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
       <PortInfo index="2" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.DSFunction guid="e900f09f-06d3-4f60-ad17-ff5250f7213d" type="Dynamo.Nodes.DSFunction" nickname="Surface.TangentAtVParameter" x="568.744406389696" y="352.265814805021" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter@double,double">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e900f09f-06d3-4f60-ad17-ff5250f7213d" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.TangentAtVParameter" x="568.744406389696" y="352.265814805021" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter@double,double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
       <PortInfo index="2" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.DSFunction guid="c356b37c-d92f-435f-8bcf-7679446fe256" type="Dynamo.Nodes.DSFunction" nickname="Surface.NormalAtParameter" x="565.740103334819" y="32.8082566364906" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.NormalAtParameter@double,double">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="c356b37c-d92f-435f-8bcf-7679446fe256" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.NormalAtParameter" x="565.740103334819" y="32.8082566364906" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.NormalAtParameter@double,double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
       <PortInfo index="2" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="01e25bfa-1872-4a50-81c5-507a3c99a75e" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="762.47887660398" y="644" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="weaveWidth/2;&#xA;-weaveWidth/2;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction guid="a0c2167f-07de-40a5-a105-e3ede8969a39" type="Dynamo.Nodes.DSFunction" nickname="Vector.Scale" x="1063.59638754231" y="576.520766521164" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Scale@double">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="01e25bfa-1872-4a50-81c5-507a3c99a75e" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="762.47887660398" y="644" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="weaveWidth/2;&#xA;-weaveWidth/2;" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="a0c2167f-07de-40a5-a105-e3ede8969a39" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Vector.Scale" x="1063.59638754231" y="576.520766521164" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Scale@double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.DSFunction guid="4fb68e59-f5eb-4ed0-a109-0a13c9df7233" type="Dynamo.Nodes.DSFunction" nickname="Vector.Scale" x="1060.78969905229" y="714.097769715671" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Scale@double">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="4fb68e59-f5eb-4ed0-a109-0a13c9df7233" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Vector.Scale" x="1060.78969905229" y="714.097769715671" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Scale@double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.DSFunction guid="0e09b92f-5fcf-4e1c-ad85-e0421463b1f7" type="Dynamo.Nodes.DSFunction" nickname="Point.Add" x="1324.79503558666" y="451.912160189981" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector" />
-    <Dynamo.Nodes.DSFunction guid="8e634519-3285-4fd7-9d90-31e8dbd75c45" type="Dynamo.Nodes.DSFunction" nickname="Point.Add" x="1323.78487230719" y="611.156680131705" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector" />
-    <Dynamo.Nodes.DSFunction guid="d12123c8-df45-4fbc-b5cc-ca6fb00a8bb8" type="Dynamo.Nodes.DSFunction" nickname="Line.ByStartPointEndPoint" x="1531.38252091646" y="508.938913952896" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point" />
-    <Dynamo.Nodes.DSFunction guid="e4bfa947-7d25-4224-a533-0cb6831a696f" type="Dynamo.Nodes.DSFunction" nickname="Geometry.Translate" x="1846.36712387655" y="325.245886706714" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.Translate@Autodesk.DesignScript.Geometry.Vector" />
-    <Dynamo.Nodes.DSFunction guid="673251c5-3697-4dc1-9f5c-080495b7c122" type="Dynamo.Nodes.DSFunction" nickname="Geometry.Translate" x="1841.26940634031" y="157.021208010629" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.Translate@Autodesk.DesignScript.Geometry.Vector" />
-    <DSCoreNodesUI.Input.DoubleSlider guid="1ed332a6-4ceb-4994-9791-8ba8c7d09314" type="DSCoreNodesUI.Input.DoubleSlider" nickname="Thickness" x="-289.528389626564" y="846.968832544207" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="0e09b92f-5fcf-4e1c-ad85-e0421463b1f7" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.Add" x="1324.79503558666" y="451.912160189981" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="8e634519-3285-4fd7-9d90-31e8dbd75c45" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.Add" x="1323.78487230719" y="611.156680131705" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="d12123c8-df45-4fbc-b5cc-ca6fb00a8bb8" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Line.ByStartPointEndPoint" x="1531.38252091646" y="508.938913952896" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e4bfa947-7d25-4224-a533-0cb6831a696f" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Geometry.Translate" x="1846.36712387655" y="325.245886706714" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.Translate@Autodesk.DesignScript.Geometry.Vector">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="673251c5-3697-4dc1-9f5c-080495b7c122" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Geometry.Translate" x="1841.26940634031" y="157.021208010629" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.Translate@Autodesk.DesignScript.Geometry.Vector">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <CoreNodeModels.Input.DoubleSlider guid="1ed332a6-4ceb-4994-9791-8ba8c7d09314" type="CoreNodeModels.Input.DoubleSlider" nickname="Thickness" x="-289.528389626564" y="846.968832544207" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Double>0.367</System.Double>
       <Range min="0" max="5" step="0.01" />
-    </DSCoreNodesUI.Input.DoubleSlider>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="3b54298a-72eb-4e81-8934-8b027d570a87" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1357.8933988763" y="207.974427566248" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="norm.Scale(depth/2);&#xA;norm.Scale(-depth/2);" ShouldFocus="false" />
-    <DSIronPythonNode.PythonNode guid="212b3202-9490-404b-a1cd-dc7fc8dfb7a7" type="DSIronPythonNode.PythonNode" nickname="Python Script" x="2147.31889847517" y="129.056111026424" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2">
+    </CoreNodeModels.Input.DoubleSlider>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="3b54298a-72eb-4e81-8934-8b027d570a87" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1357.8933988763" y="207.974427566248" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="norm.Scale(depth/2);&#xA;norm.Scale(-depth/2);" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <PythonNodeModels.PythonNode guid="212b3202-9490-404b-a1cd-dc7fc8dfb7a7" type="PythonNodeModels.PythonNode" nickname="Python Script" x="2147.31889847517" y="129.056111026424" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="2">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
       <Script>import clr
 clr.AddReference('ProtoGeometry')
 from Autodesk.DesignScript.Geometry import *
@@ -67,8 +102,10 @@ for i in range(0, len(ls1), 2):
 
 #Assign your output to the OUT variable
 OUT = set</Script>
-    </DSIronPythonNode.PythonNode>
-    <DSIronPythonNode.PythonNode guid="0216f840-53c0-47c7-9310-562b20d055ae" type="DSIronPythonNode.PythonNode" nickname="Python Script" x="2153.19590724716" y="290.098710980055" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2">
+    </PythonNodeModels.PythonNode>
+    <PythonNodeModels.PythonNode guid="0216f840-53c0-47c7-9310-562b20d055ae" type="PythonNodeModels.PythonNode" nickname="Python Script" x="2153.19590724716" y="290.098710980055" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="2">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
       <Script>import clr
 clr.AddReference('ProtoGeometry')
 from Autodesk.DesignScript.Geometry import *
@@ -86,34 +123,69 @@ for i in range(0, len(ls1), 2):
 
 #Assign your output to the OUT variable
 OUT = set</Script>
-    </DSIronPythonNode.PythonNode>
-    <Dynamo.Nodes.DSFunction guid="0435eab3-4f6e-410c-9657-b2502f67664d" type="Dynamo.Nodes.DSFunction" nickname="List.Transpose" x="2707.847030671" y="224.716542482304" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.Transpose@var[]..[]" />
-    <Dynamo.Nodes.DSFunction guid="a61474e5-618b-4f95-a8bc-a0724357b6bb" type="Dynamo.Nodes.DSFunction" nickname="List.Transpose" x="2707.02386798317" y="101.242139308135" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.Transpose@var[]..[]" />
-    <Dynamo.Nodes.DSFunction guid="6c30d411-fec9-4e05-abcd-ff5f8fa8f831" type="Dynamo.Nodes.DSFunction" nickname="Surface.PointAtParameter" x="567.121340898599" y="-344.226172870967" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.PointAtParameter@double,double">
+    </PythonNodeModels.PythonNode>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="0435eab3-4f6e-410c-9657-b2502f67664d" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.Transpose" x="2707.847030671" y="224.716542482304" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.Transpose@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="a61474e5-618b-4f95-a8bc-a0724357b6bb" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.Transpose" x="2707.02386798317" y="101.242139308135" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.Transpose@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="6c30d411-fec9-4e05-abcd-ff5f8fa8f831" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.PointAtParameter" x="567.121340898599" y="-344.226172870967" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.PointAtParameter@double,double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
       <PortInfo index="2" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.DSFunction guid="5d76e7ef-9578-405c-ab6c-f7b732b37113" type="Dynamo.Nodes.DSFunction" nickname="Surface.TangentAtVParameter" x="566.736021470879" y="-192.516693836393" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter@double,double">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="5d76e7ef-9578-405c-ab6c-f7b732b37113" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.TangentAtVParameter" x="566.736021470879" y="-192.516693836393" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.TangentAtVParameter@double,double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
       <PortInfo index="2" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="5f7de1eb-c731-43bc-8b1e-3bebe0b05978" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="355.596584312254" y="-293.346341005328" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{0,1};" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction guid="6d83d46a-6010-412a-aa3f-e0f6800d0656" type="Dynamo.Nodes.DSFunction" nickname="Point.Add" x="1595.32903088044" y="-383.151586556662" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector" />
-    <Dynamo.Nodes.DSFunction guid="ac83be8f-589d-4312-8905-8a4288249b40" type="Dynamo.Nodes.DSFunction" nickname="Line.ByStartPointEndPoint" x="1801.91651621024" y="-326.124832793747" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point" />
-    <Dynamo.Nodes.DSFunction guid="6bbc8e90-f764-4e8d-b1e2-503ca9c2cec4" type="Dynamo.Nodes.DSFunction" nickname="Point.Add" x="1594.31886760097" y="-223.907066614938" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector" />
-    <Dynamo.Nodes.DSFunction guid="67e4acf8-af3d-43d4-be08-48ef09e6db9a" type="Dynamo.Nodes.DSFunction" nickname="Vector.Scale" x="1334.13038283609" y="-258.542980225479" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Scale@double">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="5f7de1eb-c731-43bc-8b1e-3bebe0b05978" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="355.596584312254" y="-293.346341005328" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{0,1};" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="6d83d46a-6010-412a-aa3f-e0f6800d0656" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.Add" x="1595.32903088044" y="-383.151586556662" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="ac83be8f-589d-4312-8905-8a4288249b40" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Line.ByStartPointEndPoint" x="1801.91651621024" y="-326.124832793747" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="6bbc8e90-f764-4e8d-b1e2-503ca9c2cec4" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.Add" x="1594.31886760097" y="-223.907066614938" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="67e4acf8-af3d-43d4-be08-48ef09e6db9a" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Vector.Scale" x="1329.90910502638" y="-243.064961589866" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Scale@double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.DSFunction guid="b5320cf8-b1bb-4e42-9d70-f69706223abe" type="Dynamo.Nodes.DSFunction" nickname="Vector.Scale" x="1331.32369434607" y="-120.965977030972" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Scale@double">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="b5320cf8-b1bb-4e42-9d70-f69706223abe" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Vector.Scale" x="1331.32369434607" y="-120.965977030972" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Scale@double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="f0b29f53-015a-4ceb-bf99-497beb6e07bb" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="973.073549129648" y="-58.9247851896697" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="weaveWidth/2;&#xA;-weaveWidth/2;" ShouldFocus="false" />
-    <Dynamo.Nodes.CodeBlockNodeModel guid="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="2045.71316894747" y="-303.704356479136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{lines[0]};&#xA;{lines[1]};" ShouldFocus="false" />
-    <Dynamo.Nodes.DSVarArgFunction guid="df5ebb4e-26f7-418b-a9b0-91a5772dcb55" type="Dynamo.Nodes.DSVarArgFunction" nickname="List.Join" x="2428.03422741567" y="52.2489187677344" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.Join@var[]..[]" inputcount="3" />
-    <Dynamo.Nodes.DSVarArgFunction guid="3cc6f179-377b-4fea-bdaa-4d330e099844" type="Dynamo.Nodes.DSVarArgFunction" nickname="List.Join" x="2410.76627314355" y="251.897883963493" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.Join@var[]..[]" inputcount="3" />
-    <Dynamo.Nodes.DSFunction guid="3a79051a-66f8-4d2c-b736-c7c2059a2c74" type="Dynamo.Nodes.DSFunction" nickname="Surface.ByLoft" x="2893.40508731614" y="60.8386068395623" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]" />
-    <Dynamo.Nodes.DSFunction guid="d4aecc93-e8b4-4cbc-b914-59e057c5b484" type="Dynamo.Nodes.DSFunction" nickname="Surface.ByLoft" x="2896.8460423538" y="206.530747419026" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]" />
-    <DSIronPythonNode.PythonNode guid="d81c7961-63d1-4fd2-bbbf-ce7f968b13e2" type="DSIronPythonNode.PythonNode" nickname="Python Script" x="3154.53406855146" y="132.043059446878" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="f0b29f53-015a-4ceb-bf99-497beb6e07bb" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="973.073549129648" y="-58.9247851896697" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="weaveWidth/2;&#xA;-weaveWidth/2;" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="2045.71316894747" y="-303.704356479136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{lines[0]};&#xA;{lines[1]};" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="df5ebb4e-26f7-418b-a9b0-91a5772dcb55" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="List.Join" x="2428.03422741567" y="52.2489187677344" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="true" assembly="DSCoreNodes.dll" function="DSCore.List.Join@var[]..[]" inputcount="3">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="3cc6f179-377b-4fea-bdaa-4d330e099844" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="List.Join" x="2410.76627314355" y="251.897883963493" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.Join@var[]..[]" inputcount="3">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="3a79051a-66f8-4d2c-b736-c7c2059a2c74" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.ByLoft" x="2893.40508731614" y="60.8386068395623" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="true" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="d4aecc93-e8b4-4cbc-b914-59e057c5b484" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.ByLoft" x="2896.8460423538" y="206.530747419026" isVisible="false" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <PythonNodeModels.PythonNode guid="d81c7961-63d1-4fd2-bbbf-ce7f968b13e2" type="PythonNodeModels.PythonNode" nickname="Python Script" x="3154.53406855146" y="132.043059446878" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="2">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
       <Script>import clr
 clr.AddReference('ProtoGeometry')
 from Autodesk.DesignScript.Geometry import *
@@ -131,76 +203,102 @@ for i in range(0, len(ls1), 2):
 
 #Assign your output to the OUT variable
 OUT = set</Script>
-    </DSIronPythonNode.PythonNode>
-    <Dynamo.Nodes.DSFunction guid="a7b4e678-3278-4554-8ce2-7c76faca79d7" type="Dynamo.Nodes.DSFunction" nickname="Surface.Thicken" x="3494.35860713256" y="209.31753000565" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.Thicken@double">
+    </PythonNodeModels.PythonNode>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="a7b4e678-3278-4554-8ce2-7c76faca79d7" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.Thicken" x="3494.35860713256" y="209.31753000565" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="true" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.Thicken@double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
-    </Dynamo.Nodes.DSFunction>
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="56932965-caef-41b5-8983-667688f1c13c" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.FirstItem" x="888.278180725195" y="-376.993687367995" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="4128ffee-48f7-41e1-9f26-850701d51531" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.FirstItem" x="868.856845858983" y="-195.178037995673" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="4e691bf8-3256-4412-a740-529072b53d94" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.FirstItem" x="834.107844134496" y="66.9922415385277" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="de691847-5a7c-446e-a651-666c7f0beeae" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.FirstItem" x="836.093601871522" y="208.302908971633" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="ae935f19-82a6-4b06-b739-2c971a39f184" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.FirstItem" x="829.78715576646" y="361.020669007976" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
   </Elements>
   <Connectors>
-    <Dynamo.Models.ConnectorModel start="9d1d64a6-68fb-459b-bfe2-e766a705dc11" start_index="4" end="c356b37c-d92f-435f-8bcf-7679446fe256" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="9d1d64a6-68fb-459b-bfe2-e766a705dc11" start_index="4" end="2193b896-3aa4-4b34-9563-e1ef8736007a" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="9d1d64a6-68fb-459b-bfe2-e766a705dc11" start_index="4" end="e900f09f-06d3-4f60-ad17-ff5250f7213d" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="9d1d64a6-68fb-459b-bfe2-e766a705dc11" start_index="4" end="6c30d411-fec9-4e05-abcd-ff5f8fa8f831" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="9d1d64a6-68fb-459b-bfe2-e766a705dc11" start_index="4" end="5d76e7ef-9578-405c-ab6c-f7b732b37113" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="1baf1065-d559-4722-8121-2fb86dc8c1a5" start_index="0" end="73aa7872-fd75-4542-9270-80daa02de33f" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="449f1227-10f6-4302-a0c4-80e90ca1e948" start_index="0" end="73aa7872-fd75-4542-9270-80daa02de33f" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="dbb4d4c2-69c5-473a-bc9c-fbdff375cce2" start_index="0" end="01e25bfa-1872-4a50-81c5-507a3c99a75e" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="dbb4d4c2-69c5-473a-bc9c-fbdff375cce2" start_index="0" end="f0b29f53-015a-4ceb-bf99-497beb6e07bb" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="02a23767-c97e-4bc6-b62a-06460d7d0727" start_index="0" end="3b54298a-72eb-4e81-8934-8b027d570a87" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="0" end="c356b37c-d92f-435f-8bcf-7679446fe256" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="0" end="2193b896-3aa4-4b34-9563-e1ef8736007a" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="0" end="e900f09f-06d3-4f60-ad17-ff5250f7213d" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="1" end="c356b37c-d92f-435f-8bcf-7679446fe256" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="1" end="2193b896-3aa4-4b34-9563-e1ef8736007a" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="1" end="e900f09f-06d3-4f60-ad17-ff5250f7213d" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="1" end="6c30d411-fec9-4e05-abcd-ff5f8fa8f831" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="1" end="5d76e7ef-9578-405c-ab6c-f7b732b37113" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="2193b896-3aa4-4b34-9563-e1ef8736007a" start_index="0" end="0e09b92f-5fcf-4e1c-ad85-e0421463b1f7" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="2193b896-3aa4-4b34-9563-e1ef8736007a" start_index="0" end="8e634519-3285-4fd7-9d90-31e8dbd75c45" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e900f09f-06d3-4f60-ad17-ff5250f7213d" start_index="0" end="a0c2167f-07de-40a5-a105-e3ede8969a39" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e900f09f-06d3-4f60-ad17-ff5250f7213d" start_index="0" end="4fb68e59-f5eb-4ed0-a109-0a13c9df7233" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="c356b37c-d92f-435f-8bcf-7679446fe256" start_index="0" end="3b54298a-72eb-4e81-8934-8b027d570a87" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="01e25bfa-1872-4a50-81c5-507a3c99a75e" start_index="0" end="a0c2167f-07de-40a5-a105-e3ede8969a39" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="01e25bfa-1872-4a50-81c5-507a3c99a75e" start_index="1" end="4fb68e59-f5eb-4ed0-a109-0a13c9df7233" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="a0c2167f-07de-40a5-a105-e3ede8969a39" start_index="0" end="0e09b92f-5fcf-4e1c-ad85-e0421463b1f7" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="4fb68e59-f5eb-4ed0-a109-0a13c9df7233" start_index="0" end="8e634519-3285-4fd7-9d90-31e8dbd75c45" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="0e09b92f-5fcf-4e1c-ad85-e0421463b1f7" start_index="0" end="d12123c8-df45-4fbc-b5cc-ca6fb00a8bb8" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="8e634519-3285-4fd7-9d90-31e8dbd75c45" start_index="0" end="d12123c8-df45-4fbc-b5cc-ca6fb00a8bb8" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="d12123c8-df45-4fbc-b5cc-ca6fb00a8bb8" start_index="0" end="e4bfa947-7d25-4224-a533-0cb6831a696f" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="d12123c8-df45-4fbc-b5cc-ca6fb00a8bb8" start_index="0" end="673251c5-3697-4dc1-9f5c-080495b7c122" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e4bfa947-7d25-4224-a533-0cb6831a696f" start_index="0" end="212b3202-9490-404b-a1cd-dc7fc8dfb7a7" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e4bfa947-7d25-4224-a533-0cb6831a696f" start_index="0" end="0216f840-53c0-47c7-9310-562b20d055ae" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="673251c5-3697-4dc1-9f5c-080495b7c122" start_index="0" end="212b3202-9490-404b-a1cd-dc7fc8dfb7a7" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="673251c5-3697-4dc1-9f5c-080495b7c122" start_index="0" end="0216f840-53c0-47c7-9310-562b20d055ae" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="1ed332a6-4ceb-4994-9791-8ba8c7d09314" start_index="0" end="a7b4e678-3278-4554-8ce2-7c76faca79d7" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="3b54298a-72eb-4e81-8934-8b027d570a87" start_index="0" end="673251c5-3697-4dc1-9f5c-080495b7c122" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="3b54298a-72eb-4e81-8934-8b027d570a87" start_index="1" end="e4bfa947-7d25-4224-a533-0cb6831a696f" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="212b3202-9490-404b-a1cd-dc7fc8dfb7a7" start_index="0" end="df5ebb4e-26f7-418b-a9b0-91a5772dcb55" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="0216f840-53c0-47c7-9310-562b20d055ae" start_index="0" end="3cc6f179-377b-4fea-bdaa-4d330e099844" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="0435eab3-4f6e-410c-9657-b2502f67664d" start_index="0" end="d4aecc93-e8b4-4cbc-b914-59e057c5b484" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="a61474e5-618b-4f95-a8bc-a0724357b6bb" start_index="0" end="3a79051a-66f8-4d2c-b736-c7c2059a2c74" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="6c30d411-fec9-4e05-abcd-ff5f8fa8f831" start_index="0" end="6d83d46a-6010-412a-aa3f-e0f6800d0656" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="6c30d411-fec9-4e05-abcd-ff5f8fa8f831" start_index="0" end="6bbc8e90-f764-4e8d-b1e2-503ca9c2cec4" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="5d76e7ef-9578-405c-ab6c-f7b732b37113" start_index="0" end="67e4acf8-af3d-43d4-be08-48ef09e6db9a" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="5d76e7ef-9578-405c-ab6c-f7b732b37113" start_index="0" end="b5320cf8-b1bb-4e42-9d70-f69706223abe" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="5f7de1eb-c731-43bc-8b1e-3bebe0b05978" start_index="0" end="6c30d411-fec9-4e05-abcd-ff5f8fa8f831" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="5f7de1eb-c731-43bc-8b1e-3bebe0b05978" start_index="0" end="5d76e7ef-9578-405c-ab6c-f7b732b37113" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="6d83d46a-6010-412a-aa3f-e0f6800d0656" start_index="0" end="ac83be8f-589d-4312-8905-8a4288249b40" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="ac83be8f-589d-4312-8905-8a4288249b40" start_index="0" end="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="6bbc8e90-f764-4e8d-b1e2-503ca9c2cec4" start_index="0" end="ac83be8f-589d-4312-8905-8a4288249b40" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="67e4acf8-af3d-43d4-be08-48ef09e6db9a" start_index="0" end="6d83d46a-6010-412a-aa3f-e0f6800d0656" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="b5320cf8-b1bb-4e42-9d70-f69706223abe" start_index="0" end="6bbc8e90-f764-4e8d-b1e2-503ca9c2cec4" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f0b29f53-015a-4ceb-bf99-497beb6e07bb" start_index="0" end="67e4acf8-af3d-43d4-be08-48ef09e6db9a" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f0b29f53-015a-4ceb-bf99-497beb6e07bb" start_index="1" end="b5320cf8-b1bb-4e42-9d70-f69706223abe" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" start_index="0" end="df5ebb4e-26f7-418b-a9b0-91a5772dcb55" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" start_index="0" end="3cc6f179-377b-4fea-bdaa-4d330e099844" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" start_index="1" end="df5ebb4e-26f7-418b-a9b0-91a5772dcb55" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" start_index="1" end="3cc6f179-377b-4fea-bdaa-4d330e099844" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="df5ebb4e-26f7-418b-a9b0-91a5772dcb55" start_index="0" end="a61474e5-618b-4f95-a8bc-a0724357b6bb" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="3cc6f179-377b-4fea-bdaa-4d330e099844" start_index="0" end="0435eab3-4f6e-410c-9657-b2502f67664d" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="3a79051a-66f8-4d2c-b736-c7c2059a2c74" start_index="0" end="d81c7961-63d1-4fd2-bbbf-ce7f968b13e2" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="d4aecc93-e8b4-4cbc-b914-59e057c5b484" start_index="0" end="d81c7961-63d1-4fd2-bbbf-ce7f968b13e2" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="d81c7961-63d1-4fd2-bbbf-ce7f968b13e2" start_index="0" end="a7b4e678-3278-4554-8ce2-7c76faca79d7" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="9d1d64a6-68fb-459b-bfe2-e766a705dc11" start_index="4" end="c356b37c-d92f-435f-8bcf-7679446fe256" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="9d1d64a6-68fb-459b-bfe2-e766a705dc11" start_index="4" end="2193b896-3aa4-4b34-9563-e1ef8736007a" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="9d1d64a6-68fb-459b-bfe2-e766a705dc11" start_index="4" end="e900f09f-06d3-4f60-ad17-ff5250f7213d" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="9d1d64a6-68fb-459b-bfe2-e766a705dc11" start_index="4" end="6c30d411-fec9-4e05-abcd-ff5f8fa8f831" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="9d1d64a6-68fb-459b-bfe2-e766a705dc11" start_index="4" end="5d76e7ef-9578-405c-ab6c-f7b732b37113" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="1baf1065-d559-4722-8121-2fb86dc8c1a5" start_index="0" end="73aa7872-fd75-4542-9270-80daa02de33f" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="449f1227-10f6-4302-a0c4-80e90ca1e948" start_index="0" end="73aa7872-fd75-4542-9270-80daa02de33f" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="dbb4d4c2-69c5-473a-bc9c-fbdff375cce2" start_index="0" end="01e25bfa-1872-4a50-81c5-507a3c99a75e" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="dbb4d4c2-69c5-473a-bc9c-fbdff375cce2" start_index="0" end="f0b29f53-015a-4ceb-bf99-497beb6e07bb" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="02a23767-c97e-4bc6-b62a-06460d7d0727" start_index="0" end="3b54298a-72eb-4e81-8934-8b027d570a87" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="0" end="c356b37c-d92f-435f-8bcf-7679446fe256" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="0" end="2193b896-3aa4-4b34-9563-e1ef8736007a" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="0" end="e900f09f-06d3-4f60-ad17-ff5250f7213d" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="1" end="c356b37c-d92f-435f-8bcf-7679446fe256" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="1" end="2193b896-3aa4-4b34-9563-e1ef8736007a" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="1" end="e900f09f-06d3-4f60-ad17-ff5250f7213d" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="1" end="6c30d411-fec9-4e05-abcd-ff5f8fa8f831" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="73aa7872-fd75-4542-9270-80daa02de33f" start_index="1" end="5d76e7ef-9578-405c-ab6c-f7b732b37113" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="2193b896-3aa4-4b34-9563-e1ef8736007a" start_index="0" end="de691847-5a7c-446e-a651-666c7f0beeae" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e900f09f-06d3-4f60-ad17-ff5250f7213d" start_index="0" end="ae935f19-82a6-4b06-b739-2c971a39f184" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="c356b37c-d92f-435f-8bcf-7679446fe256" start_index="0" end="4e691bf8-3256-4412-a740-529072b53d94" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="01e25bfa-1872-4a50-81c5-507a3c99a75e" start_index="0" end="a0c2167f-07de-40a5-a105-e3ede8969a39" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="01e25bfa-1872-4a50-81c5-507a3c99a75e" start_index="1" end="4fb68e59-f5eb-4ed0-a109-0a13c9df7233" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="a0c2167f-07de-40a5-a105-e3ede8969a39" start_index="0" end="0e09b92f-5fcf-4e1c-ad85-e0421463b1f7" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="4fb68e59-f5eb-4ed0-a109-0a13c9df7233" start_index="0" end="8e634519-3285-4fd7-9d90-31e8dbd75c45" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="0e09b92f-5fcf-4e1c-ad85-e0421463b1f7" start_index="0" end="d12123c8-df45-4fbc-b5cc-ca6fb00a8bb8" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="8e634519-3285-4fd7-9d90-31e8dbd75c45" start_index="0" end="d12123c8-df45-4fbc-b5cc-ca6fb00a8bb8" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="d12123c8-df45-4fbc-b5cc-ca6fb00a8bb8" start_index="0" end="e4bfa947-7d25-4224-a533-0cb6831a696f" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="d12123c8-df45-4fbc-b5cc-ca6fb00a8bb8" start_index="0" end="673251c5-3697-4dc1-9f5c-080495b7c122" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e4bfa947-7d25-4224-a533-0cb6831a696f" start_index="0" end="212b3202-9490-404b-a1cd-dc7fc8dfb7a7" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e4bfa947-7d25-4224-a533-0cb6831a696f" start_index="0" end="0216f840-53c0-47c7-9310-562b20d055ae" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="673251c5-3697-4dc1-9f5c-080495b7c122" start_index="0" end="212b3202-9490-404b-a1cd-dc7fc8dfb7a7" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="673251c5-3697-4dc1-9f5c-080495b7c122" start_index="0" end="0216f840-53c0-47c7-9310-562b20d055ae" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="1ed332a6-4ceb-4994-9791-8ba8c7d09314" start_index="0" end="a7b4e678-3278-4554-8ce2-7c76faca79d7" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="3b54298a-72eb-4e81-8934-8b027d570a87" start_index="0" end="673251c5-3697-4dc1-9f5c-080495b7c122" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="3b54298a-72eb-4e81-8934-8b027d570a87" start_index="1" end="e4bfa947-7d25-4224-a533-0cb6831a696f" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="212b3202-9490-404b-a1cd-dc7fc8dfb7a7" start_index="0" end="df5ebb4e-26f7-418b-a9b0-91a5772dcb55" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="0216f840-53c0-47c7-9310-562b20d055ae" start_index="0" end="3cc6f179-377b-4fea-bdaa-4d330e099844" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="0435eab3-4f6e-410c-9657-b2502f67664d" start_index="0" end="d4aecc93-e8b4-4cbc-b914-59e057c5b484" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="a61474e5-618b-4f95-a8bc-a0724357b6bb" start_index="0" end="3a79051a-66f8-4d2c-b736-c7c2059a2c74" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="6c30d411-fec9-4e05-abcd-ff5f8fa8f831" start_index="0" end="56932965-caef-41b5-8983-667688f1c13c" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5d76e7ef-9578-405c-ab6c-f7b732b37113" start_index="0" end="4128ffee-48f7-41e1-9f26-850701d51531" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5f7de1eb-c731-43bc-8b1e-3bebe0b05978" start_index="0" end="6c30d411-fec9-4e05-abcd-ff5f8fa8f831" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5f7de1eb-c731-43bc-8b1e-3bebe0b05978" start_index="0" end="5d76e7ef-9578-405c-ab6c-f7b732b37113" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="6d83d46a-6010-412a-aa3f-e0f6800d0656" start_index="0" end="ac83be8f-589d-4312-8905-8a4288249b40" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="ac83be8f-589d-4312-8905-8a4288249b40" start_index="0" end="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="6bbc8e90-f764-4e8d-b1e2-503ca9c2cec4" start_index="0" end="ac83be8f-589d-4312-8905-8a4288249b40" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="67e4acf8-af3d-43d4-be08-48ef09e6db9a" start_index="0" end="6d83d46a-6010-412a-aa3f-e0f6800d0656" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b5320cf8-b1bb-4e42-9d70-f69706223abe" start_index="0" end="6bbc8e90-f764-4e8d-b1e2-503ca9c2cec4" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f0b29f53-015a-4ceb-bf99-497beb6e07bb" start_index="0" end="67e4acf8-af3d-43d4-be08-48ef09e6db9a" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f0b29f53-015a-4ceb-bf99-497beb6e07bb" start_index="1" end="b5320cf8-b1bb-4e42-9d70-f69706223abe" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" start_index="0" end="df5ebb4e-26f7-418b-a9b0-91a5772dcb55" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" start_index="0" end="3cc6f179-377b-4fea-bdaa-4d330e099844" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" start_index="1" end="df5ebb4e-26f7-418b-a9b0-91a5772dcb55" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e9a76244-ece4-43b4-bfb1-7ed09e6e12bc" start_index="1" end="3cc6f179-377b-4fea-bdaa-4d330e099844" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="df5ebb4e-26f7-418b-a9b0-91a5772dcb55" start_index="0" end="a61474e5-618b-4f95-a8bc-a0724357b6bb" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="3cc6f179-377b-4fea-bdaa-4d330e099844" start_index="0" end="0435eab3-4f6e-410c-9657-b2502f67664d" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="3a79051a-66f8-4d2c-b736-c7c2059a2c74" start_index="0" end="d81c7961-63d1-4fd2-bbbf-ce7f968b13e2" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="d4aecc93-e8b4-4cbc-b914-59e057c5b484" start_index="0" end="d81c7961-63d1-4fd2-bbbf-ce7f968b13e2" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="d81c7961-63d1-4fd2-bbbf-ce7f968b13e2" start_index="0" end="a7b4e678-3278-4554-8ce2-7c76faca79d7" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="56932965-caef-41b5-8983-667688f1c13c" start_index="0" end="6d83d46a-6010-412a-aa3f-e0f6800d0656" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="56932965-caef-41b5-8983-667688f1c13c" start_index="0" end="6bbc8e90-f764-4e8d-b1e2-503ca9c2cec4" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="4128ffee-48f7-41e1-9f26-850701d51531" start_index="0" end="67e4acf8-af3d-43d4-be08-48ef09e6db9a" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="4128ffee-48f7-41e1-9f26-850701d51531" start_index="0" end="b5320cf8-b1bb-4e42-9d70-f69706223abe" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="4e691bf8-3256-4412-a740-529072b53d94" start_index="0" end="3b54298a-72eb-4e81-8934-8b027d570a87" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="de691847-5a7c-446e-a651-666c7f0beeae" start_index="0" end="0e09b92f-5fcf-4e1c-ad85-e0421463b1f7" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="de691847-5a7c-446e-a651-666c7f0beeae" start_index="0" end="8e634519-3285-4fd7-9d90-31e8dbd75c45" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="ae935f19-82a6-4b06-b739-2c971a39f184" start_index="0" end="a0c2167f-07de-40a5-a105-e3ede8969a39" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="ae935f19-82a6-4b06-b739-2c971a39f184" start_index="0" end="4fb68e59-f5eb-4ed0-a109-0a13c9df7233" end_index="0" portType="0" />
   </Connectors>
   <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>


### PR DESCRIPTION
### Purpose

These regressions are caused by recent change of compiling node to static methods/properties (#7178).

More details. 

Previously, for a instance method node, say `Surface.PointAtParameter`, if its lacing is cross-product, the node will be compiled to code `surface<1>.PointAtParameters(us<2>, vs<3>)`. As `PointAtParameter(u:double, v:double)` is an instance method, the replication guide `<1>` after input `surface` will simply be discarded, so the result will be a 2D list if `us` and `vs` both are 1D list and `surface` is a single object. 

As now node is compiled to static method, that is, `Surface.PointAtParameter(s:surface, u:double, v:double)`, the replication guide `<1>` will be used. According to replication guide behavior, it forces to promote input `s` to a list, therefore the result will be a 3D list.

This PR updates some .dyn files and use `List.FirstItem` node to reduce the output dimension.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@riteshchandawar @monikaprabhu @kronz 

