### PR TITLE
Additional anlytics for preferences and update manager

### DIFF
--- a/src/DynamoCore/Logging/Analytics.cs
+++ b/src/DynamoCore/Logging/Analytics.cs
@@ -77,6 +77,17 @@ namespace Dynamo.Logging
         }
 
         /// <summary>
+        /// Tracks user preference setting and its value.
+        /// </summary>
+        /// <param name="name">Name of the preference</param>
+        /// <param name="stringValue">Preference value as string</param>
+        /// <param name="metricValue">Metric value of the preference</param>
+        public void TrackPreference(string name, string stringValue, int? metricValue)
+        {
+            if (client != null) client.TrackPreference(name, stringValue, metricValue);
+        }
+
+        /// <summary>
         /// Tracks a timed event, when it has completed.
         /// </summary>
         /// <param name="category">Event category</param>

--- a/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
+++ b/src/DynamoCore/Logging/DynamoAnalyticsClient.cs
@@ -153,6 +153,9 @@ namespace Dynamo.Logging
             //If not ReportingAnalytics, then set the idle time as infinite so idle state is not recorded.
             Service.StartUp(new ProductInfo() { Name = "Dynamo", VersionString = appversion },
                 new UserInfo(Session.UserId), ReportingAnalytics ? TimeSpan.FromMinutes(30) : TimeSpan.MaxValue);
+
+            TrackPreferenceInternal("ReportingAnalytics", "", ReportingAnalytics ? 1 : 0);
+            TrackPreferenceInternal("ReportingUsage", "", ReportingUsage ? 1 : 0);
         }
 
         public void ShutDown()
@@ -165,6 +168,17 @@ namespace Dynamo.Logging
             if (!ReportingAnalytics) return;
 
             var e = AnalyticsEvent.Create(category.ToString(), action.ToString(), description, value);
+            e.Track();
+        }
+
+        public void TrackPreference(string name, string stringValue, int? metricValue)
+        {
+            if (ReportingAnalytics) TrackPreferenceInternal(name, stringValue, metricValue);
+        }
+
+        private void TrackPreferenceInternal(string name, string stringValue, int? metricValue)
+        {
+            var e = AnalyticsEvent.Create(Categories.Preferences.ToString(), name, stringValue, metricValue);
             e.Track();
         }
 

--- a/src/DynamoCore/Logging/IAnalyticsClient.cs
+++ b/src/DynamoCore/Logging/IAnalyticsClient.cs
@@ -15,6 +15,8 @@ namespace Dynamo.Logging
         Command,
         FileOperation,
         SearchUX,
+        Preferences,
+        Upgrade,
     }
 
     /// <summary>
@@ -38,6 +40,8 @@ namespace Dynamo.Logging
         EngineFailure,
         FilterButtonClicked,
         Unresolved,
+        Downloaded,
+        Installed,
     }
 
     /// <summary>
@@ -80,6 +84,14 @@ namespace Dynamo.Logging
         /// <param name="description">Event description</param>
         /// <param name="value">A metric value associated with the event</param>
         void TrackEvent(Actions action, Categories category, string description, int? value);
+
+        /// <summary>
+        /// Tracks a preference setting and its value.
+        /// </summary>
+        /// <param name="name">Name of the preference</param>
+        /// <param name="stringValue">Preference value as string</param>
+        /// <param name="metricValue">Metric value of the preference</param>
+        void TrackPreference(string name, string stringValue, int? metricValue);
 
         /// <summary>
         /// Tracks a timed event, when it has completed.

--- a/src/DynamoCore/Updates/UpdateManager.cs
+++ b/src/DynamoCore/Updates/UpdateManager.cs
@@ -955,6 +955,7 @@ namespace Dynamo.Updates
                 p.StartInfo.Arguments += " " + hostApplicationProcessId;
             }
             p.Start();
+            Dynamo.Logging.Analytics.TrackEvent(Actions.Installed, Categories.Upgrade, AvailableVersion.ToString());
         }
 
         public void RegisterExternalApplicationProcessId(int id)
@@ -988,6 +989,7 @@ namespace Dynamo.Updates
 
             UpdateFileLocation = (string)e.UserState;
             OnLog(new LogEventArgs("Update download complete.", LogLevel.Console));
+            Dynamo.Logging.Analytics.TrackEvent(Actions.Downloaded, Categories.Upgrade, AvailableVersion.ToString());
 
             if (null != UpdateDownloaded)
                 UpdateDownloaded(this, new UpdateDownloadedEventArgs(e.Error, UpdateFileLocation));


### PR DESCRIPTION
### Purpose

This PR implements analytics instrumentation to capture some of the user preferences related to analytics and also tracking how often users download upgrades.
### Declarations

Check these if you believe they are true
- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (_No change of public methods or types etc.._)
### Reviewers

@Benglin 
### FYIs

@kronz 
