### PR TITLE
Fixed Alignment for About Window Dynamo Core Label for Dynamo Revit

### DIFF
--- a/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
+++ b/src/DynamoCoreWpf/Views/About/AboutWindow.xaml
@@ -49,23 +49,15 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock Name="DynamoCoreLabel"
+                <TextBlock Name="DynamoCoreVersion"
                            Grid.Row="0"
-                           Text="Dynamo Core"
-                           Margin="12,0,0,0"
+                           HorizontalAlignment="Center"
                            Background="Transparent" 
                            Foreground="#898989"
-                           FontSize="14"/>
-
-                <TextBlock Name ="DynamoCoreVersionNumber" 
-                         Grid.Row="0"
-                         Background="Transparent" 
-                         Foreground="#bbbbbb" 
-                         FontSize="14" 
-                         FontFamily="{StaticResource OpenSansRegular}" 
-                         Margin="105,0,0,0" 
-                         Text="{Binding Version, Mode=OneWay}" 
-                         PreviewMouseDown="OnPreviewMouseDown"/>
+                           FontSize="14">
+                           <Run Text="Dynamo Core"/>
+                           <Run Foreground="#bbbbbb" Text="{Binding Version, Mode=OneWay}"/>
+                </TextBlock>
 
                 <TextBlock Name="GenericHostVersion"
                            Grid.Row="1"


### PR DESCRIPTION
### Purpose

This PR is meant to fix the About Window text alignment for the PR made here: https://github.com/DynamoDS/Dynamo/pull/7108

Previously, after the previous was merged, the text alignment of Dynamo Core was shifted to the left by a few pixels, resulting in a mis-alignment of the Dynamo Core label. 

This fix removes the padding and replaces it with a center alignment.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu , @sharadkjaiswal 

### FYIs

@monikaprabhu 

