### PR TITLE
FRAC-512

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1544,14 +1544,23 @@ namespace Dynamo.ViewModels
 
         /// <summary>
         /// Returns the selected nodes that are "input" nodes, and makes an 
-        /// exception for CodeBlockNodes as these are marked false so they 
-        /// do not expose a IsInput checkbox
+        /// exception for CodeBlockNodes and Filename nodes as these are marked 
+        /// false so they do not expose a IsInput checkbox
         /// </summary>
         /// <returns></returns>
         internal IEnumerable<NodeModel> GetInputNodesFromSelectionForPresets()
         {
             return DynamoSelection.Instance.Selection.OfType<NodeModel>()
-                                .Where(x => x.IsInputNode || x is CodeBlockNodeModel);
+                .Where(
+                    x => x.IsInputNode ||
+                    x is CodeBlockNodeModel ||
+
+                    // NOTE: The Filename node is being matched by name due to the node definition
+                    //       being in the CoreNodeModels project instead of the DynamoCore project.
+                    //       After some discussions it was decided that this was the least bad way to 
+                    //       make this check (versus either adding a new, overridable property to 
+                    //       NodeModel, or moving Filename and the associated classes into DynamoCore).
+                    x.GetType().Name == "Filename");
         }
 
         public void ShowSaveDialogIfNeededAndSaveResult(object parameter)

--- a/src/Libraries/CoreNodeModels/Input/File.cs
+++ b/src/Libraries/CoreNodeModels/Input/File.cs
@@ -95,6 +95,14 @@ namespace CoreNodeModels.Input
         {
             ShouldDisplayPreviewCore = false;
         }
+
+      /// <summary>
+      ///     Indicates whether node is input node
+      /// </summary>
+      public override bool IsInputNode
+      {
+        get { return false; }
+      }
     }
 
     [NodeName("Directory Path")]

--- a/test/DynamoCoreWpfTests/PresetViewModelTest.cs
+++ b/test/DynamoCoreWpfTests/PresetViewModelTest.cs
@@ -98,7 +98,6 @@ namespace DynamoCoreWpfTests
         [Test]
         public void CanCreatePreset()
         {
-            //////////////////////////////////////////////////////////////////////////////
             // Positive test for input node
 
             // Create a valid input node
@@ -113,7 +112,7 @@ namespace DynamoCoreWpfTests
             // Check for input nodes in selection (should pass)
             Assert.AreEqual(true, ViewModel.GetInputNodesFromSelectionForPresets().Any());
 
-            //////////////////////////////////////////////////////////////////////////////
+
             // Negative test for input node
 
             // Create a non-input node and select it
@@ -125,7 +124,7 @@ namespace DynamoCoreWpfTests
             // Check for input nodes in selection (should fail)
             Assert.AreEqual(false, ViewModel.GetInputNodesFromSelectionForPresets().Any());
 
-            //////////////////////////////////////////////////////////////////////////////
+
             // Re-test positive test for input node
 
             // Select the first created input node
@@ -134,7 +133,7 @@ namespace DynamoCoreWpfTests
             // Check for input nodes in selection (should pass)
             Assert.AreEqual(true, ViewModel.GetInputNodesFromSelectionForPresets().Any());
 
-            //////////////////////////////////////////////////////////////////////////////
+
             // Positive test for File Path node
 
             // Create a File Path input node and select it

--- a/test/DynamoCoreWpfTests/PresetViewModelTest.cs
+++ b/test/DynamoCoreWpfTests/PresetViewModelTest.cs
@@ -98,33 +98,54 @@ namespace DynamoCoreWpfTests
         [Test]
         public void CanCreatePreset()
         {
-            //Create a Node
+            //////////////////////////////////////////////////////////////////////////////
+            // Positive test for input node
+
+            // Create a valid input node
             var numberNode = new DoubleInput();
             numberNode.Value = "1";
             ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(numberNode, false);
 
-            //verify the node was created
+            // Verify the node was created and select it
             Assert.AreEqual(1, ViewModel.Model.CurrentWorkspace.Nodes.Count());
-          
             DynamoSelection.Instance.Selection.Add(numberNode);
 
-            //Check for input nodes
+            // Check for input nodes in selection (should pass)
             Assert.AreEqual(true, ViewModel.GetInputNodesFromSelectionForPresets().Any());
 
+            //////////////////////////////////////////////////////////////////////////////
+            // Negative test for input node
+
+            // Create a non-input node and select it
             var addNode = new DSFunction(ViewModel.Model.LibraryServices.GetFunctionDescriptor("+"));
             ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(addNode, false);
-
             DynamoSelection.Instance.ClearSelection();
-
             DynamoSelection.Instance.Selection.Add(addNode);
 
+            // Check for input nodes in selection (should fail)
             Assert.AreEqual(false, ViewModel.GetInputNodesFromSelectionForPresets().Any());
 
+            //////////////////////////////////////////////////////////////////////////////
+            // Re-test positive test for input node
+
+            // Select the first created input node
             DynamoSelection.Instance.Selection.Add(numberNode);
 
-            //Check for input nodes
+            // Check for input nodes in selection (should pass)
             Assert.AreEqual(true, ViewModel.GetInputNodesFromSelectionForPresets().Any());
 
+            //////////////////////////////////////////////////////////////////////////////
+            // Positive test for File Path node
+
+            // Create a File Path input node and select it
+            var filePathNode = new Filename();
+            filePathNode.Value = "C:\\foo.txt";
+            ViewModel.Model.CurrentWorkspace.AddAndRegisterNode(filePathNode, false);
+            DynamoSelection.Instance.ClearSelection();
+            DynamoSelection.Instance.Selection.Add(filePathNode);
+
+            // Check for input nodes in selection (should pass)
+            Assert.AreEqual(true, ViewModel.GetInputNodesFromSelectionForPresets().Any());
         }
     }
 }


### PR DESCRIPTION
### Purpose

This PR removes the "Is Input" checkbox from FilePath nodes. This was not an issue previously as graphs with FilePath nodes could not be published (for either Customizer or Fractal). Now that graphs with FilePath nodes can be published, it became clear that being able to designate FilePath nodes as "Is Input", does not make any sense, as then they would appear as values in the published customizer that could be changed, but would not have any effect, which would cause confusion. However, FilePath nodes will still need to be able to be set using presets. This PR addresses this issue in the same manner as Code Block nodes (i.e. there is no "Is Input" checkbox option, but the node type is checked for and special cased when looking for nodes to include in preset settings).

### Declarations

Check these if you believe they are true
- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [n/a] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.

![image](https://cloud.githubusercontent.com/assets/10959111/18882862/f7e42934-84ae-11e6-98f7-fe5b4506a7dc.png)

### Reviewers
@ikeough 

### FYIs
