### PR TITLE
"Keep List Structure" highlight and checkbox removed when "Use levels" is disabled 

### DIFF
--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -228,6 +228,8 @@ namespace Dynamo.Graph.Nodes
                 if (useLevels != value)
                 {
                     useLevels = value;
+                    
+                    if (!useLevels) ShouldKeepListStructure = useLevels;
                     RaisePropertyChanged("UseLevels");
                 }
             }


### PR DESCRIPTION
### Purpose

The purpose of this PR, corresponding to _MAGN-10677_, is to address the bug filed here https://github.com/DynamoDS/Dynamo/issues/7149

Previously, when a user selects _Use Levels_ and _Keep List Structure_ in a node, and proceeded to deselect _Use Levels_, the _Keep List Structure_ will remain checked. This is shown here:

![keepliststructurebug](https://cloud.githubusercontent.com/assets/16283396/18859012/f5fa4a88-84a2-11e6-9347-1cf65e2c203f.png)

After this fix, the _Keep List Structure_ will revert to its original state when _Use Levels_ is unchecked.

![magn10667](https://cloud.githubusercontent.com/assets/16283396/18859018/05ca0fc0-84a3-11e6-9801-9517a68701cc.png)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 

### FYIs

@monikaprabhu 