### PR TITLE
Fix integer overflow issue in preview bubble

### DIFF
--- a/src/Engine/ProtoCore/DSASM/InstructionSet.cs
+++ b/src/Engine/ProtoCore/DSASM/InstructionSet.cs
@@ -399,7 +399,7 @@ namespace ProtoCore.DSASM
             get
             {
                 Check(IsInteger, "The Type of StackValue is not Integer");
-                return (int)opdata;
+                return opdata;
             }
         }
 

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -1075,6 +1075,14 @@ namespace Dynamo.Tests
             AssertPreviewValue("b0d7b844-93a9-43fa-b8f1-15cbb7469a84", true);
             AssertPreviewValue("d1942e84-355f-4083-bb1c-6b7203ee192c", true);
         }
+
+        [Test]
+        public void TestIntegerOverflow()
+        {
+            var dynFilePath = Path.Combine(TestDirectory, @"core\dsevaluation\integer_overflow.dyn");
+            OpenModel(dynFilePath);
+            AssertPreviewValue("17aae6a5-c4d5-4ba9-862c-5fd2e99c334e", 8388608);
+        }
     }
 
     [Category("DSCustomNode")]

--- a/test/core/dsevaluation/integer_overflow.dyn
+++ b/test/core/dsevaluation/integer_overflow.dyn
@@ -1,0 +1,24 @@
+<Workspace Version="1.2.1.2702" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="1b93f42b-021d-4d47-8509-464ea39f7bf3" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="/" x="257.6" y="60.8" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="/@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="bf3f328c-9933-4dcd-aaed-b6fef986f498" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="49" y="74" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="8589934592;&#xA;1024;" ShouldFocus="false" />
+    <CoreNodeModels.Watch guid="17aae6a5-c4d5-4ba9-862c-5fd2e99c334e" type="CoreNodeModels.Watch" nickname="Watch" x="481.6" y="91.2" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="1b93f42b-021d-4d47-8509-464ea39f7bf3" start_index="0" end="17aae6a5-c4d5-4ba9-862c-5fd2e99c334e" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="bf3f328c-9933-4dcd-aaed-b6fef986f498" start_index="0" end="1b93f42b-021d-4d47-8509-464ea39f7bf3" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="bf3f328c-9933-4dcd-aaed-b6fef986f498" start_index="1" end="1b93f42b-021d-4d47-8509-464ea39f7bf3" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

Dynamo fails to display big integer value that large than 2^31. 

It is because `StackValue.IntegerValue` cast `long` value to `int`, so preview bubble displays incorrect result.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@riteshchandawar 
