### PR TITLE
Disable lacing on List.Join()

### DIFF
--- a/src/DynamoCore/Graph/Nodes/ZeroTouch/DSFunctionBase.cs
+++ b/src/DynamoCore/Graph/Nodes/ZeroTouch/DSFunctionBase.cs
@@ -22,18 +22,31 @@ namespace Dynamo.Graph.Nodes.ZeroTouch
         protected DSFunctionBase(ZeroTouchNodeController<FunctionDescriptor> controller)
             : base(controller)
         {
-            ArgumentLacing = LacingStrategy.Shortest;
+            if (controller.Definition.IsLacingDisabled)
+            {
+                ArgumentLacing = LacingStrategy.Disabled;
+            }
+            else
+            {
+                ArgumentLacing = LacingStrategy.Shortest;
+            }
             Category = Controller.Category;
 
             if (controller.Definition.IsObsolete)
+            {
                 Warning(controller.Definition.ObsoleteMessage, true);
+            }
 
             if (controller.Definition.CanUpdatePeriodically)
+            {
                 CanUpdatePeriodically = true;
+            }
 
             string signature = String.Empty;
             if (Controller.Definition is FunctionDescriptor)
+            {
                 signature = Controller.Definition.Signature;
+            }
             Description = String.IsNullOrEmpty(Controller.Description) ? signature : Controller.Description + "\n\n" + signature;
         }
 

--- a/src/DynamoCore/Library/FunctionDescriptor.cs
+++ b/src/DynamoCore/Library/FunctionDescriptor.cs
@@ -141,6 +141,11 @@ namespace Dynamo.Engine
         ///     Indicates if the function is packaged element (either zero-touch DLLs or DYFs)
         /// </summary>
         public bool IsPackageMember { get; set; }
+
+        /// <summary>
+        ///     Indicates if the lacing strategy is disabled on the function
+        /// </summary>
+        public bool IsLacingDisabled { get; set; } 
     }
 
     /// <summary>
@@ -200,6 +205,7 @@ namespace Dynamo.Engine
             CanUpdatePeriodically = funcDescParams.CanUpdatePeriodically;
             IsBuiltIn = funcDescParams.IsBuiltIn;
             IsPackageMember = funcDescParams.IsPackageMember;
+            IsLacingDisabled = funcDescParams.IsLacingDisabled;
         }
 
         /// <summary>
@@ -509,6 +515,11 @@ namespace Dynamo.Engine
         ///     Returns instance of IPathManager
         /// </summary>
         public IPathManager PathManager { get { return pathManager; } }
+
+        /// <summary>
+        ///     Returns if the lacing strategy is disabled
+        /// </summary>
+        public bool IsLacingDisabled { get; private set; }
 
         /// <summary>
         ///     Overrides equality check of two <see cref="FunctionDescriptor"/> objects

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -960,6 +960,7 @@ namespace Dynamo.Engine
                     return new TypedParameter(arg.Name, argType, defaultArgumentNode, shortName);
                 }).ToList();
 
+            bool isLacingDisabled = false;
             IEnumerable<string> returnKeys = null;
             if (proc.MethodAttribute != null)
             {
@@ -967,6 +968,7 @@ namespace Dynamo.Engine
                     returnKeys = proc.MethodAttribute.ReturnKeys;
                 if (proc.MethodAttribute.IsObsolete)
                     obsoleteMessage = proc.MethodAttribute.ObsoleteMessage;
+                isLacingDisabled = proc.MethodAttribute.IsLacingDisabled;
             }
 
             var function = new FunctionDescriptor(new FunctionDescriptorParams
@@ -984,7 +986,8 @@ namespace Dynamo.Engine
                 ObsoleteMsg = obsoleteMessage,
                 CanUpdatePeriodically = canUpdatePeriodically,
                 IsBuiltIn = pathManager.PreloadedLibraries.Contains(library),
-                IsPackageMember = packagedLibraries.Contains(library)
+                IsPackageMember = packagedLibraries.Contains(library),
+                IsLacingDisabled = isLacingDisabled
             });
 
             AddImportedFunctions(library, new[] { function });

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -1312,6 +1312,10 @@ namespace ProtoFFI
                 {
                     CanUpdatePeriodically = (attr as CanUpdatePeriodicallyAttribute).CanUpdatePeriodically;
                 }
+                else if (attr is IsLacingDisabledAttribute)
+                {
+                    IsLacingDisabled = true; 
+                }
             }
         }
 

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -1659,6 +1659,7 @@ namespace ProtoCore.AST.AssociativeAST
         protected List<string> returnKeys;
         public string ObsoleteMessage { get; protected set; }
         public bool IsObsolete { get { return !string.IsNullOrEmpty(ObsoleteMessage); } }
+        public bool IsLacingDisabled { get; protected set; }
 
         /// <summary>
         /// Returns/Sets description for the method.

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -567,6 +567,7 @@ namespace DSCore
         /// <param name="lists">Lists to join into one.</param>
         /// <returns name="list">Joined list.</returns>
         /// <search>join lists,merge,concatenate</search>
+        [IsLacingDisabled]
         public static IList Join(params IList[] lists)
         {
             var result = new ArrayList();

--- a/src/NodeServices/Attributes.cs
+++ b/src/NodeServices/Attributes.cs
@@ -334,6 +334,10 @@ namespace Autodesk.DesignScript.Runtime
     {
     }
 
+    /// <summary>
+    /// This attribute is applied to a function to indicate whether to
+    /// disable lacing strategy on this function or not.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class IsLacingDisabledAttribute : Attribute
     {

--- a/src/NodeServices/Attributes.cs
+++ b/src/NodeServices/Attributes.cs
@@ -333,4 +333,9 @@ namespace Autodesk.DesignScript.Runtime
     public class KeepReferenceThisAttribute : Attribute
     {
     }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class IsLacingDisabledAttribute : Attribute
+    {
+    }
 }

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -5284,6 +5284,20 @@ namespace DynamoCoreWpfTests
             });
         }
 
+        [Test]
+        public void TestNoLacingOnListJoin()
+        {
+            RunCommandsFromFile("CreateListJoin.xml", (commandTag) =>
+            {
+                if (commandTag == "Run")
+                {
+                    var workspace = ViewModel.Model.CurrentWorkspace;
+                    var node = workspace.NodeFromWorkspace<Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction>("ac563e6a-ebc5-4b88-bd64-3cfe8f9e96d7");
+                    Assert.IsNotNull(node);
+                    Assert.AreEqual(LacingStrategy.Disabled, node.ArgumentLacing);
+                }
+            });
+        }
     }
 
 }

--- a/test/core/recorded/CreateListJoin.xml
+++ b/test/core/recorded/CreateListJoin.xml
@@ -1,0 +1,9 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <CreateNodeCommand X="265" Y="174" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>ac563e6a-ebc5-4b88-bd64-3cfe8f9e96d7</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="ac563e6a-ebc5-4b88-bd64-3cfe8f9e96d7" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="List.Join" x="265" y="174" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.Join@var[]..[]" inputcount="1">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction>
+  </CreateNodeCommand>
+  <PausePlaybackCommand Tag="Run" PauseDurationInMs="20" />
+</Commands>


### PR DESCRIPTION
### Purpose

This PR is fix defect MAGN-10683 that List@Level should be disabled on `List.Join()` node. 

List@Level is disabled when lacing is disabled on a node. For a UI node we are able to control lacing through setting property `ArgumentLacing` explicitly in constructor, but for zero touch functions (and `List.Join()` is from zero touch library), they all use default lacing.

This PR adds a new attribute `IsLacingDisabled` so that a zero touch function could disable lacing explicitly.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@Benglin 