### PR TITLE
Fix code block's input/output sockets display when there is no content.

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -304,19 +304,9 @@ namespace Dynamo.Graph.Nodes
 
             value = CodeBlockUtils.FormatUserText(value);
 
-            //Since an empty Code Block Node should not exist, this checks for such instances.
-            // If an empty Code Block Node is found, it is deleted. Since the creation and deletion of 
-            // an empty Code Block Node should not be recorded, this method also checks and removes
-            // any unwanted recordings
-            if (value == "")
-            {
-                Code = "";
-            }
-            else
-            {
-                if (!value.Equals(Code))
-                    SetCodeContent(value, workspaceElementResolver);
-            }
+            if (!value.Equals(Code))
+               SetCodeContent(value, workspaceElementResolver);
+
             return true;
         }
 


### PR DESCRIPTION
### Purpose

This PR is meant to address the bug filed in _MAGN-9911_. 

Previously, when a code block node was created and filled in, and the user subsequently cleared the codeblock and hit 'space', the code block input and output ports will still contain the earlier information.

![magn9911bug](https://cloud.githubusercontent.com/assets/16283396/18898115/24b717ec-8562-11e6-8cb4-0997c6d16562.png)

The steps to reproduce are as follows:
1) Create a variable in code block
2) Click on the scene
3) Replace the variable with space
4) Click on the scene

This fix essentially cleaned up legacy code which no longer served the original intent and caused this bug to occur. 

Initially, this commit (https://github.com/DynamoDS/Dynamo/commit/403d5f96288bf6414730a7107dc552939973c0ec) checked for empty codeblocks to delete them. Subsequently, however, another developer removed the code to delete the empty codeblocks but never completed his to-do (https://github.com/DynamoDS/Dynamo/commit/f063f86439919b9fd73b476959c5aa8c79aab8c5). As such, the check (and assignment) for empty codeblocks remained and the empty codeblocks were not accounted for. This resulted in the input and output ports not being re-assigned in the same fashion as updating the codeblock content did. 

The end result, of this fix, is as follows:

![cbnspacebar](https://cloud.githubusercontent.com/assets/16283396/18898131/4796c866-8562-11e6-9c86-a7975f85fb37.gif)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 

### FYIs

