### PR TITLE
Remove two language test cases

### DIFF
--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestUpdate.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestUpdate.cs
@@ -4889,65 +4889,6 @@ x = n.X;
 
         [Test]
         [Category("SmokeTest")]
-        [Category("Failure")]
-        public void T91_1467547()
-        {
-            String code = @"
- 
-        def foo()
-        {
-            return = a + 7;
-        }
-        def bar()
-        {
-            return = 3;
-        }
-        def ding()
-        {
-            return = a < 100? foo(): bar();
-        }
-        a = 10;
-        t = ding();
-        a = 50;
-";
-            // Tracked in: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1502
-            string errmsg = "MAGN-1502: Function pointer doesn't get update";
-            ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("t", 57);
-        }
-
-        [Test]
-        [Category("SmokeTest")]
-        [Category("Failure")]
-        public void T91_1467547_2()
-        {
-            String code = @"
- 
-        def foo()
-        {
-            return = a + 7;
-        }
-        def bar()
-        {
-            return = 3;
-        }
-        def ding()
-        {
-            return = a < 100? foo: bar;
-        }
-        a = 10;
-        t = ding();
-        z=t()
-        a = 50;
-";
-            // Tracked in: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1502
-            string errmsg = "MAGN-1502: Function pointer doesn't get update";
-            ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
-            thisTest.Verify("t", 57);
-        }
-
-        [Test]
-        [Category("SmokeTest")]
         public void T91_1467547_3()
         {
             String code = @"


### PR DESCRIPTION
### Purpose

Language test cases T91_1467547 and  T91_1467547_2 both are obsolete now. Remove them.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs
@monikaprabhu 

