### PR TITLE
MAGN-9768 The Package Manager status message should update to "Ready" when a valid file is added after an error is reported

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -945,6 +945,8 @@ namespace Dynamo.PackageManager
 
             if (fDialog.ShowDialog() != DialogResult.OK) return;
 
+            UploadState = PackageUploadHandle.State.Ready;
+
             foreach (var file in fDialog.FileNames)
             {
                 AddFile(file);


### PR DESCRIPTION
### Purpose
Fixed MAGN-9768 The Package Manager status message should update to "Ready" when a valid file is added after an error is reported.

Final Result: The dialog displays error messages whenever there is error and resets the state to ready when the valid files are added. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 