### PR TITLE
RemoveKey() should return list with specified key removed

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -498,13 +498,9 @@ namespace ProtoCore.Lang
                         StackValue key = formalParameters[1];
                         if (array.IsArray)
                         {
-                            bool result = runtimeCore.Heap.ToHeapObject<DSArray>(array).RemoveKey(key);
-                            ret = StackValue.BuildBoolean(result);
+                            runtimeCore.Heap.ToHeapObject<DSArray>(array).RemoveKey(key);
                         }
-                        else
-                        {
-                            ret = StackValue.BuildBoolean(false);
-                        }
+                        return array;
                         break;
                     }
                 case BuiltInMethods.MethodID.Evaluate:

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -914,7 +914,7 @@ namespace ProtoCore.Lang
 
                 new BuiltInMethod
                 {
-                    ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Bool, 0),
+                    ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank),
                     Parameters = new List<KeyValuePair<string, Type>> 
                     {
                         new KeyValuePair<string, Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank)),

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -2142,6 +2142,15 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Removes a copy of array with specified key removed.
+        /// </summary>
+        public static string RemoveKeys1 {
+            get {
+                return ResourceManager.GetString("RemoveKeys1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Removes the members of the list which are not members of the specified type.
         /// </summary>
         public static string RemovesTheMembersofTheList {

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -2133,7 +2133,7 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Returns true if the specified key is removed from list, otherwise returns false.
+        ///   Looks up a localized string similar to Removes key from list.
         /// </summary>
         public static string RemoveKeys {
             get {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -415,7 +415,7 @@
     <value>Produces the set union of two sequences by using the default equality comparer</value>
   </data>
   <data name="RemoveKeys" xml:space="preserve">
-    <value>Removes a copy of array with specified key removed</value>
+    <value>Removes key from list</value>
   </data>
   <data name="RemovesTheMembersofTheList" xml:space="preserve">
     <value>Removes the members of the list which are not members of the specified type</value>

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -415,7 +415,7 @@
     <value>Produces the set union of two sequences by using the default equality comparer</value>
   </data>
   <data name="RemoveKeys" xml:space="preserve">
-    <value>Returns true if the specified key is removed from list, otherwise returns false</value>
+    <value>Removes a copy of array with specified key removed</value>
   </data>
   <data name="RemovesTheMembersofTheList" xml:space="preserve">
     <value>Removes the members of the list which are not members of the specified type</value>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -911,4 +911,7 @@ Parameter name: {0}</value>
   <data name="InvalidFunction" xml:space="preserve">
     <value>Not an valid function.</value>
   </data>
+  <data name="RemoveKeys1" xml:space="preserve">
+    <value>Removes a copy of array with specified key removed</value>
+  </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -418,7 +418,7 @@
     <value>Produces the set union of two sequences by using the default equality comparer</value>
   </data>
   <data name="RemoveKeys" xml:space="preserve">
-    <value>Returns true if the specified key is removed from list, otherwise returns false</value>
+    <value>Removes key from list</value>
   </data>
   <data name="RemovesTheMembersofTheList" xml:space="preserve">
     <value>Removes the members of the list which are not members of the specified type</value>

--- a/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
@@ -1994,7 +1994,6 @@ r2 = ContainsKey(a, true);
         }
 
         [Test]
-        [Category("Failure")]
         public void TestDictionary22()
         {
             // Test builtin functions RemoveKey() for array
@@ -2003,17 +2002,15 @@ r2 = ContainsKey(a, true);
 a[true] = 41;
 a[""x""] = ""foo"";
 r1 = RemoveKey(a, ""x"");
-r2 = RemoveKey(a, true);
-r3 = ContainsKey(a, ""x"");
-r4 = ContainsKey(a, true);
+r2 = RemoveKey(r1, true);
+r3 = ContainsKey(r2, ""x"");
+r4 = ContainsKey(r2, true);
 ";
             // Tracked in:http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4155
             string errmsg = "MAGN-4155 : ContainsKey returns wrong value";
             thisTest.RunScriptSource(code, errmsg);
-            thisTest.Verify("r1", true);
-            thisTest.Verify("r2", true);
             thisTest.Verify("r3", false);
-            thisTest.Verify("r4", true);
+            thisTest.Verify("r4", false);
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
@@ -4329,8 +4329,7 @@ def foo ()
 x = 0;
 y = RemoveKey(x, x);
 ";
-            Assert.DoesNotThrow(() => thisTest.RunScriptSource(code));
-            thisTest.Verify("y", false);
+            thisTest.Verify("y", 0);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

`RemoveKey(list, key)` returns true value if input `list` has `key` and removes `key` from `list`; otherwise returns false.

The problem is, because of copy semantics, the original list would never be changed, so `RemoveKey()` is useless.

This PR returns list with specified key removed.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@monikaprabhu , @kronz , @riteshchandawar 
