### PR TITLE
Mod function (%) adheres to Google, Python and Excel standard for neg dividends.

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -3652,14 +3652,30 @@ namespace ProtoCore.DSASM
                     }
                     else
                     {
-                        opdata2 = StackValue.BuildInt(lhs % rhs);
+                        var intMod = lhs % rhs;
+
+                        // In order to follow the conventions of Java, Python, Scala and Google's calculator,
+                        // the returned modulo will follow the sign of the divisor (not the dividend). 
+
+                        if (intMod < 0 && rhs > 0 || intMod > 0 && rhs < 0)
+                        {
+                            intMod = intMod + rhs;
+                        }
+
+                        opdata2 = StackValue.BuildInt(intMod);
                     }
                 }
                 else
                 {
                     double lhs = opdata2.IsDouble ? opdata2.DoubleValue : opdata2.IntegerValue;
                     double rhs = opdata1.IsDouble ? opdata1.DoubleValue : opdata1.IntegerValue;
-                    opdata2 = StackValue.BuildDouble(lhs % rhs);
+                    var doubleMod = lhs % rhs;
+
+                    if (doubleMod < 0 && rhs > 0 || doubleMod > 0 && rhs < 0)
+                    {
+                        doubleMod = doubleMod + rhs;
+                    }
+                    opdata2 = StackValue.BuildDouble(doubleMod);
                 }
             }
             else

--- a/test/DynamoCoreTests/CoreDynTests.cs
+++ b/test/DynamoCoreTests/CoreDynTests.cs
@@ -235,6 +235,8 @@ namespace Dynamo.Tests
             RunModel(openPath);
 
             AssertPreviewValue("4a780dfb-74b1-453a-86ef-2f4a5c46792e", 0.0);
+            AssertPreviewValue("4839daee-5add-4686-a89d-dd36ec868993", 3);
+            AssertPreviewValue("2d1dd88e-6d47-48c5-9b79-560a6bf406ee", 3.0);
         }
 
         [Test]

--- a/test/core/math/Modulo.dyn
+++ b/test/core/math/Modulo.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="1.0.1.1743" X="0" Y="0" zoom="1" Name="" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="False">
+<Workspace Version="1.2.1.2720" X="-2.91728367164421" Y="-408.857933577007" zoom="1.83541648937758" Name="" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
     <CoreNodeModels.Input.DoubleInput guid="05087879-15df-4443-8fd5-79d80bbd0821" type="CoreNodeModels.Input.DoubleInput" nickname="Number" x="179.841590829585" y="275.611890772149" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
@@ -7,15 +7,45 @@
     <CoreNodeModels.Input.DoubleInput guid="27f2198c-fc10-489d-893e-be374e6d9933" type="CoreNodeModels.Input.DoubleInput" nickname="Number" x="178.511364484511" y="183.242474715776" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Double value="2" />
     </CoreNodeModels.Input.DoubleInput>
-    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="c34f907f-edd5-4703-b614-069e27af438f" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="%" x="314.502904244148" y="217.597429331781" isVisible="true" isUpstreamVisible="true" lacing="Longest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="%@var[]..[],var[]..[]" />
-    <CoreNodeModels.Watch guid="4a780dfb-74b1-453a-86ef-2f4a5c46792e" type="CoreNodeModels.Watch" nickname="Watch" x="481.003750511447" y="214.858469557855" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="c34f907f-edd5-4703-b614-069e27af438f" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="%" x="314.502904244148" y="217.597429331781" isVisible="true" isUpstreamVisible="true" lacing="Longest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="%@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <CoreNodeModels.Watch guid="4a780dfb-74b1-453a-86ef-2f4a5c46792e" type="CoreNodeModels.Watch" nickname="Watch" x="541.003750511447" y="216.858469557855" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="5a30aeb0-96b8-4c90-9e3c-8e0af8fecaf7" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="%" x="329.250351949462" y="396.962597444272" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="%@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="048b1c71-6110-4cf7-81d7-8894583245dd" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="171.456690096371" y="412.494092652099" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="-2;&#xA;5;" ShouldFocus="false" />
+    <CoreNodeModels.Watch guid="4839daee-5add-4686-a89d-dd36ec868993" type="CoreNodeModels.Watch" nickname="Watch" x="581.112543645176" y="412.035431310232" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="9937b756-2928-43d6-a72a-88622edbfb5e" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="%" x="332.653895080485" y="543.314952078268" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="Operators" function="%@var[]..[],var[]..[]">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="993ad43d-dcda-4e6d-8aff-2464b6c39a5d" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="162.521651757521" y="554.521651757521" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="-2.0;&#xA;5.0;" ShouldFocus="false" />
+    <CoreNodeModels.Watch guid="2d1dd88e-6d47-48c5-9b79-560a6bf406ee" type="CoreNodeModels.Watch" nickname="Watch" x="579.16766185602" y="575.891722046632" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
   </Elements>
   <Connectors>
     <Dynamo.Graph.Connectors.ConnectorModel start="05087879-15df-4443-8fd5-79d80bbd0821" start_index="0" end="c34f907f-edd5-4703-b614-069e27af438f" end_index="1" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="27f2198c-fc10-489d-893e-be374e6d9933" start_index="0" end="c34f907f-edd5-4703-b614-069e27af438f" end_index="0" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="c34f907f-edd5-4703-b614-069e27af438f" start_index="0" end="4a780dfb-74b1-453a-86ef-2f4a5c46792e" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5a30aeb0-96b8-4c90-9e3c-8e0af8fecaf7" start_index="0" end="4839daee-5add-4686-a89d-dd36ec868993" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="048b1c71-6110-4cf7-81d7-8894583245dd" start_index="0" end="5a30aeb0-96b8-4c90-9e3c-8e0af8fecaf7" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="048b1c71-6110-4cf7-81d7-8894583245dd" start_index="1" end="5a30aeb0-96b8-4c90-9e3c-8e0af8fecaf7" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="9937b756-2928-43d6-a72a-88622edbfb5e" start_index="0" end="2d1dd88e-6d47-48c5-9b79-560a6bf406ee" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="993ad43d-dcda-4e6d-8aff-2464b6c39a5d" start_index="0" end="9937b756-2928-43d6-a72a-88622edbfb5e" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="993ad43d-dcda-4e6d-8aff-2464b6c39a5d" start_index="1" end="9937b756-2928-43d6-a72a-88622edbfb5e" end_index="1" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />
   <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>


### PR DESCRIPTION
### Purpose

This PR is meant to address the task filed in _MAGN-7338_. 

Previously, in all versions of Dynamo, an modulo equation will be calculated as follows:

 `-0.5 % 3 == -0.5`

![magn7338before](https://cloud.githubusercontent.com/assets/16283396/18939933/dc3e6170-8636-11e6-8620-3cc1ff02a31f.PNG)

This form of calculation follows the C and C# convention of modulo calculation. This convention used the [truncated method of division](https://en.wikipedia.org/wiki/Truncation) and therefore, the quotient is 'rounded towards zero'. For a more detailed explanation of this, please see [Eric Lippert's post](https://blogs.msdn.microsoft.com/ericlippert/2011/12/05/whats-the-difference-remainder-vs-modulus/) on the C# implementation of modulo.

Instead, in order for ease of use for certain computation scenarios (i.e. the one mentioned by Neal in the Youtrack task as well as the task of calculating day of the week a certain number of days before the current time), Python, Excel and Google calculator returns a modulo which follows the sign of the divisor. For other languages, see [Wiki](https://en.wikipedia.org/wiki/Modulo_operation).

Now, the abovementioned calculation of

`-0.5 % 3 == 2.5` instead of `-0.5`

![magn7338](https://cloud.githubusercontent.com/assets/16283396/18940083/2f45fb0c-8638-11e6-9432-644f37184470.PNG)

In other use-cases, where the signs of both the divisor and the dividend are the same, the results will ***not*** differ from the C# convention.

Note: The modulo test case has been updated to account for this change.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 

### FYIs

@jnealb 