### PR TITLE
Update test case because of the change of RemoveKey()

### DIFF
--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -984,13 +984,13 @@ namespace Dynamo.Tests
             RunModel(dynFilePath);
             // Fix expected result after MAGN-7639 is fixed.
 
-            AssertPreviewValue("bd89982a-c3e6-4a4e-898c-2bdc8f1f8c3e", false);
+            AssertPreviewValue("bd89982a-c3e6-4a4e-898c-2bdc8f1f8c3e", null);
 
             // Reset engine and mark all nodes as dirty. A.k.a., force re-execute.
             CurrentDynamoModel.ForceRun();
 
             // Fix expected result after MAGN-7639 is fixed.
-            AssertPreviewValue("980dcd47-84e7-412c-8d9e-d66f166d2370", true);
+            AssertPreviewValue("980dcd47-84e7-412c-8d9e-d66f166d2370", new object[] { 1, 2, 3, 4 });
 
         }
 


### PR DESCRIPTION
### Purpose

Update test case Removekey_7573 because of the change of `RemoveKey()` (PR #7214).

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs
@monikaprabhu 

