### PR TITLE
Fix MAGN 10382 dictionary definition in CBN creates cross talk between CBN

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -1294,9 +1294,22 @@ namespace Dynamo.Graph.Nodes
                 //First get all the defined variables
                 while (parsedNode is BinaryExpressionNode)
                 {
-                    IdentifierNode assignedVar = GetDefinedIdentifier((parsedNode as BinaryExpressionNode).LeftNode);
+                    var binaryExpression = parsedNode as BinaryExpressionNode;
+                    IdentifierNode assignedVar = GetDefinedIdentifier(binaryExpression.LeftNode);
                     if (assignedVar != null)
+                    {
                         definedVariables.Add(new Variable(assignedVar));
+
+                        // Handle case "a;" which is compiled to "t6BBA4B28C5E54CF89F300D510499A00E_x = a;"
+                        if (assignedVar.Name.StartsWith(ProtoCore.DSASM.Constants.kTempVarForNonAssignment) && binaryExpression.Optr == Operator.assign)
+                        {
+                            var rightNode = binaryExpression.RightNode as IdentifierNode;
+                            if (rightNode != null)
+                            {
+                                definedVariables.Add(new Variable(rightNode));
+                            }
+                        }
+                    }
                     parsedNode = (parsedNode as BinaryExpressionNode).RightNode;
                 }
 

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -1083,6 +1083,17 @@ namespace Dynamo.Tests
             OpenModel(dynFilePath);
             AssertPreviewValue("17aae6a5-c4d5-4ba9-862c-5fd2e99c334e", 8388608);
         }
+
+        [Test]
+        public void TestDictionaryDefintion()
+        {
+            // Regression test for https://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10382
+            // To test that variable could still be properly renamed.
+            var dynFilePath = Path.Combine(TestDirectory, @"core\dsevaluation\define_dictionary.dyn");
+            OpenModel(dynFilePath);
+            AssertPreviewValue("a0227846-04ca-4323-9074-2bd1ea9ac8cf", new object[] { 1, 2, 3 });
+            AssertPreviewValue("ada2d384-626f-4240-b251-7df6e395f3f2", new object[] {"Bob", "Sally", "Pat" });
+        }
     }
 
     [Category("DSCustomNode")]

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -5298,6 +5298,35 @@ namespace DynamoCoreWpfTests
                 }
             });
         }
+
+        [Test]
+        public void MAGN10382()
+        {
+            // github issue: https://github.com/DynamoDS/Dynamo/issues/7151
+            RunCommandsFromFile("CodeBlockNode_DefineDictionary.xml", (commandTag) =>
+            {
+                switch (commandTag)
+                {
+                    case "CreateDictionary":
+                        AssertPreviewValue("86107112-5c2d-43ae-9d7c-e2d756a80bf3", new object[] { 1, 2, 3 });
+                        break;
+                    case "ChangeName1":
+                        AssertPreviewValue("86107112-5c2d-43ae-9d7c-e2d756a80bf3", new object[] { 1, 2, 3 });
+                        break;
+                    case "ChangeName2":
+                        AssertPreviewValue("86107112-5c2d-43ae-9d7c-e2d756a80bf3", new object[] { 1, 2, 3 });
+                        break;
+                    case "ChangeName3":
+                        AssertPreviewValue("86107112-5c2d-43ae-9d7c-e2d756a80bf3", null);
+                        break;
+                    case "ChangeName4":
+                        AssertPreviewValue("86107112-5c2d-43ae-9d7c-e2d756a80bf3", new object[] { 1, 2, 3 });
+                        break;
+                    default:
+                        break;
+                }
+            });
+        }
     }
 
 }

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -5302,25 +5302,21 @@ namespace DynamoCoreWpfTests
         [Test]
         public void MAGN10382()
         {
+            var nodeGuid = "86107112-5c2d-43ae-9d7c-e2d756a80bf3";
+
             // github issue: https://github.com/DynamoDS/Dynamo/issues/7151
             RunCommandsFromFile("CodeBlockNode_DefineDictionary.xml", (commandTag) =>
             {
                 switch (commandTag)
                 {
                     case "CreateDictionary":
-                        AssertPreviewValue("86107112-5c2d-43ae-9d7c-e2d756a80bf3", new object[] { 1, 2, 3 });
-                        break;
                     case "ChangeName1":
-                        AssertPreviewValue("86107112-5c2d-43ae-9d7c-e2d756a80bf3", new object[] { 1, 2, 3 });
-                        break;
                     case "ChangeName2":
-                        AssertPreviewValue("86107112-5c2d-43ae-9d7c-e2d756a80bf3", new object[] { 1, 2, 3 });
+                    case "ChangeName4":
+                        AssertPreviewValue(nodeGuid, new object[] { 1, 2, 3 });
                         break;
                     case "ChangeName3":
-                        AssertPreviewValue("86107112-5c2d-43ae-9d7c-e2d756a80bf3", null);
-                        break;
-                    case "ChangeName4":
-                        AssertPreviewValue("86107112-5c2d-43ae-9d7c-e2d756a80bf3", new object[] { 1, 2, 3 });
+                        AssertPreviewValue(nodeGuid, null);
                         break;
                     default:
                         break;

--- a/test/core/dsevaluation/define_dictionary.dyn
+++ b/test/core/dsevaluation/define_dictionary.dyn
@@ -1,0 +1,23 @@
+<Workspace Version="1.2.1.2722" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <CoreNodeModels.Watch guid="a0227846-04ca-4323-9074-2bd1ea9ac8cf" type="CoreNodeModels.Watch" nickname="Watch" x="388" y="125" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
+    <CoreNodeModels.Watch guid="ada2d384-626f-4240-b251-7df6e395f3f2" type="CoreNodeModels.Watch" nickname="Watch" x="464" y="345" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="1e454a5a-3828-4c74-bf53-fc3249704183" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="167" y="351" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="s[&quot;a&quot;]=&quot;Bob&quot;;&#xA;s[&quot;b&quot;]=&quot;Sally&quot;;&#xA;s[&quot;c&quot;]=&quot;Pat&quot;;&#xA;s;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="ab406c15-3272-4085-8fdb-2662bcc52276" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="166" y="160" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="s[&quot;a&quot;]=1;&#xA;s[&quot;b&quot;]=2;&#xA;s[&quot;c&quot;]=3;&#xA;s;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="1e454a5a-3828-4c74-bf53-fc3249704183" start_index="3" end="ada2d384-626f-4240-b251-7df6e395f3f2" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="ab406c15-3272-4085-8fdb-2662bcc52276" start_index="3" end="a0227846-04ca-4323-9074-2bd1ea9ac8cf" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>

--- a/test/core/recorded/CodeBlockNode_DefineDictionary.xml
+++ b/test/core/recorded/CodeBlockNode_DefineDictionary.xml
@@ -1,0 +1,44 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="229" Y="139" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>86107112-5c2d-43ae-9d7c-e2d756a80bf3</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="86107112-5c2d-43ae-9d7c-e2d756a80bf3" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="137" y="108" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="c[&quot;a&quot;..&quot;c&quot;]=1..3;&#xA;c;" ShouldFocus="false" />
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="a[&quot;a&quot;..&quot;c&quot;]=1..3;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
+    <ModelGuid>86107112-5c2d-43ae-9d7c-e2d756a80bf3</ModelGuid>
+  </UpdateModelValueCommand>
+  <PausePlaybackCommand Tag="CreateDictionary" PauseDurationInMs="20" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="b[&quot;a&quot;..&quot;c&quot;]=1..3;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
+    <ModelGuid>86107112-5c2d-43ae-9d7c-e2d756a80bf3</ModelGuid>
+  </UpdateModelValueCommand>
+  <PausePlaybackCommand Tag="ChangeName1" PauseDurationInMs="20" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="b[&quot;a&quot;..&quot;c&quot;]=1..3;&#xD;&#xA;b;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
+    <ModelGuid>86107112-5c2d-43ae-9d7c-e2d756a80bf3</ModelGuid>
+  </UpdateModelValueCommand>
+  <PausePlaybackCommand Tag="ChangeName2" PauseDurationInMs="20" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="c[&quot;a&quot;..&quot;c&quot;]=1..3;&#xA;b;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
+    <ModelGuid>86107112-5c2d-43ae-9d7c-e2d756a80bf3</ModelGuid>
+  </UpdateModelValueCommand>
+  <PausePlaybackCommand Tag="ChangeName3" PauseDurationInMs="20" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="c[&quot;a&quot;..&quot;c&quot;]=1..3;&#xA;c;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
+    <ModelGuid>86107112-5c2d-43ae-9d7c-e2d756a80bf3</ModelGuid>
+  </UpdateModelValueCommand>
+  <PausePlaybackCommand Tag="ChangeName4" PauseDurationInMs="20" />
+</Commands>


### PR DESCRIPTION
### Purpose

This PR is to fix issue that dictionary definition in CBN creates cross talk between CBN.

![2016-07-16_0818](https://cloud.githubusercontent.com/assets/2600379/18977920/2beff1c4-86f1-11e6-84eb-fa6bd55bd60f.png)

Related github issue #7151 

This is because of renaming mechanism in code block node. Code block node will rename a variable that *defined* in it to a unique name so that a variable could be local to its code block node. Note the prerequisite is variable should be defined firstly. But in the following case:
```
s["foo"] = 123;
s;
```
As `s;` will be compiled to `%t = s;`, code block node doesn't think `s` is defined in its scope, so `s` won't be renamed. Similarly, other `s` in other code block node won't be renamed as well, so these two `s` are exact the same global variable.

We should add `s` to code block node's definition list in this case.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@kronz @riteshchandawar @monikaprabhu 
