### PR TITLE
Fix big number issue in watch node

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
@@ -847,7 +847,7 @@ namespace ProtoFFI
             switch (addressType)
             {
                 case AddressType.Int:
-                    return typeof(int);
+                    return typeof(long);
                 case AddressType.Double:
                     return typeof(double);
                 case AddressType.Boolean:

--- a/src/Libraries/CoreNodes/Compare.cs
+++ b/src/Libraries/CoreNodes/Compare.cs
@@ -23,11 +23,18 @@ namespace DSCore
             {
                 if (b is int)
                     return (double)a > (int)b;
+                else if (b is long)
+                    return (double)a > (long)b;
             }
             else if (a is int)
             {
                 if (b is double || b is float)
                     return (int)a > (double)b;
+            }
+            else if (a is long)
+            {
+                if (b is double || b is float)
+                    return (long)a > (double)b;
             }
             return ((IComparable)a).CompareTo(b) > 0;
         }
@@ -43,10 +50,17 @@ namespace DSCore
         {
             if (a is double || a is float)
             {
-                if (b is int || b is long)
+                if (b is int)
+                    return (double)a >= (int)b;
+                else if (b is long)
                     return (double)a >= (long)b;
             }
-            else if (a is long || a is int)
+            else if (a is int)
+            {
+                if (b is double || b is float)
+                    return (int)a >= (double)b;
+            }
+            else if (a is long)
             {
                 if (b is double || b is float)
                     return (long)a >= (double)b;
@@ -67,11 +81,18 @@ namespace DSCore
             {
                 if (b is int)
                     return (double)a < (int)b;
+                else if (b is long)
+                    return (double)a < (long)b;
             }
             else if (a is int)
             {
                 if (b is double || b is float)
                     return (int)a < (double)b;
+            }
+            else if (a is long)
+            {
+                if (b is double || b is float)
+                    return (long)a < (double)b;
             }
             return ((IComparable)a).CompareTo(b) < 0;
         }
@@ -89,11 +110,18 @@ namespace DSCore
             {
                 if (b is int)
                     return (double)a <= (int)b;
+                else if (b is long)
+                    return (double)a <= (long)b;
             }
             else if (a is int)
             {
                 if (b is double || b is float)
                     return (int)a <= (double)b;
+            }
+            else if (a is long)
+            {
+                if (b is double || b is float)
+                    return (long)a <= (double)b;
             }
             return ((IComparable)a).CompareTo(b) <= 0;
         }

--- a/src/Libraries/CoreNodes/Compare.cs
+++ b/src/Libraries/CoreNodes/Compare.cs
@@ -43,13 +43,13 @@ namespace DSCore
         {
             if (a is double || a is float)
             {
-                if (b is int)
-                    return (double)a >= (int)b;
+                if (b is int || b is long)
+                    return (double)a >= (long)b;
             }
-            else if (a is int)
+            else if (a is long || a is int)
             {
                 if (b is double || b is float)
-                    return (int)a >= (double)b;
+                    return (long)a >= (double)b;
             }
             return ((IComparable)a).CompareTo(b) >= 0;
         }

--- a/test/DynamoCoreTests/CoreDynTests.cs
+++ b/test/DynamoCoreTests/CoreDynTests.cs
@@ -598,5 +598,14 @@ namespace Dynamo.Tests
 
             AssertPreviewValue("e9ad17aa-e30f-4fcb-9d43-71ec2ab027f4", new[] { 5, 4, 3, 2, 1 });
         }
+
+        [Test]
+        public void TestBigNumber()
+        {
+            RunModel(Path.Combine(TestDirectory, @"core\number\TestBigNumber.dyn"));
+            long value = 6640000000;
+            AssertPreviewValue("b64d00bd-695b-496f-91e2-45caadd56535", value);
+            AssertPreviewValue("8540896e-90c8-45aa-a1b3-b2d93d98668d", value);
+        }
     }
 }

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -377,7 +377,7 @@ namespace Dynamo.Tests
             // odd numbers between 0 and 5
             Assert.IsNotNull(watchNode.CachedValue);
             Assert.IsTrue(watchNode.CachedValue is ICollection);
-            var list = ((ICollection)watchNode.CachedValue).Cast<int>();
+            var list = ((ICollection)watchNode.CachedValue).Cast<long>();
 
             Assert.AreEqual(new[] { 1, 3, 5 }, list.ToList());
         }

--- a/test/Engine/FFITarget/ProtoFFITests.cs
+++ b/test/Engine/FFITarget/ProtoFFITests.cs
@@ -44,7 +44,10 @@ namespace FFITarget
         }
         public static char ToChar(object o)
         {
-            return (char)(int)o;
+            if (o is int)
+                return (char)(int)o;
+            else 
+                return (char)(long)o;
         }
         public static int ToAscii(char c)
         {
@@ -360,7 +363,10 @@ namespace FFITarget
             IEnumerator y2 = y.GetEnumerator();
             y2.Reset();
             y2.MoveNext();
-            return (int)y2.Current;
+            if (y2.Current is int)
+                return (int)y2.Current;
+            else
+                return (int)(long)y2.Current;
         }
         public object GetIEnumerable()
         {
@@ -514,18 +520,22 @@ namespace FFITarget
             return maxSubListDepth + 1;
         }
 
-        public static int SumList(IList arr)
+        public static long SumList(IList arr)
         {
-            int sum = 0;
+            long sum = 0;
             foreach (var item in arr)
             {
                 if (item is System.Collections.IList)
                 {
                     sum += SumList(item as System.Collections.IList);
                 }
-                else if (item is Int32)
+                else if (item is int) 
                 {
-                    sum += (Int32)item;
+                    sum += (int)item;
+                }
+                else if (item is long)
+                {
+                    sum += (long)item;
                 }
             }
 

--- a/test/core/number/TestBigNumber.dyn
+++ b/test/core/number/TestBigNumber.dyn
@@ -1,0 +1,18 @@
+<Workspace Version="1.2.1.2732" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="b64d00bd-695b-496f-91e2-45caadd56535" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="135" y="147" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="true" CodeText="6640000000;" ShouldFocus="false" />
+    <CoreNodeModels.Watch guid="8540896e-90c8-45aa-a1b3-b2d93d98668d" type="CoreNodeModels.Watch" nickname="Watch" x="339" y="153" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="b64d00bd-695b-496f-91e2-45caadd56535" start_index="0" end="8540896e-90c8-45aa-a1b3-b2d93d98668d" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This is because watch node internally call `VMBridgeData.BridgeData()` to pass value to watch node. As this function is a FFI function, FFI incorrectly cast `long` to `cast`.

This issue is reported by github issue #7218 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@riteshchandawar @monikaprabhu 
