### PR TITLE
Fix issues with file path storage and display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Thumbs.db
 *.cache
 *.suo
 *.user
+*.opendb
 .vs
 
 # PYTHON #
@@ -89,3 +90,7 @@ src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
 GregStandaloneAuth.dll
 /src/Libraries/Watch3DNodeModels/*.resources
 *.resources
+src/TestResults
+test/core/customast/test.txt
+test/core/files/test.png
+test/core/migration/writetext.txt

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("1.2.1.2736")]
+[assembly: AssemblyVersion("1.2.1.1955")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.2.1.2736")]
+[assembly: AssemblyFileVersion("1.2.1.1955")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("1.2.1.1955")]
+[assembly: AssemblyVersion("1.2.1.2736")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.2.1.1955")]
+[assembly: AssemblyFileVersion("1.2.1.2736")]

--- a/src/DynamoCore/Graph/Nodes/NodeCategories.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeCategories.cs
@@ -422,11 +422,20 @@ namespace Dynamo.Graph.Nodes
             var assemblyUri = new Uri(subjectPath, UriKind.Absolute);
 
             var relativeUri = documentUri.MakeRelativeUri(assemblyUri).OriginalString;
+
+            // MakeRelativePath should not return a URL encoded path.
+            // new Uri() results in a URL encoded path.
+            // Therefore, to undo that, we need to call UrlDecode on it.
+            // Also, UrlDecode will convert + to space, but the Uri creation
+            // doesn't encode + as %2B. In order to avoid + in the filename
+            // being converted to space, we need to encode + as %2B before calling it.
             var relativePath = WebUtility.UrlDecode(relativeUri.Replace("+", "%2B")).Replace('/', '\\');
+
             if (!HasPathInformation(relativePath))
             {
                 relativePath = ".\\" + relativePath;
             }
+
             return relativePath;
         }
 

--- a/src/DynamoCore/Graph/Nodes/NodeCategories.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeCategories.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Xml;
 using Dynamo.Configuration;
@@ -420,8 +421,8 @@ namespace Dynamo.Graph.Nodes
             var documentUri = new Uri(basePath, UriKind.Absolute);
             var assemblyUri = new Uri(subjectPath, UriKind.Absolute);
 
-            var relativeUri = documentUri.MakeRelativeUri(assemblyUri);
-            var relativePath = relativeUri.OriginalString.Replace('/', '\\');
+            var relativeUri = documentUri.MakeRelativeUri(assemblyUri).OriginalString;
+            var relativePath = WebUtility.UrlDecode(relativeUri.Replace("+", "%2B")).Replace('/', '\\');
             if (!HasPathInformation(relativePath))
             {
                 relativePath = ".\\" + relativePath;

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1678,7 +1678,7 @@ namespace Dynamo.Controls
             if (value == null)
                 return Resources.FilePathConverterNoFileSelected;
 
-            var str = WebUtility.UrlDecode(value.ToString());
+            var str = value.ToString();
 
             if (string.IsNullOrEmpty(str))
                 return Resources.FilePathConverterNoFileSelected;
@@ -1733,7 +1733,7 @@ namespace Dynamo.Controls
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return WebUtility.UrlEncode(value.ToString());
+            return value.ToString();
         }
     }
 

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -501,6 +501,19 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
+        public void MakeRelativePath07()
+        {
+            var tempPath = Path.GetTempPath();
+            var basePath = Path.Combine(tempPath, "home.dyn");
+            var testFilename = "SpecialCharactersSpace Plus+Percent%.txt";
+            var testPath = Path.Combine(tempPath, testFilename);
+
+            var relativePath = Graph.Nodes.Utilities.MakeRelativePath(basePath, testPath);
+            Assert.AreEqual(relativePath, ".\\" + testFilename);
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void MakeAbsolutePath00()
         {
             Assert.Throws<ArgumentNullException>(() =>


### PR DESCRIPTION
### Purpose

https://autodesk.slack.com/archives/dynamo-bugs/p1475264148000002
Fix relative path computation resulting in url encoded paths.

Remove url dencoding from display of file path nodes, as the paths aren't encoded to begin with. Since I don't know why these are here to begin with, I'm not as confident about this.  This code has been here for over 3 years, and it's hard for me to tell where it's actually used.

@sharadkjaiswal added the call to make the path relative, and @Benglin wrote the function to make the path relative, so I want them to look at this.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [n/a] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@Benglin @sharadkjaiswal 

### FYIs

@ramramps 

Before
![image](https://cloud.githubusercontent.com/assets/8569738/19005622/8ea9db76-8729-11e6-85b2-d591995ba39a.png)
![image](https://cloud.githubusercontent.com/assets/8569738/19005672/d3655a56-8729-11e6-8bfa-c7bd52d830b0.png)

After
![image](https://cloud.githubusercontent.com/assets/8569738/19005510/06dc52c8-8729-11e6-9d1e-0729e77a993f.png)