### PR TITLE
Update test cases

### DIFF
--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -1437,7 +1437,7 @@ var06 = g;
             // Expected 5 completion items
             Assert.AreEqual(5, completions.Count());
 
-            string[] expected = { "Decimal", "Imperative", "ImportFromCSV", "Minimal", "MinimalTracedClass" };
+            string[] expected = { "Imperative", "ImportFromCSV", "Minimal", "MinimalTracedClass" };
             var actual = completions.Select(x => x.Text).OrderBy(x => x);
 
             Assert.AreEqual(expected, actual);

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -377,7 +377,7 @@ namespace Dynamo.Tests
             // odd numbers between 0 and 5
             Assert.IsNotNull(watchNode.CachedValue);
             Assert.IsTrue(watchNode.CachedValue is ICollection);
-            var list = ((ICollection)watchNode.CachedValue).Cast<int>();
+            var list = ((ICollection)watchNode.CachedValue).Cast<long>();
 
             Assert.AreEqual(new[] { 1, 3, 5 }, list.ToList());
         }

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -984,13 +984,13 @@ namespace Dynamo.Tests
             RunModel(dynFilePath);
             // Fix expected result after MAGN-7639 is fixed.
 
-            AssertPreviewValue("bd89982a-c3e6-4a4e-898c-2bdc8f1f8c3e", false);
+            AssertPreviewValue("bd89982a-c3e6-4a4e-898c-2bdc8f1f8c3e", null);
 
             // Reset engine and mark all nodes as dirty. A.k.a., force re-execute.
             CurrentDynamoModel.ForceRun();
 
             // Fix expected result after MAGN-7639 is fixed.
-            AssertPreviewValue("980dcd47-84e7-412c-8d9e-d66f166d2370", true);
+            AssertPreviewValue("980dcd47-84e7-412c-8d9e-d66f166d2370", new object[] { 1, 2, 3, 4 });
 
         }
 

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -2895,7 +2895,7 @@ namespace DynamoCoreWpfTests
             NodeModel node = ViewModel.Model.CurrentWorkspace.NodeFromWorkspace
                 ("aeed3ffe-7294-43a9-8a05-83b5ff05f527");
 
-            Assert.AreEqual(ElementState.Warning, node.State);
+            Assert.AreEqual(ElementState.Dead, node.State);
         }
 
         [Test, RequiresSTA]

--- a/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
@@ -4698,7 +4698,7 @@ x = 0;
 y = RemoveKey(x, x);
 ";
             Assert.DoesNotThrow(() => thisTest.RunScriptSource(code));
-            thisTest.Verify("y", false);
+            thisTest.Verify("y", 0);
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests.cs
@@ -6242,7 +6242,7 @@ import(""FFITarget.dll"");
             TestFrameWork.Verify(mirror, "v", 3);
             TestFrameWork.Verify(mirror, "w", 3);
             TestFrameWork.Verify(mirror, "x", new object[] { 1, 1 });
-            TestFrameWork.Verify(mirror, "y", 3);
+            TestFrameWork.Verify(mirror, "y", new object[] { new object[] { 1, 1 } });
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Due to bug fixing and some updates, the following test cases' expected results are updated accordingly:
* ProtoTest.TD.MultiLangTests.TypeSystemTests.TS0198_method_resolution_1467273_3
* ProtoTest.TD.MultiLangTests.Builtin_Functions.TestRemoveKeyNoThrow
* Dynamo.Tests.CodeBlockCompletionTests.TestMethodKeywordCompletionWhenTyping
* Dynamo.Tests.DSEvaluationModelTest.Removekey_7573
* Dynamo.Tests.StringTests.TestNumberToStringInvalidInput
* DynamoCoreWpfTests.RecordedTestsDSEngine.Defect_MAGN_2563
* Dynamo.Tests.CustomNodes.FilterWithCustomNode

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs
@monikaprabhu 
