### PR TITLE
 In-canvas search is dismissed when switching to other windows / when `Save` notification pops up.

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -328,16 +328,15 @@
         </StackPanel>
 
         <Popup Name="InCanvasSearchBar"
-               StaysOpen="True"
+               StaysOpen="False"
                AllowsTransparency="True"
-               IsOpen="False"
                Placement="MousePoint"
                DataContext="{Binding InCanvasSearchViewModel}">
             <ui:InCanvasSearchControl RequestShowInCanvasSearch="ShowHideInCanvasControl" />
         </Popup>
 
         <Popup Name="ContextMenuPopup" Style="{StaticResource WorkspaceContextMenuStylePopup}"
-               Opened="OnContextMenuOpened" StaysOpen="True" AllowsTransparency="True" Placement="MousePoint">
+               Opened="OnContextMenuOpened" StaysOpen="False" AllowsTransparency="True" Placement="MousePoint">
             <Popup.Resources>
                 <Style TargetType="{x:Type MenuItem}">
                     <Setter Property="Focusable" Value="False" />


### PR DESCRIPTION
### Purpose

This PR is meant to address _MAGN-10569_. 

Previously, the in-canvas popup menu always stayed on top of other notifications (such as the Save prompt) as well as other windows (see: https://github.com/DynamoDS/Dynamo/issues/6810). These could be reproduced using the following steps:

1. Popup menu on top of other notifications:
    1. Create a New Workspace
    2. Double click to populate with a cbn and right click in the canvas and type a few letters to engage the search
    // the search pop-up stays up
    3. Click the pane X control to close the window
    // the search pop-up covers the Save prompt dialog: INCORRECT

![incanvaspopupold](https://cloud.githubusercontent.com/assets/16283396/19139787/20956f2a-8bba-11e6-84c8-2c3491386a62.PNG)

2. Popup menu on top of other windows in Dynamo Revit:
    1. Create a New Workspace
    2. Right Click in the canvas to bring up the context menu and the in-canvas search
    3. Alt-tab to switch to another window OR switch windows by clicking on the icon on the taskbar
    // You'll notice that the popup persists.

![incanvaspopupold2](https://cloud.githubusercontent.com/assets/16283396/19139797/2f5296fa-8bba-11e6-8c4f-fe18ed92481f.PNG)

With this fix, the popup menu will be dismissed when the user switches window or when another notification dialogue pops up. 

In order to achieve this, the `Popup.StaysOpen` flag was changed to `False` instead of the previous value of `True`. When declared to be `True`, the `Popup.StaysOpen` command will allow the Popup to remain on top until an explicit call to `Popup.IsOpen` is set to `false`. On the other hand, when declared to be `False`, the Popup control intercepts all mouse and keyboard events to determine when one of these events occurs outside the Popup control. 

Thus, this should be the correct case, whereby any mouse/keyboard event outside the Popup control should close the in-canvas search as this will result in the accepted outcome (declared in _MAGN-10569_ : App modal dialogs should dismiss the in-canvas search pop up window).  

See: https://msdn.microsoft.com/en-us/library/system.windows.controls.primitives.popup.staysopen(v=vs.110).aspx

**Now**, the popup is dismissed when a notification dialogue pops up / when user switches windows:

![incanvaspopupnew](https://cloud.githubusercontent.com/assets/16283396/19139822/5ecbb27c-8bba-11e6-8721-591ce7d491ab.PNG)


Note: Also tested on Dynamo Revit to see if this fix solves Problem 2. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 

### FYIs

@jnealb , @monikaprabhu - would really appreciate it if you could see if this breaks any existing functionality. Based on my preliminary testing, none so far. 

