### PR TITLE
Fix issue that using unary expression in imperative block fail to trigger update

### DIFF
--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -1927,7 +1927,7 @@ namespace ProtoImperative
             }
         }
 
-        private void EmitInlineConditionalNode(ImperativeNode node, ref ProtoCore.Type inferedType, ProtoCore.AST.ImperativeAST.BinaryExpressionNode parentNode = null, ProtoCore.AssociativeGraph.GraphNode graphNode)
+        private void EmitInlineConditionalNode(ImperativeNode node, ref ProtoCore.Type inferedType, ProtoCore.AssociativeGraph.GraphNode graphNode, BinaryExpressionNode parentNode = null)
         {
             InlineConditionalNode inlineConNode = node as InlineConditionalNode;
             IfStmtNode ifNode = new IfStmtNode();
@@ -2461,7 +2461,7 @@ namespace ProtoImperative
                     EmitForLoopNode(node, ref inferedType, isBooleanOp, graphNode);
                     break;
                 case AstKind.InlineConditional:
-                    EmitInlineConditionalNode(node, ref inferedType, parentNode as BinaryExpressionNode, graphNode);
+                    EmitInlineConditionalNode(node, ref inferedType, graphNode, parentNode as BinaryExpressionNode);
                     break;
                 case AstKind.RangeExpression:
                     EmitRangeExprNode(node, ref inferedType, graphNode);

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -1683,12 +1683,13 @@ namespace ProtoImperative
                 EmitSetExpressionUID(core.ExpressionUID++);
         }
 
-        private void EmitUnaryExpressionNode(ImperativeNode node, ref ProtoCore.Type inferedType, ProtoCore.AST.ImperativeAST.BinaryExpressionNode parentNode)
+        private void EmitUnaryExpressionNode(ImperativeNode node, ref ProtoCore.Type inferedType, ProtoCore.AST.ImperativeAST.BinaryExpressionNode parentNode,
+            ProtoCore.AssociativeGraph.GraphNode graphNode)
         {
             if (IsParsingGlobal())
             {
                 UnaryExpressionNode u = node as UnaryExpressionNode;
-                DfsTraverse(u.Expression, ref inferedType, false, null, ProtoCore.CompilerDefinitions.SubCompilePass.None, parentNode);
+                DfsTraverse(u.Expression, ref inferedType, false, graphNode, ProtoCore.CompilerDefinitions.SubCompilePass.None, parentNode);
 
                 string op = Op.GetUnaryOpName(u.Operator);
                 EmitInstrConsole(op);
@@ -1926,7 +1927,7 @@ namespace ProtoImperative
             }
         }
 
-        private void EmitInlineConditionalNode(ImperativeNode node, ref ProtoCore.Type inferedType, ProtoCore.AST.ImperativeAST.BinaryExpressionNode parentNode = null)
+        private void EmitInlineConditionalNode(ImperativeNode node, ref ProtoCore.Type inferedType, ProtoCore.AST.ImperativeAST.BinaryExpressionNode parentNode = null, ProtoCore.AssociativeGraph.GraphNode graphNode)
         {
             InlineConditionalNode inlineConNode = node as InlineConditionalNode;
             IfStmtNode ifNode = new IfStmtNode();
@@ -1943,7 +1944,7 @@ namespace ProtoImperative
             newOptions |= DebugProperties.BreakpointOptions.EmitInlineConditionalBreakpoint;
             core.DebuggerProperties.breakOptions = newOptions;
 
-            EmitIfStmtNode(ifNode, ref inferedType, parentNode, true);
+            EmitIfStmtNode(ifNode, ref inferedType, parentNode, true, graphNode);
 
             core.DebuggerProperties.breakOptions = oldOptions;
         }
@@ -2454,13 +2455,13 @@ namespace ProtoImperative
                     EmitBinaryExpressionNode(node, ref inferedType, isBooleanOp, graphNode, parentNode as BinaryExpressionNode);
                     break;
                 case AstKind.UnaryExpression:
-                    EmitUnaryExpressionNode(node, ref inferedType, parentNode as BinaryExpressionNode);
+                    EmitUnaryExpressionNode(node, ref inferedType, parentNode as BinaryExpressionNode, graphNode);
                     break;
                 case AstKind.ForLoop:
                     EmitForLoopNode(node, ref inferedType, isBooleanOp, graphNode);
                     break;
                 case AstKind.InlineConditional:
-                    EmitInlineConditionalNode(node, ref inferedType, parentNode as BinaryExpressionNode);
+                    EmitInlineConditionalNode(node, ref inferedType, parentNode as BinaryExpressionNode, graphNode);
                     break;
                 case AstKind.RangeExpression:
                     EmitRangeExprNode(node, ref inferedType, graphNode);

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -10,20 +10,20 @@ using ProtoImperative.Properties;
 
 namespace ProtoImperative
 {
-    public class BackpatchMap
-    {
-        public BackpatchMap()
-        {
-            BreakTable = new Dictionary<int, BackpatchTable>();
-            EntryTable = new Dictionary<int, int>();
-        }
-
-        public Dictionary<int, BackpatchTable> BreakTable;
-        public Dictionary<int, int> EntryTable;
-    }
-
     public class CodeGen : ProtoCore.CodeGen
     {
+        private class BackpatchMap
+        {
+            public BackpatchMap()
+            {
+                BreakTable = new Dictionary<int, BackpatchTable>();
+                EntryTable = new Dictionary<int, int>();
+            }
+
+            public Dictionary<int, BackpatchTable> BreakTable;
+            public Dictionary<int, int> EntryTable;
+        }
+
         private readonly BackpatchMap backpatchMap;
         private NodeBuilder nodeBuilder;
 
@@ -708,10 +708,6 @@ namespace ProtoImperative
             ProtoCore.Type type = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0);
 
             ProtoCore.DSASM.SymbolNode symbolnode = null;
-            //bool isAllocated = VerifyAllocation(t.Value, out blockId, out localAllocBlock, out symindex, ref type);
-            //bool allocatedLocally = isAllocated && core.runtimeTableIndex == localAllocBlock;
-            //bool allocatedExternally = isAllocated && core.runtimeTableIndex > localAllocBlock;
-            //bool isVisible = isAllocated && core.runtimeTableIndex >= localAllocBlock;
             bool isAccessible = false;
             bool isAllocated = VerifyAllocation(t.Value, globalClassIndex, globalProcIndex, out symbolnode, out isAccessible);
             if (!isAllocated && null == t.ArrayDimensions)
@@ -832,10 +828,6 @@ namespace ProtoImperative
             if (IsParsingGlobal())
             {
                 LanguageBlockNode langblock = node as LanguageBlockNode;
-                //(Fuqiang, Ayush) : Throwing an assert stops NUnit. Negative tests expect to catch a 
-                // CompilerException, so we throw that instead.
-                //Validity.Assert(ProtoCore.Language.kInvalid != langblock.codeblock.language);
-
                 if (ProtoCore.Language.NotSpecified == langblock.codeblock.Language)
                 {
                     throw new ProtoCore.Exceptions.CompileErrorsOccured("Invalid language block");
@@ -892,7 +884,6 @@ namespace ProtoImperative
 
                 setBlkId(blockId);
                 inferedType = core.InferedType;
-                //Validity.Assert(codeBlock.children[codeBlock.children.Count - 1].blockType == ProtoCore.DSASM.CodeBlockType.kLanguage);
                 codeBlock.children[codeBlock.children.Count - 1].Attributes = PopulateAttributes(langblock.Attributes);
 
                 EmitInstrConsole("bounce " + blockId + ", " + entry.ToString());
@@ -2478,8 +2469,6 @@ namespace ProtoImperative
             }
 
             int blockId = codeBlock.codeBlockId; 
-            //updatePcDictionary(node, blockId);
-            //updatePcDictionary(node.line, node.col);
         }
     }
 


### PR DESCRIPTION
### Purpose

This is to fix github issue #7237 that using ! in imperative block fails to trigger update. That is, for the following code block node:

```
x;
[Imperative]
{
    if (!x)
        return = ...
    else
        return = ...
}
```

Changing `x` doesn't trigger the execution of imperative language block.

That is because graph node is not passed down to unary expression in imperative block, see `DfsTraverse()` in imperative code gen.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@monikaprabhu @Benglin @riteshchandawar @kronz  @ThomasMahon
