### PR TITLE
Fix backslash character parsing issue

### DIFF
--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -1005,7 +1005,7 @@ namespace ProtoCore.AST.AssociativeAST
 
         public override string ToString()
         {
-            return "\"" + Value + "\"";
+            return "\"" + CompilerUtils.ToLiteral(Value) + "\"";
         }
 
         public override AstKind Kind
@@ -2584,7 +2584,7 @@ namespace ProtoCore.AST.AssociativeAST
 
         public override string ToString()
         {
-            return Keyword.Import + "(\"" + ModuleName + "\")" + Constants.termline;
+            return Keyword.Import + " (\"" + CompilerUtils.ToLiteral(ModuleName) + "\") " + Constants.termline;
         }
 
         public override AstKind Kind

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -1005,7 +1005,7 @@ namespace ProtoCore.AST.AssociativeAST
 
         public override string ToString()
         {
-            return "\"" + CompilerUtils.ToLiteral(Value) + "\"";
+            return "\"" + Value + "\"";
         }
 
         public override AstKind Kind

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -1814,7 +1814,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_LogicalExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		Associative_ComparisonExpression(out node);
-		while (la.kind == 59 || la.kind == 60) {
+		while (la.kind == 57 || la.kind == 58) {
 			Operator op;
 			Associative_LogicalOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
@@ -1843,7 +1843,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		node = null; 
 		if (StartOf(13)) {
 			Associative_NegExpression(out node);
-		} else if (la.kind == 14 || la.kind == 61) {
+		} else if (la.kind == 14 || la.kind == 59) {
 			Associative_BitUnaryExpression(out node);
 		} else SynErr(82);
 	}
@@ -1874,7 +1874,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Get();
 			op = UnaryOperator.Not;    
 			#if ENABLE_BIT_OP          
-		} else if (la.kind == 61) {
+		} else if (la.kind == 59) {
 			Get();
 			op = UnaryOperator.Negate; 
 			#endif                     
@@ -1934,9 +1934,9 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_LogicalOp(out Operator op) {
 		op = Operator.and; 
-		if (la.kind == 59) {
+		if (la.kind == 57) {
 			Get();
-		} else if (la.kind == 60) {
+		} else if (la.kind == 58) {
 			Get();
 			op = Operator.or; 
 		} else SynErr(86);
@@ -1987,7 +1987,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			bool hasRangeAmountOperator = false;
 			
 			Get();
-			if (la.kind == 62) {
+			if (la.kind == 60) {
 				Associative_rangeAmountOperator(out hasRangeAmountOperator);
 			}
 			rnode.HasRangeAmountOperator = hasRangeAmountOperator; 
@@ -2023,14 +2023,14 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_rangeAmountOperator(out bool hasRangeAmountOperator) {
 		hasRangeAmountOperator = false; 
-		Expect(62);
+		Expect(60);
 		hasRangeAmountOperator = true; 
 	}
 
 	void Associative_rangeStepOperator(out RangeStepOperator op) {
 		op = RangeStepOperator.StepSize; 
-		if (la.kind == 61 || la.kind == 62) {
-			if (la.kind == 62) {
+		if (la.kind == 59 || la.kind == 60) {
+			if (la.kind == 60) {
 				Get();
 				op = RangeStepOperator.Number; 
 			} else {
@@ -2063,44 +2063,11 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else SynErr(89);
 	}
 
-	void Associative_BitOp(out Operator op) {
-		op = Operator.bitwiseand; 
-		if (la.kind == 57) {
-			Get();
-		} else if (la.kind == 58) {
-			Get();
-			op = Operator.bitwisexor; 
-		} else if (la.kind == 16) {
-			Get();
-			op = Operator.bitwiseor; 
-		} else SynErr(90);
-	}
-
 	void Associative_Term(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		#if ENABLE_BIT_OP 
-		Associative_interimfactor(out node);
-		#else             
 		Associative_Factor(out node);
-		#endif            
 		while (la.kind == 54 || la.kind == 55 || la.kind == 56) {
 			Operator op; 
 			Associative_MulOp(out op);
-			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
-			#if ENABLE_BIT_OP 
-			Associative_interimfactor(out expr2);
-			#else             
-			Associative_Factor(out expr2);
-			#endif            
-			node = GenerateBinaryOperatorMethodCallNode(op, node, expr2);
-			
-		}
-	}
-
-	void Associative_interimfactor(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		Associative_Factor(out node);
-		while (la.kind == 16 || la.kind == 57 || la.kind == 58) {
-			Operator op; 
-			Associative_BitOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
 			Associative_Factor(out expr2);
 			node = GenerateBinaryOperatorMethodCallNode(op, node, expr2);
@@ -2166,7 +2133,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			   node.line = line; node.col = col;
 			}
 			
-		} else SynErr(91);
+		} else SynErr(90);
 	}
 
 	void Associative_Char(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -2250,7 +2217,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Associative_ArrayExprList(out node);
 			nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode;
 			
-		} else SynErr(92);
+		} else SynErr(91);
 		if (la.kind == 10) {
 			ProtoCore.AST.AssociativeAST.ArrayNode array = new ProtoCore.AST.AssociativeAST.ArrayNode(); 
 			
@@ -2392,7 +2359,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			} else if (la.kind == 2) {
 				Get();
 				isLongest = false; 
-			} else SynErr(93);
+			} else SynErr(92);
 			repguide = t.val;
 			if (isLongest)
 			{
@@ -2414,7 +2381,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				} else if (la.kind == 2) {
 					Get();
 					isLongest = false; 
-				} else SynErr(94);
+				} else SynErr(93);
 				repguide = t.val;
 				if (isLongest)
 				{
@@ -2528,7 +2495,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			  SynErr(Resources.SemiColonExpected);
 			
 			Get();
-		} else SynErr(95);
+		} else SynErr(94);
 	}
 
 	void Imperative_languageblock(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -2557,7 +2524,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Hydrogen(out codeBlockNode);
 		} else if (langblock.codeblock.Language == ProtoCore.Language.Imperative ) {
 			Imperative(out codeBlockNode);
-		} else SynErr(96);
+		} else SynErr(95);
 		if (langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			int openCurlyBraceCount = 0, closeCurlyBraceCount = 0; 
 			ProtoCore.AST.ImperativeAST.CodeBlockNode codeBlockInvalid = new ProtoCore.AST.ImperativeAST.CodeBlockNode(); 
@@ -2578,12 +2545,12 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 					break; 
 				} else if (StartOf(8)) {
 					Get(); 
-				} else SynErr(97);
+				} else SynErr(96);
 			}
 			codeBlockNode = codeBlockInvalid; 
 		} else if (la.kind == 45) {
 			Get();
-		} else SynErr(98);
+		} else SynErr(97);
 		langblock.CodeBlockNode = codeBlockNode; 
 		node = langblock; 
 	}
@@ -2610,7 +2577,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt; 
 			Imperative_stmt(out singleStmt);
 			ifStmtNode.IfBody.Add(singleStmt); 
-		} else SynErr(99);
+		} else SynErr(98);
 		NodeUtils.SetNodeEndLocation(ifStmtNode.IfBodyPosition, t); 
 		while (la.kind == 30) {
 			ProtoCore.AST.ImperativeAST.ElseIfBlock elseifBlock = new ProtoCore.AST.ImperativeAST.ElseIfBlock(); 
@@ -2634,7 +2601,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				elseifBlock.Body.Add(singleStmt); 
-			} else SynErr(100);
+			} else SynErr(99);
 			NodeUtils.SetNodeEndLocation(elseifBlock.ElseIfBodyPosition, t); 
 			ifStmtNode.ElseIfList.Add(elseifBlock); 
 		}
@@ -2650,7 +2617,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				ifStmtNode.ElseBody.Add(singleStmt); 
-			} else SynErr(101);
+			} else SynErr(100);
 			NodeUtils.SetNodeEndLocation(ifStmtNode.ElseBodyPosition, t); 
 		}
 		node = ifStmtNode; 
@@ -2688,7 +2655,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		int idLine = la.line; int idCol = la.col; 
 		Imperative_Ident(out node);
 		loopNode.LoopVariable = node; loopNode.LoopVariable.line = idLine; loopNode.LoopVariable.col = idCol; 
-		Expect(63);
+		Expect(61);
 		loopNode.KwInLine = t.line; loopNode.KwInCol = t.col; int exprLine = la.line; int exprCol = la.col; 
 		Imperative_expr(out node);
 		loopNode.Expression = node; if (loopNode.Expression != null) {  loopNode.Expression.line = exprLine; loopNode.Expression.col = exprCol; } 
@@ -2703,7 +2670,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 			Imperative_stmt(out singleStmt);
 			loopNode.Body.Add(singleStmt); 
-		} else SynErr(102);
+		} else SynErr(101);
 		forloop = loopNode;
 		
 	}
@@ -2737,7 +2704,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				Expect(23);
 			} else if (la.kind == 10) {
 				Imperative_languageblock(out rhsNode);
-			} else SynErr(103);
+			} else SynErr(102);
 			bNode.LeftNode = lhsNode;
 			bNode.RightNode = rhsNode;
 			bNode.Optr = Operator.assign;
@@ -2746,7 +2713,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			
 		} else if (StartOf(8)) {
 			SynErr("';' is expected"); 
-		} else SynErr(104);
+		} else SynErr(103);
 	}
 
 	void Imperative_expr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -2882,7 +2849,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			node = typedVar; 
 		} else if (la.kind == 1 || la.kind == 12 || la.kind == 44) {
 			Imperative_IdentifierList(out node);
-		} else SynErr(105);
+		} else SynErr(104);
 	}
 
 	void Imperative_IdentifierList(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -2933,7 +2900,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	void Imperative_binexpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null;
 		Imperative_logicalexpr(out node);
-		while (la.kind == 59 || la.kind == 60) {
+		while (la.kind == 57 || la.kind == 58) {
 			Operator op; 
 			Imperative_logicalop(out op);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode = null; 
@@ -2992,7 +2959,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Imperative_ExprList(out node);
 			nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
 			
-		} else SynErr(106);
+		} else SynErr(105);
 		if (la.kind == 10) {
 			ProtoCore.AST.ImperativeAST.ArrayNode array = new ProtoCore.AST.ImperativeAST.ArrayNode();
 			
@@ -3067,9 +3034,9 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		node = null; 
 		if (la.kind == 15) {
 			Imperative_negexpr(out node);
-		} else if (la.kind == 14 || la.kind == 61) {
+		} else if (la.kind == 14 || la.kind == 59) {
 			Imperative_bitunaryexpr(out node);
-		} else SynErr(107);
+		} else SynErr(106);
 	}
 
 	void Imperative_negexpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3107,11 +3074,11 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Get();
 			op = UnaryOperator.Not; 
 			#if ENABLE_BIT_OP       
-		} else if (la.kind == 61) {
+		} else if (la.kind == 59) {
 			Get();
 			op = UnaryOperator.Negate; 
 			#endif                     
-		} else SynErr(108);
+		} else SynErr(107);
 	}
 
 	void Imperative_factor(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3139,9 +3106,9 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			
 		} else if (la.kind == 1 || la.kind == 12 || la.kind == 44) {
 			Imperative_IdentifierList(out node);
-		} else if (la.kind == 14 || la.kind == 15 || la.kind == 61) {
+		} else if (la.kind == 14 || la.kind == 15 || la.kind == 59) {
 			Imperative_unaryexpr(out node);
-		} else SynErr(109);
+		} else SynErr(108);
 	}
 
 	void Imperative_negop(out UnaryOperator op) {
@@ -3169,13 +3136,13 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Imperative_logicalop(out Operator op) {
 		op = Operator.none; 
-		if (la.kind == 59) {
+		if (la.kind == 57) {
 			Get();
 			op = Operator.and; 
-		} else if (la.kind == 60) {
+		} else if (la.kind == 58) {
 			Get();
 			op = Operator.or; 
-		} else SynErr(110);
+		} else SynErr(109);
 	}
 
 	void Imperative_RangeExpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3187,7 +3154,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			bool hasAmountOperator = false;
 			
 			Get();
-			if (la.kind == 62) {
+			if (la.kind == 60) {
 				Imperative_rangeAmountOperator(out hasAmountOperator);
 			}
 			rnode.HasRangeAmountOperator = hasAmountOperator; 
@@ -3242,7 +3209,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			op = Operator.nq; 
 			break;
 		}
-		default: SynErr(111); break;
+		default: SynErr(110); break;
 		}
 	}
 
@@ -3266,14 +3233,14 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Imperative_rangeAmountOperator(out bool hasAmountOperator) {
 		hasAmountOperator = false; 
-		Expect(62);
+		Expect(60);
 		hasAmountOperator = true; 
 	}
 
 	void Imperative_rangeStepOperator(out RangeStepOperator op) {
 		op = RangeStepOperator.StepSize; 
-		if (la.kind == 61 || la.kind == 62) {
-			if (la.kind == 62) {
+		if (la.kind == 59 || la.kind == 60) {
+			if (la.kind == 60) {
 				Get();
 				op = RangeStepOperator.Number; 
 			} else {
@@ -3317,13 +3284,13 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else if (la.kind == 15) {
 			Get();
 			op = Operator.sub; 
-		} else SynErr(112);
+		} else SynErr(111);
 	}
 
 	void Imperative_interimfactor(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null;
 		Imperative_factor(out node);
-		while (la.kind == 16 || la.kind == 57 || la.kind == 58) {
+		while (la.kind == 16 || la.kind == 62 || la.kind == 63) {
 			Operator op; 
 			Imperative_bitop(out op);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode; 
@@ -3349,21 +3316,21 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else if (la.kind == 56) {
 			Get();
 			op = Operator.mod; 
-		} else SynErr(113);
+		} else SynErr(112);
 	}
 
 	void Imperative_bitop(out Operator op) {
 		op = Operator.none; 
-		if (la.kind == 57) {
+		if (la.kind == 62) {
 			Get();
 			op = Operator.bitwiseand; 
 		} else if (la.kind == 16) {
 			Get();
 			op = Operator.bitwiseor; 
-		} else if (la.kind == 58) {
+		} else if (la.kind == 63) {
 			Get();
 			op = Operator.bitwisexor; 
-		} else SynErr(114);
+		} else SynErr(113);
 	}
 
 	void Imperative_Char(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3444,7 +3411,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			else{
 			   NodeUtils.SetNodeLocation(node, t); }
 			
-		} else SynErr(115);
+		} else SynErr(114);
 	}
 
 	void Imperative_functioncall(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3505,21 +3472,21 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	}
 	
 	static readonly bool[,] set = {
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,T,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x},
+		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
+		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,T,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
+		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
+		{x,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
+		{x,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
 		{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,T,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,T, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x},
+		{T,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
 		{T,T,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,T,x,T, x,T,T,T, T,T,x,x, x,T,T,x, x,T,T,T, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,T,x,x, T,T,x,x, x,T,T,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x},
+		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,T,x,T, x,T,T,T, T,T,x,x, x,T,T,x, x,T,T,T, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
+		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
+		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,T,x,x, T,T,x,x, x,T,T,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
 		{x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x},
+		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
 		{x,T,x,x, x,x,x,x, x,x,x,x, T,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x},
+		{x,T,x,x, x,x,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
 		{x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,T,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x}
 
 	};
@@ -3593,13 +3560,13 @@ public class Errors {
 			case 54: s = "\"*\" expected"; break;
 			case 55: s = "\"/\" expected"; break;
 			case 56: s = "\"%\" expected"; break;
-			case 57: s = "\"&\" expected"; break;
-			case 58: s = "\"^\" expected"; break;
-			case 59: s = "\"&&\" expected"; break;
-			case 60: s = "\"||\" expected"; break;
-			case 61: s = "\"~\" expected"; break;
-			case 62: s = "\"#\" expected"; break;
-			case 63: s = "\"in\" expected"; break;
+			case 57: s = "\"&&\" expected"; break;
+			case 58: s = "\"||\" expected"; break;
+			case 59: s = "\"~\" expected"; break;
+			case 60: s = "\"#\" expected"; break;
+			case 61: s = "\"in\" expected"; break;
+			case 62: s = "\"&\" expected"; break;
+			case 63: s = "\"^\" expected"; break;
 			case 64: s = "??? expected"; break;
 			case 65: s = "this symbol not expected in Import_Statement"; break;
 			case 66: s = "invalid Import_Statement"; break;
@@ -3626,32 +3593,31 @@ public class Errors {
 			case 87: s = "invalid Associative_ComparisonOp"; break;
 			case 88: s = "invalid Associative_AddOp"; break;
 			case 89: s = "invalid Associative_MulOp"; break;
-			case 90: s = "invalid Associative_BitOp"; break;
-			case 91: s = "invalid Associative_Number"; break;
+			case 90: s = "invalid Associative_Number"; break;
+			case 91: s = "invalid Associative_NameReference"; break;
 			case 92: s = "invalid Associative_NameReference"; break;
 			case 93: s = "invalid Associative_NameReference"; break;
-			case 94: s = "invalid Associative_NameReference"; break;
-			case 95: s = "invalid Imperative_stmt"; break;
+			case 94: s = "invalid Imperative_stmt"; break;
+			case 95: s = "invalid Imperative_languageblock"; break;
 			case 96: s = "invalid Imperative_languageblock"; break;
 			case 97: s = "invalid Imperative_languageblock"; break;
-			case 98: s = "invalid Imperative_languageblock"; break;
+			case 98: s = "invalid Imperative_ifstmt"; break;
 			case 99: s = "invalid Imperative_ifstmt"; break;
 			case 100: s = "invalid Imperative_ifstmt"; break;
-			case 101: s = "invalid Imperative_ifstmt"; break;
-			case 102: s = "invalid Imperative_forloop"; break;
+			case 101: s = "invalid Imperative_forloop"; break;
+			case 102: s = "invalid Imperative_assignstmt"; break;
 			case 103: s = "invalid Imperative_assignstmt"; break;
-			case 104: s = "invalid Imperative_assignstmt"; break;
-			case 105: s = "invalid Imperative_decoratedIdentifier"; break;
-			case 106: s = "invalid Imperative_NameReference"; break;
-			case 107: s = "invalid Imperative_unaryexpr"; break;
-			case 108: s = "invalid Imperative_unaryop"; break;
-			case 109: s = "invalid Imperative_factor"; break;
-			case 110: s = "invalid Imperative_logicalop"; break;
-			case 111: s = "invalid Imperative_relop"; break;
-			case 112: s = "invalid Imperative_addop"; break;
-			case 113: s = "invalid Imperative_mulop"; break;
-			case 114: s = "invalid Imperative_bitop"; break;
-			case 115: s = "invalid Imperative_num"; break;
+			case 104: s = "invalid Imperative_decoratedIdentifier"; break;
+			case 105: s = "invalid Imperative_NameReference"; break;
+			case 106: s = "invalid Imperative_unaryexpr"; break;
+			case 107: s = "invalid Imperative_unaryop"; break;
+			case 108: s = "invalid Imperative_factor"; break;
+			case 109: s = "invalid Imperative_logicalop"; break;
+			case 110: s = "invalid Imperative_relop"; break;
+			case 111: s = "invalid Imperative_addop"; break;
+			case 112: s = "invalid Imperative_mulop"; break;
+			case 113: s = "invalid Imperative_bitop"; break;
+			case 114: s = "invalid Imperative_num"; break;
 
 			default: s = "error " + n; break;
 		}

--- a/src/Engine/ProtoCore/Parser/Scanner.cs
+++ b/src/Engine/ProtoCore/Parser/Scanner.cs
@@ -610,24 +610,24 @@ public class Scanner {
 		start[41] = 17; 
 		start[33] = 31; 
 		start[45] = 18; 
-		start[124] = 52; 
+		start[124] = 51; 
 		start[60] = 32; 
 		start[62] = 33; 
-		start[61] = 53; 
+		start[61] = 52; 
 		start[59] = 23; 
-		start[47] = 54; 
-		start[123] = 39; 
-		start[125] = 40; 
-		start[58] = 41; 
-		start[44] = 42; 
-		start[63] = 43; 
-		start[43] = 44; 
-		start[42] = 45; 
-		start[37] = 46; 
-		start[38] = 55; 
-		start[94] = 47; 
-		start[126] = 50; 
-		start[35] = 51; 
+		start[47] = 53; 
+		start[123] = 38; 
+		start[125] = 39; 
+		start[58] = 40; 
+		start[44] = 41; 
+		start[63] = 42; 
+		start[43] = 43; 
+		start[42] = 44; 
+		start[37] = 45; 
+		start[38] = 54; 
+		start[126] = 48; 
+		start[35] = 49; 
+		start[94] = 50; 
 		start[Buffer.EOF] = -1;
 
 	}
@@ -716,7 +716,7 @@ public class Scanner {
 			case "public": t.kind = 47; break;
 			case "private": t.kind = 48; break;
 			case "protected": t.kind = 49; break;
-			case "in": t.kind = 63; break;
+			case "in": t.kind = 61; break;
 			default: break;
 		}
 	}
@@ -846,12 +846,10 @@ public class Scanner {
 				if (ch == '=') {AddCh(); goto case 20;}
 				else {t.kind = 18; break;}
 			case 34:
-				if (ch <= '!' || ch >= '#' && ch <= '[' || ch >= ']' && ch <= 65535) {AddCh(); goto case 7;}
-				else if (ch == '"') {AddCh(); goto case 37;}
-				else if (ch == 92) {AddCh(); goto case 34;}
+				if (ch == '"' || ch == 39 || ch == '0' || ch == 92 || ch >= 'a' && ch <= 'b' || ch == 'f' || ch == 'n' || ch == 'r' || ch >= 't' && ch <= 'v') {AddCh(); goto case 7;}
 				else {goto case 0;}
 			case 35:
-				if (ch == 39) {AddCh(); goto case 38;}
+				if (ch == 39) {AddCh(); goto case 37;}
 				else if (ch == '"' || ch == '0' || ch == 92 || ch >= 'a' && ch <= 'b' || ch == 'f' || ch == 'n' || ch == 'r' || ch >= 't' && ch <= 'v') {AddCh(); goto case 10;}
 				else {goto case 0;}
 			case 36:
@@ -860,31 +858,27 @@ public class Scanner {
 				else if (ch == '*') {AddCh(); goto case 36;}
 				else {goto case 0;}
 			case 37:
-				recEnd = pos; recKind = 4;
-				if (ch <= '!' || ch >= '#' && ch <= '[' || ch >= ']' && ch <= 65535) {AddCh(); goto case 7;}
-				else if (ch == '"') {AddCh(); goto case 8;}
-				else if (ch == 92) {AddCh(); goto case 34;}
-				else {t.kind = 4; break;}
-			case 38:
 				recEnd = pos; recKind = 5;
 				if (ch == 39) {AddCh(); goto case 11;}
 				else {t.kind = 5; break;}
-			case 39:
+			case 38:
 				{t.kind = 44; break;}
-			case 40:
+			case 39:
 				{t.kind = 45; break;}
-			case 41:
+			case 40:
 				{t.kind = 46; break;}
-			case 42:
+			case 41:
 				{t.kind = 50; break;}
-			case 43:
+			case 42:
 				{t.kind = 52; break;}
-			case 44:
+			case 43:
 				{t.kind = 53; break;}
-			case 45:
+			case 44:
 				{t.kind = 54; break;}
-			case 46:
+			case 45:
 				{t.kind = 56; break;}
+			case 46:
+				{t.kind = 57; break;}
 			case 47:
 				{t.kind = 58; break;}
 			case 48:
@@ -892,26 +886,24 @@ public class Scanner {
 			case 49:
 				{t.kind = 60; break;}
 			case 50:
-				{t.kind = 61; break;}
+				{t.kind = 63; break;}
 			case 51:
-				{t.kind = 62; break;}
-			case 52:
 				recEnd = pos; recKind = 16;
-				if (ch == '|') {AddCh(); goto case 49;}
+				if (ch == '|') {AddCh(); goto case 47;}
 				else {t.kind = 16; break;}
-			case 53:
+			case 52:
 				recEnd = pos; recKind = 51;
 				if (ch == '=') {AddCh(); goto case 21;}
 				else {t.kind = 51; break;}
-			case 54:
+			case 53:
 				recEnd = pos; recKind = 55;
 				if (ch == '/') {AddCh(); goto case 25;}
 				else if (ch == '*') {AddCh(); goto case 26;}
 				else {t.kind = 55; break;}
-			case 55:
-				recEnd = pos; recKind = 57;
-				if (ch == '&') {AddCh(); goto case 48;}
-				else {t.kind = 57; break;}
+			case 54:
+				recEnd = pos; recKind = 62;
+				if (ch == '&') {AddCh(); goto case 46;}
+				else {t.kind = 62; break;}
 
 		}
 		t.val = new String(tval, 0, tlen);

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1198,13 +1198,6 @@ Associative_MulOp<out Operator op>
   | "%"				(. op = Operator.mod; .)
   ).
 
-Associative_BitOp<out Operator op>
-=                   (. op = Operator.bitwiseand; .)
-  ( '&'
-  | '^'             (. op = Operator.bitwisexor; .)
-  | '|'             (. op = Operator.bitwiseor; .)
-  ).
-
 Associative_LogicalOp<out Operator op>
 =                   (. op = Operator.and; .)
 ( "&&"
@@ -1271,42 +1264,19 @@ Associative_Term<out node>
 
 Associative_Term<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 = 
-(. #if ENABLE_BIT_OP .)
-Associative_interimfactor<out node>     
-(. #else             .)
 Associative_Factor<out node>
-(. #endif            .)
-
 {
     (. Operator op; .)
 
     Associative_MulOp<out op> 
     (. ProtoCore.AST.AssociativeAST.AssociativeNode expr2; .)   
 
-    (. #if ENABLE_BIT_OP .)
-    Associative_interimfactor<out expr2>
-    (. #else             .)
     Associative_Factor<out expr2>
-    (. #endif            .)
 
     (.	
         node = GenerateBinaryOperatorMethodCallNode(op, node, expr2);
     .)
 }
-.
-
-Associative_interimfactor<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
-= 
-    Associative_Factor<out node>        
-    {
-                                (. Operator op; .)
-        Associative_BitOp<out op> 
-                                (. ProtoCore.AST.AssociativeAST.AssociativeNode expr2; .)   
-        Associative_Factor<out expr2>
-                                (.	
-                                    node = GenerateBinaryOperatorMethodCallNode(op, node, expr2);
-                                .)
-    }
 .
 
 Associative_Number<out ProtoCore.AST.AssociativeAST.AssociativeNode node>               

--- a/src/Engine/ProtoCore/Parser/atg/Start.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Start.atg
@@ -547,7 +547,7 @@ CHARACTERS
     cr  = '\r'. 
     lf  = '\n'.
     tab = '\t'.
-    anyButDoubleQuote = ANY - '\"'.
+    anyButDoubleQuote = ANY - '\"' - '\\'.
     anyButQuote = ANY - '\''.
     anychar = ANY.
     other = ANY - '/' - '*'.
@@ -557,8 +557,8 @@ TOKENS
     ident = unicodeIdentifierStart {unicodeIdentifierPart}.
     number = digit {digit} .
     float = digit {digit} '.' digit {digit} [('E' | 'e') ['+'|'-'] digit {digit}].
-    textstring = '"' {anyButDoubleQuote | "\\\""} '"'.
-    char = '\'' (anyButQuote | "\\\'" | "\\\"" | "\\\\" | "\\0" | "\\a" | "\\b" | "\\f" | "\\n" | "\\r" | "\\t" | "\\v" | "\\u") '\''.
+    textstring = '"' {anyButDoubleQuote | "\\\'" | "\\\"" | "\\\\" | "\\0" | "\\a" | "\\b" | "\\f" | "\\n" | "\\r" | "\\t" | "\\v" | "\\u"} '"'.
+    char = "'" (anyButQuote | "\\\'" | "\\\"" | "\\\\" | "\\0" | "\\a" | "\\b" | "\\f" | "\\n" | "\\r" | "\\t" | "\\v" | "\\u") "'".
     period = '.'.
     postfixed_replicationguide = digit {digit} 'L'.
 

--- a/src/Engine/ProtoCore/Utils/CompilerUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CompilerUtils.cs
@@ -234,8 +234,9 @@ namespace ProtoCore.Utils
             {
                 using (var provider = CodeDomProvider.CreateProvider("CSharp"))
                 {
-                    provider.GenerateCodeFromExpression(new CodePrimitiveExpression(input), writer, null);
+                    provider.GenerateCodeFromExpression(new CodePrimitiveExpression(input), writer, new CodeGeneratorOptions { IndentString = "\t" });
                     var literString = writer.ToString();
+                    literString = literString.Replace(string.Format("\" +{0}\t\"", Environment.NewLine), "");
                     return literString.Substring(1, literString.Length - 2);
                 }
             }

--- a/src/Engine/ProtoCore/Utils/CompilerUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CompilerUtils.cs
@@ -4,7 +4,10 @@ using ProtoCore.DSASM;
 using ProtoCore.Namespace;
 using ProtoCore.Properties;
 using System;
+using System.CodeDom;
+using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace ProtoCore.Utils
@@ -225,6 +228,19 @@ namespace ProtoCore.Utils
             return core.BuildStatus;
         }
 
+        internal static string ToLiteral(string input)
+        {
+            using (var writer = new StringWriter())
+            {
+                using (var provider = CodeDomProvider.CreateProvider("CSharp"))
+                {
+                    provider.GenerateCodeFromExpression(new CodePrimitiveExpression(input), writer, null);
+                    var literString = writer.ToString();
+                    return literString.Substring(1, literString.Length - 2);
+                }
+            }
+        }
+
         public static bool TryLoadAssemblyIntoCore(Core core, string assemblyPath)
         {
             bool parsingPreloadFlag = core.IsParsingPreloadedAssembly;
@@ -233,7 +249,7 @@ namespace ProtoCore.Utils
             core.IsParsingCodeBlockNode = false;
 
             int blockId;
-            string importStatement = @"import (""" + assemblyPath + @""");";
+            string importStatement = @"import (""" + ToLiteral(assemblyPath) + @""");";
 
             core.ResetForPrecompilation();
             var status = PreCompile(importStatement, core, null, out blockId);

--- a/test/Engine/ProtoTest/DebugTests/RunEqualityTests.cs
+++ b/test/Engine/ProtoTest/DebugTests/RunEqualityTests.cs
@@ -3701,7 +3701,7 @@ a3 = 1 > 2 ? true : b;
         public void DebugEQT021_Defect_1457354()
         {
             string code = @"
-import (""c:\wrongPath\test.ds"");
+import (""c:\\wrongPath\\test.ds"");
 a = 1;
 b = a * 2;
 ";

--- a/test/Engine/ProtoTest/DebugTests/RunEqualityTests.cs
+++ b/test/Engine/ProtoTest/DebugTests/RunEqualityTests.cs
@@ -1515,7 +1515,7 @@ a = a + 2;	// I am assuming that this statement (on line 27) is executed after t
 
 
             string code = @"
-import (""..\..\..\test\Engine\ProtoTest\ImportFiles\basicImport.ds"");
+import (""..\\..\\..\\test\\Engine\\ProtoTest\\ImportFiles\\basicImport.ds"");
 a = {1.1,2.2};
 b = 2;
 c = Scale(a,b);
@@ -1881,7 +1881,7 @@ a  = a2 + b;    // 6
         public void DebugEQT005_BasicImport_RelativePath()
         {
             string code = @"
-import ("".\ExtraFolderToTestRelativePath\basicImport.ds"");
+import ("".\\ExtraFolderToTestRelativePath\\basicImport.ds"");
 a = {1.1,2.2};
 b = 2;
 c = Scale(a,b);

--- a/test/Engine/ProtoTest/DebugTests/RunWatchTestsIncluded.cs
+++ b/test/Engine/ProtoTest/DebugTests/RunWatchTestsIncluded.cs
@@ -13065,7 +13065,7 @@ c = Scale(a,b);";
         public void DebugWatch1380_T005_BasicImport_RelativePath()
         {
             Dictionary<int, List<string>> map = new Dictionary<int, List<string>>();
-            string src = @"import ("".\ExtraFolderToTestRelativePath\basicImport.ds"");
+            string src = @"import ("".\\ExtraFolderToTestRelativePath\\basicImport.ds"");
 a = {1.1,2.2};
 b = 2;
 c = Scale(a,b);";
@@ -13148,7 +13148,7 @@ b = a * 2;";
         public void DebugWatch1395_T021_Defect_1457354()
         {
             Dictionary<int, List<string>> map = new Dictionary<int, List<string>>();
-            string src = @"import (""c:\wrongPath\test.ds"");
+            string src = @"import (""c:\\wrongPath\\test.ds"");
 a = 1;
 b = a * 2;";
             WatchTestFx.GeneratePrintStatements(src, ref map);

--- a/test/Engine/ProtoTest/ParserTest/ParserTest.cs
+++ b/test/Engine/ProtoTest/ParserTest/ParserTest.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ProtoTest.ParserTest
+{
+    [TestFixture]
+    class ParserTest : ProtoTestBase
+    {
+        [Test]        public void TestEscapeString()        {            String code =@"x = ""hello\\"" + ""\\"" + ""world"";";            thisTest.RunScriptSource(code);            thisTest.Verify("x", "hello\\\\world");        }
+
+        [Test]
+        public void TestInvalidEscape1()
+        {
+            string code = @"x = ""\\""";
+            Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
+            {
+                thisTest.RunScriptSource(code);
+            });
+        }
+
+        [Test]
+        public void TestInvalidEscape2()
+        {
+            string code = @"x = ""\\X""";
+            Assert.Throws(typeof(ProtoCore.Exceptions.CompileErrorsOccured), () =>
+            {
+                thisTest.RunScriptSource(code);
+            });
+        }
+
+    }
+}

--- a/test/Engine/ProtoTest/ProtoTest.csproj
+++ b/test/Engine/ProtoTest/ProtoTest.csproj
@@ -155,6 +155,7 @@
     </Compile>
     <Compile Include="MultiLangTests\UnicodeTest.cs" />
     <Compile Include="NameSpaceTests.cs" />
+    <Compile Include="ParserTest\ParserTest.cs" />
     <Compile Include="ProtoAST\AstFactoryTest.cs" />
     <Compile Include="ProtoAST\ProtoASTExecutionTests.cs" />
     <Compile Include="ProtoAST\RoundTripTests.cs" />

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestImport.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestImport.cs
@@ -66,7 +66,7 @@ c = Scale(a,b);";
         public void T005_BasicImport_RelativePath()
         {
             string code = @"
-import (""\ExtraFolderToTestRelativePath\basicImport.ds"");
+import (""\\ExtraFolderToTestRelativePath\\basicImport.ds"");
 a = {1.1,2.2};
 b = 2;
 c = Scale(a,b);";


### PR DESCRIPTION
### Purpose

This is to fix github issue #7248, DS parser fails to parse value string `"a" + "\\" + "b"`.

This is because the parser treat the first backslash `\` as a token, and then treat `\"` as an escape character, so the parser continue to read more character (` + `) until `"` before `b`.

Parser updated to fix this error.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs
@Benglin @riteshchandawar @kronz @monikaprabhu 
