### PR TITLE
add nuget steps for dynamoCoreNodes and add output documentation for …

### DIFF
--- a/src/Libraries/Display/Display.csproj
+++ b/src/Libraries/Display/Display.csproj
@@ -35,6 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>..\..\..\bin\AnyCPU\Release\Display.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ProtoGeometry">

--- a/tools/NuGet/BuildDynamoCoreNodesPackage.bat
+++ b/tools/NuGet/BuildDynamoCoreNodesPackage.bat
@@ -1,0 +1,21 @@
+SET base=..\..\bin\AnyCPU\Release
+SET framework=net45
+
+SET dcn=DynamoVisualProgramming.DynamoCoreNodes
+
+rmdir /s /q .\%dcn%\build
+rmdir /s /q .\%dcn%\content
+rmdir /s /q .\%dcn%\lib
+rmdir /s /q .\%dcn%\tools
+
+mkdir .\%dcn%\build\net45
+mkdir .\%dcn%\content
+mkdir .\%dcn%\lib\net45
+mkdir .\%dcn%\tools
+
+copy %base%\Display.dll .\%dcn%\lib\%framework%\Display.dll
+copy %base%\Display.xml .\%dcn%\build\%framework%\Display.xml
+copy %base%\DSCoreNodes.dll .\%dcn%\lib\%framework%\DSCoreNodes.dll
+copy %base%\DSCoreNodes.xml .\%dcn%\build\%framework%\DSCoreNodes.xml
+
+nuget pack .\%dcn%\DynamoVisualProgramming.DynamoCoreNodes.nuspec

--- a/tools/NuGet/DynamoVisualProgramming.DynamoCoreNodes/DynamoVisualProgramming.DynamoCoreNodes.nuspec
+++ b/tools/NuGet/DynamoVisualProgramming.DynamoCoreNodes/DynamoVisualProgramming.DynamoCoreNodes.nuspec
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+    <metadata>
+        <id>DynamoVisualProgramming.DynamoCoreNodes</id>
+        <version>1.2.0</version>
+        <authors>Autodesk</authors>
+        <licenseUrl>https://opensource.org/licenses/Apache-2.0</licenseUrl>
+        <projectUrl>https://github.com/DynamoDS/Dynamo</projectUrl>
+        <iconUrl>https://raw.githubusercontent.com/DynamoDS/Dynamo/master/doc/distrib/Images/logo_square_32x32.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Build core nodes for Dynamo 1.2.0.  It contains the following files:
+
+1)DsCoreNodes.dll
+
+2)Display.dll</description>
+        <copyright>Copyright Autodesk 2016</copyright>
+        <dependencies>
+            <group targetFramework=".NETFramework4.5">
+                <dependency id="DynamoVisualProgramming.DynamoServices" version="1.2.0" />
+                <dependency id="DynamoVisualProgramming.ZeroTouchLibrary" version="1.2.0" />
+            </group>
+        </dependencies>
+    </metadata>
+</package>


### PR DESCRIPTION
### Purpose

Adds a bat file and nuspec for the `DynamoCoreNodes` package. This package is used by MeshToolkit for access to some CoreNodes like color and display.
Others have requested such a package, like @ColinDayOrg. 

This package has existed previously, but this PR creates a .bat file and .nuspec so updating it is easier and comes into line like the other Dynamo public nugets.

This PR also enables the generation of the XML doc file for display.dll, for some reason this was turned off for release and on for debug builds of this dll.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@QilongTang 

### FYIs

@ColinDayOrg 
