### PR TITLE
Not to use hardcoded LibG version in test

### DIFF
--- a/test/Libraries/TestServices/TestSessionConfiguration.cs
+++ b/test/Libraries/TestServices/TestSessionConfiguration.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reflection;
 
 using DynamoShapeManager;
+using System.Collections.Generic;
 
 namespace TestServices
 {
@@ -48,7 +49,15 @@ namespace TestServices
             if (!File.Exists(configPath))
             {
                 DynamoCorePath = dynamoCoreDirectory;
-                RequestedLibraryVersion = LibraryVersion.Version220;
+
+                var versions = new List<LibraryVersion>
+                {
+                    LibraryVersion.Version220,
+                    LibraryVersion.Version221,
+                    LibraryVersion.Version222
+                };
+                var shapeManagerPath = string.Empty;
+                RequestedLibraryVersion = Utilities.GetInstalledAsmVersion(versions, ref shapeManagerPath, dynamoCoreDirectory);
                 return;
             }
 


### PR DESCRIPTION
### Purpose

Some tests in DSCoreNodeTests and DisplayTests fail if Revit2015 is not installed on test coverage machine.

They both rely on LibG. But previously they used hard-coded LibG version (220), which may not be available on test machine. This PR added more options so that they could look up other versions (221 and 222).

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@sharadkjaiswal 

### FYIs

@monikaprabhu 

