### PR TITLE
MAGN-9948 Camera is not always reset in Node View with File, New

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -884,6 +884,8 @@ namespace Dynamo.Graph.Workspaces
             X = 0.0;
             Y = 0.0;
             Zoom = 1.0;
+            // Reset the workspace offset
+            OnCurrentOffsetChanged(this, new PointEventArgs(new Point2D(X, Y)));
             workspaceLoaded = true;
         }
 


### PR DESCRIPTION
### Purpose

- **Issue:** Camera is not always reset in Node View with File > New:
```
Ways to reproduce:
1. Populate canvas with "Point.ByCoordinates" form the context menu
2. Select it and drag it off of the screen to the right
3. Enter Pan mode and pan it even further away, > 5 pan operations sweeping the screen left to right
// move the node far, far away
4. Click Geometry View and orbit several times
5. Click the Node View control
6. Click the File, New button and say No to the prompt
7. Right click the canvas, type Point and hit the Enter key
// the Point node is not displayed on the screen: INCORRECT
// if you click to populate instead of hitting Enter there is no issue
```

- This PR attempts to fix the problem of method **`Clear()`** in **`WorkSpaceModel.cs`**:

When we open a new work space, this function is called to clear the old one. However, previously the **`CurrentOffset`** is not set back to **`0,0`** when **`Clear()`** and this caused the issue as mentioned above. 
Fixed by calling **`OnCurrentOffsetChanged()`** in **`Clear()`** to set the **`CurrentOffset`** of the **`WorkSpace`** to **`0,0`**.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@Benglin 

### FYIs



