### PR TITLE
Enable toggling of selection of node (in preview bubble) 

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1290,11 +1290,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                         .Where(pair => pair.Item1 == path || pair.Item1.StartsWith(path + ":")).ToList()).Any())
                 {
                     // If the nodesSelected Dictionary does not contain the current nodePath as a key,
-                    // or if the current value of the nodePath key is null or not the same as the current path
-                    // then, create new labels for the Watch3DView.
-                    // Else, allow the labels to be removed.
+                    // or if the current value of the nodePath key is not the same as the current path 
+                    // (which is currently being selected) then, create new label(s) for the Watch3DView.
+                    // Else, remove the label(s) in the Watch 3D View.
 
-                    if (!nodesSelected.ContainsKey(nodePath) || nodesSelected[nodePath] == null || nodesSelected[nodePath] != path)
+                    if (!nodesSelected.ContainsKey(nodePath) || nodesSelected[nodePath] != path)
                     {
                         // second, add requested labels
                         var textGeometry = HelixRenderPackage.InitText3D();
@@ -1318,10 +1318,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                         nodesSelected[nodePath] = path;
                     }
 
-                    // if no node is being selected, that means the current node is being unselected.
+                    // if no node is being selected, that means the current node is being unselected
+                    // and no node within the parent node is currently selected.
                     else
                     {
-                        nodesSelected[nodePath] = null;
+                        nodesSelected.Remove(nodePath);
                     }
                 }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -732,6 +732,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     Model3DDictionary.Remove(kvp.Key);
                     var nodePath = kvp.Key.Split(':')[0];
                     labelPlaces.Remove(nodePath);
+                    nodesSelected.Remove(nodePath);
                 }
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -124,6 +124,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         private List<Model3D> sceneItems;
 
+        private Dictionary<string, string> nodesSelected = new Dictionary<string, string>();
+
+
 #if DEBUG
         private readonly Stopwatch renderTimer = new Stopwatch();
 #endif
@@ -553,6 +556,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 }
 
                 labelPlaces.Clear();
+                nodesSelected = new Dictionary<string, string>();
             }
 
             OnSceneItemsChanged();
@@ -1284,25 +1288,40 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     (requestedLabelPlaces = labelPlaces[nodePath]
                         .Where(pair => pair.Item1 == path || pair.Item1.StartsWith(path + ":")).ToList()).Any())
                 {
-                    // second, add requested labels
-                    var textGeometry = HelixRenderPackage.InitText3D();
-                    var bbText = new BillboardTextModel3D
-                    {
-                        Geometry = textGeometry
-                    };
+                    // If the nodesSelected Dictionary does not contain the current nodePath as a key,
+                    // or if the current value of the nodePath key is null or not the same as the current path
+                    // then, create new labels for the Watch3DView.
+                    // Else, allow the labels to be removed.
 
-                    foreach (var id_position in requestedLabelPlaces)
+                    if (!nodesSelected.ContainsKey(nodePath) || nodesSelected[nodePath] == null || nodesSelected[nodePath] != path)
                     {
-                        var text = HelixRenderPackage.CleanTag(id_position.Item1);
-                        var textPosition = id_position.Item2 + defaultLabelOffset;
+                        // second, add requested labels
+                        var textGeometry = HelixRenderPackage.InitText3D();
+                        var bbText = new BillboardTextModel3D
+                        {
+                            Geometry = textGeometry
+                        };
 
-                        var textInfo = new TextInfo(text, textPosition);
-                        textGeometry.TextInfo.Add(textInfo);
+                        foreach (var id_position in requestedLabelPlaces)
+                        {
+                            var text = HelixRenderPackage.CleanTag(id_position.Item1);
+                            var textPosition = id_position.Item2 + defaultLabelOffset;
+
+                            var textInfo = new TextInfo(text, textPosition);
+                            textGeometry.TextInfo.Add(textInfo);
+                        }
+
+                        Model3DDictionary.Add(labelName, bbText);
+                        sceneItemsChanged = true;
+                        AttachAllGeometryModel3DToRenderHost();
+                        nodesSelected[nodePath] = path;
                     }
 
-                    Model3DDictionary.Add(labelName, bbText);
-                    sceneItemsChanged = true;
-                    AttachAllGeometryModel3DToRenderHost();
+                    // if no node is being selected, that means the current node is being unselected.
+                    else
+                    {
+                        nodesSelected[nodePath] = null;
+                    }
                 }
 
                 if (sceneItemsChanged)

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -118,6 +118,7 @@
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
                 <Setter Property="FocusVisualStyle" Value="{StaticResource TreeViewItemFocusVisual}"/>
                 <EventSetter Event="MouseLeftButtonUp" Handler="treeviewItem_MouseLeftButtonUp" />
+                <EventSetter Event="KeyUp" Handler="treeviewItem_KeyUp" />
 
                 <Setter Property="Template">
                     <Setter.Value>

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -117,6 +117,7 @@
                 <Setter Property="Padding" Value="1,0,0,0"/>
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
                 <Setter Property="FocusVisualStyle" Value="{StaticResource TreeViewItemFocusVisual}"/>
+                <EventSetter Event="MouseLeftButtonUp" Handler="treeviewItem_MouseLeftButtonUp" />
 
                 <Setter Property="Template">
                     <Setter.Value>
@@ -252,8 +253,7 @@
                   BorderBrush="{x:Null}"
                   VirtualizingStackPanel.IsVirtualizing="True"
                   VirtualizingStackPanel.VirtualizationMode="Recycling"
-                  ItemContainerStyle="{StaticResource WatchTreeViewItem}"
-                  SelectedItemChanged="TreeView1_OnSelectedItemChanged">
+                  ItemContainerStyle="{StaticResource WatchTreeViewItem}">
 
             <TreeView.Style>
                 <Style TargetType="TreeView">

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -88,25 +88,5 @@ namespace Dynamo.Controls
                 _vm.FindNodeForPathCommand.Execute(node.Path);
             }
         }
-
-
-
-        //private void treeView1_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
-        //{
-
-        //    TreeView tv = sender as TreeView;
-        //    //WatchViewModel vm = tv.SelectedItem as WatchViewModel; 
-
-        //    var node = e.NewValue as WatchViewModel;
-        //    if ( node == null)
-        //        return;
-
-        //    this.prevVM = node;
-
-        //    if (_vm.FindNodeForPathCommand.CanExecute(node.Path))
-        //    {
-        //        _vm.FindNodeForPathCommand.Execute(node.Path);
-        //    }
-        //}
     }
 }

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -12,7 +12,7 @@ namespace Dynamo.Controls
     public partial class WatchTree : UserControl
     {
         private WatchViewModel _vm;
-        private TreeViewItem prevTVI;
+        private WatchViewModel prevVM;
 
         public WatchTree()
         {
@@ -45,31 +45,68 @@ namespace Dynamo.Controls
             TreeViewItem tvi = (TreeViewItem)sender;
             var node = tvi.DataContext as WatchViewModel;
 
+            HandleItemChanged(tvi, node);
+
+            e.Handled = true; 
+        }
+        private void treeviewItem_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Up || e.Key == System.Windows.Input.Key.Down)
+            {
+                TreeViewItem tvi = sender as TreeViewItem;
+                var node = tvi.DataContext as WatchViewModel;
+
+                HandleItemChanged(tvi, node);
+            }
+            e.Handled = true;
+        }
+
+        private void HandleItemChanged (TreeViewItem tvi, WatchViewModel node)
+        {
             if (tvi == null || node == null)
                 return;
 
             // checks to see if the currently selected node is the same as the previous selected node
             // if so, then de-select the currently selected node.
 
-            if (tvi == this.prevTVI)
+            if (prevVM == null || node.Path != this.prevVM.Path)
             {
-                this.prevTVI = null;
+                this.prevVM = node;
+            }
+            else
+            {
+                this.prevVM = null;
                 if (tvi.IsSelected)
                 {
                     tvi.IsSelected = false;
                     tvi.Focus();
                 }
             }
-            else
-            {
-                this.prevTVI = tvi;
-            }
 
             if (_vm.FindNodeForPathCommand.CanExecute(node.Path))
             {
                 _vm.FindNodeForPathCommand.Execute(node.Path);
             }
-            e.Handled = true; 
         }
+
+
+
+        //private void treeView1_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        //{
+
+        //    TreeView tv = sender as TreeView;
+        //    //WatchViewModel vm = tv.SelectedItem as WatchViewModel; 
+
+        //    var node = e.NewValue as WatchViewModel;
+        //    if ( node == null)
+        //        return;
+
+        //    this.prevVM = node;
+
+        //    if (_vm.FindNodeForPathCommand.CanExecute(node.Path))
+        //    {
+        //        _vm.FindNodeForPathCommand.Execute(node.Path);
+        //    }
+        //}
     }
 }

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -12,7 +12,7 @@ namespace Dynamo.Controls
     public partial class WatchTree : UserControl
     {
         private WatchViewModel _vm;
-        private WatchViewModel prevVM;
+        private WatchViewModel prevWatchViewModel;
 
         public WatchTree()
         {
@@ -66,21 +66,21 @@ namespace Dynamo.Controls
             if (tvi == null || node == null)
                 return;
 
-            // checks to see if the currently selected node is the same as the previous selected node
+            // checks to see if the node to be selected is the same as the currently selected node
             // if so, then de-select the currently selected node.
 
-            if (prevVM == null || node.Path != this.prevVM.Path)
+            if (node == prevWatchViewModel)
             {
-                this.prevVM = node;
-            }
-            else
-            {
-                this.prevVM = null;
+                this.prevWatchViewModel = null;
                 if (tvi.IsSelected)
                 {
                     tvi.IsSelected = false;
                     tvi.Focus();
                 }
+            }
+            else
+            {
+                this.prevWatchViewModel = node;
             }
 
             if (_vm.FindNodeForPathCommand.CanExecute(node.Path))

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -49,15 +49,28 @@ namespace Dynamo.Controls
 
             e.Handled = true; 
         }
+
         private void treeviewItem_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
         {
-            if (e.Key == System.Windows.Input.Key.Up || e.Key == System.Windows.Input.Key.Down)
+            if (prevWatchViewModel != null)
             {
-                TreeViewItem tvi = sender as TreeViewItem;
-                var node = tvi.DataContext as WatchViewModel;
+                if (e.Key == System.Windows.Input.Key.Up || e.Key == System.Windows.Input.Key.Down)
+                {
+                    TreeViewItem tvi = sender as TreeViewItem;
+                    var node = tvi.DataContext as WatchViewModel;
+                    
+                    // checks to see if the currently selected WatchViewModel is the top most item in the tree
+                    // if so, prevent the user from using the up arrow.
 
-                HandleItemChanged(tvi, node);
+                    // also if the current selected node is equal to the previous selected node, do not execute the change.
+
+                    if (!(e.Key == System.Windows.Input.Key.Up && prevWatchViewModel.IsTopLevel) && node != prevWatchViewModel)
+                    {
+                        HandleItemChanged(tvi, node);
+                    }
+                }
             }
+
             e.Handled = true;
         }
 

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml.cs
@@ -12,6 +12,7 @@ namespace Dynamo.Controls
     public partial class WatchTree : UserControl
     {
         private WatchViewModel _vm;
+        private TreeViewItem prevTVI;
 
         public WatchTree()
         {
@@ -39,18 +40,36 @@ namespace Dynamo.Controls
                 node.Click();
         }
 
-        private void TreeView1_OnSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        private void treeviewItem_MouseLeftButtonUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            var node = e.NewValue as WatchViewModel;
-            if (node == null)
+            TreeViewItem tvi = (TreeViewItem)sender;
+            var node = tvi.DataContext as WatchViewModel;
+
+            if (tvi == null || node == null)
                 return;
+
+            // checks to see if the currently selected node is the same as the previous selected node
+            // if so, then de-select the currently selected node.
+
+            if (tvi == this.prevTVI)
+            {
+                this.prevTVI = null;
+                if (tvi.IsSelected)
+                {
+                    tvi.IsSelected = false;
+                    tvi.Focus();
+                }
+            }
+            else
+            {
+                this.prevTVI = tvi;
+            }
 
             if (_vm.FindNodeForPathCommand.CanExecute(node.Path))
             {
                 _vm.FindNodeForPathCommand.Execute(node.Path);
             }
+            e.Handled = true; 
         }
-
     }
-
 }


### PR DESCRIPTION
### Purpose

This PR is meant to address _MAGN-10739_. 

Previously, de-selecting a previously selected node in the preview bubble was not possible. This meant that, in order to de-select a selected node, one had to select _another_ node to allow for the de-selection. This made it impossible to de-select across different preview bubbles as well. See the picture for an example:

![deselecttreeviewitemold](https://cloud.githubusercontent.com/assets/16283396/19263529/56bb9f16-8fcf-11e6-9e30-3ddb9368c182.gif)

In order to fix this, I had to re-write the selection control in WatchTree.xaml. Using `OnSelectedItemChanged` did not offer the flexibility of toggling a selected `TreeViewItem`. Instead, an item was only de-selected when another item was selected. As such, instead of relying on the traditional `IsSelected` control, I had to adapt `MouseLeftButtonUp` to check if a particular `TreeViewItem` was selected or de-selected. 

In addition, the `AddLabelForPath` method in `HelixWatch3DViewModel` had to be adapted to handle the toggling of the items in the Preview Bubble.

As such, the new behavior allows for the toggling of individual nodes within a preview bubble and across preview bubbles as well:

![deselecttreeviewitemnew1](https://cloud.githubusercontent.com/assets/16283396/19263528/56b5ece2-8fcf-11e6-85ef-839d65da222d.gif)
![deselecttreeviewitemnew2](https://cloud.githubusercontent.com/assets/16283396/19263530/56c021d0-8fcf-11e6-83d8-f4c7c6cfca90.gif)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 

### FYIs

@jnealb , @monikaprabhu 

