### PR TITLE
Changes for using DynamoCore for background computations

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -1205,7 +1205,7 @@ namespace Dynamo.Core
             return newWorkspace;
         }
 
-        internal IEnumerable<Guid> GetAllDependenciesGuids(CustomNodeDefinition def)
+        public IEnumerable<Guid> GetAllDependenciesGuids(CustomNodeDefinition def)
         {
             var idSet = new HashSet<Guid>();
             idSet.Add(def.FunctionId);

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -1206,8 +1206,8 @@ namespace Dynamo.Core
         }
 
         /// <summary>
-        ///     Returns identifiers of other custom node which are dependencies
-        ///     of the passed custom node.
+        ///     Returns identifiers of custom nodes which are dependencies
+        ///     of the given custom node.
         /// </summary>
         /// <param name="def">Custom node definition to search dependencies for</param>
         /// <returns></returns>

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -1205,6 +1205,12 @@ namespace Dynamo.Core
             return newWorkspace;
         }
 
+        /// <summary>
+        ///     Returns identifiers of other custom node which are dependencies
+        ///     of the passed custom node.
+        /// </summary>
+        /// <param name="def">Custom node definition to search dependencies for</param>
+        /// <returns></returns>
         public IEnumerable<Guid> GetAllDependenciesGuids(CustomNodeDefinition def)
         {
             var idSet = new HashSet<Guid>();

--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -287,7 +287,7 @@ namespace Dynamo.Engine
         /// <param name="definition"></param>
         /// <param name="verboseLogging"></param>
         /// <returns></returns>
-        internal bool GenerateGraphSyncDataForCustomNode(IEnumerable<NodeModel> nodes, CustomNodeDefinition definition, bool verboseLogging)
+        public bool GenerateGraphSyncDataForCustomNode(IEnumerable<NodeModel> nodes, CustomNodeDefinition definition, bool verboseLogging)
         {
             lock (macroMutex)
             {

--- a/src/DynamoCore/Engine/NodeToCode/NodeToCode.cs
+++ b/src/DynamoCore/Engine/NodeToCode/NodeToCode.cs
@@ -113,7 +113,7 @@ namespace Dynamo.Engine.NodeToCode
     /// code, its inputs and outputs may be renamed to avoid confliction, the
     /// result contains maps for inputs/new-inputs and outputs/new-outputs.
     /// </summary>
-    internal class NodeToCodeResult
+    public class NodeToCodeResult
     {
         /// <summary>
         /// AST nodes that compiled from NodeModel.
@@ -549,7 +549,7 @@ namespace Dynamo.Engine.NodeToCode
         }
     }
 
-    internal class NodeToCodeCompiler
+    public class NodeToCodeCompiler
     {
         /// <summary>
         /// The numbering state of a variable.
@@ -1210,7 +1210,7 @@ namespace Dynamo.Engine.NodeToCode
         /// <param name="nodes">Selected node that can be converted to a single code block node</param>
         /// <param name="namingProvider"></param>
         /// <returns></returns>
-        internal static NodeToCodeResult NodeToCode(
+        public static NodeToCodeResult NodeToCode(
             ProtoCore.Core core,
             IEnumerable<NodeModel> workspaceNodes,
             IEnumerable<NodeModel> nodes,

--- a/src/DynamoCore/Engine/NodeToCode/NodeToCode.cs
+++ b/src/DynamoCore/Engine/NodeToCode/NodeToCode.cs
@@ -549,6 +549,10 @@ namespace Dynamo.Engine.NodeToCode
         }
     }
 
+    /// <summary>
+    /// The class to get string representation from a set of <see cref="NodeModel"/> objects.
+    /// String is written on DesignScipt programming language and can be used in code block node or by DesignScript evaluation engine
+    /// </summary>
     public class NodeToCodeCompiler
     {
         /// <summary>
@@ -695,7 +699,7 @@ namespace Dynamo.Engine.NodeToCode
         /// </summary>
         /// <param name="selection"></param>
         /// <returns></returns>
-        public static List<List<NodeModel>> GetCliques(
+        internal static List<List<NodeModel>> GetCliques(
             IEnumerable<NodeModel> selection)
         {
             var selectionSet = new HashSet<NodeModel>(selection);

--- a/src/DynamoCore/Extensions/ReadyParams.cs
+++ b/src/DynamoCore/Extensions/ReadyParams.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Logging;
 
 namespace Dynamo.Extensions
 {
@@ -57,6 +58,14 @@ namespace Dynamo.Extensions
         public virtual ICommandExecutive CommandExecutive 
         {
             get { return commandExecutive ?? (commandExecutive = new ExtensionCommandExecutive(dynamoModel)); }
+        }
+
+        /// <summary>
+        /// Return logger for sending information to Dynamo console
+        /// </summary>
+        public ILogger Logger
+        {
+            get { return dynamoModel.Logger; }
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Nodes/NodeCategories.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeCategories.cs
@@ -449,9 +449,11 @@ namespace Dynamo.Graph.Nodes
             // If base path is not provided then other path should be absolute
             if (string.IsNullOrEmpty(basePath))
             {
-                if (!Uri.IsWellFormedUriString(relativePath, UriKind.Absolute))
+                //Check if relativePath is already in absolute form
+                Uri uri;
+                if (!Uri.TryCreate(relativePath, UriKind.Absolute, out uri))
                     throw new ArgumentNullException(basePath);
-                return relativePath;
+                return uri.LocalPath;
             }
 
             var baseUri = new Uri(basePath, UriKind.Absolute);

--- a/src/DynamoCore/Graph/Nodes/NodeCategories.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeCategories.cs
@@ -261,9 +261,7 @@ namespace Dynamo.Graph.Nodes
 
             if (attrib == null)
             {
-                throw new InvalidOperationException(
-                    string.Format("'{0}' attribute not found in XmlDocument",
-                    Configurations.FilePathAttribName));
+                return string.Empty;
             }
 
             return attrib.Value;
@@ -397,7 +395,7 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         /// <param name="basePath">The base path which relative path is to be 
         /// computed from. This base path does not need to point to a valid file
-        /// on disk, but it cannot be an empty string.</param>
+        /// on disk.</param>
         /// <param name="subjectPath">The subject path of which the relative
         /// path is to be computed. If this path is not empty but does not 
         /// represent a valid path string, a UriFormatException is thrown.</param>
@@ -405,16 +403,14 @@ namespace Dynamo.Graph.Nodes
         /// path.</returns>
         internal static string MakeRelativePath(string basePath, string subjectPath)
         {
-            if (string.IsNullOrEmpty(basePath))
-                throw new ArgumentNullException("basePath");
-
             if (string.IsNullOrEmpty(subjectPath))
                 return string.Empty;
 
             // Determine if we have any directory information in the 
             // subjectPath. For example, we won't want to form a relative 
             // path if the input of this method is just "ProtoGeometry.dll".
-            if (!HasPathInformation(subjectPath))
+            // Also if base path is not provided absolute path is returned.
+            if (!HasPathInformation(subjectPath) || string.IsNullOrEmpty(basePath))
                 return subjectPath;
 
             var documentUri = new Uri(basePath, UriKind.Absolute);
@@ -435,14 +431,12 @@ namespace Dynamo.Graph.Nodes
         /// base path and the relative path.
         /// </summary>
         /// <param name="basePath">The base path from which the absolute path is 
-        /// to be computed. This argument cannot be null or empty.</param>
+        /// to be computed.</param>
         /// <param name="relativePath">The relative path to the target. This 
         /// argument cannot be null or empty.</param>
         /// <returns>Returns the absolute path.</returns>
         internal static string MakeAbsolutePath(string basePath, string relativePath)
         {
-            if (string.IsNullOrEmpty(basePath))
-                throw new ArgumentNullException("basePath");
             if (string.IsNullOrEmpty(relativePath))
                 throw new ArgumentNullException("relativePath");
 
@@ -451,6 +445,14 @@ namespace Dynamo.Graph.Nodes
             // path if the input of this method is just "ProtoGeometry.dll".
             if (!HasPathInformation(relativePath))
                 return relativePath;
+
+            // If base path is not provided then other path should be absolute
+            if (string.IsNullOrEmpty(basePath))
+            {
+                if (!Uri.IsWellFormedUriString(relativePath, UriKind.Absolute))
+                    throw new ArgumentNullException(basePath);
+                return relativePath;
+            }
 
             var baseUri = new Uri(basePath, UriKind.Absolute);
             var relativeUri = new Uri(relativePath, UriKind.Relative);

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -171,7 +171,20 @@ namespace Dynamo.Graph.Workspaces
 
         #region Initializators and constructors
 
-        public static HomeWorkspaceModel CreateFromXml(
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HomeWorkspaceModel"/> class
+        /// by given information about it and its parsed xml representation
+        /// </summary>
+        /// <param name="document">XmlDocument representing the parsed home workspace</param>
+        /// <param name="engine"><see cref="EngineController"/> object assosiated with this home workspace
+        /// to coordinate the interactions between some DesignScript sub components.</param>
+        /// <param name="scheduler"><see cref="DynamoScheduler"/> object to add tasks in queue to execute</param>
+        /// <param name="factory">Node factory to create nodes</param>
+        /// <param name="info">Information for creating custom node workspace</param>
+        /// <param name="verboseLogging">Indicates if detailed descriptions should be logged</param>
+        /// <param name="isTestMode">Indicates if current code is running in tests</param>
+        /// <returns></returns>
+        public static HomeWorkspaceModel FromXmlDocument(
             XmlDocument document,
             EngineController engine,
             DynamoScheduler scheduler,

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -15,6 +15,7 @@ using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Xml;
+using Utils = Dynamo.Graph.Nodes.Utilities;
 
 namespace Dynamo.Graph.Workspaces
 {
@@ -168,7 +169,35 @@ namespace Dynamo.Graph.Workspaces
 
         #endregion
 
-        #region Constructors
+        #region Initializators and constructors
+
+        public static HomeWorkspaceModel CreateFromXml(
+            XmlDocument document,
+            EngineController engine,
+            DynamoScheduler scheduler,
+            NodeFactory factory,
+            WorkspaceInfo info,
+            bool verboseLogging,
+            bool isTestMode)
+        {
+            var nodeGraph = NodeGraph.LoadGraphFromXml(document, factory);
+
+            var newWorkspace = new HomeWorkspaceModel(
+                engine,
+                scheduler,
+                factory,
+                Utils.LoadTraceDataFromXmlDocument(document),
+                nodeGraph.Nodes,
+                nodeGraph.Notes,
+                nodeGraph.Annotations,
+                nodeGraph.Presets,
+                nodeGraph.ElementResolver,
+                info,
+                verboseLogging,
+                isTestMode);
+
+            return newWorkspace;
+        }
 
         /// <summary>
         /// Initializes a new empty instance of the <see cref="HomeWorkspaceModel"/> class

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
@@ -27,7 +27,7 @@ namespace Dynamo.Graph.Workspaces
             HasRunWithoutCrash = true;
         }
 
-        internal static bool FromXmlDocument(XmlDocument xmlDoc, string path, bool isTestMode, 
+        public static bool FromXmlDocument(XmlDocument xmlDoc, string path, bool isTestMode, 
             bool forceManualExecutionMode, ILogger logger, out WorkspaceInfo workspaceInfo)
         {
             try

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
@@ -27,6 +27,18 @@ namespace Dynamo.Graph.Workspaces
             HasRunWithoutCrash = true;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkspaceInfo"/> class
+        /// by its parsed xml representation
+        /// </summary>
+        /// <param name="xmlDoc">XmlDocument representing the parsed workspace information</param>
+        /// <param name="path">Path to the file where workspace is stored</param>
+        /// <param name="isTestMode">Indicates if current code is running in tests</param>
+        /// <param name="forceManualExecutionMode">Indicates if discard execution mode
+        /// specified in the file and set manual mode</param>
+        /// <param name="logger">A logger to be used to log the exception</param>
+        /// <param name="workspaceInfo">Workspace header filled inside the function</param>
+        /// <returns></returns>
         public static bool FromXmlDocument(XmlDocument xmlDoc, string path, bool isTestMode, 
             bool forceManualExecutionMode, ILogger logger, out WorkspaceInfo workspaceInfo)
         {

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -925,6 +925,15 @@ namespace Dynamo.Graph.Workspaces
             return true;
         }
 
+        /// <summary>
+        ///     Serializes the workspace to XmlDocument
+        /// </summary>
+        /// <param name="targetPath">The path associated with xml file.
+        /// Empty string can be passed if xml document shouldn't be related to a file on disk.</param>
+        /// <param name="runtimeCore">The <see cref="ProtoCore.RuntimeCore"/> object
+        /// to obtain serialized trace data for node list to save.</param>
+        /// <param name="document">Xml representation of the workspace filled inside the function</param>
+        /// <returns></returns>
         public bool SerializeAsXml(
             string targetPath, ProtoCore.RuntimeCore runtimeCore, out XmlDocument document)
         {

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -903,8 +903,15 @@ namespace Dynamo.Graph.Workspaces
             Log(String.Format(Resources.SavingInProgress, newPath));
             try
             {
-                if (SaveInternal(newPath, runtimeCore) && !isBackup)
-                    OnWorkspaceSaved();
+                XmlDocument document = null;
+                if (SerializeAsXml(newPath, runtimeCore, out document))
+                {
+                    document.Save(newPath);
+
+                    FileName = newPath;
+                    if (!isBackup)
+                        OnWorkspaceSaved();
+                }
             }
             catch (Exception ex)
             {
@@ -915,6 +922,26 @@ namespace Dynamo.Graph.Workspaces
                 throw (ex);
             }
 
+            return true;
+        }
+
+        public bool SerializeAsXml(
+            string targetPath, ProtoCore.RuntimeCore runtimeCore, out XmlDocument document)
+        {
+            document = new XmlDocument();
+            document.CreateXmlDeclaration("1.0", null, null);
+            document.AppendChild(document.CreateElement("Workspace"));
+
+            if(!string.IsNullOrEmpty(targetPath))
+                Utils.SetDocumentXmlPath(document, targetPath);
+
+            if (!PopulateXmlDocument(document))
+                return false;
+
+            SerializeSessionData(document, runtimeCore);
+
+            if (!string.IsNullOrEmpty(targetPath))
+                Utils.SetDocumentXmlPath(document, targetPath);
             return true;
         }
 
@@ -1743,38 +1770,6 @@ namespace Dynamo.Graph.Workspaces
         #endregion
 
         #region private/internal methods
-
-        private bool SaveInternal(string targetFilePath, ProtoCore.RuntimeCore runtimeCore)
-        {
-            // Create the xml document to write to.
-            var document = new XmlDocument();
-            document.CreateXmlDeclaration("1.0", null, null);
-            document.AppendChild(document.CreateElement("Workspace"));
-
-            Utils.SetDocumentXmlPath(document, targetFilePath);
-
-            if (!PopulateXmlDocument(document))
-                return false;
-
-            SerializeSessionData(document, runtimeCore);
-
-            try
-            {
-                Utils.SetDocumentXmlPath(document, string.Empty);
-                document.Save(targetFilePath);
-            }
-            catch (IOException ex)
-            {
-                throw (ex);
-            }
-            catch (System.UnauthorizedAccessException ex)
-            {
-                throw (ex);
-            }
-
-            FileName = targetFilePath;
-            return true;
-        }
 
         private void SerializeElementResolver(XmlDocument xmlDoc)
         {
@@ -2643,15 +2638,8 @@ namespace Dynamo.Graph.Workspaces
             document.CreateXmlDeclaration("1.0", null, null);
             document.AppendChild(document.CreateElement("Workspace"));
 
-            //This is only used for computing relative offsets, it's not actually created
-            string virtualFileName = Path.Combine(Path.GetTempPath(), "DynamoTemp.dyn");
-            Utils.SetDocumentXmlPath(document, virtualFileName);
-
             if (!PopulateXmlDocument(document))
                 return String.Empty;
-
-            //Now unset the temp file name again
-            Utils.SetDocumentXmlPath(document, null);
 
             return document.OuterXml;
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1350,7 +1350,7 @@ namespace Dynamo.Models
         private bool OpenHomeWorkspace(
             XmlDocument xmlDoc, WorkspaceInfo workspaceInfo, out WorkspaceModel workspace)
         {
-            var newWorkspace = HomeWorkspaceModel.CreateFromXml(
+            var newWorkspace = HomeWorkspaceModel.FromXmlDocument(
                 xmlDoc,
                 EngineController,
                 Scheduler,

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1350,22 +1350,14 @@ namespace Dynamo.Models
         private bool OpenHomeWorkspace(
             XmlDocument xmlDoc, WorkspaceInfo workspaceInfo, out WorkspaceModel workspace)
         {
-            var nodeGraph = NodeGraph.LoadGraphFromXml(xmlDoc, NodeFactory);
-
-            var newWorkspace = new HomeWorkspaceModel(
+            var newWorkspace = HomeWorkspaceModel.CreateFromXml(
+                xmlDoc,
                 EngineController,
                 Scheduler,
                 NodeFactory,
-                Utils.LoadTraceDataFromXmlDocument(xmlDoc),
-                nodeGraph.Nodes,
-                nodeGraph.Notes,
-                nodeGraph.Annotations,
-                nodeGraph.Presets,
-                nodeGraph.ElementResolver,
                 workspaceInfo,
                 DebugSettings.VerboseLogging,
-                IsTestMode
-               );
+                IsTestMode);
 
             RegisterHomeWorkspace(newWorkspace);
 
@@ -1407,7 +1399,7 @@ namespace Dynamo.Models
                 {
                     if (!workspace.HasUnsavedChanges)
                     {
-                        if (workspace.Nodes.Any() &&
+                        if (!workspace.Nodes.Any() &&
                             !workspace.Notes.Any())
                             continue;
 

--- a/src/DynamoCore/Models/DynamoModelEventArgs.cs
+++ b/src/DynamoCore/Models/DynamoModelEventArgs.cs
@@ -71,7 +71,7 @@ namespace Dynamo.Models
         }
     }
 
-    internal class TaskDialogEventArgs : EventArgs
+    public class TaskDialogEventArgs : EventArgs
     {
         List<Tuple<int, string, bool>> buttons = null;
 
@@ -107,16 +107,16 @@ namespace Dynamo.Models
         #region Public Class Properties
 
         // Settable properties.
-        internal int ClickedButtonId { get; set; }
-        internal Exception Exception { get; set; }
+        public int ClickedButtonId { get; set; }
+        public Exception Exception { get; set; }
 
         // Read-only properties.
-        internal Uri ImageUri { get; private set; }
-        internal string DialogTitle { get; private set; }
-        internal string Summary { get; private set; }
-        internal string Description { get; private set; }
+        public Uri ImageUri { get; private set; }
+        public string DialogTitle { get; private set; }
+        public string Summary { get; private set; }
+        public string Description { get; private set; }
 
-        internal IEnumerable<Tuple<int, string, bool>> Buttons
+        public IEnumerable<Tuple<int, string, bool>> Buttons
         {
             get { return buttons; }
         }

--- a/src/DynamoCore/Models/DynamoModelEvents.cs
+++ b/src/DynamoCore/Models/DynamoModelEvents.cs
@@ -268,24 +268,46 @@ namespace Dynamo.Models
                 RequestsCrashPrompt(this, args);
         }
 
+        /// <summary>
+        /// Represents the method that will handle the <see cref="RequestTaskDialog"/> event of the <see cref="DynamoModel"/> class.
+        /// </summary>
+        /// <param name="sender">The object which caused the event</param>
+        /// <param name="e">Event arguments <see cref="TaskDialogEventArgs"/> object</param>
         public delegate void TaskDialogHandler(object sender, TaskDialogEventArgs e);
+
+        /// <summary>
+        /// Occurs when <see cref="DynamoModel"/> requests dialog
+        /// </summary>
         public event TaskDialogHandler RequestTaskDialog;
-        public void OnRequestTaskDialog(object sender, TaskDialogEventArgs args)
+
+        internal void OnRequestTaskDialog(object sender, TaskDialogEventArgs args)
         {
             if (RequestTaskDialog != null)
                 RequestTaskDialog(sender, args);
         }
 
+        /// <summary>
+        /// Empty delegate
+        /// </summary>
         public delegate void VoidHandler();
+
+        /// <summary>
+        /// Occurs when <see cref="DynamoModel"/> requests download of new Dynamo version
+        /// </summary>
         public event VoidHandler RequestDownloadDynamo;
-        public void OnRequestDownloadDynamo()
+
+        internal void OnRequestDownloadDynamo()
         {
             if (RequestDownloadDynamo != null)
                 RequestDownloadDynamo();
         }
 
+        /// <summary>
+        /// Occurs when <see cref="DynamoModel"/> requests a bug report
+        /// </summary>
         public event VoidHandler RequestBugReport;
-        public void OnRequestBugReport()
+
+        internal void OnRequestBugReport()
         {
             if (RequestBugReport != null)
                 RequestBugReport();

--- a/src/DynamoCore/Models/DynamoModelEvents.cs
+++ b/src/DynamoCore/Models/DynamoModelEvents.cs
@@ -268,24 +268,24 @@ namespace Dynamo.Models
                 RequestsCrashPrompt(this, args);
         }
 
-        internal delegate void TaskDialogHandler(object sender, TaskDialogEventArgs e);
-        internal event TaskDialogHandler RequestTaskDialog;
-        internal void OnRequestTaskDialog(object sender, TaskDialogEventArgs args)
+        public delegate void TaskDialogHandler(object sender, TaskDialogEventArgs e);
+        public event TaskDialogHandler RequestTaskDialog;
+        public void OnRequestTaskDialog(object sender, TaskDialogEventArgs args)
         {
             if (RequestTaskDialog != null)
                 RequestTaskDialog(sender, args);
         }
 
-        internal delegate void VoidHandler();
-        internal event VoidHandler RequestDownloadDynamo;
-        internal void OnRequestDownloadDynamo()
+        public delegate void VoidHandler();
+        public event VoidHandler RequestDownloadDynamo;
+        public void OnRequestDownloadDynamo()
         {
             if (RequestDownloadDynamo != null)
                 RequestDownloadDynamo();
         }
 
-        internal event VoidHandler RequestBugReport;
-        internal void OnRequestBugReport()
+        public event VoidHandler RequestBugReport;
+        public void OnRequestBugReport()
         {
             if (RequestBugReport != null)
                 RequestBugReport();

--- a/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
+++ b/src/Engine/ProtoCore/FFI/FFIExecutionManager.cs
@@ -81,10 +81,14 @@ namespace ProtoFFI
             {
                 if (mSessions.TryGetValue(sender, out session))
                 {
-                    mSessions.Remove(sender);
                     session.Dispose();
-                    sender.Dispose -= OnDispose;
-                    sender.ExecutionEvent -= OnExecutionEvent;
+                }
+
+                //Need unsubscribe from all events before deleting the singletone 
+                foreach (var item in mSessions)
+                {
+                    item.Key.Dispose -= OnDispose;
+                    item.Key.ExecutionEvent -= OnExecutionEvent;
                 }
                 mSelf = null;
             }

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -230,11 +230,7 @@ namespace Dynamo.Tests
 
             // Test target file path removal through an empty string.
             Graph.Nodes.Utilities.SetDocumentXmlPath(document, string.Empty);
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                Graph.Nodes.Utilities.GetDocumentXmlPath(document);
-            });
+            Assert.IsEmpty(Graph.Nodes.Utilities.GetDocumentXmlPath(document));
         }
 
         [Test]
@@ -252,11 +248,7 @@ namespace Dynamo.Tests
 
             // Test target file path removal through a null value.
             Graph.Nodes.Utilities.SetDocumentXmlPath(document, null);
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                Graph.Nodes.Utilities.GetDocumentXmlPath(document);
-            });
+            Assert.IsEmpty(Graph.Nodes.Utilities.GetDocumentXmlPath(document));
         }
 
         [Test]
@@ -286,13 +278,11 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void GetDocumentXmlPath02()
         {
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                // Test XmlDocument root element without path.
-                XmlDocument document = new XmlDocument();
-                document.AppendChild(document.CreateElement("RootElement"));
-                Graph.Nodes.Utilities.GetDocumentXmlPath(document);
-            });
+            // Test XmlDocument root element without path.
+            XmlDocument document = new XmlDocument();
+            document.AppendChild(document.CreateElement("RootElement"));
+            var path = Graph.Nodes.Utilities.GetDocumentXmlPath(document);
+            Assert.IsEmpty(path);
         }
 
         [Test]
@@ -424,22 +414,20 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void MakeRelativePath00()
         {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                // Test method call without a valid base path.
-                Graph.Nodes.Utilities.MakeRelativePath(null, Path.GetTempPath());
-            });
+            // Test method call without a valid base path.
+            string basePath = Path.GetTempPath();
+            var result = Graph.Nodes.Utilities.MakeRelativePath(null, basePath);
+            Assert.AreEqual(basePath, result);
         }
 
         [Test]
         [Category("UnitTests")]
         public void MakeRelativePath01()
         {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                // Test method call without an empty base path.
-                Graph.Nodes.Utilities.MakeRelativePath("", Path.GetTempPath());
-            });
+            // Test method call without an empty base path.
+            string basePath = Path.GetTempPath();
+            var result = Graph.Nodes.Utilities.MakeRelativePath("", basePath);
+            Assert.AreEqual(basePath, result);
         }
 
         [Test]
@@ -503,14 +491,16 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void MakeAbsolutePath00()
         {
+            //If path is relative, then base path must be presented
+            string relative = @"Dummy\Path.dyn";
             Assert.Throws<ArgumentNullException>(() =>
             {
-                Graph.Nodes.Utilities.MakeAbsolutePath(null, "Dummy");
+                Graph.Nodes.Utilities.MakeAbsolutePath(null, relative);
             });
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                Graph.Nodes.Utilities.MakeAbsolutePath(string.Empty, "Dummy");
+                Graph.Nodes.Utilities.MakeAbsolutePath(string.Empty, relative);
             });
 
             Assert.Throws<ArgumentNullException>(() =>
@@ -522,6 +512,12 @@ namespace Dynamo.Tests
             {
                 Graph.Nodes.Utilities.MakeAbsolutePath("Dummy", string.Empty);
             });
+
+            string absolute = Path.Combine(Path.GetTempPath(), "Dummy.dyn");
+            Assert.AreEqual(absolute,
+                Graph.Nodes.Utilities.MakeAbsolutePath(null, absolute));
+            Assert.AreEqual(absolute,
+                Graph.Nodes.Utilities.MakeAbsolutePath(string.Empty, absolute));
         }
 
         [Test]
@@ -570,6 +566,12 @@ namespace Dynamo.Tests
             // will not be modified to prefix with a directory.
             // 
             var result = Graph.Nodes.Utilities.MakeAbsolutePath(basePath, relativePath);
+            Assert.AreEqual(relativePath, result);
+
+            result = Graph.Nodes.Utilities.MakeAbsolutePath(string.Empty, relativePath);
+            Assert.AreEqual(relativePath, result);
+
+            result = Graph.Nodes.Utilities.MakeAbsolutePath(null, relativePath);
             Assert.AreEqual(relativePath, result);
         }
 


### PR DESCRIPTION
### Purpose

The purpose of this PR is to enlarge available public API and give more freedom in 
using workspaces with current DynamoModel configuration.
Using DynamoCore as a background calculator is a amazing possibility but lack of the public features restricts the opportunities.
Currently to achieve target workflows I must use C# reflection.
If all main facilities used in DynamoMode were available, it would allow to use DynamoCore for a broader set solutions.

PR has next changes:
1) In DynamoModel.SaveBackupFiles fixed saving backup file if workspace has no nodes.
2) ILogger has been added to ReadyParams to allow use Dynamo console by extensions.
3) In FFIExecutionManager events.cleaning has been added. Without it using of several consistent executions of different workspaces is impossible. 
4) Removed mandatory need of FilePath attribute in NodeCategories. This attribute introduces inconvenient restrictions for using workspace xml serialization without the file on disk. When it is not used all paths are absolute.
5) Added public methods for serializing HomeWorkspace to XmlDocument and deserialize HomeWorkspace from it.
6) Changed access modifier from internal to public for the next cases:
- NodeToCodeCompiler. LiveRunner is available for execution of the code, but currently there is no public abilities for getting code from workspace.
- EngineController.GenerateGraphSyncDataForCustomNode. Allows directly register custom nodes used in the binded workspaces.
- DynamoModel.RequestTaskDialog. Allows react to messages from DynamoModel, if it is not handled by the default UI.
### Declarations
- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (_No change of public methods or types etc.._)
