### PR TITLE
Add back OpenSans files and license information

### DIFF
--- a/doc/distrib/License.rtf
+++ b/doc/distrib/License.rtf
@@ -271,6 +271,17 @@ HYPERLINK https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md }{\r
 72003d0032002e0036002e0032000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000100}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \fs22\insrsid11605080 \hich\af37\dbch\af31505\loch\f37 http://www.nunit.org/index.php?p=license&r=2.6.2}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \fs22\cf20\insrsid11605080 
 \par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb240\nowidctlpar\wrapdefault\faauto\outlinelevel2\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af37\hich\af37\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
+\ab\af37\afs22 \ltrch\fcs0 \b\fs22\cf19\insrsid11605080 \hich\af37\dbch\af31505\loch\f37 OpenSans font from Google
+\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af37\hich\af37\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \fs22\insrsid11605080 \hich\af37\dbch\af31505\loch\f37 HYPERLINK http://www.google.com/fonts/specimen/Open+Sans }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \fs22\insrsid459247 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7600000068007400740070003a002f002f007700770077002e0067006f006f0067006c0065002e0063006f006d002f0066006f006e00740073002f00730070006500630069006d0065006e002f004f00700065006e00
+2b00530061006e0073000000795881f43b1d7f48af2c825dc485276300000000a5ab000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \fs22\insrsid11605080 \hich\af37\dbch\af31505\loch\f37 http://www.google.com/fonts/specimen/Open+Sans}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \fs22\cf20\insrsid11605080 \line }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \fs22\insrsid11605080 \hich\af37\dbch\af31505\loch\f37 
+HYPERLINK http://www.apache.org/licenses/LICENSE-2.0.html }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \fs22\insrsid459247 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7800000068007400740070003a002f002f007700770077002e006100700061006300680065002e006f00720067002f006c006900630065006e007300650073002f004c004900430045004e00530045002d0032002e00
+30002e00680074006d006c000000795881f43b1d7f48af2c825dc485276300000000a5ab000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \fs22\insrsid11605080 \hich\af37\dbch\af31505\loch\f37 http://www.apache.org/licenses/LICENSE-2.0.html}}}\sectd \ltrsect
+\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \fs22\cf20\insrsid11605080 
+\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb240\nowidctlpar\wrapdefault\faauto\outlinelevel2\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af37\hich\af37\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \ab\af37\afs22 \ltrch\fcs0 \b\fs22\cf19\insrsid11605080 \hich\af37\dbch\af31505\loch\f37 Prism
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af37\hich\af37\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \fs22\insrsid11605080 \hich\af37\dbch\af31505\loch\f37 HYPERLINK http://msdn.microsoft.com/en-us/library/gg406140.aspx }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \fs22\insrsid459247 {\*\datafield 

--- a/src/DynamoInstall/Release.xsl
+++ b/src/DynamoInstall/Release.xsl
@@ -55,10 +55,6 @@
     <xsl:key name="nunit-search" match="wix:Component[contains(wix:File/@Source, 'nunit')]" use="@Id"/>
     <xsl:template match="wix:Component[key('nunit-search', @Id)]" />
 	
-    <!--Exclude OpenSans* fonts-->
-    <xsl:key name="OpenSans-search" match="wix:Component[contains(wix:File/@Source, 'OpenSans')]" use="@Id"/>
-    <xsl:template match="wix:Component[key('OpenSans-search', @Id)]" />
-  
     <!--Exclude *.vshost.exe*-->
     <xsl:key name="vshost-search" match="wix:Component[contains(wix:File/@Source, 'vshost.exe')]" use="@Id"/>
     <xsl:template match="wix:Component[key('vshost-search', @Id)]" />


### PR DESCRIPTION
### Purpose

[MAGN-10628](https://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10628) *Dynamo RC 1.2 font is not Open Sans*

"Open Sans" font files still reside in this repository, but they were mistakenly excluded from Dynamo 1.0.0 installer during a cleanup task. Its licensing information was also removed from the license page.

Adding them back as Open Sans has always been the intended font for all Dynamo products.

#### Before: the font was Segoe UI
![image](https://cloud.githubusercontent.com/assets/6386550/19348601/4b0851ec-9181-11e6-81b4-1db2a50656f1.png)

#### After: the font is Open Sans and the licensing information has been added back
![image](https://cloud.githubusercontent.com/assets/6386550/19348605/4f4f6556-9181-11e6-8d13-fc26df26876a.png)
![image](https://cloud.githubusercontent.com/assets/6386550/19348395/4162643a-9180-11e6-9dad-5d518d54a30e.png)

### Declarations

- [x] Snapshot of UI changes, if any.

### Reviewers

@Benglin 

### FYIs

@Racel @kronz 