### PR TITLE
Update some flaky Dynamo test cases

### DIFF
--- a/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests.cs
@@ -2277,7 +2277,6 @@ import(""FFITarget.dll"");
         [Test]
         [Category("DSDefinedClass_Ported")]
         [Category("Type System")]
-        [Category("Failure")]
         public void TS056_Return_AlltypeTo_BoolArray()
         {
             string code =
@@ -2301,14 +2300,14 @@ import(""FFITarget.dll"");
             // Tracked in: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3968
             string error = "MAGN-3968: Type conversion from var to bool array promotion is not happening ";
             thisTest.RunScriptSource(code, error);
-            thisTest.Verify("a", new object[] { true, true });
-            thisTest.Verify("a1", new object[] { true, true });
-            thisTest.Verify("b", new object[] { true, false });
-            thisTest.Verify("c", new object[] { true, false });
-            thisTest.Verify("d", new object[] { true, false });
-            thisTest.Verify("e", new object[] { true, true });
-            thisTest.Verify("f", new object[] { false, true });
-            thisTest.Verify("g", null);
+            thisTest.Verify("a", new object[] { new object[] { true }, new object[] { true } });
+            thisTest.Verify("a1", new object[] { new object[] { true }, new object[] { true } });
+            thisTest.Verify("b", new object[] { new object[] { true }, new object[] { false } });
+            thisTest.Verify("c", new object[] { new object[] { true }, new object[] { false } });
+            thisTest.Verify("d", new object[] { new object[] { true }, new object[] { false } });
+            thisTest.Verify("e", new object[] { new object[] { true }, new object[] { true } });
+            thisTest.Verify("f", new object[] { new object[] { false }, new object[] { true } });
+            thisTest.Verify("g", new object[] { null, null });
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TypeSystemTests.cs
@@ -2277,6 +2277,7 @@ import(""FFITarget.dll"");
         [Test]
         [Category("DSDefinedClass_Ported")]
         [Category("Type System")]
+        [Category("Failure")]
         public void TS056_Return_AlltypeTo_BoolArray()
         {
             string code =
@@ -2300,14 +2301,14 @@ import(""FFITarget.dll"");
             // Tracked in: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-3968
             string error = "MAGN-3968: Type conversion from var to bool array promotion is not happening ";
             thisTest.RunScriptSource(code, error);
-            thisTest.Verify("a", new object[] { new object[] { true }, new object[] { true } });
-            thisTest.Verify("a1", new object[] { new object[] { true }, new object[] { true } });
-            thisTest.Verify("b", new object[] { new object[] { true }, new object[] { false } });
-            thisTest.Verify("c", new object[] { new object[] { true }, new object[] { false } });
-            thisTest.Verify("d", new object[] { new object[] { true }, new object[] { false } });
-            thisTest.Verify("e", new object[] { new object[] { true }, new object[] { true } });
-            thisTest.Verify("f", new object[] { new object[] { false }, new object[] { true } });
-            thisTest.Verify("g", new object[] { null, null });
+            thisTest.Verify("a", new object[] { true, true });
+            thisTest.Verify("a1", new object[] { true, true });
+            thisTest.Verify("b", new object[] { true, false });
+            thisTest.Verify("c", new object[] { true, false });
+            thisTest.Verify("d", new object[] { true, false });
+            thisTest.Verify("e", new object[] { true, true });
+            thisTest.Verify("f", new object[] { false, true });
+            thisTest.Verify("g", null);
         }
 
         [Test]

--- a/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
+++ b/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
@@ -1079,47 +1079,8 @@ namespace Dynamo.Tests
             Assert.IsTrue(watch.CachedValue.IsCollection);
             var data = new object[] { new object[] { 5 }, new object[] { 6 }, new object[] { 7 }, new object[] { 8 }, new object[] { 9 }, new object[] { 10 } };
             AssertPreviewValue(watch.GUID.ToString(), data);
-
-
         }
        
-        [Test,Category("Failure")]
-        public void WriteModifyGraph_2()
-        {
-            // Failing due to -http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7515
-            // 1.  Write into  an Existing excel file and Run
-            // 2.  Reduce the array size written to an excel file
-            //3.  Rerun the file 
-            
-            string openPath = Path.Combine(TestDirectory, @"core\excel\WriteModifyGraph_2.dyn");
-            ViewModel.OpenCommand.Execute(openPath);
-
-            var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<Filename>();
-
-            // remap the filename as Excel requires an absolute path
-            filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
-
-            ViewModel.HomeSpace.Run();
-            var watch = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.ReadFromFile");
-            var watch2 = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.WriteToFile");
-            var watch3 = ViewModel.Model.CurrentWorkspace.NodeFromWorkspace("17bf44dd-0285-496f-a388-58649cadbff8");
-            Assert.IsTrue(watch.CachedValue.IsCollection);
-            //from excel - {5,6,7,8,9,10}
-            var data = new object[] { new object[] {5}, new object[] { 6 }, new object[] { 7 }, new object[] { 8 }, new object[] { 9 }, new object[] { 10 } };
-            AssertPreviewValue(watch.GUID.ToString(), data);
-
-            // decrease the data written into excel
-            // Write {2,3,4,5} into excel 
-            ConnectorModel.Make(watch3, watch2, 0, 4);
-            
-            ViewModel.HomeSpace.Run();
-
-            Assert.IsTrue(watch2.CachedValue.IsCollection);
-            
-            var data2 = new object[] { new object[] { 2}, new object[] { 3 }, new object[] { 4 }, new object[] { 5 }, new object[] { null}, new object[] { null} };
-            AssertPreviewValue(watch2.GUID.ToString(), data2);
-
-        }
 
         [Test]
         public void WriteModifyGraph_3()

--- a/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
+++ b/test/Libraries/DynamoMSOfficeTests/ExcelTests.cs
@@ -1082,39 +1082,7 @@ namespace Dynamo.Tests
 
 
         }
-        [Test]
-        public void WriteModifyGraph()
-        {
-
-            // 1.  Write into  an Existing excel file and Run
-            // 2.  Modify the contents written to an excel file wiht option overwrite
-            //3.  Rerun the file  
-            string openPath = Path.Combine(TestDirectory, @"core\excel\WriteModifyGraph.dyn");
-            ViewModel.OpenCommand.Execute(openPath);
-
-            var filename = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<Filename>();
-
-            // remap the filename as Excel requires an absolute path
-            filename.Value = filename.Value.Replace(@"..\..\..\test", TestDirectory);
-
-            ViewModel.HomeSpace.Run();
-            var watch = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.ReadFromFile");
-            var watch2 = ViewModel.Model.CurrentWorkspace.GetDSFunctionNodeFromWorkspace("Excel.WriteToFile"); // {5,6,7,8,9,10}
-            var watch3 = ViewModel.Model.CurrentWorkspace.NodeFromWorkspace("17bf44dd-0285-496f-a388-58649cadbff8");
-            Assert.IsTrue(watch.CachedValue.IsCollection);
-            var data = new object[] { new object[] { 5 }, new object[] { 6 }, new object[] { 7 }, new object[] { 8 }, new object[] { 9 }, new object[] { 10 } };
-            AssertPreviewValue(watch.GUID.ToString(), data);
-            // change the data written into Excel
-
-            ConnectorModel.Make(watch3, watch2, 0, 4);
-            ViewModel.HomeSpace.Run();
-            Assert.IsTrue(watch2.CachedValue.IsCollection);
-           
-            var data2 = new object[] { new object[] { 0 }, new object[] { 1 }, new object[] { 2 }, new object[] { 3 }, new object[] { 4 }, new object[] { 5 } };
-            AssertPreviewValue(watch2.GUID.ToString(), data2);
-
-
-        }
+       
         [Test,Category("Failure")]
         public void WriteModifyGraph_2()
         {

--- a/test/Libraries/DynamoPythonTests/CodeCompletionTests.cs
+++ b/test/Libraries/DynamoPythonTests/CodeCompletionTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using System.Linq;
 using Dynamo;
 using Dynamo.Interfaces;
 using Dynamo.Logging;
@@ -260,7 +261,10 @@ namespace DynamoPythonTests
 
             var completionData = completionProvider.GetCompletionData(str);
 
-            Assert.AreEqual(224, completionData.Length);
+            // Randomly verify some namepsaces are in the completion list
+            var completionList = completionData.Select(d => d.Text);
+            Assert.IsTrue(completionList.Any());
+            Assert.IsTrue(completionList.Intersect(new[] { "IO", "Console", "Reflection" }).Count() == 3);
             Assert.AreEqual(1, completionProvider.ImportedTypes.Count);
             Assert.IsTrue(completionProvider.ImportedTypes.ContainsKey("System"));
 
@@ -274,7 +278,9 @@ namespace DynamoPythonTests
             var completionProvider = new IronPythonCompletionProvider();
 
             var completionData = completionProvider.GetCompletionData(str);
-
+            var completionList = completionData.Select(d => d.Text);
+            Assert.IsTrue(completionList.Any());
+            Assert.IsTrue(completionList.Intersect(new[] { "Hashtable", "Queue", "Stack"}).Count() == 3);
             Assert.AreEqual(29, completionData.Length);
         }
 


### PR DESCRIPTION
### Purpose

This PR update some flaky Dynamo test cases. They may fail locally or on CI machine out of reason.

DynamoMSOfficeTests.WriteModifyGraph and DynamoMSOfficeTests.WriteModifyGraph_2 are both removed. These two test cases read from excel file and write to excel file at the same time, but the order of read and write is totally nondeterministic, so they may randomly fail:

![untitled](https://cloud.githubusercontent.com/assets/2600379/19379056/c0d32fa4-9222-11e6-8e46-6d6476fc8447.png)

Two completion test cases in DynamoPythonTests are updated. They are trying to verify the number of completion data in some .Net namespace, say "System". Depending on the version of .Net framework, different machine may have different result, so this PR removes number checking. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@monikaprabhu @Benglin @riteshchandawar 
