### PR TITLE
In-canvas search is dismissed when switching to other windows / when other notification dialogues pops up. 

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1487,7 +1487,8 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <param name="parameter"></param>
         private void ShowNewFunctionDialogAndMakeFunction(object parameter)
-        {           
+        {
+            HidePopUp();
             var args = new FunctionNamePromptEventArgs();
             this.Model.OnRequestsFunctionNamePrompt(this, args);
 
@@ -1510,6 +1511,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         private void ShowNewPresetStateDialogAndMakePreset(object parameter)
         {
+            HidePopUp();
             var selectedNodes = GetInputNodesFromSelectionForPresets().ToList();
 
             //If there are NO input nodes then show the error message
@@ -1835,6 +1837,13 @@ namespace Dynamo.ViewModels
             return DynamoSelection.Instance.Selection.Count > 0;
         }
 
+        internal event Action<ShowHideFlags> RequestHidePopUp;
+
+        public void HidePopUp()
+        {
+            if (RequestHidePopUp != null)
+                RequestHidePopUp (ShowHideFlags.Hide);
+        }
 
         public void SaveImage(object parameters)
         {
@@ -1857,6 +1866,7 @@ namespace Dynamo.ViewModels
 
         public void ShowSaveImageDialogAndSaveResult(object parameter)
         {
+            HidePopUp();
             FileDialog _fileDialog = null;
 
             if (_fileDialog == null)
@@ -2140,6 +2150,7 @@ namespace Dynamo.ViewModels
 
         public void ImportLibrary(object parameter)
         {
+            HidePopUp(); 
             string[] fileFilter = {string.Format(Resources.FileDialogLibraryFiles, "*.dll; *.ds" ), string.Format(Resources.FileDialogAssemblyFiles, "*.dll"), 
                                    string.Format(Resources.FileDialogDesignScriptFiles, "*.ds"), string.Format(Resources.FileDialogAllFiles,"*.*")};
             OpenFileDialog openFileDialog = new OpenFileDialog();
@@ -2194,6 +2205,7 @@ namespace Dynamo.ViewModels
 
         private void ExportToSTL(object parameter)
         {
+            HidePopUp();
             FileDialog _fileDialog = null ?? new SaveFileDialog()
             {
                 AddExtension = true,

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -589,6 +589,22 @@ namespace Dynamo.Controls
             };
             BackgroundPreview.SetBinding(VisibilityProperty, vizBinding);
             TrackStartupAnalytics();
+
+            // In native host scenario (e.g. Revit), the "Application.Current" will be "null". Therefore, the InCanvasSearchControl.OnRequestShowInCanvasSearch
+            // will not work. Instead, we have to check if the Owner Window (DynamoView) is deactivated or not.  
+            if (Application.Current == null)
+            {
+                this.Deactivated += (s, args) => { HidePopupWhenWindowDeactivated(ShowHideFlags.Hide); };
+            }
+        }
+        /// <summary>
+        /// Close Popup when the Dynamo window is not in the foreground.
+        /// </summary>
+        /// <param name="flag"></param>
+        private void HidePopupWhenWindowDeactivated(ShowHideFlags flag)
+        {
+            var workspace = this.ChildOfType<WorkspaceView>();
+            workspace.HidePopUp(flag);
         }
 
         private void TrackStartupAnalytics()
@@ -617,6 +633,7 @@ namespace Dynamo.Controls
         /// 
         private bool DisplayTermsOfUseForAcceptance()
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             var prefSettings = dynamoViewModel.Model.PreferenceSettings;
             if (prefSettings.PackageDownloadTouAccepted)
                 return true; // User accepts the terms of use.
@@ -635,6 +652,7 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestAboutWindow(DynamoViewModel model)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             var aboutWindow = model.BrandingResourceProvider.CreateAboutBox(model);
             aboutWindow.Owner = this;
             aboutWindow.WindowStartupLocation = WindowStartupLocation.CenterOwner;
@@ -649,6 +667,7 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestShowHideGallery(bool showGallery)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             if (showGallery)
             {
                 if (galleryView == null) //On-demand instantiation
@@ -682,6 +701,7 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestRequestPackageManagerPublish(PublishPackageViewModel model)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             var cmd = Analytics.TrackCommandEvent("PublishPackage");
             if (_pubPkgView == null)
             {
@@ -704,6 +724,7 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestShowPackageManagerSearch(object s, EventArgs e)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             if (!DisplayTermsOfUseForAcceptance())
                 return; // Terms of use not accepted.
 
@@ -733,6 +754,7 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestPackagePaths(object sender, EventArgs e)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             var loadPackagesParams = new LoadPackageParams {
                 Preferences = dynamoViewModel.PreferenceSettings,
                 PathManager = dynamoViewModel.Model.PathManager,
@@ -748,6 +770,7 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestShowInstalledPackages(object s, EventArgs e)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             var cmd = Analytics.TrackCommandEvent("ManagePackage");
             if (_installedPkgsView == null)
             {
@@ -776,8 +799,7 @@ namespace Dynamo.Controls
         private void DynamoViewModelRequestUserSaveWorkflow(object sender, WorkspaceSaveEventArgs e)
         {
 
-            var workspace = this.ChildOfType<WorkspaceView>();
-            workspace.HidePopUp();
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
 
             var dialogText = "";
             // If the file is read only, display a different message.
@@ -837,24 +859,28 @@ namespace Dynamo.Controls
 
         private void Controller_RequestsCrashPrompt(object sender, CrashPromptArgs args)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             var prompt = new CrashPrompt(args, dynamoViewModel);
             prompt.ShowDialog();
         }
 
         private void Controller_RequestTaskDialog(object sender, TaskDialogEventArgs e)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             var taskDialog = new UI.Prompts.GenericTaskDialog(e);
             taskDialog.ShowDialog();
         }
 
         private void DynamoViewModelRequestSaveImage(object sender, ImageSaveEventArgs e)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             var workspace = this.ChildOfType<WorkspaceView>();
             workspace.SaveWorkspaceAsImage(e.Path);
         }
 
         private void DynamoViewModelRequestSave3DImage(object sender, ImageSaveEventArgs e)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             var canvas = (DPFCanvas)BackgroundPreview.View.RenderHost;
 
             var encoder = new PngBitmapEncoder();
@@ -904,6 +930,7 @@ namespace Dynamo.Controls
         /// <returns></returns>
         internal void ShowNewFunctionDialog(FunctionNamePromptEventArgs e)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             var categorized =
                 SearchCategoryUtil.CategorizeSearchEntries(
                     dynamoViewModel.Model.SearchModel.SearchEntries,
@@ -968,6 +995,7 @@ namespace Dynamo.Controls
         /// </summary>
         internal void ShowNewPresetDialog(PresetsNamePromptEventArgs e)
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             string error = "";
 
             do
@@ -1010,6 +1038,7 @@ namespace Dynamo.Controls
 
         private void ShowPresetWarning()
         {
+            HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
             var newDialog = new  PresetOverwritePrompt()
             {
                 Owner = this,

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -775,6 +775,10 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestUserSaveWorkflow(object sender, WorkspaceSaveEventArgs e)
         {
+
+            var workspace = this.ChildOfType<WorkspaceView>();
+            workspace.HidePopUp();
+
             var dialogText = "";
             // If the file is read only, display a different message.
             if (e.Workspace.IsReadOnly)

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -798,9 +798,7 @@ namespace Dynamo.Controls
 
         private void DynamoViewModelRequestUserSaveWorkflow(object sender, WorkspaceSaveEventArgs e)
         {
-
             HidePopupWhenWindowDeactivated(ShowHideFlags.Hide);
-
             var dialogText = "";
             // If the file is read only, display a different message.
             if (e.Workspace.IsReadOnly)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -328,7 +328,7 @@
         </StackPanel>
 
         <Popup Name="InCanvasSearchBar"
-               StaysOpen="False"
+               StaysOpen="True"
                AllowsTransparency="True"
                Placement="MousePoint"
                DataContext="{Binding InCanvasSearchViewModel}">
@@ -336,7 +336,7 @@
         </Popup>
 
         <Popup Name="ContextMenuPopup" Style="{StaticResource WorkspaceContextMenuStylePopup}"
-               Opened="OnContextMenuOpened" StaysOpen="False" AllowsTransparency="True" Placement="MousePoint">
+               Opened="OnContextMenuOpened" StaysOpen="True" AllowsTransparency="True" Placement="MousePoint">
             <Popup.Resources>
                 <Style TargetType="{x:Type MenuItem}">
                     <Setter Property="Focusable" Value="False" />

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -167,6 +167,13 @@ namespace Dynamo.Views
             }
         }
 
+        public void HidePopUp()
+        {
+            ContextMenuPopup.IsOpen = false;
+            InCanvasSearchBar.IsOpen = false;
+        }
+
+
         internal Point GetCenterPoint()
         {
             var x = outerCanvas.ActualWidth / 2.0;

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -168,7 +168,10 @@ namespace Dynamo.Views
                     break;
             }
         }
-
+        /// <summary>
+        /// Hides Context Menu as well as InCanvasControl (Right Click PopUp)
+        /// </summary>
+        /// <param name="flag"></param>
         public void HidePopUp(ShowHideFlags flag)
         {
             ShowHideContextMenu(flag);

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -110,6 +110,7 @@ namespace Dynamo.Views
 
             ViewModel.RequestShowInCanvasSearch += ShowHideInCanvasControl;
             ViewModel.DynamoViewModel.PropertyChanged += ViewModel_PropertyChanged;
+            ViewModel.DynamoViewModel.RequestHidePopUp += HidePopUp;
 
             infiniteGridView.AttachToZoomBorder(zoomBorder);
         }
@@ -136,6 +137,7 @@ namespace Dynamo.Views
             {
                 ViewModel.RequestShowInCanvasSearch -= ShowHideInCanvasControl;
                 ViewModel.DynamoViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+                ViewModel.DynamoViewModel.RequestHidePopUp -= HidePopUp;
             }
 
             infiniteGridView.DetachFromZoomBorder(zoomBorder);
@@ -167,12 +169,11 @@ namespace Dynamo.Views
             }
         }
 
-        public void HidePopUp()
+        public void HidePopUp(ShowHideFlags flag)
         {
-            ContextMenuPopup.IsOpen = false;
-            InCanvasSearchBar.IsOpen = false;
+            ShowHideContextMenu(flag);
+            ShowHideInCanvasControl(flag);
         }
-
 
         internal Point GetCenterPoint()
         {


### PR DESCRIPTION
### Purpose

This PR is meant to resolve the issue in _MAGN-10569_. The previous PR (https://github.com/DynamoDS/Dynamo/pull/7249) caused the `Menu Items` in the `ContextMenu` to break. While I'm still not entirely clear why changing the `StaysOpen` toggle to `False` in the Popup menu would cause the break, I suspect that it has to do with the way `ContextMenuPopup` and `InCanvasSearchBar` is linked to the `InCanvasSearchControl` for UI Controls.

After much investigation, however, I could not find a way to fix the `StaysOpen` option. Instead, I tried to find a workaround to dismiss the Popup. 

This PR contains the workaround which I implemented to dismiss the Context Menu Popup whenever:

1. The `OwnerWindow` is not Dynamo (i.e. when the Dynamo window is not in the foreground).
2. A dialog popups (be it 'Save Workspace' or 'Export Image' or 'About Window' etc.)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 

### FYIs

@jnealb , @riteshchandawar 