### PR TITLE
Geometry Label Removed after Disconnecting Watch node 

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -482,6 +482,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             // Override in inherited classes.
         }
 
+        public virtual void ClearPathLabel(string path)
+        {
+            // Override in inherited classes.
+        }
+
         public void Invoke(Action action)
         {
             var dynamoViewModel = viewModel as DynamoViewModel;

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -482,6 +482,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             // Override in inherited classes.
         }
 
+        /// <summary>
+        /// Remove the labels (in Watch3D View) for geometry once the Watch node is disconnected
+        /// </summary>
+        /// <param name="path"></param>
         public virtual void ClearPathLabel(string path)
         {
             // Override in inherited classes.

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1312,6 +1312,26 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
         }
 
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="path"></param>
+        public override void ClearPathLabel(string path)
+        {
+            var nodePath = path.Contains(':') ? path.Remove(path.IndexOf(':')) : path;
+            var labelName = nodePath + TextKey;
+            lock (Model3DDictionaryMutex)
+            {
+                var sceneItemsChanged = Model3DDictionary.Remove(labelName);
+                if (sceneItemsChanged)
+                {
+                    OnSceneItemsChanged();
+                }
+            }
+        }
+
+
         /// <summary>
         /// Given a collection of render packages, generates
         /// corresponding <see cref="GeometryModel3D"/> objects for visualization, and

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1314,7 +1314,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         
         /// <summary>
-        /// Remove the labels for geometry based on their paths
+        /// Remove the labels (in Watch3D View) for geometry once the Watch node is disconnected
         /// </summary>
         /// <param name="path"></param>
         public override void ClearPathLabel(string path)

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1314,7 +1314,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         
         /// <summary>
-        /// 
+        /// Remove the labels for geometry based on their paths
         /// </summary>
         /// <param name="path"></param>
         public override void ClearPathLabel(string path)

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -167,6 +167,11 @@ namespace CoreNodeModelsWpf.Nodes
             // Without doing this, the preview would say "null"
             if (watch.IsPartiallyApplied)
             {
+                foreach (var node in rootWatchViewModel.Children)
+                {
+                    dynamoViewModel.BackgroundPreviewViewModel.ClearPathLabel(node.Path);
+                }
+
                 rootWatchViewModel.Children.Clear();
                 rootWatchViewModel.IsCollection = false;
                 return;

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -167,9 +167,11 @@ namespace CoreNodeModelsWpf.Nodes
             // Without doing this, the preview would say "null"
             if (watch.IsPartiallyApplied)
             {
+                // There should be only one node in rootWatchViewModel.Children
+                // as it is the parent node. Therefore, the iteration should only occur once.
                 foreach (var node in rootWatchViewModel.Children)
                 {
-                    // remove all labels upon disconnect of Watch Node
+                    // remove all labels (in Watch 3D View) upon disconnect of Watch Node
                     dynamoViewModel.BackgroundPreviewViewModel.ClearPathLabel(node.Path);
                 }
 

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/Watch.cs
@@ -169,6 +169,7 @@ namespace CoreNodeModelsWpf.Nodes
             {
                 foreach (var node in rootWatchViewModel.Children)
                 {
+                    // remove all labels upon disconnect of Watch Node
                     dynamoViewModel.BackgroundPreviewViewModel.ClearPathLabel(node.Path);
                 }
 


### PR DESCRIPTION
### Purpose

This PR is meant to address _MAGN-9630_, where the labels for the geometry are not removed after the Watch Node is disconnected. 

Previously, when the Watch Node is connected, and a node within the list is selected, after the Watch Node is disconnected, the label is not removed from the geometry display:

![disconnectwatchnodeold](https://cloud.githubusercontent.com/assets/16283396/19383363/81395990-9236-11e6-835a-5007cc837abe.gif)

Now, after this fix, the label will be removed upon disconnect:

![disconnectwatchnodenew](https://cloud.githubusercontent.com/assets/16283396/19383362/8137de3a-9236-11e6-9625-2e5ba18e841c.gif)

The fix mainly involved creating a new method `ClearLabelPath` to provide this functionality of removing the label from geometry. Previously, when the Watch Node was disconnected, there was no functionality which was tasked with removing the label.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@ke-yu 

### FYIs
