### PR TITLE
WIP - Not to generate input port if a variable defined in CBN

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -603,10 +603,15 @@ namespace Dynamo.Graph.Nodes
                 {
                     inputIdentifiers = new List<string>();
                     inputPortNames = new List<string>();
+
+                    var definedVariables = new HashSet<string>(CodeBlockUtils.GetStatementVariables(codeStatements, true).SelectMany(s => s));
                     foreach (var kvp in parseParam.UnboundIdentifiers)
                     {
-                        inputIdentifiers.Add(kvp.Value);
-                        inputPortNames.Add(kvp.Key);
+                        if (!definedVariables.Contains(kvp.Value))
+                        {
+                            inputIdentifiers.Add(kvp.Value);
+                            inputPortNames.Add(kvp.Key);
+                        }
                     }
                 }
                 else

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -1241,7 +1241,13 @@ namespace Dynamo.Graph.Nodes
             if(leftNode is TypedIdentifierNode)
                 return new IdentifierNode(leftNode as IdentifierNode);
             if (leftNode is IdentifierNode)
-                return leftNode as IdentifierNode;
+            {
+                var identiferNode = leftNode as IdentifierNode;
+                if (identiferNode.ArrayDimensions != null)
+                    return null;
+                else
+                    return identiferNode;
+            }
             else if (leftNode is IdentifierListNode || leftNode is FunctionCallNode)
                 return null;
             else
@@ -1309,16 +1315,6 @@ namespace Dynamo.Graph.Nodes
                     if (assignedVar != null)
                     {
                         definedVariables.Add(new Variable(assignedVar));
-
-                        // Handle case "a;" which is compiled to "t6BBA4B28C5E54CF89F300D510499A00E_x = a;"
-                        if (assignedVar.Name.StartsWith(ProtoCore.DSASM.Constants.kTempVarForNonAssignment) && binaryExpression.Optr == Operator.assign)
-                        {
-                            var rightNode = binaryExpression.RightNode as IdentifierNode;
-                            if (rightNode != null)
-                            {
-                                definedVariables.Add(new Variable(rightNode));
-                            }
-                        }
                     }
                     parsedNode = (parsedNode as BinaryExpressionNode).RightNode;
                 }
@@ -1395,7 +1391,7 @@ namespace Dynamo.Graph.Nodes
             if (identNode == null)
                 throw new ArgumentNullException();
 
-            Name = identNode.ToString();
+            Name = identNode.Name;
             Row = identNode.line;
             StartColumn = identNode.col;
         }

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -254,7 +254,7 @@ b = c[w][x][y][z];";
             // After code changes, there should be two output ports.
             UpdateCodeBlockNodeContent(codeBlockNode, "a = 1..6;\na[2]=a[2] + 1;");
             Assert.AreEqual(0, codeBlockNode.InPortData.Count);
-            Assert.AreEqual(2, codeBlockNode.OutPortData.Count);
+            Assert.AreEqual(1, codeBlockNode.OutPortData.Count);
         }
 
         [Test]

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -1102,16 +1102,10 @@ namespace Dynamo.Tests
             // To test that variable could still be properly renamed.
             var dynFilePath = Path.Combine(TestDirectory, @"core\dsevaluation\define_dictionary2.dyn");
             OpenModel(dynFilePath);
-            AssertPreviewValue("14da40b5-f836-4178-85ff-882195917bbc", "bar");
-            AssertPreviewValue("69f1ec59-6a8c-49b1-a4d7-6690c6a1e594", 1024);
-            AssertPreviewValue("82b91c7e-e7cf-41e0-b392-ab737326ccaa", new object[] { 1024 });
-            AssertPreviewValue("372c04aa-4088-4224-a922-d34fc2869fc1", "qux");
-            AssertPreviewValue("58a3e8e3-9648-4253-81c1-cd2960629d70", new object[] { "qux" });
-            AssertPreviewValue("231d235b-0d7f-4bd8-b19a-5dda561aea3d", 1024);
+            AssertPreviewValue("231d235b-0d7f-4bd8-b19a-5dda561aea3d", new object[] { 1024 });
+            AssertPreviewValue("372c04aa-4088-4224-a922-d34fc2869fc1", new object[] { "qux" });
             AssertPreviewValue("e7bf0921-cf77-4f37-8336-8aa9c56b22a6", new object[] { "qux" });
             AssertPreviewValue("756497b4-4f7a-4ae3-9e5c-de5f69762d16", new object[] { 1024 });
-            AssertPreviewValue("bd3c1997-9785-49d0-acc7-62e168ec3125", "qux");
-            AssertPreviewValue("962dc07d-c213-459c-87b5-f36b7075091f", 1024);
         }
     }
 

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1835,11 +1835,11 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(0, cbn.InPorts.Count);
 
             //Check the position of ports
-            Assert.AreEqual("b", cbn.OutPorts[1].ToolTipContent);
-            Assert.AreEqual(3, cbn.OutPorts[1].LineIndex);
+            Assert.AreEqual("b", cbn.OutPorts[0].ToolTipContent);
+            Assert.AreEqual(3, cbn.OutPorts[0].LineIndex);
 
-            Assert.AreEqual("a", cbn.OutPorts[2].ToolTipContent);
-            Assert.AreEqual(5, cbn.OutPorts[2].LineIndex);
+            Assert.AreEqual("a", cbn.OutPorts[1].ToolTipContent);
+            Assert.AreEqual(5, cbn.OutPorts[1].LineIndex);
         }
 
         [Test, RequiresSTA]

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1610,9 +1610,8 @@ namespace DynamoCoreWpfTests
             var cbn = GetNode("fc209d2f-1724-4485-bde4-92670802aaa3") as CodeBlockNodeModel;
             Assert.NotNull(cbn);
 
-            Assert.AreEqual(2, cbn.InPortData.Count);
-            Assert.AreEqual("a", cbn.InPortData[0].ToolTipString);
-            Assert.AreEqual("b", cbn.InPortData[1].ToolTipString);
+            Assert.AreEqual(1, cbn.InPortData.Count);
+            Assert.AreEqual("b", cbn.InPortData[0].ToolTipString);
         }
 
         [Test, RequiresSTA]
@@ -1832,13 +1831,10 @@ namespace DynamoCoreWpfTests
             //Check the CBN for input and output ports count
             var cbn = GetNode("c9929987-69c8-42bd-9cda-04ef90d029cb") as CodeBlockNodeModel;
             Assert.AreNotEqual(ElementState.Error, cbn.State);
-            Assert.AreEqual(3, cbn.OutPorts.Count);
+            Assert.AreEqual(2, cbn.OutPorts.Count);
             Assert.AreEqual(0, cbn.InPorts.Count);
 
             //Check the position of ports
-            Assert.AreEqual("a[0]", cbn.OutPorts[0].ToolTipContent);
-            Assert.AreEqual(1, cbn.OutPorts[0].LineIndex);
-
             Assert.AreEqual("b", cbn.OutPorts[1].ToolTipContent);
             Assert.AreEqual(3, cbn.OutPorts[1].LineIndex);
 
@@ -2013,21 +2009,12 @@ namespace DynamoCoreWpfTests
             //Check the CBN for input and output ports count
             var cbn = GetNode("3c7c3458-70be-4588-b162-b1099cf30ebc") as CodeBlockNodeModel;
             Assert.AreNotEqual(ElementState.Error, cbn.State);
-            Assert.AreEqual(4, cbn.OutPorts.Count);
+            Assert.AreEqual(1, cbn.OutPorts.Count);
             Assert.AreEqual(0, cbn.InPorts.Count);
 
             //Check the position of ports
             Assert.AreEqual("a", cbn.OutPorts[0].ToolTipContent);
             Assert.AreEqual(0, cbn.OutPorts[0].LineIndex);
-
-            Assert.AreEqual("a[0]", cbn.OutPorts[1].ToolTipContent);
-            Assert.AreEqual(1, cbn.OutPorts[1].LineIndex);
-
-            Assert.AreEqual("a[1]", cbn.OutPorts[2].ToolTipContent);
-            Assert.AreEqual(2, cbn.OutPorts[2].LineIndex);
-
-            Assert.AreEqual("a[2]", cbn.OutPorts[3].ToolTipContent);
-            Assert.AreEqual(3, cbn.OutPorts[3].LineIndex);
         }
 
         [Test, RequiresSTA]

--- a/test/core/DynamoDefects/Defect_MAGN_4046.dyn
+++ b/test/core/DynamoDefects/Defect_MAGN_4046.dyn
@@ -1,15 +1,25 @@
-<Workspace Version="0.7.1.17276" X="-3.92075658744434" Y="-50.5633745163204" zoom="1.130842140625" Description="" Category="" Name="Home">
+<Workspace Version="1.2.1.2902" X="-3.92075658744434" Y="-50.5633745163204" zoom="1.130842140625" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="False">
+  <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="615cc15f-0798-43f3-810f-7e0f0dd88886" nickname="Code Block" x="554.429479512483" y="181.339113934959" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="t= {{0, 1}, {x, 3}};&#xA;v_out0 = t[0];&#xA;v_out1 = t[1];&#xA;v = {};&#xA;v[&quot;out&quot;] = v_out1;" ShouldFocus="false" />
-    <Dynamo.Nodes.IntegerSlider type="Dynamo.Nodes.IntegerSlider" guid="65d226ea-cfb5-4c5a-940e-a5c4eab1915d" nickname="Integer Slider" x="190.863547414014" y="295.336677380306" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="615cc15f-0798-43f3-810f-7e0f0dd88886" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="554.429479512483" y="181.339113934959" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="t= {{0, 1}, {x, 3}};&#xA;v_out0 = t[0];&#xA;v_out1 = t[1];&#xA;v = {};&#xA;v[&quot;out&quot;] = v_out1;&#xA;r = v[&quot;out&quot;];" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <CoreNodeModels.Input.IntegerSlider guid="65d226ea-cfb5-4c5a-940e-a5c4eab1915d" type="CoreNodeModels.Input.IntegerSlider" nickname="Integer Slider" x="190.863547414014" y="295.336677380306" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Int32>55</System.Int32>
-      <Range min="0" max="100" />
-    </Dynamo.Nodes.IntegerSlider>
-    <DSCoreNodesUI.CreateList type="DSCoreNodesUI.CreateList" guid="354ec30b-b13f-4399-beb2-a68753c09bfc" nickname="List.Create" x="831.094375387807" y="247.584654299388" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="1" />
+      <Range min="0" max="100" step="1" />
+    </CoreNodeModels.Input.IntegerSlider>
+    <CoreNodeModels.CreateList guid="354ec30b-b13f-4399-beb2-a68753c09bfc" type="CoreNodeModels.CreateList" nickname="List.Create" x="831.094375387807" y="247.584654299388" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="1">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.CreateList>
   </Elements>
   <Connectors>
-    <Dynamo.Models.ConnectorModel start="615cc15f-0798-43f3-810f-7e0f0dd88886" start_index="4" end="354ec30b-b13f-4399-beb2-a68753c09bfc" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="65d226ea-cfb5-4c5a-940e-a5c4eab1915d" start_index="0" end="615cc15f-0798-43f3-810f-7e0f0dd88886" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="615cc15f-0798-43f3-810f-7e0f0dd88886" start_index="4" end="354ec30b-b13f-4399-beb2-a68753c09bfc" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="65d226ea-cfb5-4c5a-940e-a5c4eab1915d" start_index="0" end="615cc15f-0798-43f3-810f-7e0f0dd88886" end_index="0" portType="0" />
   </Connectors>
   <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>

--- a/test/core/dsevaluation/CBN_array_indexnull_619.dyn
+++ b/test/core/dsevaluation/CBN_array_indexnull_619.dyn
@@ -1,10 +1,15 @@
-<Workspace Version="1.0.1.1743" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="False">
+<Workspace Version="1.2.1.2902" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="6985948e-992c-4420-8c39-1f5f5d57dc64" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="128" y="232" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="a[null]=5;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="6985948e-992c-4420-8c39-1f5f5d57dc64" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="128" y="232" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="true" CodeText="a;&#xA;a[null]=5;" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </Elements>
   <Connectors />
   <Notes />
   <Annotations />
   <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>

--- a/test/core/dsevaluation/define_dictionary.dyn
+++ b/test/core/dsevaluation/define_dictionary.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="1.2.1.2722" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+<Workspace Version="1.2.1.2902" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
     <CoreNodeModels.Watch guid="a0227846-04ca-4323-9074-2bd1ea9ac8cf" type="CoreNodeModels.Watch" nickname="Watch" x="388" y="125" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
@@ -7,12 +7,16 @@
     <CoreNodeModels.Watch guid="ada2d384-626f-4240-b251-7df6e395f3f2" type="CoreNodeModels.Watch" nickname="Watch" x="464" y="345" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
       <PortInfo index="0" default="False" />
     </CoreNodeModels.Watch>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="1e454a5a-3828-4c74-bf53-fc3249704183" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="167" y="351" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="s[&quot;a&quot;]=&quot;Bob&quot;;&#xA;s[&quot;b&quot;]=&quot;Sally&quot;;&#xA;s[&quot;c&quot;]=&quot;Pat&quot;;&#xA;s;" ShouldFocus="false" />
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="ab406c15-3272-4085-8fdb-2662bcc52276" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="166" y="160" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="s[&quot;a&quot;]=1;&#xA;s[&quot;b&quot;]=2;&#xA;s[&quot;c&quot;]=3;&#xA;s;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="1e454a5a-3828-4c74-bf53-fc3249704183" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="167" y="351" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="s[&quot;a&quot;]=&quot;Bob&quot;;&#xA;s[&quot;b&quot;]=&quot;Sally&quot;;&#xA;s[&quot;c&quot;]=&quot;Pat&quot;;&#xA;s;" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="ab406c15-3272-4085-8fdb-2662bcc52276" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="166" y="160" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="s[&quot;a&quot;]=1;&#xA;s[&quot;b&quot;]=2;&#xA;s[&quot;c&quot;]=3;&#xA;s;" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </Elements>
   <Connectors>
-    <Dynamo.Graph.Connectors.ConnectorModel start="1e454a5a-3828-4c74-bf53-fc3249704183" start_index="3" end="ada2d384-626f-4240-b251-7df6e395f3f2" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="ab406c15-3272-4085-8fdb-2662bcc52276" start_index="3" end="a0227846-04ca-4323-9074-2bd1ea9ac8cf" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="1e454a5a-3828-4c74-bf53-fc3249704183" start_index="0" end="ada2d384-626f-4240-b251-7df6e395f3f2" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="ab406c15-3272-4085-8fdb-2662bcc52276" start_index="0" end="a0227846-04ca-4323-9074-2bd1ea9ac8cf" end_index="0" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />

--- a/test/core/dsevaluation/define_dictionary2.dyn
+++ b/test/core/dsevaluation/define_dictionary2.dyn
@@ -1,4 +1,4 @@
-<Workspace Version="1.2.1.2861" X="-119" Y="19" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+<Workspace Version="1.2.1.2902" X="-119" Y="19" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
     <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="dfa4f4e3-6e74-4866-a196-95c2c981ba30" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="253" y="129" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="true" CodeText="s[&quot;foo&quot;] = &quot;bar&quot;;" ShouldFocus="false">
@@ -7,28 +7,16 @@
     <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="f769c8ab-a865-4681-b41f-0b0c1dfe9fc9" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="256" y="322" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="true" CodeText="s[&quot;foo&quot;] = 1024;" ShouldFocus="false">
       <PortInfo index="0" default="False" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
-    <CoreNodeModels.Watch guid="14da40b5-f836-4178-85ff-882195917bbc" type="CoreNodeModels.Watch" nickname="watch-bar" x="551" y="134" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
-      <PortInfo index="0" default="False" />
-    </CoreNodeModels.Watch>
-    <CoreNodeModels.Watch guid="69f1ec59-6a8c-49b1-a4d7-6690c6a1e594" type="CoreNodeModels.Watch" nickname="watch-1024" x="549" y="301" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
-      <PortInfo index="0" default="False" />
-    </CoreNodeModels.Watch>
     <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="a2985ad3-2ec3-4b9c-a987-bb86584ca2d2" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="703" y="145" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="t[&quot;bar&quot;] = &quot;qux&quot;;&#xA;t;" ShouldFocus="false">
       <PortInfo index="0" default="False" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
     <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="a718b332-346c-4df0-838b-be93b70e1aae" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="708" y="337" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="t[&quot;bar&quot;] = 1024;&#xA;t;" ShouldFocus="false">
       <PortInfo index="0" default="False" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
-    <CoreNodeModels.Watch guid="82b91c7e-e7cf-41e0-b392-ab737326ccaa" type="CoreNodeModels.Watch" nickname="watch {1024}" x="977" y="468" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+    <CoreNodeModels.Watch guid="372c04aa-4088-4224-a922-d34fc2869fc1" type="CoreNodeModels.Watch" nickname="watch-qux" x="978" y="37" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
       <PortInfo index="0" default="False" />
     </CoreNodeModels.Watch>
-    <CoreNodeModels.Watch guid="372c04aa-4088-4224-a922-d34fc2869fc1" type="CoreNodeModels.Watch" nickname="watch-qux" x="982" y="105" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
-      <PortInfo index="0" default="False" />
-    </CoreNodeModels.Watch>
-    <CoreNodeModels.Watch guid="58a3e8e3-9648-4253-81c1-cd2960629d70" type="CoreNodeModels.Watch" nickname="watch-{qux}" x="980" y="210" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
-      <PortInfo index="0" default="False" />
-    </CoreNodeModels.Watch>
-    <CoreNodeModels.Watch guid="231d235b-0d7f-4bd8-b19a-5dda561aea3d" type="CoreNodeModels.Watch" nickname="watch-1024" x="981" y="363" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+    <CoreNodeModels.Watch guid="231d235b-0d7f-4bd8-b19a-5dda561aea3d" type="CoreNodeModels.Watch" nickname="watch-1024" x="988" y="325" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
       <PortInfo index="0" default="False" />
     </CoreNodeModels.Watch>
     <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="047660dc-be17-4b29-84ec-1059d9637e07" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1177" y="209" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="m;&#xA;m[&quot;bar&quot;] = &quot;qux&quot;;" ShouldFocus="false">
@@ -43,24 +31,12 @@
     <CoreNodeModels.Watch guid="756497b4-4f7a-4ae3-9e5c-de5f69762d16" type="CoreNodeModels.Watch" nickname="watch{1024}" x="1422.5" y="392.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
       <PortInfo index="0" default="False" />
     </CoreNodeModels.Watch>
-    <CoreNodeModels.Watch guid="bd3c1997-9785-49d0-acc7-62e168ec3125" type="CoreNodeModels.Watch" nickname="watch qux" x="1434.5" y="232.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
-      <PortInfo index="0" default="False" />
-    </CoreNodeModels.Watch>
-    <CoreNodeModels.Watch guid="962dc07d-c213-459c-87b5-f36b7075091f" type="CoreNodeModels.Watch" nickname="watch-1024" x="1423.5" y="550.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
-      <PortInfo index="0" default="False" />
-    </CoreNodeModels.Watch>
   </Elements>
   <Connectors>
-    <Dynamo.Graph.Connectors.ConnectorModel start="dfa4f4e3-6e74-4866-a196-95c2c981ba30" start_index="0" end="14da40b5-f836-4178-85ff-882195917bbc" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="f769c8ab-a865-4681-b41f-0b0c1dfe9fc9" start_index="0" end="69f1ec59-6a8c-49b1-a4d7-6690c6a1e594" end_index="0" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="a2985ad3-2ec3-4b9c-a987-bb86584ca2d2" start_index="0" end="372c04aa-4088-4224-a922-d34fc2869fc1" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="a2985ad3-2ec3-4b9c-a987-bb86584ca2d2" start_index="1" end="58a3e8e3-9648-4253-81c1-cd2960629d70" end_index="0" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="a718b332-346c-4df0-838b-be93b70e1aae" start_index="0" end="231d235b-0d7f-4bd8-b19a-5dda561aea3d" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="a718b332-346c-4df0-838b-be93b70e1aae" start_index="1" end="82b91c7e-e7cf-41e0-b392-ab737326ccaa" end_index="0" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="047660dc-be17-4b29-84ec-1059d9637e07" start_index="0" end="e7bf0921-cf77-4f37-8336-8aa9c56b22a6" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="047660dc-be17-4b29-84ec-1059d9637e07" start_index="1" end="bd3c1997-9785-49d0-acc7-62e168ec3125" end_index="0" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="d74944a0-098c-421d-911f-cf5935aa0d20" start_index="0" end="756497b4-4f7a-4ae3-9e5c-de5f69762d16" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="d74944a0-098c-421d-911f-cf5935aa0d20" start_index="1" end="962dc07d-c213-459c-87b5-f36b7075091f" end_index="0" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />

--- a/test/core/recorded/CodeBlockNode_DefineDictionary.xml
+++ b/test/core/recorded/CodeBlockNode_DefineDictionary.xml
@@ -9,14 +9,14 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="a[&quot;a&quot;..&quot;c&quot;]=1..3;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
+  <UpdateModelValueCommand Name="Code" Value="a;&#xD;&#xA;a[&quot;a&quot;..&quot;c&quot;]=1..3;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
     <ModelGuid>86107112-5c2d-43ae-9d7c-e2d756a80bf3</ModelGuid>
   </UpdateModelValueCommand>
   <PausePlaybackCommand Tag="CreateDictionary" PauseDurationInMs="20" />
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="b[&quot;a&quot;..&quot;c&quot;]=1..3;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
+  <UpdateModelValueCommand Name="Code" Value="b;&#xD;&#xA;b[&quot;a&quot;..&quot;c&quot;]=1..3;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
     <ModelGuid>86107112-5c2d-43ae-9d7c-e2d756a80bf3</ModelGuid>
   </UpdateModelValueCommand>
   <PausePlaybackCommand Tag="ChangeName1" PauseDurationInMs="20" />
@@ -30,7 +30,7 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="c[&quot;a&quot;..&quot;c&quot;]=1..3;&#xA;b;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
+  <UpdateModelValueCommand Name="Code" Value="c;&#xD;&#xA;c[&quot;a&quot;..&quot;c&quot;]=1..3;&#xA;b;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
     <ModelGuid>86107112-5c2d-43ae-9d7c-e2d756a80bf3</ModelGuid>
   </UpdateModelValueCommand>
   <PausePlaybackCommand Tag="ChangeName3" PauseDurationInMs="20" />


### PR DESCRIPTION
### Purpose

This PR is to fix issue that input port is created for variable that defined in code block node. For example, in the following picture, though `v` is defined in code block node, as `v` is referenced in the first assignment, code block node still creates an input port for `v`:

![image](https://cloud.githubusercontent.com/assets/2600379/19442040/80b60384-94ba-11e6-99a3-253bd27ac19c.png)

Because of this input port, the result of this graph is confusing if connecting some value to `v` and then  the assignment of `v = 8` updates value of `a` later. Now code block node won't create input port for a variable if it is defined in the scope. 

Besides, code block node won't create an output port for array indexing expression. For example, the following code block node creates an output port for `a[0] = 21`. 

![untitled](https://cloud.githubusercontent.com/assets/2600379/19442683/c535b3c2-94bc-11e6-982f-89a645c07fe7.png)

Generating output port for array indexing expression may generate weird result if the whole array is updated later on. 

Following picture shows new behavior:

![untitled](https://cloud.githubusercontent.com/assets/2600379/19442861/654ea2f6-94bd-11e6-8784-dd128627cfe4.png)



### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@monikaprabhu @riteshchandawar @Benglin @kronz 
