### PR TITLE
Number node only accepts numerical input:

### DIFF
--- a/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
+++ b/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
@@ -201,8 +201,14 @@ namespace Dynamo.Nodes
                     // data source (also record the update for undo).
 
                     if (false == recordForUndo)
-                        expr.UpdateSource();
-                    else if (nvm != null)
+                    {
+                        if (expr.ValidateWithoutUpdate())
+                        {
+                            expr.UpdateSource();
+                        }
+                    }
+
+                    else if (nvm != null && expr.ValidateWithoutUpdate())
                     {
                         string propName = expr.ParentBinding.Path.Path;
                         nvm.DynamoViewModel.ExecuteCommand(

--- a/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
+++ b/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
@@ -201,7 +201,8 @@ namespace Dynamo.Nodes
                     // data source (also record the update for undo).
 
                     if (false == recordForUndo)
-                    {
+                    {   //when first bound we do not update the
+                        //source unless the input text is valid
                         if (expr.ValidateWithoutUpdate())
                         {
                             expr.UpdateSource();
@@ -215,6 +216,11 @@ namespace Dynamo.Nodes
                             new DynamoModel.UpdateModelValueCommand(
                                 nodeViewModel.WorkspaceViewModel.Model.Guid,
                                 nvm.NodeModel.GUID, propName, Text));
+                    }
+
+                    if (expr.HasValidationError && nvm != null)
+                    {
+                        nvm.NodeModel.Error(expr.ValidationError.ErrorContent as string);
                     }
                 }
 

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -155,7 +155,7 @@ namespace CoreNodeModels.Input
                 }
                 else
                 {
-                    Error("Input Must Be Number");
+                    Error(Resources.NumberNodeInputMustBeNumeric);
                 }
             }
         }

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -108,7 +108,7 @@ namespace CoreNodeModels.Input
             //ws.DynamoModel.PreferenceSettings.PropertyChanged += Preferences_PropertyChanged;
         }
 
-    public virtual double Convert(double value)
+        public virtual double Convert(double value)
         {
             return value;
         }

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -109,16 +109,16 @@ namespace CoreNodeModels.Input
         }
 
         //if the string can be parsed to a common numeric type return true
-        private bool validateInput(string value)
+        internal bool validateInput(string value)
         {
             bool canConvert = false;
 
             int intVal;
-            var canConvertInt = int.TryParse(value, out intVal);
+            var canConvertInt = int.TryParse(value,NumberStyles.Integer,CultureInfo.InvariantCulture, out intVal);
             double doubleVal;
-            var canConvertDouble = double.TryParse(value, out doubleVal);
+            var canConvertDouble = double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out doubleVal);
             long longVal;
-            var canConvertLong = long.TryParse(value, out longVal);
+            var canConvertLong = long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out longVal);
 
             canConvert = canConvertInt || canConvertDouble || canConvertLong;
 

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -103,12 +103,28 @@ namespace CoreNodeModels.Input
 
             ShouldDisplayPreviewCore = false;
             ConvertToken = Convert;
-            Value = "0";
+            NumericalValue = "0";
 
             //ws.DynamoModel.PreferenceSettings.PropertyChanged += Preferences_PropertyChanged;
         }
 
-        public virtual double Convert(double value)
+        private bool validateInput(string value)
+        {
+            bool canConvert = false;
+
+            int intVal;
+            var canConvertInt = int.TryParse(value, out intVal);
+            double doubleVal;
+            var canConvertDouble = double.TryParse(value, out doubleVal);
+            long longVal;
+            var canConvertLong = long.TryParse(value, out longVal);
+
+            canConvert = canConvertInt || canConvertDouble || canConvertLong;
+
+            return canConvert;
+    }
+
+    public virtual double Convert(double value)
         {
             return value;
         }
@@ -126,6 +142,23 @@ namespace CoreNodeModels.Input
         private List<IDoubleSequence> _parsed;
         private string _value;
         protected ConversionDelegate ConvertToken;
+
+        public string NumericalValue {
+            get { return _value; }
+            set
+            {
+                if (_value != null && _value.Equals(value))
+                    return;
+                if (validateInput(value))
+                {
+                    Value = value;
+                }
+                else
+                {
+                    Error("Input Must Be Number");
+                }
+            }
+        }
 
         public string Value
         {
@@ -181,6 +214,11 @@ namespace CoreNodeModels.Input
             if (name == "Value")
             {
                 Value = value;
+                return true; // UpdateValueCore handled.
+            }
+            if (name == "NumericalValue")
+            {
+                NumericalValue = value;
                 return true; // UpdateValueCore handled.
             }
 

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -128,22 +128,11 @@ namespace CoreNodeModels.Input
         protected ConversionDelegate ConvertToken;
 
         /// <summary>
-        /// This property sets the value of the number node, but validates
-        /// that the input is numeric first - it does not allow range syntax
+        /// This property sets the value of the number node, but is validated
+        /// on the view - it does not allow range syntax
         /// or unassigned identifier syntax.i.e *start..end*
-        /// This property should be used going forward from Dynamo 1.2.
+        /// This property is only validated for new user input.
         /// </summary>
-        public string NumericalValue {
-            get { return _value; }
-            set
-            {
-                if (_value != null && _value.Equals(value))
-                    return;
-                Value = value; }
-            }
-        
-
-        [Obsolete("Please use the NumericalValue property, this property still exists for backwards comptability")]
         public string Value
         {
             get { return _value; }
@@ -201,13 +190,6 @@ namespace CoreNodeModels.Input
                 Value = value;
                 return true; // UpdateValueCore handled.
             }
-            //UI is now bound to NumericalValue so we must handle that update value.
-            if (name == "NumericalValue")
-            {
-                NumericalValue = value;
-                return true; // UpdateValueCore handled.
-            }
-
             return base.UpdateValueCore(updateValueParams);
         }
 

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -103,27 +103,10 @@ namespace CoreNodeModels.Input
 
             ShouldDisplayPreviewCore = false;
             ConvertToken = Convert;
-            NumericalValue = "0";
+            Value = "0";
 
             //ws.DynamoModel.PreferenceSettings.PropertyChanged += Preferences_PropertyChanged;
         }
-
-        //if the string can be parsed to a common numeric type return true
-        internal bool validateInput(string value)
-        {
-            bool canConvert = false;
-
-            int intVal;
-            var canConvertInt = int.TryParse(value,NumberStyles.Integer,CultureInfo.InvariantCulture, out intVal);
-            double doubleVal;
-            var canConvertDouble = double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out doubleVal);
-            long longVal;
-            var canConvertLong = long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out longVal);
-
-            canConvert = canConvertInt || canConvertDouble || canConvertLong;
-
-            return canConvert;
-    }
 
     public virtual double Convert(double value)
         {
@@ -156,16 +139,9 @@ namespace CoreNodeModels.Input
             {
                 if (_value != null && _value.Equals(value))
                     return;
-                if (validateInput(value))
-                {
-                    Value = value;
-                }
-                else
-                {
-                    Error(Resources.NumberNodeInputMustBeNumeric);
-                }
+                Value = value; }
             }
-        }
+        
 
         [Obsolete("Please use the NumericalValue property, this property still exists for backwards comptability")]
         public string Value

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -108,6 +108,7 @@ namespace CoreNodeModels.Input
             //ws.DynamoModel.PreferenceSettings.PropertyChanged += Preferences_PropertyChanged;
         }
 
+        //if the string can be parsed to a common numeric type return true
         private bool validateInput(string value)
         {
             bool canConvert = false;
@@ -143,6 +144,12 @@ namespace CoreNodeModels.Input
         private string _value;
         protected ConversionDelegate ConvertToken;
 
+        /// <summary>
+        /// This property sets the value of the number node, but validates
+        /// that the input is numeric first - it does not allow range syntax
+        /// or unassigned identifier syntax.i.e *start..end*
+        /// This property should be used going forward from Dynamo 1.2.
+        /// </summary>
         public string NumericalValue {
             get { return _value; }
             set
@@ -160,6 +167,7 @@ namespace CoreNodeModels.Input
             }
         }
 
+        [Obsolete("Please use the NumericalValue property, this property still exists for backwards comptability")]
         public string Value
         {
             get { return _value; }
@@ -211,11 +219,13 @@ namespace CoreNodeModels.Input
             string name = updateValueParams.PropertyName;
             string value = updateValueParams.PropertyValue;
 
+            //We must still handle Value updates from deserialization or webUI.
             if (name == "Value")
             {
                 Value = value;
                 return true; // UpdateValueCore handled.
             }
+            //UI is now bound to NumericalValue so we must handle that update value.
             if (name == "NumericalValue")
             {
                 NumericalValue = value;

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -184,7 +184,6 @@ namespace CoreNodeModels.Input
             string name = updateValueParams.PropertyName;
             string value = updateValueParams.PropertyValue;
 
-            //We must still handle Value updates from deserialization or webUI.
             if (name == "Value")
             {
                 Value = value;

--- a/src/Libraries/CoreNodeModels/Properties/AssemblyInfo.cs
+++ b/src/Libraries/CoreNodeModels/Properties/AssemblyInfo.cs
@@ -12,3 +12,4 @@ using System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo("DynamoCoreTests")]
 [assembly: InternalsVisibleTo("DynamoCoreWpfTests")]
+[assembly: InternalsVisibleTo("DSCoreNodesTests")]

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -808,6 +808,15 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The input must be numeric..
+        /// </summary>
+        public static string NumberNodeInputMustBeNumeric {
+            get {
+                return ResourceManager.GetString("NumberNodeInputMustBeNumeric", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Boolean OR: Returns true if either of the inputs are true. If neither are true, returns false..
         /// </summary>
         public static string OrDescription {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -581,4 +581,7 @@
   <data name="SelectionPointsOutputPortName" xml:space="preserve">
     <value>Points</value>
   </data>
+  <data name="NumberNodeInputMustBeNumeric" xml:space="preserve">
+    <value>The input must be numeric.</value>
+  </data>
 </root>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -581,4 +581,7 @@
   <data name="SelectionPointsOutputPortName" xml:space="preserve">
     <value>Points</value>
   </data>
+  <data name="NumberNodeInputMustBeNumeric" xml:space="preserve">
+    <value>The input must be numeric.</value>
+  </data>
 </root>

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
@@ -8,6 +8,7 @@ using CoreNodeModels.Input;
 using Dynamo.Controls;
 using Dynamo.Nodes;
 using Dynamo.Wpf;
+using CoreNodeModels.Properties;
 
 namespace CoreNodeModelsWpf.Nodes
 {
@@ -16,39 +17,29 @@ namespace CoreNodeModelsWpf.Nodes
         //if the string can be parsed to a common numeric type return true
         internal bool validateInput(string value)
         {
-            bool canConvert = false;
-
-            int intVal;
-            var canConvertInt = int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out intVal);
             double doubleVal;
-            var canConvertDouble = double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out doubleVal);
             long longVal;
-            var canConvertLong = long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out longVal);
 
-            canConvert = canConvertInt || canConvertDouble || canConvertLong;
-
-            return canConvert;
+            if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out doubleVal)
+                || long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out longVal))
+            {
+                return true;
+            }
+            return false;
         }
 
         public override ValidationResult Validate(object value, CultureInfo cultureInfo)
         {
-            try
+
+            if (!validateInput(value as string))
             {
-                if (!validateInput(value as string))
-                {
-                    return new ValidationResult(false, "non numeric input");
-                }
-                else
-                {
-                    return new ValidationResult(true, null);
-                }
+                return new ValidationResult(false, Resources.NumberNodeInputMustBeNumeric);
             }
-            catch
+            else
             {
-                return new ValidationResult(false, "trouble parsing input");
+                return new ValidationResult(true, null);
             }
         }
-    }
    
     public class DoubleInputNodeViewCustomization : INodeViewCustomization<DoubleInput>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
@@ -40,43 +40,42 @@ namespace CoreNodeModelsWpf.Nodes
                 return new ValidationResult(true, null);
             }
         }
-
-        public class DoubleInputNodeViewCustomization : INodeViewCustomization<DoubleInput>
+   
+    public class DoubleInputNodeViewCustomization : INodeViewCustomization<DoubleInput>
+    {
+        public void CustomizeView(DoubleInput nodeModel, NodeView nodeView)
         {
-            public void CustomizeView(DoubleInput nodeModel, NodeView nodeView)
+            //add a text box to the input grid of the control
+            var tb = new DynamoTextBox(nodeModel.Value ?? "0.0")
             {
-                //add a text box to the input grid of the control
-                var tb = new DynamoTextBox(nodeModel.Value ?? "0.0")
-                {
-                    HorizontalAlignment = HorizontalAlignment.Stretch,
-                    VerticalAlignment = VerticalAlignment.Stretch,
-                    Background =
-                        new SolidColorBrush(Color.FromArgb(0x88, 0xFF, 0xFF, 0xFF))
-                };
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                Background =
+                    new SolidColorBrush(Color.FromArgb(0x88, 0xFF, 0xFF, 0xFF))  
+            };
 
-                nodeView.inputGrid.Children.Add(tb);
-                Grid.SetColumn(tb, 0);
-                Grid.SetRow(tb, 0);
+            nodeView.inputGrid.Children.Add(tb);
+            Grid.SetColumn(tb, 0);
+            Grid.SetRow(tb, 0);
 
-                tb.DataContext = nodeModel;
-                var textToValueBinding = new Binding("Value")
-                {
-                    Mode = BindingMode.TwoWay,
-                    Converter = new DoubleInputDisplay(),
-                    NotifyOnValidationError = false,
-                    Source = nodeModel,
-                    UpdateSourceTrigger = UpdateSourceTrigger.Explicit
-                };
-                var numericalValidation = new NumericValidationRule();
-                numericalValidation.ValidationStep = ValidationStep.ConvertedProposedValue;
-                textToValueBinding.ValidationRules.Add(numericalValidation);
-                tb.BindToProperty(textToValueBinding);
-                Validation.SetErrorTemplate(tb, null);
-            }
-
-            public void Dispose()
+            tb.DataContext = nodeModel;
+            var textToValueBinding = new Binding("Value")
             {
-            }
+                Mode = BindingMode.TwoWay,
+                Converter = new DoubleInputDisplay(),
+                NotifyOnValidationError = false,
+                Source = nodeModel,
+                UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+            };
+            var numericalValidation = new NumericValidationRule();
+            numericalValidation.ValidationStep = ValidationStep.ConvertedProposedValue;
+            textToValueBinding.ValidationRules.Add(numericalValidation);
+            tb.BindToProperty(textToValueBinding);
+            Validation.SetErrorTemplate(tb, null);
+        }
+
+        public void Dispose()
+        {
         }
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
@@ -11,7 +11,7 @@ using Dynamo.Wpf;
 
 namespace CoreNodeModelsWpf.Nodes
 {
-    public class NumericValidationRule : ValidationRule
+    internal class NumericValidationRule : ValidationRule
     {
         //if the string can be parsed to a common numeric type return true
         internal bool validateInput(string value)

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
@@ -40,42 +40,43 @@ namespace CoreNodeModelsWpf.Nodes
                 return new ValidationResult(true, null);
             }
         }
-   
-    public class DoubleInputNodeViewCustomization : INodeViewCustomization<DoubleInput>
-    {
-        public void CustomizeView(DoubleInput nodeModel, NodeView nodeView)
+
+        public class DoubleInputNodeViewCustomization : INodeViewCustomization<DoubleInput>
         {
-            //add a text box to the input grid of the control
-            var tb = new DynamoTextBox(nodeModel.Value ?? "0.0")
+            public void CustomizeView(DoubleInput nodeModel, NodeView nodeView)
             {
-                HorizontalAlignment = HorizontalAlignment.Stretch,
-                VerticalAlignment = VerticalAlignment.Stretch,
-                Background =
-                    new SolidColorBrush(Color.FromArgb(0x88, 0xFF, 0xFF, 0xFF))  
-            };
+                //add a text box to the input grid of the control
+                var tb = new DynamoTextBox(nodeModel.Value ?? "0.0")
+                {
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    VerticalAlignment = VerticalAlignment.Stretch,
+                    Background =
+                        new SolidColorBrush(Color.FromArgb(0x88, 0xFF, 0xFF, 0xFF))
+                };
 
-            nodeView.inputGrid.Children.Add(tb);
-            Grid.SetColumn(tb, 0);
-            Grid.SetRow(tb, 0);
+                nodeView.inputGrid.Children.Add(tb);
+                Grid.SetColumn(tb, 0);
+                Grid.SetRow(tb, 0);
 
-            tb.DataContext = nodeModel;
-            var textToValueBinding = new Binding("Value")
+                tb.DataContext = nodeModel;
+                var textToValueBinding = new Binding("Value")
+                {
+                    Mode = BindingMode.TwoWay,
+                    Converter = new DoubleInputDisplay(),
+                    NotifyOnValidationError = false,
+                    Source = nodeModel,
+                    UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+                };
+                var numericalValidation = new NumericValidationRule();
+                numericalValidation.ValidationStep = ValidationStep.ConvertedProposedValue;
+                textToValueBinding.ValidationRules.Add(numericalValidation);
+                tb.BindToProperty(textToValueBinding);
+                Validation.SetErrorTemplate(tb, null);
+            }
+
+            public void Dispose()
             {
-                Mode = BindingMode.TwoWay,
-                Converter = new DoubleInputDisplay(),
-                NotifyOnValidationError = false,
-                Source = nodeModel,
-                UpdateSourceTrigger = UpdateSourceTrigger.Explicit
-            };
-            var numericalValidation = new NumericValidationRule();
-            numericalValidation.ValidationStep = ValidationStep.ConvertedProposedValue;
-            textToValueBinding.ValidationRules.Add(numericalValidation);
-            tb.BindToProperty(textToValueBinding);
-            Validation.SetErrorTemplate(tb, null);
-        }
-
-        public void Dispose()
-        {
+            }
         }
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
@@ -40,6 +40,7 @@ namespace CoreNodeModelsWpf.Nodes
                 return new ValidationResult(true, null);
             }
         }
+    }
    
     public class DoubleInputNodeViewCustomization : INodeViewCustomization<DoubleInput>
     {

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
@@ -55,7 +55,7 @@ namespace CoreNodeModelsWpf.Nodes
         public void CustomizeView(DoubleInput nodeModel, NodeView nodeView)
         {
             //add a text box to the input grid of the control
-            var tb = new DynamoTextBox(nodeModel.NumericalValue ?? "0.0")
+            var tb = new DynamoTextBox(nodeModel.Value ?? "0.0")
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch,

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/DoubleInput.cs
@@ -14,7 +14,7 @@ namespace CoreNodeModelsWpf.Nodes
         public void CustomizeView(DoubleInput nodeModel, NodeView nodeView)
         {
             //add a text box to the input grid of the control
-            var tb = new DynamoTextBox(nodeModel.Value ?? "0.0")
+            var tb = new DynamoTextBox(nodeModel.NumericalValue ?? "0.0")
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch,
@@ -28,7 +28,7 @@ namespace CoreNodeModelsWpf.Nodes
 
             tb.DataContext = nodeModel;
 
-            tb.BindToProperty(new Binding("Value")
+            tb.BindToProperty(new Binding("NumericalValue")
             {
                 Mode = BindingMode.TwoWay,
                 Converter = new DoubleInputDisplay(),

--- a/test/DynamoCoreWpfTests/ConverterTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterTests.cs
@@ -18,6 +18,7 @@ using Dynamo.UI.Controls;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.ViewModels;
 using NUnit.Framework;
+using CoreNodeModelsWpf.Nodes;
 
 namespace Dynamo.Tests
 {
@@ -682,5 +683,38 @@ namespace Dynamo.Tests
             equal = converter.Convert(objects, typeof(float), null, new CultureInfo("de-DE"));
             Assert.AreEqual(equal, true);
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void validateNumericFailsOnNonNumericInputs()
+        {
+            var numericalRule = new NumericValidationRule();
+
+            Assert.IsFalse(numericalRule.Validate("0..10",CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("0..10..2", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("0..10..5", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("0..10..#5", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("0.0..10..0.5", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("start..end", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("a..b", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("a..10", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("a", CultureInfo.InvariantCulture).IsValid);
+
+        }
+        [Test]
+        [Category("UnitTests")]
+        public static void validateNumericPassesOnNumericInputs()
+        {
+            var numericalRule = new NumericValidationRule();
+
+            Assert.IsTrue(numericalRule.Validate("10", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(numericalRule.Validate("2147483647", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(numericalRule.Validate("9223372036854775807", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(numericalRule.Validate(".00000000001", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(numericalRule.Validate("100,000,000", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(numericalRule.Validate("1,2", CultureInfo.InvariantCulture).IsValid);
+
+        }
+
     }
 }

--- a/test/DynamoCoreWpfTests/ConverterTests.cs
+++ b/test/DynamoCoreWpfTests/ConverterTests.cs
@@ -18,7 +18,6 @@ using Dynamo.UI.Controls;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.ViewModels;
 using NUnit.Framework;
-using CoreNodeModelsWpf.Nodes;
 
 namespace Dynamo.Tests
 {
@@ -683,38 +682,5 @@ namespace Dynamo.Tests
             equal = converter.Convert(objects, typeof(float), null, new CultureInfo("de-DE"));
             Assert.AreEqual(equal, true);
         }
-
-        [Test]
-        [Category("UnitTests")]
-        public static void validateNumericFailsOnNonNumericInputs()
-        {
-            var numericalRule = new NumericValidationRule();
-
-            Assert.IsFalse(numericalRule.Validate("0..10",CultureInfo.InvariantCulture).IsValid);
-            Assert.IsFalse(numericalRule.Validate("0..10..2", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsFalse(numericalRule.Validate("0..10..5", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsFalse(numericalRule.Validate("0..10..#5", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsFalse(numericalRule.Validate("0.0..10..0.5", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsFalse(numericalRule.Validate("start..end", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsFalse(numericalRule.Validate("a..b", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsFalse(numericalRule.Validate("a..10", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsFalse(numericalRule.Validate("a", CultureInfo.InvariantCulture).IsValid);
-
-        }
-        [Test]
-        [Category("UnitTests")]
-        public static void validateNumericPassesOnNumericInputs()
-        {
-            var numericalRule = new NumericValidationRule();
-
-            Assert.IsTrue(numericalRule.Validate("10", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsTrue(numericalRule.Validate("2147483647", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsTrue(numericalRule.Validate("9223372036854775807", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsTrue(numericalRule.Validate(".00000000001", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsTrue(numericalRule.Validate("100,000,000", CultureInfo.InvariantCulture).IsValid);
-            Assert.IsTrue(numericalRule.Validate("1,2", CultureInfo.InvariantCulture).IsValid);
-
-        }
-
     }
 }

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -15,6 +15,8 @@ using Dynamo.Utilities;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
 using CoreNodeModels.Input;
+using CoreNodeModelsWpf.Nodes;
+using System.Globalization;
 
 namespace DynamoCoreWpfTests
 {
@@ -134,6 +136,41 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(number.IsInErrorState);
 
         }
+
+        //these tests live here as they have a dependencey on CoreNodesWpf which
+        //is only accessible at test time after it is loaded via Dynamo 
+        [Test]
+        [Category("UnitTests")]
+        public static void validateNumericFailsOnNonNumericInputs()
+        {
+            var numericalRule = new NumericValidationRule();
+
+            Assert.IsFalse(numericalRule.Validate("0..10", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("0..10..2", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("0..10..5", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("0..10..#5", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("0.0..10..0.5", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("start..end", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("a..b", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("a..10", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsFalse(numericalRule.Validate("a", CultureInfo.InvariantCulture).IsValid);
+
+        }
+        [Test]
+        [Category("UnitTests")]
+        public static void validateNumericPassesOnNumericInputs()
+        {
+            var numericalRule = new NumericValidationRule();
+
+            Assert.IsTrue(numericalRule.Validate("10", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(numericalRule.Validate("2147483647", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(numericalRule.Validate("9223372036854775807", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(numericalRule.Validate(".00000000001", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(numericalRule.Validate("100,000,000", CultureInfo.InvariantCulture).IsValid);
+            Assert.IsTrue(numericalRule.Validate("1,2", CultureInfo.InvariantCulture).IsValid);
+
+        }
+
 
         [Test]
         public void IntegerSliderHasSliderAndCorrectValues()

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -14,6 +14,7 @@ using Dynamo.Nodes;
 using Dynamo.Utilities;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
+using CoreNodeModels.Input;
 
 namespace DynamoCoreWpfTests
 {
@@ -102,6 +103,36 @@ namespace DynamoCoreWpfTests
 
             var element = nodeView.ChildrenOfType<DynamoSlider>().First();
             Assert.AreEqual(1.0, element.slider.Value, 1e-6);
+        }
+
+        [Test]
+        public void doubleInputNodeWillNotAcceptRangeSyntax()
+        {
+            var number = new DoubleInput();
+            Model.AddNodeToCurrentWorkspace(number, true);
+            DispatcherUtil.DoEvents();
+            var nodeView = NodeViewWithGuid(number.GUID.ToString());
+            nodeView.inputGrid.ChildrenOfType<DynamoTextBox>().First().Text = "0..10";
+            DispatcherUtil.DoEvents();
+            Assert.IsTrue(number.Value != "0..10");
+            Assert.IsTrue(number.Value == "0");
+            Assert.IsTrue(number.IsInErrorState);
+
+        }
+
+        [Test]
+        public void doubleInputNodeWillNotAcceptIds()
+        {
+            var number = new DoubleInput();
+            Model.AddNodeToCurrentWorkspace(number, true);
+            DispatcherUtil.DoEvents();
+            var nodeView = NodeViewWithGuid(number.GUID.ToString());
+            nodeView.inputGrid.ChildrenOfType<DynamoTextBox>().First().Text = "start..end";
+            DispatcherUtil.DoEvents();
+            Assert.IsTrue(number.Value != "start..end");
+            Assert.IsTrue(number.Value == "0");
+            Assert.IsTrue(number.IsInErrorState);
+
         }
 
         [Test]
@@ -422,4 +453,5 @@ namespace DynamoCoreWpfTests
             }
         }
     }
+
 }

--- a/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
+++ b/test/Libraries/CoreNodesTests/CoreNodesTests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="LogicTests.cs" />
     <Compile Include="MathTests.cs" />
     <Compile Include="NodeWithUITests.cs" />
+    <Compile Include="NumberTests.cs" />
     <Compile Include="ObjectTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProtoNodesTests.cs" />

--- a/test/Libraries/CoreNodesTests/NumberTests.cs
+++ b/test/Libraries/CoreNodesTests/NumberTests.cs
@@ -48,7 +48,7 @@ namespace DSCoreNodesTests
 
         [Test]
         [Category("UnitTests")]
-        public static void validateNumericPassesNonNumericInputs()
+        public static void validateNumericPassesOnNumericInputs()
         {
             var number = new DoubleInput();
 

--- a/test/Libraries/CoreNodesTests/NumberTests.cs
+++ b/test/Libraries/CoreNodesTests/NumberTests.cs
@@ -1,0 +1,62 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DSCore;
+using CoreNodeModels.Input;
+
+namespace DSCoreNodesTests
+{
+    class NumberTests
+    {
+
+        [Test]
+        [Category("UnitTests")]
+        public static void SettingNumericalValueToRangeExpressionFails()
+        {
+              var number = new DoubleInput();
+            number.NumericalValue = "0..10";
+            Assert.IsFalse(number.Value == "0..10");
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void SettingValueToRangeExpressionSucceeds()
+        {
+            var number = new DoubleInput();
+            number.Value = "0..10";
+            Assert.True(number.Value == "0..10");
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void validateNumericFailsOnNonNumericInputs()
+        {
+            var number = new DoubleInput();
+
+            Assert.IsFalse(number.validateInput("0..10"));
+            Assert.IsFalse(number.validateInput("0..10..2"));
+            Assert.IsFalse(number.validateInput("0..10..#5"));
+            Assert.IsFalse(number.validateInput("0.0..10..0.5"));
+            Assert.IsFalse(number.validateInput("start..end"));
+            Assert.IsFalse(number.validateInput("a..b"));
+            Assert.IsFalse(number.validateInput("a"));
+
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public static void validateNumericPassesNonNumericInputs()
+        {
+            var number = new DoubleInput();
+
+            Assert.True(number.validateInput("10"));
+            Assert.True(number.validateInput("2147483647"));
+            Assert.True(number.validateInput("9223372036854775807"));
+            Assert.True(number.validateInput(".00000000001"));
+
+        }
+    }
+}

--- a/test/Libraries/CoreNodesTests/NumberTests.cs
+++ b/test/Libraries/CoreNodesTests/NumberTests.cs
@@ -14,15 +14,6 @@ namespace DSCoreNodesTests
 
         [Test]
         [Category("UnitTests")]
-        public static void SettingNumericalValueToRangeExpressionFails()
-        {
-              var number = new DoubleInput();
-            number.NumericalValue = "0..10";
-            Assert.IsFalse(number.Value == "0..10");
-        }
-
-        [Test]
-        [Category("UnitTests")]
         public static void SettingValueToRangeExpressionSucceeds()
         {
             var number = new DoubleInput();
@@ -32,31 +23,20 @@ namespace DSCoreNodesTests
 
         [Test]
         [Category("UnitTests")]
-        public static void validateNumericFailsOnNonNumericInputs()
+        public static void SettingValueToNumberSucceeds()
         {
             var number = new DoubleInput();
-
-            Assert.IsFalse(number.validateInput("0..10"));
-            Assert.IsFalse(number.validateInput("0..10..2"));
-            Assert.IsFalse(number.validateInput("0..10..#5"));
-            Assert.IsFalse(number.validateInput("0.0..10..0.5"));
-            Assert.IsFalse(number.validateInput("start..end"));
-            Assert.IsFalse(number.validateInput("a..b"));
-            Assert.IsFalse(number.validateInput("a"));
-
+            number.Value = "5";
+            Assert.True(number.Value == "5");
         }
 
         [Test]
         [Category("UnitTests")]
-        public static void validateNumericPassesOnNumericInputs()
+        public static void SettingValueToLetterSucceeds()
         {
             var number = new DoubleInput();
-
-            Assert.True(number.validateInput("10"));
-            Assert.True(number.validateInput("2147483647"));
-            Assert.True(number.validateInput("9223372036854775807"));
-            Assert.True(number.validateInput(".00000000001"));
-
+            number.Value = "a";
+            Assert.True(number.Value == "a");
         }
     }
 }


### PR DESCRIPTION
### Purpose

https://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10399

This PR modifies the number node in Dynamo in the following ways:
When the binding is created between the `doubleInput` node model and the `DynamoTextBox` control, a numericValidation rule is added to the binding. This rule is used to validate the input when the `DyanmoText` box attempts to update the source of the binding (the nodeModel value property).

This means that flood updates, and loading value sets should be able to set the value to whatever they want, but user input in Dynamo will be validated.

If a user enters a non numerical string in the number node they get the error: 
`The input must be numeric`

I will send a related flood PR which will basically do the same thing.

I need to run the tests still. **(do not merge yet)**
### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

<img width="731" alt="screen shot 2016-10-17 at 3 41 30 pm" src="https://cloud.githubusercontent.com/assets/508936/19452747/37a6f69c-9480-11e6-85b9-fa5060b779d7.png">


### Reviewers

@QilongTang 

### FYIs

@ikeough 
@Racel 