### PR TITLE
Disable delta computation on code block node

### DIFF
--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -364,15 +364,22 @@ namespace Dynamo.Engine
                 nodes.Where(n => n.NeedsForceExecution)
                      .Select(n => n.GUID));
 
+            var codeBlockNodes = new HashSet<Guid>(
+                nodes.Where(n => n is CodeBlockNodeModel).Select(n => n.GUID));
+
             if (reExecuteNodesIds.Any())
             {
                 for (int i = 0; i < graphSyncdata.ModifiedSubtrees.Count; ++i)
                 {
                     var st = graphSyncdata.ModifiedSubtrees[i];
-                    if (reExecuteNodesIds.Contains(st.GUID))
+                    var forceExecution = reExecuteNodesIds.Contains(st.GUID);
+                    var isCodeBlockNode = codeBlockNodes.Contains(st.GUID);
+                    
+                    if (forceExecution || isCodeBlockNode) 
                     {
                         Subtree newSt = new Subtree(st.AstNodes, st.GUID);
-                        newSt.ForceExecution = true;
+                        newSt.ForceExecution = forceExecution;
+                        newSt.DeltaComputation = !isCodeBlockNode;
                         graphSyncdata.ModifiedSubtrees[i] = newSt;
                     }
                 }

--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -367,7 +367,7 @@ namespace Dynamo.Engine
             var codeBlockNodes = new HashSet<Guid>(
                 nodes.Where(n => n is CodeBlockNodeModel).Select(n => n.GUID));
 
-            if (reExecuteNodesIds.Any())
+            if (reExecuteNodesIds.Any() || codeBlockNodes.Any())
             {
                 for (int i = 0; i < graphSyncdata.ModifiedSubtrees.Count; ++i)
                 {

--- a/src/Engine/ProtoAssociative/CodeGen.cs
+++ b/src/Engine/ProtoAssociative/CodeGen.cs
@@ -1961,6 +1961,7 @@ namespace ProtoAssociative
                 {
                     AssociativeNode lastNode = DFSEmitSplitAssign_AST(bnode.RightNode, ref astList);
                     var newBNode = AstFactory.BuildBinaryExpression(bnode.LeftNode, lastNode, Operator.assign);
+                    newBNode.OriginalAstID = bnode.OriginalAstID;
 
                     astList.Add(newBNode);
                     return bnode.LeftNode;

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -2076,11 +2076,6 @@ namespace ProtoCore.AST.AssociativeAST
         public bool isSSAPointerAssignment { get; set; }
         public bool IsFirstIdentListNode { get; set; }
 
-        // These properties are used only for the GraphUI ProtoAST
-        public uint Guid { get; set; }
-        //private uint splitFromUID = 0;
-        //public uint SplitFromUID { get { return splitFromUID; } set { splitFromUID = value; } }
-
         public BinaryExpressionNode(AssociativeNode left = null, AssociativeNode right = null, Operator optr = Operator.none)
         {
             isSSAAssignment = false;

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -707,7 +707,7 @@ namespace ProtoScript.Runners
                     List<AssociativeNode> deletedExpressions = new List<AssociativeNode>();
                     if (currentSubTreeList.TryGetValue(modifiedSubTree.GUID, out oldSubTree) && oldSubTree.AstNodes != null)
                     {
-                        csData.DeletedFunctionDefASTNodes.AddRange(oldSubTree.AstNodes.Where(f => f is FunctionDefinitionNode));
+                        csData.RemovedFunctionDefNodesFromModification.AddRange(oldSubTree.AstNodes.Where(f => f is FunctionDefinitionNode));
                         deletedExpressions.AddRange(oldSubTree.AstNodes);
                         var nullNodes = BuildNullAssignments(deletedExpressions, modifiedSubTree.GUID);
                         deltaAstList.AddRange(nullNodes);

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -972,9 +972,10 @@ namespace ProtoScript.Runners
                 return astNodeList;
             }
 
-            foreach (var node in astList)
+            Stack<AssociativeNode> workingStack = new Stack<AssociativeNode>(astList);
+            while (workingStack.Any())
             {
-                BinaryExpressionNode bNode = node as BinaryExpressionNode;
+                var bNode = workingStack.Pop() as BinaryExpressionNode;
                 if (bNode == null)
                 {
                     continue;
@@ -989,6 +990,11 @@ namespace ProtoScript.Runners
                 var nullAssignment = AstFactory.BuildAssignment(leftNode, AstFactory.BuildNullNode());
                 nullAssignment.guid = guid;
                 astNodeList.Add(nullAssignment);
+
+                if (bNode.RightNode is BinaryExpressionNode)
+                {
+                    workingStack.Push(bNode.RightNode);
+                }
             }
 
             return astNodeList;

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -276,18 +276,29 @@ namespace ProtoScript.Runners
                 return;
             }
 
-            foreach (var node in nodeList)
+            var workingStack = new Stack<AssociativeNode>(nodeList);
+            var astIDs = new HashSet<int>();
+
+            while (workingStack.Any())
             {
-                BinaryExpressionNode bNode = node as BinaryExpressionNode;
-                if (bNode != null)
+                var node = workingStack.Pop() as BinaryExpressionNode;
+                if (node != null)
                 {
-                    foreach (var gnode in core.DSExecutable.instrStreamList[0].dependencyGraph.GraphList)
-                    {
-                        if (gnode.OriginalAstID == bNode.OriginalAstID)
-                        {
-                            gnode.isActive = false;
-                        }
-                    }
+                    astIDs.Add(node.OriginalAstID);
+                    workingStack.Push(node.RightNode);
+                }
+            }
+
+            if (!astIDs.Any())
+            {
+                return;
+            }
+
+            foreach (var gnode in core.DSExecutable.instrStreamList[0].dependencyGraph.GraphList)
+            {
+                if (astIDs.Contains(gnode.OriginalAstID))
+                {
+                    gnode.isActive = false;
                 }
             }
         }

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -714,7 +714,10 @@ namespace ProtoScript.Runners
                 }
                 else
                 {
-                    // No delta computation.
+                    // No delta computation. 
+                    // Right now it is only disabled for code block node, but we may
+                    // completely disable it. Details about why doing so:
+                    // https://github.com/DynamoDS/Dynamo/pull/7282
                     Subtree oldSubTree;
                     List<AssociativeNode> deletedExpressions = new List<AssociativeNode>();
                     if (currentSubTreeList.TryGetValue(modifiedSubTree.GUID, out oldSubTree) && oldSubTree.AstNodes != null)

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -29,16 +29,40 @@ namespace ProtoScript.Runners
     /// </summary>
     public struct Subtree
     {
-        public Guid GUID;
+        /// <summary>
+        /// The GUID of corresponding UI node.
+        /// </summary>
+        public Guid GUID
+        {
+            get; private set;
+        }
+
+        /// <summary>
+        /// Specify if all ast nodes should be executed.
+        /// </summary>
+        public bool ForceExecution
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Sepcify if the VM should do delta computation for these ASTs
+        /// By default it is true.
+        /// </summary>
+        public bool DeltaComputation
+        {
+            get; set;
+        } 
+
         public List<AssociativeNode> AstNodes;
         public List<AssociativeNode> ModifiedAstNodes;
-        public bool ForceExecution;
 
         public Subtree(List<AssociativeNode> astNodes, System.Guid guid)
         {
             GUID = guid;
             AstNodes = astNodes;
             ForceExecution = false;
+            DeltaComputation = true;
             ModifiedAstNodes = new List<AssociativeNode>();
         }
 
@@ -789,14 +813,18 @@ namespace ProtoScript.Runners
             {
                 // Check if node exists in the prev AST list
                 bool nodeFound = false;
-                foreach (AssociativeNode prevNode in st.AstNodes)
+                if (subtree.DeltaComputation)
                 {
-                    if (prevNode.Equals(node))
+                    foreach (AssociativeNode prevNode in st.AstNodes)
                     {
-                        nodeFound = true;
-                        break;
+                        if (prevNode.Equals(node))
+                        {
+                            nodeFound = true;
+                            break;
+                        }
                     }
                 }
+
                 if (!nodeFound)
                 {
                     // At this point, the ast was determined to have been modified

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -17,13 +17,6 @@ using ProtoCore.DSASM;
 
 namespace ProtoScript.Runners
 {
-    public enum EventStatus
-    {
-        OK,
-        Error,
-        Warning
-    }
-
     /// <summary>
     /// A subtree represents a node in graph. It contains a list of AST node.
     /// </summary>

--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -226,6 +226,7 @@ namespace ProtoScript.Runners
         {
             DeactivateGraphnodes(changeSet.DeletedBinaryExprASTNodes);
             UndefineFunctions(changeSet.DeletedFunctionDefASTNodes);
+            ProtoCore.AssociativeEngine.Utils.MarkGraphNodesDirtyFromFunctionRedef(runtimeCore, changeSet.DeletedFunctionDefASTNodes);
         }
 
         private void ApplyChangeSetModified(ChangeSetData changeSet)

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -1107,6 +1107,16 @@ namespace Dynamo.Tests
             AssertPreviewValue("e7bf0921-cf77-4f37-8336-8aa9c56b22a6", new object[] { "qux" });
             AssertPreviewValue("756497b4-4f7a-4ae3-9e5c-de5f69762d16", new object[] { 1024 });
         }
+
+        [Test]
+        public void TestMAGN9507()
+        {
+            // x = {1, 2, 3};
+            // x = Count(x);
+            var dynFilePath = Path.Combine(TestDirectory, @"core\dsevaluation\MAGN-9507.dyn");
+            OpenModel(dynFilePath);
+            AssertPreviewValue("3bf992eb-ecc9-4fcc-a90b-9b1ee7e925e9", 3);
+        }
     }
 
     [Category("DSCustomNode")]

--- a/test/Engine/ProtoTest/LiveRunnerTests/ChangeSetComputerTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/ChangeSetComputerTests.cs
@@ -217,7 +217,7 @@ namespace ProtoTest.LiveRunner
             // The list must be in the order that it is expected
             List<string> expectedCode = new List<string>() 
             {
-                "b = 1;"
+                "a = null; b = 1;"
             };
             List<AssociativeNode> expectedAstList = ProtoCore.Utils.CoreUtils.BuildASTList(core, expectedCode);
 
@@ -262,7 +262,7 @@ namespace ProtoTest.LiveRunner
             // The list must be in the order that it is expected
             List<string> expectedCode = new List<string>() 
             {
-                "c = 1;"
+                "b = null; c = null; c = 1;"
             };
             List<AssociativeNode> expectedAstList = ProtoCore.Utils.CoreUtils.BuildASTList(core, expectedCode);
 

--- a/test/Engine/ProtoTest/LiveRunnerTests/ChangeSetComputerTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/ChangeSetComputerTests.cs
@@ -262,7 +262,7 @@ namespace ProtoTest.LiveRunner
             // The list must be in the order that it is expected
             List<string> expectedCode = new List<string>() 
             {
-                "b = null; c = null; c = 1;"
+                "b = null; a = null; c = 1;"
             };
             List<AssociativeNode> expectedAstList = ProtoCore.Utils.CoreUtils.BuildASTList(core, expectedCode);
 

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -2982,7 +2982,6 @@ r = Equals(x, {41, 42});
         }
 
         [Test]
-        [Category("Failure")]
         public void TestCodeBlockDeleteLine01()
         {
             // Tracked in: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4159

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -5505,10 +5505,10 @@ a = p.UpdateCount;
             deleted.Add(subtree);
 
             var guid3 = Guid.NewGuid();
-            var code3 = "__GC();";
+            var code3 = "__GC();z = DisposeTracer.DisposeCount;";
             syncData = new GraphSyncData(deleted, new List<Subtree> { ProtoTestFx.TD.TestFrameWork.CreateSubTreeFromCode(guid3, code3)}, null);
             liveRunner.UpdateGraph(syncData);
-            AssertValue("y", 1);
+            AssertValue("z", 1);
         }
 
         [Test]

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -5209,13 +5209,13 @@ v = foo(t);
 @"
     a = [Imperative]
     {
-        return = 10;
+        return = 20;
     }
 
     b = [Imperative]
     {
     
-        return = 20;
+        return = 30;
     }
 
 
@@ -5226,7 +5226,7 @@ v = foo(t);
         {
             e = 40;
         }
-        return = 50;
+        return = 60;
     }
 ",
 
@@ -5246,12 +5246,18 @@ v = foo(t);
             List<Subtree> modified = new List<Subtree>();
             Subtree subtree = ProtoTestFx.TD.TestFrameWork.CreateSubTreeFromCode(guid1, codes[1]);
             modified.Add(subtree);
+            syncData = new GraphSyncData(null, null, modified);
+            liveRunner.UpdateGraph(syncData);
+            AssertValue("a", 20);
+            AssertValue("b", 30);
+            AssertValue("c", 60);
+            AssertValue("f", null);
 
             // Create a new CBN to add the removed line
             Guid guid2 = System.Guid.NewGuid();
             added = new List<Subtree>();
             added.Add(ProtoTestFx.TD.TestFrameWork.CreateSubTreeFromCode(guid2, codes[2]));
-            syncData = new GraphSyncData(null, added, modified);
+            syncData = new GraphSyncData(null, added, null);
             liveRunner.UpdateGraph(syncData);
             AssertValue("f", 60);
 

--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -892,6 +892,7 @@ namespace ProtoTestFx.TD
         {
             var cbn = ProtoCore.Utils.ParserUtils.Parse(code);
             var subtree = null == cbn ? new Subtree(null, guid) : new Subtree(cbn.Body, guid);
+            subtree.DeltaComputation = false;
             return subtree;
         }
 

--- a/test/core/dsevaluation/MAGN-9507.dyn
+++ b/test/core/dsevaluation/MAGN-9507.dyn
@@ -1,0 +1,22 @@
+<Workspace Version="1.2.1.2931" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="2ac2cd51-7fd9-40aa-a70e-cbf8fe96762a" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="88" y="170" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="{1,2,3};" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="a3d712af-3e73-4c53-8001-055b4c0b78fb" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="286" y="175" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="true" CodeText="x= y;&#xA;x = Count(x);" ShouldFocus="false">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <CoreNodeModels.Watch guid="3bf992eb-ecc9-4fcc-a90b-9b1ee7e925e9" type="CoreNodeModels.Watch" nickname="Watch" x="497" y="184" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="2ac2cd51-7fd9-40aa-a70e-cbf8fe96762a" start_index="0" end="a3d712af-3e73-4c53-8001-055b4c0b78fb" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="a3d712af-3e73-4c53-8001-055b4c0b78fb" start_index="0" end="3bf992eb-ecc9-4fcc-a90b-9b1ee7e925e9" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>

--- a/test/core/recorded/CodeBlockNode_DefineDictionary.xml
+++ b/test/core/recorded/CodeBlockNode_DefineDictionary.xml
@@ -30,7 +30,7 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="c;&#xD;&#xA;c[&quot;a&quot;..&quot;c&quot;]=1..3;&#xA;b;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
+  <UpdateModelValueCommand Name="Code" Value="b;&#xD;&#xA;c[&quot;a&quot;..&quot;c&quot;]=1..3;&#xA;c;" WorkspaceGuid="23bfffaa-4bbe-44c9-bde2-5763578bceca">
     <ModelGuid>86107112-5c2d-43ae-9d7c-e2d756a80bf3</ModelGuid>
   </UpdateModelValueCommand>
   <PausePlaybackCommand Tag="ChangeName3" PauseDurationInMs="20" />


### PR DESCRIPTION
### Purpose

This PR disables delta computation on code block node.

#### Delta computation
Delta computation is a VM feature which takes a series of AST nodes compiled by a Dynamo UI node in an execution session, and computes delta AST nodes of these nodes and cached nodes that it executes in last session, and only executes delta nodes.

For example,  the VM initially runs a code block node: 
```
+--------------+
|  a = 1;      |
|  b = 2;      |
|  c = a + b;  |
+--------------+
```
Then this code block node is modified to
```
+--------------+
|  a = 1;      |
|  b = 3;      |
|  c = a + b;  |
+--------------+
```
Though this code block node sends all AST nodes to the VM, the VM will do delta computation and only executes `b = 3;`. The value of `c` will be updated. 

#### Issues
Though delta computation looks avoids to do unnecessary computation, it fails in some cases. The fundamental issue is delta computation is *temporal* : it depends on both the *last* and *current* states; whereas the whole graph execution is not temporal: the output of the graph should is determined by current state without referring to the previous state. 

Here we show three failure cases.

* Case 1: Self modification

    Code block node below is modified from state 1 to state 2. Delta AST nodes of these two states will be `a[1] = "foo"`. But after execution the value of `a` will be `{"foo", "foo", 3}`, instead of being `{1, "foo", 3}`.
    ```
        state 1                            state 2
    +-----------------+             +-----------------+
    |  a = {1, 2, 3}; |    ====>    |  a = {1, 2, 3}; | 
    |  a[0] = "foo";  |             |  a[1] = "foo";  |
    +-----------------+             +-----------------+
    ```

* Case 2: Multiple assignment to a variable
    Code block node below is modified from state 1 to state 2. Delta AST nodes are empty, so the value `a` will still be `2` instead of being `1`.
    ```
      state 1                   state 2
    +----------+             +----------+
    |  a = 1;  |    ====>    |  a = 1;  | 
    |  a = 2;  |             |          |
    +----------+             +----------+
    ```

* Case 3: Change order
    Code block node below is modified from state 1 to state 2. Delta AST nodes are empty, so the value `a` will still be `2` instead of being `1`.
    ```
      state 1                   state 2
    +----------+             +----------+
    |  a = 1;  |    ====>    |  a = 2;  | 
    |  a = 2;  |             |  a = 1;  |
    +----------+             +----------+
    ```

To make delta computation work correctly, the VM should be able to undo changes. E.g., undoing `a = 2` in case 3 and including this undo operation in delta AST nodes, but it is impossible in current VM implementation, not to mention if some execution incur side-effects on external world (like deleting a file). 

In all, delta computation on code block node should be disabled. In the long term, we might disable delta computation completely.

Note disabling delta computation doesn't fix all issues. It could still fail at the following case where change comes from other node:
```
+----------+         +----------------------+
|  x = 1;  +-------->| x  | a = {1, 2, 3};  | 
|          |         |    | a[x] = "foo";   | 
+----------+         +----------------------+
```
In this case we have to do force re-execution of code block node if any upstream node is modified. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@monikaprabhu @riteshchandawar @Benglin @sharadkjaiswal  @aparajit-pratap 
