### PR TITLE
In-canvas search is dismissed when switching to other windows / when other notification dialogues pops up. 

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -177,7 +177,8 @@
     <Grid Name="mainGrid"
           FocusManager.IsFocusScope="True"
           PreviewMouseDown="Window_PreviewMouseDown"
-          PreviewMouseUp="Window_PreviewMouseUp">
+          PreviewMouseUp="Window_PreviewMouseUp"
+          PreviewMouseLeftButtonUp="Window_PreviewMouseLeftButtonUp">
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -601,7 +601,6 @@ namespace Dynamo.Controls
         /// <summary>
         /// Close Popup when the Dynamo window is not in the foreground.
         /// </summary>
-        /// <param name="flag"></param>
 
         private void HidePopupWhenWindowDeactivated()
         {
@@ -1706,8 +1705,7 @@ namespace Dynamo.Controls
 
         private void Window_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
-            var workspace = this.ChildOfType<WorkspaceView>();
-            workspace.HidePopUp();
+            HidePopupWhenWindowDeactivated();
         }
 
         public void Dispose()

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -593,20 +593,23 @@ namespace Dynamo.Controls
             // In native host scenario (e.g. Revit), the "Application.Current" will be "null". Therefore, the InCanvasSearchControl.OnRequestShowInCanvasSearch
             // will not work. Instead, we have to check if the Owner Window (DynamoView) is deactivated or not.  
             if (Application.Current == null)
-                {
+            {
                 this.Deactivated += (s, args) => { HidePopupWhenWindowDeactivated(); };
-                }
+            }
         }
+
         /// <summary>
         /// Close Popup when the Dynamo window is not in the foreground.
         /// </summary>
         /// <param name="flag"></param>
+
         private void HidePopupWhenWindowDeactivated()
         {
             var workspace = this.ChildOfType<WorkspaceView>();
             workspace.HidePopUp();
          }
-    private void TrackStartupAnalytics()
+
+        private void TrackStartupAnalytics()
         {
             if (!Analytics.ReportingAnalytics) return;
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -589,9 +589,24 @@ namespace Dynamo.Controls
             };
             BackgroundPreview.SetBinding(VisibilityProperty, vizBinding);
             TrackStartupAnalytics();
-        }
 
-        private void TrackStartupAnalytics()
+            // In native host scenario (e.g. Revit), the "Application.Current" will be "null". Therefore, the InCanvasSearchControl.OnRequestShowInCanvasSearch
+            // will not work. Instead, we have to check if the Owner Window (DynamoView) is deactivated or not.  
+            if (Application.Current == null)
+                {
+                this.Deactivated += (s, args) => { HidePopupWhenWindowDeactivated(); };
+                }
+        }
+        /// <summary>
+        /// Close Popup when the Dynamo window is not in the foreground.
+        /// </summary>
+        /// <param name="flag"></param>
+        private void HidePopupWhenWindowDeactivated()
+        {
+            var workspace = this.ChildOfType<WorkspaceView>();
+            workspace.HidePopUp();
+         }
+    private void TrackStartupAnalytics()
         {
             if (!Analytics.ReportingAnalytics) return;
 
@@ -1684,6 +1699,12 @@ namespace Dynamo.Controls
         private void Log(string message)
         {
             Log(LogMessage.Info(message));
+        }
+
+        private void Window_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            var workspace = this.ChildOfType<WorkspaceView>();
+            workspace.HidePopUp();
         }
 
         public void Dispose()

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -170,7 +170,6 @@ namespace Dynamo.Views
         /// <summary>
         /// Hides Context Menu as well as InCanvasControl (Right Click PopUp)
         /// </summary>
-        /// <param name="flag"></param>
         public void HidePopUp()
         {
             if (InCanvasSearchBar.IsOpen || ContextMenuPopup.IsOpen)

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -179,7 +179,7 @@ namespace Dynamo.Views
             }
         }
 
-    internal Point GetCenterPoint()
+        internal Point GetCenterPoint()
         {
             var x = outerCanvas.ActualWidth / 2.0;
             var y = outerCanvas.ActualHeight / 2.0;

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -167,7 +167,20 @@ namespace Dynamo.Views
             }
         }
 
-        internal Point GetCenterPoint()
+        /// <summary>
+        /// Hides Context Menu as well as InCanvasControl (Right Click PopUp)
+        /// </summary>
+        /// <param name="flag"></param>
+        public void HidePopUp()
+        {
+            if (InCanvasSearchBar.IsOpen || ContextMenuPopup.IsOpen)
+            {
+                ShowHideContextMenu(ShowHideFlags.Hide);
+                ShowHideInCanvasControl(ShowHideFlags.Hide);
+            }
+        }
+
+    internal Point GetCenterPoint()
         {
             var x = outerCanvas.ActualWidth / 2.0;
             var y = outerCanvas.ActualHeight / 2.0;


### PR DESCRIPTION
### Purpose

This PR is meant to resolve the issue in _MAGN-10569_. The previous PR (https://github.com/DynamoDS/Dynamo/pull/7249) caused the `Menu Items` in the `ContextMenu` to break. 

While I'm still not entirely clear why changing the `StaysOpen` toggle to `False` in the Popup menu would cause the break, I suspect that it has to do with the way `ContextMenuPopup` and `InCanvasSearchBar` is linked to the `InCanvasSearchControl` for UI Controls. 

After much investigation, however, I could not find a way to fix the `StaysOpen` option. Instead, I tried to find a workaround to dismiss the Popup. This PR also approaches the problem from a different way (targeting the `Main Grid` of DynamoView.xaml) as compared to the previous fix (https://github.com/DynamoDS/Dynamo/pull/7272) - which was cumbersome in nature and required a tagging of every dialog window which opened in DynamoView.

This PR contains the workaround which I implemented to dismiss the Context Menu Popup whenever:
1. The `OwnerWindow` is not Dynamo (i.e. when the Dynamo window is not in the foreground).
2. A dialog popups (be it 'Save Workspace' or 'Export Image' or 'About Window' etc.)
### Declarations

Check these if you believe they are true
- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (_No change of public methods or types etc.._)
### Reviewers

@ke-yu 
### FYIs

@jnealb , @riteshchandawar 
