### PR TITLE
Fix package manager test failures

### DIFF
--- a/src/DynamoCore/Configuration/PathManager.cs
+++ b/src/DynamoCore/Configuration/PathManager.cs
@@ -203,10 +203,8 @@ namespace Dynamo.Core
             {
                 if (!Directory.Exists(path))
                 {
-                    throw new Exception(String.Format(Resources.NoBinFolder, path));
-                }
-                  
-
+                    throw new Exception(String.Format(Resources.DirectoryNotFound, path));
+                }                 
                 additionalResolutionPaths.Add(path);
             }
         }

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -349,6 +349,15 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Directory not found : {0}.
+        /// </summary>
+        public static string DirectoryNotFound {
+            get {
+                return ResourceManager.GetString("DirectoryNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The virtual machine that powers Dynamo is experiencing some unexpected errors internally and is likely &quot;having great difficulties pulling itself together. It is &quot;recommended that you save your work now and reload the file. Giving the Dynamo VM a new lease of life can potentially make it feel happier and behave better. 
         ///
         ///If you don&apos;t mind, it would be helpful for you to send us your file. That will make it quicker for us to get these issues fixed..
@@ -815,15 +824,6 @@ namespace Dynamo.Properties {
         public static string NewNoteString {
             get {
                 return ResourceManager.GetString("NewNoteString", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} contains a package without a bin folder.  Ignoring it..
-        /// </summary>
-        public static string NoBinFolder {
-            get {
-                return ResourceManager.GetString("NoBinFolder", resourceCulture);
             }
         }
         

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -353,7 +353,7 @@ Sorry about that.</value>
     <value>The package was found to be empty and was not installed.</value>
   </data>
   <data name="PackageTooLarge" xml:space="preserve">
-    <value>The package is too large!  The package must be less than 1 GB!</value>
+    <value>The package is too large!  The package must be less than 15 MB!</value>
   </data>
   <data name="PathNotRegconizableAsStableOrDailyBuild" xml:space="preserve">
     <value>The specified file path is not recognizable as a stable or a daily build</value>
@@ -622,8 +622,8 @@ value : bool = false</value>
   <data name="CodeBlockSearchTags" xml:space="preserve">
     <value>codeblock;</value>
   </data>
-  <data name="NoBinFolder" xml:space="preserve">
-    <value>{0} contains a package without a bin folder.  Ignoring it.</value>
+  <data name="DirectoryNotFound" xml:space="preserve">
+    <value>Directory Not Found {0}</value>
   </data>
   <data name="CustomNodeFolderLoadFailure" xml:space="preserve">
     <value>Failed to load custom node directory. Do you have permission to access {0}?</value>

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -623,7 +623,7 @@ value : bool = false</value>
     <value>codeblock;</value>
   </data>
   <data name="DirectoryNotFound" xml:space="preserve">
-    <value>Directory Not Found {0}</value>
+    <value>Directory not found : {0}</value>
   </data>
   <data name="CustomNodeFolderLoadFailure" xml:space="preserve">
     <value>Failed to load custom node directory. Do you have permission to access {0}?</value>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -623,7 +623,7 @@ value : bool = false</value>
     <value>codeblock;</value>
   </data>
   <data name="DirectoryNotFound" xml:space="preserve">
-    <value>Directory Not Found {0}</value>
+    <value>Directory not found : {0}</value>
   </data>
   <data name="CustomNodeFolderLoadFailure" xml:space="preserve">
     <value>Failed to load custom node directory. Do you have permission to access {0}?</value>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -622,8 +622,8 @@ value : bool = false</value>
   <data name="CodeBlockSearchTags" xml:space="preserve">
     <value>codeblock;</value>
   </data>
-  <data name="NoBinFolder" xml:space="preserve">
-    <value>{0} contains a package without a bin folder.  Ignoring it.</value>
+  <data name="DirectoryNotFound" xml:space="preserve">
+    <value>Directory Not Found {0}</value>
   </data>
   <data name="CustomNodeFolderLoadFailure" xml:space="preserve">
     <value>Failed to load custom node directory. Do you have permission to access {0}?</value>

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -172,7 +172,11 @@ namespace Dynamo.PackageManager
             {
                 foreach (var pkg in LocalPackages)
                 {
-                    pathManager.AddResolutionPath(pkg.BinaryDirectory);
+                    if (File.Exists(pkg.BinaryDirectory))
+                    {
+                        pathManager.AddResolutionPath(pkg.BinaryDirectory);
+                    } 
+                    
                 }
             }
 


### PR DESCRIPTION
### Fix package manager test failures

To fix package manager test failures on CI. The fix is to make sure the folder added 
to path manager exists. 


### @Benglin - Please review the PR



