### PR TITLE
Fix build error on Mono

### DIFF
--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -25,27 +25,18 @@ namespace ProtoScript.Runners
         /// <summary>
         /// The GUID of corresponding UI node.
         /// </summary>
-        public Guid GUID
-        {
-            get; private set;
-        }
+        public Guid GUID;
 
         /// <summary>
         /// Specify if all ast nodes should be executed.
         /// </summary>
-        public bool ForceExecution
-        {
-            get; set;
-        }
+        public bool ForceExecution;
 
         /// <summary>
         /// Sepcify if the VM should do delta computation for these ASTs
         /// By default it is true.
         /// </summary>
-        public bool DeltaComputation
-        {
-            get; set;
-        } 
+        public bool DeltaComputation;
 
         public List<AssociativeNode> AstNodes;
         public List<AssociativeNode> ModifiedAstNodes;


### PR DESCRIPTION
### Purpose

This is because some fields in `Subtree` are changed to properties, as `Subtree` is a struct, it requires all fields to be explicitly initialized in constructor.

Revert properties back to fields, and also keep backward binary compatibility.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs

@ramramps 

