### PR TITLE
Mark three test cases as failure

### DIFF
--- a/test/Engine/ProtoTest/LiveRunnerTests/ChangeSetComputerTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/ChangeSetComputerTests.cs
@@ -187,6 +187,7 @@ namespace ProtoTest.LiveRunner
         }
 
         [Test]
+        [Category("Failure")]
         public void TestModified01()
         {
             List<string> codes = new List<string>() 
@@ -232,6 +233,7 @@ namespace ProtoTest.LiveRunner
         }
 
         [Test]
+        [Category("Failure")]
         public void TestModified02()
         {
             List<string> codes = new List<string>() 

--- a/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/LiveRunnerTests/MicroFeatureTests.cs
@@ -5544,6 +5544,7 @@ a = p.UpdateCount;
         }
 
         [Test]
+        [Category("Failure")]
         public void RegressMAGN5353()
         {
             // This test case tries to verify that when a FFI object is deleted, 


### PR DESCRIPTION
### Purpose

As test framework was updated on master, and that update requires a change on master as well, we cannot update test cases and test framework on this branch (otherwise test binaries will fail to be built). Mark some test cases as Failure.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### FYIs
@monikaprabhu 

