### PR TITLE
Add a new category for tests failing due to hardware configuration differences

### DIFF
--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -42,7 +42,7 @@ namespace DynamoCoreWpfTests
             base.GetLibrariesToPreload(libraries);
         }
 
-        [Test]
+        [Test, Category("Display Hardware Dependant")]
         public void Watch3DHasViewer()
         {
             var renderingTier = (System.Windows.Media.RenderCapability.Tier >> 16);
@@ -218,7 +218,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(0, items.Count());
         }
 
-        [Test]
+       [Test, Category("Display Hardware Dependant")]
         public void WatchContainsExpectedUiElements()
         {
             OpenAndRun(@"UI\WatchUINodes.dyn");
@@ -232,7 +232,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(8, items.Count());
         }
 
-        [Test]
+        [Test, Category("Display Hardware Dependant")]
         public void WatchImageCoreContainsImage()
         {
             OpenAndRun(@"UI\WatchUINodes.dyn");
@@ -352,7 +352,7 @@ namespace DynamoCoreWpfTests
             Assert.Pass(); // We should reach here safely without exception.
         }
 
-        [Test]
+        [Test, Category("Display Hardware Dependant")]
         public void WatchConnectDisconnectTest()
         {
             WatchIsEmptyWhenLoaded();

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -42,7 +42,7 @@ namespace DynamoCoreWpfTests
             base.GetLibrariesToPreload(libraries);
         }
 
-        [Test, Category("Display Hardware Dependant")]
+        [Test, Category("Display Hardware Dependent")]
         public void Watch3DHasViewer()
         {
             var renderingTier = (System.Windows.Media.RenderCapability.Tier >> 16);
@@ -218,7 +218,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(0, items.Count());
         }
 
-       [Test, Category("Display Hardware Dependant")]
+       [Test, Category("Display Hardware Dependent")]
         public void WatchContainsExpectedUiElements()
         {
             OpenAndRun(@"UI\WatchUINodes.dyn");
@@ -232,7 +232,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(8, items.Count());
         }
 
-        [Test, Category("Display Hardware Dependant")]
+        [Test, Category("Display Hardware Dependent")]
         public void WatchImageCoreContainsImage()
         {
             OpenAndRun(@"UI\WatchUINodes.dyn");
@@ -352,7 +352,7 @@ namespace DynamoCoreWpfTests
             Assert.Pass(); // We should reach here safely without exception.
         }
 
-        [Test, Category("Display Hardware Dependant")]
+        [Test, Category("Display Hardware Dependent")]
         public void WatchConnectDisconnectTest()
         {
             WatchIsEmptyWhenLoaded();

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -42,7 +42,7 @@ namespace DynamoCoreWpfTests
             base.GetLibrariesToPreload(libraries);
         }
 
-        [Test, Category("Display Hardware Dependent")]
+        [Test, Category("DisplayHardwareDependent")]
         public void Watch3DHasViewer()
         {
             var renderingTier = (System.Windows.Media.RenderCapability.Tier >> 16);
@@ -218,7 +218,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(0, items.Count());
         }
 
-       [Test, Category("Display Hardware Dependent")]
+       [Test, Category("DisplayHardwareDependent")]
         public void WatchContainsExpectedUiElements()
         {
             OpenAndRun(@"UI\WatchUINodes.dyn");
@@ -232,7 +232,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(8, items.Count());
         }
 
-        [Test, Category("Display Hardware Dependent")]
+        [Test, Category("DisplayHardwareDependent")]
         public void WatchImageCoreContainsImage()
         {
             OpenAndRun(@"UI\WatchUINodes.dyn");
@@ -352,7 +352,7 @@ namespace DynamoCoreWpfTests
             Assert.Pass(); // We should reach here safely without exception.
         }
 
-        [Test, Category("Display Hardware Dependent")]
+        [Test, Category("DisplayHardwareDependent")]
         public void WatchConnectDisconnectTest()
         {
             WatchIsEmptyWhenLoaded();


### PR DESCRIPTION
### Purpose

Some of the test cases are more sensitive to the display hardware's capabilities. These test cases fail to create `HelixWatch3DViewModel` on some machines even though `Media.RenderCapability.Tier` returns a value greater than `2` (which means hardware acceleration exists).

In order to filter out these tests only on *very specific machines*, we introduced `DisplayHardwareDependent` category to these test cases.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin

### FYIs

@ikeough
