### PR TITLE
Modify the dotcover configuration to exclude Category "DisplayHardwareDependent" 

### DIFF
--- a/src/finalConfig.xml
+++ b/src/finalConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
 	<TargetExecutable><!-- Required.   -->C:\Program Files (x86)\NUnit 2.6.2\bin\nunit-console.exe</TargetExecutable>
-	<TargetArguments>DataBridgeTests.dll DynamoCoreWpfTests.dll DSCoreNodesTests.dll DynamoServicesTests.dll DynamoPythonTests.dll DynamoMSOfficeTests.dll DynamoCoreTests.dll DynamoUtilitiesTests.dll IntegrationTests.dll ProtoTest.dll WorkflowTests.dll CommandLineTests.dll PackageManagerTests.dll DisplayTests.dll  --labels=On /noshadow /exclude:Failure /xml=nunit-result.xml</TargetArguments> 
+	<TargetArguments>DataBridgeTests.dll DynamoCoreWpfTests.dll DSCoreNodesTests.dll DynamoServicesTests.dll DynamoPythonTests.dll DynamoMSOfficeTests.dll DynamoCoreTests.dll DynamoUtilitiesTests.dll IntegrationTests.dll ProtoTest.dll WorkflowTests.dll CommandLineTests.dll PackageManagerTests.dll DisplayTests.dll  --labels=On /noshadow /exclude:Failure,DisplayHardwareDependent /xml=nunit-result.xml</TargetArguments> 
 	<TargetWorkingDir>..\bin\AnyCPU\Release\</TargetWorkingDir>
 	<Output>Snapshot.dcvr</Output>
 <Filters>


### PR DESCRIPTION
### Purpose

Modify the Dotcover configuration to exclude Category `DisplayHardwareDependent` while running the tests on CI.   

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewer

(@Benglin ) 



