### PR TITLE
Do not ignore Exit Code

### DIFF
--- a/src/DynamoInstall/DynamoInstall.wixproj
+++ b/src/DynamoInstall/DynamoInstall.wixproj
@@ -76,7 +76,7 @@
     <Exec Command="rd /s /q $(DYNAMO_HARVEST_PATH)" />
     <Exec Command="robocopy $(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration) $(DYNAMO_HARVEST_PATH) -XF %2aTest%2a.dll %2a.pdb TestResult.xml -e -XD int -XD Revit_2015 -XD Revit_2016 -XD Revit_2017 -XD samples -XD gallery -XD 0.8" IgnoreExitCode="true" />
     <Exec Command="$(DYNAMO_BASE_PATH)\tools\install\Extra\InstallerSpec.exe $(DYNAMO_HARVEST_PATH) $(DYNAMO_HARVEST_PATH)\InstallSpec.xml" IgnoreExitCode="true" />
-    <Exec Condition="Exists('$(MSBuildProjectDirectory)\Digital_Sign.bat')" Command="$(MSBuildProjectDirectory)\Digital_Sign.bat $(DYNAMO_HARVEST_PATH)\binariestosign.txt" IgnoreExitCode="true" />
+    <Exec Condition="Exists('$(MSBuildProjectDirectory)\Digital_Sign.bat')" Command="$(MSBuildProjectDirectory)\Digital_Sign.bat $(DYNAMO_HARVEST_PATH)\binariestosign.txt" IgnoreExitCode="false" />
     
     <!-- Copy README file to install folder -->
     <Exec Command="xcopy /y $(DYNAMO_BASE_PATH)\bin\AnyCPU\$(Configuration)\README.txt $(DYNAMO_BASE_PATH)\tools\install\Installers\" IgnoreExitCode="true" />


### PR DESCRIPTION
### Purpose

Do not ignore the exit state of the signing step. After this change, in the future, for the build we are posting, we should not see "this dll is not signed" error message.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (*No change of public methods or types etc..*)

### Reviewers

@sharadkjaiswal

### FYIs



