### PR TITLE
Visualization for Meshes / Surfaces / Solids in Preview Bubble and Watch Node

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1312,10 +1312,17 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                             textGeometry.TextInfo.Add(textInfo);
                         }
 
+                        if (nodesSelected.ContainsKey(nodePath))
+                        {
+                            ToggleTreeViewItemHighlighting(nodesSelected[nodePath], false); // switch off selection for previous path
+                        }
+                        
                         Model3DDictionary.Add(labelName, bbText);
                         sceneItemsChanged = true;
                         AttachAllGeometryModel3DToRenderHost();
                         nodesSelected[nodePath] = path;
+
+                        ToggleTreeViewItemHighlighting(path, true); // switch on selection for current path
                     }
 
                     // if no node is being selected, that means the current node is being unselected
@@ -1323,6 +1330,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     else
                     {
                         nodesSelected.Remove(nodePath);
+                        ToggleTreeViewItemHighlighting(path, false);
                     }
                 }
 
@@ -1352,6 +1360,22 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
         }
 
+        /// <summary>
+        /// Toggles on the highlighting for the specific node (in Helix preview) when
+        /// selected in the PreviewBubble as well as the Watch Node
+        /// </summary>
+        private void ToggleTreeViewItemHighlighting (string path, bool isSelected)
+        {
+            // Add Geometry Highlighting for selected TreeViewItems
+            var geometryModels = Model3DDictionary.Where(x => x.Key.Contains(path) && x.Value is GeometryModel3D).ToArray();
+
+            var modelValues = geometryModels.Select(x => x.Value);
+
+            foreach (GeometryModel3D g in modelValues)
+            {
+                g.SetValue(AttachedProperties.ShowSelectedProperty, isSelected);
+            }
+        }
 
         /// <summary>
         /// Given a collection of render packages, generates

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -625,11 +625,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                         }
                     }
 
-                    var modelValues = geometryModels.Select(x => x.Value);
-
-                    foreach (GeometryModel3D g in modelValues)
+                    foreach (var geometryModel in geometryModels)
                     {
-                        g.SetValue(AttachedProperties.ShowSelectedProperty, false);
+                        geometryModel.Value.SetValue(AttachedProperties.ShowSelectedProperty, false);
                     }
                     return;
 
@@ -1406,21 +1404,17 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
             var nodeGeometryModels = Model3DDictionary.Where(x => x.Key.Contains(nodePath) && x.Value is GeometryModel3D).ToArray();
 
-            var nodeModelValues = nodeGeometryModels.Select(x => x.Value);
-
-            foreach (GeometryModel3D g in nodeModelValues)
+            foreach (var nodeGeometryModel in nodeGeometryModels)
             {
-                g.SetValue(AttachedProperties.ShowSelectedProperty, false);
+                nodeGeometryModel.Value.SetValue(AttachedProperties.ShowSelectedProperty, false);
             }
 
             // Then, select the individual node
             var geometryModels = Model3DDictionary.Where(x => x.Key.Contains(path) && x.Value is GeometryModel3D).ToArray();
 
-            var modelValues = geometryModels.Select(x => x.Value);
-
-            foreach (GeometryModel3D g in modelValues)
+            foreach (var geometryModel in geometryModels)
             {
-                g.SetValue(AttachedProperties.ShowSelectedProperty, isSelected);
+                geometryModel.Value.SetValue(AttachedProperties.ShowSelectedProperty, isSelected);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1366,7 +1366,6 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// </summary>
         private void ToggleTreeViewItemHighlighting (string path, bool isSelected)
         {
-            // Add Geometry Highlighting for selected TreeViewItems
             var geometryModels = Model3DDictionary.Where(x => x.Key.Contains(path) && x.Value is GeometryModel3D).ToArray();
 
             var modelValues = geometryModels.Select(x => x.Value);

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -979,6 +979,40 @@ namespace WpfVisualizationTests
             var views = View.ChildrenOfType<Watch3DView>();
             return views.Last();
         }
+
+        [Test]
+        public void GeometryPreviewWhenClickingArrayItemInPreview()
+        {
+            OpenVisualizationTest("magn_10809.dyn");
+            RunCurrentModel();
+            DispatcherUtil.DoEvents();
+
+            var vm = ViewModel.BackgroundPreviewViewModel as HelixWatch3DViewModel;
+            Assert.NotNull(vm);
+
+            // select original node
+            vm.AddLabelForPath("var_88f09e6c057f4a5c95a7f4f0b25161e2:0:0:0");
+            var originalNode = vm.Model3DDictionary["var_88f09e6c057f4a5c95a7f4f0b25161e2:0:0:0" + ":mesh"];
+            var otherNode = vm.Model3DDictionary["var_88f09e6c057f4a5c95a7f4f0b25161e2:0:0:1" + ":mesh"];
+            Assert.IsTrue((bool)originalNode.GetValue(AttachedProperties.ShowSelectedProperty)); 
+            Assert.IsFalse((bool)otherNode.GetValue(AttachedProperties.ShowSelectedProperty));
+
+            // deselect original node
+            vm.AddLabelForPath("var_88f09e6c057f4a5c95a7f4f0b25161e2:0:0:0");
+            Assert.IsFalse((bool)originalNode.GetValue(AttachedProperties.ShowSelectedProperty));
+            Assert.IsFalse((bool)otherNode.GetValue(AttachedProperties.ShowSelectedProperty));
+
+            // select another node
+            vm.AddLabelForPath("var_88f09e6c057f4a5c95a7f4f0b25161e2:0:0:1");
+            Assert.IsFalse((bool)originalNode.GetValue(AttachedProperties.ShowSelectedProperty));
+            Assert.IsTrue((bool)otherNode.GetValue(AttachedProperties.ShowSelectedProperty));
+
+            // Select node one level up
+            vm.AddLabelForPath("var_88f09e6c057f4a5c95a7f4f0b25161e2:0:0");
+            Assert.IsTrue((bool)originalNode.GetValue(AttachedProperties.ShowSelectedProperty));
+            Assert.IsTrue((bool)otherNode.GetValue(AttachedProperties.ShowSelectedProperty));
+        }
+
     }
 
     internal static class GeometryDictionaryExtensions

--- a/test/core/visualization/magn_10809.dyn
+++ b/test/core/visualization/magn_10809.dyn
@@ -1,0 +1,32 @@
+<Workspace Version="1.2.1.3062" X="-1380.31582761709" Y="-245.794392238871" zoom="1.19342907491028" Name="Home" Description="" RunType="Automatic" RunPeriod="100" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="8190039b-694b-4ef2-ad33-c48f5d964519" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="2065.42112593653" y="429.407649315122" isVisible="true" isUpstreamVisible="true" lacing="CrossProduct" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="7c9f9b44-efd4-4908-93d4-dc76fc3c10fe" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1844.15858759244" y="680.26187577305" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="2..1;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="88f09e6c-057f-4a5c-95a7-f4f0b25161e2" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Sphere.ByCenterPointRadius" x="1517.26025149393" y="220.903706276298" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="true" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <CoreNodeModels.Input.DoubleSlider guid="e639df93-1332-4b9e-a988-8262dbdc86f6" type="CoreNodeModels.Input.DoubleSlider" nickname="Number Slider" x="860.480693591339" y="631.592940593066" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <System.Double>0.45</System.Double>
+      <Range min="0" max="1" step="0.05" />
+    </CoreNodeModels.Input.DoubleSlider>
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="8190039b-694b-4ef2-ad33-c48f5d964519" start_index="0" end="88f09e6c-057f-4a5c-95a7-f4f0b25161e2" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="7c9f9b44-efd4-4908-93d4-dc76fc3c10fe" start_index="0" end="8190039b-694b-4ef2-ad33-c48f5d964519" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="7c9f9b44-efd4-4908-93d4-dc76fc3c10fe" start_index="0" end="8190039b-694b-4ef2-ad33-c48f5d964519" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="7c9f9b44-efd4-4908-93d4-dc76fc3c10fe" start_index="0" end="8190039b-694b-4ef2-ad33-c48f5d964519" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e639df93-1332-4b9e-a988-8262dbdc86f6" start_index="0" end="88f09e6c-057f-4a5c-95a7-f4f0b25161e2" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="9.15464496612549" eyeY="11.1293563842773" eyeZ="6.63933086395264" lookX="-4.15464496612549" lookY="-6.12935638427734" lookZ="-11.6393299102783" upX="-0.0813279300928116" upY="0.97029572725296" upZ="-0.22784198820591" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR is meant to address the _MAGN-10809_.

Previously, when users selected the nodes within a preview bubble or a Watch Node, all that they will see is the label on the HelixWatch3DPreview. The highlighting of the nodes in the HelixWatch3DPreview is only toggled on when the entire node is selected:

![10809old](https://cloud.githubusercontent.com/assets/16283396/19763668/b15d8d0e-9c71-11e6-9119-d2bfc6433a71.gif)

After this implementation, users will be able to select individual nodes in the TreeViewItem and see the highlighting/ visualization of the specific node which they had selected:

![10809new](https://cloud.githubusercontent.com/assets/16283396/19763670/b5be2250-9c71-11e6-94f3-cabe57e90122.gif)

One limitation, however, is that this preview ability is currently only constrained to Meshes, Surfaces and Solids. Lines, Curves and Points currently are not supported in this implementation as they are grouped as one object each (i.e. all the lines will be collapsed into a `Lines` object and so on) in the `Model3DDictionary` within HelixWatch3DViewModel. Due to the lack of granularity, individual lines when selected, cannot be teased out and highlighted.
### Declarations

Check these if you believe they are true
- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Follows [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) standards (_No change of public methods or types etc.._)
### Reviewers

@ke-yu 
### FYIs

@riteshchandawar 
