### PR TITLE
Fix Context Menue

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -1018,20 +1018,20 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _Create Custom Node.
+        /// </summary>
+        public static string DynamoViewEditMenuCreateCustomNode {
+            get {
+                return ResourceManager.GetString("DynamoViewEditMenuCreateCustomNode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Create Group.
         /// </summary>
         public static string DynamoViewEditMenuCreateGroup {
             get {
                 return ResourceManager.GetString("DynamoViewEditMenuCreateGroup", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to _Create Node From Selection.
-        /// </summary>
-        public static string DynamoViewEditMenuCreateNodeFromSelection {
-            get {
-                return ResourceManager.GetString("DynamoViewEditMenuCreateNodeFromSelection", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -265,8 +265,8 @@
     <value>_Copy</value>
     <comment>Edit menu | Copy</comment>
   </data>
-  <data name="DynamoViewEditMenuCreateNodeFromSelection" xml:space="preserve">
-    <value>_Create Node From Selection</value>
+  <data name="DynamoViewEditMenuCreateCustomNode" xml:space="preserve">
+    <value>_Create Custom Node</value>
     <comment>Edit menu | Create custom node from selected nodes</comment>
   </data>
   <data name="DynamoViewEditMenuCreateNote" xml:space="preserve">

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -265,8 +265,8 @@
     <value>_Copy</value>
     <comment>Edit menu | Copy</comment>
   </data>
-  <data name="DynamoViewEditMenuCreateNodeFromSelection" xml:space="preserve">
-    <value>_Create Node From Selection</value>
+  <data name="DynamoViewEditMenuCreateCustomNode" xml:space="preserve">
+    <value>_Create Custom Node</value>
     <comment>Edit menu | Create custom node from selected nodes</comment>
   </data>
   <data name="DynamoViewEditMenuCreateNote" xml:space="preserve">

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -454,7 +454,7 @@
                                   Name="ungroupGroup"
                                   InputGestureText="Ctrl + U" />
                         <MenuItem Focusable="False"                                
-                                  Header="{x:Static p:Resources.DynamoViewEditMenuCreateNodeFromSelection}"
+                                  Header="{x:Static p:Resources.DynamoViewEditMenuCreateCustomNode}"
                                   Command="{Binding Path=NodeFromSelectionCommand}"
                                   Name="nodeFromSelection"
                                   InputGestureText="Ctrl + D" />


### PR DESCRIPTION
### Purpose

[DYN-62](https://jira.autodesk.com/browse/DYN-62) Fix context menu language so that it is easier for users to make custom nodes

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
![image](https://cloud.githubusercontent.com/assets/3942418/20206635/d7cf81d8-a7af-11e6-8108-2998f83c8566.png)

- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@Racel 

### FYIs


