### PR TITLE
New UpgradeCode for Dynamo 2.0.0

### DIFF
--- a/src/DynamoInstall/DynamoInstall.wixproj
+++ b/src/DynamoInstall/DynamoInstall.wixproj
@@ -67,7 +67,7 @@
     <CreateProperty Value="Dynamo Core">
       <Output TaskParameter="Value" PropertyName="ProductName" />
     </CreateProperty>
-    <CreateProperty Value="{584B3E06-FE7A-4341-8C22-339B00ABD58A}">
+    <CreateProperty Value="{2E05E21E-FC6E-42AE-BE9D-228CF34341F2}">
       <Output TaskParameter="Value" PropertyName="UpgradeCode" />
     </CreateProperty>
     <CreateProperty Value="UpgradeCode=$(UpgradeCode);ProductName=$(ProductName);FullVersion=$(FullVersion);Major=$(Major);Minor=$(Minor);Rev=$(Rev);Build=$(Build);$(DefineConstants)">


### PR DESCRIPTION
### Purpose

As discussed with the team, we are changing the installer's `UpgradeCode` in order to enable side-by-side installation between **Dynamo 1.x** and **Dynamo 2.x**.

Relates to PR #7300 *Updated version to 2.0.0*

### Reviewers

@Benglin 

### FYIs

@riteshchandawar 