### PR TITLE
Fixed Multiple Selection Issue in Visualization for Meshes / Surfaces / Solids in Preview Bubble and Watch Node

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1381,16 +1381,13 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// Toggles on the highlighting for the specific node (in Helix preview) when
         /// selected in the PreviewBubble as well as the Watch Node
         /// </summary>
-        private void ToggleTreeViewItemHighlighting (string path, bool isSelected)
+        private void ToggleTreeViewItemHighlighting(string path, bool isSelected)
         {
             // First, deselect parentnode in DynamoSelection
-
             var nodePath = path.Contains(':') ? path.Remove(path.IndexOf(':')) : path;
-
             if (DynamoSelection.Instance.Selection.Any())
             {
-                var selNodes = DynamoSelection.Instance.Selection.Where(s => s is NodeModel).Cast<NodeModel>().ToArray();
-                
+                var selNodes = DynamoSelection.Instance.Selection.ToList().OfType<NodeModel>();
                 foreach (var node in selNodes)
                 {
                     if (node.AstIdentifierBase == nodePath)
@@ -1401,16 +1398,15 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
 
             // Next, deselect the parentnode in HelixWatch3DView
-
             var nodeGeometryModels = Model3DDictionary.Where(x => x.Key.Contains(nodePath) && x.Value is GeometryModel3D).ToArray();
-
             foreach (var nodeGeometryModel in nodeGeometryModels)
             {
                 nodeGeometryModel.Value.SetValue(AttachedProperties.ShowSelectedProperty, false);
             }
 
             // Then, select the individual node
-            var geometryModels = Model3DDictionary.Where(x => x.Key.Contains(path) && x.Value is GeometryModel3D).ToArray();
+            var pathInDict = path + ":";
+            var geometryModels = Model3DDictionary.Where(x => x.Key.Contains(pathInDict) && x.Value is GeometryModel3D).ToArray();
 
             foreach (var geometryModel in geometryModels)
             {

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -1404,13 +1404,14 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 nodeGeometryModel.Value.SetValue(AttachedProperties.ShowSelectedProperty, false);
             }
 
-            // Then, select the individual node
-            var pathInDict = path + ":";
-            var geometryModels = Model3DDictionary.Where(x => x.Key.Contains(pathInDict) && x.Value is GeometryModel3D).ToArray();
-
-            foreach (var geometryModel in geometryModels)
+            // Then, select the individual node only if isSelected is true since all geometryModels' Selected Property is set to false
+            if (isSelected)
             {
-                geometryModel.Value.SetValue(AttachedProperties.ShowSelectedProperty, isSelected);
+                var geometryModels = Model3DDictionary.Where(x => x.Key.StartsWith(path + ":") && x.Value is GeometryModel3D).ToArray();
+                foreach (var geometryModel in geometryModels)
+                {
+                    geometryModel.Value.SetValue(AttachedProperties.ShowSelectedProperty, isSelected);
+                }
             }
         }
 


### PR DESCRIPTION
### Purpose

Previously, I implemented a feature (https://github.com/DynamoDS/Dynamo/pull/7305) which allowed users to visualize their selection of tree items within a preview bubble or watch node.

After the feature was integrated, there was a bug which resulted in the selection of multiple surfaces / solids even though only one surface or solid was selected in the preview bubble:

![10809v2old](https://cloud.githubusercontent.com/assets/16283396/20420633/038757ca-ad9a-11e6-8d9d-96a3ad9f07f6.gif)

After this fix, the feature is working as it should - one surface showing up per tree item selection:

![10809v2new](https://cloud.githubusercontent.com/assets/16283396/20420446/d677388c-ad98-11e6-907f-6a3172610fdc.gif)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ellensi 

### FYIs

@monikaprabhu 