### PR TITLE
DYN-70 Crash when changing the folder of opened dynamo file

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2210,6 +2210,16 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A problem occurred when trying to access the directory of currently opened file. Dynamo is unable to obtain read/write access to
+        ///{0}.
+        /// </summary>
+        public static string FileDirectoryNotAccessible {
+            get {
+                return ResourceManager.GetString("FileDirectoryNotAccessible", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Publish Fail!.
         /// </summary>
         public static string FileNotPublishCaption {
@@ -4800,6 +4810,15 @@ namespace Dynamo.Wpf.Properties {
         public static string TooltipCurrentIndex {
             get {
                 return ResourceManager.GetString("TooltipCurrentIndex", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable To Access File Directory.
+        /// </summary>
+        public static string UnableToAccessFileDirectory {
+            get {
+                return ResourceManager.GetString("UnableToAccessFileDirectory", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2104,4 +2104,11 @@ Want to publish a different package?</value>
   <data name="SolutionToFolderNotWritatbleError" xml:space="preserve">
     <value>Please update the permissions or go to 'Settings &gt; Manage Node and Package Paths...' to change your default directory.</value>
   </data>
+  <data name="FileDirectoryNotAccessible" xml:space="preserve">
+    <value>A problem occurred when trying to access the directory of currently opened file. Dynamo is unable to obtain read/write access to
+{0}</value>
+  </data>
+  <data name="UnableToAccessFileDirectory" xml:space="preserve">
+    <value>Unable To Access File Directory</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2106,4 +2106,11 @@ Want to publish a different package?</value>
   <data name="SolutionToFolderNotWritatbleError" xml:space="preserve">
     <value>Please update the permissions or go to 'Settings &gt; Manage Node and Package Paths...' to change your default directory.</value>
   </data>
+  <data name="FileDirectoryNotAccessible" xml:space="preserve">
+    <value>A problem occurred when trying to access the directory of currently opened file. Dynamo is unable to obtain read/write access to
+{0}</value>
+  </data>
+  <data name="UnableToAccessFileDirectory" xml:space="preserve">
+    <value>Unable To Access File Directory</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1264,8 +1264,30 @@ namespace Dynamo.ViewModels
             // if you've got the current space path, use it as the inital dir
             if (!string.IsNullOrEmpty(Model.CurrentWorkspace.FileName))
             {
-                var fi = new FileInfo(Model.CurrentWorkspace.FileName);
-                _fileDialog.InitialDirectory = fi.DirectoryName;
+                var path = Model.CurrentWorkspace.FileName;
+
+                // Create folder if the directory is no longer exist and check for error (errors are usually from inaccessible directory)
+                var errorCannotCreateFolder = PathHelper.CreateFolderIfNotExist(Path.GetDirectoryName(path));
+
+                // Ask user to SaveAs the current homespace if the homespace directory happened to be not existed
+                if (!Directory.Exists(path))
+                {
+                    var args = new WorkspaceSaveEventArgs(HomeSpace, true);
+                    OnRequestUserSaveHomeSpace(this, args);
+                }
+
+                // Handle for the case, args.Path does not exist.
+                if(errorCannotCreateFolder == null)
+                {
+                    var fi = new FileInfo(Model.CurrentWorkspace.FileName);
+                    _fileDialog.InitialDirectory = fi.DirectoryName;
+                }
+                else
+                {
+                    string errorMessage = string.Format(Wpf.Properties.Resources.FileDirectoryNotAccessible, path);
+                    System.Windows.Forms.MessageBox.Show(errorMessage, Wpf.Properties.Resources.UnableToAccessFileDirectory, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+               
             }
             else // use the samples directory, if it exists
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEvents.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModelEvents.cs
@@ -86,6 +86,15 @@ namespace Dynamo.ViewModels
             }
         }
 
+        public event WorkspaceSaveEventHandler RequestUserSaveHomeSpace;
+        public virtual void OnRequestUserSaveHomeSpace(Object sender, WorkspaceSaveEventArgs e)
+        {
+            if (RequestUserSaveHomeSpace != null)
+            {
+                RequestUserSaveHomeSpace(this, e);
+            }
+        }
+
         public event RequestAboutWindowHandler RequestAboutWindow;
         public virtual void OnRequestAboutWindow(DynamoViewModel vm)
         {

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -547,6 +547,7 @@ namespace Dynamo.Controls
             DynamoSelection.Instance.Selection.CollectionChanged += Selection_CollectionChanged;
 
             dynamoViewModel.RequestUserSaveWorkflow += DynamoViewModelRequestUserSaveWorkflow;
+            dynamoViewModel.RequestUserSaveHomeSpace += DynamoViewModelRequestUserSaveCurrentHomeSpace;
 
             dynamoViewModel.Model.ClipBoard.CollectionChanged += ClipBoard_CollectionChanged;
 
@@ -824,6 +825,35 @@ namespace Dynamo.Controls
             }
         }
 
+        /// <summary>
+        /// This method is to handle the event when user was working on the homespace but the file was
+        /// deleted from external operation and we need to request user to SaveAs the current homespace
+        /// </summary>
+        private void DynamoViewModelRequestUserSaveCurrentHomeSpace(object sender, WorkspaceSaveEventArgs e)
+        {
+            var dialogText = "";
+            dialogText = Dynamo.Wpf.Properties.Resources.MessageConfirmToSaveHomeWorkSpace;
+            var buttons = e.AllowCancel ? MessageBoxButton.YesNoCancel : MessageBoxButton.YesNo;
+            var result = System.Windows.MessageBox.Show(this, dialogText,
+                Dynamo.Wpf.Properties.Resources.SaveConfirmationMessageBoxTitle,
+                buttons, MessageBoxImage.Question);
+            if (result == MessageBoxResult.Yes)
+            {
+                dynamoViewModel.ShowSaveDialogAndSaveResult(e.Workspace);
+                e.Success = true;
+            }
+            else if (result == MessageBoxResult.Cancel)
+            {
+                //return false;
+                e.Success = false;
+            }
+            else
+            {
+                e.Success = true;
+            }
+
+        }
+
         private void Selection_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             dynamoViewModel.CopyCommand.RaiseCanExecuteChanged();
@@ -1090,6 +1120,7 @@ namespace Dynamo.Controls
             DynamoSelection.Instance.Selection.CollectionChanged -= Selection_CollectionChanged;
 
             dynamoViewModel.RequestUserSaveWorkflow -= DynamoViewModelRequestUserSaveWorkflow;
+            dynamoViewModel.RequestUserSaveHomeSpace -= DynamoViewModelRequestUserSaveCurrentHomeSpace;
 
             if (dynamoViewModel.Model != null)
             {


### PR DESCRIPTION
### Purpose

- This PR is to fix the Crash when changing the folder of opened dynamo file. 
  - https://jira.autodesk.com/browse/DYN-70
  - https://github.com/DynamoDS/Dynamo/issues/4650
- Steps to reproduce:

1. Open a .dyn file from folder foo
2. Delete folder foo
3. Click open dialog -> crash

- User will also be asked to save the current workspace if the folder that he/she working on is no longer existed.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@Benglin 

### FYIs
