### PR TITLE
DYN-70 Crash when changing the folder of opened dynamo file

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -420,7 +420,19 @@ namespace Dynamo.Graph.Workspaces
         /// </summary>
         public bool HasUnsavedChanges
         {
-            get { return hasUnsavedChanges; }
+            get 
+            {
+                if(!string.IsNullOrEmpty(this.FileName)) // if there is a filename
+                {
+                    if (!File.Exists(this.FileName)) // but the filename is invalid
+                    {
+                        this.fileName = string.Empty;
+                        hasUnsavedChanges = true;
+                    }
+                }
+
+                return hasUnsavedChanges;
+            }
             set
             {
                 hasUnsavedChanges = value;

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1272,17 +1272,7 @@ namespace Dynamo.ViewModels
                 }
                 else
                 {
-                    Model.CurrentWorkspace.FileName = string.Empty;
-                    HomeSpace.FileName = string.Empty;
-                    if (AskUserToSaveWorkspaceOrCancel(HomeSpace))
-                    {
-                        _fileDialog.InitialDirectory = string.Empty;
-                    }
-                    else
-                    {
-                        HomeSpace.HasUnsavedChanges = true;
-                        return;
-                    }
+                    _fileDialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyComputer);
                 }
             }
             else // use the samples directory, if it exists

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1264,8 +1264,26 @@ namespace Dynamo.ViewModels
             // if you've got the current space path, use it as the inital dir
             if (!string.IsNullOrEmpty(Model.CurrentWorkspace.FileName))
             {
-                var fi = new FileInfo(Model.CurrentWorkspace.FileName);
-                _fileDialog.InitialDirectory = fi.DirectoryName;
+                string path = Model.CurrentWorkspace.FileName;
+                if (File.Exists(path))
+                {
+                    var fi = new FileInfo(Model.CurrentWorkspace.FileName);
+                    _fileDialog.InitialDirectory = fi.DirectoryName;
+                }
+                else
+                {
+                    Model.CurrentWorkspace.FileName = string.Empty;
+                    HomeSpace.FileName = string.Empty;
+                    if (AskUserToSaveWorkspaceOrCancel(HomeSpace))
+                    {
+                        _fileDialog.InitialDirectory = string.Empty;
+                    }
+                    else
+                    {
+                        HomeSpace.HasUnsavedChanges = true;
+                        return;
+                    }
+                }
             }
             else // use the samples directory, if it exists
             {
@@ -1382,6 +1400,9 @@ namespace Dynamo.ViewModels
                 // sadly it's not usually possible to cancel a crash
 
                 var fd = this.GetSaveDialog(workspace);
+                // since the workspace file directory is null, we set the initial directory
+                // for the file to be MyDocument folder in the local computer. 
+                fd.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
                 if (fd.ShowDialog() == DialogResult.OK)
                 {
                     workspace.SaveAs(fd.FileName, EngineController.LiveRunnerRuntimeCore);


### PR DESCRIPTION
### Purpose

- This PR is to fix the Crash when changing the folder of opened dynamo file. 
  - https://jira.autodesk.com/browse/DYN-70
  - https://github.com/DynamoDS/Dynamo/issues/4650
- Steps to reproduce:

  - Open a .dyn file from folder foo
  - Delete folder foo
  - Click open dialog -> crash

- User will also be asked to save the current workspace if the folder that he/she working on is no longer existed.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@Benglin 

### FYIs
