### PR TITLE
Add more binaries to NuGet packages

### DIFF
--- a/tools/NuGet/template/DynamoVisualProgramming.Core.nuspec
+++ b/tools/NuGet/template/DynamoVisualProgramming.Core.nuspec
@@ -28,5 +28,10 @@
     <file src="ProtoCore.dll" target="lib\net45" />
     <file src="DynamoShapeManager.dll" target="lib\net45" />
     <file src="DynamoUtilities.dll" target="lib\net45" />
+    <file src="Analysis.dll" target="lib\net45" />
+    <file src="Analysis.xml" target="build\net45" />
+    <file src="DSIronPython.dll" target="lib\net45" />
+    <file src="DynamoApplications.dll" target="lib\net45" />
+    <file src="DynamoInstallDetective.dll" target="lib\net45" />
   </files>
 </package>

--- a/tools/NuGet/template/DynamoVisualProgramming.Tests.nuspec
+++ b/tools/NuGet/template/DynamoVisualProgramming.Tests.nuspec
@@ -20,6 +20,7 @@
   </metadata>
   <files>
     <file src="..\..\..\bin\AnyCPU\Release\TestServices.dll" target="lib\net45" />
+    <file src="..\..\..\bin\AnyCPU\Release\DynamoCoreTests.dll" target="lib\net45" />
     <!--file src="..\..\..\bin\AnyCPU\Release\SystemTestServices.xml" target="lib\net45" /-->
   </files>
 </package>


### PR DESCRIPTION
### Purpose

Reference: [DYN-154](https://jira.autodesk.com/browse/DYN-154) *Include more assemblies into core nuget package*

Adding more assemblies to the `DynamoVisualProgramming.Core` and `DynamoVisualProgramming.Tests` packages for consumption by DynamoRevit and Dynamo Studio.

New contents of `DynamoVisualProgramming.Core` package:
* `DynamoCore.dll` and `DynamoCore.xml` (existing)
* `ProtoCore.dll` (existing)
* `DynamoShapeManager.dll` (existing)
* `DynamoUtilities.dll` (existing)
* **`Analysis.dll`** and **`Analysis.xml`** (newly added)
* **`DSIronPython.dll`** (newly added)
* **`DynamoApplications.dll`** (newly added)
* **`DynamoInstallDetective.dll`** (newly added)

New contents of `DynamoVisualProgramming.Tests` package:
* `TestServices.dll` (existing)
* **`DynamoCoreTests.dll`** (newly added)

### Reviewers

@sharadkjaiswal 

### FYIs

@aparajit-pratap @NightHawk-Michael 