### PR TITLE
Update BoolSelector's NodeType to BooleanInputNode

### DIFF
--- a/src/DynamoCore/Graph/Nodes/ZeroTouch/DSVarArgFunction.cs
+++ b/src/DynamoCore/Graph/Nodes/ZeroTouch/DSVarArgFunction.cs
@@ -42,9 +42,22 @@ namespace Dynamo.Graph.Nodes.ZeroTouch
         }
 
         /// <summary>
-        /// Returns the default number of inputs for the node
-        /// </summary>
-        private readonly int defaultNumInputs;
+         /// The NodeType property provides a name which maps to the 
+         /// server type for the node. This property should only be
+        /// used for serialization. 
+         /// </summary>
+         public override string NodeType
+         {
+             get
+             {
+                 return "FunctionNode";
+             }
+        }
+
+    /// <summary>
+    /// Returns the default number of inputs for the node
+    /// </summary>
+    private readonly int defaultNumInputs;
         [JsonIgnore]
         internal int DefaultNumInputs { get { return defaultNumInputs; } }
 

--- a/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
+++ b/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
@@ -71,5 +71,18 @@ namespace CoreNodeModels.Input
             Value = false;
             ShouldDisplayPreviewCore = false;
         }
+
+        /// <summary>
+        /// The NodeType property provides a name which maps to the 
+        /// server type for the node. This property should only be
+        /// used for serialization. 
+        /// </summary>
+        public override string NodeType
+        {
+            get
+            {
+                return "BooleanInputNode";
+            }
+        }
     }
 }


### PR DESCRIPTION
### Purpose

By default its NodeType is "ExtensionNode"

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ikeough 

