### PR TITLE
Fix the issue that warning msg persists after it should be cleared up

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1268,6 +1268,7 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         public virtual void ClearRuntimeError()
         {
+            SetNodeStateBasedOnConnectionAndDefaults();
             if (!string.IsNullOrEmpty(persistentWarning))
             {
                 ToolTipText = persistentWarning;
@@ -1276,7 +1277,6 @@ namespace Dynamo.Graph.Nodes
             {
                 ClearTooltipText();
             }
-            SetNodeStateBasedOnConnectionAndDefaults();
         }
 
         public void SelectNeighbors()


### PR DESCRIPTION
### Purpose

This is to fix the issue that sometimes the error tooltip won't go away even if the graph is executed successfully and there are no nodes with issues.

The issue is a regression from https://github.com/DynamoDS/Dynamo/pull/7301. The tooltip can only be updated successfully when the state of the node is not in a warning or error state (Refer NodeViewModel.UpdateBubbleContent). The fix here is to update the node state before updating the tooltip text which is like this before the change in https://github.com/DynamoDS/Dynamo/pull/7301.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@ikeough 
@mjkkirschner 

### FYIs
@kronz 
@jnealb 

