### PR TITLE
Add ScaleFactor property to TessellationParameters

### DIFF
--- a/src/NodeServices/GraphicsDataInterfaces.cs
+++ b/src/NodeServices/GraphicsDataInterfaces.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Dynamo.Events;
 
 namespace Autodesk.DesignScript.Interfaces
 {
@@ -289,11 +290,26 @@ namespace Autodesk.DesignScript.Interfaces
         /// </summary>
         public bool ShowEdges { get; set; }
 
+        /// <summary>
+        /// The scale factor set in the workspace that must be applied to 
+        /// distance and coordinate values used in rendering geometry.
+        /// This scale factor can be consumed by clients implementing Tessellate method of IGraphicItem.
+        /// </summary>
+        public double ScaleFactor { get; private set; }
+
         public TessellationParameters()
         {
             Tolerance = -1;
             MaxTessellationDivisions = 512;
             ShowEdges = false;
+            ScaleFactor = 1.0;
+
+            WorkspaceEvents.WorkspaceSettingsChanged += WorkspaceSettingsChanged;
+        }
+
+        private void WorkspaceSettingsChanged(WorkspacesSettingsChangedEventArgs args)
+        {
+            ScaleFactor = args.ScaleFactor;
         }
     }
 


### PR DESCRIPTION
### Purpose

This PR adds a `ScaleFactor` property to `TessellationParameters`. This is in order to pass in the current scale factor setting (from the Dynamo UI) packed into a `TessellationParameters` object to an `IGraphicItem` client that implements `Tessellate` method. Specifically `GraphicItemHost` defined in `LibG.ProtoInterface` consumes the scale factor in its `Tessellate` implementation in order to make corrections for the scale factor while tessellating geometry. Now it can obtain the scale factor by querying this property from the `TessellationParameters` argument passed to `Tessellate`.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ellensi 


