### PR TITLE
Fix Crash due to changes in #7283

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -605,7 +605,8 @@ namespace Dynamo.Controls
         private void HidePopupWhenWindowDeactivated()
         {
             var workspace = this.ChildOfType<WorkspaceView>();
-            workspace.HidePopUp();
+            if(workspace != null)
+                workspace.HidePopUp();
          }
 
         private void TrackStartupAnalytics()


### PR DESCRIPTION
### Purpose

I am frequently observing a crash while debugging Dynamo and at times even when opening files. I found it to be due to a `NullReferenceException` that is caused when the child node of `DynamoView` does not happen to be a `WorkspaceView` as expected. This change was made recently in https://github.com/DynamoDS/Dynamo/pull/7283. Simply added a null check here to avoid the crash.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@Benglin 

