### PR TITLE
Use config file to locate DynamoRuntime

### DIFF
--- a/src/Tools/DynamoInstallDetective/DynamoInstallDetective.csproj
+++ b/src/Tools/DynamoInstallDetective/DynamoInstallDetective.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Tools/DynamoInstallDetective/ProductLookUp.cs
+++ b/src/Tools/DynamoInstallDetective/ProductLookUp.cs
@@ -326,11 +326,11 @@ namespace DynamoInstallDetective
             var additionalPath = debugPath;
             var configPath = Path.Combine(Path.GetDirectoryName(
                     Assembly.GetExecutingAssembly().Location), "Dynamo.config");
-            if (string.IsNullOrEmpty(additionalPath) && File.Exists(configPath))
+            if (File.Exists(configPath))
             {
-                // Get DynamoCore path from the generated Dynamo.config file
-                var map = new ExeConfigurationFileMap();
-                map.ExeConfigFilename = configPath;
+                // Get DynamoCore path from the Dynamo.config file, if it exists
+                var map = new ExeConfigurationFileMap() { ExeConfigFilename = configPath };
+                
                 var config = ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.None);
                 var runtime = config.AppSettings.Settings["DynamoRuntime"];
                 if (runtime != null)


### PR DESCRIPTION
### Purpose

This PR allows Dynamo applications to use config file to locate Dynamo Core Runtime, when the application is built at a location other than the Dynamo Core. The config file must have following appSetting entry to provide an alternate path for Dynamo Core.

```
  <appSettings>
     <add key="DynamoRuntime" value="E:\GitHub\Dynamo\bin\AnyCPU\Debug"/>
  </appSettings>
```

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ellensi 
