### PR TITLE
Change Auto lacing icon to text "AUTO"

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1396,23 +1396,6 @@ namespace Dynamo.Controls
         }
     }
 
-    public class NonAutoLacingToVisibilityConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            LacingStrategy strategy = (LacingStrategy)value;
-            if (strategy == LacingStrategy.Disabled || strategy == LacingStrategy.Auto)
-                return Visibility.Collapsed;
-            else
-                return Visibility.Visible;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            throw new NotSupportedException();
-        }
-    }
-
     public class AutoLacingToVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1424,7 +1424,7 @@ namespace Dynamo.Controls
                 case LacingStrategy.Disabled:
                     return "";
                 case LacingStrategy.Auto:
-                    return "Auto";
+                    return "AUTO";
                 case LacingStrategy.CrossProduct:
                     return "XXX";
                 case LacingStrategy.First:

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -107,7 +107,6 @@
     <controls:BoolToCanvasCursorConverter x:Key="BoolToCanvasCursorConverter" />
     <controls:LacingToVisibilityConverter x:Key="LacingToVisibilityConverter" />
     <controls:AutoLacingToVisibilityConverter x:Key="AutoLacingToVisibilityConverter" />
-    <controls:NonAutoLacingToVisibilityConverter x:Key="NonAutoLacingToVisibilityConverter" />
     <controls:LacingToAbbreviationConverter x:Key="LacingToAbbreviationConverter" />
     <controls:LacingToTooltipConverter x:Key="LacingToTooltipConverter" />
     <controls:BoolToVisibilityConverter x:Key="BooleanToVisibilityConverter" />

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -345,15 +345,6 @@
                     Visibility="{Binding ShouldShowGlyphBar, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
 
             <Grid>
-                <fa:FontAwesome 
-                       ToolTip="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToTooltipConverter}}"
-                       Visibility="{Binding Path=ArgumentLacing, Converter={StaticResource AutoLacingToVisibilityConverter}}"
-                       Icon="Ban"
-                       FontSize="8"
-                       Margin="5"
-                       HorizontalAlignment="Right"
-                       VerticalAlignment="Center"
-                       Foreground="#99000000"/>
                 <TextBlock Name="lacingOptionTextBlock"
                        Text="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToAbbreviationConverter}}"
                        ToolTip="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToTooltipConverter}}"

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -357,7 +357,7 @@
                 <TextBlock Name="lacingOptionTextBlock"
                        Text="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToAbbreviationConverter}}"
                        ToolTip="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToTooltipConverter}}"
-                       Visibility="{Binding Path=ArgumentLacing, Converter={StaticResource NonAutoLacingToVisibilityConverter}}"
+                       Visibility="{Binding Path=ArgumentLacing, Converter={StaticResource LacingToVisibilityConverter}}"
                        FontFamily="Tahoma"
                        FontSize="8"
                        Margin="5"


### PR DESCRIPTION
### Purpose

Previously we used "Ban" icon. Now change to text "AUTO":

![untitled](https://cloud.githubusercontent.com/assets/2600379/21133380/856e4100-c153-11e6-987d-322d2a0f2fe8.png)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@Racel 
