### PR TITLE
Fix regression - update expected default font size of group in test

### DIFF
--- a/test/DynamoCoreTests/AnnotationModelTest.cs
+++ b/test/DynamoCoreTests/AnnotationModelTest.cs
@@ -473,7 +473,7 @@ namespace Dynamo.Tests
             Assert.AreNotEqual(0, annotation.Width);
 
             //Check the default font size
-            Assert.AreEqual(annotation.FontSize, 14.0);
+            Assert.AreEqual(annotation.FontSize, 36.0);
         }
 
         [Test]
@@ -502,7 +502,7 @@ namespace Dynamo.Tests
             Assert.AreNotEqual(0, annotation.Width);
 
             //Check the default font size
-            Assert.AreEqual(annotation.FontSize, 14.0);
+            Assert.AreEqual(annotation.FontSize, 36.0);
 
             //Change the font size
             annotation.FontSize = 30;


### PR DESCRIPTION
### Purpose

Default font size of group has been updated to 36. This PR updated expected default font size of group in two test cases.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs

@Racel 

