### PR TITLE
Further address issues related to warning messages

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1274,6 +1274,7 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         public virtual void ClearRuntimeError()
         {
+            State = ElementState.Dead;
             SetNodeStateBasedOnConnectionAndDefaults();
             if (!string.IsNullOrEmpty(persistentWarning))
             {
@@ -1318,13 +1319,13 @@ namespace Dynamo.Graph.Nodes
             // if there are inputs without connections
             // mark as dead; otherwise, if the original state is dead,
             // update it as active.
-            if (inPorts.Any(x => !x.IsConnected))
+            if (inPorts.Any(x => !x.IsConnected && !(x.UsingDefaultValue && x.DefaultValue != null)))
             {
-                State = ElementState.Dead;
+                if (State == ElementState.Active) State = ElementState.Dead;
             }
             else
             {
-                State = ElementState.Active;
+                if (State == ElementState.Dead) State = ElementState.Active;
             }
         }
 


### PR DESCRIPTION
### Purpose

This is a follow-up pull request to further address issues related to warning messages (refer https://github.com/DynamoDS/Dynamo/pull/7387 for the former pull request). There are some subtle tricky logic related to warning messages.

Firstly, there are two test cases which are still failing: 
- MAGN_7348_Core_Python
- MAGN_7348_ListLacing

Secondly, there is one case when the warning message still persists after the graph is run successfully.

In the following graph, connecting A and B will cause an error message in the Line.ByStartEndPoint node:
![image](https://cloud.githubusercontent.com/assets/5584246/21174434/07d5e174-c218-11e6-9465-5cff9abafcf5.png)

![image](https://cloud.githubusercontent.com/assets/5584246/21174441/1a061ddc-c218-11e6-97da-f069ade3544d.png)

Now, if we disconnect it, ideally the warning message should go away. But before this fix, it does not. The reason is that SetNodeStateBasedOnConnectionAndDefaults is called whenever two ports are connected or disconnected. But when it is called, the original state is not checked before updating. In this fix, in addition to the existing conditions, before the node state is updated to Dead or Active, the original state is checked. The logic to make the fix is that assuming that the node has some runtime errors, ensure that all inports are connected or have default values can not prevent these runtime errors so we can not update the state to Active/Dead if there are already warnings/errors.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### FYIs

@ikeough 
@mjkkirschner 

