### PR TITLE
Filter out test files for serialization tests that consist of CBN in error state

### DIFF
--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -236,7 +236,8 @@ namespace Dynamo.Tests
             var cbnErrorNodes = ws1.Nodes.Where(n => n is CodeBlockNodeModel && n.State == ElementState.Error);
             if (cbnErrorNodes.Any())
             {
-                Assert.Inconclusive("The Workspace contains code block nodes in error state for: ");
+                Assert.Inconclusive("The Workspace contains code block nodes in error state due to which rest " +
+                                    "of the graph will not execute; skipping test ...");
             }
 
             if (((HomeWorkspaceModel)ws1).RunSettings.RunType== Models.RunType.Manual)

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -233,6 +233,12 @@ namespace Dynamo.Tests
                 Assert.Inconclusive("The Workspace contains dummy nodes for: " + string.Join(",", dummyNodes.Select(n => n.NickName).ToArray()));
             }
 
+            var cbnErrorNodes = ws1.Nodes.Where(n => n is CodeBlockNodeModel && n.State == ElementState.Error);
+            if (cbnErrorNodes.Any())
+            {
+                Assert.Inconclusive("The Workspace contains code block nodes in error state for: ");
+            }
+
             if (((HomeWorkspaceModel)ws1).RunSettings.RunType== Models.RunType.Manual)
             {
                 RunCurrentModel();


### PR DESCRIPTION
### Purpose

This fixes failing serialization test when a DYN file containing a CBN in error state is run. Due to recent changes in CBN behaviour in https://github.com/DynamoDS/Dynamo/pull/7401, where output port connections for CBN's in error state are maintained, the rest of the nodes in the same graph stop executing unless all output port connections are dropped or the CBN error is fixed. This is an existing defect and logged separately in https://jira.autodesk.com/browse/DYN-313. In this fix, we are simply filtering out such graphs that have one or more CBN's in error state from participating in the tests.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
