### PR TITLE
Added String.AllIndicesOf method

### DIFF
--- a/src/Libraries/CoreNodes/String.cs
+++ b/src/Libraries/CoreNodes/String.cs
@@ -303,6 +303,23 @@ namespace DSCore
                     : StringComparison.InvariantCulture);
         }
 
+        public static int[] AllIndicesOf(string str, string searchFor, bool ignoreCase = false)
+        {
+            var indices = new List<int>();
+            if (searchFor == System.String.Empty) return indices.ToArray();
+
+            for (int index = 0; ; index += searchFor.Length)
+            {
+                index = str.IndexOf(searchFor, index, ignoreCase
+                    ? StringComparison.InvariantCultureIgnoreCase
+                    : StringComparison.InvariantCulture);
+                if (index == -1)
+                    break;
+                indices.Add(index);
+            }
+            return indices.ToArray();
+        }
+
         /// <summary>
         ///     Finds the zero-based index of the last occurrence of a sub-string inside a string.
         ///     Returns -1 if no index could be found.

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -233,6 +233,12 @@ namespace Dynamo.Tests
                 Assert.Inconclusive("The Workspace contains dummy nodes for: " + string.Join(",", dummyNodes.Select(n => n.NickName).ToArray()));
             }
 
+            var cbnErrorNodes = ws1.Nodes.Where(n => n is CodeBlockNodeModel && n.State == ElementState.Error);
+            if (cbnErrorNodes.Any())
+            {
+                Assert.Inconclusive("The Workspace contains code block nodes in error state for: ");
+            }
+
             if (((HomeWorkspaceModel)ws1).RunSettings.RunType== Models.RunType.Manual)
             {
                 RunCurrentModel();

--- a/test/Libraries/CoreNodesTests/StringTests.cs
+++ b/test/Libraries/CoreNodesTests/StringTests.cs
@@ -260,6 +260,19 @@ namespace DSCoreNodesTests
 
         [Test]
         [Category("UnitTests")]
+        public static void AllIndicesOf()
+        {
+            Assert.AreEqual(new int[] {}, String.AllIndicesOf("", ""));
+            Assert.AreEqual(new int[] { }, String.AllIndicesOf("a", ""));
+            Assert.AreEqual(new int[] { }, String.AllIndicesOf("abcdef", "g"));
+            Assert.AreEqual(new int[] { }, String.AllIndicesOf("abcdef", "F"));
+            Assert.AreEqual(new[] {5}, String.AllIndicesOf("abcdef", "F", true));
+            Assert.AreEqual(new[] {1, 4, 7, 10}, String.AllIndicesOf("mississippi", "i"));
+            Assert.AreEqual(new[] {1, 4}, String.AllIndicesOf("mississippi", "is"));
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public static void LastIndexOf()
         {
             Assert.AreEqual(0, String.LastIndexOf("", ""));


### PR DESCRIPTION
### Purpose

Added String.AllIndicesOf similar to List.AllIndicesOf node. Refer to https://github.com/DynamoDS/Dynamo/issues/7415

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@jnealb 

### FYIs

@mccrone 

