### PR TITLE
If Dynamo.config contains a path that is not available, use the input debugPath to locate DynamoCore

### DIFF
--- a/src/Tools/DynamoInstallDetective/ProductLookUp.cs
+++ b/src/Tools/DynamoInstallDetective/ProductLookUp.cs
@@ -333,7 +333,7 @@ namespace DynamoInstallDetective
                 
                 var config = ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.None);
                 var runtime = config.AppSettings.Settings["DynamoRuntime"];
-                if (runtime != null)
+                if (runtime != null && !string.IsNullOrEmpty(runtime.Value) && Directory.Exists(runtime.Value))
                 {
                     additionalPath = runtime.Value;
                 }


### PR DESCRIPTION
### Purpose

This PR fixes Revit tests, when Dynamo.config doesn't contain a valid path. Allow DynamoInstallDetective to use the input debugPath, when Dynamo.config doesn't contain a valid directory path.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

