### PR TITLE
List@level syntax support as @L1

### DIFF
--- a/src/Engine/ProtoCore/BuildStatus.cs
+++ b/src/Engine/ProtoCore/BuildStatus.cs
@@ -518,6 +518,7 @@ namespace ProtoCore
                 case   "invalid Associative_Number":
                     return Properties.Resources.invalid_Associative_Number;
                 case "invalid Associative_Level":
+                    return Properties.Resources.invalid_Associative_Level;
                 case "invalid Associative_NameReference":
                     return Properties.Resources.invalid_Associative_NameReference;                        
                 case  "invalid Imperative_stmt":

--- a/src/Engine/ProtoCore/BuildStatus.cs
+++ b/src/Engine/ProtoCore/BuildStatus.cs
@@ -556,7 +556,7 @@ namespace ProtoCore
                 case   "invalid Imperative_PostFixOp":
                     return Properties.Resources.invalid_Imperative_PostFixOp;
                 default :
-                    return Properties.Resources.error;
+                    return errorMessage;
             }
         }
 

--- a/src/Engine/ProtoCore/BuildStatus.cs
+++ b/src/Engine/ProtoCore/BuildStatus.cs
@@ -517,7 +517,8 @@ namespace ProtoCore
                     return Properties.Resources.invalid_Associative_PostFixOp;
                 case   "invalid Associative_Number":
                     return Properties.Resources.invalid_Associative_Number;
-                case   "invalid Associative_NameReference":
+                case "invalid Associative_Level":
+                case "invalid Associative_NameReference":
                     return Properties.Resources.invalid_Associative_NameReference;                        
                 case  "invalid Imperative_stmt":
                     return Properties.Resources.invalid_Imperative_stmt;

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -369,10 +369,10 @@ namespace ProtoCore.AST.AssociativeAST
         {
             var buf = new StringBuilder();
             if (IsDominant)
-                buf.Append("@@");
+                buf.Append("@@L");
             else
-                buf.Append("@");
-            buf.Append(Level);
+                buf.Append("@L");
+            buf.Append(Math.Abs(Level));
             return buf.ToString();
         }
     }

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -2077,6 +2077,8 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_Level(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		node = null; 
+		int sign = 1;
+		
 		if (la.kind == 1) {
 			Get();
 			if(t.val[0] != 'L')
@@ -2087,7 +2089,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Int64 value;
 			if (Int64.TryParse(level, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
 			{
-			   node = new ProtoCore.AST.AssociativeAST.IntNode(value);
+			   node = new ProtoCore.AST.AssociativeAST.IntNode(-1*value);
 			}
 			else
 			{
@@ -2099,12 +2101,14 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else if (la.kind == 2 || la.kind == 15) {
 			if (la.kind == 15) {
 				Get();
+				sign = -1; 
+				
 			}
 			Expect(2);
 			Int64 value;
 			if (Int64.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
 			{
-			   node = new ProtoCore.AST.AssociativeAST.IntNode(value);
+			   node = new ProtoCore.AST.AssociativeAST.IntNode(sign*value);
 			}
 			else
 			{

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -2075,6 +2075,47 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		}
 	}
 
+	void Associative_Level(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
+		node = null; 
+		if (la.kind == 1) {
+			Get();
+			if(t.val[0] != 'L')
+			{
+			   errors.SemErr(t.line, t.col, String.Format(Resources.kInvalidListLevelName, t.val));
+			}
+			var level = t.val.Remove(0, 1);
+			Int64 value;
+			if (Int64.TryParse(level, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+			{
+			   node = new ProtoCore.AST.AssociativeAST.IntNode(value);
+			}
+			else
+			{
+			   errors.SemErr(t.line, t.col, String.Format(Resources.kInvalidListLevelName, t.val));
+			}
+			
+			NodeUtils.SetNodeLocation(node, t);
+			
+		} else if (la.kind == 2 || la.kind == 15) {
+			if (la.kind == 15) {
+				Get();
+			}
+			Expect(2);
+			Int64 value;
+			if (Int64.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+			{
+			   node = new ProtoCore.AST.AssociativeAST.IntNode(value);
+			}
+			else
+			{
+			   errors.SemErr(t.line, t.col, String.Format(Resources.kInvalidListLevelName, t.val));
+			}
+			
+			NodeUtils.SetNodeLocation(node, t);
+			
+		} else SynErr(90);
+	}
+
 	void Associative_Number(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		node = null; 
 		int sign = 1;
@@ -2133,7 +2174,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			   node.line = line; node.col = col;
 			}
 			
-		} else SynErr(90);
+		} else SynErr(91);
 	}
 
 	void Associative_Char(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -2217,7 +2258,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Associative_ArrayExprList(out node);
 			nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode;
 			
-		} else SynErr(91);
+		} else SynErr(92);
 		if (la.kind == 10) {
 			ProtoCore.AST.AssociativeAST.ArrayNode array = new ProtoCore.AST.AssociativeAST.ArrayNode(); 
 			
@@ -2332,10 +2373,10 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			
 			if (la.kind == 8) {
 				Get();
-				Associative_Number(out levelNode);
+				Associative_Level(out levelNode);
 			} else {
 				Get();
-				Associative_Number(out levelNode);
+				Associative_Level(out levelNode);
 				isDominant = true; 
 			}
 			IntNode listAtLevel = levelNode as IntNode;
@@ -2359,7 +2400,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			} else if (la.kind == 2) {
 				Get();
 				isLongest = false; 
-			} else SynErr(92);
+			} else SynErr(93);
 			repguide = t.val;
 			if (isLongest)
 			{
@@ -2381,7 +2422,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				} else if (la.kind == 2) {
 					Get();
 					isLongest = false; 
-				} else SynErr(93);
+				} else SynErr(94);
 				repguide = t.val;
 				if (isLongest)
 				{
@@ -2495,7 +2536,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			  SynErr(Resources.SemiColonExpected);
 			
 			Get();
-		} else SynErr(94);
+		} else SynErr(95);
 	}
 
 	void Imperative_languageblock(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -2524,7 +2565,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Hydrogen(out codeBlockNode);
 		} else if (langblock.codeblock.Language == ProtoCore.Language.Imperative ) {
 			Imperative(out codeBlockNode);
-		} else SynErr(95);
+		} else SynErr(96);
 		if (langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			int openCurlyBraceCount = 0, closeCurlyBraceCount = 0; 
 			ProtoCore.AST.ImperativeAST.CodeBlockNode codeBlockInvalid = new ProtoCore.AST.ImperativeAST.CodeBlockNode(); 
@@ -2545,12 +2586,12 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 					break; 
 				} else if (StartOf(8)) {
 					Get(); 
-				} else SynErr(96);
+				} else SynErr(97);
 			}
 			codeBlockNode = codeBlockInvalid; 
 		} else if (la.kind == 45) {
 			Get();
-		} else SynErr(97);
+		} else SynErr(98);
 		langblock.CodeBlockNode = codeBlockNode; 
 		node = langblock; 
 	}
@@ -2577,7 +2618,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt; 
 			Imperative_stmt(out singleStmt);
 			ifStmtNode.IfBody.Add(singleStmt); 
-		} else SynErr(98);
+		} else SynErr(99);
 		NodeUtils.SetNodeEndLocation(ifStmtNode.IfBodyPosition, t); 
 		while (la.kind == 30) {
 			ProtoCore.AST.ImperativeAST.ElseIfBlock elseifBlock = new ProtoCore.AST.ImperativeAST.ElseIfBlock(); 
@@ -2601,7 +2642,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				elseifBlock.Body.Add(singleStmt); 
-			} else SynErr(99);
+			} else SynErr(100);
 			NodeUtils.SetNodeEndLocation(elseifBlock.ElseIfBodyPosition, t); 
 			ifStmtNode.ElseIfList.Add(elseifBlock); 
 		}
@@ -2617,7 +2658,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				ifStmtNode.ElseBody.Add(singleStmt); 
-			} else SynErr(100);
+			} else SynErr(101);
 			NodeUtils.SetNodeEndLocation(ifStmtNode.ElseBodyPosition, t); 
 		}
 		node = ifStmtNode; 
@@ -2670,7 +2711,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 			Imperative_stmt(out singleStmt);
 			loopNode.Body.Add(singleStmt); 
-		} else SynErr(101);
+		} else SynErr(102);
 		forloop = loopNode;
 		
 	}
@@ -2704,7 +2745,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				Expect(23);
 			} else if (la.kind == 10) {
 				Imperative_languageblock(out rhsNode);
-			} else SynErr(102);
+			} else SynErr(103);
 			bNode.LeftNode = lhsNode;
 			bNode.RightNode = rhsNode;
 			bNode.Optr = Operator.assign;
@@ -2713,7 +2754,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			
 		} else if (StartOf(8)) {
 			SynErr("';' is expected"); 
-		} else SynErr(103);
+		} else SynErr(104);
 	}
 
 	void Imperative_expr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -2849,7 +2890,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			node = typedVar; 
 		} else if (la.kind == 1 || la.kind == 12 || la.kind == 44) {
 			Imperative_IdentifierList(out node);
-		} else SynErr(104);
+		} else SynErr(105);
 	}
 
 	void Imperative_IdentifierList(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -2959,7 +3000,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Imperative_ExprList(out node);
 			nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
 			
-		} else SynErr(105);
+		} else SynErr(106);
 		if (la.kind == 10) {
 			ProtoCore.AST.ImperativeAST.ArrayNode array = new ProtoCore.AST.ImperativeAST.ArrayNode();
 			
@@ -3036,7 +3077,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Imperative_negexpr(out node);
 		} else if (la.kind == 14 || la.kind == 59) {
 			Imperative_bitunaryexpr(out node);
-		} else SynErr(106);
+		} else SynErr(107);
 	}
 
 	void Imperative_negexpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3078,7 +3119,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Get();
 			op = UnaryOperator.Negate; 
 			#endif                     
-		} else SynErr(107);
+		} else SynErr(108);
 	}
 
 	void Imperative_factor(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3108,7 +3149,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Imperative_IdentifierList(out node);
 		} else if (la.kind == 14 || la.kind == 15 || la.kind == 59) {
 			Imperative_unaryexpr(out node);
-		} else SynErr(108);
+		} else SynErr(109);
 	}
 
 	void Imperative_negop(out UnaryOperator op) {
@@ -3142,7 +3183,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else if (la.kind == 58) {
 			Get();
 			op = Operator.or; 
-		} else SynErr(109);
+		} else SynErr(110);
 	}
 
 	void Imperative_RangeExpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3209,7 +3250,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			op = Operator.nq; 
 			break;
 		}
-		default: SynErr(110); break;
+		default: SynErr(111); break;
 		}
 	}
 
@@ -3284,7 +3325,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else if (la.kind == 15) {
 			Get();
 			op = Operator.sub; 
-		} else SynErr(111);
+		} else SynErr(112);
 	}
 
 	void Imperative_interimfactor(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3316,7 +3357,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else if (la.kind == 56) {
 			Get();
 			op = Operator.mod; 
-		} else SynErr(112);
+		} else SynErr(113);
 	}
 
 	void Imperative_bitop(out Operator op) {
@@ -3330,7 +3371,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else if (la.kind == 63) {
 			Get();
 			op = Operator.bitwisexor; 
-		} else SynErr(113);
+		} else SynErr(114);
 	}
 
 	void Imperative_Char(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3411,7 +3452,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			else{
 			   NodeUtils.SetNodeLocation(node, t); }
 			
-		} else SynErr(114);
+		} else SynErr(115);
 	}
 
 	void Imperative_functioncall(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3593,31 +3634,32 @@ public class Errors {
 			case 87: s = "invalid Associative_ComparisonOp"; break;
 			case 88: s = "invalid Associative_AddOp"; break;
 			case 89: s = "invalid Associative_MulOp"; break;
-			case 90: s = "invalid Associative_Number"; break;
-			case 91: s = "invalid Associative_NameReference"; break;
+			case 90: s = "invalid Associative_Level"; break;
+			case 91: s = "invalid Associative_Number"; break;
 			case 92: s = "invalid Associative_NameReference"; break;
 			case 93: s = "invalid Associative_NameReference"; break;
-			case 94: s = "invalid Imperative_stmt"; break;
-			case 95: s = "invalid Imperative_languageblock"; break;
+			case 94: s = "invalid Associative_NameReference"; break;
+			case 95: s = "invalid Imperative_stmt"; break;
 			case 96: s = "invalid Imperative_languageblock"; break;
 			case 97: s = "invalid Imperative_languageblock"; break;
-			case 98: s = "invalid Imperative_ifstmt"; break;
+			case 98: s = "invalid Imperative_languageblock"; break;
 			case 99: s = "invalid Imperative_ifstmt"; break;
 			case 100: s = "invalid Imperative_ifstmt"; break;
-			case 101: s = "invalid Imperative_forloop"; break;
-			case 102: s = "invalid Imperative_assignstmt"; break;
+			case 101: s = "invalid Imperative_ifstmt"; break;
+			case 102: s = "invalid Imperative_forloop"; break;
 			case 103: s = "invalid Imperative_assignstmt"; break;
-			case 104: s = "invalid Imperative_decoratedIdentifier"; break;
-			case 105: s = "invalid Imperative_NameReference"; break;
-			case 106: s = "invalid Imperative_unaryexpr"; break;
-			case 107: s = "invalid Imperative_unaryop"; break;
-			case 108: s = "invalid Imperative_factor"; break;
-			case 109: s = "invalid Imperative_logicalop"; break;
-			case 110: s = "invalid Imperative_relop"; break;
-			case 111: s = "invalid Imperative_addop"; break;
-			case 112: s = "invalid Imperative_mulop"; break;
-			case 113: s = "invalid Imperative_bitop"; break;
-			case 114: s = "invalid Imperative_num"; break;
+			case 104: s = "invalid Imperative_assignstmt"; break;
+			case 105: s = "invalid Imperative_decoratedIdentifier"; break;
+			case 106: s = "invalid Imperative_NameReference"; break;
+			case 107: s = "invalid Imperative_unaryexpr"; break;
+			case 108: s = "invalid Imperative_unaryop"; break;
+			case 109: s = "invalid Imperative_factor"; break;
+			case 110: s = "invalid Imperative_logicalop"; break;
+			case 111: s = "invalid Imperative_relop"; break;
+			case 112: s = "invalid Imperative_addop"; break;
+			case 113: s = "invalid Imperative_mulop"; break;
+			case 114: s = "invalid Imperative_bitop"; break;
+			case 115: s = "invalid Imperative_num"; break;
 
 			default: s = "error " + n; break;
 		}

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1280,7 +1280,10 @@ Associative_Factor<out node>
 .
 
 Associative_Level<out ProtoCore.AST.AssociativeAST.AssociativeNode node>               
-=   (.  node = null; .)  
+=   (.  
+        node = null; 
+        int sign = 1;
+    .)  
     (
         ident
         (.
@@ -1292,7 +1295,7 @@ Associative_Level<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
             Int64 value;
             if (Int64.TryParse(level, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
             {
-                node = new ProtoCore.AST.AssociativeAST.IntNode(value);
+                node = new ProtoCore.AST.AssociativeAST.IntNode(-1*value);
             }
             else
             {
@@ -1302,13 +1305,17 @@ Associative_Level<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
             NodeUtils.SetNodeLocation(node, t);
         .)
         |
-        ['-']
-        number
+        [
+            '-' 
+            (. 
+                sign = -1; 
+            .)
+        ] number
         (.
             Int64 value;
             if (Int64.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
             {
-                node = new ProtoCore.AST.AssociativeAST.IntNode(value);
+                node = new ProtoCore.AST.AssociativeAST.IntNode(sign*value);
             }
             else
             {

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1279,6 +1279,47 @@ Associative_Factor<out node>
 }
 .
 
+Associative_Level<out ProtoCore.AST.AssociativeAST.AssociativeNode node>               
+=   (.  node = null; .)  
+    (
+        ident
+        (.
+            if(t.val[0] != 'L')
+            {
+                errors.SemErr(t.line, t.col, String.Format(Resources.kInvalidListLevelName, t.val));
+            }
+            var level = t.val.Remove(0, 1);
+            Int64 value;
+            if (Int64.TryParse(level, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+            {
+                node = new ProtoCore.AST.AssociativeAST.IntNode(value);
+            }
+            else
+            {
+                errors.SemErr(t.line, t.col, String.Format(Resources.kInvalidListLevelName, t.val));
+            }
+
+            NodeUtils.SetNodeLocation(node, t);
+        .)
+        |
+        ['-']
+        number
+        (.
+            Int64 value;
+            if (Int64.TryParse(t.val, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out value))
+            {
+                node = new ProtoCore.AST.AssociativeAST.IntNode(value);
+            }
+            else
+            {
+                errors.SemErr(t.line, t.col, String.Format(Resources.kInvalidListLevelName, t.val));
+            }
+
+            NodeUtils.SetNodeLocation(node, t);
+        .)
+    )
+.
+
 Associative_Number<out ProtoCore.AST.AssociativeAST.AssociativeNode node>               
 =           
     (. 
@@ -1637,9 +1678,9 @@ Associative_NameReference<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
                                            bool isDominant = false;
                                         .)
         (
-            list_at Associative_Number<out levelNode> 
+            list_at Associative_Level<out levelNode> 
             |
-            dominant_list_at Associative_Number<out levelNode> (. isDominant = true; .)
+            dominant_list_at Associative_Level<out levelNode> (. isDominant = true; .)
         )
                                         (. 
                                             IntNode listAtLevel = levelNode as IntNode;

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -1286,6 +1286,15 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; cannot be used as list level name, consider using L1 for level 1..
+        /// </summary>
+        public static string kInvalidListLevelName {
+            get {
+                return ResourceManager.GetString("kInvalidListLevelName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A cyclic dependency exists between two variables.
         /// </summary>
         public static string kInvalidStaticCyclicDependency {

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -674,6 +674,15 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid list@level syntax, consider using @L1 for level 1..
+        /// </summary>
+        public static string invalid_Associative_Level {
+            get {
+                return ResourceManager.GetString("invalid_Associative_Level", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to invalid Associative_LogicalOp.
         /// </summary>
         public static string invalid_Associative_LogicalOp {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -911,4 +911,7 @@ Parameter name: {0}</value>
   <data name="InvalidFunction" xml:space="preserve">
     <value>Not an valid function.</value>
   </data>
+  <data name="kInvalidListLevelName" xml:space="preserve">
+    <value>'{0}' cannot be used as list level name, consider using L1 for level 1.</value>
+  </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -914,4 +914,7 @@ Parameter name: {0}</value>
   <data name="kInvalidListLevelName" xml:space="preserve">
     <value>'{0}' cannot be used as list level name, consider using L1 for level 1.</value>
   </data>
+  <data name="invalid_Associative_Level" xml:space="preserve">
+    <value>Invalid list@level syntax, consider using @L1 for level 1.</value>
+  </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -914,4 +914,7 @@ Parameter name: {0}</value>
   <data name="RemoveKeys1" xml:space="preserve">
     <value>Removes a copy of array with specified key removed</value>
   </data>
+  <data name="kInvalidListLevelName" xml:space="preserve">
+    <value>'{0}' cannot be used as list level name, consider using L1 for level 1.</value>
+  </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -917,4 +917,7 @@ Parameter name: {0}</value>
   <data name="kInvalidListLevelName" xml:space="preserve">
     <value>'{0}' cannot be used as list level name, consider using L1 for level 1.</value>
   </data>
+  <data name="invalid_Associative_Level" xml:space="preserve">
+    <value>Invalid list@level syntax, consider using @L1 for level 1.</value>
+  </data>
 </root>

--- a/test/Engine/ProtoTest/AtLevel/AtLevelTest.cs
+++ b/test/Engine/ProtoTest/AtLevel/AtLevelTest.cs
@@ -429,7 +429,7 @@ import (AtLevelTestClass from ""FFITarget.dll"");
 t = AtLevelTestClass();
 xs = {{{1,2}, {3, 4}}, {{5, 6}, {7, 8}}};
 ys = {""a"", ""b"", ""c""};
-r1 = t.sumAndConcat(xs@@2<1L>, ys@1<1L>);
+r1 = t.sumAndConcat(xs@@L2<1L>, ys@L1<1L>);
 ";
             thisTest.RunScriptSource(code);
             thisTest.Verify("r1", new object[] { new object[] { "3a", "7b" }, new object[] { "11c", "15c" } });

--- a/test/Engine/ProtoTest/AtLevel/AtLevelTest.cs
+++ b/test/Engine/ProtoTest/AtLevel/AtLevelTest.cs
@@ -429,7 +429,7 @@ import (AtLevelTestClass from ""FFITarget.dll"");
 t = AtLevelTestClass();
 xs = {{{1,2}, {3, 4}}, {{5, 6}, {7, 8}}};
 ys = {""a"", ""b"", ""c""};
-r1 = t.sumAndConcat(xs@@-2<1L>, ys@-1<1L>);
+r1 = t.sumAndConcat(xs@@2<1L>, ys@1<1L>);
 ";
             thisTest.RunScriptSource(code);
             thisTest.Verify("r1", new object[] { new object[] { "3a", "7b" }, new object[] { "11c", "15c" } });
@@ -446,7 +446,7 @@ def foo(x, y)
 
 xs = {{1,2,3}};
 ys = {{4,5,6}};
-r = foo(xs@@-1, ys@@-1);
+r = foo(xs@@L1, ys@@L1);
 ";
             thisTest.RunAndVerifyRuntimeWarning(code, ProtoCore.Runtime.WarningID.MoreThanOneDominantList);
             thisTest.Verify("r", new object[] { 5, 7, 9 });


### PR DESCRIPTION
### Purpose

This PR provides support for a new syntax for list@level, to use `list@L1` instead of `list@-1`. This PR also provides a better error message when the wrong syntax is used.

![image](https://cloud.githubusercontent.com/assets/1754137/21450814/121dbd86-c935-11e6-882a-9e43611b2884.png)

![image](https://cloud.githubusercontent.com/assets/1754137/21450852/60e3a444-c935-11e6-8fde-7969bd3ca6cd.png)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ke-yu 

### FYIs

@Racel
@riteshchandawar  
@Benglin 
