### PR TITLE
Serialization change

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -268,7 +268,7 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         ///     Indicates if node preview is pinned
         /// </summary>
-        [JsonIgnore]
+        [JsonProperty("isPinned")]
         public bool PreviewPinned { get; internal set; }
 
         /// <summary>
@@ -665,7 +665,7 @@ namespace Dynamo.Graph.Nodes
         /// <value>
         ///   <c>true</c> if this node is frozen; otherwise, <c>false</c>.
         /// </value>
-        [JsonIgnore]
+        [JsonProperty("isFrozen")]
         public bool IsFrozen
         {
             get

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -268,7 +268,7 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         ///     Indicates if node preview is pinned
         /// </summary>
-        [JsonProperty("isPinned")]
+        [JsonProperty("IsPinned")]
         public bool PreviewPinned { get; internal set; }
 
         /// <summary>
@@ -665,7 +665,7 @@ namespace Dynamo.Graph.Nodes
         /// <value>
         ///   <c>true</c> if this node is frozen; otherwise, <c>false</c>.
         /// </value>
-        [JsonProperty("isFrozen")]
+        [JsonProperty("IsFrozen")]
         public bool IsFrozen
         {
             get


### PR DESCRIPTION
### Purpose

As part of https://github.com/DynamoDS/Reach/pull/267, Dynamo Team found that the Json serialization of nodeModel in Dynamo ignored several attribute we serialize in flood db. We know eventually we want to switch from DynamoStorage to this version of workspace serialization. So adding these two properties into the serialized ones and use the same name as flood. If you have other concerns or suggestions, let us know.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@ikeough 

### FYIs
@mjkkirschner 
