### PR TITLE
Build fix

### DIFF
--- a/test/DynamoPackagesUITests/DynamoPackagesUITests.csproj
+++ b/test/DynamoPackagesUITests/DynamoPackagesUITests.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />


### PR DESCRIPTION
### Purpose

This PR fixes the build break due to missing assembly reference to DynamoPackagesUITests project.

- Add System.Windows.Forms reference to DynamoPackagesUITests.csproj to resolve `[RequiresThread] attribute`.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs
@jitnev 
@Benglin 