### PR TITLE
Add node for custom formatted current DateTime

### DIFF
--- a/src/Libraries/CoreNodes/DateTime.cs
+++ b/src/Libraries/CoreNodes/DateTime.cs
@@ -48,17 +48,19 @@ namespace DSCore
         {
             get { return System.DateTime.Today; }
         }
-        
+
         /// <summary>
-        ///     The current system date and time as a string, in the specified format.
+        ///     Return a specified date and time as a string, in the specified format.
         /// </summary>
-        /// <param name="format">String representation of the date format, search "MSDN Custom Date and Time Format Strings". Defaults to : dd/MM/yyyy
+        /// <param name="dateTime">The DateTime to format.</param>
+        /// <param name="format">String representation of the date format, defaults to : dddd dd MMMM yyyy (Sunday 01 January 2017)
+        /// Search "MSDN Custom Date and Time Format Strings" for a comprehensive list of format specifiers.
         ///</param>
-        /// <returns name="string">The current system date and time as a string, in the specified format.</returns>
-        [CanUpdatePeriodicallyAttribute(true)]
-        public static string NowByFormat(string format="dd/MM/yyyy")
+        /// <returns name="string">The specified date and time as a string, in the specified format.</returns>
+        public static string Format(System.DateTime dateTime, string format="dd MMM yyyy")
         {
-            return System.DateTime.Now.ToString(format, CultureInfo.InvariantCulture);
+            if (System.String.IsNullOrEmpty(format)) format = "dd MMM yyyy";
+            return dateTime.ToString(format, CultureInfo.InvariantCulture);
         }
         
         /// <summary>

--- a/src/Libraries/CoreNodes/DateTime.cs
+++ b/src/Libraries/CoreNodes/DateTime.cs
@@ -53,13 +53,13 @@ namespace DSCore
         ///     Return a specified date and time as a string, in the specified format.
         /// </summary>
         /// <param name="dateTime">The DateTime to format.</param>
-        /// <param name="format">String representation of the date format, defaults to : dddd dd MMMM yyyy (Sunday 01 January 2017)
+        /// <param name="format">String representation of the date format. Defaults to standard format "F", which outputs acording to operating system locale : "Monday, June 15, 2009 1:45:30 PM" for (en-US).
         /// Search "MSDN Custom Date and Time Format Strings" for a comprehensive list of format specifiers.
         ///</param>
         /// <returns name="string">The specified date and time as a string, in the specified format.</returns>
-        public static string Format(System.DateTime dateTime, string format="dd MMM yyyy")
+        public static string Format(System.DateTime dateTime, string format="F")
         {
-            if (System.String.IsNullOrEmpty(format)) format = "dd MMM yyyy";
+            if (System.String.IsNullOrEmpty(format)) format = "F";
             return dateTime.ToString(format, CultureInfo.InvariantCulture);
         }
         

--- a/src/Libraries/CoreNodes/DateTime.cs
+++ b/src/Libraries/CoreNodes/DateTime.cs
@@ -52,11 +52,9 @@ namespace DSCore
         /// <summary>
         ///     The current system date and time as a string, in the specified format.
         /// </summary>
-        /// <param name="format">
-        /// String representation of the date format, see https://msdn.microsoft.com/en-us/library/8kb3ddd4(v=vs.110).aspx
-        /// Defaults to : dd/MM/yyyy
+        /// <param name="format">String representation of the date format, search "MSDN Custom Date and Time Format Strings". Defaults to : dd/MM/yyyy
         ///</param>
-        /// <returns name="dateTime">The current system date and time as a string, in the specified format.</returns>
+        /// <returns name="string">The current system date and time as a string, in the specified format.</returns>
         [CanUpdatePeriodicallyAttribute(true)]
         public static string NowByFormat(string format="dd/MM/yyyy")
         {

--- a/src/Libraries/CoreNodes/DateTime.cs
+++ b/src/Libraries/CoreNodes/DateTime.cs
@@ -48,7 +48,21 @@ namespace DSCore
         {
             get { return System.DateTime.Today; }
         }
-
+        
+        /// <summary>
+        ///     The current system date and time as a string, in the specified format.
+        /// </summary>
+        /// <param name="format">
+        /// String representation of the date format, see https://msdn.microsoft.com/en-us/library/8kb3ddd4(v=vs.110).aspx
+        /// Defaults to : dd/MM/yyyy
+        ///</param>
+        /// <returns name="dateTime">DateTime</returns>
+        [CanUpdatePeriodicallyAttribute(true)]
+        public static string NowByFormat(string format="dd/MM/yyyy")
+        {
+            return System.DateTime.Now.ToString(format, CultureInfo.InvariantCulture);
+        }
+        
         /// <summary>
         ///     Creates a new DateTime at an exact date.
         /// </summary>

--- a/src/Libraries/CoreNodes/DateTime.cs
+++ b/src/Libraries/CoreNodes/DateTime.cs
@@ -56,7 +56,7 @@ namespace DSCore
         /// String representation of the date format, see https://msdn.microsoft.com/en-us/library/8kb3ddd4(v=vs.110).aspx
         /// Defaults to : dd/MM/yyyy
         ///</param>
-        /// <returns name="dateTime">DateTime</returns>
+        /// <returns name="dateTime">The current system date and time as a string, in the specified format.</returns>
         [CanUpdatePeriodicallyAttribute(true)]
         public static string NowByFormat(string format="dd/MM/yyyy")
         {

--- a/test/Libraries/CoreNodesTests/DateTimeTests.cs
+++ b/test/Libraries/CoreNodesTests/DateTimeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Collections.Generic;
 using NUnit.Framework;
 
@@ -47,6 +48,11 @@ namespace DSCoreNodesTests
                     { "millisecond", aDateTime.Millisecond },
                 },
                 WrappedDT.Components(aDateTime));
+        }
+        [Test, Category("UnitTests")]
+        public static void TestDateTime_Format()
+        {
+            Assert.AreEqual(aDateTime.ToString("dd MMM yyyy", CultureInfo.InvariantCulture), WrappedDT.Format(WrappedDT.FromString(aDateTime.ToString()), "dd MMM yyyy"));
         }
 
         [Test, Category("UnitTests")]


### PR DESCRIPTION
### Purpose

This PR adds a new node to Core.DateTime, called NowByFormat.
The node takes in a string parameter that specifies a format (according to standard MSDN documentation ) and returns an accordingly formatted current system date & time.

Came about as a response to David's question here : https://twitter.com/dourevit/status/817405784367763456

![nowbyformat](https://cloud.githubusercontent.com/assets/11439624/21737448/ae295da2-d470-11e6-8e3e-544713c05a5a.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

Introduces no additional dependencies on Dynamo APIs, external packages, namespaces, etc and does not change the Dynamo API.

### FYIs

