### PR TITLE
Use automatic enum serialization in json workspaces.

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -17,6 +17,7 @@ using Dynamo.Selection;
 using Dynamo.Utilities;
 using Dynamo.Visualization;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM;
 using ProtoCore.Mirror;
@@ -50,10 +51,10 @@ namespace Dynamo.Graph.Nodes
 
         /// <summary>
         /// The cached value of this node. The cachedValue object is protected by the cachedValueMutex
-        /// as it may be accessed from multiple threads concurrently. 
-        /// 
+        /// as it may be accessed from multiple threads concurrently.
+        ///
         /// However, generally access to the cachedValue property should be protected by usage
-        /// of the Scheduler. 
+        /// of the Scheduler.
         /// </summary>
         private MirrorData cachedValue;
         private readonly object cachedValueMutex = new object();
@@ -76,15 +77,15 @@ namespace Dynamo.Graph.Nodes
         public virtual string CreationName { get { return this.Name; } }
 
         /// <summary>
-        /// This property queries all the Upstream Nodes  for a given node, ONLY after the graph is loaded. 
+        /// This property queries all the Upstream Nodes  for a given node, ONLY after the graph is loaded.
         /// This property is computed in ComputeUpstreamOnDownstreamNodes function
         /// </summary>
         internal HashSet<NodeModel> UpstreamCache = new HashSet<NodeModel>();
 
         /// <summary>
-        /// The NodeType property provides a name which maps to the 
+        /// The NodeType property provides a name which maps to the
         /// server type for the node. This property should only be
-        /// used for serialization. 
+        /// used for serialization.
         /// </summary>
         public virtual string NodeType
         {
@@ -198,7 +199,7 @@ namespace Dynamo.Graph.Nodes
 
         /// <summary>
         /// Input nodes are used in Customizer and Presets. Input nodes can be numbers, number sliders,
-        /// strings, bool, code blocks and custom nodes, which don't specify path. This property 
+        /// strings, bool, code blocks and custom nodes, which don't specify path. This property
         /// is true for nodes that are potential inputs for Customizers and Presets.
         /// </summary>
         [JsonIgnore]
@@ -244,7 +245,7 @@ namespace Dynamo.Graph.Nodes
                 if (value != ElementState.Error && value != ElementState.AstBuildBroken)
                     ClearTooltipText();
 
-                // Check before settings and raising 
+                // Check before settings and raising
                 // a notification.
                 if (state == value) return;
 
@@ -356,7 +357,7 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         ///     Control how arguments lists of various sizes are laced.
         /// </summary>
-        [JsonProperty("Replication"), JsonConverter(typeof(LacingStrategyConverter))]
+        [JsonProperty("Replication"), JsonConverter(typeof(StringEnumConverter))]
         public LacingStrategy ArgumentLacing
         {
             get
@@ -364,21 +365,21 @@ namespace Dynamo.Graph.Nodes
                 return argumentLacing;
             }
 
-            // The property setter is marked as private/protected because it 
+            // The property setter is marked as private/protected because it
             // should not be set from an external component directly. The ability
-            // to directly set the property value causes a NodeModel to be altered 
-            // without careful consideration of undo/redo recording. If changing 
-            // this property value should be undo-able, then the caller should use 
-            // "DynamoModel.UpdateModelValueCommand" to set the property value. 
+            // to directly set the property value causes a NodeModel to be altered
+            // without careful consideration of undo/redo recording. If changing
+            // this property value should be undo-able, then the caller should use
+            // "DynamoModel.UpdateModelValueCommand" to set the property value.
             // The command ensures changes to the NodeModel is recorded for undo.
-            // 
-            // In some cases being able to set the property value directly is 
-            // desirable, for example, some unit test scenarios require the given 
-            // NodeModel property to be of certain value. In such cases the 
+            //
+            // In some cases being able to set the property value directly is
+            // desirable, for example, some unit test scenarios require the given
+            // NodeModel property to be of certain value. In such cases the
             // easiest workaround is to use "NodeModel.UpdateValue" method:
-            // 
+            //
             //      someNode.UpdateValue("ArgumentLacing", "CrossProduct");
-            // 
+            //
             protected set
             {
                 if (argumentLacing != value)
@@ -453,9 +454,9 @@ namespace Dynamo.Graph.Nodes
 
         /// <summary>
         /// The value of this node after the most recent computation
-        /// 
-        /// As this property could be modified by the virtual machine, it's dangerous 
-        /// to access this value without using the active Scheduler. Use the Scheduler to 
+        ///
+        /// As this property could be modified by the virtual machine, it's dangerous
+        /// to access this value without using the active Scheduler. Use the Scheduler to
         /// remove the possibility of race conditions.
         /// </summary>
         [JsonIgnore]
@@ -481,16 +482,16 @@ namespace Dynamo.Graph.Nodes
 
         /// <summary>
         /// This flag is used to determine if a node was involved in a recent execution.
-        /// The primary purpose of this flag is to determine if the node's render packages 
-        /// should be returned to client browser when it requests for them. This is mainly 
+        /// The primary purpose of this flag is to determine if the node's render packages
+        /// should be returned to client browser when it requests for them. This is mainly
         /// to avoid returning redundant data that has not changed during an execution.
         /// </summary>
         internal bool WasInvolvedInExecution { get; set; }
 
         /// <summary>
-        /// This flag indicates if render packages of a NodeModel has been updated 
-        /// since the last execution. UpdateRenderPackageAsyncTask will always be 
-        /// generated for a NodeModel that took part in the evaluation, if this flag 
+        /// This flag indicates if render packages of a NodeModel has been updated
+        /// since the last execution. UpdateRenderPackageAsyncTask will always be
+        /// generated for a NodeModel that took part in the evaluation, if this flag
         /// is false.
         /// </summary>
         internal bool WasRenderPackageUpdatedAfterExecution { get; set; }
@@ -648,7 +649,7 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        ///      The possible type of output at specified port. This 
+        ///      The possible type of output at specified port. This
         ///      type information is not necessary to be accurate.
         /// </summary>
         /// <returns></returns>
@@ -656,11 +657,11 @@ namespace Dynamo.Graph.Nodes
         {
             return ProtoCore.TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.Var);
         }
-    
+
         /// <summary>
         /// A flag indicating whether the node is frozen.
         /// When a node is frozen, the node, and all nodes downstream will not participate in execution.
-        /// This will return true if any upstream node is frozen or if the node was explicitly frozen.        
+        /// This will return true if any upstream node is frozen or if the node was explicitly frozen.
         /// </summary>
         /// <value>
         ///   <c>true</c> if this node is frozen; otherwise, <c>false</c>.
@@ -678,9 +679,9 @@ namespace Dynamo.Graph.Nodes
                 //If the node is Unfreezed then Mark all the downstream nodes as
                 // modified. This is essential recompiling the AST.
                 if (!value)
-                { 
+                {
                     MarkDownStreamNodesAsModified(this);
-                    OnNodeModified();  
+                    OnNodeModified();
                     RaisePropertyChanged("IsFrozen");
                 }
                 //If the node is frozen, then do not execute the graph immediately.
@@ -688,7 +689,7 @@ namespace Dynamo.Graph.Nodes
                 else
                 {
                     ComputeUpstreamOnDownstreamNodes();
-                    OnUpdateASTCollection();                  
+                    OnUpdateASTCollection();
                 }
             }
         }
@@ -723,7 +724,7 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         /// <returns></returns>
         internal bool IsAnyUpstreamFrozen()
-        {            
+        {
             return UpstreamCache.Any(x => x.isFrozenExplicitly);
         }
 
@@ -751,8 +752,8 @@ namespace Dynamo.Graph.Nodes
         /// by gathering the cached upstream nodes on this node's immediate parents.
         /// If a node has any downstream nodes, then for all those downstream nodes, upstream
         /// nodes will be computed. Essentially this method propogates the UpstreamCache down.
-        /// Also this function gets called only after the workspace is added.    
-        /// </summary>      
+        /// Also this function gets called only after the workspace is added.
+        /// </summary>
         internal void ComputeUpstreamOnDownstreamNodes()
         {
             //first compute upstream nodes for this node
@@ -766,7 +767,7 @@ namespace Dynamo.Graph.Nodes
             foreach (var downstreamNode in AstBuilder.TopologicalSort(downStreamNodes))
             {
                 downstreamNode.UpstreamCache = new HashSet<NodeModel>();
-                var currentinpNodes = downstreamNode.InputNodes.Values;                
+                var currentinpNodes = downstreamNode.InputNodes.Values;
                 foreach (var inputnode in currentinpNodes.Where(x => x != null))
                 {
                     downstreamNode.UpstreamCache.Add(inputnode.Item2);
@@ -776,10 +777,10 @@ namespace Dynamo.Graph.Nodes
                     }
                 }
             }
-                    
-            RaisePropertyChanged("IsFrozen");           
+
+            RaisePropertyChanged("IsFrozen");
         }
-       
+
         private void MarkDownStreamNodesAsModified(NodeModel node)
         {
             HashSet<NodeModel> gathered = new HashSet<NodeModel>();
@@ -901,7 +902,7 @@ namespace Dynamo.Graph.Nodes
                             // the 'sender' with the port, which is required
                             // for the disconnect operations.
                             ConnectorsCollectionChanged(p, args);
-                        };                        
+                        };
                         p.PropertyChanged += OnPortPropertyChanged;
                         SetNodeStateBasedOnConnectionAndDefaults();
                     }
@@ -922,7 +923,7 @@ namespace Dynamo.Graph.Nodes
         private void ConnectorsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
             var p = (PortModel)sender;
-            
+
             switch (e.Action)
             {
                 case System.Collections.Specialized.NotifyCollectionChangedAction.Add:
@@ -973,8 +974,8 @@ namespace Dynamo.Graph.Nodes
 
         /// <summary>
         ///     Indicate if the node should respond to NodeModified event. It
-        ///     always should be true, unless is temporarily set to false to 
-        ///     avoid flood of Modified event. 
+        ///     always should be true, unless is temporarily set to false to
+        ///     avoid flood of Modified event.
         /// </summary>
         [JsonIgnore]
         public bool RaisesModificationEvents { get; set; }
@@ -987,7 +988,7 @@ namespace Dynamo.Graph.Nodes
         {
             if (!RaisesModificationEvents || IsFrozen)
                 return;
-           
+
             MarkNodeAsModified(forceExecute);
             var handler = Modified;
             if (handler != null) handler(this);
@@ -1006,9 +1007,9 @@ namespace Dynamo.Graph.Nodes
 
         /// <summary>
         /// Called when a node is requesting that the workspace's node modified events be
-        /// silenced. This is particularly critical for code block nodes, whose modification can 
+        /// silenced. This is particularly critical for code block nodes, whose modification can
         /// mutate the workspace.
-        /// 
+        ///
         /// As opposed to RaisesModificationEvents, this modifies the entire parent workspace
         /// </summary>
         internal event Action<NodeModel, bool> RequestSilenceNodeModifiedEvents;
@@ -1060,9 +1061,9 @@ namespace Dynamo.Graph.Nodes
                 // If any exception from BuildOutputAst(), we emit
                 // a function call "var_guid = %nodeAstFailed(full.node.name)"
                 // for this node, set the state of node to AstBuildBroken and
-                // disply the corresponding error message. 
-                // 
-                // The return value of function %nodeAstFailed() is always 
+                // disply the corresponding error message.
+                //
+                // The return value of function %nodeAstFailed() is always
                 // null.
                 var errorMsg = Properties.Resources.NodeProblemEncountered;
                 var fullMsg = errorMsg + "\n\n" + e.Message;
@@ -1269,7 +1270,7 @@ namespace Dynamo.Graph.Nodes
         /// Clears the errors/warnings that are generated when running the graph.
         /// If the node has a value supplied for the persistentWarning, then the
         /// node's State will be set to ElementState.Persistent and the ToolTipText will
-        /// be set to the persistent warning. Otherwise, the State will be 
+        /// be set to the persistent warning. Otherwise, the State will be
         /// set to ElementState.Dead
         /// </summary>
         public virtual void ClearRuntimeError()
@@ -1336,7 +1337,7 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        /// Set a warning on a node. 
+        /// Set a warning on a node.
         /// </summary>
         /// <param name="p">The warning text.</param>
         /// <param name="isPersistent">Is the warning persistent? If true, the warning will not be
@@ -1358,7 +1359,7 @@ namespace Dynamo.Graph.Nodes
 
         /// <summary>
         /// Change the state of node to ElementState.AstBuildBroken and display
-        /// "p" in tooltip window. 
+        /// "p" in tooltip window.
         /// </summary>
         /// <param name="p"></param>
         public void NotifyAstBuildBroken(string p)
@@ -1381,12 +1382,12 @@ namespace Dynamo.Graph.Nodes
 
         /// <summary>
         /// If a "PortModel.LineIndex" property isn't "-1", then it is a PortModel
-        /// meant to match up with a line in code block node. A code block node may 
-        /// contain empty lines in it, resulting in one PortModel being spaced out 
-        /// from another one. In such cases, the vertical position of PortModel is 
+        /// meant to match up with a line in code block node. A code block node may
+        /// contain empty lines in it, resulting in one PortModel being spaced out
+        /// from another one. In such cases, the vertical position of PortModel is
         /// dependent of its "LineIndex".
-        /// 
-        /// If a "PortModel.LineIndex" property is "-1", then it is a regular 
+        ///
+        /// If a "PortModel.LineIndex" property is "-1", then it is a regular
         /// PortModel. Regular PortModel stacks up on one another with equal spacing,
         /// so their positions are based solely on "PortModel.Index".
         /// </summary>
@@ -1567,7 +1568,7 @@ namespace Dynamo.Graph.Nodes
             {
                 RegisterOutputPorts(outPortDatas);
             }
-                
+
             RaisesModificationEvents = true;
             areInputPortsRegistered = true;
         }
@@ -2031,21 +2032,21 @@ namespace Dynamo.Graph.Nodes
 
                 // We only notify property changes in an undo/redo operation. Normal
                 // operations like file loading or copy-paste have the models created
-                // in different ways and their views will always be up-to-date with 
+                // in different ways and their views will always be up-to-date with
                 // respect to their models.
                 RaisePropertyChanged("InteractionEnabled");
                 RaisePropertyChanged("State");
                 RaisePropertyChanged("NickName");
                 RaisePropertyChanged("ArgumentLacing");
                 RaisePropertyChanged("IsVisible");
-                RaisePropertyChanged("IsUpstreamVisible");    
-            
-                //we need to modify the downstream nodes manually in case the 
+                RaisePropertyChanged("IsUpstreamVisible");
+
+                //we need to modify the downstream nodes manually in case the
                 //undo is for toggling freeze. This is ONLY modifying the execution hint.
                 // this does not run the graph.
                 RaisePropertyChanged("IsFrozen");
                 MarkDownStreamNodesAsModified(this);
-               
+
                 // Notify listeners that the position of the node has changed,
                 // then all connected connectors will also redraw themselves.
                 ReportPosition();
@@ -2107,15 +2108,15 @@ namespace Dynamo.Graph.Nodes
 
         /// <summary>
         /// Call this method to update the cached MirrorData for this NodeModel.
-        /// Note this method should be called from scheduler thread. 
+        /// Note this method should be called from scheduler thread.
         /// </summary>
-        /// 
+        ///
         internal void RequestValueUpdate(EngineController engine)
         {
-            // A NodeModel should have its cachedMirrorData reset when it is 
-            // requested to update its value. When the QueryMirrorDataAsyncTask 
+            // A NodeModel should have its cachedMirrorData reset when it is
+            // requested to update its value. When the QueryMirrorDataAsyncTask
             // returns, it will update cachedMirrorData with the latest value.
-            // 
+            //
             lock (cachedValueMutex)
             {
                 cachedValue = null;
@@ -2135,8 +2136,8 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        /// Call this method to asynchronously regenerate render package for 
-        /// this node. This method accesses core properties of a NodeModel and 
+        /// Call this method to asynchronously regenerate render package for
+        /// this node. This method accesses core properties of a NodeModel and
         /// therefore is typically called on the main/UI thread.
         /// </summary>
         /// <param name="scheduler">An IScheduler on which the task will be scheduled.</param>
@@ -2167,13 +2168,13 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        /// This event handler is invoked when UpdateRenderPackageAsyncTask is 
-        /// completed, at which point the render packages (specific to this node) 
-        /// become available. 
+        /// This event handler is invoked when UpdateRenderPackageAsyncTask is
+        /// completed, at which point the render packages (specific to this node)
+        /// become available.
         /// </summary>
         /// <param name="asyncTask">The instance of UpdateRenderPackageAsyncTask
         /// that was responsible of generating the render packages.</param>
-        /// 
+        ///
         private void OnRenderPackageUpdateCompleted(AsyncTask asyncTask)
         {
             var task = asyncTask as UpdateRenderPackageAsyncTask;
@@ -2189,13 +2190,13 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public event Func<IEnumerable<IRenderPackage>> RequestRenderPackages;
 
         /// <summary>
-        /// This event handler is invoked when the render packages (specific to this node)  
-        /// become available and in addition the node requests for associated render packages 
+        /// This event handler is invoked when the render packages (specific to this node)
+        /// become available and in addition the node requests for associated render packages
         /// if any for example, packages used for associated node manipulators
         /// </summary>
         private IEnumerable<IRenderPackage> OnRequestRenderPackages()
@@ -2208,7 +2209,7 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        /// Returns list of drawable Ids as registered with visualization manager 
+        /// Returns list of drawable Ids as registered with visualization manager
         /// for all the output port of the given node.
         /// </summary>
         /// <returns>List of Drawable Ids</returns>
@@ -2378,68 +2379,5 @@ namespace Dynamo.Graph.Nodes
         /// Action to call on UI thread.
         /// </summary>
         public Action ActionToDispatch { get; set; }
-    }
-
-    /// <summary>
-    /// The LacingStrategyConverter is used to serialize and deserialize LacingStrategy enum values.
-    /// The mapping to string like 'applyDisabled' is to support the historical representation
-    /// of 'lacing' on Flood.
-    /// </summary>
-    class LacingStrategyConverter : JsonConverter
-    {
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(LacingStrategy);
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            var s = reader.Value.ToString();
-            switch (s)
-            {
-                case "Auto":
-                    return LacingStrategy.Auto;
-                case "Cartesian":
-                    return LacingStrategy.CrossProduct;
-                case "Disabled":
-                    return LacingStrategy.Disabled;
-                case "First":
-                    return LacingStrategy.First;
-                case "Longest":
-                    return LacingStrategy.Longest;
-                case "Shortest":
-                    return LacingStrategy.Shortest;
-                default:
-                    return LacingStrategy.Disabled;
-            }
-        }
-
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            var s = (LacingStrategy)value;
-
-            switch (s)
-            {
-
-                case LacingStrategy.Auto:
-                    writer.WriteValue("Auto");
-                    break;
-                case LacingStrategy.CrossProduct:
-                    writer.WriteValue("Cartesian");
-                    break;
-                case LacingStrategy.Disabled:
-                    writer.WriteValue("Disabled");
-                    break;
-                case LacingStrategy.First:
-                    writer.WriteValue("First");
-                    break;
-                case LacingStrategy.Longest:
-                    writer.WriteValue("Longest");
-                    break;
-                case LacingStrategy.Shortest:
-                    writer.WriteValue("Shortest");
-                    break;
-            }
-        }
     }
 }

--- a/src/Libraries/CoreNodeModels/DynamoConvert.cs
+++ b/src/Libraries/CoreNodeModels/DynamoConvert.cs
@@ -7,6 +7,7 @@ using System.Xml;
 using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace CoreNodeModels
 {
@@ -28,9 +29,9 @@ namespace CoreNodeModels
         private List<ConversionUnit> selectedToConversionSource;
 
         /// <summary>
-        /// The NodeType property provides a name which maps to the 
+        /// The NodeType property provides a name which maps to the
         /// server type for the node. This property should only be
-        /// used for serialization. 
+        /// used for serialization.
         /// </summary>
         public override string NodeType
         {
@@ -62,13 +63,13 @@ namespace CoreNodeModels
             }
         }
 
-        [JsonProperty("MetricConversion")]
+        [JsonProperty("MetricConversion"), JsonConverter(typeof(StringEnumConverter))]
         public ConversionMetricUnit SelectedMetricConversion
         {
             get { return selectedMetricConversion; }
             set
             {
-                selectedMetricConversion = (ConversionMetricUnit)Enum.Parse(typeof(ConversionMetricUnit), value.ToString()); ;               
+                selectedMetricConversion = (ConversionMetricUnit)Enum.Parse(typeof(ConversionMetricUnit), value.ToString()); ;
                 SelectedFromConversionSource =
                     Conversions.ConversionMetricLookup[(ConversionMetricUnit)Enum.Parse(typeof(ConversionMetricUnit),value.ToString())];
                 SelectedToConversionSource =
@@ -80,7 +81,7 @@ namespace CoreNodeModels
             }
         }
 
-        [JsonProperty("FromConversion")]
+        [JsonProperty("FromConversion"), JsonConverter(typeof(StringEnumConverter))]
         public ConversionUnit SelectedFromConversion
         {
             get { return selectedFromConversion; }
@@ -92,7 +93,7 @@ namespace CoreNodeModels
             }
         }
 
-        [JsonProperty("ToConversion")]
+        [JsonProperty("ToConversion"), JsonConverter(typeof(StringEnumConverter))]
         public ConversionUnit SelectedToConversion
         {
             get { return selectedToConversion; }
@@ -135,8 +136,8 @@ namespace CoreNodeModels
         }
 
         public DynamoConvert()
-        {           
-            SelectedMetricConversion = ConversionMetricUnit.Length;  
+        {
+            SelectedMetricConversion = ConversionMetricUnit.Length;
             AssociativeNode defaultNode = new DoubleNode(0.0);
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("", Properties.Resources.UnitNodeFromPortTooltip, defaultNode)));
             OutPorts.Add(new PortModel(PortType.Output, this, new PortData("", Properties.Resources.UnitNodeToPortToolTip)));
@@ -145,21 +146,21 @@ namespace CoreNodeModels
             IsSelectionFromBoxEnabled = true;
             RegisterAllPorts();
         }
-      
+
         public override IEnumerable<AssociativeNode> BuildOutputAst(
             List<AssociativeNode> inputAstNodes)
-        {       
+        {
             var conversionToNode =
                 AstFactory.BuildDoubleNode(Conversions.ConversionDictionary[SelectedToConversion]);
 
             var conversionFromNode =
                 AstFactory.BuildDoubleNode(Conversions.ConversionDictionary[SelectedFromConversion]);
             AssociativeNode node = null;
-           
+
             node = AstFactory.BuildFunctionCall(
                         new Func<double, double, double, double>(Conversions.ConvertUnitTypes),
                         new List<AssociativeNode> { inputAstNodes[0], conversionFromNode, conversionToNode });
-          
+
             return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), node) };
         }
 
@@ -226,6 +227,6 @@ namespace CoreNodeModels
         }
 
         #endregion
-    }      
+    }
 }
 

--- a/src/Libraries/CoreNodeModels/Input/SliderBase.cs
+++ b/src/Libraries/CoreNodeModels/Input/SliderBase.cs
@@ -1,4 +1,5 @@
 ﻿using Dynamo.Graph.Nodes;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -11,6 +12,7 @@ namespace CoreNodeModels.Input
         private T min;
         private T step;
 
+        [JsonProperty("RangeMax")]
         public T Max
         {
             get { return max; }
@@ -32,6 +34,7 @@ namespace CoreNodeModels.Input
             }
         }
 
+        [JsonProperty("RangeMin")]
         public T Min
         {
             get { return min; }
@@ -53,6 +56,7 @@ namespace CoreNodeModels.Input
             }
         }
 
+        [JsonProperty("RangeStep")]
         public T Step
         {
             get { return step; }
@@ -93,7 +97,7 @@ namespace CoreNodeModels.Input
             if (Value.CompareTo(Min) < 0) Min = Value;
             if (Value.CompareTo(Max) > 0) Max = Value;
         }
-        
+
         public static string ConvertNumberToString(T value)
         {
             return Convert.ToString(value, CultureInfo.InvariantCulture);
@@ -121,7 +125,7 @@ namespace CoreNodeModels.Input
                     {
                         return 0;
                     }
-                    
+
                 }
                 result = start == 0 ? int.MaxValue : int.MinValue;
             }

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -41,7 +41,7 @@ namespace Dynamo.Tests
             ExecutionEvents.GraphPostExecution += ExecutionEvents_GraphPostExecution;
         }
 
-        [TearDown]
+        [TestFixtureTearDown]
         public void TearDown()
         {
             ExecutionEvents.GraphPostExecution -= ExecutionEvents_GraphPostExecution;


### PR DESCRIPTION
### Purpose

Replace manual serialization with automatic serialization now that the schemas match.
Add enum serialization to a type that has changed from an int to an enum.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [n/a] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [n/a] Snapshot of UI changes, if any.
- [n/a] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ikeough 
