### PR TITLE
DYN-236 cherry pick

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1310,6 +1310,12 @@ namespace Dynamo.ViewModels
 
         private void OpenRecent(object path)
         {
+            // Make sure user get chance to save unsaved changes first
+            if (CurrentSpaceViewModel.HasUnsavedChanges)
+            {
+                if (!AskUserToSaveWorkspaceOrCancel(HomeSpace))
+                    return;
+            }
             this.Open(path as string);
         }
 

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -3,12 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using Dynamo.Graph;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
-using Dynamo.Nodes;
 using Dynamo.Search.SearchElements;
 using Dynamo.Wpf.ViewModels;
 
@@ -457,6 +455,33 @@ namespace Dynamo.Tests
             ViewModel.OpenIfSavedCommand.Execute(new Dynamo.Models.DynamoModel.OpenFileCommand(openPath));
             //assert the request was made
             Assert.AreEqual(1,eventCount);
+            //dispose handler
+            ViewModel.RequestUserSaveWorkflow -= handler;
+
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void EnsureAskUserToSaveDialogIsShownOnOpenRecent()
+        {
+            //openPath
+            string openPath = Path.Combine(TestDirectory, (@"UI\GroupTest.dyn"));
+
+            //workspace has unsaved changes
+            this.GetModel().CurrentWorkspace.HasUnsavedChanges = true;
+
+            var eventCount = 0;
+
+            var handler = new WorkspaceSaveEventHandler((o, e) => { eventCount = eventCount + 1; });
+
+            //attach handler to the save request
+            ViewModel.RequestUserSaveWorkflow += handler;
+
+            //send the command
+            ViewModel.OpenRecentCommand.Execute(openPath);
+
+            //assert the request was made
+            Assert.AreEqual(1, eventCount);
             //dispose handler
             ViewModel.RequestUserSaveWorkflow -= handler;
 

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -453,11 +453,12 @@ namespace Dynamo.Tests
             ViewModel.RequestUserSaveWorkflow += handler;
             //send the command
             ViewModel.OpenIfSavedCommand.Execute(new Dynamo.Models.DynamoModel.OpenFileCommand(openPath));
-            //assert the request was made
-            Assert.AreEqual(1,eventCount);
+
             //dispose handler
             ViewModel.RequestUserSaveWorkflow -= handler;
 
+            //assert the request was made
+            Assert.AreEqual(1,eventCount);
         }
 
         [Test]
@@ -480,11 +481,11 @@ namespace Dynamo.Tests
             //send the command
             ViewModel.OpenRecentCommand.Execute(openPath);
 
-            //assert the request was made
-            Assert.AreEqual(1, eventCount);
             //dispose handler
             ViewModel.RequestUserSaveWorkflow -= handler;
 
+            //assert the request was made
+            Assert.AreEqual(1, eventCount);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

Cherry pick work from [DYN-236](https://jira.autodesk.com/browse/DYN-236) Open recent files does not prompt to save existing graph to RC1.2.2_master

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers



### FYIs

@jnealb @Racel @kronz @Benglin 