### PR TITLE
AstVisitor cleanup

### DIFF
--- a/src/DynamoCore/Engine/NodeToCode/NodeToCode.cs
+++ b/src/DynamoCore/Engine/NodeToCode/NodeToCode.cs
@@ -234,14 +234,15 @@ namespace Dynamo.Engine.NodeToCode
             this.core = core;
         }
 
-        public override void VisitIdentifierNode(IdentifierNode node)
+        public override bool VisitIdentifierNode(IdentifierNode node)
         {
             identFunc(node);
             if (node.ArrayDimensions != null)
                 node.ArrayDimensions.Accept(this);
+            return true;
         }
 
-        public override void VisitIdentifierListNode(IdentifierListNode node)
+        public override bool VisitIdentifierListNode(IdentifierListNode node)
         {
             if (node.LeftNode is IdentifierNode || node.LeftNode is IdentifierListNode)
             {
@@ -256,10 +257,10 @@ namespace Dynamo.Engine.NodeToCode
                     if (!(node.RightNode is IdentifierNode))
                         node.RightNode.Accept(this);
 
-                    return;
+                    return true;
                 }
             }
-            base.VisitIdentifierListNode(node);
+            return base.VisitIdentifierListNode(node);
         }
     }
 

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -1,15 +1,14 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using ProtoCore.AST.ImperativeAST;
-using ProtoCore.DesignScriptParser;
 using ProtoCore.DSASM;
 using ProtoCore.DSDefinitions;
 using ProtoCore.Lang;
+using ProtoCore.SyntaxAnalysis.Associative;
 using ProtoCore.Utils;
-using ProtoCore.SyntaxAnalysis;
+using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Text;
 
 namespace ProtoCore.AST.AssociativeAST
 {
@@ -70,8 +69,7 @@ namespace ProtoCore.AST.AssociativeAST
         }
 
         public abstract AstKind Kind { get; }
-        public abstract void Accept(AssociativeAstVisitor visitor);
-        public abstract TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor);
+        public abstract TResult Accept<TResult>(IAstVisitor<TResult> visitor);
     }
 
     public class CommentNode : AssociativeNode
@@ -129,12 +127,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitCommentNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitCommentNode(this);
         }
@@ -222,12 +215,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitLanguageBlockNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitLanguageBlockNode(this);
         }
@@ -296,12 +284,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitReplicationGuideNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitReplicationGuideNode(this);
         }
@@ -341,12 +324,7 @@ namespace ProtoCore.AST.AssociativeAST
                 return AstKind.AtLevel;
             }
         }
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitAtLevelNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitAtLevelNode(this);
         }
@@ -485,12 +463,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitArrayNameNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitArrayNameNode(this);
         }
@@ -544,12 +517,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitGroupExpressionNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitGroupExpressionNode(this);
         }
@@ -623,12 +591,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitIdentifierNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitIdentifierNode(this);
         }
@@ -656,12 +619,7 @@ namespace ProtoCore.AST.AssociativeAST
                 return AstKind.TypedIdentifier;
             }
         }
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitTypedIdentifierNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitTypedIdentifierNode(this);
         }
@@ -737,12 +695,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitIdentifierListNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitIdentifierListNode(this);
         }
@@ -790,12 +743,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitIntNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitIntNode(this);
         }
@@ -846,12 +794,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitDoubleNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitDoubleNode(this);
         }
@@ -905,12 +848,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitBooleanNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitBooleanNode(this);
         }
@@ -960,12 +898,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitCharNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitCharNode(this);
         }
@@ -1016,12 +949,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitStringNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitStringNode(this);
         }
@@ -1057,12 +985,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitNullNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitNullNode(this);
         }
@@ -1197,12 +1120,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitFunctionCallNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitFunctionCallNode(this);
         }
@@ -1274,12 +1192,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitFunctionDotCallNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitFunctionDotCallNode(this);
         }
@@ -1365,12 +1278,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitVarDeclNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitVarDeclNode(this);
         }
@@ -1432,12 +1340,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitArgumentSignatureNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitArgumentSignatureNode(this);
         }
@@ -1498,12 +1401,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitCodeBlockNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitCodeBlockNode(this);
         }
@@ -1620,12 +1518,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitClassDeclNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitClassDeclNode(this);
         }
@@ -1789,12 +1682,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitConstructorDefinitionNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitConstructorDefinitionNode(this);
         }
@@ -1916,12 +1804,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitFunctionDefinitionNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitFunctionDefinitionNode(this);
         }
@@ -1970,12 +1853,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitIfStatementNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitIfStatementNode(this);
         }
@@ -2049,12 +1927,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitInlineConditionalNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitInlineConditionalNode(this);
         }
@@ -2193,12 +2066,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitBinaryExpressionNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitBinaryExpressionNode(this);
         }
@@ -2239,12 +2107,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitUnaryExpressionNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitUnaryExpressionNode(this);
         }
@@ -2349,12 +2212,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitRangeExprNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitRangeExprNode(this);
         }
@@ -2415,12 +2273,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitExprListNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitExprListNode(this);
         }
@@ -2502,12 +2355,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitArrayNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitArrayNode(this);
         }
@@ -2590,12 +2438,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitImportNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitImportNode(this);
         }
@@ -2611,12 +2454,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitDefaultArgNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitDefaultArgNode(this);
         }
@@ -2640,12 +2478,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitDynamicNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitDynamicNode(this);
         }
@@ -2683,12 +2516,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitDynamicBlockNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitDynamicBlockNode(this);
         }
@@ -2727,12 +2555,7 @@ namespace ProtoCore.AST.AssociativeAST
             }
         }
 
-        public override void Accept(AssociativeAstVisitor visitor)
-        {
-            visitor.VisitThisPointerNode(this);
-        }
-
-        public override TResult Accept<TResult>(AssociativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitThisPointerNode(this);
         }

--- a/src/Engine/ProtoCore/Parser/ImperativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/ImperativeAST.cs
@@ -1,12 +1,12 @@
+using ProtoCore.AST.AssociativeAST;
+using ProtoCore.DSASM;
+using ProtoCore.SyntaxAnalysis.Imperative;
+using ProtoCore.Utils;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
-using ProtoCore.Utils;
-using ProtoCore.DSASM;
-using ProtoCore.AST.AssociativeAST;
-using System.Globalization;
-using ProtoCore.SyntaxAnalysis;
 
 namespace ProtoCore.AST.ImperativeAST
 {
@@ -52,8 +52,8 @@ namespace ProtoCore.AST.ImperativeAST
         }
 
         public abstract AstKind Kind { get; }
-        public abstract void Accept(ImperativeAstVisitor visitor);
-        public abstract TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor);
+        
+        public abstract TResult Accept<TResult>(IAstVisitor<TResult> visitor);
     }
 
     public class LanguageBlockNode : ImperativeNode
@@ -140,12 +140,7 @@ namespace ProtoCore.AST.ImperativeAST
             return buf.ToString();
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitLanguageBlockNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitLanguageBlockNode(this);
         }
@@ -207,12 +202,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitArrayNameNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitArrayNameNode(this);
         }
@@ -245,12 +235,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitGroupExpressionNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitGroupExpressionNode(this);
         }
@@ -319,12 +304,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitIdentifierNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitIdentifierNode(this);
         }
@@ -340,12 +320,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitTypedIdentifierNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitTypedIdentifierNode(this);
         }
@@ -390,12 +365,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitIntNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitIntNode(this);
         }
@@ -444,12 +414,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitDoubleNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitDoubleNode(this);
         }
@@ -499,12 +464,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitBooleanNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitBooleanNode(this);
         }
@@ -551,13 +511,8 @@ namespace ProtoCore.AST.ImperativeAST
                 return AstKind.Char;
             }
         }
-
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitCharNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitCharNode(this);
         }
@@ -606,12 +561,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitStringNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitStringNode(this);
         }
@@ -642,12 +592,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitNullNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitNullNode(this);
         }
@@ -728,12 +673,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitArrayNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitArrayNode(this);
         }
@@ -856,12 +796,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitFunctionCallNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitFunctionCallNode(this);
         }
@@ -930,12 +865,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitExprListNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitExprListNode(this);
         }
@@ -992,12 +922,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitCodeBlockNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitCodeBlockNode(this);
         }
@@ -1069,12 +994,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitInlineConditionalNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitInlineConditionalNode(this);
         }
@@ -1164,12 +1084,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitBinaryExpressionNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitBinaryExpressionNode(this);
         }
@@ -1252,12 +1167,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitElseIfNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitElseIfNode(this);
         }
@@ -1281,12 +1191,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitIfStmtPositionNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitIfStmtPositionNode(this);
         }
@@ -1424,12 +1329,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitIfStatementNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitIfStatementNode(this);
         }
@@ -1505,12 +1405,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitWhileStatementNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitWhileStatementNode(this);
         }
@@ -1562,12 +1457,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitUnaryExpressionNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitUnaryExpressionNode(this);
         }
@@ -1669,12 +1559,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitRangeExprNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitRangeExprNode(this);
         }
@@ -1770,12 +1655,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitForLoopNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitForLoopNode(this);
         }
@@ -1834,12 +1714,7 @@ namespace ProtoCore.AST.ImperativeAST
         }
 
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitIdentifierListNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitIdentifierListNode(this);
         }
@@ -1864,12 +1739,7 @@ namespace ProtoCore.AST.ImperativeAST
         }
 
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitBreakNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitBreakNode(this);
         }
@@ -1893,12 +1763,7 @@ namespace ProtoCore.AST.ImperativeAST
             }
         }
 
-        public override void Accept(ImperativeAstVisitor visitor)
-        {
-            visitor.VisitContinueNode(this);
-        }
-
-        public override TResult Accept<TResult>(ImperativeAstVisitor<TResult> visitor)
+        public override TResult Accept<TResult>(IAstVisitor<TResult> visitor)
         {
             return visitor.VisitContinueNode(this);
         }

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -104,7 +104,6 @@
     <Compile Include="DSASM\HeapObjects.cs" />
     <Compile Include="Lang\InternalAttributes.cs" />
     <Compile Include="Lang\Replication\ArgumentAtLevel.cs" />
-    <Compile Include="SyntaxAnalysis\AstVisitor.cs" />
     <Compile Include="AttributeEntry.cs" />
     <Compile Include="BuildStatus.cs" />
     <Compile Include="CodeBlock.cs" />
@@ -114,6 +113,9 @@
     <Compile Include="CodePoint.cs" />
     <Compile Include="Compiler.cs" />
     <Compile Include="CompilerOptions.cs" />
+    <Compile Include="SyntaxAnalysis\AssociativeAstVisitor.cs" />
+    <Compile Include="SyntaxAnalysis\Interface\Associative.cs" />
+    <Compile Include="SyntaxAnalysis\Interface\Imperative.cs" />
     <Compile Include="SyntaxAnalysis\ImperativeAstVisitor.cs" />
     <Compile Include="Utils\CompilerUtils.cs" />
     <Compile Include="Core.cs" />

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Compiler.cs" />
     <Compile Include="CompilerOptions.cs" />
     <Compile Include="SyntaxAnalysis\AssociativeAstVisitor.cs" />
+    <Compile Include="SyntaxAnalysis\AstVisitor.cs" />
     <Compile Include="SyntaxAnalysis\Interface\Associative.cs" />
     <Compile Include="SyntaxAnalysis\Interface\Imperative.cs" />
     <Compile Include="SyntaxAnalysis\ImperativeAstVisitor.cs" />

--- a/src/Engine/ProtoCore/SyntaxAnalysis/AssociativeAstVisitor.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/AssociativeAstVisitor.cs
@@ -5,96 +5,97 @@ using ProtoCore.AST;
 
 namespace ProtoCore.SyntaxAnalysis
 {
-    public abstract class AssociativeAstVisitor
+    public abstract class AssociativeAstVisitor : Associative.IAstVisitor<bool>
     {
-        public virtual void DefaultVisit(AssociativeNode node)
+        public virtual bool DefaultVisit(AssociativeNode node)
         {
+            return false;
         }
 
-        public virtual void Visit(Node node)
+        public virtual bool Visit(Node node)
         {
             AssociativeNode assocNode = node as AssociativeNode;
-            if (assocNode != null)
-                assocNode.Accept(this);
+            return (assocNode != null) ? assocNode.Accept(this) : false;
         }
 
-        public virtual void VisitCommentNode(CommentNode node)
+        public virtual bool VisitCommentNode(CommentNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitLanguageBlockNode(LanguageBlockNode node)
+        public virtual bool VisitLanguageBlockNode(LanguageBlockNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitReplicationGuideNode(ReplicationGuideNode node)
+        public virtual bool VisitReplicationGuideNode(ReplicationGuideNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitAtLevelNode(AtLevelNode node)
+        public virtual bool VisitAtLevelNode(AtLevelNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitArrayNameNode(ArrayNameNode node)
+        public virtual bool VisitArrayNameNode(ArrayNameNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitGroupExpressionNode(GroupExpressionNode node)
+        public virtual bool VisitGroupExpressionNode(GroupExpressionNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitIdentifierNode(IdentifierNode node)
+        public virtual bool VisitIdentifierNode(IdentifierNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitTypedIdentifierNode(TypedIdentifierNode node)
+        public virtual bool VisitTypedIdentifierNode(TypedIdentifierNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitIdentifierListNode(IdentifierListNode node)
+        public virtual bool VisitIdentifierListNode(IdentifierListNode node)
         {
             node.LeftNode.Accept(this);
             node.RightNode.Accept(this);
+            return true;
         }
 
-        public virtual void VisitIntNode(IntNode node)
+        public virtual bool VisitIntNode(IntNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitDoubleNode(DoubleNode node)
+        public virtual bool VisitDoubleNode(DoubleNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitBooleanNode(BooleanNode node)
+        public virtual bool VisitBooleanNode(BooleanNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitCharNode(CharNode node)
+        public virtual bool VisitCharNode(CharNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitStringNode(StringNode node)
+        public virtual bool VisitStringNode(StringNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitNullNode(NullNode node)
+        public virtual bool VisitNullNode(NullNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitFunctionCallNode(FunctionCallNode node)
+        public virtual bool VisitFunctionCallNode(FunctionCallNode node)
         {
             for (int i = 0; i < node.FormalArguments.Count; ++i)
             {
@@ -103,67 +104,73 @@ namespace ProtoCore.SyntaxAnalysis
 
             if (node.ArrayDimensions != null)
                 node.ArrayDimensions.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitFunctionDotCallNode(FunctionDotCallNode node)
+        public virtual bool VisitFunctionDotCallNode(FunctionDotCallNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitVarDeclNode(VarDeclNode node)
+        public virtual bool VisitVarDeclNode(VarDeclNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
         
-        public virtual void VisitArgumentSignatureNode(ArgumentSignatureNode node)
+        public virtual bool VisitArgumentSignatureNode(ArgumentSignatureNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitCodeBlockNode(CodeBlockNode node)
+        public virtual bool VisitCodeBlockNode(CodeBlockNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitClassDeclNode(ClassDeclNode node)
+        public virtual bool VisitClassDeclNode(ClassDeclNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitConstructorDefinitionNode(ConstructorDefinitionNode node)
+        public virtual bool VisitConstructorDefinitionNode(ConstructorDefinitionNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitFunctionDefinitionNode(FunctionDefinitionNode node)
+        public virtual bool VisitFunctionDefinitionNode(FunctionDefinitionNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitIfStatementNode(IfStatementNode node)
+        public virtual bool VisitIfStatementNode(IfStatementNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitInlineConditionalNode(InlineConditionalNode node)
+        public virtual bool VisitInlineConditionalNode(InlineConditionalNode node)
         {
             node.ConditionExpression.Accept(this);
             node.TrueExpression.Accept(this);
             node.FalseExpression.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitBinaryExpressionNode(BinaryExpressionNode node)
+        public virtual bool VisitBinaryExpressionNode(BinaryExpressionNode node)
         {
             node.LeftNode.Accept(this);
             node.RightNode.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitUnaryExpressionNode(UnaryExpressionNode node)
+        public virtual bool VisitUnaryExpressionNode(UnaryExpressionNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitRangeExprNode(RangeExprNode node)
+        public virtual bool VisitRangeExprNode(RangeExprNode node)
         {
             node.From.Accept(this);
             node.To.Accept(this);
@@ -173,9 +180,11 @@ namespace ProtoCore.SyntaxAnalysis
 
             if (node.ArrayDimensions != null)
                 node.ArrayDimensions.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitExprListNode(ExprListNode node)
+        public virtual bool VisitExprListNode(ExprListNode node)
         {
             for (int i = 0; i < node.Exprs.Count; ++i)
             {
@@ -184,44 +193,48 @@ namespace ProtoCore.SyntaxAnalysis
 
             if (node.ArrayDimensions != null)
                 node.ArrayDimensions.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitArrayNode(ArrayNode node)
+        public virtual bool VisitArrayNode(ArrayNode node)
         {
             if (node.Expr != null)
                 node.Expr.Accept(this);
 
             if (node.Type != null)
                 node.Type.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitImportNode(ImportNode node)
+        public virtual bool VisitImportNode(ImportNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitDynamicNode(DynamicNode node)
+        public virtual bool VisitDynamicNode(DynamicNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitDynamicBlockNode(DynamicBlockNode node)
+        public virtual bool VisitDynamicBlockNode(DynamicBlockNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitThisPointerNode(ThisPointerNode node)
+        public virtual bool VisitThisPointerNode(ThisPointerNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitDefaultArgNode(DefaultArgNode node)
+        public virtual bool VisitDefaultArgNode(DefaultArgNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
     }
 
-    public abstract class AssociativeAstVisitor<TResult>
+    public abstract class AssociativeAstVisitor<TResult> : Associative.IAstVisitor<TResult>
     {
         public virtual TResult DefaultVisit(AssociativeNode node)
         {

--- a/src/Engine/ProtoCore/SyntaxAnalysis/AssociativeAstVisitor.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/AssociativeAstVisitor.cs
@@ -426,7 +426,7 @@ namespace ProtoCore.SyntaxAnalysis
         }
     }
 
-    public class AstReplacer : AssociativeAstVisitor<AssociativeNode>
+    public class AssociativeAstReplacer : AssociativeAstVisitor<AssociativeNode>
     {
         public override AssociativeNode DefaultVisit(AssociativeNode node)
         {

--- a/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
@@ -1,0 +1,769 @@
+﻿using ProtoCore.AST;
+using ProtoCore.AST.AssociativeAST;
+using ImperativeNode = ProtoCore.AST.ImperativeAST.ImperativeNode;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ProtoCore.SyntaxAnalysis
+{
+    public abstract class AstVisitor<TAssociative, TImperative> : Associative.IAstVisitor<TAssociative>, Imperative.IAstVisitor<TImperative>
+    {
+        public abstract TAssociative VisitAssociativeNode(AssociativeNode node);
+
+        public abstract TImperative VisitImperativeNode(ImperativeNode node);
+        
+        public virtual TAssociative VisitCommentNode(CommentNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitLanguageBlockNode(LanguageBlockNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitReplicationGuideNode(ReplicationGuideNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitAtLevelNode(AtLevelNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitArrayNameNode(ArrayNameNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitGroupExpressionNode(GroupExpressionNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitIdentifierNode(IdentifierNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitTypedIdentifierNode(TypedIdentifierNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitIdentifierListNode(IdentifierListNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitIntNode(IntNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitDoubleNode(DoubleNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitBooleanNode(BooleanNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitCharNode(CharNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitStringNode(StringNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitNullNode(NullNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitFunctionCallNode(FunctionCallNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitFunctionDotCallNode(FunctionDotCallNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitVarDeclNode(VarDeclNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitArgumentSignatureNode(ArgumentSignatureNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitCodeBlockNode(CodeBlockNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitClassDeclNode(ClassDeclNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitConstructorDefinitionNode(ConstructorDefinitionNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitFunctionDefinitionNode(FunctionDefinitionNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitIfStatementNode(IfStatementNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitInlineConditionalNode(InlineConditionalNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitBinaryExpressionNode(BinaryExpressionNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitUnaryExpressionNode(UnaryExpressionNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitRangeExprNode(RangeExprNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitExprListNode(ExprListNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitArrayNode(ArrayNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitImportNode(ImportNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitDynamicNode(DynamicNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitDynamicBlockNode(DynamicBlockNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitThisPointerNode(ThisPointerNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+
+        public virtual TAssociative VisitDefaultArgNode(DefaultArgNode node)
+        {
+            return VisitAssociativeNode(node);
+        }
+        
+        public virtual TImperative VisitLanguageBlockNode(AST.ImperativeAST.LanguageBlockNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitArrayNameNode(AST.ImperativeAST.ArrayNameNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitGroupExpressionNode(AST.ImperativeAST.GroupExpressionNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitIdentifierNode(AST.ImperativeAST.IdentifierNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitTypedIdentifierNode(AST.ImperativeAST.TypedIdentifierNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitIdentifierListNode(AST.ImperativeAST.IdentifierListNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitIntNode(AST.ImperativeAST.IntNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitDoubleNode(AST.ImperativeAST.DoubleNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitBooleanNode(AST.ImperativeAST.BooleanNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitCharNode(AST.ImperativeAST.CharNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitStringNode(AST.ImperativeAST.StringNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitNullNode(AST.ImperativeAST.NullNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitFunctionCallNode(AST.ImperativeAST.FunctionCallNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitCodeBlockNode(AST.ImperativeAST.CodeBlockNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitIfStatementNode(AST.ImperativeAST.IfStmtNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitElseIfNode(AST.ImperativeAST.ElseIfBlock node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitInlineConditionalNode(AST.ImperativeAST.InlineConditionalNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitBinaryExpressionNode(AST.ImperativeAST.BinaryExpressionNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitUnaryExpressionNode(AST.ImperativeAST.UnaryExpressionNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitRangeExprNode(AST.ImperativeAST.RangeExprNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitExprListNode(AST.ImperativeAST.ExprListNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitArrayNode(AST.ImperativeAST.ArrayNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitWhileStatementNode(AST.ImperativeAST.WhileStmtNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitForLoopNode(AST.ImperativeAST.ForLoopNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+        public virtual TImperative VisitBreakNode(AST.ImperativeAST.BreakNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitContinueNode(AST.ImperativeAST.ContinueNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+
+        public virtual TImperative VisitIfStmtPositionNode(AST.ImperativeAST.IfStmtPositionNode node)
+        {
+            return VisitImperativeNode(node);
+        }
+    }
+
+    public class AstReplacer : AstVisitor<AssociativeNode, ImperativeNode>
+    {
+        public Node VisitNode(Node node)
+        {
+            var assocNode = node as AssociativeNode;
+            if (null != assocNode)
+            {
+                return assocNode.Accept(this);
+            }
+
+            var impNode = node as ImperativeNode;
+            if(null != impNode)
+            {
+                return impNode.Accept(this);
+            }
+
+            return node;
+        }
+        
+        public List<Node> VisitNodeList(List<Node> nodes)
+        {
+            for (int i = 0; i < nodes.Count; ++i)
+            {
+                var newItem = this.VisitNode(nodes[i]);
+                if (nodes[i] != newItem)
+                    nodes[i] = newItem;
+            }
+
+            return nodes;
+        }
+
+        public override AssociativeNode VisitAssociativeNode(AssociativeNode node)
+        {
+            return node;
+        }
+
+        public List<AssociativeNode> VisitNodeList(List<AssociativeNode> nodes)
+        {
+            for (int i = 0; i < nodes.Count; ++i)
+            {
+                var newItem = nodes[i].Accept(this);
+                if (nodes[i] != newItem)
+                    nodes[i] = newItem;
+            }
+
+            return nodes;
+        }
+
+        public override AssociativeNode VisitGroupExpressionNode(GroupExpressionNode node)
+        {
+            var newExpression = node.Expression.Accept(this);
+
+            if (node.Expression != newExpression)
+                node.Expression = newExpression;
+
+            return node;
+        }
+
+        public override AssociativeNode VisitIdentifierNode(IdentifierNode node)
+        {
+            if (node.ArrayDimensions != null)
+            {
+                var newArrayDimensions = node.ArrayDimensions.Accept(this);
+                if (node.ArrayDimensions != newArrayDimensions)
+                    node.ArrayDimensions = newArrayDimensions as ArrayNode;
+            }
+
+            return node;
+        }
+
+        public override AssociativeNode VisitTypedIdentifierNode(TypedIdentifierNode node)
+        {
+            return VisitIdentifierNode(node);
+        }
+
+        public override AssociativeNode VisitIdentifierListNode(IdentifierListNode node)
+        {
+            var newLeftNode = node.LeftNode.Accept(this);
+            if (newLeftNode != node.LeftNode)
+                node.LeftNode = newLeftNode;
+
+            var newRightNode = node.RightNode.Accept(this);
+            if (newRightNode != node.RightNode)
+                node.RightNode = newRightNode;
+
+            return node;
+        }
+
+        public override AssociativeNode VisitFunctionCallNode(FunctionCallNode node)
+        {
+            var func = node.Function.Accept(this);
+            if (node.Function != func)
+                node.Function = func;
+
+            node.FormalArguments = VisitNodeList(node.FormalArguments);
+
+            if (node.ArrayDimensions != null)
+            {
+                var newArrayDimensions = node.ArrayDimensions.Accept(this);
+                if (node.ArrayDimensions != newArrayDimensions)
+                    node.ArrayDimensions = newArrayDimensions as ArrayNode;
+            }
+
+            return node;
+        }
+
+        public override AssociativeNode VisitLanguageBlockNode(LanguageBlockNode node)
+        {
+            var cbn = node.CodeBlockNode as CodeBlockNode;
+            if (cbn == null)
+            {
+                var icbn = VisitCodeBlockNode(node.CodeBlockNode as AST.ImperativeAST.CodeBlockNode);
+                node.CodeBlockNode = icbn;
+                return node;
+            }
+
+            var nodeList = cbn.Body.Select(astNode => astNode.Accept(this)).ToList();
+            cbn.Body = nodeList;
+            return node;
+        }
+
+        public override AssociativeNode VisitFunctionDefinitionNode(FunctionDefinitionNode node)
+        {
+            var nodeList = node.FunctionBody.Body.Select(astNode => astNode.Accept(this)).ToList();
+            node.FunctionBody.Body = nodeList;
+            return node;
+        }
+
+        public override AssociativeNode VisitInlineConditionalNode(InlineConditionalNode node)
+        {
+            var newCondition = node.ConditionExpression.Accept(this);
+            if (node.ConditionExpression != newCondition)
+                node.ConditionExpression = newCondition;
+
+            var newTrueExpr = node.TrueExpression.Accept(this);
+            if (node.TrueExpression != newTrueExpr)
+                node.TrueExpression = newTrueExpr;
+
+            var newFalseExpr = node.FalseExpression.Accept(this);
+            if (node.FalseExpression != newFalseExpr)
+                node.FalseExpression = newFalseExpr;
+
+            return node;
+        }
+
+        public override AssociativeNode VisitBinaryExpressionNode(BinaryExpressionNode node)
+        {
+            var newLeftNode = node.LeftNode.Accept(this);
+            if (node.LeftNode != newLeftNode)
+                node.LeftNode = newLeftNode;
+
+            var newRightNode = node.RightNode.Accept(this);
+            if (node.RightNode != newRightNode)
+                node.RightNode = newRightNode;
+
+            return node;
+        }
+
+        public override AssociativeNode VisitUnaryExpressionNode(UnaryExpressionNode node)
+        {
+            var newExpression = node.Expression.Accept(this);
+            if (node.Expression != newExpression)
+                node.Expression = newExpression;
+
+            return node;
+        }
+
+        public override AssociativeNode VisitRangeExprNode(RangeExprNode node)
+        {
+            var newFromNode = node.From.Accept(this);
+            if (node.From != newFromNode)
+                node.From = newFromNode;
+
+            var newToNode = node.To.Accept(this);
+            if (node.To != newToNode)
+                node.To = newToNode;
+
+            if (node.Step != null)
+            {
+                var newStepNode = node.Step.Accept(this);
+                if (node.Step != newStepNode)
+                    node.Step = newStepNode;
+            }
+
+            return node;
+        }
+
+        public override AssociativeNode VisitExprListNode(ExprListNode node)
+        {
+            node.Exprs = VisitNodeList(node.Exprs);
+
+            if (node.ArrayDimensions != null)
+            {
+                var newArrayDimensions = node.ArrayDimensions.Accept(this);
+                if (node.ArrayDimensions != newArrayDimensions)
+                    node.ArrayDimensions = newArrayDimensions as ArrayNode;
+            }
+
+            return node;
+        }
+
+        public override AssociativeNode VisitArrayNode(ArrayNode node)
+        {
+            var newExpr = node.Expr.Accept(this);
+            if (node.Expr != newExpr)
+                node.Expr = newExpr;
+
+            if (node.Type != null)
+            {
+                var newType = node.Type.Accept(this);
+                if (node.Type != newType)
+                    node.Type = newType;
+            }
+
+            return node;
+        }
+
+        public override ImperativeNode VisitImperativeNode(ImperativeNode node)
+        {
+            return node;
+        }
+
+        public override ImperativeNode VisitLanguageBlockNode(AST.ImperativeAST.LanguageBlockNode node)
+        {
+            var icbn = node.CodeBlockNode as AST.ImperativeAST.CodeBlockNode;
+            if (icbn == null)
+            {
+                var cbn = VisitCodeBlockNode(node.CodeBlockNode as CodeBlockNode);
+                node.CodeBlockNode = cbn;
+                return node;
+            }
+
+            var nodeList = icbn.Body.Select(astNode => astNode.Accept(this)).ToList();
+            icbn.Body = nodeList;
+            return node;
+        }
+
+        public override ImperativeNode VisitCodeBlockNode(AST.ImperativeAST.CodeBlockNode node)
+        {
+            var nodeList = node.Body.Select(n => n.Accept(this)).ToList();
+            node.Body = nodeList;
+            return node;
+        }
+
+        public override ImperativeNode VisitGroupExpressionNode(AST.ImperativeAST.GroupExpressionNode node)
+        {
+            var newExpression = node.Expression.Accept(this);
+
+            if (node.Expression != newExpression)
+                node.Expression = newExpression;
+
+            return node;
+        }
+
+        public override ImperativeNode VisitIdentifierNode(AST.ImperativeAST.IdentifierNode node)
+        {
+            if (node.ArrayDimensions != null)
+            {
+                var newArrayDimensions = node.ArrayDimensions.Accept(this);
+                if (node.ArrayDimensions != newArrayDimensions)
+                    node.ArrayDimensions = newArrayDimensions as AST.ImperativeAST.ArrayNode;
+            }
+
+            return node;
+        }
+
+        public override ImperativeNode VisitTypedIdentifierNode(AST.ImperativeAST.TypedIdentifierNode node)
+        {
+            return VisitIdentifierNode(node);
+        }
+
+        public override ImperativeNode VisitIdentifierListNode(AST.ImperativeAST.IdentifierListNode node)
+        {
+            var newLeftNode = node.LeftNode.Accept(this);
+            if (newLeftNode != node.LeftNode)
+                node.LeftNode = newLeftNode;
+
+            var newRightNode = node.RightNode.Accept(this);
+            if (newRightNode != node.RightNode)
+                node.RightNode = newRightNode;
+
+            return node;
+        }
+
+        public override ImperativeNode VisitFunctionCallNode(AST.ImperativeAST.FunctionCallNode node)
+        {
+            var func = node.Function.Accept(this);
+            if (node.Function != func)
+                node.Function = func;
+
+            node.FormalArguments = VisitNodeList(node.FormalArguments);
+
+            if (node.ArrayDimensions != null)
+            {
+                var newArrayDimensions = node.ArrayDimensions.Accept(this);
+                if (node.ArrayDimensions != newArrayDimensions)
+                    node.ArrayDimensions = newArrayDimensions as AST.ImperativeAST.ArrayNode;
+            }
+
+            return node;
+        }
+
+        public override ImperativeNode VisitBinaryExpressionNode(AST.ImperativeAST.BinaryExpressionNode node)
+        {
+            var newLeftNode = node.LeftNode.Accept(this);
+            if (node.LeftNode != newLeftNode)
+                node.LeftNode = newLeftNode;
+
+            var newRightNode = node.RightNode.Accept(this);
+            if (node.RightNode != newRightNode)
+                node.RightNode = newRightNode;
+
+            return node;
+        }
+
+        public override ImperativeNode VisitUnaryExpressionNode(AST.ImperativeAST.UnaryExpressionNode node)
+        {
+            var newExpression = node.Expression.Accept(this);
+            if (node.Expression != newExpression)
+                node.Expression = newExpression;
+
+            return node;
+        }
+
+        public override ImperativeNode VisitRangeExprNode(AST.ImperativeAST.RangeExprNode node)
+        {
+            var newFromNode = node.From.Accept(this);
+            if (node.From != newFromNode)
+                node.From = newFromNode;
+
+            var newToNode = node.To.Accept(this);
+            if (node.To != newToNode)
+                node.To = newToNode;
+
+            if (node.Step != null)
+            {
+                var newStepNode = node.Step.Accept(this);
+                if (node.Step != newStepNode)
+                    node.Step = newStepNode;
+            }
+
+            return node;
+        }
+
+        public override ImperativeNode VisitExprListNode(AST.ImperativeAST.ExprListNode node)
+        {
+            node.Exprs = VisitNodeList(node.Exprs);
+
+            if (node.ArrayDimensions != null)
+            {
+                var newArrayDimensions = node.ArrayDimensions.Accept(this);
+                if (node.ArrayDimensions != newArrayDimensions)
+                    node.ArrayDimensions = newArrayDimensions as AST.ImperativeAST.ArrayNode;
+            }
+
+            return node;
+        }
+
+        public override ImperativeNode VisitArrayNode(AST.ImperativeAST.ArrayNode node)
+        {
+            var newExpr = node.Expr.Accept(this);
+            if (node.Expr != newExpr)
+                node.Expr = newExpr;
+
+            if (node.Type != null)
+            {
+                var newType = node.Type.Accept(this);
+                if (node.Type != newType)
+                    node.Type = newType;
+            }
+
+            return node;
+        }
+
+        public override ImperativeNode VisitInlineConditionalNode(AST.ImperativeAST.InlineConditionalNode node)
+        {
+            var newCondition = node.ConditionExpression.Accept(this);
+            if (node.ConditionExpression != newCondition)
+                node.ConditionExpression = newCondition;
+
+            var newTrueExpr = node.TrueExpression.Accept(this);
+            if (node.TrueExpression != newTrueExpr)
+                node.TrueExpression = newTrueExpr;
+
+            var newFalseExpr = node.FalseExpression.Accept(this);
+            if (node.FalseExpression != newFalseExpr)
+                node.FalseExpression = newFalseExpr;
+
+            return node;
+        }
+
+        public override ImperativeNode VisitIfStatementNode(AST.ImperativeAST.IfStmtNode node)
+        {
+            var newIfExpr = node.IfExprNode.Accept(this);
+            if (node.IfExprNode != newIfExpr)
+                node.IfExprNode = newIfExpr;
+
+            node.IfBody = VisitNodeList(node.IfBody);
+            node.ElseIfList = node.ElseIfList.Select(n=>n.Accept(this)).Cast<AST.ImperativeAST.ElseIfBlock>().ToList();
+            node.ElseBody = VisitNodeList(node.ElseBody);
+
+            return node;
+        }
+
+        public override ImperativeNode VisitElseIfNode(AST.ImperativeAST.ElseIfBlock node)
+        {
+            var newExpr = node.Expr.Accept(this);
+            if (node.Expr != newExpr)
+                node.Expr = newExpr;
+
+            node.Body = VisitNodeList(node.Body);
+            return node;
+        }
+
+        public override ImperativeNode VisitWhileStatementNode(AST.ImperativeAST.WhileStmtNode node)
+        {
+            var newExpr = node.Expr.Accept(this);
+            if (node.Expr != newExpr)
+                node.Expr = newExpr;
+
+            node.Body = VisitNodeList(node.Body);
+            return node;
+        }
+
+        public override ImperativeNode VisitForLoopNode(AST.ImperativeAST.ForLoopNode node)
+        {
+            var newLoopVar = node.LoopVariable.Accept(this);
+            if (node.LoopVariable != newLoopVar)
+                node.LoopVariable = newLoopVar;
+
+            var newExpr = node.Expression.Accept(this);
+            if (node.Expression != newExpr)
+                node.Expression = newExpr;
+
+            node.Body = VisitNodeList(node.Body);
+            return node;
+        }
+
+        private List<ImperativeNode> VisitNodeList(List<ImperativeNode> nodes)
+        {
+            return nodes.Select(n => n.Accept(this)).ToList();
+        }
+    }
+}

--- a/src/Engine/ProtoCore/SyntaxAnalysis/ImperativeAstVisitor.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/ImperativeAstVisitor.cs
@@ -5,81 +5,82 @@ using System.Collections.Generic;
 
 namespace ProtoCore.SyntaxAnalysis
 {
-    public abstract class ImperativeAstVisitor
+    public abstract class ImperativeAstVisitor : Imperative.IAstVisitor<bool>
     {
-        public virtual void DefaultVisit(ImperativeNode node)
+        public virtual bool DefaultVisit(ImperativeNode node)
         {
+            return false;
         }
 
-        public virtual void Visit(Node node)
+        public virtual bool Visit(Node node)
         {
             ImperativeNode impNode = node as ImperativeNode;
-            if (impNode != null)
-                impNode.Accept(this);
+            return (impNode != null) ? impNode.Accept(this) : false;
         }
 
-        public virtual void VisitLanguageBlockNode(LanguageBlockNode node)
+        public virtual bool VisitLanguageBlockNode(LanguageBlockNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitArrayNameNode(ArrayNameNode node)
+        public virtual bool VisitArrayNameNode(ArrayNameNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitGroupExpressionNode(GroupExpressionNode node)
+        public virtual bool VisitGroupExpressionNode(GroupExpressionNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitIdentifierNode(IdentifierNode node)
+        public virtual bool VisitIdentifierNode(IdentifierNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitTypedIdentifierNode(TypedIdentifierNode node)
+        public virtual bool VisitTypedIdentifierNode(TypedIdentifierNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitIdentifierListNode(IdentifierListNode node)
+        public virtual bool VisitIdentifierListNode(IdentifierListNode node)
         {
             node.LeftNode.Accept(this);
             node.RightNode.Accept(this);
+            return true;
         }
 
-        public virtual void VisitIntNode(IntNode node)
+        public virtual bool VisitIntNode(IntNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitDoubleNode(DoubleNode node)
+        public virtual bool VisitDoubleNode(DoubleNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitBooleanNode(BooleanNode node)
+        public virtual bool VisitBooleanNode(BooleanNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitCharNode(CharNode node)
+        public virtual bool VisitCharNode(CharNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitStringNode(StringNode node)
+        public virtual bool VisitStringNode(StringNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitNullNode(NullNode node)
+        public virtual bool VisitNullNode(NullNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitFunctionCallNode(FunctionCallNode node)
+        public virtual bool VisitFunctionCallNode(FunctionCallNode node)
         {
             for (int i = 0; i < node.FormalArguments.Count; ++i)
             {
@@ -88,42 +89,48 @@ namespace ProtoCore.SyntaxAnalysis
 
             if (node.ArrayDimensions != null)
                 node.ArrayDimensions.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitCodeBlockNode(CodeBlockNode node)
+        public virtual bool VisitCodeBlockNode(CodeBlockNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitIfStatementNode(IfStmtNode node)
+        public virtual bool VisitIfStatementNode(IfStmtNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitElseIfNode(ElseIfBlock node)
+        public virtual bool VisitElseIfNode(ElseIfBlock node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitInlineConditionalNode(InlineConditionalNode node)
+        public virtual bool VisitInlineConditionalNode(InlineConditionalNode node)
         {
             node.ConditionExpression.Accept(this);
             node.TrueExpression.Accept(this);
             node.FalseExpression.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitBinaryExpressionNode(BinaryExpressionNode node)
+        public virtual bool VisitBinaryExpressionNode(BinaryExpressionNode node)
         {
             node.LeftNode.Accept(this);
             node.RightNode.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitUnaryExpressionNode(UnaryExpressionNode node)
+        public virtual bool VisitUnaryExpressionNode(UnaryExpressionNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitRangeExprNode(RangeExprNode node)
+        public virtual bool VisitRangeExprNode(RangeExprNode node)
         {
             node.From.Accept(this);
             node.To.Accept(this);
@@ -133,9 +140,11 @@ namespace ProtoCore.SyntaxAnalysis
 
             if (node.ArrayDimensions != null)
                 node.ArrayDimensions.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitExprListNode(ExprListNode node)
+        public virtual bool VisitExprListNode(ExprListNode node)
         {
             for (int i = 0; i < node.Exprs.Count; ++i)
             {
@@ -144,44 +153,48 @@ namespace ProtoCore.SyntaxAnalysis
 
             if (node.ArrayDimensions != null)
                 node.ArrayDimensions.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitArrayNode(ArrayNode node)
+        public virtual bool VisitArrayNode(ArrayNode node)
         {
             if (node.Expr != null)
                 node.Expr.Accept(this);
 
             if (node.Type != null)
                 node.Type.Accept(this);
+
+            return true;
         }
 
-        public virtual void VisitWhileStatementNode(WhileStmtNode node)
+        public virtual bool VisitWhileStatementNode(WhileStmtNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitForLoopNode(ForLoopNode node)
+        public virtual bool VisitForLoopNode(ForLoopNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitBreakNode(BreakNode node)
+        public virtual bool VisitBreakNode(BreakNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitContinueNode(ContinueNode node)
+        public virtual bool VisitContinueNode(ContinueNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
 
-        public virtual void VisitIfStmtPositionNode(IfStmtPositionNode node)
+        public virtual bool VisitIfStmtPositionNode(IfStmtPositionNode node)
         {
-            DefaultVisit(node);
+            return DefaultVisit(node);
         }
     }
 
-    public abstract class ImperativeAstVisitor<TResult>
+    public abstract class ImperativeAstVisitor<TResult> : Imperative.IAstVisitor<TResult>
     {
         public virtual TResult DefaultVisit(ImperativeNode node)
         {

--- a/src/Engine/ProtoCore/SyntaxAnalysis/Interface/Associative.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/Interface/Associative.cs
@@ -1,0 +1,80 @@
+﻿using ProtoCore.AST;
+using ProtoCore.AST.AssociativeAST;
+
+namespace ProtoCore.SyntaxAnalysis.Associative
+{
+    public interface IAstVisitor<TResult>
+    {
+        TResult Visit(Node node);
+
+        TResult VisitCommentNode(CommentNode node);
+
+        TResult VisitLanguageBlockNode(LanguageBlockNode node);
+
+        TResult VisitReplicationGuideNode(ReplicationGuideNode node);
+
+        TResult VisitAtLevelNode(AtLevelNode node);
+
+        TResult VisitArrayNameNode(ArrayNameNode node);
+
+        TResult VisitGroupExpressionNode(GroupExpressionNode node);
+
+        TResult VisitIdentifierNode(IdentifierNode node);
+
+        TResult VisitTypedIdentifierNode(TypedIdentifierNode node);
+
+        TResult VisitIdentifierListNode(IdentifierListNode node);
+
+        TResult VisitIntNode(IntNode node);
+
+        TResult VisitDoubleNode(DoubleNode node);
+
+        TResult VisitBooleanNode(BooleanNode node);
+
+        TResult VisitCharNode(CharNode node);
+
+        TResult VisitStringNode(StringNode node);
+
+        TResult VisitNullNode(NullNode node);
+
+        TResult VisitFunctionCallNode(FunctionCallNode node);
+
+        TResult VisitFunctionDotCallNode(FunctionDotCallNode node);
+
+        TResult VisitVarDeclNode(VarDeclNode node);
+
+        TResult VisitArgumentSignatureNode(ArgumentSignatureNode node);
+
+        TResult VisitCodeBlockNode(CodeBlockNode node);
+
+        TResult VisitClassDeclNode(ClassDeclNode node);
+
+        TResult VisitConstructorDefinitionNode(ConstructorDefinitionNode node);
+
+        TResult VisitFunctionDefinitionNode(FunctionDefinitionNode node);
+
+        TResult VisitIfStatementNode(IfStatementNode node);
+
+        TResult VisitInlineConditionalNode(InlineConditionalNode node);
+
+        TResult VisitBinaryExpressionNode(BinaryExpressionNode node);
+
+        TResult VisitUnaryExpressionNode(UnaryExpressionNode node);
+
+        TResult VisitRangeExprNode(RangeExprNode node);
+
+        TResult VisitExprListNode(ExprListNode node);
+
+        TResult VisitArrayNode(ArrayNode node);
+
+        TResult VisitImportNode(ImportNode node);
+
+        TResult VisitDynamicNode(DynamicNode node);
+
+        TResult VisitDynamicBlockNode(DynamicBlockNode node);
+
+        TResult VisitThisPointerNode(ThisPointerNode node);
+
+        TResult VisitDefaultArgNode(DefaultArgNode node);
+    }
+}

--- a/src/Engine/ProtoCore/SyntaxAnalysis/Interface/Associative.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/Interface/Associative.cs
@@ -5,8 +5,6 @@ namespace ProtoCore.SyntaxAnalysis.Associative
 {
     public interface IAstVisitor<TResult>
     {
-        TResult Visit(Node node);
-
         TResult VisitCommentNode(CommentNode node);
 
         TResult VisitLanguageBlockNode(LanguageBlockNode node);

--- a/src/Engine/ProtoCore/SyntaxAnalysis/Interface/Imperative.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/Interface/Imperative.cs
@@ -5,8 +5,6 @@ namespace ProtoCore.SyntaxAnalysis.Imperative
 {
     public interface IAstVisitor<TResult>
     {
-        TResult Visit(Node node);
-
         TResult VisitLanguageBlockNode(LanguageBlockNode node);
 
         TResult VisitArrayNameNode(ArrayNameNode node);

--- a/src/Engine/ProtoCore/SyntaxAnalysis/Interface/Imperative.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/Interface/Imperative.cs
@@ -1,0 +1,64 @@
+﻿using ProtoCore.AST;
+using ProtoCore.AST.ImperativeAST;
+
+namespace ProtoCore.SyntaxAnalysis.Imperative
+{
+    public interface IAstVisitor<TResult>
+    {
+        TResult Visit(Node node);
+
+        TResult VisitLanguageBlockNode(LanguageBlockNode node);
+
+        TResult VisitArrayNameNode(ArrayNameNode node);
+
+        TResult VisitGroupExpressionNode(GroupExpressionNode node);
+
+        TResult VisitIdentifierNode(IdentifierNode node);
+
+        TResult VisitTypedIdentifierNode(TypedIdentifierNode node);
+
+        TResult VisitIdentifierListNode(IdentifierListNode node);
+
+        TResult VisitIntNode(IntNode node);
+
+        TResult VisitDoubleNode(DoubleNode node);
+
+        TResult VisitBooleanNode(BooleanNode node);
+
+        TResult VisitCharNode(CharNode node);
+
+        TResult VisitStringNode(StringNode node);
+
+        TResult VisitNullNode(NullNode node);
+
+        TResult VisitFunctionCallNode(FunctionCallNode node);
+
+        TResult VisitCodeBlockNode(CodeBlockNode node);
+
+        TResult VisitIfStatementNode(IfStmtNode node);
+
+        TResult VisitElseIfNode(ElseIfBlock node);
+
+        TResult VisitInlineConditionalNode(InlineConditionalNode node);
+
+        TResult VisitBinaryExpressionNode(BinaryExpressionNode node);
+
+        TResult VisitUnaryExpressionNode(UnaryExpressionNode node);
+
+        TResult VisitRangeExprNode(RangeExprNode node);
+
+        TResult VisitExprListNode(ExprListNode node);
+
+        TResult VisitArrayNode(ArrayNode node);
+
+        TResult VisitWhileStatementNode(WhileStmtNode node);
+
+        TResult VisitForLoopNode(ForLoopNode node);
+
+        TResult VisitBreakNode(BreakNode node);
+
+        TResult VisitContinueNode(ContinueNode node);
+
+        TResult VisitIfStmtPositionNode(IfStmtPositionNode node);
+    }
+}


### PR DESCRIPTION
### Purpose

This PR provides cleanup of AstVisitor pattern.
- Defined `Associative.IAstVisitor<TResult>` and `Imperative.IAstVisitor<TResult>` interfaces. Now we can have a single class that can implement both these interfaces and provide a visitor for Associative as well as Imperative nodes.
- `AssociativeNode` and `ImperativeNode` accepts these interfaces respectively, the other overload of Accept method on these classes are removed.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ke-yu 
@aparajit-pratap 

