### PR TITLE
Cleanup builtin method IDs

### DIFF
--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -211,20 +211,28 @@ namespace ProtoCore.Lang
                             ret = ProtoCore.DSASM.StackValue.BuildInt(ArrayUtilsForBuiltIns.IndexOf(formalParameters[0], formalParameters[1], interpreter));
                         break;
                     }
-                case ProtoCore.Lang.BuiltInMethods.MethodID.Sort:
-                    ret = ArrayUtilsForBuiltIns.Sort(formalParameters[0], interpreter);
-                    break;
                 case BuiltInMethods.MethodID.SortPointer:
                     ret = ArrayUtilsForBuiltIns.SortPointers(formalParameters[0], formalParameters[1], interpreter, stackFrame);
                     break;
-                case ProtoCore.Lang.BuiltInMethods.MethodID.SortWithMode:
-                    ret = ArrayUtilsForBuiltIns.SortWithMode(formalParameters[0], formalParameters[1], interpreter);
+                case ProtoCore.Lang.BuiltInMethods.MethodID.Sort:
+                    if (FormalParams.Count() == 1)
+                    {
+                        ret = ArrayUtilsForBuiltIns.Sort(formalParameters[0], interpreter);
+                    }
+                    else
+                    {
+                        ret = ArrayUtilsForBuiltIns.SortWithMode(formalParameters[0], formalParameters[1], interpreter);
+                    }
                     break;
                 case ProtoCore.Lang.BuiltInMethods.MethodID.SortIndexByValue:
-                    ret = ArrayUtilsForBuiltIns.SortIndexByValue(formalParameters[0], interpreter);
-                    break;
-                case ProtoCore.Lang.BuiltInMethods.MethodID.SortIndexByValueWithMode:
-                    ret = ArrayUtilsForBuiltIns.SortIndexByValueWithMode(formalParameters[0], formalParameters[1], interpreter);
+                    if (FormalParams.Count() == 1)
+                    {
+                        ret = ArrayUtilsForBuiltIns.SortIndexByValue(formalParameters[0], interpreter);
+                    }
+                    else
+                    {
+                        ret = ArrayUtilsForBuiltIns.SortIndexByValueWithMode(formalParameters[0], formalParameters[1], interpreter);
+                    }
                     break;
                 case ProtoCore.Lang.BuiltInMethods.MethodID.Reorder:
                     ret = ArrayUtilsForBuiltIns.Reorder(formalParameters[0], formalParameters[1], interpreter);
@@ -269,20 +277,28 @@ namespace ProtoCore.Lang
                     else
                         ret = ProtoCore.DSASM.StackValue.Null;
                     break;
-                case ProtoCore.Lang.BuiltInMethods.MethodID.NormalizeDepthWithRank:
-                    ret = ArrayUtilsForBuiltIns.NormalizeDepthWithRank(formalParameters[0], formalParameters[1], interpreter);
-                    break;
                 case ProtoCore.Lang.BuiltInMethods.MethodID.NormalizeDepth:
-                    ret = ArrayUtilsForBuiltIns.NormalizeDepth(formalParameters[0], interpreter);
+                    if (formalParameters.Count() == 1)
+                    {
+                        ret = ArrayUtilsForBuiltIns.NormalizeDepth(formalParameters[0], interpreter);
+                    }
+                    else
+                    {
+                        ret = ArrayUtilsForBuiltIns.NormalizeDepthWithRank(formalParameters[0], formalParameters[1], interpreter);
+                    }
                     break;
                 case ProtoCore.Lang.BuiltInMethods.MethodID.Transpose:
                     ret = ArrayUtilsForBuiltIns.Transpose(formalParameters[0], interpreter);
                     break;
                 case ProtoCore.Lang.BuiltInMethods.MethodID.LoadCSV:
-                    ret = FileIOBuiltIns.LoadCSV(formalParameters[0], interpreter);
-                    break;
-                case ProtoCore.Lang.BuiltInMethods.MethodID.LoadCSVWithMode:
-                    ret = FileIOBuiltIns.LoadCSVWithMode(formalParameters[0], formalParameters[1], interpreter);
+                    if (FormalParams.Count() == 1)
+                    {
+                        ret = FileIOBuiltIns.LoadCSV(formalParameters[0], interpreter);
+                    }
+                    else
+                    {
+                        ret = FileIOBuiltIns.LoadCSVWithMode(formalParameters[0], formalParameters[1], interpreter);
+                    }
                     break;
                 case ProtoCore.Lang.BuiltInMethods.MethodID.Print:
                     ret = FileIOBuiltIns.Print(formalParameters[0], interpreter);

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -33,12 +33,10 @@ namespace ProtoCore.Lang
             IsUniformDepth,
             IsRectangular,
             IsHomogeneous,
-            LoadCSVWithMode,
             LoadCSV,
             Map,
             MapTo,
             NormalizeDepth,
-            NormalizeDepthWithRank,
             Print,
             PrintIndexable,
             Rank,
@@ -52,9 +50,7 @@ namespace ProtoCore.Lang
             SomeNulls,
             SomeTrue,
             Sort,
-            SortWithMode,
             SortIndexByValue,
-            SortIndexByValueWithMode,
             SortPointer,
             Reorder,
             RangeExpression,
@@ -99,12 +95,10 @@ namespace ProtoCore.Lang
             "IsUniformDepth",           // kIsUniformDepth
             "IsRectangular",            // kIsRectangular
             "IsHomogeneous",            // kIsHomogeneous
-            "ImportFromCSV",            // kLoadCSVWithMode
             "ImportFromCSV",            // kLoadCSV
             "Map",                      // kMap
             "MapTo",                    // kMapTo
             "NormalizeDepth",           // kNormalizeDepth
-            "NormalizeDepth",           // kNormalizeDepthWithRank
             "Print",                    // kPrint
             "Print",                    // kPrint
             "Rank",                     // kRank
@@ -118,9 +112,7 @@ namespace ProtoCore.Lang
             "SomeNulls",                // kSomeNulls
             "SomeTrue",                 // kSomeTrue
             "Sort",                     // kSort
-            "Sort",                     // kSortWithMode
             "SortIndexByValue",         // kSortIndexByValue
-            "SortIndexByValue",         // kSortIndexByValueWithMode
             "Sort",                     // kSortPointer
             "Reorder",                  // kReorder
             Constants.kFunctionRangeExpression, // kGenerateRange
@@ -559,7 +551,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, ProtoCore.Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Integer, 1)),
                         new KeyValuePair<string, ProtoCore.Type>("ascending", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Bool, 0)),
                     },
-                    ID = BuiltInMethods.MethodID.SortWithMode,
+                    ID = BuiltInMethods.MethodID.Sort,
                     MethodAttributes = new MethodAttributes(true),
                 },
 
@@ -582,7 +574,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, ProtoCore.Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Double, 1)),
                         new KeyValuePair<string, ProtoCore.Type>("ascending", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Bool, 0)),
                     },
-                    ID = BuiltInMethods.MethodID.SortWithMode,
+                    ID = BuiltInMethods.MethodID.Sort,
                     MethodAttributes = new MethodAttributes(true),
                 },
 
@@ -618,7 +610,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, ProtoCore.Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Double, 1)),
                         new KeyValuePair<string, ProtoCore.Type>("ascending", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Bool, 0)),
                     },
-                    ID = BuiltInMethods.MethodID.SortIndexByValueWithMode,
+                    ID = BuiltInMethods.MethodID.SortIndexByValue,
                      MethodAttributes = new MethodAttributes(){Description = Resources.SortsListByValue}
                     //MAGN-3382 MethodAttributes = new MethodAttributes(true), 
                 },
@@ -679,7 +671,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, ProtoCore.Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank)),
                         new KeyValuePair<string, ProtoCore.Type>("rank", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0)),
                     },
-                    ID = BuiltInMethods.MethodID.NormalizeDepthWithRank,
+                    ID = BuiltInMethods.MethodID.NormalizeDepth,
                     MethodAttributes = new MethodAttributes(){Description = Resources.ReturnsListWithRankDepth}
                     //MAGN-3382 MethodAttributes = new MethodAttributes(true),
                 }, 
@@ -757,7 +749,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, ProtoCore.Type>("filePath", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.String, 0)),
                         new KeyValuePair<string, ProtoCore.Type>("transpose", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Bool, 0)),
                     },
-                    ID = BuiltInMethods.MethodID.LoadCSVWithMode,
+                    ID = BuiltInMethods.MethodID.LoadCSV,
                     MethodAttributes = new MethodAttributes(){Description = Resources.ImportFileByGivenFilePathWithMode}
                 },
 


### PR DESCRIPTION
### Purpose

Some builtin method overloads have different method IDs, e.g., `Sort` and `SortByMode`. This PR cleanups these duplicate method IDs.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs

@gregmarr 
