### PR TITLE
Exclude Revit2018 binaries from DynamoCore MSI

### DIFF
--- a/src/DynamoInstall/Release.xsl
+++ b/src/DynamoInstall/Release.xsl
@@ -82,6 +82,11 @@
     <xsl:template match="wix:Directory[@Name = 'Revit_2017']" />
     <xsl:template match="wix:Component[key('revit_2017-search', @Id)]" />
 
+    <!--Exclude 'revit_2018' folders-->
+    <xsl:key name="revit_2018-search" match="wix:Component[contains(wix:File/@Source, '\Revit_2018\')]" use="@Id"/>
+    <xsl:template match="wix:Directory[@Name = 'Revit_2018']" />
+    <xsl:template match="wix:Component[key('revit_2018-search', @Id)]" />
+
     <!--Exclude 'int' folders-->
     <xsl:template match="wix:Directory[@Name = 'int']" />
     <xsl:key name="int-search" match="wix:Component[contains(wix:File/@Source, '\int\')]" use="@Id"/>


### PR DESCRIPTION
### Purpose

This PR excludes Revit_2018 folder in DynamoCore.msi, since DynamoRevit binaries are built in Dynamo\bin folder, we need to update the filter to exclude Revit_2018 binaries from the build.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs

@kronz 
@monikaprabhu 
@QilongTang 