### PR TITLE
Add UI affordance to indicate that subcategories of search results are hoverable

### DIFF
--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml
@@ -73,7 +73,8 @@
                                     <!-- Node class, group icon, node category -->
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="{Binding Class}"
-                                                   PreviewMouseDown="OnClassNamePreviewMouseDown">
+                                                   PreviewMouseDown="OnClassNamePreviewMouseDown"
+                                                   TextDecorations="Underline">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
                                                     <Setter Property="Foreground"
@@ -82,7 +83,7 @@
                                                         <Trigger Property="IsMouseOver"
                                                                  Value="True">
                                                             <Setter Property="Foreground"
-                                                                    Value="White" />
+                                                                    Value="#42adff" />
                                                             <Setter Property="Cursor"
                                                                     Value="Hand" />
                                                             <Setter Property="TextBlock.TextDecorations"


### PR DESCRIPTION
### Purpose

Addresses issue [DYN-427](https://jira.autodesk.com/browse/DYN-427).
Previously the subcategory items in search result appear as normal text, user may not notice that it is actually a hyperlink. Now they appear underlined.
When a user hovers over the subcategory in the search result, the font color change to a blue highlight.
As shown in the image below.

![untitled](https://cloud.githubusercontent.com/assets/14089267/22544913/b4e5802e-e971-11e6-8aeb-b93f3d683e6e.png)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs

@riteshchandawar 
