### PR TITLE
Implement SelectionBase<>::UpdateValueCore()

### DIFF
--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -235,6 +235,33 @@ namespace CoreNodeModels
             RaisePropertyChanged("SelectionResults");
         }
 
+        protected override bool UpdateValueCore(UpdateValueParams updateValueParams)
+        {
+            string name = updateValueParams.PropertyName;
+            string value = updateValueParams.PropertyValue;
+
+            if (name == "Value" && value != null)
+            {
+                List<string> savedUuids = value.Split(',').ToList();
+
+                // Do whatever DeserializeCore() does:
+                var loadedSelection =
+                        savedUuids.Select(GetModelObjectFromIdentifer)
+                            // ReSharper disable once CompareNonConstrainedGenericWithNull
+                            .Where(el => el != null);
+
+                UpdateSelection(loadedSelection);
+
+                // But Select() does NOT do these things - do we need to?
+                OnNodeModified();
+                // RaisePropertyChanged("SelectionResults"); -- Only needed when Dynamo UI is up
+
+                return true; // UpdateValueCore handled.
+            }
+
+            return base.UpdateValueCore(updateValueParams);
+        }
+
         /// <summary>
         /// Returns an object in the model from a string identifier.
         /// </summary>

--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -224,6 +224,11 @@ namespace CoreNodeModels
                     .Select(subNode => subNode.Attributes[0].Value)
                     .ToList();
 
+            ResetSelectionFromIds(savedUuids);
+        }
+
+        private void ResetSelectionFromIds(List<string> savedUuids)
+        {
             var loadedSelection =
                     savedUuids.Select(GetModelObjectFromIdentifer)
                         // ReSharper disable once CompareNonConstrainedGenericWithNull
@@ -243,19 +248,7 @@ namespace CoreNodeModels
             if (name == "Value" && value != null)
             {
                 List<string> savedUuids = value.Split(',').ToList();
-
-                // Do whatever DeserializeCore() does:
-                var loadedSelection =
-                        savedUuids.Select(GetModelObjectFromIdentifer)
-                            // ReSharper disable once CompareNonConstrainedGenericWithNull
-                            .Where(el => el != null);
-
-                UpdateSelection(loadedSelection);
-
-                // But Select() does NOT do these things - do we need to?
-                OnNodeModified();
-                // RaisePropertyChanged("SelectionResults"); -- Only needed when Dynamo UI is up
-
+                ResetSelectionFromIds(savedUuids);
                 return true; // UpdateValueCore handled.
             }
 


### PR DESCRIPTION
Override implementation that would allow us to programmatically push a
selection into a SelectionBase<>-derived Node.

### Purpose

This allows Dynamo Player to save Selection node values in memory/in session and subsequently push and override a node's selection before running a script. This is necessary when a user navigates to different scripts and maybe changes selections in-session. Without this override, any selection change of a node will be lost once a user decides to look at a different script and we close the model.

Note that we are NOT talking about writing anything to file here.

### Declarations

Check these if you believe they are true

- [x ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs
