### PR TITLE
Connector compatibility check for shift + click reconnections (bug fix)

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -426,7 +426,10 @@ namespace Dynamo.Models
             {
                 models.Add(connectorToRemove, UndoRedoRecorder.UserAction.Deletion);
             }
-            models.Add(newConnectorModel, UndoRedoRecorder.UserAction.Creation);
+            if (newConnectorModel != null)
+            {
+                models.Add(newConnectorModel, UndoRedoRecorder.UserAction.Creation);
+            }
             return models;
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -218,23 +218,23 @@ namespace Dynamo.ViewModels
                 return false;
             }
 
-            PortModel srcPortM = FirstActiveConnector.ActiveStartPort;
-            PortModel desPortM = portVM.PortModel;
-
-            // No self connection
-            // No start to start or end or end connection
-            if (srcPortM.Owner != desPortM.Owner && srcPortM.PortType != desPortM.PortType)
+            for (int i = 0; i < activeConnectors.Count(); i++)
             {
-                // Change cursor to show compatible port connection
-                CurrentCursor = CursorLibrary.GetCursor(CursorSet.ArcAdding);
-                return true;
+                PortModel srcPortM = activeConnectors[i].ActiveStartPort;
+                PortModel desPortM = portVM.PortModel;
+                // No self connection
+                // No start to start or end or end connection
+                if (srcPortM.Owner == desPortM.Owner || srcPortM.PortType == desPortM.PortType)
+                {
+                    // Change cursor to show not compatible
+                    CurrentCursor = CursorLibrary.GetCursor(CursorSet.ArcSelect);
+                    return false;
+                }
+                Console.WriteLine("CheckActiveConnectorCompatibility: ");
             }
-            else
-            {
-                // Change cursor to show not compatible
-                CurrentCursor = CursorLibrary.GetCursor(CursorSet.ArcSelect);
-                return false;
-            }
+            // If all connections are compatible, change cursor to show compatible port connection
+            CurrentCursor = CursorLibrary.GetCursor(CursorSet.ArcAdding);
+            return true;
         }
 
         internal void CancelConnection()

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -218,10 +218,10 @@ namespace Dynamo.ViewModels
                 return false;
             }
 
-            for (int i = 0; i < activeConnectors.Count(); i++)
+            foreach (ConnectorViewModel activeConnector in activeConnectors)
             {
-                PortModel srcPortM = activeConnectors[i].ActiveStartPort;
-                PortModel desPortM = portVM.PortModel;
+                var srcPortM = activeConnector.ActiveStartPort;
+                var desPortM = portVM.PortModel;
                 // No self connection
                 // No start to start or end or end connection
                 if (srcPortM.Owner == desPortM.Owner || srcPortM.PortType == desPortM.PortType)

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -230,7 +230,6 @@ namespace Dynamo.ViewModels
                     CurrentCursor = CursorLibrary.GetCursor(CursorSet.ArcSelect);
                     return false;
                 }
-                Console.WriteLine("CheckActiveConnectorCompatibility: ");
             }
             // If all connections are compatible, change cursor to show compatible port connection
             CurrentCursor = CursorLibrary.GetCursor(CursorSet.ArcAdding);


### PR DESCRIPTION
### Purpose

This PR is to address [DYN-461](https://jira.autodesk.com/browse/DYN-461), to fix the bug in PR #7534 (Shift + click reconnections).
Connector compatibility will be checked for all selected connectors, instead of only the first connector. The behavior is the same as handling incompatible single connections.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@Benglin 
