### PR TITLE
Migrate number nodes with sequence to CBNs.

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2276,7 +2276,7 @@ namespace Dynamo.Graph.Nodes
             return migrationData;
         }
 
-        [NodeMigration(@from: "1.3.0.0")]
+        [NodeMigration(version: "1.3.0.0")]
         public static NodeMigrationData MigrateShortestLacingToAutoLacing(NodeMigrationData data)
         {
             var migrationData = new NodeMigrationData(data.Document);

--- a/src/DynamoCore/Migration/Migration.cs
+++ b/src/DynamoCore/Migration/Migration.cs
@@ -321,14 +321,9 @@ namespace Dynamo.Migration
             var migrationData = new NodeMigrationData(elNode.OwnerDocument);
             migrationData.AppendNode(elNode as XmlElement);
 
-            while (workspaceVersion != null && workspaceVersion < currentVersion)
+            foreach(var migration in migrations.Where(m=>m.From >= workspaceVersion))
             {
-                var nextMigration = migrations.FirstOrDefault(x => x.From >= workspaceVersion);
-
-                if (nextMigration == null)
-                    break;
-
-                object ret = nextMigration.method.Invoke(this, new object[] { migrationData });
+                object ret = migration.method.Invoke(this, new object[] { migrationData });
                 migrationData = ret as NodeMigrationData;
 
                 if (DynamoModel.EnableMigrationLogging)
@@ -336,7 +331,6 @@ namespace Dynamo.Migration
                     // record migration data for successful migrations
                     migrationReport.AddMigrationDataToNodeMap(nodeToMigrate.Name, migrationData.MigratedNodes);
                 }
-                workspaceVersion = nextMigration.To;
             }
 
             return migrationData;
@@ -1360,6 +1354,7 @@ namespace Dynamo.Migration
         /// <summary>
         /// Version this migrates to.
         /// </summary>
+        [Obsolete("All migrations are now processed, beginning with the first migration whose version is >= the workspace version. The To property will be ignored.", false)]
         public Version To { get; private set; }
 
         public NodeMigrationAttribute(string from, string to = "")

--- a/src/DynamoCore/Migration/Migration.cs
+++ b/src/DynamoCore/Migration/Migration.cs
@@ -313,15 +313,15 @@ namespace Dynamo.Migration
                               let attribute =
                                   method.GetCustomAttributes(false).OfType<NodeMigrationAttribute>().FirstOrDefault()
                               where attribute != null
-                              let result = new { method, attribute.From, attribute.To }
-                              orderby result.From
+                              let result = new { method, attribute.Version}
+                              orderby result.Version
                               select result).ToList();
 
             var nodeToMigrate = elNode as XmlElement;
             var migrationData = new NodeMigrationData(elNode.OwnerDocument);
             migrationData.AppendNode(elNode as XmlElement);
 
-            foreach(var migration in migrations.Where(m=>m.From >= workspaceVersion))
+            foreach(var migration in migrations.Where(m=>m.Version >= workspaceVersion))
             {
                 object ret = migration.method.Invoke(this, new object[] { migrationData });
                 migrationData = ret as NodeMigrationData;
@@ -1347,20 +1347,13 @@ namespace Dynamo.Migration
     public class NodeMigrationAttribute : Attribute
     {
         /// <summary>
-        /// Latest Version this migration applies to.
+        /// Version specifies the latest workspace version to which this migration will be applied.
         /// </summary>
-        public Version From { get; private set; }
+        public Version Version { get; private set; }
 
-        /// <summary>
-        /// Version this migrates to.
-        /// </summary>
-        [Obsolete("All migrations are now processed, beginning with the first migration whose version is >= the workspace version. The To property will be ignored.", false)]
-        public Version To { get; private set; }
-
-        public NodeMigrationAttribute(string from, string to = "")
+        public NodeMigrationAttribute(string version)
         {
-            From = new Version(from);
-            To = String.IsNullOrEmpty(to) ? null : new Version(to);
+            Version = new Version(version);
         }
     }
 

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -747,7 +747,8 @@ namespace CoreNodeModels.Input
             var valEls = oldNode.GetElementsByTagName("System.Double"); // The Value node
             var val = valEls[0].Attributes["value"].Value;
 
-            if (!val.Contains(".."))
+            double result = 0.0;
+            if (double.TryParse(val, out result))
             {
                 return data;
             }

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -739,7 +739,7 @@ namespace CoreNodeModels.Input
             }
         }
 
-        [NodeMigration(from: "2.0.0.0")]
+        [NodeMigration(version: "2.0.0.0")]
         public static NodeMigrationData Migrate_Range(NodeMigrationData data)
         {
             var migrationData = new NodeMigrationData(data.Document);

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -744,8 +744,8 @@ namespace CoreNodeModels.Input
         {
             var migrationData = new NodeMigrationData(data.Document);
             var oldNode = data.MigratedNodes.ElementAt(0);
-            var valEl = oldNode.ChildNodes[0]; // The Value node
-            var val = valEl.Attributes["value"].Value;
+            var valEls = oldNode.GetElementsByTagName("System.Double"); // The Value node
+            var val = valEls[0].Attributes["value"].Value;
 
             if (!val.Contains(".."))
             {

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -739,7 +739,7 @@ namespace CoreNodeModels.Input
             }
         }
 
-        [NodeMigration(from: "1.0.0.0")]
+        [NodeMigration(from: "2.0.0.0")]
         public static NodeMigrationData Migrate_Range(NodeMigrationData data)
         {
             var migrationData = new NodeMigrationData(data.Document);

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -13,6 +13,7 @@ using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM;
 using CoreNodeModels.Properties;
 using Newtonsoft.Json;
+using Dynamo.Migration;
 
 namespace CoreNodeModels.Input
 {
@@ -736,6 +737,25 @@ namespace CoreNodeModels.Input
                 double.TryParse((string)value, out d);
                 writer.WriteValue(d);
             }
+        }
+
+        [NodeMigration(from: "1.0.0.0")]
+        public static NodeMigrationData Migrate_Range(NodeMigrationData data)
+        {
+            var migrationData = new NodeMigrationData(data.Document);
+            var oldNode = data.MigratedNodes.ElementAt(0);
+            var valEl = oldNode.ChildNodes[0]; // The Value node
+            var val = valEl.Attributes["value"].Value;
+
+            if (!val.Contains(".."))
+            {
+                return data;
+            }
+
+            var newNode = MigrationManager.CreateCodeBlockNodeFrom(oldNode);
+            newNode.Attributes["CodeText"].Value = val + ";";
+            migrationData.AppendNode(newNode);
+            return migrationData;
         }
     }
 }

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -164,7 +164,7 @@ namespace Dynamo.Nodes
 {
     public class DoubleSlider
     {
-        [NodeMigration(@from: "0.7.5.0")]
+        [NodeMigration(version: "0.7.5.0")]
         public static NodeMigrationData Migrate_0750(NodeMigrationData data)
         {
             var migrationData = new NodeMigrationData(data.Document);

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -184,7 +184,7 @@ namespace Dynamo.Nodes
 {
     public class IntegerSlider
     {
-        [NodeMigration(@from: "0.7.5.0")]
+        [NodeMigration(version: "0.7.5.0")]
         public static NodeMigrationData Migrate_0750(NodeMigrationData data)
         {
             var migrationData = new NodeMigrationData(data.Document);

--- a/src/Libraries/UnitsUI/UnitsUI.cs
+++ b/src/Libraries/UnitsUI/UnitsUI.cs
@@ -226,7 +226,7 @@ namespace UnitsUI
             RegisterAllPorts();
         }
 
-        [NodeMigration(from: "0.6.2")]
+        [NodeMigration(version: "0.6.2")]
         public void MigrateLengthFromFeetToMeters(XmlNode node)
         {
             //length values were previously stored as decimal feet
@@ -244,7 +244,7 @@ namespace UnitsUI
             }
         }
 
-        [NodeMigration(@from: "0.7.5.0")]
+        [NodeMigration(version: "0.7.5.0")]
         public static NodeMigrationData Migrate_0750(NodeMigrationData data)
         {
             var migrationData = new NodeMigrationData(data.Document);

--- a/src/Migrations/CoreNodes/dynBaseTypes.cs
+++ b/src/Migrations/CoreNodes/dynBaseTypes.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Web;
+﻿using System.Linq;
 using System.Xml;
-using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
-using Dynamo.Models;
 using Dynamo.Migration;
 
 namespace Dynamo.Nodes
@@ -15,7 +8,7 @@ namespace Dynamo.Nodes
     [AlsoKnownAs("DSCore.SortByKey")]
     public class SortByKey : MigrationNode
     {
-        [NodeMigration(from: "0.8.3.0", to: "0.9.0.0")]
+        [NodeMigration(version: "0.8.3.0")]
         public static NodeMigrationData Migrate_0830_to_0900(NodeMigrationData data)
         {
             NodeMigrationData migrationData = new NodeMigrationData(data.Document);
@@ -30,7 +23,7 @@ namespace Dynamo.Nodes
             return migrationData;
         }
 
-        [NodeMigration(from: "0.9.0.0", to: "0.9.1.0")]
+        [NodeMigration(version: "0.9.0.0")]
         public static NodeMigrationData Migrate_0900_to_0910(NodeMigrationData data)
         {
             return Migrate_0830_to_0900(data);
@@ -40,7 +33,7 @@ namespace Dynamo.Nodes
     [AlsoKnownAs("DSCore.GroupByKey")]
     public class GroupByKey : MigrationNode
     {
-        [NodeMigration(from: "0.8.3.0", to: "0.9.0.0")]
+        [NodeMigration(version: "0.8.3.0")]
         public static NodeMigrationData Migrate_0830_to_0900(NodeMigrationData data)
         {
             NodeMigrationData migrationData = new NodeMigrationData(data.Document);
@@ -55,7 +48,7 @@ namespace Dynamo.Nodes
             return migrationData;
         }
 
-        [NodeMigration(from: "0.9.0.0", to: "0.9.1.0")]
+        [NodeMigration(version: "0.9.0.0")]
         public static NodeMigrationData Migrate_0900_to_0910(NodeMigrationData data)
         {
             return Migrate_0830_to_0900(data);
@@ -65,7 +58,7 @@ namespace Dynamo.Nodes
     [AlsoKnownAs("Dynamo.Nodes.dynBuildSeq", "Dynamo.Nodes.BuildSeq", "DSCoreNodesUI.NumberRange")]
     public class NumberRange : MigrationNode
     {
-        [NodeMigration(from: "0.8.2.0", to: "0.8.3.0")]
+        [NodeMigration(version: "0.8.2.0")]
         public static NodeMigrationData Migrate_0820_to_0830(NodeMigrationData data)
         {
             NodeMigrationData migrationData = new NodeMigrationData(data.Document);
@@ -82,7 +75,7 @@ namespace Dynamo.Nodes
     [AlsoKnownAs("DSCoreNodesUI.NumberSeq")]
     public class NumberSeq : MigrationNode
     {
-        [NodeMigration(from: "0.8.2.0", to: "0.8.3.0")]
+        [NodeMigration(version: "0.8.2.0")]
         public static NodeMigrationData Migrate_0820_to_0830(NodeMigrationData data)
         {
             NodeMigrationData migrationData = new NodeMigrationData(data.Document);

--- a/src/Migrations/DynamoPython/dynPython.cs
+++ b/src/Migrations/DynamoPython/dynPython.cs
@@ -1,13 +1,11 @@
 ﻿using Dynamo.Migration;
 using System.Linq;
-using System.Text.RegularExpressions;
-using System.Xml;
 
 namespace DSIronPythonNode
 {
     public class PythonNode : MigrationNode
     {
-        [NodeMigration(from: "0.8.3.0", to: "0.9.0.0")]
+        [NodeMigration(version: "0.8.3.0")]
         public static NodeMigrationData Migrate_0830_to_0900(NodeMigrationData data)
         {
             System.Xml.XmlElement xmlNode = data.MigratedNodes.ElementAt(0);
@@ -21,7 +19,7 @@ namespace DSIronPythonNode
 
     public class PythonStringNode : MigrationNode
     {
-        [NodeMigration(from: "0.8.3.0", to: "0.9.0.0")]
+        [NodeMigration(version: "0.8.3.0")]
         public static NodeMigrationData Migrate_0830_to_0900(NodeMigrationData data)
         {
             System.Xml.XmlElement xmlNode = data.MigratedNodes.ElementAt(0);

--- a/src/Migrations/RevitNodes/SunPath.cs
+++ b/src/Migrations/RevitNodes/SunPath.cs
@@ -1,16 +1,13 @@
 ﻿using System;
 using System.Linq;
-using System.Xml;
-using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
-using Dynamo.Models;
 using Dynamo.Migration;
 
 namespace Dynamo.Nodes
 {
     public class SunPathDirection : MigrationNode
     {
-        [NodeMigration(from: "0.7.0.0", to: "0.7.3.0")]
+        [NodeMigration(version: "0.7.0.0")]
         public static NodeMigrationData Migrate_0700_to_0730(NodeMigrationData data)
         {
             var migrationData = new NodeMigrationData(data.Document);
@@ -56,7 +53,7 @@ namespace DSRevitNodesUI
 {
     public class SunPathDirection : MigrationNode
     {
-        [NodeMigration(from: "0.7.0.0", to: "0.7.3.0")]
+        [NodeMigration(version: "0.7.0.0")]
         public static NodeMigrationData Migrate_0700_to_0730(NodeMigrationData data)
         {
             return Dynamo.Nodes.SunPathDirection.Migrate_0700_to_0730(data);

--- a/test/DynamoCoreTests/CallsiteTests.cs
+++ b/test/DynamoCoreTests/CallsiteTests.cs
@@ -9,7 +9,7 @@ using Dynamo.Engine;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
 using NUnit.Framework;
-
+using Dynamo.Graph.Nodes;
 
 namespace Dynamo.Tests
 {
@@ -96,10 +96,10 @@ namespace Dynamo.Tests
 
             CurrentDynamoModel.TraceReconciliationProcessor = new TestTraceReconciliationProcessor(expectedOrphanCount);
 
-            var numNode = ws.FirstNodeFromWorkspace<DoubleInput>();
+            var numNode = ws.FirstNodeFromWorkspace<CodeBlockNodeModel>();
 
             // Increase the number values.
-            numNode.Value = numNodeValue;
+            numNode.SetCodeContent(numNodeValue + ";", new ProtoCore.Namespace.ElementResolver());
 
             BeginRun();
         }

--- a/test/DynamoCoreTests/DynamoDefects.cs
+++ b/test/DynamoCoreTests/DynamoDefects.cs
@@ -284,8 +284,8 @@ namespace Dynamo.Tests
             RunModel(openPath);
             AssertPreviewCount("2ea813c4-7729-45b5-b23b-d7a3377f0b31", 4);
             var doubleInput = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace
-                ("7eba96c0-4715-47f0-a874-01f1887ac465") as DoubleInput;
-            doubleInput.Value = "6..8";
+                ("7eba96c0-4715-47f0-a874-01f1887ac465") as CodeBlockNodeModel;
+            doubleInput.SetCodeContent("6..8;", new ProtoCore.Namespace.ElementResolver());
             BeginRun();
             AssertPreviewCount("2ea813c4-7729-45b5-b23b-d7a3377f0b31", 3);
         }

--- a/test/DynamoCoreTests/NodeMigrationTests.cs
+++ b/test/DynamoCoreTests/NodeMigrationTests.cs
@@ -1788,15 +1788,15 @@ namespace Dynamo.Tests
                 "27d6c83d-602c-4d44-a9b6-ab229cb2143d");
             var number50 = workspace.NodeFromWorkspace<DoubleInput>(
                 "ffd50d99-b51d-4104-9e19-041219ca5740");
-            var numberRange = workspace.NodeFromWorkspace<DoubleInput>(
+            var numberRange = workspace.NodeFromWorkspace<CodeBlockNodeModel>(
                 "eb6aa95d-8be4-4ca7-95a6-e696904a71fa");
-            var numberStep = workspace.NodeFromWorkspace<DoubleInput>(
+            var numberStep = workspace.NodeFromWorkspace<CodeBlockNodeModel>(
                 "5fde015f-8a95-4b46-ba64-29de06850938");
-            var numberCount = workspace.NodeFromWorkspace<DoubleInput>(
+            var numberCount = workspace.NodeFromWorkspace<CodeBlockNodeModel>(
                 "ace69b4e-5092-42cf-9fba-9aee6729509d");
-            var numberApprox = workspace.NodeFromWorkspace<DoubleInput>(
+            var numberApprox = workspace.NodeFromWorkspace<CodeBlockNodeModel>(
                 "30e9b7fd-fc09-4243-a34a-146ad841868a");
-            var numberIncr = workspace.NodeFromWorkspace<DoubleInput>(
+            var numberIncr = workspace.NodeFromWorkspace<CodeBlockNodeModel>(
                 "bede0d80-6382-4430-9403-a14c3916e041");
 
             Assert.NotNull(number5);

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -250,8 +250,13 @@ namespace Dynamo.Tests
 
             var wcd1 = new WorkspaceComparisonData(ws1, CurrentDynamoModel.EngineController);
 
+            var dirPath = Path.Combine(Path.GetTempPath(), "json");
+            if (!Directory.Exists(dirPath))
+            {
+                Directory.CreateDirectory(dirPath);
+            }
             var fi = new FileInfo(filePath);
-            var filePathBase = Path.Combine(Path.GetTempPath() + @"\json\" + Path.GetFileNameWithoutExtension(fi.Name));
+            var filePathBase = dirPath + @"\" +  Path.GetFileNameWithoutExtension(fi.Name);
 
             ConvertCurrentWorkspaceToDesignScriptAndSave(filePathBase);
 
@@ -396,8 +401,6 @@ namespace Dynamo.Tests
         {
             try
             {
-
-
                 var workspace = CurrentDynamoModel.CurrentWorkspace;
 
                 var libCore = CurrentDynamoModel.EngineController.LibraryServices.LibraryManagementCore;


### PR DESCRIPTION
### Purpose
While developing a migration for the number node, a behavior was noticed in the migration framework that causes a second migration to not be applied when the first migration has the `to` field set to `null`. The `to` field has never really been clear in its intent, and could potentially cause a migration to get "swallowed" by another migration. Ex. you have a migration `from: 0.0.0.1 to: 2.0.0.0` and one `from: 1.0.0.0 to: 2.0.0.0`. The second migration would never be applied because the first would set the current version to `2.0.0.0` during the loop. Similarly, without `to:` defined as in `from: 0.0.0.1`, any other migrations would not get processed because the loop exits when `to:` is null.

This PR marks the `To` field as obsolete on `NodeMigrationAttribute`, and adjusts the migration code to apply all migrations sequentially starting with the one whose version is `>=` the version of the stored workspace. All existing migrations have this intent, with migrations version ranges being sequential. So this change does not affect those migrations, and they will continue to be processed sequentially.

This PR also migrates number nodes with sequences, i.e. `0..5` to CBNs with `0..5;`. Currently, we do not allow the user to input `0..5` in a number node, but we do not disallow the number node from opening such a node. It has been tested to work on number nodes with numeric ranges like `0..5` and ranges with variables like `a..b..c`. All connectors are successfully re-established after migration.

- [x] All tests pass on the self-service CI
- [x] Changes to the API have been listed in the API Changes doc.

PTAL @mjkkirschner 
FYI @gregmarr 