### PR TITLE
DSDropDownBase::UpdateValueCore() implementation

### DIFF
--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -112,6 +112,22 @@ namespace CoreNodeModels
             }
         }
 
+        protected override bool UpdateValueCore(UpdateValueParams updateValueParams)
+        {
+            string name = updateValueParams.PropertyName;
+            string value = updateValueParams.PropertyValue;
+
+            if (name == "Value" && value != null)
+            {
+                selectedIndex = ParseSelectedIndex(value, Items);
+                if (selectedIndex < 0)
+                    Warning(Dynamo.Properties.Resources.NothingIsSelectedWarning);
+                return true; // UpdateValueCore handled.
+            }
+
+            return base.UpdateValueCore(updateValueParams);
+        }
+
         protected virtual int ParseSelectedIndex(string index, IList<DynamoDropDownItem> items)
         {
             return ParseSelectedIndexImpl(index, items);


### PR DESCRIPTION
### Purpose

This is one more override, just like https://github.com/DynamoDS/Dynamo/pull/7573

This allows us to push values into DSDropDownBase Nodes.

Here, I have not abstracted any common code between `DeserializeCore()` and `UpdateValueCore()`. The common code is one call + one Warning. I would be happy to abstract it though, if that is considered preferable.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
