### PR TITLE
Adjust nuget build file to allow you to specify Dynamo directory.

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.0.0.3911")]
+[assembly: AssemblyVersion("2.0.0.4057")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.0.0.3911")]
+[assembly: AssemblyFileVersion("2.0.0.4057")]

--- a/tools/NuGet/BuildPackages.bat
+++ b/tools/NuGet/BuildPackages.bat
@@ -1,14 +1,22 @@
-:: Argument %1: path to template folder
+﻿:: Argument %1: path to template folder
+:: Argument %2: path to dynamo build directory
 ::
 
-@echo off
+if not "%2"=="" goto :harvestpathdefined
+
 set harvestPath=..\..\src\DynamoInstall\harvest
 if not exist %harvestPath% (
   echo Dynamo\src\DynamoInstall\harvest folder not found.
   echo Please build Dynamo\src\Install.sln before running this script!
   exit /b 1
 )
+goto :build
 
+:harvestpathdefined
+set harvestPath=%2
+
+:build
+@echo off
 :: Get version string from "DynamoCore.dll"
 set count=1
 for /f %%f in ('cscript //Nologo ..\install\GetFileVersion.vbs %harvestPath%\DynamoCore.dll') do (

--- a/tools/NuGet/BuildPackages.bat
+++ b/tools/NuGet/BuildPackages.bat
@@ -4,6 +4,7 @@
 
 if not "%2"=="" goto :harvestpathdefined
 
+echo The path to the Dynamo dlls was not specified. Using the dlls in the install directory...
 set harvestPath=..\..\src\DynamoInstall\harvest
 if not exist %harvestPath% (
   echo Dynamo\src\DynamoInstall\harvest folder not found.


### PR DESCRIPTION
This PR adjusts the build script for the Dynamo NuGet packages to allow the creation of the packages without having to build `Install.sln`. It adds an additional command line argument to specify a build directory from which to get the Dynamo dlls. If this command line argument is not used, it falls back to the previous behavior of requiring that you first run `Install.sln`.

Example:
`BuildPackages.bat "template-nuget" ..\..\bin\AnyCPU\Debug`

PTAL @sharadkjaiswal @ellensi 
