### PR TITLE
Turning on Preview Bubble for Rest of Revit Selection Nodes

### DIFF
--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -112,7 +112,7 @@ namespace CoreNodeModels
 
             State = ElementState.Warning; 
             
-            ShouldDisplayPreviewCore = false;
+            ShouldDisplayPreviewCore = true;
         }
 
         #endregion


### PR DESCRIPTION
### Purpose

In a previous PR, only the "All Elements of" Selection nodes had their
Preview Bubbles turned on. This turns the Preview Bubble on  for the
remaining Selection nodes. Once merged, this will need to be cherry-picked into 1.2.3 RC.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner  @QilongTang 

### FYIs

@jnealb @kronz 

![image](https://cloud.githubusercontent.com/assets/2551261/22893262/3140e2b6-f1e3-11e6-8499-4503d6aefeec.png)

