### PR TITLE
Update some test cases to use UI node instead of code block node

### DIFF
--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -401,7 +401,7 @@ namespace Dynamo.Tests
         {
             // MAGN-7463
             RunModel(@"core\dsevaluation\CBN_TypedIdentifier01.dyn");
-            AssertPreviewValue("9c422c81-821f-456e-9965-4aea6afe81f9", 1);
+            AssertPreviewValue("1472b79b-59b0-40ab-ab0e-3504fbc7be83", 1);
         }
 
         [Test]
@@ -619,7 +619,7 @@ namespace Dynamo.Tests
         public void CBN_Geometry()
         {
             RunModel(@"core\dsevaluation\CBN_Geometry.dyn");
-            AssertPreviewValue("9c51f2d5-a9f2-4825-bda6-f062e69efc46", 5.00000);
+            AssertPreviewValue("a23b89fc-f219-46ca-ab7a-5a3f0ee93ba4", 5.00000);
         }
         [Test]
         [Category("RegressionTests")]
@@ -807,7 +807,7 @@ namespace Dynamo.Tests
             // http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5236
 
             RunModel(@"core\dsevaluation\createCube_codeBlockNode.dyn");
-            AssertPreviewValue("3669d05c-c741-44f9-87ab-8961e7f5f112", 150);
+            AssertPreviewValue("8187805a-cc0d-4220-8595-4ee38bbee079", 150);
             var guid = Guid.Parse("3669d05c-c741-44f9-87ab-8961e7f5f112");
             var node = CurrentDynamoModel.CurrentWorkspace.Nodes.FirstOrDefault(n => n.GUID == guid);
             Assert.IsTrue(node.State != ElementState.Warning);

--- a/test/Libraries/WorkflowTests/ComplexTests.cs
+++ b/test/Libraries/WorkflowTests/ComplexTests.cs
@@ -1053,7 +1053,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(surface2.ToString(), "Surface");
           
             //check CBN, which includes a list of Vector
-            var cbnId = "e14439c9-b377-4653-bb63-4edd9a4f90a0";
+            var cbnId = "be2abed2-282f-44d5-8981-3cfb3e231d1b";
             AssertPreviewCount(cbnId, 18);
             for (int i = 0; i < 18; i++)
             {

--- a/test/core/GeometrySanityCheck/Curve.PlaneAtDistance.Simple.dyn
+++ b/test/core/GeometrySanityCheck/Curve.PlaneAtDistance.Simple.dyn
@@ -1,23 +1,48 @@
-<Workspace Version="1.0.1.1743" X="-674.664363500904" Y="-474.50323141071" zoom="0.889203022025035" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="False">
+<Workspace Version="2.0.0.4093" X="-513.023130021732" Y="-488.519541272745" zoom="0.960233205802179" ScaleFactor="1" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap>
     <ClassMap partialName="Line" resolvedName="Autodesk.DesignScript.Geometry.Line" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="Point" resolvedName="Autodesk.DesignScript.Geometry.Point" assemblyName="ProtoGeometry.dll" />
   </NamespaceResolutionMap>
   <Elements>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="c2bd117e-89b3-4578-97a0-a146d111d242" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1052.60487160395" y="746.981334420475" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="point1              = Point.ByCoordinates(0,0,0);&#xA;point2              = Point.ByCoordinates(0,10,0);&#xA;curve               = Line.ByStartPointEndPoint(point1, point2);&#xA;distanceForPlane    = 8;&#xA;myPlaneAtDistance = curve.PlaneAtDistance(distanceForPlane);&#xA;&#xA;myPlaneOrigin       = myPlaneAtDistance.Origin;&#xA;myPlaneNormal       = myPlaneAtDistance.Normal;&#xA;myPlaneSize         = myPlaneAtDistance.Size;&#xA;myPlaneDistance     = myPlaneAtDistance.Distance;&#xA;myPlaneParameter    = myPlaneAtDistance.T;" ShouldFocus="false" />
-    <CoreNodeModels.Watch guid="e823b80c-a2dd-4fae-9a71-283171be5932" type="CoreNodeModels.Watch" nickname="Watch" x="1810.16886088292" y="806.311745207325" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
-    <CoreNodeModels.Watch guid="b6c7580a-6ab7-485c-b975-532055e749f3" type="CoreNodeModels.Watch" nickname="Watch" x="1823.24033210926" y="1078.50591074405" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
-    <CoreNodeModels.Watch guid="56cf6f40-4d3e-453e-965b-0b889523a4e8" type="CoreNodeModels.Watch" nickname="Watch" x="1829.39161268636" y="925.492806388659" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
-    <CoreNodeModels.Watch guid="a715967a-b678-4e05-ae8e-fec6a3db3506" type="CoreNodeModels.Watch" nickname="Watch" x="1877.06403715889" y="1181.53986041049" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
-    <CoreNodeModels.Watch guid="ff9708f0-2947-453f-abd1-c3e16197390e" type="CoreNodeModels.Watch" nickname="Watch" x="1949.34158393983" y="1023.14438555014" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="c2bd117e-89b3-4578-97a0-a146d111d242" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="722.230691372734" y="779.491559602802" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="point1              = Point.ByCoordinates(0,0,0);&#xA;point2              = Point.ByCoordinates(0,10,0);&#xA;curve               = Line.ByStartPointEndPoint(point1, point2);&#xA;distanceForPlane    = 8;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+      <OutPortInfo LineIndex="1" />
+      <OutPortInfo LineIndex="2" />
+      <OutPortInfo LineIndex="3" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <CoreNodeModels.Watch guid="e823b80c-a2dd-4fae-9a71-283171be5932" type="CoreNodeModels.Watch" nickname="Watch" x="1945.16591571437" y="621.854239122965" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
+    <CoreNodeModels.Watch guid="56cf6f40-4d3e-453e-965b-0b889523a4e8" type="CoreNodeModels.Watch" nickname="Watch" x="1946.02994525312" y="761.99085805847" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
+    <CoreNodeModels.Watch guid="ff9708f0-2947-453f-abd1-c3e16197390e" type="CoreNodeModels.Watch" nickname="Watch" x="1950.38299762346" y="919.003017186962" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="0d4a02c4-a504-4518-8f20-32ffccd5d0bb" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Curve.PlaneAtParameter" x="1350.50027306065" y="807.454261726102" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.PlaneAtParameter@double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="372e63cd-c69f-4169-a194-3ac8a62ffb19" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Plane.Origin" x="1674.56476504734" y="819.101956317373" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Plane.Origin">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="daa0bc5e-627e-44f0-94c1-0ef1e6b736f1" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Plane.Normal" x="1673.17940988458" y="950.150013811893" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Plane.Normal">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
   </Elements>
   <Connectors>
-    <Dynamo.Graph.Connectors.ConnectorModel start="c2bd117e-89b3-4578-97a0-a146d111d242" start_index="5" end="e823b80c-a2dd-4fae-9a71-283171be5932" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="c2bd117e-89b3-4578-97a0-a146d111d242" start_index="6" end="56cf6f40-4d3e-453e-965b-0b889523a4e8" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="c2bd117e-89b3-4578-97a0-a146d111d242" start_index="7" end="ff9708f0-2947-453f-abd1-c3e16197390e" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="c2bd117e-89b3-4578-97a0-a146d111d242" start_index="8" end="b6c7580a-6ab7-485c-b975-532055e749f3" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="c2bd117e-89b3-4578-97a0-a146d111d242" start_index="9" end="a715967a-b678-4e05-ae8e-fec6a3db3506" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="c2bd117e-89b3-4578-97a0-a146d111d242" start_index="2" end="0d4a02c4-a504-4518-8f20-32ffccd5d0bb" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="c2bd117e-89b3-4578-97a0-a146d111d242" start_index="3" end="0d4a02c4-a504-4518-8f20-32ffccd5d0bb" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="0d4a02c4-a504-4518-8f20-32ffccd5d0bb" start_index="0" end="e823b80c-a2dd-4fae-9a71-283171be5932" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="0d4a02c4-a504-4518-8f20-32ffccd5d0bb" start_index="0" end="372e63cd-c69f-4169-a194-3ac8a62ffb19" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="0d4a02c4-a504-4518-8f20-32ffccd5d0bb" start_index="0" end="daa0bc5e-627e-44f0-94c1-0ef1e6b736f1" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="372e63cd-c69f-4169-a194-3ac8a62ffb19" start_index="0" end="56cf6f40-4d3e-453e-965b-0b889523a4e8" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="daa0bc5e-627e-44f0-94c1-0ef1e6b736f1" start_index="0" end="ff9708f0-2947-453f-abd1-c3e16197390e" end_index="0" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />
   <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>

--- a/test/core/GeometrySanityCheck/Solid.Union.ArrayOfSolids.Simple.dyn
+++ b/test/core/GeometrySanityCheck/Solid.Union.ArrayOfSolids.Simple.dyn
@@ -1,13 +1,25 @@
-<Workspace Version="1.0.1.1743" X="58.3977693099254" Y="173.560914792667" zoom="1.17131835730765" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="False">
+<Workspace Version="2.0.0.4093" X="58.3977693099254" Y="173.560914792667" zoom="1.17131835730765" ScaleFactor="1" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap>
     <ClassMap partialName="CoordinateSystem" resolvedName="Autodesk.DesignScript.Geometry.CoordinateSystem" assemblyName="ProtoGeometry.dll" />
     <ClassMap partialName="Cylinder" resolvedName="Autodesk.DesignScript.Geometry.Cylinder" assemblyName="ProtoGeometry.dll" />
     <ClassMap partialName="Cuboid" resolvedName="Autodesk.DesignScript.Geometry.Cuboid" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="Solid" resolvedName="Autodesk.DesignScript.Geometry.Solid" assemblyName="ProtoGeometry.dll" />
   </NamespaceResolutionMap>
   <Elements>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="532f8b75-4957-460e-bfff-8247f285e14a" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1.8595621133635" y="77.5603572279534" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="WCS = CoordinateSystem.Identity();&#xA;&#xA;//======Establish the context for creating Solid================&#xA;firstSolid      = Cylinder.ByRadiusHeight(WCS.Translate&#xA;                                        (15, 15, 0), 2.5, 50);&#xA;ArrayOfSolids   =&#xA;{&#xA;    firstSolid,&#xA;    firstSolid.Translate(-30, 0, 0),&#xA;    firstSolid.Translate(-30, -30, 0),&#xA;    firstSolid.Translate(0, -30, 0)&#xA;};&#xA;secondSolid     = Cuboid.ByLengths(WCS, 30, 30, 30);" ShouldFocus="false" />
-    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="824707aa-3c5f-4fc3-a183-a21ff7804932" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Solid.Union" x="707.698954775303" y="121.592429832398" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Solid.Union@Autodesk.DesignScript.Geometry.Solid" />
-    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="0ef5c7c7-4fa5-4542-a6bc-b45a041bf9f6" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Solid.Union" x="718.000095560657" y="452.143540086233" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Solid.Union@Autodesk.DesignScript.Geometry.Solid" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="532f8b75-4957-460e-bfff-8247f285e14a" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1.8595621133635" y="77.5603572279534" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="WCS = CoordinateSystem.Identity();&#xA;&#xA;//======Establish the context for creating Solid================&#xA;firstSolid      = Cylinder.ByRadiusHeight(&#xA;    CoordinateSystem.Translate(WCS, 15, 15, 0), 2.5, 50);&#xA;ArrayOfSolids   =&#xA;{&#xA;    firstSolid,&#xA;    Solid.Translate(firstSolid, -30, 0, 0),&#xA;    Solid.Translate(firstSolid, -30, -30, 0),&#xA;    Solid.Translate(firstSolid, 0, -30, 0)&#xA;};&#xA;secondSolid     = Cuboid.ByLengths(WCS, 30, 30, 30);" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+      <OutPortInfo LineIndex="3" />
+      <OutPortInfo LineIndex="5" />
+      <OutPortInfo LineIndex="12" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="824707aa-3c5f-4fc3-a183-a21ff7804932" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Solid.Union" x="707.698954775303" y="121.592429832398" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Solid.Union@Autodesk.DesignScript.Geometry.Solid">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="0ef5c7c7-4fa5-4542-a6bc-b45a041bf9f6" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Solid.Union" x="736.78235049822" y="320.667755523291" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Solid.Union@Autodesk.DesignScript.Geometry.Solid">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
   </Elements>
   <Connectors>
     <Dynamo.Graph.Connectors.ConnectorModel start="532f8b75-4957-460e-bfff-8247f285e14a" start_index="1" end="0ef5c7c7-4fa5-4542-a6bc-b45a041bf9f6" end_index="0" portType="0" />
@@ -21,4 +33,7 @@
   </Notes>
   <Annotations />
   <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>

--- a/test/core/GeometrySanityCheck/Solid.Union.NonManifold.Simple.dyn
+++ b/test/core/GeometrySanityCheck/Solid.Union.NonManifold.Simple.dyn
@@ -1,14 +1,30 @@
-<Workspace Version="1.0.1.1743" X="-450.454152133446" Y="-372.005739693096" zoom="1.01204214144457" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="False">
+<Workspace Version="2.0.0.4093" X="-12.1845411873608" Y="-27.0819729330225" zoom="1.11798788304238" ScaleFactor="1" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap>
     <ClassMap partialName="CoordinateSystem" resolvedName="Autodesk.DesignScript.Geometry.CoordinateSystem" assemblyName="ProtoGeometry.dll" />
     <ClassMap partialName="Cylinder" resolvedName="Autodesk.DesignScript.Geometry.Cylinder" assemblyName="ProtoGeometry.dll" />
     <ClassMap partialName="Cuboid" resolvedName="Autodesk.DesignScript.Geometry.Cuboid" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="Solid" resolvedName="Autodesk.DesignScript.Geometry.Solid" assemblyName="ProtoGeometry.dll" />
   </NamespaceResolutionMap>
   <Elements>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="66097d3d-9132-4d1b-9c88-d34c43d36549" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="452" y="392" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="WCS = CoordinateSystem.Identity();&#xA;firstSolid = Cylinder.ByRadiusHeight(WCS.Translate(15, 15, 0), 2.5, 50);&#xA;ArrayOfSolids   =&#xA;{&#xA;    firstSolid,&#xA;    firstSolid.Translate(-30, 0, 0),&#xA;    firstSolid.Translate(-30, -30, 0),&#xA;    firstSolid.Translate(0, -30, 0)&#xA;};&#xA;secondSolid     = Cuboid.ByLengths(WCS, 30, 30, 30);&#xA;myUnionSolid = secondSolid.Union(ArrayOfSolids, false);&#xA;false;" ShouldFocus="false" />
-    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="a286bf12-7f0d-4b0a-b6d3-5026175138e8" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Solid.Union" x="1033.92875418667" y="515.414855017205" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Solid.Union@Autodesk.DesignScript.Geometry.Solid" />
-    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="46db7d8c-c9e0-4793-b102-12ae3dd6eebc" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Geometry.Translate" x="1256.54805814837" y="560.19359122186" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.Translate@double,double,double" />
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="fb1512e8-8950-4034-9703-9fb5f1478918" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1090.2169845691" y="668.347175310561" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="50;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="66097d3d-9132-4d1b-9c88-d34c43d36549" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="122.261159922597" y="309.717544493684" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="WCS = CoordinateSystem.Identity();&#xA;firstSolid = Cylinder.ByRadiusHeight(CoordinateSystem.Translate(WCS, 15, 15, 0), 2.5, 50);&#xA;ArrayOfSolids   =&#xA;{&#xA;    firstSolid,&#xA;    Solid.Translate(firstSolid,-30, 0, 0),&#xA;    Solid.Translate(firstSolid,-30, -30, 0),&#xA;    Solid.Translate(firstSolid,0, -30, 0)&#xA;};&#xA;secondSolid     = Cuboid.ByLengths(WCS, 30, 30, 30);" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+      <OutPortInfo LineIndex="1" />
+      <OutPortInfo LineIndex="2" />
+      <OutPortInfo LineIndex="9" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="a286bf12-7f0d-4b0a-b6d3-5026175138e8" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Solid.Union" x="1064.34053280763" y="394.662204610454" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Solid.Union@Autodesk.DesignScript.Geometry.Solid">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="46db7d8c-c9e0-4793-b102-12ae3dd6eebc" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Geometry.Translate" x="1250.28680960876" y="456.435758279763" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Geometry.Translate@double,double,double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+      <PortInfo index="3" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="fb1512e8-8950-4034-9703-9fb5f1478918" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1075.90555933571" y="547.59452490381" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="50;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </Elements>
   <Connectors>
     <Dynamo.Graph.Connectors.ConnectorModel start="66097d3d-9132-4d1b-9c88-d34c43d36549" start_index="2" end="a286bf12-7f0d-4b0a-b6d3-5026175138e8" end_index="1" portType="0" />
@@ -21,4 +37,7 @@
   <Notes />
   <Annotations />
   <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-31.223644246016" eyeY="39.408947933184" eyeZ="118.747613855744" lookX="26.223644246016" lookY="-28.408947933184" lookZ="-126.747613855744" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>

--- a/test/core/WorkflowTestFiles/MiscDefinitions/mobius.dyn
+++ b/test/core/WorkflowTestFiles/MiscDefinitions/mobius.dyn
@@ -1,99 +1,203 @@
-<Workspace Version="0.8.1.1302" X="-46.8685275607735" Y="279.867495363223" zoom="0.312449567343726" Name="Home" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
+<Workspace Version="2.0.0.4093" X="-355.886006374708" Y="-164.0585736164" zoom="0.595199253964677" ScaleFactor="1" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="False">
   <NamespaceResolutionMap>
     <ClassMap partialName="Math" resolvedName="DSCore.Math" assemblyName="DSCoreNodes.dll" />
   </NamespaceResolutionMap>
   <Elements>
-    <DSCoreNodesUI.Input.DoubleSlider guid="b104bcdb-eb55-4553-b02b-85aec2bff925" type="DSCoreNodesUI.Input.DoubleSlider" nickname="Number Slider" x="347.35894851259" y="193.290596567506" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    <CoreNodeModels.Input.DoubleSlider guid="b104bcdb-eb55-4553-b02b-85aec2bff925" type="CoreNodeModels.Input.DoubleSlider" nickname="Number Slider" x="347.35894851259" y="193.290596567506" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Double>5.573</System.Double>
       <Range min="0" max="20" step="0.1" />
-    </DSCoreNodesUI.Input.DoubleSlider>
-    <DSCoreNodesUI.Input.DoubleSlider guid="1ec3bf7a-c859-4e17-a74f-29139a5ca821" type="DSCoreNodesUI.Input.DoubleSlider" nickname="Number Slider" x="346.55894851259" y="302.108719262679" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </CoreNodeModels.Input.DoubleSlider>
+    <CoreNodeModels.Input.DoubleSlider guid="1ec3bf7a-c859-4e17-a74f-29139a5ca821" type="CoreNodeModels.Input.DoubleSlider" nickname="Number Slider" x="346.55894851259" y="302.108719262679" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Double>4.561</System.Double>
       <Range min="0" max="10" step="0.1" />
-    </DSCoreNodesUI.Input.DoubleSlider>
-    <Dynamo.Nodes.DSFunction guid="5485a2d4-ed38-4c2d-bc27-ea3c448840af" type="Dynamo.Nodes.DSFunction" nickname="Circle.ByCenterPointRadius" x="929.059740801225" y="203.414392583342" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double">
+    </CoreNodeModels.Input.DoubleSlider>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="5485a2d4-ed38-4c2d-bc27-ea3c448840af" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Circle.ByCenterPointRadius" x="929.059740801225" y="203.414392583342" isVisible="false" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.DSFunction guid="5abff7f6-fd49-4d69-bdf8-d7804407528f" type="Dynamo.Nodes.DSFunction" nickname="Point.Origin" x="809.059740801225" y="177.014392583342" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Origin" />
-    <Dynamo.Nodes.CodeBlockNodeModel guid="ec1d92e7-ed74-455d-8dce-a8c4a4cd6c2d" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1010.67793342326" y="601.676276707143" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="-90..90..#numLines;" ShouldFocus="false" />
-    <DSCoreNodesUI.Input.IntegerSlider guid="631404f5-29eb-4506-a664-f60047320ae8" type="DSCoreNodesUI.Input.IntegerSlider" nickname="Integer Slider" x="606.02821308868" y="497.908290113401" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="5abff7f6-fd49-4d69-bdf8-d7804407528f" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.Origin" x="809.059740801225" y="177.014392583342" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Origin" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="ec1d92e7-ed74-455d-8dce-a8c4a4cd6c2d" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1010.67793342326" y="601.676276707143" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="-90..90..#numLines;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="numLines" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <CoreNodeModels.Input.IntegerSlider guid="631404f5-29eb-4506-a664-f60047320ae8" type="CoreNodeModels.Input.IntegerSlider" nickname="Integer Slider" x="606.02821308868" y="497.908290113401" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <System.Int32>18</System.Int32>
       <Range min="0" max="100" step="1" />
-    </DSCoreNodesUI.Input.IntegerSlider>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="381419bf-5cdc-4d2e-b002-8b07af5c85a3" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="945.611674205005" y="435.028785166684" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0..1..#numLines;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction guid="7cb48ff7-81c1-4134-86a9-ff90f54f9fad" type="Dynamo.Nodes.DSFunction" nickname="Curve.PointAtParameter" x="1255.62951320282" y="419.361011236606" isVisible="false" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.PointAtParameter@double">
+    </CoreNodeModels.Input.IntegerSlider>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="381419bf-5cdc-4d2e-b002-8b07af5c85a3" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="945.611674205005" y="435.028785166684" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="0..1..#numLines;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="numLines" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="7cb48ff7-81c1-4134-86a9-ff90f54f9fad" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Curve.PointAtParameter" x="1255.62951320282" y="419.361011236606" isVisible="false" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.PointAtParameter@double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.DSFunction guid="6d526736-66d3-4aea-9fd4-62411a20ac08" type="Dynamo.Nodes.DSFunction" nickname="Vector.ZAxis" x="1478.72686888893" y="149.112481038255" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.ZAxis" />
-    <Dynamo.Nodes.DSFunction guid="cda8f969-2162-410a-b70d-b44956b86200" type="Dynamo.Nodes.DSFunction" nickname="Vector.Rotate" x="1649.53300318225" y="315.464013667393" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Rotate@Autodesk.DesignScript.Geometry.Vector,double">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="6d526736-66d3-4aea-9fd4-62411a20ac08" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Vector.ZAxis" x="1478.72686888893" y="149.112481038255" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.ZAxis" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="cda8f969-2162-410a-b70d-b44956b86200" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Vector.Rotate" x="1649.53300318225" y="315.464013667393" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Rotate@Autodesk.DesignScript.Geometry.Vector,double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
       <PortInfo index="2" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.DSFunction guid="4f4f6e9e-9a1f-4b99-92b2-eb319a5c3845" type="Dynamo.Nodes.DSFunction" nickname="Curve.TangentAtParameter" x="1253.00405892648" y="295.168416896313" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.TangentAtParameter@double">
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="4f4f6e9e-9a1f-4b99-92b2-eb319a5c3845" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Curve.TangentAtParameter" x="1253.00405892648" y="295.168416896313" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.TangentAtParameter@double">
+      <PortInfo index="0" default="False" />
       <PortInfo index="1" default="True" />
-    </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.DSFunction guid="f5cecdeb-9c3a-4f9c-b29d-7c2442f9cdbf" type="Dynamo.Nodes.DSFunction" nickname="Point.Add" x="2200.55703122876" y="453.295091255038" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector" />
-    <Dynamo.Nodes.CodeBlockNodeModel guid="e14439c9-b377-4653-bb63-4edd9a4f90a0" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1847.54567500793" y="608.606522064922" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="vec.Scale(width/2);&#xA;vec.Scale(-width/2);" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction guid="6f204b06-20a1-48de-838e-453395bcb5a5" type="Dynamo.Nodes.DSFunction" nickname="Point.Add" x="2200.16536627488" y="574.523840109622" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector" />
-    <Dynamo.Nodes.DSFunction guid="832fba68-c235-4646-8be9-e80b68b20013" type="Dynamo.Nodes.DSFunction" nickname="NurbsCurve.ByPoints" x="2948.03948630451" y="434.136986916889" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
-    <Dynamo.Nodes.DSFunction guid="a17ace63-4fd1-4237-a286-639ce1082320" type="Dynamo.Nodes.DSFunction" nickname="NurbsCurve.ByPoints" x="2949.40938178915" y="527.109971435272" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
-    <DSCoreNodesUI.CreateList guid="f5683641-8998-421d-a168-a54f81ac89b6" type="DSCoreNodesUI.CreateList" nickname="List.Create" x="3185.87130614538" y="456.479778136671" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2" />
-    <Dynamo.Nodes.DSFunction guid="391316f2-8b98-4480-927d-dff10c5ab16e" type="Dynamo.Nodes.DSFunction" nickname="List.Sublists" x="2550.1441618779" y="604.990484806576" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.Sublists@var[]..[],var[]..[],int" />
-    <Dynamo.Nodes.CodeBlockNodeModel guid="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="2200.02042888122" y="869.463039191754" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0..num/2;&#xA;Math.Floor(num/2);" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction guid="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" type="Dynamo.Nodes.DSFunction" nickname="List.Sublists" x="2550.62104213357" y="761.084462547301" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.Sublists@var[]..[],var[]..[],int" />
-    <Dynamo.Nodes.DSFunction guid="f6a3faed-2dfa-4404-b2e9-64f0da8a3d55" type="Dynamo.Nodes.DSFunction" nickname="List.FirstItem" x="2747.31750355695" y="578.297236472069" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]" />
-    <Dynamo.Nodes.DSFunction guid="8b4ec1a1-6c97-4b87-bad9-4beeab54c3b8" type="Dynamo.Nodes.DSFunction" nickname="List.FirstItem" x="2747.31750355695" y="776.808815092065" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]" />
-    <Dynamo.Nodes.DSFunction guid="e45f9e81-8460-40e9-945e-266cb0800ed9" type="Dynamo.Nodes.DSFunction" nickname="List.LastItem" x="2747.31750355695" y="661.881059048909" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.LastItem@var[]..[]" />
-    <Dynamo.Nodes.DSFunction guid="07cd7506-a1c8-400c-8069-966ec2a53f55" type="Dynamo.Nodes.DSFunction" nickname="List.LastItem" x="2747.31750355695" y="862.354223421489" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="DSCoreNodes.dll" function="DSCore.List.LastItem@var[]..[]" />
-    <DSCoreNodesUI.CreateList guid="ea73e9e9-aeca-455e-b341-b01b89e493d0" type="DSCoreNodesUI.CreateList" nickname="List.Create" x="3175.06845926758" y="732.019498672573" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="2" />
-    <Dynamo.Nodes.DSFunction guid="43fdeae6-e5b2-44fb-9761-0fd0b517d170" type="Dynamo.Nodes.DSFunction" nickname="NurbsCurve.ByPoints" x="2956.2693375098" y="806.182252490865" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
-    <Dynamo.Nodes.DSFunction guid="a75734d0-77a7-4812-b4f8-e4266f89711d" type="Dynamo.Nodes.DSFunction" nickname="NurbsCurve.ByPoints" x="2954.89944202516" y="713.209267972482" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]" />
-    <Dynamo.Nodes.DSFunction guid="3675e40d-1d1d-4869-b3e1-f8ea67286486" type="Dynamo.Nodes.DSFunction" nickname="Surface.ByLoft" x="3370.60244505668" y="734.20697687921" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]" />
-    <Dynamo.Nodes.DSFunction guid="bca2356e-9225-43d1-a4c1-79f9b9c7e52d" type="Dynamo.Nodes.DSFunction" nickname="Surface.ByLoft" x="3355.58906284799" y="462.199816862999" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="f5cecdeb-9c3a-4f9c-b29d-7c2442f9cdbf" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.Add" x="2200.55703122876" y="453.295091255038" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="6f204b06-20a1-48de-838e-453395bcb5a5" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.Add" x="2200.16536627488" y="574.523840109622" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.Add@Autodesk.DesignScript.Geometry.Vector">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="832fba68-c235-4646-8be9-e80b68b20013" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="NurbsCurve.ByPoints" x="2948.03948630451" y="434.136986916889" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="a17ace63-4fd1-4237-a286-639ce1082320" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="NurbsCurve.ByPoints" x="2949.40938178915" y="527.109971435272" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <CoreNodeModels.CreateList guid="f5683641-8998-421d-a168-a54f81ac89b6" type="CoreNodeModels.CreateList" nickname="List.Create" x="3185.87130614538" y="456.479778136671" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="2">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </CoreNodeModels.CreateList>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="391316f2-8b98-4480-927d-dff10c5ab16e" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.Sublists" x="2550.1441618779" y="604.990484806576" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.Sublists@var[]..[],var[]..[],int">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="2200.02042888122" y="869.463039191754" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="0..num/2;&#xA;Math.Floor(num/2);" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="num" />
+      <OutPortInfo LineIndex="0" />
+      <OutPortInfo LineIndex="1" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.Sublists" x="2550.62104213357" y="761.084462547301" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.Sublists@var[]..[],var[]..[],int">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="f6a3faed-2dfa-4404-b2e9-64f0da8a3d55" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.FirstItem" x="2747.31750355695" y="578.297236472069" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="8b4ec1a1-6c97-4b87-bad9-4beeab54c3b8" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.FirstItem" x="2747.31750355695" y="776.808815092065" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.FirstItem@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e45f9e81-8460-40e9-945e-266cb0800ed9" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.LastItem" x="2747.31750355695" y="661.881059048909" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.LastItem@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="07cd7506-a1c8-400c-8069-966ec2a53f55" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.LastItem" x="2747.31750355695" y="862.354223421489" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.List.LastItem@var[]..[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <CoreNodeModels.CreateList guid="ea73e9e9-aeca-455e-b341-b01b89e493d0" type="CoreNodeModels.CreateList" nickname="List.Create" x="3175.06845926758" y="732.019498672573" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="2">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </CoreNodeModels.CreateList>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="43fdeae6-e5b2-44fb-9761-0fd0b517d170" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="NurbsCurve.ByPoints" x="2956.2693375098" y="806.182252490865" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="a75734d0-77a7-4812-b4f8-e4266f89711d" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="NurbsCurve.ByPoints" x="2954.89944202516" y="713.209267972482" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="3675e40d-1d1d-4869-b3e1-f8ea67286486" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.ByLoft" x="3370.60244505668" y="734.20697687921" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="bca2356e-9225-43d1-a4c1-79f9b9c7e52d" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Surface.ByLoft" x="3355.58906284799" y="462.199816862999" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Surface.ByLoft@Autodesk.DesignScript.Geometry.Curve[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="be2abed2-282f-44d5-8981-3cfb3e231d1b" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Vector.Scale" x="1569.72648224309" y="576.714864813384" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Scale@double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="3e70a043-35a7-4dde-bbac-58e97e72c605" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Vector.Scale" x="1572.12314824152" y="794.498648341335" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Vector.Scale@double">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="ddcffbb2-3ab4-4050-9193-bb2d48b70e49" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1326.31166790994" y="765.859827571424" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="width/2;&#xA;-width/2;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="width" />
+      <OutPortInfo LineIndex="0" />
+      <OutPortInfo LineIndex="1" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </Elements>
   <Connectors>
-    <Dynamo.Models.ConnectorModel start="b104bcdb-eb55-4553-b02b-85aec2bff925" start_index="0" end="5485a2d4-ed38-4c2d-bc27-ea3c448840af" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="1ec3bf7a-c859-4e17-a74f-29139a5ca821" start_index="0" end="e14439c9-b377-4653-bb63-4edd9a4f90a0" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="5485a2d4-ed38-4c2d-bc27-ea3c448840af" start_index="0" end="7cb48ff7-81c1-4134-86a9-ff90f54f9fad" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="5485a2d4-ed38-4c2d-bc27-ea3c448840af" start_index="0" end="4f4f6e9e-9a1f-4b99-92b2-eb319a5c3845" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="5abff7f6-fd49-4d69-bdf8-d7804407528f" start_index="0" end="5485a2d4-ed38-4c2d-bc27-ea3c448840af" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="ec1d92e7-ed74-455d-8dce-a8c4a4cd6c2d" start_index="0" end="cda8f969-2162-410a-b70d-b44956b86200" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="631404f5-29eb-4506-a664-f60047320ae8" start_index="0" end="ec1d92e7-ed74-455d-8dce-a8c4a4cd6c2d" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="631404f5-29eb-4506-a664-f60047320ae8" start_index="0" end="381419bf-5cdc-4d2e-b002-8b07af5c85a3" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="631404f5-29eb-4506-a664-f60047320ae8" start_index="0" end="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="381419bf-5cdc-4d2e-b002-8b07af5c85a3" start_index="0" end="7cb48ff7-81c1-4134-86a9-ff90f54f9fad" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="381419bf-5cdc-4d2e-b002-8b07af5c85a3" start_index="0" end="4f4f6e9e-9a1f-4b99-92b2-eb319a5c3845" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="7cb48ff7-81c1-4134-86a9-ff90f54f9fad" start_index="0" end="f5cecdeb-9c3a-4f9c-b29d-7c2442f9cdbf" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="7cb48ff7-81c1-4134-86a9-ff90f54f9fad" start_index="0" end="6f204b06-20a1-48de-838e-453395bcb5a5" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="6d526736-66d3-4aea-9fd4-62411a20ac08" start_index="0" end="cda8f969-2162-410a-b70d-b44956b86200" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="cda8f969-2162-410a-b70d-b44956b86200" start_index="0" end="e14439c9-b377-4653-bb63-4edd9a4f90a0" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="4f4f6e9e-9a1f-4b99-92b2-eb319a5c3845" start_index="0" end="cda8f969-2162-410a-b70d-b44956b86200" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f5cecdeb-9c3a-4f9c-b29d-7c2442f9cdbf" start_index="0" end="391316f2-8b98-4480-927d-dff10c5ab16e" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e14439c9-b377-4653-bb63-4edd9a4f90a0" start_index="0" end="f5cecdeb-9c3a-4f9c-b29d-7c2442f9cdbf" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e14439c9-b377-4653-bb63-4edd9a4f90a0" start_index="1" end="6f204b06-20a1-48de-838e-453395bcb5a5" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="6f204b06-20a1-48de-838e-453395bcb5a5" start_index="0" end="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="832fba68-c235-4646-8be9-e80b68b20013" start_index="0" end="f5683641-8998-421d-a168-a54f81ac89b6" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="a17ace63-4fd1-4237-a286-639ce1082320" start_index="0" end="f5683641-8998-421d-a168-a54f81ac89b6" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f5683641-8998-421d-a168-a54f81ac89b6" start_index="0" end="bca2356e-9225-43d1-a4c1-79f9b9c7e52d" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="391316f2-8b98-4480-927d-dff10c5ab16e" start_index="0" end="f6a3faed-2dfa-4404-b2e9-64f0da8a3d55" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="391316f2-8b98-4480-927d-dff10c5ab16e" start_index="0" end="e45f9e81-8460-40e9-945e-266cb0800ed9" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" start_index="0" end="391316f2-8b98-4480-927d-dff10c5ab16e" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" start_index="0" end="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" start_index="1" end="391316f2-8b98-4480-927d-dff10c5ab16e" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" start_index="1" end="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" end_index="2" portType="0" />
-    <Dynamo.Models.ConnectorModel start="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" start_index="0" end="8b4ec1a1-6c97-4b87-bad9-4beeab54c3b8" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" start_index="0" end="07cd7506-a1c8-400c-8069-966ec2a53f55" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="f6a3faed-2dfa-4404-b2e9-64f0da8a3d55" start_index="0" end="832fba68-c235-4646-8be9-e80b68b20013" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="8b4ec1a1-6c97-4b87-bad9-4beeab54c3b8" start_index="0" end="a17ace63-4fd1-4237-a286-639ce1082320" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e45f9e81-8460-40e9-945e-266cb0800ed9" start_index="0" end="a75734d0-77a7-4812-b4f8-e4266f89711d" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="07cd7506-a1c8-400c-8069-966ec2a53f55" start_index="0" end="43fdeae6-e5b2-44fb-9761-0fd0b517d170" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="ea73e9e9-aeca-455e-b341-b01b89e493d0" start_index="0" end="3675e40d-1d1d-4869-b3e1-f8ea67286486" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="43fdeae6-e5b2-44fb-9761-0fd0b517d170" start_index="0" end="ea73e9e9-aeca-455e-b341-b01b89e493d0" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="a75734d0-77a7-4812-b4f8-e4266f89711d" start_index="0" end="ea73e9e9-aeca-455e-b341-b01b89e493d0" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="b104bcdb-eb55-4553-b02b-85aec2bff925" start_index="0" end="5485a2d4-ed38-4c2d-bc27-ea3c448840af" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="1ec3bf7a-c859-4e17-a74f-29139a5ca821" start_index="0" end="ddcffbb2-3ab4-4050-9193-bb2d48b70e49" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5485a2d4-ed38-4c2d-bc27-ea3c448840af" start_index="0" end="7cb48ff7-81c1-4134-86a9-ff90f54f9fad" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5485a2d4-ed38-4c2d-bc27-ea3c448840af" start_index="0" end="4f4f6e9e-9a1f-4b99-92b2-eb319a5c3845" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5abff7f6-fd49-4d69-bdf8-d7804407528f" start_index="0" end="5485a2d4-ed38-4c2d-bc27-ea3c448840af" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="ec1d92e7-ed74-455d-8dce-a8c4a4cd6c2d" start_index="0" end="cda8f969-2162-410a-b70d-b44956b86200" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="631404f5-29eb-4506-a664-f60047320ae8" start_index="0" end="ec1d92e7-ed74-455d-8dce-a8c4a4cd6c2d" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="631404f5-29eb-4506-a664-f60047320ae8" start_index="0" end="381419bf-5cdc-4d2e-b002-8b07af5c85a3" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="631404f5-29eb-4506-a664-f60047320ae8" start_index="0" end="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="381419bf-5cdc-4d2e-b002-8b07af5c85a3" start_index="0" end="7cb48ff7-81c1-4134-86a9-ff90f54f9fad" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="381419bf-5cdc-4d2e-b002-8b07af5c85a3" start_index="0" end="4f4f6e9e-9a1f-4b99-92b2-eb319a5c3845" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="7cb48ff7-81c1-4134-86a9-ff90f54f9fad" start_index="0" end="f5cecdeb-9c3a-4f9c-b29d-7c2442f9cdbf" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="7cb48ff7-81c1-4134-86a9-ff90f54f9fad" start_index="0" end="6f204b06-20a1-48de-838e-453395bcb5a5" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="6d526736-66d3-4aea-9fd4-62411a20ac08" start_index="0" end="cda8f969-2162-410a-b70d-b44956b86200" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="cda8f969-2162-410a-b70d-b44956b86200" start_index="0" end="be2abed2-282f-44d5-8981-3cfb3e231d1b" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="cda8f969-2162-410a-b70d-b44956b86200" start_index="0" end="3e70a043-35a7-4dde-bbac-58e97e72c605" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="4f4f6e9e-9a1f-4b99-92b2-eb319a5c3845" start_index="0" end="cda8f969-2162-410a-b70d-b44956b86200" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f5cecdeb-9c3a-4f9c-b29d-7c2442f9cdbf" start_index="0" end="391316f2-8b98-4480-927d-dff10c5ab16e" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="6f204b06-20a1-48de-838e-453395bcb5a5" start_index="0" end="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="832fba68-c235-4646-8be9-e80b68b20013" start_index="0" end="f5683641-8998-421d-a168-a54f81ac89b6" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="a17ace63-4fd1-4237-a286-639ce1082320" start_index="0" end="f5683641-8998-421d-a168-a54f81ac89b6" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f5683641-8998-421d-a168-a54f81ac89b6" start_index="0" end="bca2356e-9225-43d1-a4c1-79f9b9c7e52d" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="391316f2-8b98-4480-927d-dff10c5ab16e" start_index="0" end="f6a3faed-2dfa-4404-b2e9-64f0da8a3d55" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="391316f2-8b98-4480-927d-dff10c5ab16e" start_index="0" end="e45f9e81-8460-40e9-945e-266cb0800ed9" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" start_index="0" end="391316f2-8b98-4480-927d-dff10c5ab16e" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" start_index="0" end="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" start_index="1" end="391316f2-8b98-4480-927d-dff10c5ab16e" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" start_index="1" end="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" start_index="0" end="8b4ec1a1-6c97-4b87-bad9-4beeab54c3b8" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" start_index="0" end="07cd7506-a1c8-400c-8069-966ec2a53f55" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="f6a3faed-2dfa-4404-b2e9-64f0da8a3d55" start_index="0" end="832fba68-c235-4646-8be9-e80b68b20013" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="8b4ec1a1-6c97-4b87-bad9-4beeab54c3b8" start_index="0" end="a17ace63-4fd1-4237-a286-639ce1082320" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e45f9e81-8460-40e9-945e-266cb0800ed9" start_index="0" end="a75734d0-77a7-4812-b4f8-e4266f89711d" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="07cd7506-a1c8-400c-8069-966ec2a53f55" start_index="0" end="43fdeae6-e5b2-44fb-9761-0fd0b517d170" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="ea73e9e9-aeca-455e-b341-b01b89e493d0" start_index="0" end="3675e40d-1d1d-4869-b3e1-f8ea67286486" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="43fdeae6-e5b2-44fb-9761-0fd0b517d170" start_index="0" end="ea73e9e9-aeca-455e-b341-b01b89e493d0" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="a75734d0-77a7-4812-b4f8-e4266f89711d" start_index="0" end="ea73e9e9-aeca-455e-b341-b01b89e493d0" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="be2abed2-282f-44d5-8981-3cfb3e231d1b" start_index="0" end="f5cecdeb-9c3a-4f9c-b29d-7c2442f9cdbf" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="3e70a043-35a7-4dde-bbac-58e97e72c605" start_index="0" end="6f204b06-20a1-48de-838e-453395bcb5a5" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="ddcffbb2-3ab4-4050-9193-bb2d48b70e49" start_index="1" end="be2abed2-282f-44d5-8981-3cfb3e231d1b" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="ddcffbb2-3ab4-4050-9193-bb2d48b70e49" start_index="1" end="3e70a043-35a7-4dde-bbac-58e97e72c605" end_index="1" portType="0" />
   </Connectors>
   <Notes>
-    <Dynamo.Models.NoteModel guid="223c8879-681f-4c19-a7e2-f03f4efc11bb" text="Use any even number" x="608.276271008346" y="453.588249510047" />
+    <Dynamo.Graph.Notes.NoteModel guid="223c8879-681f-4c19-a7e2-f03f4efc11bb" text="Use any even number" x="608.276271008346" y="453.588249510047" />
   </Notes>
   <Annotations>
-    <Dynamo.Models.AnnotationModel guid="0db88d6e-a446-4671-a7d5-548b0738b1d0" annotationText="&lt;Click here to edit the group title&gt;" left="0" top="-615" width="0" height="0" fontSize="14" InitialTop="0" InitialHeight="0" TextblockHeight="605" backgrouund="#FFC1D676" />
+    <Dynamo.Graph.Annotations.AnnotationModel guid="0db88d6e-a446-4671-a7d5-548b0738b1d0" annotationText="&lt;Click here to edit the group title&gt;" left="336.55894851259" top="119.112481038255" width="3291.04349654409" height="853.350558153499" fontSize="14" InitialTop="149.112481038255" InitialHeight="1450.3505581535" TextblockHeight="20" backgrouund="#FFC1D676">
+      <Models ModelGuid="b104bcdb-eb55-4553-b02b-85aec2bff925" />
+      <Models ModelGuid="1ec3bf7a-c859-4e17-a74f-29139a5ca821" />
+      <Models ModelGuid="5485a2d4-ed38-4c2d-bc27-ea3c448840af" />
+      <Models ModelGuid="5abff7f6-fd49-4d69-bdf8-d7804407528f" />
+      <Models ModelGuid="ec1d92e7-ed74-455d-8dce-a8c4a4cd6c2d" />
+      <Models ModelGuid="631404f5-29eb-4506-a664-f60047320ae8" />
+      <Models ModelGuid="381419bf-5cdc-4d2e-b002-8b07af5c85a3" />
+      <Models ModelGuid="7cb48ff7-81c1-4134-86a9-ff90f54f9fad" />
+      <Models ModelGuid="6d526736-66d3-4aea-9fd4-62411a20ac08" />
+      <Models ModelGuid="cda8f969-2162-410a-b70d-b44956b86200" />
+      <Models ModelGuid="4f4f6e9e-9a1f-4b99-92b2-eb319a5c3845" />
+      <Models ModelGuid="f5cecdeb-9c3a-4f9c-b29d-7c2442f9cdbf" />
+      <Models ModelGuid="6f204b06-20a1-48de-838e-453395bcb5a5" />
+      <Models ModelGuid="832fba68-c235-4646-8be9-e80b68b20013" />
+      <Models ModelGuid="a17ace63-4fd1-4237-a286-639ce1082320" />
+      <Models ModelGuid="f5683641-8998-421d-a168-a54f81ac89b6" />
+      <Models ModelGuid="391316f2-8b98-4480-927d-dff10c5ab16e" />
+      <Models ModelGuid="319afc6e-01ce-4e7d-a01b-9bc5c15ef9c0" />
+      <Models ModelGuid="07ad5b99-cbb0-481c-b1cc-0b569a88ff2e" />
+      <Models ModelGuid="f6a3faed-2dfa-4404-b2e9-64f0da8a3d55" />
+      <Models ModelGuid="8b4ec1a1-6c97-4b87-bad9-4beeab54c3b8" />
+      <Models ModelGuid="e45f9e81-8460-40e9-945e-266cb0800ed9" />
+      <Models ModelGuid="07cd7506-a1c8-400c-8069-966ec2a53f55" />
+      <Models ModelGuid="ea73e9e9-aeca-455e-b341-b01b89e493d0" />
+      <Models ModelGuid="43fdeae6-e5b2-44fb-9761-0fd0b517d170" />
+      <Models ModelGuid="a75734d0-77a7-4812-b4f8-e4266f89711d" />
+      <Models ModelGuid="3675e40d-1d1d-4869-b3e1-f8ea67286486" />
+      <Models ModelGuid="bca2356e-9225-43d1-a4c1-79f9b9c7e52d" />
+      <Models ModelGuid="223c8879-681f-4c19-a7e2-f03f4efc11bb" />
+    </Dynamo.Graph.Annotations.AnnotationModel>
   </Annotations>
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>

--- a/test/core/dsevaluation/CBN_TypedIdentifier01.dyn
+++ b/test/core/dsevaluation/CBN_TypedIdentifier01.dyn
@@ -1,14 +1,22 @@
-<Workspace Version="0.8.2.1480" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+<Workspace Version="2.0.0.4093" X="0" Y="0" zoom="1" ScaleFactor="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
   <NamespaceResolutionMap>
     <ClassMap partialName="Point" resolvedName="Autodesk.DesignScript.Geometry.Point" assemblyName="ProtoGeometry.dll" />
   </NamespaceResolutionMap>
   <Elements>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="1c8156d3-3a5c-48ab-aa78-739d4a2e6062" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="81" y="156" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="a : Point = Point.ByCoordinates(1,2,3);" ShouldFocus="false" />
-    <Dynamo.Nodes.CodeBlockNodeModel guid="9c422c81-821f-456e-9965-4aea6afe81f9" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="538" y="231" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="p = ptr;&#xA;i = p.X;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="1c8156d3-3a5c-48ab-aa78-739d4a2e6062" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="81" y="156" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="a : Point = Point.ByCoordinates(1,2,3);" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="1472b79b-59b0-40ab-ab0e-3504fbc7be83" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.X" x="530" y="157" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.X">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
   </Elements>
   <Connectors>
-    <Dynamo.Models.ConnectorModel start="1c8156d3-3a5c-48ab-aa78-739d4a2e6062" start_index="0" end="9c422c81-821f-456e-9965-4aea6afe81f9" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="1c8156d3-3a5c-48ab-aa78-739d4a2e6062" start_index="0" end="1472b79b-59b0-40ab-ab0e-3504fbc7be83" end_index="0" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>

--- a/test/core/dsevaluation/CBN_geometry.dyn
+++ b/test/core/dsevaluation/CBN_geometry.dyn
@@ -1,19 +1,37 @@
-<Workspace Version="1.0.1.1743" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="False">
-  <NamespaceResolutionMap />
+<Workspace Version="2.0.0.4093" X="0" Y="0" zoom="1" ScaleFactor="1" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Point" resolvedName="Autodesk.DesignScript.Geometry.Point" assemblyName="ProtoGeometry.dll" />
+  </NamespaceResolutionMap>
   <Elements>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="f2dba8ea-9a90-4aca-aed6-b1b657ec66f3" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="24" y="109" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="h=1;" ShouldFocus="false" />
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="fdb47152-240d-4682-8f5d-50db0063577b" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="234" y="136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="ll=k+2;" ShouldFocus="false" />
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="69f56690-5c85-4040-8ef1-db3c78f3cc84" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="298" y="329" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="hf=v+2;" ShouldFocus="false" />
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="03c7ed31-182b-4539-934e-710b3fabe5ad" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="431" y="178.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="vv=Point.ByCoordinates(a45,3,1);" ShouldFocus="false" />
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="9c51f2d5-a9f2-4825-bda6-f062e69efc46" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="762" y="190" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="x.X;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="f2dba8ea-9a90-4aca-aed6-b1b657ec66f3" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="24" y="109" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="h=1;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="fdb47152-240d-4682-8f5d-50db0063577b" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="234" y="136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="ll=k+2;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="k" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="69f56690-5c85-4040-8ef1-db3c78f3cc84" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="298" y="329" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="hf=v+2;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="v" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="03c7ed31-182b-4539-934e-710b3fabe5ad" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="431" y="178.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="vv=Point.ByCoordinates(a45,3,1);" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="a45" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="a23b89fc-f219-46ca-ab7a-5a3f0ee93ba4" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.X" x="841" y="202" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="true" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.X">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
   </Elements>
   <Connectors>
     <Dynamo.Graph.Connectors.ConnectorModel start="f2dba8ea-9a90-4aca-aed6-b1b657ec66f3" start_index="0" end="fdb47152-240d-4682-8f5d-50db0063577b" end_index="0" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="fdb47152-240d-4682-8f5d-50db0063577b" start_index="0" end="69f56690-5c85-4040-8ef1-db3c78f3cc84" end_index="0" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="69f56690-5c85-4040-8ef1-db3c78f3cc84" start_index="0" end="03c7ed31-182b-4539-934e-710b3fabe5ad" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="03c7ed31-182b-4539-934e-710b3fabe5ad" start_index="0" end="9c51f2d5-a9f2-4825-bda6-f062e69efc46" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="03c7ed31-182b-4539-934e-710b3fabe5ad" start_index="0" end="a23b89fc-f219-46ca-ab7a-5a3f0ee93ba4" end_index="0" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />
   <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>

--- a/test/core/dsevaluation/createCube_codeBlockNode.dyn
+++ b/test/core/dsevaluation/createCube_codeBlockNode.dyn
@@ -1,16 +1,44 @@
-<Workspace Version="0.7.4.3101" X="-1866.68457277717" Y="-1620.21008275207" zoom="0.998328843087185" Description="" Category="" Name="Home">
+<Workspace Version="2.0.0.4093" X="-1866.68457277717" Y="-1620.21008275207" zoom="0.998328843087185" ScaleFactor="1" Name="Home" Description="" RunType="Manual" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Plane" resolvedName="Autodesk.DesignScript.Geometry.Plane" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="Vector" resolvedName="Autodesk.DesignScript.Geometry.Vector" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="Rectangle" resolvedName="Autodesk.DesignScript.Geometry.Rectangle" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="Point" resolvedName="Autodesk.DesignScript.Geometry.Point" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="Line" resolvedName="Autodesk.DesignScript.Geometry.Line" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="Solid" resolvedName="Autodesk.DesignScript.Geometry.Solid" assemblyName="ProtoGeometry.dll" />
+  </NamespaceResolutionMap>
   <Elements>
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="06eb7ca7-3e9c-4011-a7eb-08e47cef9671" nickname="Code Block" x="1954.10062862083" y="2097.3977868134" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="5;" ShouldFocus="false" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="3669d05c-c741-44f9-87ab-8961e7f5f112" nickname="Code Block" x="2145.05331785436" y="1988.12187308034" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="pln = Plane.ByOriginNormal(ctrPt,Vector.ZAxis());&#xA;rect = Rectangle.ByWidthLength(pln,x,x);&#xA;p1 = Point.Origin();&#xA;p2 = Point.ByCoordinates(0,0,(ctrPt.X+x));&#xA;path = Line.ByStartPointEndPoint(p1,p2);&#xA;s = Solid.BySweep(rect,path);&#xA;s.Area;" ShouldFocus="false" />
-    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="efafb62b-e09f-4850-a0c3-5c14b6d6e66d" nickname="Point.ByCoordinates" x="1948.05240595467" y="1905.37528613162" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="06eb7ca7-3e9c-4011-a7eb-08e47cef9671" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1954.10062862083" y="2097.3977868134" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="5;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="3669d05c-c741-44f9-87ab-8961e7f5f112" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="2145.05331785436" y="1988.12187308034" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="pln = Plane.ByOriginNormal(ctrPt,Vector.ZAxis());&#xA;rect = Rectangle.ByWidthLength(pln,x,x);&#xA;p1 = Point.Origin();&#xA;p2 = Point.ByCoordinates(0,0,(ctrPt.X+x));&#xA;path = Line.ByStartPointEndPoint(p1,p2);&#xA;s = Solid.BySweep(rect,path);" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="ctrPt" />
+      <PortInfo index="1" default="False" name="x" />
+      <OutPortInfo LineIndex="0" />
+      <OutPortInfo LineIndex="1" />
+      <OutPortInfo LineIndex="2" />
+      <OutPortInfo LineIndex="3" />
+      <OutPortInfo LineIndex="4" />
+      <OutPortInfo LineIndex="5" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="efafb62b-e09f-4850-a0c3-5c14b6d6e66d" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="1948.05240595467" y="1905.37528613162" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
       <PortInfo index="0" default="True" />
       <PortInfo index="1" default="True" />
       <PortInfo index="2" default="True" />
-    </Dynamo.Nodes.DSFunction>
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="8187805a-cc0d-4220-8595-4ee38bbee079" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Solid.Area" x="2830.41463976855" y="1998.54997335565" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="true" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Solid.Area">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
   </Elements>
   <Connectors>
-    <Dynamo.Models.ConnectorModel start="06eb7ca7-3e9c-4011-a7eb-08e47cef9671" start_index="0" end="3669d05c-c741-44f9-87ab-8961e7f5f112" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="efafb62b-e09f-4850-a0c3-5c14b6d6e66d" start_index="0" end="3669d05c-c741-44f9-87ab-8961e7f5f112" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="06eb7ca7-3e9c-4011-a7eb-08e47cef9671" start_index="0" end="3669d05c-c741-44f9-87ab-8961e7f5f112" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="3669d05c-c741-44f9-87ab-8961e7f5f112" start_index="5" end="8187805a-cc0d-4220-8595-4ee38bbee079" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="efafb62b-e09f-4850-a0c3-5c14b6d6e66d" start_index="0" end="3669d05c-c741-44f9-87ab-8961e7f5f112" end_index="0" portType="0" />
   </Connectors>
   <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>


### PR DESCRIPTION
### Purpose

Update some test cases which use field expression (e.g., `pt.X`) and member function (e.g., `g.Translate(...)`) in code block node. Replace these expressions with UI node.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs
@gregmarr 