### PR TITLE
Bug fix for dictionary links on Context Menu Help Popup

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -401,21 +401,25 @@ namespace Dynamo.Graph.Nodes
             {
                 Type type = GetType();
                 object[] attribs = type.GetCustomAttributes(typeof(NodeNameAttribute), false);
-                if (type.Namespace.Split('.')[0] == "CoreNodeModels" && (attribs.Length > 0) && (attribs[0] is NodeNameAttribute))
+
+                if (CreationName != null && CreationName != "")
+                {
+                    // Obtain the node's default name from its creation name.
+                    // e.g. For creation name DSCore.Math.Max@double,double - the name "Max" is obtained and appended to the final link.
+                    int indexAfter = (CreationName.LastIndexOf('@') == -1) ? CreationName.Length : CreationName.LastIndexOf('@');
+                    string s = CreationName.Substring(0, indexAfter);
+
+                    int indexBefore = s.LastIndexOf(Configurations.CategoryDelimiterString);
+                    int firstChar = (indexBefore == -1) ? 0 : indexBefore + 1;
+                    return s.Substring(firstChar, s.Length - CreationName.Substring(0, firstChar).Length);
+                }
+
+                if (!type.IsAbstract && (attribs.Length > 0) && (attribs[0] is NodeNameAttribute))
                 {
                     string name = ((NodeNameAttribute)attribs[0]).Name;
                     if (name != null) return name;
                 }
-                // Obtain the node's default name from its creation name.
-                // e.g. For creation name DSCore.Math.Max@double,double - the name "Max" is obtained and appended to the final link.
-                if (CreationName == null) return "";
-
-                int indexAfter = (CreationName.LastIndexOf('@') == -1) ? CreationName.Length : CreationName.LastIndexOf('@');
-                string s = CreationName.Substring(0, indexAfter);
-
-                int indexBefore = s.LastIndexOf(Configurations.CategoryDelimiterString);
-                int firstChar = (indexBefore == -1) ? 0 : indexBefore + 1;
-                return s.Substring(firstChar, s.Length - CreationName.Substring(0, firstChar).Length);
+                return "";
             }
         }
 
@@ -446,7 +450,7 @@ namespace Dynamo.Graph.Nodes
         {
             Type type = GetType();
             object[] attribs = type.GetCustomAttributes(typeof(NodeCategoryAttribute), false);
-            if (type.Namespace.Split('.')[0] == "CoreNodeModels" && (attribs.Length > 0) && (attribs[0] is NodeCategoryAttribute))
+            if (!type.IsAbstract && (attribs.Length > 0) && (attribs[0] is NodeCategoryAttribute))
             {
                 string category = ((NodeCategoryAttribute)attribs[0]).ElementCategory;
                 if (category != null) return category;

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -423,7 +423,6 @@ namespace Dynamo.Graph.Nodes
             }
         }
 
-
         /// <summary>
         ///     Category property
         /// </summary>

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -395,14 +395,14 @@ namespace Dynamo.Graph.Nodes
             }
         }
 
-        public virtual string ShortenName
+        private string ShortenName
         {
             get
             {
                 Type type = GetType();
                 object[] attribs = type.GetCustomAttributes(typeof(NodeNameAttribute), false);
 
-                if (CreationName != null && CreationName != "")
+                if (!string.IsNullOrEmpty(CreationName))
                 {
                     // Obtain the node's default name from its creation name.
                     // e.g. For creation name DSCore.Math.Max@double,double - the name "Max" is obtained and appended to the final link.
@@ -414,10 +414,14 @@ namespace Dynamo.Graph.Nodes
                     return s.Substring(firstChar, s.Length - CreationName.Substring(0, firstChar).Length);
                 }
 
-                if (!type.IsAbstract && (attribs.Length > 0) && (attribs[0] is NodeNameAttribute))
+                if (!type.IsAbstract && (attribs.Length > 0))
                 {
-                    string name = ((NodeNameAttribute)attribs[0]).Name;
-                    if (name != null) return name;
+                    var attrib = attribs[0] as NodeNameAttribute;
+                    if (attrib != null)
+                    {
+                        string name = attrib.Name;
+                        if (!string.IsNullOrEmpty(name)) return name;
+                    }
                 }
                 return "";
             }

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -395,6 +395,31 @@ namespace Dynamo.Graph.Nodes
             }
         }
 
+        public virtual string ShortenName
+        {
+            get
+            {
+                Type type = GetType();
+                object[] attribs = type.GetCustomAttributes(typeof(NodeNameAttribute), false);
+                if (type.Namespace.Split('.')[0] == "CoreNodeModels" && (attribs.Length > 0) && (attribs[0] is NodeNameAttribute))
+                {
+                    string name = ((NodeNameAttribute)attribs[0]).Name;
+                    if (name != null) return name;
+                }
+                // Obtain the node's default name from its creation name.
+                // e.g. For creation name DSCore.Math.Max@double,double - the name "Max" is obtained and appended to the final link.
+                if (CreationName == null) return "";
+
+                int indexAfter = (CreationName.LastIndexOf('@') == -1) ? CreationName.Length : CreationName.LastIndexOf('@');
+                string s = CreationName.Substring(0, indexAfter);
+
+                int indexBefore = s.LastIndexOf(Configurations.CategoryDelimiterString);
+                int firstChar = (indexBefore == -1) ? 0 : indexBefore + 1;
+                return s.Substring(firstChar, s.Length - CreationName.Substring(0, firstChar).Length);
+            }
+        }
+
+
         /// <summary>
         ///     Category property
         /// </summary>
@@ -421,6 +446,11 @@ namespace Dynamo.Graph.Nodes
         {
             Type type = GetType();
             object[] attribs = type.GetCustomAttributes(typeof(NodeCategoryAttribute), false);
+            if (type.Namespace.Split('.')[0] == "CoreNodeModels" && (attribs.Length > 0) && (attribs[0] is NodeCategoryAttribute))
+            {
+                string category = ((NodeCategoryAttribute)attribs[0]).ElementCategory;
+                if (category != null) return category;
+            }
 
             if (type.Namespace != "Dynamo.Graph.Nodes" || type.IsAbstract || attribs.Length <= 0
                 || !type.IsSubclassOf(typeof(NodeModel)))
@@ -468,15 +498,7 @@ namespace Dynamo.Graph.Nodes
                         finalLink += "Action/";
                         break;
                 }
-
-                // Obtain the node's default name from its creation name.
-                // e.g. For creation name DSCore.Math.Max@double,double - the name "Max" is obtained and appended to the final link.
-                int indexAfter = (CreationName.LastIndexOf('@') == -1) ? CreationName.Length : CreationName.LastIndexOf('@');
-                string s = CreationName.Substring(0, indexAfter);
-
-                int indexBefore = s.LastIndexOf(Configurations.CategoryDelimiterString);
-                int firstChar = (indexBefore == -1) ? 0 : indexBefore + 1;
-                finalLink += s.Substring(firstChar, s.Length - CreationName.Substring(0, firstChar).Length);
+                finalLink += this.ShortenName;
 
                 return finalLink;
             }

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml
@@ -14,21 +14,16 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <ScrollViewer>
-        <StackPanel>
+    <StackPanel>
 
-            <StackPanel.Background>
-                <LinearGradientBrush  StartPoint="0.5,0" EndPoint="0.5,1">
-                    <GradientStop Color="#FFF" Offset="0.0" />
-                    <GradientStop Color="#EEE" Offset="1.0" />
-                </LinearGradientBrush>
-            </StackPanel.Background>
-            <Grid MinHeight="440"> <!-- (the window's height - total margin) -->
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="auto"/>
-                </Grid.RowDefinitions>
-            <StackPanel Grid.Row="0" Margin="10" Background="Transparent">
+        <StackPanel.Background>
+            <LinearGradientBrush  StartPoint="0.5,0" EndPoint="0.5,1">
+                <GradientStop Color="#FFF" Offset="0.0" />
+                <GradientStop Color="#EEE" Offset="1.0" />
+            </LinearGradientBrush>
+        </StackPanel.Background>
+        <ScrollViewer Height="415">
+            <StackPanel Margin="10" Background="Transparent">
 
                 <TextBlock Name="TitleLabel" FontSize="10" Foreground="#AAA" Margin="0,10,0,10" Text="{x:Static p:Resources.NodeHelpWindowNodeType}"></TextBlock>
                 <TextBlock Name="titleText" FontSize="16" Text="{Binding NickName}" Foreground="#555" TextWrapping="Wrap"></TextBlock>
@@ -72,13 +67,13 @@
                 </ListBox>
 
             </StackPanel>
-            <StackPanel Grid.Row="1" Margin="10" Background="Transparent">
-                <TextBlock Name="DynamoDictionary" FontSize="12" Foreground="#2380C0" Text="{x:Static p:Resources.NodeHelpWindowDynamoDictionary}"
+        </ScrollViewer>
+
+        <StackPanel>
+            <TextBlock Name="DynamoDictionary" FontSize="12" Foreground="#2380C0" Margin="10,5,10,5" Text="{x:Static p:Resources.NodeHelpWindowDynamoDictionary}"
                            Cursor="Hand" Tag="{Binding DictionaryLink}" MouseLeftButtonUp="OpenDynamoDictionary" />
-            </StackPanel>
-            </Grid>
         </StackPanel>
-    </ScrollViewer>
+    </StackPanel>
 
 
 

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
@@ -23,7 +23,7 @@ namespace Dynamo.Prompts
 
         private void OpenDynamoDictionary(object sender, MouseButtonEventArgs e)
         {
-            Process.Start(((TextBlock)sender).Tag.ToString());
+            Process.Start(new ProcessStartInfo("explorer.exe", ((TextBlock)sender).Tag.ToString()));
         }
 
         protected override void OnClosing(System.ComponentModel.CancelEventArgs e)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -791,7 +791,7 @@ namespace Dynamo.ViewModels
 
         public static void ReportABug(object parameter)
         {
-            Process.Start(Configurations.GitHubBugReportingLink);
+            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.GitHubBugReportingLink));
         }
 
         public static void ReportABug()
@@ -801,7 +801,7 @@ namespace Dynamo.ViewModels
 
         internal static void DownloadDynamo()
         {
-            Process.Start(Configurations.DynamoDownloadLink);
+            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.DynamoDownloadLink));
         }
 
         internal bool CanReportABug(object parameter)
@@ -2012,7 +2012,7 @@ namespace Dynamo.ViewModels
 
         public void GoToWiki(object parameter)
         {
-            Process.Start(Configurations.DynamoWikiLink);
+            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.DynamoWikiLink));
         }
 
         internal bool CanGoToWiki(object parameter)
@@ -2022,7 +2022,7 @@ namespace Dynamo.ViewModels
 
         public void GoToSourceCode(object parameter)
         {
-            Process.Start(Configurations.GitHubDynamoLink);
+            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.GitHubDynamoLink));
         }
 
         internal bool CanGoToSourceCode(object parameter)
@@ -2032,7 +2032,7 @@ namespace Dynamo.ViewModels
 
         public void GoToDictionary(object parameter)
         {
-            Process.Start(Configurations.DynamoDictionary);
+            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.DynamoDictionary));
         }
 
         internal bool CanGoToDictionary(object parameter)


### PR DESCRIPTION
### Purpose

This PR is to address [DYN-306](https://jira.autodesk.com/browse/DYN-306) and the bugs resulted from #7572. The bugs are listed in the comments on JIRA.
- The nodes that redirect users to the Dictionary home page are resulted from their `category` property being empty strings (https://github.com/DynamoDS/Dynamo/pull/7572#issuecomment-277626631). This is resolved by adding additional checking and obtaining their categories and names from `NodeCategoryAttribute` and `NodeNameAttribute` respectively.
- I am unable to reproduce the crash on Parallels VM using Google Chrome, but it's most likely because I was testing it on Windows 10. The use of `ProcessStartInfo` is added to handle opening external links as suggested. (related to [this](http://stackoverflow.com/questions/12206368/process-starturl-broken-on-windows-8-chrome-are-there-alternatives/12248929#12248929))
- The UI is edited to have the link to stick to the bottom of the window regardless of the description length.
![dictionary window](https://cloud.githubusercontent.com/assets/17231814/23293707/a895a4ec-faa2-11e6-8bd1-eff77c6ce1d7.PNG)
(Changes will be cross merged to the master branch later)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 

### FYIs

@Racel @riteshchandawar 