### PR TITLE
Open Geometry Working Range window in warning info bubble

### DIFF
--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -177,7 +177,7 @@ namespace Dynamo.Configuration
         internal static double ErrorCondensedContentMaxHeight = ErrorCondensedMaxHeight - 16;
 
         internal static double ErrorTextFontSize = 13;
-        internal static Thickness ErrorContentMargin = new Thickness(5, 5, 5, 12);
+        internal static Thickness ErrorContentMargin = new Thickness(7, 5, 7, 12);
 
         internal static double ErrorArrowWidth = 12;
         internal static double ErrorArrowHeight = 6;

--- a/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
@@ -491,35 +491,6 @@ namespace Dynamo.Controls
             return textBlock;
         }
 
-        private TextBox GetNewTextBox(string text)
-        {
-            TextBox textBox = new TextBox();
-            textBox.Text = text;
-            textBox.TextWrapping = TextWrapping.Wrap;
-
-            textBox.Margin      = ContentMargin;
-            textBox.MaxHeight   = ContentMaxHeight;
-            textBox.MaxWidth    = ContentMaxWidth;
-
-            textBox.Foreground  = ContentForeground;
-            textBox.FontWeight  = ContentFontWeight;
-            textBox.FontSize    = ContentFontSize;
-
-            var font = SharedDictionaryManager.DynamoModernDictionary["OpenSansRegular"];
-            textBox.FontFamily = font as FontFamily;
-
-            textBox.Background      = Brushes.Transparent;
-            textBox.IsReadOnly      = true;
-            textBox.BorderThickness = new System.Windows.Thickness(0);
-
-            textBox.HorizontalAlignment = HorizontalAlignment.Center;
-            textBox.VerticalAlignment   = VerticalAlignment.Center;
-
-            textBox.VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
-
-            return textBox;
-        }
-
         #endregion
 
         #region Update Shape

--- a/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/InfoBubbleView.xaml.cs
@@ -12,6 +12,8 @@ using Dynamo.Wpf.Utilities;
 using InfoBubbleViewModel = Dynamo.ViewModels.InfoBubbleViewModel;
 using Dynamo.ViewModels;
 using Dynamo.Utilities;
+using System.Diagnostics;
+using System.Windows.Documents;
 
 namespace Dynamo.Controls
 {
@@ -437,9 +439,56 @@ namespace Dynamo.Controls
                 {
                     content = Wpf.Properties.Resources.InfoBubbleError + content;
                 }
-                TextBox textBox = GetNewTextBox(content);
-                ContentContainer.Children.Add(textBox);
+                var newTextBlock = AddTextToTextBlock(GetNewTextBlock(), content);
+                ContentContainer.Children.Add(newTextBlock);
             }
+        }
+
+        private TextBlock GetNewTextBlock()
+        {
+            TextBlock textBlock = new TextBlock();
+
+            textBlock.TextWrapping = TextWrapping.Wrap;
+            textBlock.Margin = ContentMargin;
+            textBlock.MaxHeight = ContentMaxHeight;
+            textBlock.MaxWidth = ContentMaxWidth;
+
+            textBlock.Foreground = ContentForeground;
+            textBlock.FontWeight = ContentFontWeight;
+            textBlock.FontSize = ContentFontSize;
+
+            var font = SharedDictionaryManager.DynamoModernDictionary["OpenSansRegular"];
+            textBlock.FontFamily = font as FontFamily;
+
+            textBlock.Background = Brushes.Transparent;
+
+            textBlock.HorizontalAlignment = HorizontalAlignment.Center;
+            textBlock.VerticalAlignment = VerticalAlignment.Center;
+            return textBlock;
+        }
+
+        private TextBlock AddTextToTextBlock(TextBlock textBlock, string text)
+        {
+            string settingStr = "Settings => Geometry Working Range";
+            string[] content = text.Split(new[] { settingStr }, StringSplitOptions.None);
+            if (content.Length == 2)
+            {
+                textBlock.Inlines.Add(content[0]);
+
+                Hyperlink link = new Hyperlink();
+                link.Background = Brushes.Transparent;
+                link.Foreground = new SolidColorBrush(Color.FromRgb(35, 128, 192));
+                link.PreviewMouseLeftButtonUp += ViewModel.DynamoViewModel.OnRequestScaleFactorDialog;
+                link.Inlines.Add(settingStr);
+                textBlock.Inlines.Add(link);
+
+                textBlock.Inlines.Add(content[1]);
+            }
+            else
+            {
+                textBlock.Inlines.Add(text);
+            }
+            return textBlock;
         }
 
         private TextBox GetNewTextBox(string text)


### PR DESCRIPTION
### Purpose

This PR adds a link on ASM scaling warning bubbles.
![warning bubble](https://cloud.githubusercontent.com/assets/17231814/23392842/72ddcf5e-fdb9-11e6-91ac-81009e1c3fb5.png)
Clicking the link opens the "Geometry Working Range" window, similar to selecting Settings > Geometry Working Range.
This only works on warnings with strings "Settings => Geometry Working Range".

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 
