### PR TITLE
Adding parameters to dictionary URLs

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -514,7 +514,7 @@ namespace Dynamo.Graph.Nodes
 
         private string dictionaryLink;
 
-        public string GetDictionaryLinkFromLibrary(LibraryServices libraryServices)
+        internal string ConstructDictionaryLinkFromLibrary(LibraryServices libraryServices)
         {
             string finalLink = Configurations.DynamoDictionary + "#/";
             if (IsCustomFunction)
@@ -550,7 +550,7 @@ namespace Dynamo.Graph.Nodes
 
             // Check if the method has overloads
             IEnumerable<FunctionDescriptor> descriptors = libraryServices.GetAllFunctionDescriptors(CreationName.Split('@')[0]);
-            if (descriptors != null && descriptors.Count() > 1)
+            if (descriptors != null && descriptors.Skip(1).Any())
             {
                 // If there are overloads
                 string parameters = "(";
@@ -573,7 +573,8 @@ namespace Dynamo.Graph.Nodes
                         parameters += inputParameters.ElementAt(k).Item1 + "_" + inputParameters.ElementAt(k).Item2 + "-";
                     }
                     // Append the last parameter without the dash and with the close bracket
-                    parameters += inputParameters.ElementAt(parameterCount - 1).Item1 + "_" + inputParameters.ElementAt(parameterCount - 1).Item2 + ")";
+                    var lastInputParam = inputParameters.ElementAt(parameterCount - 1);
+                    parameters += lastInputParam.Item1 + "_" + lastInputParam.Item2 + ")";
                     finalLink += parameters;
                 }
             }

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -26,9 +26,6 @@ using String = System.String;
 using StringNode = ProtoCore.AST.AssociativeAST.StringNode;
 using System.Runtime.Serialization;
 using System.Diagnostics;
-using Dynamo.Models;
-using System.Collections;
-using Dynamo.Library;
 
 namespace Dynamo.Graph.Nodes
 {
@@ -507,70 +504,81 @@ namespace Dynamo.Graph.Nodes
         {
             get
             {
-                string finalLink = Configurations.DynamoDictionary + "#/";
-                if (IsCustomFunction)
-                {
-                    return ""; // If it is not a core or Revit function, do not display the dictionary link
-                }
-                if (category == null || category == "")
-                {
-                    return Configurations.DynamoDictionary; // if there is no category, return the link to home page
-                }
-
-                int i = category.LastIndexOf(Configurations.CategoryDelimiterString);
-                switch (category.Substring(i + 1))
-                {
-                    case Configurations.CategoryGroupAction:
-                        finalLink += ObtainURL(category.Substring(0, i));
-                        finalLink += "Action/";
-                        break;
-                    case Configurations.CategoryGroupCreate:
-                        finalLink += ObtainURL(category.Substring(0, i));
-                        finalLink += "Create/";
-                        break;
-                    case Configurations.CategoryGroupQuery:
-                        finalLink += ObtainURL(category.Substring(0, i));
-                        finalLink += "Query/";
-                        break;
-                    default:
-                        finalLink += ObtainURL(category);
-                        finalLink += "Action/";
-                        break;
-                }
-                finalLink += this.ShortenName;
-
-                // Check if the method has overloads
-                libraryServices = DynamoModel.StaticLibraryServices;
-                IEnumerable<FunctionDescriptor> descriptors = libraryServices.GetAllFunctionDescriptors(CreationName.Split('@')[0]);
-                if (descriptors != null && descriptors.Count() > 1)
-                {
-                    // If there are overloads
-                    string parameters = "(";
-                    IEnumerable<Tuple<string, string>> inputParameters = null;
-
-                    foreach (FunctionDescriptor fd in descriptors)
-                    {
-                        if (fd.MangledName == CreationName) // Find the function descriptor among the overloads and obtain their parameter names
-                        {
-                            inputParameters = fd.InputParameters;
-                            break;
-                        }
-                    }
-                    // Convert the parameters into a valid Dictionary URL format, e.g. (x_double-y_double-z_double)
-                    if (inputParameters != null)
-                    {
-                        int parameterCount = inputParameters.Count();
-                        for (int k = 0; k < parameterCount - 1; k++)
-                        {
-                            parameters += inputParameters.ElementAt(k).Item1 + "_" + inputParameters.ElementAt(k).Item2 + "-";
-                        }
-                        // Append the last parameter without the dash and with the close bracket
-                        parameters += inputParameters.ElementAt(parameterCount - 1).Item1 + "_" + inputParameters.ElementAt(parameterCount - 1).Item2 + ")";
-                        finalLink += parameters;
-                    }
-                }
-                return finalLink;
+                dictionaryLink = dictionaryLink ?? Configurations.DynamoDictionary;
+                return dictionaryLink;
             }
+            set
+            {
+                dictionaryLink = value;
+            }
+        }
+
+        private string dictionaryLink;
+
+        public string GetDictionaryLinkFromLibrary(LibraryServices libraryServices)
+        {
+            string finalLink = Configurations.DynamoDictionary + "#/";
+            if (IsCustomFunction)
+            {
+                return ""; // If it is not a core or Revit function, do not display the dictionary link
+            }
+            if (category == null || category == "")
+            {
+                return Configurations.DynamoDictionary; // if there is no category, return the link to home page
+            }
+
+            int i = category.LastIndexOf(Configurations.CategoryDelimiterString);
+            switch (category.Substring(i + 1))
+            {
+                case Configurations.CategoryGroupAction:
+                    finalLink += ObtainURL(category.Substring(0, i));
+                    finalLink += "Action/";
+                    break;
+                case Configurations.CategoryGroupCreate:
+                    finalLink += ObtainURL(category.Substring(0, i));
+                    finalLink += "Create/";
+                    break;
+                case Configurations.CategoryGroupQuery:
+                    finalLink += ObtainURL(category.Substring(0, i));
+                    finalLink += "Query/";
+                    break;
+                default:
+                    finalLink += ObtainURL(category);
+                    finalLink += "Action/";
+                    break;
+            }
+            finalLink += this.ShortenName;
+
+            // Check if the method has overloads
+            IEnumerable<FunctionDescriptor> descriptors = libraryServices.GetAllFunctionDescriptors(CreationName.Split('@')[0]);
+            if (descriptors != null && descriptors.Count() > 1)
+            {
+                // If there are overloads
+                string parameters = "(";
+                IEnumerable<Tuple<string, string>> inputParameters = null;
+
+                foreach (FunctionDescriptor fd in descriptors)
+                {
+                    if (fd.MangledName == CreationName) // Find the function descriptor among the overloads and obtain their parameter names
+                    {
+                        inputParameters = fd.InputParameters;
+                        break;
+                    }
+                }
+                // Convert the parameters into a valid Dictionary URL format, e.g. (x_double-y_double-z_double)
+                if (inputParameters != null)
+                {
+                    int parameterCount = inputParameters.Count();
+                    for (int k = 0; k < parameterCount - 1; k++)
+                    {
+                        parameters += inputParameters.ElementAt(k).Item1 + "_" + inputParameters.ElementAt(k).Item2 + "-";
+                    }
+                    // Append the last parameter without the dash and with the close bracket
+                    parameters += inputParameters.ElementAt(parameterCount - 1).Item1 + "_" + inputParameters.ElementAt(parameterCount - 1).Item2 + ")";
+                    finalLink += parameters;
+                }
+            }
+            return finalLink;
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -26,6 +26,9 @@ using String = System.String;
 using StringNode = ProtoCore.AST.AssociativeAST.StringNode;
 using System.Runtime.Serialization;
 using System.Diagnostics;
+using Dynamo.Models;
+using System.Collections;
+using Dynamo.Library;
 
 namespace Dynamo.Graph.Nodes
 {
@@ -46,6 +49,7 @@ namespace Dynamo.Graph.Nodes
         private string persistentWarning = "";
         private bool areInputPortsRegistered;
         private bool areOutputPortsRegistered;
+        private LibraryServices libraryServices;
 
         ///A flag indicating whether the node has been explicitly frozen.
         internal bool isFrozenExplicitly;
@@ -531,6 +535,36 @@ namespace Dynamo.Graph.Nodes
                 }
                 finalLink += this.ShortenName;
 
+                // Check if the method has overloads
+                libraryServices = DynamoModel.StaticLibraryServices;
+                IEnumerable<FunctionDescriptor> descriptors = libraryServices.GetAllFunctionDescriptors(CreationName.Split('@')[0]);
+                if (descriptors != null && descriptors.Count() > 1)
+                {
+                    // If there are overloads
+                    string parameters = "(";
+                    IEnumerable<Tuple<string, string>> inputParameters = null;
+
+                    foreach (FunctionDescriptor fd in descriptors)
+                    {
+                        if (fd.MangledName == CreationName) // Find the function descriptor among the overloads and obtain their parameter names
+                        {
+                            inputParameters = fd.InputParameters;
+                            break;
+                        }
+                    }
+                    // Convert the parameters into a valid Dictionary URL format, e.g. (x_double-y_double-z_double)
+                    if (inputParameters != null)
+                    {
+                        int parameterCount = inputParameters.Count();
+                        for (int k = 0; k < parameterCount - 1; k++)
+                        {
+                            parameters += inputParameters.ElementAt(k).Item1 + "_" + inputParameters.ElementAt(k).Item2 + "-";
+                        }
+                        // Append the last parameter without the dash and with the close bracket
+                        parameters += inputParameters.ElementAt(parameterCount - 1).Item1 + "_" + inputParameters.ElementAt(parameterCount - 1).Item2 + ")";
+                        finalLink += parameters;
+                    }
+                }
                 return finalLink;
             }
         }

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -46,7 +46,6 @@ namespace Dynamo.Graph.Nodes
         private string persistentWarning = "";
         private bool areInputPortsRegistered;
         private bool areOutputPortsRegistered;
-        private LibraryServices libraryServices;
 
         ///A flag indicating whether the node has been explicitly frozen.
         internal bool isFrozenExplicitly;

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -508,6 +508,10 @@ namespace Dynamo.Graph.Nodes
             get
             {
                 string finalLink = Configurations.DynamoDictionary + "#/";
+                if (IsCustomFunction)
+                {
+                    return ""; // If it is not a core or Revit function, do not display the dictionary link
+                }
                 if (category == null || category == "")
                 {
                     return Configurations.DynamoDictionary; // if there is no category, return the link to home page

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -420,27 +420,25 @@ namespace Dynamo.Engine
         /// <summary>
         ///     Returns a list of function descriptors associated with the function name.
         /// </summary>
-        /// <param name="mangledName"></param>
+        /// <param name="qualifiedName"></param>
         /// <returns></returns>
-        public IEnumerable<FunctionDescriptor> GetAllFunctionDescriptors(string mangledName)
+        public IEnumerable<FunctionDescriptor> GetAllFunctionDescriptors(string qualifiedName)
         {
             IEnumerable<FunctionDescriptor> descriptors = null;
-            string qualifiedName = mangledName.Split('@')[0];
             FunctionGroup functionGroup;
 
             // Check through both builtinFunctionGroups and importedFunctionGroups to find the function descriptors
             if (builtinFunctionGroups.TryGetValue(qualifiedName, out functionGroup))
             {
-                functionGroup = builtinFunctionGroups[qualifiedName];
                 descriptors = functionGroup.Functions;
                 return descriptors;
             }
 
-            foreach (KeyValuePair<string, Dictionary<string, FunctionGroup>> fg in importedFunctionGroups)
+            foreach (var fg in importedFunctionGroups)
             {
                 if (fg.Value.TryGetValue(qualifiedName, out functionGroup))
                 {
-                    descriptors = fg.Value[qualifiedName].Functions;
+                    descriptors = functionGroup.Functions;
                     return descriptors;
                 }
             }

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -418,6 +418,37 @@ namespace Dynamo.Engine
         }
 
         /// <summary>
+        ///     Returns a list of function descriptors associated with the function name.
+        /// </summary>
+        /// <param name="mangledName"></param>
+        /// <returns></returns>
+        public IEnumerable<FunctionDescriptor> GetAllFunctionDescriptors(string mangledName)
+        {
+            IEnumerable<FunctionDescriptor> descriptors = null;
+            string qualifiedName = mangledName.Split('@')[0];
+            FunctionGroup functionGroup;
+
+            // Check through both builtinFunctionGroups and importedFunctionGroups to find the function descriptors
+            if (builtinFunctionGroups.TryGetValue(qualifiedName, out functionGroup))
+            {
+                functionGroup = builtinFunctionGroups[qualifiedName];
+                descriptors = functionGroup.Functions;
+                return descriptors;
+            }
+
+            foreach (KeyValuePair<string, Dictionary<string, FunctionGroup>> fg in importedFunctionGroups)
+            {
+                if (fg.Value.TryGetValue(qualifiedName, out functionGroup))
+                {
+                    descriptors = fg.Value[qualifiedName].Functions;
+                    return descriptors;
+                }
+            }
+
+            return null; // If no function descriptors are found
+        }
+
+        /// <summary>
         /// Checks if a given library is already loaded or not.
         /// Only unique assembly names are allowed to be loaded
         /// </summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -187,11 +187,6 @@ namespace Dynamo.Models
         public readonly LibraryServices LibraryServices;
 
         /// <summary>
-        ///     A static copy of LibraryServices.
-        /// </summary>
-        public static LibraryServices StaticLibraryServices;
-
-        /// <summary>
         ///     Flag specifying whether a shutdown of Dynamo was requested.
         /// </summary>
         public bool ShutdownRequested { get; internal set; }
@@ -622,7 +617,6 @@ namespace Dynamo.Models
             LibraryServices = new LibraryServices(libraryCore, pathManager, PreferenceSettings);
             LibraryServices.MessageLogged += LogMessage;
             LibraryServices.LibraryLoaded += LibraryLoaded;
-            StaticLibraryServices = LibraryServices;
 
             ResetEngineInternal();
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -187,6 +187,11 @@ namespace Dynamo.Models
         public readonly LibraryServices LibraryServices;
 
         /// <summary>
+        ///     A static copy of LibraryServices.
+        /// </summary>
+        public static LibraryServices StaticLibraryServices;
+
+        /// <summary>
         ///     Flag specifying whether a shutdown of Dynamo was requested.
         /// </summary>
         public bool ShutdownRequested { get; internal set; }
@@ -617,6 +622,7 @@ namespace Dynamo.Models
             LibraryServices = new LibraryServices(libraryCore, pathManager, PreferenceSettings);
             LibraryServices.MessageLogged += LogMessage;
             LibraryServices.LibraryLoaded += LibraryLoaded;
+            StaticLibraryServices = LibraryServices;
 
             ResetEngineInternal();
 

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml
@@ -75,7 +75,7 @@
         </ScrollViewer>
 
         <TextBlock Name="DynamoDictionary" Grid.Row="1" FontSize="12" Foreground="#2380C0" Margin="10,5,10,5" Text="{x:Static p:Resources.NodeHelpWindowDynamoDictionary}"
-                           Cursor="Hand" Tag="{Binding DictionaryLink}" MouseLeftButtonUp="OpenDynamoDictionary" />
+                           Cursor="Hand" MouseLeftButtonUp="OpenDynamoDictionary" />
     </Grid>
 
 

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml
@@ -14,15 +14,20 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <StackPanel>
-
-        <StackPanel.Background>
+    <Grid>
+        <Grid.Background>
             <LinearGradientBrush  StartPoint="0.5,0" EndPoint="0.5,1">
                 <GradientStop Color="#FFF" Offset="0.0" />
                 <GradientStop Color="#EEE" Offset="1.0" />
             </LinearGradientBrush>
-        </StackPanel.Background>
-        <ScrollViewer Height="415">
+        </Grid.Background>
+        
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition Name="DynamoDictionaryHeight" Height="28" />
+        </Grid.RowDefinitions>
+
+        <ScrollViewer Grid.Row="0">
             <StackPanel Margin="10" Background="Transparent">
 
                 <TextBlock Name="TitleLabel" FontSize="10" Foreground="#AAA" Margin="0,10,0,10" Text="{x:Static p:Resources.NodeHelpWindowNodeType}"></TextBlock>
@@ -35,14 +40,14 @@
                 <TextBlock Name="Category" Text="{Binding Category}" Foreground="#555" TextWrapping="Wrap"></TextBlock>
 
                 <TextBlock Name="InputsLabel" FontSize="10" Foreground="#AAA" Margin="0,20,0,0" Text="{x:Static p:Resources.NodeHelpWindowNodeInput}"></TextBlock>
-                <ListBox Name="Inputs" ItemsSource="{Binding InPorts}" BorderThickness="0" Padding="0" Margin="3" Background="Transparent">
+                <ListBox Name="Inputs" ItemsSource="{Binding InPortData}" BorderThickness="0" Padding="0" Margin="3" Background="Transparent">
 
                     <ListBox.ItemTemplate>
                         <DataTemplate>
 
                             <StackPanel Width="230" >
-                                <TextBlock FontSize="12" Text="{Binding Path=PortName, Converter={StaticResource PortNameConverter}}" FontWeight="Bold" Foreground="#555" Padding="0,10,0,5"/>
-                                <TextBlock FontSize="11" Text="{Binding Path=ToolTipContent}" Foreground="#555" TextWrapping="Wrap"/>
+                                <TextBlock FontSize="12" Text="{Binding Path=NickName, Converter={StaticResource PortNameConverter}}" FontWeight="Bold" Foreground="#555" Padding="0,10,0,5"/>
+                                <TextBlock FontSize="11" Text="{Binding Path=ToolTipString}" Foreground="#555" TextWrapping="Wrap"/>
 
                             </StackPanel>
 
@@ -69,11 +74,9 @@
             </StackPanel>
         </ScrollViewer>
 
-        <StackPanel>
-            <TextBlock Name="DynamoDictionary" FontSize="12" Foreground="#2380C0" Margin="10,5,10,5" Text="{x:Static p:Resources.NodeHelpWindowDynamoDictionary}"
+        <TextBlock Name="DynamoDictionary" Grid.Row="1" FontSize="12" Foreground="#2380C0" Margin="10,5,10,5" Text="{x:Static p:Resources.NodeHelpWindowDynamoDictionary}"
                            Cursor="Hand" Tag="{Binding DictionaryLink}" MouseLeftButtonUp="OpenDynamoDictionary" />
-        </StackPanel>
-    </StackPanel>
+    </Grid>
 
 
 

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using Dynamo.Configuration;
 using System.Windows.Input;
 using System.Windows.Controls;
+using System;
 
 namespace Dynamo.Prompts
 {
@@ -19,6 +20,12 @@ namespace Dynamo.Prompts
             this.DataContext = node;
             this.WindowStartupLocation = WindowStartupLocation.CenterOwner;
             InitializeComponent();
+
+            Type type = node.GetType();
+            if (type.Namespace == "Dynamo.Graph.Nodes.CustomNodes")
+            {
+                DynamoDictionaryHeight.Height = new GridLength(0);
+            }
         }
 
         private void OpenDynamoDictionary(object sender, MouseButtonEventArgs e)

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
@@ -7,6 +7,8 @@ using Dynamo.Configuration;
 using System.Windows.Input;
 using System.Windows.Controls;
 using System;
+using Dynamo.Controls;
+using Dynamo.ViewModels;
 
 namespace Dynamo.Prompts
 {
@@ -30,7 +32,11 @@ namespace Dynamo.Prompts
 
         private void OpenDynamoDictionary(object sender, MouseButtonEventArgs e)
         {
-            Process.Start(new ProcessStartInfo("explorer.exe", ((TextBlock)sender).Tag.ToString()));
+            var dynView = this.Owner.DataContext as DynamoViewModel;
+            var node = this.DataContext as NodeModel;
+            node.DictionaryLink = node.GetDictionaryLinkFromLibrary(dynView.Model.LibraryServices);
+
+            Process.Start(new ProcessStartInfo("explorer.exe", node.DictionaryLink));
         }
 
         protected override void OnClosing(System.ComponentModel.CancelEventArgs e)

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
@@ -20,9 +20,8 @@ namespace Dynamo.Prompts
             this.DataContext = node;
             this.WindowStartupLocation = WindowStartupLocation.CenterOwner;
             InitializeComponent();
-
-            Type type = node.GetType();
-            if (type.Namespace == "Dynamo.Graph.Nodes.CustomNodes")
+            
+            if (node.IsCustomFunction)
             {
                 // Hide the dictionary link if the node is a custom node
                 DynamoDictionaryHeight.Height = new GridLength(0);

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
@@ -22,9 +22,9 @@ namespace Dynamo.Prompts
             InitializeComponent();
 
             Type type = node.GetType();
-            if (type.Namespace == "Dynamo.Graph.Nodes.CustomNodes" || node.Category.Contains("Revit"))
+            if (type.Namespace == "Dynamo.Graph.Nodes.CustomNodes")
             {
-                // Hide the dictionary link if the node is a custom node or a revit node
+                // Hide the dictionary link if the node is a custom node
                 DynamoDictionaryHeight.Height = new GridLength(0);
             }
         }

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
@@ -22,8 +22,9 @@ namespace Dynamo.Prompts
             InitializeComponent();
 
             Type type = node.GetType();
-            if (type.Namespace == "Dynamo.Graph.Nodes.CustomNodes")
+            if (type.Namespace == "Dynamo.Graph.Nodes.CustomNodes" || node.Category.Contains("Revit"))
             {
+                // Hide the dictionary link if the node is a custom node or a revit node
                 DynamoDictionaryHeight.Height = new GridLength(0);
             }
         }

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml.cs
@@ -34,9 +34,15 @@ namespace Dynamo.Prompts
         {
             var dynView = this.Owner.DataContext as DynamoViewModel;
             var node = this.DataContext as NodeModel;
-            node.DictionaryLink = node.GetDictionaryLinkFromLibrary(dynView.Model.LibraryServices);
-
-            Process.Start(new ProcessStartInfo("explorer.exe", node.DictionaryLink));
+            if (dynView != null && node != null)
+            {
+                node.DictionaryLink = node.ConstructDictionaryLinkFromLibrary(dynView.Model.LibraryServices);
+                Process.Start(new ProcessStartInfo("explorer.exe", node.DictionaryLink));
+            }
+            else
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", Configurations.DynamoDictionary));
+            }
         }
 
         protected override void OnClosing(System.ComponentModel.CancelEventArgs e)


### PR DESCRIPTION
### Purpose

This PR is to address [DYN-555](https://jira.autodesk.com/browse/DYN-555) and [DYN-306](https://jira.autodesk.com/browse/DYN-306).
The changes include:
- Adding parameters to dictionary URLs of methods that contain overloads 
(e.g. Dictionary links for all Point.ByCoordinates methods are:
[ByCoordinates(x_double-y_double)](http://dictionary.dynamobim.com/#/Geometry/Point/Create/ByCoordinates(x_double-y_double)) 
[ByCoordinates(x_double-y_double-z_double)](http://dictionary.dynamobim.com/#/Geometry/Point/Create/ByCoordinates(x_double-y_double-z_double))
- Minor updates to the UI so that the content is resizeable with the popup window.
- Hiding the dictionary link if the node is a custom node. e.g.
![capture](https://cloud.githubusercontent.com/assets/17231814/23534432/e2c37400-fff2-11e6-9044-b100c88a006c.PNG)
The same thing can be done for Revit nodes as well, if required.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 

### FYIs

@Racel 
