### PR TITLE
Set IsInput to false for ColorPicker

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -118,5 +118,13 @@ namespace CoreNodeModels.Input
         {
             return string.Format("Color(Alpha = {3}, Red = {0}, Green = {1}, Blue = {2})", dsColor.Alpha, dsColor.Red, dsColor.Green, dsColor.Blue);
         }
+
+        /// <summary>
+        ///     Indicates whether node is input node
+        /// </summary>
+        public override bool IsInputNode
+        {
+            get { return false; }
+        }
     }
 }


### PR DESCRIPTION
### Purpose

ColorPicker should not be available in the customizer yet. So, we are turning off IsInputNode.
https://jira.autodesk.com/browse/DYN-546

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@QilongTang 

### FYIs

@jnealb 

![image](https://cloud.githubusercontent.com/assets/2551261/23570055/854e2ff2-0030-11e7-83c5-66fe87658290.png)
