### PR TITLE
Changed Group title default size to 36 from 14

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -192,7 +192,7 @@ namespace Dynamo.Graph.Annotations
             }
         }
 
-        private double fontSize = 14;
+        private double fontSize = 36;
         /// <summary>
         /// Returns font size of the text of the group
         /// </summary>


### PR DESCRIPTION
### Purpose

This is the fix for Default Group Size changes to 36 from 14. The user on Master branch made this change, but as there were multiple commits, so I have created the new one commit rather than cherry picking from Master.


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 

### FYIs

@kronz @Benglin 
