### PR TITLE
Copy Revit 2018 resource files for localization

### DIFF
--- a/tools/install/ExtractResources.bat
+++ b/tools/install/ExtractResources.bat
@@ -53,6 +53,12 @@ robocopy "%binroot%\Revit_2017\en-US"         "%wwlroot%\Revit_2017\en-US"      
 robocopy "%binroot%\Revit_2017\nodes"         "%wwlroot%\Revit_2017\nodes"          *.dll
 robocopy "%binroot%\Revit_2017\nodes\en-US"   "%wwlroot%\Revit_2017\nodes\en-US"    *.resources.dll *.xml
 )
+IF EXIST "%binroot%\Revit_2018" (
+robocopy "%binroot%\Revit_2018"               "%wwlroot%\Revit_2018"                *.dll *.exe -XF *tests.dll *.customization.dll 
+robocopy "%binroot%\Revit_2018\en-US"         "%wwlroot%\Revit_2018\en-US"          *.resources.dll *.xml
+robocopy "%binroot%\Revit_2018\nodes"         "%wwlroot%\Revit_2018\nodes"          *.dll
+robocopy "%binroot%\Revit_2018\nodes\en-US"   "%wwlroot%\Revit_2018\nodes\en-US"    *.resources.dll *.xml
+)
 
 rem Reset error codes of "1" returned from "robocopy" for downstream scripts.
 if %ERRORLEVEL% equ 1 ( set errorlevel=0 ) else if %ERRORLEVEL% equ 3 ( set errorlevel=0 )


### PR DESCRIPTION
Copy Revit 2018 localization files into 1.2.3 branch. 

### Declarations

Check these if you believe they are true

- [ x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.



