### PR TITLE
Changed group size to 30 as requested by Racel and fixed two failing Test Cases

### DIFF
--- a/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
+++ b/src/DynamoCore/Graph/Annotations/AnnotationModel.cs
@@ -192,7 +192,7 @@ namespace Dynamo.Graph.Annotations
             }
         }
 
-        private double fontSize = 36;
+        private double fontSize = 30;
         /// <summary>
         /// Returns font size of the text of the group
         /// </summary>

--- a/test/DynamoCoreTests/AnnotationModelTest.cs
+++ b/test/DynamoCoreTests/AnnotationModelTest.cs
@@ -473,7 +473,7 @@ namespace Dynamo.Tests
             Assert.AreNotEqual(0, annotation.Width);
 
             //Check the default font size
-            Assert.AreEqual(annotation.FontSize, 14.0);
+            Assert.AreEqual(annotation.FontSize, 30.0);
         }
 
         [Test]
@@ -502,11 +502,11 @@ namespace Dynamo.Tests
             Assert.AreNotEqual(0, annotation.Width);
 
             //Check the default font size
-            Assert.AreEqual(annotation.FontSize, 14.0);
+            Assert.AreEqual(annotation.FontSize, 30.0);
 
             //Change the font size
-            annotation.FontSize = 30;
-            Assert.AreEqual(annotation.FontSize, 30.0);
+            annotation.FontSize = 48;
+            Assert.AreEqual(annotation.FontSize, 48.0);
         }
 
         [Test]


### PR DESCRIPTION
There was a PR submitted by me a few days back to change the group tile size, because of that two test were failing. I have fixed those two tests as well as changed back the group title text size to 30 as requested by @Racel 
### Purpose

(FILL ME IN) This section describes why this PR is here. Usually, it would include a reference 
to the tracking task that it is part or all of the solution for.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 

### FYIs

@Benglin @kronz @Racel 
