### PR TITLE
Fix crash issue while undoing during reconnection operation (#7731)

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -2197,6 +2197,14 @@ namespace Dynamo.Graph.Workspaces
                 return;
             if (!ShouldProceedWithRecording(models))
                 return;
+            
+            if (null != savedModels)
+            {
+                // Before an existing connector is reconnected, we have one action group
+                // which records the deletion of the connector. Pop that out so that we can
+                // record the deletion and reconnection in one action group.
+                recorder.PopFromUndoGroup();
+            }
 
             using (recorder.BeginActionGroup())
             {
@@ -2323,17 +2331,21 @@ namespace Dynamo.Graph.Workspaces
 
         internal void DeleteSavedModels()
         {
-            if (null != savedModels)
-            {
-                RecordAndDeleteModels(savedModels);
-                savedModels = null;
-            }
+            savedModels = null;
         }
 
-        internal void SaveModelsForUndo(List<ModelBase> models)
+        internal void SaveAndDeleteModels(List<ModelBase> models)
         {
-            // save the models for deletion later in one action group
-            savedModels = models;
+            if (null != models)
+            {
+                // If an existing connector is grabbed (to be reconnected), save the 
+                // models for deletion later in one action group.
+                savedModels = models;
+
+                // After saving the models, delete them from the workspace
+                // in one action group.
+                RecordAndDeleteModels(models);
+            }
         }
 
         internal void RecordGroupModelBeforeUngroup(AnnotationModel annotation)

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -298,7 +298,7 @@ namespace Dynamo.Models
                 if (CurrentWorkspace.Connectors.Contains(connector))
                 {
                     var models = new List<ModelBase> { connector };
-                    CurrentWorkspace.SaveModelsForUndo(models);
+                    CurrentWorkspace.SaveAndDeleteModels(models);
                     connector.Delete();
                 }
             }
@@ -328,7 +328,7 @@ namespace Dynamo.Models
                 connectorsForDeletion.Add(connector);
                 activeStartPorts[i] = connector.End;
             }
-            CurrentWorkspace.SaveModelsForUndo(connectorsForDeletion);
+            CurrentWorkspace.SaveAndDeleteModels(connectorsForDeletion);
             for (int i = 0; i < numOfConnectors; i++) //delete the connectors
             {
                 selectedPort.Connectors[0].Delete();

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -164,6 +164,10 @@ namespace Dynamo.ViewModels
                     MakeConnectionImpl(command as DynamoModel.MakeConnectionCommand);
                     break;
 
+                case "UndoRedoCommand":
+                    UndoRedoImpl(command as DynamoModel.UndoRedoCommand);
+                    break;
+
                 case "OpenFileCommand":
                 case "RunCancelCommand":
                 case "ForceRunCancelCommand":
@@ -175,7 +179,6 @@ namespace Dynamo.ViewModels
                 case "SelectInRegionCommand":
                 case "DragSelectionCommand":
                 case "DeleteModelCommand":
-                case "UndoRedoCommand":
                 case "ModelEventCommand":
                 case "UpdateModelValueCommand":
                 case "ConvertNodesToCodeCommand":
@@ -225,6 +228,14 @@ namespace Dynamo.ViewModels
                 case DynamoModel.MakeConnectionCommand.Mode.Cancel:
                     CurrentSpaceViewModel.CancelConnection();
                     break;
+            }
+        }
+
+        private void UndoRedoImpl(DynamoModel.UndoRedoCommand command)
+        {
+            if (command.CmdOperation == DynamoModel.UndoRedoCommand.Operation.Undo)
+            {
+                CurrentSpaceViewModel.CancelActiveState();
             }
         }
 

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1068,6 +1068,25 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(0, workspace.Connectors.Count()); //reconnections are cancelled; connectors are removed from workspace
         }
 
+        /// <summary>
+        /// The following tests exercise the following steps:
+        /// 
+        /// 1. Create one number node and one Point.ByCoordinates node
+        /// 2. Connect the number node to x and y input ports
+        /// 3. Grab the connector from y input port and hit undo
+        /// 
+        /// </summary>
+        [Test, RequiresSTA]
+        public void TestReconnectionUndo()
+        {
+            RunCommandsFromFile("TestReconnectionUndo.xml");
+
+            Assert.AreEqual(2, workspace.Nodes.Count());
+
+            // After hitting undo, the connector should be placed back to y input port.
+            // Hence there are two connectors: one from number node to x, and another one to y.
+            Assert.AreEqual(2, workspace.Connectors.Count()); 
+        }
 
         #endregion
 

--- a/test/core/recorded/TestReconnectionUndo.xml
+++ b/test/core/recorded/TestReconnectionUndo.xml
@@ -1,0 +1,32 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <CreateNodeCommand X="216" Y="269" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>ef399a2b-628c-471e-867c-13af985c3126</ModelGuid>
+    <CoreNodeModels.Input.DoubleInput guid="ef399a2b-628c-471e-867c-13af985c3126" type="CoreNodeModels.Input.DoubleInput" nickname="Number" x="216" y="269" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <System.Double value="0" />
+    </CoreNodeModels.Input.DoubleInput>
+  </CreateNodeCommand>
+  <CreateNodeCommand X="511" Y="281" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>af41cdde-5118-4b35-8fd0-d83e62bca5a5</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="af41cdde-5118-4b35-8fd0-d83e62bca5a5" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Point.ByCoordinates" x="511" y="281" isVisible="true" isUpstreamVisible="true" lacing="Auto" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </CreateNodeCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>ef399a2b-628c-471e-867c-13af985c3126</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>af41cdde-5118-4b35-8fd0-d83e62bca5a5</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>ef399a2b-628c-471e-867c-13af985c3126</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="1">
+    <ModelGuid>af41cdde-5118-4b35-8fd0-d83e62bca5a5</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="0">
+    <ModelGuid>af41cdde-5118-4b35-8fd0-d83e62bca5a5</ModelGuid>
+  </MakeConnectionCommand>
+  <UndoRedoCommand CmdOperation="0" />
+</Commands>


### PR DESCRIPTION
* undo fix between reconnection operations

* removed unnecessary function

* test case for reconnection

### Purpose

(FILL ME IN) This section describes why this PR is here. Usually it would include a reference 
to the tracking task that it is part or all of the solution for.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 

### FYIs

@yeexinc 
