### PR TITLE
Details view  implementation over Dynamo canvas

### DIFF
--- a/src/LibraryViewExtension/LibraryViewController.cs
+++ b/src/LibraryViewExtension/LibraryViewController.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using CefSharp;
+using CefSharp.Wpf;
+using Dynamo.Extensions;
+using Dynamo.LibraryUI.ViewModels;
+using Dynamo.LibraryUI.Views;
+using Dynamo.Models;
+
+namespace Dynamo.LibraryUI
+{
+    /// <summary>
+    /// This class holds methods and data to be called from javascript
+    /// </summary>
+    public class LibraryViewController
+    {
+        private Window dynamoWindow;
+        private ICommandExecutive commandExecutive;
+        private DetailsViewModel detailsViewModel;
+
+        /// <summary>
+        /// Creates LibraryViewController
+        /// </summary>
+        /// <param name="dynamoView">DynamoView hosting library component</param>
+        /// <param name="commandExecutive">Command executive to run dynamo commands</param>
+        public LibraryViewController(Window dynamoView, ICommandExecutive commandExecutive)
+        {
+            this.dynamoWindow = dynamoView;
+            this.commandExecutive = commandExecutive;
+        }
+
+        /// <summary>
+        /// Call this method to create a new node in Dynamo canvas.
+        /// </summary>
+        /// <param name="nodeName">Node creation name</param>
+        public void CreateNode(string nodeName)
+        {
+            dynamoWindow.Dispatcher.BeginInvoke(new Action(() =>
+            {
+                //Create the node of given item name
+                var cmd = new DynamoModel.CreateNodeCommand(Guid.NewGuid().ToString(), nodeName, -1, -1, true, false);
+                commandExecutive.ExecuteCommand(cmd, Guid.NewGuid().ToString(), ViewExtension.ExtensionName);
+            }));
+        }
+
+        /// <summary>
+        /// Displays the details view over Dynamo canvas.
+        /// </summary>
+        /// <param name="item">item data for which details need to be shown</param>
+        public void ShowDetailsView(string item)
+        {
+            if(detailsViewModel == null)
+            {
+                dynamoWindow.Dispatcher.BeginInvoke(new Action(() => AddDetailsView(item)));
+            }
+            else
+            {
+                detailsViewModel.IsVisible = true;
+                detailsViewModel.Address = "http://www.google.com"; //change it based on item
+            }
+        }
+
+        /// <summary>
+        /// Closes the details view
+        /// </summary>
+        public void CloseDetailsView()
+        {
+            detailsViewModel.IsVisible = false;
+        }
+        
+        /// <summary>
+        /// Creates and add the library view to the WPF visual tree
+        /// </summary>
+        /// <returns>LibraryView control</returns>
+        internal LibraryView AddLibraryView()
+        {
+            var sidebarGrid = dynamoWindow.FindName("sidebarGrid") as Grid;
+            var model = new LibraryViewModel("http://localhost/library.html");
+            var view = new LibraryView(model);
+
+            var browser = view.Browser;
+            sidebarGrid.Children.Add(view);
+            browser.RegisterJsObject("controller", this);
+            RegisterResources(browser);
+
+            view.Loaded += OnLibraryViewLoaded;
+            return view;
+        }
+
+        /// <summary>
+        /// Returns a mime type based on the path extension 
+        /// </summary>
+        /// <param name="path">Relative path</param>
+        /// <returns>mime type string</returns>
+        private string MimeType(string path)
+        {
+            var idx = path.LastIndexOf('.');
+            var ext = path.Substring(idx);
+            switch (ext)
+            {
+                case "svg":
+                    return "text/svg";
+                case "png":
+                    return "image/png";
+                case "js":
+                    return "text/javascript";
+                default:
+                    return "text/html";
+            }
+        }
+
+        private Stream LoadResource(string url)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var textStream = assembly.GetManifestResourceStream(url);
+            return textStream;
+        }
+
+        private void OnLibraryViewLoaded(object sender, RoutedEventArgs e)
+        {
+#if DEBUG
+            var view = sender as LibraryView;
+            var browser = view.Browser;
+            browser.ConsoleMessage += OnBrowserConsoleMessage;
+#endif
+        }
+
+        private void OnBrowserConsoleMessage(object sender, ConsoleMessageEventArgs e)
+        {
+            System.Diagnostics.Trace.WriteLine("*****Chromium Browser Messages******");
+            System.Diagnostics.Trace.Write(e.Message);
+        }
+
+        private DetailsView AddDetailsView(string item)
+        {
+            detailsViewModel = new DetailsViewModel("http://dictionary.dynamobim.com/");
+
+            var tabcontrol = dynamoWindow.FindName("WorkspaceTabs") as TabControl;
+            var grid = tabcontrol.Parent as Grid;
+
+            var detailView = new DetailsView(detailsViewModel, grid);
+            grid.Children.Add(detailView);
+
+            var browser = detailView.Browser;
+            browser.RegisterJsObject("controller", detailsViewModel);
+            RegisterResources(browser);
+            detailView.Loaded += OnDescriptionViewLoaded;
+
+            return detailView;
+        }
+
+        private void RegisterResources(ChromiumWebBrowser browser)
+        {
+            var rootnamespace = "Dynamo.LibraryUI.web.";
+
+            var factory = (DefaultResourceHandlerFactory)(browser.ResourceHandlerFactory);
+            if (factory == null) return;
+
+            var resourceNames = Assembly.GetExecutingAssembly()
+            .GetManifestResourceNames();
+            foreach (var resource in resourceNames)
+            {
+                if (!resource.StartsWith(rootnamespace))
+                    continue;
+
+                var url = resource.Replace(rootnamespace, "");
+                if (url.StartsWith("dist."))
+                {
+                    url = url.Replace("dist.", "dist/");
+                    url = url.Replace("/v0._0._1.", "/v0.0.1/");
+                    url = url.Replace("/resources.", "/resources/");
+                }
+
+                var r = LoadResource(resource);
+                factory.RegisterHandler("http://localhost/" + url,
+                     ResourceHandler.FromStream(r, MimeType(url)));
+            }
+        }
+
+        private void OnDescriptionViewLoaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            var view = sender as DetailsView;
+            var browser = view.Browser;
+            browser.ConsoleMessage += OnBrowserConsoleMessage;
+        }
+    }
+}

--- a/src/LibraryViewExtension/LibraryViewController.cs
+++ b/src/LibraryViewExtension/LibraryViewController.cs
@@ -23,8 +23,9 @@ namespace Dynamo.LibraryUI
     {
         private Window dynamoWindow;
         private ICommandExecutive commandExecutive;
+        private DetailsView detailsView;
         private DetailsViewModel detailsViewModel;
-
+        
         /// <summary>
         /// Creates LibraryViewController
         /// </summary>
@@ -56,14 +57,14 @@ namespace Dynamo.LibraryUI
         /// <param name="item">item data for which details need to be shown</param>
         public void ShowDetailsView(string item)
         {
-            if(detailsViewModel == null)
+            DetailsViewContextData = item;
+            if(detailsView == null)
             {
                 dynamoWindow.Dispatcher.BeginInvoke(new Action(() => AddDetailsView(item)));
             }
             else
             {
-                detailsViewModel.IsVisible = true;
-                detailsViewModel.Address = "http://www.google.com"; //change it based on item
+                dynamoWindow.Dispatcher.BeginInvoke(new Action(() => detailsView.Visibility = Visibility.Visible));
             }
         }
 
@@ -72,8 +73,13 @@ namespace Dynamo.LibraryUI
         /// </summary>
         public void CloseDetailsView()
         {
-            detailsViewModel.IsVisible = false;
+            dynamoWindow.Dispatcher.BeginInvoke(new Action(() => detailsView.Visibility = Visibility.Collapsed));
         }
+
+        /// <summary>
+        /// Gets details view context data, e.g. packageId if it shows details of a package
+        /// </summary>
+        public string DetailsViewContextData { get; set; }
         
         /// <summary>
         /// Creates and add the library view to the WPF visual tree
@@ -140,20 +146,20 @@ namespace Dynamo.LibraryUI
 
         private DetailsView AddDetailsView(string item)
         {
-            detailsViewModel = new DetailsViewModel("http://dictionary.dynamobim.com/");
+            detailsViewModel = new DetailsViewModel("http://localhost/details.html");
 
             var tabcontrol = dynamoWindow.FindName("WorkspaceTabs") as TabControl;
             var grid = tabcontrol.Parent as Grid;
 
-            var detailView = new DetailsView(detailsViewModel, grid);
-            grid.Children.Add(detailView);
+            detailsView = new DetailsView(detailsViewModel, grid);
+            grid.Children.Add(detailsView);
 
-            var browser = detailView.Browser;
-            browser.RegisterJsObject("controller", detailsViewModel);
+            var browser = detailsView.Browser;
+            browser.RegisterJsObject("controller", detailsView);
             RegisterResources(browser);
-            detailView.Loaded += OnDescriptionViewLoaded;
+            detailsView.Loaded += OnDescriptionViewLoaded;
 
-            return detailView;
+            return detailsView;
         }
 
         private void RegisterResources(ChromiumWebBrowser browser)

--- a/src/LibraryViewExtension/LibraryViewExtension.cs
+++ b/src/LibraryViewExtension/LibraryViewExtension.cs
@@ -15,7 +15,7 @@ namespace Dynamo.LibraryUI
         private ViewLoadedParams viewLoadedParams;
         private ViewStartupParams viewStartupParams;
 
-        private LibraryViewModel model;
+        private LibraryViewController controller;
 
         public string UniqueId
         {
@@ -36,81 +36,8 @@ namespace Dynamo.LibraryUI
         public void Loaded(ViewLoadedParams p)
         {
             viewLoadedParams = p;
-            AddLibraryView(p);
-        }
-
-        private void AddLibraryView(ViewLoadedParams p)
-        {
-            var sidebarGrid = p.DynamoWindow.FindName("sidebarGrid") as Grid;
-            model = new LibraryViewModel("http://localhost/library.html");
-            var view = new LibraryView(model);
-            var browser = view.Browser;
-            var rootnamespace = "Dynamo.LibraryUI.web.";
-
-            sidebarGrid.Children.Add(view);
-            view.Browser.RegisterJsObject("controller", new LibraryViewController(browser, p.CommandExecutive));
-            var factory = (DefaultResourceHandlerFactory)(browser.ResourceHandlerFactory);
-            if (factory == null) return;
-
-            var resourceNames = Assembly.GetExecutingAssembly()
-            .GetManifestResourceNames();
-            foreach (var resource in resourceNames)
-            {
-                if (!resource.StartsWith(rootnamespace))
-                    continue;
-
-                var url = resource.Replace(rootnamespace, "");
-                if(url.StartsWith("dist."))
-                {
-                    url = url.Replace("dist.v0._0._1.", "dist/v0.0.1/");
-                    url = url.Replace("v0.0.1/resources.", "v0.0.1/resources/");
-                }
-
-                var r = LoadResource(resource);                
-                factory.RegisterHandler("http://localhost/" + url,
-                     ResourceHandler.FromStream(r, MimeType(url)));
-            }
-
-            view.Loaded += OnLibraryViewLoaded;
-        }
-
-        private string MimeType(string url)
-        {
-            var idx = url.LastIndexOf('.');
-            var ext = url.Substring(idx);
-            switch (ext)
-            {
-                case "svg":
-                    return "text/svg";
-                case "png":
-                    return "image/png";
-                case "js":
-                    return "text/javascript";
-                default:
-                    return "text/html";
-            }
-        }
-
-        private Stream LoadResource(string url)
-        {
-            var assembly = Assembly.GetExecutingAssembly();
-            var textStream = assembly.GetManifestResourceStream(url);
-            return textStream;
-        }
-
-        private void OnLibraryViewLoaded(object sender, System.Windows.RoutedEventArgs e)
-        {
-#if DEBUG
-            var view = sender as LibraryView;
-            var browser = view.Browser;
-            browser.ConsoleMessage += OnBrowserConsoleMessage;
-#endif
-        }
-
-        private void OnBrowserConsoleMessage(object sender, ConsoleMessageEventArgs e)
-        {
-            System.Diagnostics.Trace.WriteLine("*****Chromium Browser Messages******");
-            System.Diagnostics.Trace.Write(e.Message);
+            controller = new LibraryViewController(p.DynamoWindow, p.CommandExecutive);
+            controller.AddLibraryView();
         }
 
         public void Shutdown()

--- a/src/LibraryViewExtension/LibraryViewExtension.csproj
+++ b/src/LibraryViewExtension/LibraryViewExtension.csproj
@@ -74,6 +74,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LibraryViewController.cs" />
     <Compile Include="LibraryViewExtension.cs" />
     <Compile Include="Properties\Resources.en-US.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -84,6 +85,10 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Include="ViewModels\DetailsViewModel.cs" />
+    <Compile Include="Views\DetailsView.xaml.cs">
+      <DependentUpon>DetailsView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\LibraryView.xaml.cs">
       <DependentUpon>LibraryView.xaml</DependentUpon>
@@ -113,6 +118,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Views\DetailsView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\LibraryView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/src/LibraryViewExtension/ViewModels/DetailsViewModel.cs
+++ b/src/LibraryViewExtension/ViewModels/DetailsViewModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dynamo.LibraryUI.ViewModels
+{
+    public class DetailsViewModel : LibraryViewModel
+    {
+        public DetailsViewModel(string address) : base(address)
+        {
+        }
+    }
+}

--- a/src/LibraryViewExtension/ViewModels/LibraryViewModel.cs
+++ b/src/LibraryViewExtension/ViewModels/LibraryViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Practices.Prism.ViewModel;
+﻿using System.Windows;
+using Microsoft.Practices.Prism.ViewModel;
 
 namespace Dynamo.LibraryUI.ViewModels
 {
@@ -31,19 +32,28 @@ namespace Dynamo.LibraryUI.ViewModels
         }
 
         /// <summary>
-        /// Checks if the view is visible
+        /// Checks and updates the visibility property
         /// </summary>
         public bool IsVisible
         {
-            get { return visible; }
+            get { return Visibility == Visibility.Visible; }
+            set { Visibility = value ? Visibility.Visible : Visibility.Collapsed; }
+        }
+
+        /// <summary>
+        /// Controls visibilty of the view
+        /// </summary>
+        public Visibility Visibility
+        {
+            get { return visibility; }
             set
             {
-                visible = value;
-                RaisePropertyChanged("IsVisible");
+                visibility = value;
+                RaisePropertyChanged("Visibility");
             }
         }
 
-        private bool visible = true;
+        private Visibility visibility = Visibility.Visible;
         private string address;
     }
 }

--- a/src/LibraryViewExtension/ViewModels/LibraryViewModel.cs
+++ b/src/LibraryViewExtension/ViewModels/LibraryViewModel.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
-using System.Text;
-using System.Windows;
-using CefSharp;
-using CefSharp.Wpf;
-using Dynamo.Extensions;
-using Dynamo.LibraryUI.Properties;
-using Dynamo.Models;
-using Microsoft.Practices.Prism.ViewModel;
-using Newtonsoft.Json;
+﻿using Microsoft.Practices.Prism.ViewModel;
 
 namespace Dynamo.LibraryUI.ViewModels
 {
@@ -42,6 +30,20 @@ namespace Dynamo.LibraryUI.ViewModels
             }
         }
 
+        /// <summary>
+        /// Checks if the view is visible
+        /// </summary>
+        public bool IsVisible
+        {
+            get { return visible; }
+            set
+            {
+                visible = value;
+                RaisePropertyChanged("IsVisible");
+            }
+        }
+
+        private bool visible = true;
         private string address;
     }
 }

--- a/src/LibraryViewExtension/Views/DetailsView.xaml
+++ b/src/LibraryViewExtension/Views/DetailsView.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl x:Class="Dynamo.LibraryUI.Views.DetailsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ui="clr-namespace:Dynamo.UI"
+             xmlns:controls="clr-namespace:Dynamo.Controls"
+             xmlns:uicontrols="clr-namespace:Dynamo.UI.Controls"
+             xmlns:vms="clr-namespace:Dynamo.Wpf.ViewModels"
+             xmlns:p="clr-namespace:Dynamo.Wpf.Properties"
+             xmlns:local="clr-namespace:Dynamo.LibraryUI.Views"
+             xmlns:cefSharp="clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf"
+             mc:Ignorable="d"
+             d:DesignHeight="525"
+             d:DesignWidth="350"
+             Visibility="{Binding Path=IsVisible, Converter=controls:BoolToVisibilityCollapsedConverter}">
+    <cefSharp:ChromiumWebBrowser x:Name="Browser" Address="{Binding Address}"/>
+    
+</UserControl>

--- a/src/LibraryViewExtension/Views/DetailsView.xaml
+++ b/src/LibraryViewExtension/Views/DetailsView.xaml
@@ -13,7 +13,7 @@
              mc:Ignorable="d"
              d:DesignHeight="525"
              d:DesignWidth="350"
-             Visibility="{Binding Path=IsVisible, Converter=controls:BoolToVisibilityCollapsedConverter}">
+             Visibility="{Binding Path=IsVisible}">
     <cefSharp:ChromiumWebBrowser x:Name="Browser" Address="{Binding Address}"/>
     
 </UserControl>

--- a/src/LibraryViewExtension/Views/DetailsView.xaml.cs
+++ b/src/LibraryViewExtension/Views/DetailsView.xaml.cs
@@ -40,8 +40,6 @@ namespace Dynamo.LibraryUI.Views
 
             InitializeComponent();
 
-            UpdateVisibility();
-
             this.IsVisibleChanged += OnVisibilityChange;
         }
 
@@ -49,7 +47,7 @@ namespace Dynamo.LibraryUI.Views
         {
             foreach (UIElement item in parentGrid.Children)
             {
-                if (item.Visibility == Visibility.Visible)
+                if (item.Visibility == Visibility.Visible && item != this)
                 {
                     lastVisibleItem = item;
                     lastVisibleItem.Visibility = Visibility.Collapsed;
@@ -60,9 +58,14 @@ namespace Dynamo.LibraryUI.Views
 
         private void OnVisibilityChange(object sender, DependencyPropertyChangedEventArgs e)
         {
-            if (lastVisibleItem != null)
+            if (this.Visibility != Visibility.Visible)
             {
-                lastVisibleItem.Visibility = Visibility.Visible;
+                if(lastVisibleItem != null) lastVisibleItem.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                lastVisibleItem = null;
+                UpdateVisibility();
             }
         }
     }

--- a/src/LibraryViewExtension/Views/DetailsView.xaml.cs
+++ b/src/LibraryViewExtension/Views/DetailsView.xaml.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using CefSharp;
+using Dynamo.LibraryUI.ViewModels;
+
+namespace Dynamo.LibraryUI.Views
+{
+    /// <summary>
+    /// Interaction logic for DetailsView.xaml
+    /// </summary>
+    public partial class DetailsView : UserControl
+    {
+        private Grid parentGrid;
+        private UIElement lastVisibleItem;
+
+        public DetailsView(DetailsViewModel viewModel, Grid parent)
+        {
+            this.DataContext = viewModel;
+            this.parentGrid = parent;
+
+            if (!Cef.IsInitialized)
+            {
+                var settings = new CefSettings { RemoteDebuggingPort = 8088 };
+                //to fix Fickering set disable-gpu to true
+                settings.CefCommandLineArgs.Add("disable-gpu", "1");
+                Cef.Initialize(settings);
+            }
+
+            InitializeComponent();
+
+            UpdateVisibility();
+
+            this.IsVisibleChanged += OnVisibilityChange;
+        }
+
+        private void UpdateVisibility()
+        {
+            foreach (UIElement item in parentGrid.Children)
+            {
+                if (item.Visibility == Visibility.Visible)
+                {
+                    lastVisibleItem = item;
+                    lastVisibleItem.Visibility = Visibility.Collapsed;
+                    break;
+                }
+            }
+        }
+
+        private void OnVisibilityChange(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (lastVisibleItem != null)
+            {
+                lastVisibleItem.Visibility = Visibility.Visible;
+            }
+        }
+    }
+}

--- a/src/LibraryViewExtension/Views/LibraryView.xaml.cs
+++ b/src/LibraryViewExtension/Views/LibraryView.xaml.cs
@@ -1,4 +1,7 @@
 using System;
+using System.IO;
+using System.Reflection;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
 using CefSharp;
@@ -27,31 +30,6 @@ namespace Dynamo.LibraryUI.Views
             }
             
             InitializeComponent();
-        }
-    }
-
-    /// <summary>
-    /// This class holds methods and data to be called from javascript
-    /// </summary>
-    public class LibraryViewController
-    {
-        private ChromiumWebBrowser browser;
-        private ICommandExecutive commandExecutive;
-
-        public LibraryViewController(ChromiumWebBrowser browser, ICommandExecutive commandExecutive)
-        {
-            this.browser = browser;
-            this.commandExecutive = commandExecutive;
-        }
-
-        public void OnItemClicked(string item)
-        {
-            browser.Dispatcher.BeginInvoke(new Action(() =>
-            {
-                //Create the node of given item name
-                var cmd = new DynamoModel.CreateNodeCommand(Guid.NewGuid().ToString(), item, -1, -1, true, false);
-                commandExecutive.ExecuteCommand(cmd, Guid.NewGuid().ToString(), ViewExtension.ExtensionName);
-            }));
         }
     }
 }

--- a/src/LibraryViewExtension/web/library.html
+++ b/src/LibraryViewExtension/web/library.html
@@ -30,9 +30,9 @@
         let controller = window["controller"];
         let libView = new LibraryEntryPoint.LibraryView(configuration);
 
-        libView.on("itemClicked", function(item) {
-            console.log(item);
-            controller.onItemClicked(item);
+        libView.on("itemClicked", function(nodeCreationName) {
+            console.log(nodeCreationName);
+            controller.createNode(nodeCreationName);
         })
     </script>
 


### PR DESCRIPTION
### Purpose

This PR refactors code to support details view on the right side covering the canvas when details of an item need to be shown. LibraryViewController class is implemented to support the communication between javascript and c#. It provides methods such as CreateNode(), Show/Hide details view etc.

The details view is created as a chromium browser based control and hosted as a child of the grid owning WorkspaceTabs control. The DetailsView control hides other controls in the grid when it's active and will bring back the last active view when dismissed.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs

@Benglin 
@aparajit-pratap 