### PR TITLE
Fix the issue that one json string may be invalid

### DIFF
--- a/src/LibraryViewExtension/DynamoPackagesHelper.cs
+++ b/src/LibraryViewExtension/DynamoPackagesHelper.cs
@@ -46,7 +46,10 @@ namespace Dynamo.LibraryUI
                 pkgStr.Append(pkg.VersionName);
                 pkgStr.Append("\"},");
             }
-            pkgStr.Remove(pkgStr.Length - 1, 1); // Remove the last comma
+            if (localPackages.Any())
+            {
+                pkgStr.Remove(pkgStr.Length - 1, 1); // Remove the last comma
+            }
             pkgStr.Append("] }");
             return pkgStr.ToString();
         }


### PR DESCRIPTION
### Purpose

This is to fix an issue that when there are no packages installed. One json string is not valid.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@sharadkjaiswal 


