### PR TITLE
Update the library UI to recategorize two nodes

### DIFF
--- a/src/LibraryViewExtension/web/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/layoutSpecs.json
@@ -1045,7 +1045,7 @@
       "text": "String",
       "iconUrl": "http://54.169.171.233:3456/src/resources/icons/Category.String.svg",
       "elementType": "category",
-      "include": [],
+      "include": [ ],
       "childElements": [
         {
           "text": "Inspect",
@@ -1077,7 +1077,7 @@
               "path": "DSCore.String.StartsWith"
             }
           ],
-          "childElements": []
+          "childElements": [ ]
         },
         {
           "text": "Modify",
@@ -1130,7 +1130,7 @@
               "path": "DSCore.String.ChangeCase"
             }
           ],
-          "childElements": []
+          "childElements": [ ]
         },
         {
           "text": "Generate",
@@ -1148,6 +1148,30 @@
             },
             {
               "path": "DSCore.String.Join"
+            }
+          ],
+          "childElements": [ ]
+        }
+      ]
+    },
+    {
+      "text": "Modifiers",
+      "iconUrl": "",
+      "elementType": "category",
+      "include": [],
+      "childElements": [
+        {
+          "text": "Geometry Color",
+          "iconUrl": "",
+          "elementType": "group",
+          "include": [
+            {
+              "path": "Modifiers.GeometryColor.ByGeometryColor",
+              "iconUrl": "http://54.169.171.233:3456/src/resources/icons/Category.Geometry.svg"
+            },
+            {
+              "path": "Modifiers.GeometryColor.BySurfaceColors",
+              "iconUrl": "http://54.169.171.233:3456/src/resources/icons/Category.Geometry.svg"
             }
           ],
           "childElements": []
@@ -1346,25 +1370,7 @@
               "iconUrl": "http://54.169.171.233:3456/src/resources/icons/Autodesk.DesignScript.Geometry.Geometry.png"
             }
           ],
-          "childElements": [
-            {
-              "text": "Display",
-              "iconUrl": "",
-              "elementType": "group",
-              "include": [
-                {
-                  "path": "Display.Display.ByGeometryColor"
-                },
-                {
-                  "path": "Display.Display.BySurfaceColors"
-                },
-                {
-                  "path": "Display.Display.BySurfaceColors"
-                }
-              ],
-              "childElements": []
-            }
-          ]
+          "childElements": []
         },
         {
           "text": "Tessellation",

--- a/src/LibraryViewExtension/web/loadedTypes.json
+++ b/src/LibraryViewExtension/web/loadedTypes.json
@@ -4393,15 +4393,15 @@
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "Display.Display.ByGeometryColor",
+      "fullyQualifiedName": "Modifiers.GeometryColor.ByGeometryColor",
       "iconUrl": "http://54.169.171.233:3456/src/resources/icons/Display.Display.ByGeometryColor.png",
-      "contextData": "Display.Display.ByGeometryColor@Autodesk.DesignScript.Geometry.Geometry,DSCore.Color",
+      "contextData": "Modifiers.GeometryColor.ByGeometryColor@Autodesk.DesignScript.Geometry.Geometry,DSCore.Color",
       "itemType": "creation"
     },
     {
-      "fullyQualifiedName": "Display.Display.BySurfaceColors",
+      "fullyQualifiedName": "Modifiers.GeometryColor.BySurfaceColors",
       "iconUrl": "http://54.169.171.233:3456/src/resources/icons/Display.Display.BySurfaceColors.png",
-      "contextData": "Display.Display.BySurfaceColors@Autodesk.DesignScript.Geometry.Surface,DSCore.Color[][]",
+      "contextData": "Modifiers.GeometryColor.BySurfaceColors@Autodesk.DesignScript.Geometry.Surface,DSCore.Color[][]",
       "itemType": "creation"
     }
   ]


### PR DESCRIPTION
### Purpose

This is to recategorize GeometryColor.ByGeometryColor and GeometryColor.BySurfaceColors.

![image](https://cloud.githubusercontent.com/assets/5584246/25217456/959716a2-25d9-11e7-9fbb-f9b1195f142b.png)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@sharadkjaiswal 

### FYIs

@riteshchandawar 
