### PR TITLE
Color picker undo fix

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -32,36 +32,14 @@ namespace CoreNodeModels.Input
     public class ColorPalette : NodeModel
     {
         private DSColor dscolor = DSColor.ByARGB(255, 0, 0, 0);
-        private DSColor prevColor = DSColor.ByARGB(255, 0, 0, 0);
-        private bool ShouldRecordForUndo = true;
         public DSColor DsColor
         {
             get { return dscolor; }
             set
             {
-                if (dscolor.Equals(value) || prevColor.Equals(value))
-                {
-                    //Checks if undorecorder is being used
-                    ShouldRecordForUndo = false;
-                }
-
-                if (ShouldRecordForUndo)
-                {
-                    //If undo recorder is not being used updates the undorecorder stack with new value
-                    ShouldRecordForUndo = true;
-                    Update = dscolor;
-                }
-                prevColor = dscolor;
                 dscolor = value;
                 OnNodeModified();
                 RaisePropertyChanged("DsColor");
-            }
-        }
-        public DSColor Update
-        {
-            set
-            {
-                RaisePropertyChanged("Update");
             }
         }
         /// <summary>

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -32,24 +32,27 @@ namespace CoreNodeModels.Input
     public class ColorPalette : NodeModel
     {
         private DSColor dscolor = DSColor.ByARGB(255, 0, 0, 0);
+        private DSColor prevColor = DSColor.ByARGB(255, 0, 0, 0);
         private bool Isundo = false;
         public DSColor DsColor
         {
             get { return dscolor; }
             set
             {
-                if (dscolor.Equals(value))
+                if (dscolor.Equals(value) ||prevColor.Equals(value))
                 {
                     //Checks if undorecorder is being used
                     Isundo = true;     
                 }
-                dscolor = value;
+                
                 if (!Isundo)
                 {
                     //If undo recorder is not being used updates the undorecorder stack with new value
                     Isundo = false;
                     Update = dscolor;
                 }
+                prevColor = dscolor;
+                dscolor = value;
                 OnNodeModified();
                 RaisePropertyChanged("DsColor");
             }
@@ -69,6 +72,22 @@ namespace CoreNodeModels.Input
             //this.PropertyChanged += RaisePropertyChanged;
             RegisterAllPorts();
         }
+
+        protected override bool UpdateValueCore(UpdateValueParams updateValueParams)
+        {
+            string name = updateValueParams.PropertyName;
+            string value = updateValueParams.PropertyValue;
+
+            switch (name)
+            {
+                case "DsColor":
+                    this.DsColor = this.DeserializeValue(value);
+                    return true;
+            }
+
+            return base.UpdateValueCore(updateValueParams);
+        }
+
         private DSColor DeserializeValue(string val)
         {
             try

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml;
+
+using System.Runtime.CompilerServices;
 
 using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
@@ -13,6 +16,7 @@ using CoreNodeModels.Properties;
 using DSColor = DSCore.Color;
 
 using Autodesk.DesignScript.Runtime;
+using Dynamo.Graph.Workspaces;
 
 
 namespace CoreNodeModels.Input
@@ -25,17 +29,45 @@ namespace CoreNodeModels.Input
     [OutPortNames("Color")]
     [OutPortTypes("Color")]
     [OutPortDescriptions("Selected Color.")]
-    public class ColorPalette : NodeModel
+    public class ColorPalette : NodeModel, INotifyPropertyChanged
     {
-        private DSColor dscolor = DSColor.ByARGB(255,0,0,0);
-        public DSColor dsColor
+        private DSColor dscolor = DSColor.ByARGB(255, 0, 0, 0);
+        private bool Isundo = false;
+        public DSColor DsColor
         {
             get { return dscolor; }
             set
-            {                              
+            {
+                if (dscolor.Equals(value))
+                {
+                    //Checks if undorecorder is being used
+                    Isundo = true;
+                }
                 dscolor = value;
+                if (!Isundo)
+                {
+                    //If undo recorder is not being used updates the undorecorder stack with new value
+                    Isundo = false;
+                    Update = dscolor;
+                }
                 OnNodeModified();
+                OnPropertyChanged();
             }
+        }
+
+        public DSColor Update
+        {
+            set
+            {
+                OnPropertyChanged();
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
         /// <summary>
         ///     Node constructor.
@@ -45,7 +77,7 @@ namespace CoreNodeModels.Input
             RegisterAllPorts();
         }
         private DSColor DeserializeValue(string val)
-         {
+        {
             try
             {
                 //Splits the xml string and returns each of the ARGB values as a string array.
@@ -59,7 +91,7 @@ namespace CoreNodeModels.Input
         }
         private string SerializeValue()
         {
-            return dsColor.ToString();
+            return DsColor.ToString();
         }
         /// <summary>
         ///     Store color value when graph is saved.
@@ -70,7 +102,7 @@ namespace CoreNodeModels.Input
         {
             base.SerializeCore(element, context);
 
-            XmlElement color = element.OwnerDocument.CreateElement("dsColor");
+            XmlElement color = element.OwnerDocument.CreateElement("DsColor");
             color.InnerText = SerializeValue();
             element.AppendChild(color);
         }
@@ -83,11 +115,11 @@ namespace CoreNodeModels.Input
         {
             base.DeserializeCore(element, context);
 
-            var colorNode = element.ChildNodes.Cast<XmlNode>().FirstOrDefault(x => x.Name == "dsColor");
+            var colorNode = element.ChildNodes.Cast<XmlNode>().FirstOrDefault(x => x.Name == "DsColor");
 
             if (colorNode != null)
             {
-                dsColor = DeserializeValue(colorNode.InnerText);
+                DsColor = DeserializeValue(colorNode.InnerText);
             }
 
         }
@@ -99,10 +131,10 @@ namespace CoreNodeModels.Input
         [IsVisibleInDynamoLibrary(false)]
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            var av = AstFactory.BuildIntNode(Convert.ToInt32(dsColor.Alpha));
-            var ar = AstFactory.BuildIntNode(Convert.ToInt32(dsColor.Red));
-            var ag = AstFactory.BuildIntNode(Convert.ToInt32(dsColor.Green));
-            var ab = AstFactory.BuildIntNode(Convert.ToInt32(dsColor.Blue));
+            var av = AstFactory.BuildIntNode(Convert.ToInt32(DsColor.Alpha));
+            var ar = AstFactory.BuildIntNode(Convert.ToInt32(DsColor.Red));
+            var ag = AstFactory.BuildIntNode(Convert.ToInt32(DsColor.Green));
+            var ab = AstFactory.BuildIntNode(Convert.ToInt32(DsColor.Blue));
 
             var colorNode = AstFactory.BuildFunctionCall(
                     new Func<int, int, int, int, DSColor>(DSColor.ByARGB), new List<AssociativeNode> { av, ar, ag, ab });
@@ -116,15 +148,7 @@ namespace CoreNodeModels.Input
         /// <returns></returns>
         public override string ToString()
         {
-            return string.Format("Color(Alpha = {3}, Red = {0}, Green = {1}, Blue = {2})", dsColor.Alpha, dsColor.Red, dsColor.Green, dsColor.Blue);
-        }
-
-        /// <summary>
-        ///     Indicates whether node is input node
-        /// </summary>
-        public override bool IsInputNode
-        {
-            get { return false; }
+            return string.Format("Color(Alpha = {3}, Red = {0}, Green = {1}, Blue = {2} )", DsColor.Alpha, DsColor.Red, DsColor.Green, DsColor.Blue);
         }
     }
 }

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -33,22 +33,22 @@ namespace CoreNodeModels.Input
     {
         private DSColor dscolor = DSColor.ByARGB(255, 0, 0, 0);
         private DSColor prevColor = DSColor.ByARGB(255, 0, 0, 0);
-        private bool Isundo = false;
+        private bool ShouldRecordForUndo = true;
         public DSColor DsColor
         {
             get { return dscolor; }
             set
             {
-                if (dscolor.Equals(value) ||prevColor.Equals(value))
+                if (dscolor.Equals(value) || prevColor.Equals(value))
                 {
                     //Checks if undorecorder is being used
-                    Isundo = true;     
+                    ShouldRecordForUndo = false;
                 }
-                
-                if (!Isundo)
+
+                if (ShouldRecordForUndo)
                 {
                     //If undo recorder is not being used updates the undorecorder stack with new value
-                    Isundo = false;
+                    ShouldRecordForUndo = true;
                     Update = dscolor;
                 }
                 prevColor = dscolor;
@@ -68,8 +68,7 @@ namespace CoreNodeModels.Input
         ///     Node constructor.
         /// </summary>
         public ColorPalette()
-        {           
-            //this.PropertyChanged += RaisePropertyChanged;
+        {
             RegisterAllPorts();
         }
 
@@ -152,6 +151,14 @@ namespace CoreNodeModels.Input
                     new Func<int, int, int, int, DSColor>(DSColor.ByARGB), new List<AssociativeNode> { av, ar, ag, ab });
 
             return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), colorNode) };
+        }
+
+        /// <summary>
+        ///     Indicates whether node is input node
+        /// </summary>
+        public override bool IsInputNode
+        {
+            get { return false; }
         }
     }
 }

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -141,14 +141,5 @@ namespace CoreNodeModels.Input
 
             return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), colorNode) };
         }
-
-        /// <summary>
-        ///     Override string representation of color in watch node.
-        /// </summary>
-        /// <returns></returns>
-        public override string ToString()
-        {
-            return string.Format("Color(Alpha = {3}, Red = {0}, Green = {1}, Blue = {2} )", DsColor.Alpha, DsColor.Red, DsColor.Green, DsColor.Blue);
-        }
     }
 }

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -5,10 +5,10 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml;
 
-using System.Runtime.CompilerServices;
-
 using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
+
+using System.Runtime.CompilerServices;
 
 using ProtoCore.AST.AssociativeAST;
 using CoreNodeModels.Properties;
@@ -29,7 +29,7 @@ namespace CoreNodeModels.Input
     [OutPortNames("Color")]
     [OutPortTypes("Color")]
     [OutPortDescriptions("Selected Color.")]
-    public class ColorPalette : NodeModel, INotifyPropertyChanged
+    public class ColorPalette : NodeModel
     {
         private DSColor dscolor = DSColor.ByARGB(255, 0, 0, 0);
         private bool Isundo = false;
@@ -41,7 +41,7 @@ namespace CoreNodeModels.Input
                 if (dscolor.Equals(value))
                 {
                     //Checks if undorecorder is being used
-                    Isundo = true;
+                    Isundo = true;     
                 }
                 dscolor = value;
                 if (!Isundo)
@@ -51,29 +51,22 @@ namespace CoreNodeModels.Input
                     Update = dscolor;
                 }
                 OnNodeModified();
-                OnPropertyChanged();
+                RaisePropertyChanged("DsColor");
             }
         }
-
         public DSColor Update
         {
             set
             {
-                OnPropertyChanged();
+                RaisePropertyChanged("Update");
             }
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
         /// <summary>
         ///     Node constructor.
         /// </summary>
         public ColorPalette()
-        {
+        {           
+            //this.PropertyChanged += RaisePropertyChanged;
             RegisterAllPorts();
         }
         private DSColor DeserializeValue(string val)

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml
@@ -3,12 +3,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:m="clr-namespace:CoreNodeModelsWpf.Nodes"
+             xmlns:m="clr-namespace:CoreNodeModels.Input;assembly=CoreNodeModels"
+             xmlns:converters="clr-namespace:CoreNodeModelsWpf.Converters"
              xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit" 
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="90">
-
+    <UserControl.Resources>
+        <converters:MediatoDSColorConverter x:Key="DsColorConverter"></converters:MediatoDSColorConverter>
+    </UserControl.Resources>
     <Grid>
-        <xctk:ColorPicker HorizontalAlignment="Center" Margin="0,0,0,0" VerticalAlignment="Center" Width="80" SelectedColor="{Binding MColor , Mode=TwoWay}" AvailableColorsHeader="Standard Colors" ShowStandardColors="False" ShowRecentColors="True" RecentColorsHeader="Recent Colors"/>
+        <xctk:ColorPicker HorizontalAlignment="Center" Margin="0,0,0,0" VerticalAlignment="Center" Width="80" SelectedColor="{Binding Path=DsColor , Mode=TwoWay, Converter={StaticResource DsColorConverter}}" AvailableColorsHeader="Standard Colors" ShowStandardColors="False" ShowRecentColors="True" RecentColorsHeader="Recent Colors" />
     </Grid>
 </UserControl>

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml
@@ -4,14 +4,11 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:m="clr-namespace:CoreNodeModels.Input;assembly=CoreNodeModels"
-             xmlns:converters="clr-namespace:CoreNodeModelsWpf.Converters"
              xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit" 
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="90">
-    <UserControl.Resources>
-        <converters:MediatoDSColorConverter x:Key="DsColorConverter"></converters:MediatoDSColorConverter>
-    </UserControl.Resources>
+ 
     <Grid>
-        <xctk:ColorPicker HorizontalAlignment="Center" Margin="0,0,0,0" VerticalAlignment="Center" Width="80" SelectedColor="{Binding Path=DsColor , Mode=TwoWay, Converter={StaticResource DsColorConverter}}" AvailableColorsHeader="Standard Colors" ShowStandardColors="False" ShowRecentColors="True" RecentColorsHeader="Recent Colors" />
+        <xctk:ColorPicker Name="xceedColorPickerControl" HorizontalAlignment="Center" Margin="0,0,0,0" VerticalAlignment="Center" Width="80"  AvailableColorsHeader="Standard Colors" ShowStandardColors="False" ShowRecentColors="True" RecentColorsHeader="Recent Colors" />
     </Grid>
 </UserControl>

--- a/src/Libraries/CoreNodeModelsWpf/Converters/MediatoDSColorConverter.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Converters/MediatoDSColorConverter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+using System.Windows.Media;
+using DSColor = DSCore.Color;
+
+namespace CoreNodeModelsWpf.Converters
+{
+    public class MediatoDSColorConverter : IValueConverter
+    {
+        private DSColor dscolor;
+        private Color color;
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            dscolor = (DSColor)value;
+
+            if (!dscolor.Equals(null))
+            {
+                color = Color.FromArgb(dscolor.Alpha, dscolor.Red, dscolor.Green, dscolor.Blue);
+            }
+            else
+            {
+                color = Color.FromArgb(0, 0, 0, 0);
+            }
+
+            return color;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            color = (Color)value;
+            if (!color.Equals(null))
+            {
+                dscolor = DSColor.ByARGB(color.A, color.R, color.G, color.B);
+            }
+            else
+            {
+                dscolor = DSColor.ByARGB(0, 0, 0, 0);
+            }
+
+            return dscolor;
+        }
+    }
+}

--- a/src/Libraries/CoreNodeModelsWpf/CoreNodeModelsWpf.csproj
+++ b/src/Libraries/CoreNodeModelsWpf/CoreNodeModelsWpf.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Controls\DynamoSlider.xaml.cs">
       <DependentUpon>DynamoSlider.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Converters\MediatoDSColorConverter.cs" />
     <Compile Include="Converters\StringToDateTimeOffsetConverter.cs" />
     <Compile Include="ConverterViewModel.cs" />
     <Compile Include="NodeViewCustomizations\ColorPalette.cs" />

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
@@ -5,7 +5,7 @@ using Dynamo.Wpf;
 
 using CoreNodeModelsWpf.Controls;
 using CoreNodeModels.Input;
-
+using Dynamo.Graph.Workspaces;
 using DSColor = DSCore.Color;
 
 namespace CoreNodeModelsWpf.Nodes
@@ -16,21 +16,9 @@ namespace CoreNodeModelsWpf.Nodes
         ///     WPF Control.
         /// </summary>
         private ColorPaletteUI ColorPaletteUINode;
+        private NodeView viewNode;
         private ColorPalette colorPaletteNode;
-        private Color mcolor;
-        /// <summary>
-        /// Selected Color
-        /// </summary>
-        public Color MColor
-        {
-            get { return mcolor; }
-            set
-            {                
-                mcolor = value;              
-                colorPaletteNode.dsColor = DSColor.ByARGB(mcolor.A, mcolor.R, mcolor.G, mcolor.B);
-                RaisePropertyChanged("MColor");
-            }
-        }
+        private Color color;
         /// <summary>
         ///     Customize View.
         /// </summary>
@@ -38,11 +26,22 @@ namespace CoreNodeModelsWpf.Nodes
         /// <param name="nodeView"></param>
         public void CustomizeView(ColorPalette model, NodeView nodeView)
         {
+            viewNode = nodeView;
             colorPaletteNode = model;
-            mcolor = Color.FromArgb(model.dsColor.Alpha, model.dsColor.Red, model.dsColor.Green, model.dsColor.Blue);
+            model.PropertyChanged += Model_PropertyChanged;
+            var undoRecorder = viewNode.ViewModel.WorkspaceViewModel.Model.UndoRecorder;
+            WorkspaceModel.RecordModelForModification(colorPaletteNode, undoRecorder);
             ColorPaletteUINode = new ColorPaletteUI();
             nodeView.inputGrid.Children.Add(ColorPaletteUINode);
-            ColorPaletteUINode.DataContext = this;
+            ColorPaletteUINode.DataContext = model;
+        }
+        private void Model_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "Update")
+            {
+                var undoRecorder = viewNode.ViewModel.WorkspaceViewModel.Model.UndoRecorder;
+                WorkspaceModel.RecordModelForModification(colorPaletteNode, undoRecorder);
+            }
         }
         /// <summary>
         ///     Dispose.

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
@@ -68,11 +68,19 @@ namespace CoreNodeModelsWpf.Nodes
 
         private void ColorPickerControl_Closed(object sender, System.Windows.RoutedEventArgs e)
         {
-            //we need to record a version of the colorPaleteNode set to the previous color.
-            var undoRecorder = viewNode.ViewModel.WorkspaceViewModel.Model.UndoRecorder;
-            WorkspaceModel.RecordModelForModification(colorPaletteNode, undoRecorder);
-            //now that we have recorded the old state, set the color on the model.
-            colorPaletteNode.DsColor = converter.ConvertBack(ColorPaletteUINode.xceedColorPickerControl.SelectedColor, null, null, null) as DSColor;
+            //if the model color is the same as the selected color when the color control is closed
+            //we should not record the model for undo again, it's already there.
+            var convertedModelColor = ((Color)(converter.Convert(colorPaletteNode.DsColor, null, null, null)));
+            var isSameColor = convertedModelColor
+                 .Equals(ColorPaletteUINode.xceedColorPickerControl.SelectedColor);
+            if (!isSameColor)
+            {
+                //we need to record the colorPicker node before the model is updated.
+                var undoRecorder = viewNode.ViewModel.WorkspaceViewModel.Model.UndoRecorder;
+                WorkspaceModel.RecordModelForModification(colorPaletteNode, undoRecorder);
+                //now that we have recorded the old state, set the color on the model.
+                colorPaletteNode.DsColor = converter.ConvertBack(ColorPaletteUINode.xceedColorPickerControl.SelectedColor, null, null, null) as DSColor;
+            }
         }
 
         /// <summary>

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Media;
+﻿using System.ComponentModel;
+using System.Windows.Media;
 using Dynamo.Controls;
 using Dynamo.Core;
 using Dynamo.Wpf;
@@ -29,23 +30,26 @@ namespace CoreNodeModelsWpf.Nodes
             viewNode = nodeView;
             colorPaletteNode = model;
             model.PropertyChanged += Model_PropertyChanged;
-            var undoRecorder = viewNode.ViewModel.WorkspaceViewModel.Model.UndoRecorder;
-            WorkspaceModel.RecordModelForModification(colorPaletteNode, undoRecorder);
             ColorPaletteUINode = new ColorPaletteUI();
             nodeView.inputGrid.Children.Add(ColorPaletteUINode);
             ColorPaletteUINode.DataContext = model;
         }
-        private void Model_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void Model_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
+            var undoRecorder = viewNode.ViewModel.WorkspaceViewModel.Model.UndoRecorder;
+
             if (e.PropertyName == "Update")
-            {
-                var undoRecorder = viewNode.ViewModel.WorkspaceViewModel.Model.UndoRecorder;
+            {              
                 WorkspaceModel.RecordModelForModification(colorPaletteNode, undoRecorder);
             }
         }
+
         /// <summary>
         ///     Dispose.
         /// </summary>
-        public void Dispose() { }
+        public void Dispose()
+        {
+            colorPaletteNode.PropertyChanged -= Model_PropertyChanged;
+        }
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
@@ -33,6 +33,11 @@ namespace CoreNodeModelsWpf.Nodes
             ColorPaletteUINode = new ColorPaletteUI();
             nodeView.inputGrid.Children.Add(ColorPaletteUINode);
             ColorPaletteUINode.DataContext = model;
+
+            var undoRecorder = viewNode.ViewModel.WorkspaceViewModel.Model.UndoRecorder;
+            WorkspaceModel.RecordModelForModification(colorPaletteNode, undoRecorder);
+            
+
         }
         private void Model_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {

--- a/test/DynamoCoreWpfTests/ColorPaletteTests.cs
+++ b/test/DynamoCoreWpfTests/ColorPaletteTests.cs
@@ -29,7 +29,7 @@ namespace DynamoCoreWpfTests
             Model.AddNodeToCurrentWorkspace(colorPalette, true);
             homespace.Run();           
             Assert.DoesNotThrow(DispatcherUtil.DoEvents);
-            Assert.AreEqual(colorPalette.dsColor, DSColor.ByARGB(255,0,0,0));
+            Assert.AreEqual(colorPalette.DsColor, DSColor.ByARGB(255,0,0,0));
             Assert.Pass();
         }
     }

--- a/test/DynamoCoreWpfTests/ColorPaletteTests.cs
+++ b/test/DynamoCoreWpfTests/ColorPaletteTests.cs
@@ -14,6 +14,7 @@ using ProtoCore.AST.AssociativeAST;
 using CoreNodeModels.Properties;
 
 using DSColor = DSCore.Color;
+using System.Collections.Generic;
 
 namespace DynamoCoreWpfTests
 {
@@ -31,6 +32,23 @@ namespace DynamoCoreWpfTests
             Assert.DoesNotThrow(DispatcherUtil.DoEvents);
             Assert.AreEqual(colorPalette.DsColor, DSColor.ByARGB(255,0,0,0));
             Assert.Pass();
+        }
+        [Test]
+        public void ColorPalette_Undo()
+        {
+            var homespace = Model.CurrentWorkspace as HomeWorkspaceModel;
+            Assert.NotNull(homespace, "The current workspace is not a HomeWorkspaceModel");
+            var colorPalette = new ColorPalette();
+            Model.AddNodeToCurrentWorkspace(colorPalette, true);
+            homespace.Run();
+            Assert.DoesNotThrow(DispatcherUtil.DoEvents);
+            Assert.AreEqual(DSColor.ByARGB(255, 0, 0, 0),colorPalette.DsColor);
+            homespace.UpdateModelValue(new List<System.Guid>() { colorPalette.GUID }, "DsColor", DSColor.ByARGB(255, 255, 255, 255).ToString());
+            Assert.AreEqual(DSColor.ByARGB(255, 255, 255, 255), colorPalette.DsColor);
+            homespace.Undo();
+            Assert.AreEqual(DSColor.ByARGB(255, 0, 0, 0), colorPalette.DsColor);
+            homespace.Redo();
+            Assert.AreEqual(DSColor.ByARGB(255, 255, 255, 255), colorPalette.DsColor);
         }
     }
 }

--- a/test/DynamoCoreWpfTests/ColorPaletteTests.cs
+++ b/test/DynamoCoreWpfTests/ColorPaletteTests.cs
@@ -50,5 +50,33 @@ namespace DynamoCoreWpfTests
             homespace.Redo();
             Assert.AreEqual(DSColor.ByARGB(255, 255, 255, 255), colorPalette.DsColor);
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Test]
+        public void ColorPalette_CreatesCorrectUndoStackForComplexState()
+        {
+            var homespace = Model.CurrentWorkspace as HomeWorkspaceModel;
+            Assert.NotNull(homespace, "The current workspace is not a HomeWorkspaceModel");
+            var colorPalette = new ColorPalette();
+            Model.AddNodeToCurrentWorkspace(colorPalette, true);
+            homespace.Run();
+            Assert.DoesNotThrow(DispatcherUtil.DoEvents);
+            Assert.AreEqual(DSColor.ByARGB(255, 0, 0, 0), colorPalette.DsColor);
+            homespace.UpdateModelValue(new List<System.Guid>() { colorPalette.GUID }, "DsColor", DSColor.ByARGB(255, 255, 0, 0).ToString());
+            homespace.UpdateModelValue(new List<System.Guid>() { colorPalette.GUID }, "DsColor", DSColor.ByARGB(255, 0, 0, 255).ToString());
+            homespace.UpdateModelValue(new List<System.Guid>() { colorPalette.GUID }, "DsColor", DSColor.ByARGB(255, 255, 0, 0).ToString());
+
+            //now undo a few times and assert the color is red.
+            homespace.Undo();
+            Assert.AreEqual(DSColor.ByARGB(255, 0, 0, 255), colorPalette.DsColor);
+            homespace.Undo();
+            Assert.AreEqual(DSColor.ByARGB(255, 255, 0, 0), colorPalette.DsColor);
+            Assert.IsTrue(homespace.UndoRecorder.CanUndo);
+            homespace.Undo();
+            Assert.AreEqual(DSColor.ByARGB(255, 0, 0, 0), colorPalette.DsColor);
+
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This PR enables undo/redo for the color picker - it finishes up changes initiated in this PR:
https://github.com/DynamoDS/Dynamo/pull/7769

Because the xceed color picker provides no event **before** the color changes we use the property change event on the model to record the state of the model for undo, and save the state before we set the field to the new value.

As a consequence of this the undo action actually can set values into the undo redo stack... not good! So to avoid that another property *Update* is used to define when a redo/ undo should be recorded - An undo state should only be recorded when the new value is not equal to the current value or previous value - otherwise we are in an undo or redo.

There is also a test added - to facilitate this test I implemented *UpdateValueCore* for the color picker node.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@kronz @Gytaco