### PR TITLE
Update LayoutSpecs and LoadedTypes to include Directory and Data nodes

### DIFF
--- a/src/LibraryViewExtension/web/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/layoutSpecs.json
@@ -929,7 +929,7 @@
               "path": "Core.File.File.FromPath"
             },
             {
-              "path": "Core.File.Directory.FromPath"
+              "path": "Core.File.DirectoryFromPath"
             },
             {
               "path": "DSCore.IO.File.CombinePath"
@@ -968,19 +968,19 @@
               "path": "DSCore.IO.File.WriteText"
             },
             {
-              "path": "DSCore.IO.Directory.Move"
+              "path": "DSCore.IO.File.MoveDirectory"
             },
             {
-              "path": "DSCore.IO.Directory.Copy"
+              "path": "DSCore.IO.File.CopyDirectory"
             },
             {
-              "path": "DSCore.IO.Directory.Delete"
+              "path": "DSCore.IO.File.DeleteDirectory"
             },
             {
-              "path": "DSCore.IO.Directory.Contents"
+              "path": "DSCore.IO.File.GetDirectoryContents"
             },
             {
-              "path": "DSCore.IO.Directory.Exists"
+              "path": "DSCore.IO.File.DirectoryExists"
             }
           ],
           "childElements": []
@@ -1017,16 +1017,16 @@
           "elementType": "group",
           "include": [
             {
-              "path": "DSOffice.Excel.ReadFromFile"
+              "path": "DSOffice.Data.ImportExcel"
             },
             {
-              "path": "DSOffice.Excel.WriteToFile"
+              "path": "DSOffice.Data.ExportExcel"
             },
             {
-              "path": "DSCore.IO.CSV.WriteToFile"
+              "path": "DSOffice.Data.ImportCSV"
             },
             {
-              "path": "DSCore.IO.CSV.ReadFromFile"
+              "path": "DSOffice.Data.ExportCSV"
             }
           ],
           "childElements": []

--- a/src/LibraryViewExtension/web/loadedTypes.json
+++ b/src/LibraryViewExtension/web/loadedTypes.json
@@ -205,9 +205,9 @@
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "Core.File.Directory.FromPath",
+      "fullyQualifiedName": "Core.File.DirectoryFromPath",
       "iconUrl": "http://54.169.171.233:3456/src/resources/icons/CoreNodeModels.Input.DirectoryObject.png",
-      "contextData": "Directory.FromPath",
+      "contextData": "DirectoryFromPath",
       "itemType": "action"
     },
     {
@@ -412,18 +412,6 @@
       "fullyQualifiedName": "MapTo",
       "iconUrl": "http://54.169.171.233:3456/src/resources/icons/MapTo.png",
       "contextData": "MapTo@double,double,double,double,double",
-      "itemType": "action"
-    },
-    {
-      "fullyQualifiedName": "ImportFromCSV",
-      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/ImportFromCSV.string.png",
-      "contextData": "ImportFromCSV@string",
-      "itemType": "action"
-    },
-    {
-      "fullyQualifiedName": "ImportFromCSV",
-      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/ImportFromCSV.string-bool.png",
-      "contextData": "ImportFromCSV@string,bool",
       "itemType": "action"
     },
     {
@@ -4243,33 +4231,33 @@
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "DSCore.IO.Directory.Move",
-      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.Directory.Move.png",
-      "contextData": "DSCore.IO.Directory.Move@string,string,bool",
+      "fullyQualifiedName": "DSCore.IO.File.MoveDirectory",
+      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.File.MoveDirectory.png",
+      "contextData": "DSCore.IO.File.MoveDirectory@string,string,bool",
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "DSCore.IO.Directory.Copy",
-      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.Directory.Copy.png",
-      "contextData": "DSCore.IO.Directory.Copy@var,string,bool",
+      "fullyQualifiedName": "DSCore.IO.File.CopyDirectory",
+      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.File.CopyDirectory.png",
+      "contextData": "DSCore.IO.File.CopyDirectory@var,string,bool",
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "DSCore.IO.Directory.Delete",
-      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.Directory.Delete.png",
-      "contextData": "DSCore.IO.Directory.Delete@string,bool",
+      "fullyQualifiedName": "DSCore.IO.File.DeleteDirectory",
+      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.File.DeleteDirectory.png",
+      "contextData": "DSCore.IO.File.DeleteDirectory@string,bool",
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "DSCore.IO.Directory.Contents",
-      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.Directory.Contents.png",
-      "contextData": "DSCore.IO.Directory.Contents@var,string",
+      "fullyQualifiedName": "DSCore.IO.File.GetDirectoryContents",
+      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.File.GetDirectoryContents.png",
+      "contextData": "DSCore.IO.File.GetDirectoryContents@var,string",
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "DSCore.IO.Directory.Exists",
-      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.Directory.Exists.png",
-      "contextData": "DSCore.IO.Directory.Exists@string",
+      "fullyQualifiedName": "DSCore.IO.File.DirectoryExists",
+      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.File.DirectoryExists.png",
+      "contextData": "DSCore.IO.File.DirectoryExists@string",
       "itemType": "action"
     },
     {
@@ -4309,27 +4297,27 @@
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "DSCore.IO.CSV.WriteToFile",
-      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.CSV.WriteToFile.png",
-      "contextData": "DSCore.IO.CSV.WriteToFile@string,var[][]",
+      "fullyQualifiedName": "DSOffice.Data.ExportCSV",
+      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSOffice.Data.ExportCSV.png",
+      "contextData": "DSOffice.Data.ExportCSV@string,var[][]",
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "DSCore.IO.CSV.ReadFromFile",
-      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSCore.IO.CSV.ReadFromFile.png",
-      "contextData": "DSCore.IO.CSV.ReadFromFile@var",
+      "fullyQualifiedName": "DSOffice.Data.ImportCSV",
+      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSOffice.Data.ImportCSV.png",
+      "contextData": "DSOffice.Data.ImportCSV@var",
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "DSOffice.Excel.ReadFromFile",
-      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSOffice.Excel.ReadFromFile.png",
-      "contextData": "DSOffice.Excel.ReadFromFile@var,string,bool",
+      "fullyQualifiedName": "DSOffice.Data.ImportExcel",
+      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSOffice.Data.ImportExcel.png",
+      "contextData": "DSOffice.Data.ImportExcel@var,string,bool",
       "itemType": "action"
     },
     {
-      "fullyQualifiedName": "DSOffice.Excel.WriteToFile",
-      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSOffice.Excel.WriteToFile.png",
-      "contextData": "DSOffice.Excel.WriteToFile@string,string,int,int,var[][],bool",
+      "fullyQualifiedName": "DSOffice.Data.ExportExcel",
+      "iconUrl": "http://54.169.171.233:3456/src/resources/icons/DSOffice.Data.ExportExcel.png",
+      "contextData": "DSOffice.Data.ExportExcel@string,string,int,int,var[][],bool",
       "itemType": "action"
     },
     {


### PR DESCRIPTION
### Purpose

[DYN-717](https://jira.autodesk.com/browse/DYN-717) [DYN-718](https://jira.autodesk.com/browse/DYN-718)
Include the recategorized nodes from #7761 and #7809 in the library web UI.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@Randy-Ma 

### FYIs
@monikaprabhu 
