### PR TITLE
Recategorize two GeometryColor nodes

### DIFF
--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -1331,15 +1331,15 @@
               ],
               "childElements": [
                 {
-                  "text": "Display",
+                  "text": "Geometry Color",
                   "iconUrl": "",
                   "elementType": "group",
                   "include": [
                     {
-                      "path": "Display.Display.ByGeometryColor"
+                      "path": "Modifiers.GeometryColor.ByGeometryColor"
                     },
                     {
-                      "path": "Display.Display.BySurfaceColors"
+                      "path": "Modifiers.GeometryColor.BySurfaceColors"
                     }
                   ],
                   "childElements": [ ]


### PR DESCRIPTION
### Purpose

This is to recategorize the two nodes: 
- ByGeometryColor
- BySurfaceColors
They will be put in "Geometry"->"Modifiers"->"Geometry Color".

![image](https://cloud.githubusercontent.com/assets/5584246/25517956/4bd84e22-2c24-11e7-8c8e-72cc9fec232c.png)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@sharadkjaiswal 

### FYIs

@Benglin @riteshchandawar
