### PR TITLE
Add ImportExport.CAD nodes under library

### DIFF
--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -1020,16 +1020,16 @@
               "elementType": "group",
               "include": [
                 {
-                  "path": "DSOffice.Excel.ReadFromFile"
+                  "path": "DSOffice.Data.ImportExcel"
                 },
                 {
-                  "path": "DSOffice.Excel.WriteToFile"
+                  "path": "DSOffice.Data.ExportExcel"
                 },
                 {
-                  "path": "DSCore.IO.CSV.WriteToFile"
+                  "path": "DSOffice.Data.ImportCSV"
                 },
                 {
-                  "path": "DSCore.IO.CSV.ReadFromFile"
+                  "path": "DSOffice.Data.ExportCSV"
                 }
               ],
               "childElements": [ ]

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -903,6 +903,29 @@
               "elementType": "group",
               "include": [
                 {
+                  "path": "Dynamo.Translation.CAD.Import"
+                },
+                {
+                  "path": "Dynamo.Translation.CAD.Export"
+                },
+                {
+                  "path": "Dynamo.Translation.CAD.ConvertToGeometries"
+                },
+                {
+                  "path": "Dynamo.Translation.Models.Filter CAD Objects"
+                },
+                {
+                  "path": "Dynamo.Translation.Models.Select CAD Objects"
+                }
+              ],
+              "childElements": [ ]
+            },
+            {
+              "text": "File",
+              "iconUrl": "",
+              "elementType": "group",
+              "include": [
+                {
                   "path": "Core.Input.File Path"
                 },
                 {


### PR DESCRIPTION
### Purpose

*Reference: [DYN-716](https://jira.autodesk.com/browse/DYN-716) Consolidate all translation (ATF) nodes under Import/Export Category.*

### Reviewers

@sharadkjaiswal 