### PR TITLE
Force exit when failing to create NuGet packages

### DIFF
--- a/tools/NuGet/BuildPackages.bat
+++ b/tools/NuGet/BuildPackages.bat
@@ -23,7 +23,7 @@ setlocal DisableDelayedExpansion
 set version=%Major%.%Minor%.%Build%-beta%Revision%
 
 :: Clean files generated from the previous run
-del *.nupkg
+if exist *.nupkg ( del *.nupkg )
 if exist nuspec ( rmdir /s /q nuspec )
 mkdir nuspec
 
@@ -40,7 +40,9 @@ for %%f in (%1\*.nuspec) do (
 )
 
 :: Pack .nupkg files based on each .nuspec in the "nuspec" folder
-@echo on
 for %%f in (nuspec\*.nuspec) do (
   nuget pack %%f -basepath %harvestPath%
+  if not exist %%~nf.%version%.nupkg (
+    exit /b 1
+  )
 )


### PR DESCRIPTION
### Purpose

When the command `nuget pack` fails to create nupkg files from nuspec files, the build should fail. This step will only be done if "Upload Nuget Packages" is checked when triggering the build.

This PR should prevent the following successful build to happen, there were 6 nuspec files but only 5 nupkg files were created:

```
Could Not Find E:\Dynamo\tools\NuGet\*.nupkg

Attempting to build package from 'DynamoVisualProgramming.Core.nuspec'.
Successfully created package 'E:\Dynamo\tools\NuGet\DynamoVisualProgramming.Core.1.3.0.nupkg'.
Attempting to build package from 'DynamoVisualProgramming.DynamoCoreNodes.nuspec'.
File not found: 'Display.xml'.
Attempting to build package from 'DynamoVisualProgramming.DynamoServices.nuspec'.
Successfully created package 'E:\Dynamo\tools\NuGet\DynamoVisualProgramming.DynamoServices.1.3.0.nupkg'.
Attempting to build package from 'DynamoVisualProgramming.Tests.nuspec'.
Successfully created package 'E:\Dynamo\tools\NuGet\DynamoVisualProgramming.Tests.1.3.0.nupkg'.
Attempting to build package from 'DynamoVisualProgramming.WpfUILibrary.nuspec'.
Successfully created package 'E:\Dynamo\tools\NuGet\DynamoVisualProgramming.WpfUILibrary.1.3.0.nupkg'.
Attempting to build package from 'DynamoVisualProgramming.ZeroTouchLibrary.nuspec'.
Successfully created package 'E:\Dynamo\tools\NuGet\DynamoVisualProgramming.ZeroTouchLibrary.1.3.0.nupkg'.

Pushing DynamoVisualProgramming.Core 1.3.0 to the NuGet gallery (https://www.nuget.org)...
Your package was pushed.
Pushing DynamoVisualProgramming.DynamoServices 1.3.0 to the NuGet gallery (https://www.nuget.org)...
Your package was pushed.
Pushing DynamoVisualProgramming.Tests 1.3.0 to the NuGet gallery (https://www.nuget.org)...
Your package was pushed.
Pushing DynamoVisualProgramming.WpfUILibrary 1.3.0 to the NuGet gallery (https://www.nuget.org)...
Your package was pushed.
Pushing DynamoVisualProgramming.ZeroTouchLibrary 1.3.0 to the NuGet gallery (https://www.nuget.org)...
Your package was pushed.
```
This log file was taken and modified from [here](https://ecwest.autodesk.com/commander/link/workspaceFile/workspaces/SCL-Workspace?jobStepId=73b8c85f-1b51-11e7-aadf-a0d3c1eff5a4&fileName=Upload+Nuget+Package.73b8c85f-1b51-11e7-aadf-a0d3c1eff5a4.log&jobName=Dynamo_Dynamo_8131239_201704062217&jobId=73982112-1b51-11e7-a451-a0d3c1eff5a4&diagCharEncoding=&resourceName=USECSDWINB05&completed=1).

### Reviewers

@DynamoEngOps 

### FYIs

@aparajit-pratap 