### PR TITLE
Duplicate connectors on ctrl + click on input ports

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -271,12 +271,12 @@ namespace Dynamo.Models
                     EndShiftReconnections(nodeId, command.PortIndex, command.Type);
                     break;
 
-                case MakeConnectionCommand.Mode.BeginCtrlConnection:
-                    BeginCtrlConnection(nodeId, command.PortIndex, command.Type);
+                case MakeConnectionCommand.Mode.BeginDuplicateConnection:
+                    BeginDuplicateConnection(nodeId, command.PortIndex, command.Type);
                     break;
 
-                case MakeConnectionCommand.Mode.EndAndStartCtrlConnection:
-                    EndAndStartCtrlConnection(nodeId, command.PortIndex, command.Type);
+                case MakeConnectionCommand.Mode.BeginCreateConnections:
+                    BeginCreateConnections(nodeId, command.PortIndex, command.Type);
                     break;
 
                 case MakeConnectionCommand.Mode.Cancel:
@@ -319,7 +319,7 @@ namespace Dynamo.Models
             }
         }
 
-        void BeginCtrlConnection(Guid nodeId, int portIndex, PortType portType)
+        void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
         {
             // If the port clicked is an output port, begin connection as per normal
             if (portType == PortType.Output) 
@@ -418,7 +418,7 @@ namespace Dynamo.Models
             return;
         }
 
-        void EndAndStartCtrlConnection(Guid nodeId, int portIndex, PortType portType)
+        void BeginCreateConnections(Guid nodeId, int portIndex, PortType portType)
         {
             if (portType == PortType.Output) return; // Only handle ctrl connections if selected port is an input port
             if (firstStartPort == null || activeStartPorts == null || activeStartPorts.Count() <= 0) return;

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -271,6 +271,10 @@ namespace Dynamo.Models
                     EndShiftReconnections(nodeId, command.PortIndex, command.Type);
                     break;
 
+                case MakeConnectionCommand.Mode.BeginCtrlConnection:
+                    BeginCtrlConnection(nodeId, command.PortIndex, command.Type);
+                    break;
+
                 case MakeConnectionCommand.Mode.EndAndStartCtrlConnection:
                     EndAndStartCtrlConnection(nodeId, command.PortIndex, command.Type);
                     break;
@@ -313,6 +317,32 @@ namespace Dynamo.Models
                 activeStartPorts = new PortModel[] { portModel };
                 firstStartPort = isInPort ? null : portModel; // Only assign firstStartPort if the port selected is an output port
             }
+        }
+
+        void BeginCtrlConnection(Guid nodeId, int portIndex, PortType portType)
+        {
+            // If the port clicked is an output port, begin connection as per normal
+            if (portType == PortType.Output) 
+            {
+                BeginConnection(nodeId, portIndex, portType);
+                return;
+            }
+
+            // Otherwise, if the port is an input port, check if the port already has a connection.
+            // If it does, duplicate the existing connection.
+            var node = CurrentWorkspace.GetModelInternal(nodeId) as NodeModel;
+            if (node == null)
+                return;
+            PortModel portModel = node.InPorts[portIndex];
+            if (portModel.Connectors.Count == 0)
+            {   
+                // If the port doesn't have any existing connections, begin connection as per normal
+                BeginConnection(nodeId, portIndex, portType);
+                return;
+            }
+            // Duplicate the existing connection
+            activeStartPorts = new PortModel[] { portModel.Connectors[0].Start };
+            firstStartPort = portModel.Connectors[0].Start;
         }
 
         void BeginShiftReconnections(Guid nodeId, int portIndex, PortType portType)

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1356,13 +1356,13 @@ namespace Dynamo.Models
                 /// </summary>
                 EndShiftReconnections,
                 /// <summary>
-                /// Begin control connection.
+                /// Begin duplicate connection.
                 /// </summary>
-                BeginCtrlConnection,
+                BeginDuplicateConnection,
                 /// <summary>
-                /// End and start control connections.
+                /// End current connection and create new connections.
                 /// </summary>
-                EndAndStartCtrlConnection,
+                BeginCreateConnections,
                 /// <summary>
                 /// Cancel connection.
                 /// </summary>

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1356,6 +1356,10 @@ namespace Dynamo.Models
                 /// </summary>
                 EndShiftReconnections,
                 /// <summary>
+                /// Begin control connection.
+                /// </summary>
+                BeginCtrlConnection,
+                /// <summary>
                 /// End and start control connections.
                 /// </summary>
                 EndAndStartCtrlConnection,

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -225,13 +225,13 @@ namespace Dynamo.ViewModels
                         nodeId, command.PortIndex, command.Type);
                     break;
 
-                case DynamoModel.MakeConnectionCommand.Mode.BeginCtrlConnection:
+                case DynamoModel.MakeConnectionCommand.Mode.BeginDuplicateConnection:
                     CurrentSpaceViewModel.BeginConnection(
                         nodeId, command.PortIndex, command.Type);
                     break;
 
-                case DynamoModel.MakeConnectionCommand.Mode.EndAndStartCtrlConnection:
-                    CurrentSpaceViewModel.EndAndStartCtrlConnection(
+                case DynamoModel.MakeConnectionCommand.Mode.BeginCreateConnections:
+                    CurrentSpaceViewModel.BeginCreateConnections(
                         nodeId, command.PortIndex, command.Type);
                     break;
 

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -225,6 +225,11 @@ namespace Dynamo.ViewModels
                         nodeId, command.PortIndex, command.Type);
                     break;
 
+                case DynamoModel.MakeConnectionCommand.Mode.BeginCtrlConnection:
+                    CurrentSpaceViewModel.BeginConnection(
+                        nodeId, command.PortIndex, command.Type);
+                    break;
+
                 case DynamoModel.MakeConnectionCommand.Mode.EndAndStartCtrlConnection:
                     CurrentSpaceViewModel.EndAndStartCtrlConnection(
                         nodeId, command.PortIndex, command.Type);

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -212,7 +212,7 @@ namespace Dynamo.ViewModels
             this.SetActiveConnectors(null);
         }
 
-        internal void EndAndStartCtrlConnection(Guid nodeId, int portIndex, PortType portType)
+        internal void BeginCreateConnections(Guid nodeId, int portIndex, PortType portType)
         {
             // Only handle ctrl connections if selected port is an input port
             if (firstStartPort == null || portType == PortType.Output) return; 
@@ -780,7 +780,7 @@ namespace Dynamo.ViewModels
                     else if (Keyboard.Modifiers == ModifierKeys.Control)
                     {
                         // If the control key is held down, check if there is a need to duplicate connections
-                        mode = DynamoModel.MakeConnectionCommand.Mode.BeginCtrlConnection;
+                        mode = DynamoModel.MakeConnectionCommand.Mode.BeginDuplicateConnection;
                     }
 
                     var command = new DynamoModel.MakeConnectionCommand(nodeId, portIndex, portModel.PortType, mode);
@@ -811,7 +811,7 @@ namespace Dynamo.ViewModels
                         }
                         else if (Keyboard.Modifiers == ModifierKeys.Control) // If the control key is held down
                         {
-                            mode = DynamoModel.MakeConnectionCommand.Mode.EndAndStartCtrlConnection;
+                            mode = DynamoModel.MakeConnectionCommand.Mode.BeginCreateConnections;
                             this.currentState = State.Connection; // Start a new connection
                             owningWorkspace.CurrentCursor = CursorLibrary.GetCursor(CursorSet.ArcSelect); // Reassign the cursor
                         }

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -777,6 +777,11 @@ namespace Dynamo.ViewModels
                         multipleConnections = true;
                         mode = DynamoModel.MakeConnectionCommand.Mode.BeginShiftReconnections;
                     }
+                    else if (Keyboard.Modifiers == ModifierKeys.Control)
+                    {
+                        // If the control key is held down, check if there is a need to duplicate connections
+                        mode = DynamoModel.MakeConnectionCommand.Mode.BeginCtrlConnection;
+                    }
 
                     var command = new DynamoModel.MakeConnectionCommand(nodeId, portIndex, portModel.PortType, mode);
                     owningWorkspace.DynamoViewModel.ExecuteCommand(command);


### PR DESCRIPTION
### Purpose

Duplicate connectors when the user does a ctrl + click on input ports.
![duplicatectrl](https://cloud.githubusercontent.com/assets/17231814/25736140/a3335f4e-31a2-11e7-8542-37258097ed21.gif)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@Benglin 
@riteshchandawar 