### PR TITLE
Add parameters for overloads in librarie.js

### DIFF
--- a/src/LibraryViewExtension/Handlers/NodeItemDataProvider.cs
+++ b/src/LibraryViewExtension/Handlers/NodeItemDataProvider.cs
@@ -19,6 +19,7 @@ namespace Dynamo.LibraryUI.Handlers
         public string fullyQualifiedName { get; set; }
         public string iconUrl { get; set; }
         public string contextData { get; set; }
+        public string parameters { get; set; }
         public string itemType { get; set; }
         public string keywords { get; set; }
     }
@@ -63,6 +64,7 @@ namespace Dynamo.LibraryUI.Handlers
                     fullyQualifiedName = GetFullyQualifiedName(e),
                     contextData = e.CreationName,
                     iconUrl = string.Format("{0}{1}.png", IconUrlServiceEndpoint, e.IconName),
+                    parameters = e.Parameters,
                     itemType = e.Group.ToString().ToLower(),
                     keywords = e.SearchKeywords.Any() 
                         ? e.SearchKeywords.Where(s => !string.IsNullOrEmpty(s)).Aggregate((x, y) => string.Format("{0}, {1}", x, y)) 

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -129,9 +129,6 @@
                   "path": "DSCore.List.Flatten"
                 },
                 {
-                  "path": "DSCore.List.Flatten"
-                },
-                {
                   "path": "DSCore.List.Deconstruct"
                 },
                 {


### PR DESCRIPTION
### Purpose

- Add an attribute `parameters` to `loadedTypes` for overloaded methods.
Please refer https://github.com/DynamoDS/librarie.js/pull/44 and [DYN-812](https://jira.autodesk.com/browse/DYN-812).

- Removed a redundant `DSCore.List.Flatten` path in `layoutSpecs`.


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@sharadkjaiswal 

### FYIs

@Benglin 
