### PR TITLE
Fix for DYN-870, removed Keys section from Organize group

### DIFF
--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -213,42 +213,33 @@
                 },
                 {
                   "path": "DSCore.List.SortIndexByValue"
+                },
+				{
+                  "path": "List.GetKeys"
+                },
+                {
+                  "path": "List.GetValues"
+                },
+                {
+                  "path": "List.MaximumItemByKey"
+                },
+                {
+                  "path": "List.MinimumItemByKey"
+                },
+                {
+                  "path": "List.ContainsKey"
+                },
+                {
+                  "path": "List.RemoveKey"
+                },
+                {
+                  "path": "DSCore.List.GroupByKey"
+                },
+                {
+                  "path": "DSCore.List.SortByKey"
                 }
               ],
-              "childElements": [
-                {
-                  "text": "Keys",
-                  "iconUrl": "./dist/v0.0.1/resources/Category.Keys.svg",
-                  "elementType": "category",
-                  "include": [
-                    {
-                      "path": "List.GetKeys"
-                    },
-                    {
-                      "path": "List.GetValues"
-                    },
-                    {
-                      "path": "List.MaximumItemByKey"
-                    },
-                    {
-                      "path": "List.MinimumItemByKey"
-                    },
-                    {
-                      "path": "List.ContainsKey"
-                    },
-                    {
-                      "path": "List.RemoveKey"
-                    },
-                    {
-                      "path": "DSCore.List.GroupByKey"
-                    },
-                    {
-                      "path": "DSCore.List.SortByKey"
-                    }
-                  ],
-                  "childItems": [ ]
-                }
-              ]
+				"childElements": [ ]
             },
             {
               "text": "Generate",


### PR DESCRIPTION
### Purpose

There was extra section "Keys" added under Organize group, we don't need that, so I removed that section and moved all those nodes under Organize group.

https://jira.autodesk.com/browse/DYN-870

Thanks to Sharad for suggesting the change.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@sharadkjaiswal 

### FYIs
@Benglin 

This is how the UI will look like after this change.
![image](https://cloud.githubusercontent.com/assets/5109531/26389755/10cc9c24-408e-11e7-8e47-2f76ea7f9e2f.png)

