### PR TITLE
Disable right-click on LibraryView

### DIFF
--- a/src/LibraryViewExtension/Views/LibraryView.xaml.cs
+++ b/src/LibraryViewExtension/Views/LibraryView.xaml.cs
@@ -30,6 +30,30 @@ namespace Dynamo.LibraryUI.Views
             }
             
             InitializeComponent();
+
+            this.Browser.MenuHandler = new LibraryViewContextMenuHandler();
+        }
+
+        private class LibraryViewContextMenuHandler : IContextMenuHandler
+        {
+            public void OnBeforeContextMenu(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model)
+            {
+                model.Clear();
+            }
+
+            public bool OnContextMenuCommand(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, CefMenuCommand commandId, CefEventFlags eventFlags)
+            {
+                return false;
+            }
+
+            public void OnContextMenuDismissed(IWebBrowser browserControl, IBrowser browser, IFrame frame)
+            {
+            }
+
+            public bool RunContextMenu(IWebBrowser browserControl, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model, IRunContextMenuCallback callback)
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
*[DYN-872](https://jira.autodesk.com/browse/DYN-872) Right click on the Library view should be disabled.*

### Purpose

Right-click should be disabled on Dynamo only, but should still be accessible from a Chrome browser.

### Reviewers

@sharadkjaiswal 

### FYIs

@riteshchandawar 