### PR TITLE
 x,y, and zoom should exist on WorkspaceViewModel

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -35,15 +35,7 @@ namespace Dynamo.Graph.Workspaces
     public abstract class WorkspaceModel : NotificationObject, ILocatable, IUndoRedoRecorderClient, ILogSource, IDisposable, IWorkspaceModel
     {
 
-        /// <summary>
-        /// Represents maximum value of workspace zoom
-        /// </summary>
-        public const double ZOOM_MAXIMUM = 4.0;
-
-        /// <summary>
-        /// Represents minimum value of workspace zoom
-        /// </summary>
-        public const double ZOOM_MINIMUM = 0.01;
+       
 
         #region private/internal members
 
@@ -125,34 +117,6 @@ namespace Dynamo.Graph.Workspaces
             if (RequestNodeCentered != null)
                 RequestNodeCentered(this, e);
         }
-
-
-        /// <summary>
-        ///     Function that can be used to respond to a changed workspace Zoom amount.
-        /// </summary>
-        /// <param name="sender">The object where the event handler is attached.</param>
-        /// <param name="e">The event data.</param>
-        public delegate void ZoomEventHandler(object sender, EventArgs e);
-
-        /// <summary>
-        ///     Event that is fired every time the zoom factor of a workspace changes.
-        /// </summary>
-        public event ZoomEventHandler ZoomChanged;
-
-        /// <summary>
-        /// Used during open and workspace changes to set the zoom of the workspace
-        /// </summary>
-        /// <param name="sender">The object which triggers the event</param>
-        /// <param name="e">The zoom event data.</param>
-        internal virtual void OnZoomChanged(object sender, ZoomEventArgs e)
-        {
-            if (ZoomChanged != null)
-            {
-                //Debug.WriteLine(string.Format("Setting zoom to {0}", e.Zoom));
-                ZoomChanged(this, e);
-            }
-        }
-
         /// <summary>
         ///     Function that can be used to respond to a "point event"
         /// </summary>
@@ -612,19 +576,6 @@ namespace Dynamo.Graph.Workspaces
         }
 
         /// <summary>
-        ///     Get or set the zoom value of the workspace.
-        /// </summary>
-        public double Zoom
-        {
-            get { return zoom; }
-            set
-            {
-                zoom = value;
-                RaisePropertyChanged("Zoom");
-            }
-        }
-
-        /// <summary>
         ///     Returns the height of the workspace's bounds.
         /// </summary>
         public double Height
@@ -766,7 +717,6 @@ namespace Dynamo.Graph.Workspaces
             X = info.X;
             Y = info.Y;
             FileName = info.FileName;
-            Zoom = info.Zoom;
 
             HasUnsavedChanges = false;
             IsReadOnly = DynamoUtilities.PathHelper.IsReadOnlyPath(fileName);
@@ -900,7 +850,6 @@ namespace Dynamo.Graph.Workspaces
 
             X = 0.0;
             Y = 0.0;
-            Zoom = 1.0;
             ScaleFactor = 1.0;
             // Reset the workspace offset
             OnCurrentOffsetChanged(this, new PointEventArgs(new Point2D(X, Y)));
@@ -1829,7 +1778,6 @@ namespace Dynamo.Graph.Workspaces
                 root.SetAttribute("Version", WorkspaceVersion.ToString());
                 root.SetAttribute("X", X.ToString(CultureInfo.InvariantCulture));
                 root.SetAttribute("Y", Y.ToString(CultureInfo.InvariantCulture));
-                root.SetAttribute("zoom", Zoom.ToString(CultureInfo.InvariantCulture));
                 root.SetAttribute("ScaleFactor", ScaleFactor.ToString(CultureInfo.InvariantCulture));
                 root.SetAttribute("Name", Name);
                 root.SetAttribute("Description", Description);

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -553,6 +553,7 @@ namespace Dynamo.Graph.Workspaces
         /// <summary>
         ///     Returns or set the X position of the workspace.
         /// </summary>
+        [Obsolete("This property will be removed from the model, please use the X property on the WorkspaceViewModel in DynamoCoreWpf assembly.")]
         public double X
         {
             get { return x; }
@@ -566,6 +567,7 @@ namespace Dynamo.Graph.Workspaces
         /// <summary>
         ///     Returns or set the Y position of the workspace
         /// </summary>
+        [Obsolete("This property will be removed from the model, please use the Y property on the WorkspaceViewModel in DynamoCoreWpf assembly.")]
         public double Y
         {
             get { return y; }
@@ -579,6 +581,7 @@ namespace Dynamo.Graph.Workspaces
         ///     Get or set the zoom value of the workspace.
         /// </summary>
         [JsonIgnore]
+        [Obsolete("This property will be removed from the model, please use the Zoom property on the WorkspaceViewModel in DynamoCoreWpf assembly.")]
         public double Zoom
         {
             get { return zoom; }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -16,6 +16,7 @@ using Dynamo.Models;
 using Dynamo.Properties;
 using Dynamo.Selection;
 using Dynamo.Utilities;
+using Newtonsoft.Json;
 using ProtoCore.Namespace;
 using System;
 using System.Collections.Generic;
@@ -574,6 +575,19 @@ namespace Dynamo.Graph.Workspaces
                 RaisePropertyChanged("Y");
             }
         }
+        /// <summary>
+        ///     Get or set the zoom value of the workspace.
+        /// </summary>
+        [JsonIgnore]
+        public double Zoom
+        {
+            get { return zoom; }
+            set
+            {
+                zoom = value;
+                RaisePropertyChanged("Zoom");
+            }
+        }
 
         /// <summary>
         ///     Returns the height of the workspace's bounds.
@@ -717,6 +731,8 @@ namespace Dynamo.Graph.Workspaces
             X = info.X;
             Y = info.Y;
             FileName = info.FileName;
+            Zoom = info.Zoom; 
+
 
             HasUnsavedChanges = false;
             IsReadOnly = DynamoUtilities.PathHelper.IsReadOnlyPath(fileName);
@@ -850,6 +866,7 @@ namespace Dynamo.Graph.Workspaces
 
             X = 0.0;
             Y = 0.0;
+            Zoom = 1.0;
             ScaleFactor = 1.0;
             // Reset the workspace offset
             OnCurrentOffsetChanged(this, new PointEventArgs(new Point2D(X, Y)));

--- a/src/DynamoCoreWpf/Controls/InfiniteGridView.xaml.cs
+++ b/src/DynamoCoreWpf/Controls/InfiniteGridView.xaml.cs
@@ -17,6 +17,7 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using Dynamo.Graph;
 using Dynamo.Graph.Workspaces;
+using Dynamo.ViewModels;
 
 namespace Dynamo.Controls
 {
@@ -30,7 +31,7 @@ namespace Dynamo.Controls
         private const double MaxMajorGridSpacing = MinMajorGridSpacing * MinorDivisions;
         private const double ScaleFactor = MaxMajorGridSpacing / MinMajorGridSpacing;
 
-        private WorkspaceModel workspaceModel;
+        private WorkspaceViewModel workspaceViewModel;
         private Pen majorGridPen, minorGridPen;
         private DrawingVisual drawingVisual = new DrawingVisual();
 
@@ -78,18 +79,18 @@ namespace Dynamo.Controls
                     "InfiniteGridView should be a nested element of WorkspaceView");
             }
 
-            workspaceModel = workspaceView.ViewModel.Model;
+            workspaceViewModel = workspaceView.ViewModel;
         }
 
         private void UpdateDrawingVisual()
         {
-            if (workspaceModel == null)
+            if (workspaceViewModel == null)
             {
                 // Indicates that this is a first load, so ws should be initialized first
                 InitializeWorkspaceModel();
             }
-
-            UpdateDrawingVisual(workspaceModel.X, workspaceModel.Y, workspaceModel.Zoom);
+            
+            UpdateDrawingVisual(workspaceViewModel.X, workspaceViewModel.Y, workspaceViewModel.Zoom);
         }
 
         private void UpdateDrawingVisual(double x, double y, double zoom)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1477,7 +1477,7 @@ namespace Dynamo.ViewModels
             {
                 //set the zoom and offsets events
                 CurrentSpace.OnCurrentOffsetChanged(this, new PointEventArgs(new Point2D(CurrentSpace.X, CurrentSpace.Y)));
-                CurrentSpace.OnZoomChanged(this, new ZoomEventArgs(CurrentSpace.Zoom));
+                CurrentSpaceViewModel.OnZoomChanged(this, new ZoomEventArgs(CurrentSpaceViewModel.Zoom));
             }
         }
 
@@ -1722,7 +1722,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         public void GoHomeView(object parameter)
         {
-            model.CurrentWorkspace.Zoom = 1.0;
+            CurrentSpaceViewModel.Zoom = 1.0;
 
             var ws = this.Model.Workspaces.First(x => x == model.CurrentWorkspace);
             ws.OnCurrentOffsetChanged(this, new PointEventArgs(new Point2D(0, 0)));
@@ -2096,10 +2096,10 @@ namespace Dynamo.ViewModels
 
         internal void Pan(object parameter)
         {
-            Debug.WriteLine(string.Format("Offset: {0},{1}, Zoom: {2}", model.CurrentWorkspace.X, model.CurrentWorkspace.Y, model.CurrentWorkspace.Zoom));
+            Debug.WriteLine(string.Format("Offset: {0},{1}, Zoom: {2}", CurrentSpaceViewModel.X, CurrentSpaceViewModel.Y, currentWorkspaceViewModel.Zoom));
             var panType = parameter.ToString();
             double pan = 10;
-            var pt = new Point2D(model.CurrentWorkspace.X, model.CurrentWorkspace.Y);
+            var pt = new Point2D(CurrentSpaceViewModel.X, CurrentSpaceViewModel.Y);
 
             switch (panType)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -49,7 +49,6 @@ namespace Dynamo.ViewModels
 
         public DynamoViewModel DynamoViewModel { get; private set; }
         public readonly WorkspaceModel Model;
-        private double zoom;
 
         private bool _canFindNodesFromElements = false;
 
@@ -281,10 +280,10 @@ namespace Dynamo.ViewModels
         /// </summary>
         public double Zoom
         {
-            get { return zoom; }
+            get { return this.Model.Zoom; }
             set
             {
-                zoom = value;
+                this.Model.Zoom = value;
                 RaisePropertyChanged("Zoom");
             }
         }
@@ -345,7 +344,6 @@ namespace Dynamo.ViewModels
         public WorkspaceViewModel(WorkspaceModel model, DynamoViewModel dynamoViewModel)
         {
             this.DynamoViewModel = dynamoViewModel;
-            this.Zoom = 1.0;
             Model = model;
             stateMachine = new StateMachine(this);
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -33,16 +33,29 @@ namespace Dynamo.ViewModels
 
     public partial class WorkspaceViewModel : ViewModelBase
     {
+        #region constants
+        /// <summary>
+        /// Represents maximum value of workspace zoom
+        /// </summary>
+        public const double ZOOM_MAXIMUM = 4.0;
+
+        /// <summary>
+        /// Represents minimum value of workspace zoom
+        /// </summary>
+        public const double ZOOM_MINIMUM = 0.01;
+        #endregion
+
         #region Properties and Fields
 
         public DynamoViewModel DynamoViewModel { get; private set; }
         public readonly WorkspaceModel Model;
+        private double zoom;
 
         private bool _canFindNodesFromElements = false;
 
-        public event WorkspaceModel.ZoomEventHandler RequestZoomToViewportCenter;
-        public event WorkspaceModel.ZoomEventHandler RequestZoomToViewportPoint;
-        public event WorkspaceModel.ZoomEventHandler RequestZoomToFitView;
+        public event ZoomEventHandler RequestZoomToViewportCenter;
+        public event ZoomEventHandler RequestZoomToViewportPoint;
+        public event ZoomEventHandler RequestZoomToFitView;
 
         public event NodeEventHandler RequestCenterViewOnElement;
 
@@ -56,6 +69,32 @@ namespace Dynamo.ViewModels
         /// ViewModel that is used in InCanvasSearch in context menu and called by Shift+DoubleClick.
         /// </summary>
         public SearchViewModel InCanvasSearchViewModel { get; private set; }
+
+        /// <summary>
+        ///     Function that can be used to respond to a changed workspace Zoom amount.
+        /// </summary>
+        /// <param name="sender">The object where the event handler is attached.</param>
+        /// <param name="e">The event data.</param>
+        public delegate void ZoomEventHandler(object sender, EventArgs e);
+
+        /// <summary>
+        ///     Event that is fired every time the zoom factor of a workspace changes.
+        /// </summary>
+        public event ZoomEventHandler ZoomChanged;
+
+        /// <summary>
+        /// Used during open and workspace changes to set the zoom of the workspace
+        /// </summary>
+        /// <param name="sender">The object which triggers the event</param>
+        /// <param name="e">The zoom event data.</param>
+        internal virtual void OnZoomChanged(object sender, ZoomEventArgs e)
+        {
+            if (ZoomChanged != null)
+            {
+                //Debug.WriteLine(string.Format("Setting zoom to {0}", e.Zoom));
+                ZoomChanged(this, e);
+            }
+        }
 
         /// <summary>
         /// For requesting registered workspace to zoom in center
@@ -177,6 +216,29 @@ namespace Dynamo.ViewModels
                 return Model.Name;
             }
         }
+        /// <summary>
+        ///     Returns or set the X position of the workspace.
+        /// </summary>
+        public double X
+        {
+            get { return Model.X; }
+            set
+            {
+                Model.X = value;
+            }
+        }
+
+        /// <summary>
+        ///     Returns or set the Y position of the workspace
+        /// </summary>
+        public double Y
+        {
+            get { return Model.Y; }
+            set
+            {
+                Model.Y = value;
+            }
+        }
 
         public string FileName
         {
@@ -214,9 +276,17 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        ///     Get or set the zoom value of the workspace.
+        /// </summary>
         public double Zoom
         {
-            get { return Model.Zoom; }
+            get { return zoom; }
+            set
+            {
+                zoom = value;
+                RaisePropertyChanged("Zoom");
+            }
         }
 
         public bool CanZoomIn
@@ -486,7 +556,7 @@ namespace Dynamo.ViewModels
                 case "Y":
                     break;
                 case "Zoom":
-                    this.Model.OnZoomChanged(this, new ZoomEventArgs(Model.Zoom));
+                    this.OnZoomChanged(this, new ZoomEventArgs(this.Zoom));
                     RaisePropertyChanged("Zoom");
                     break;
                 case "IsCurrentSpace":
@@ -906,19 +976,19 @@ namespace Dynamo.ViewModels
 
         private bool CanZoom(double zoom)
         {
-            return (!(zoom < 0) || !(Model.Zoom <= WorkspaceModel.ZOOM_MINIMUM)) && (!(zoom > 0) 
-                || !(Model.Zoom >= WorkspaceModel.ZOOM_MAXIMUM));
+            return (!(zoom < 0) || !(this.Zoom <= WorkspaceViewModel.ZOOM_MINIMUM)) && (!(zoom > 0) 
+                || !(this.Zoom >= WorkspaceViewModel.ZOOM_MAXIMUM));
         }
 
         private void SetZoom(object zoom)
         {
-            Model.Zoom = Convert.ToDouble(zoom);
+            this.Zoom = Convert.ToDouble(zoom);
         }
 
         private static bool CanSetZoom(object zoom)
         {
             double setZoom = Convert.ToDouble(zoom);
-            return setZoom >= WorkspaceModel.ZOOM_MINIMUM && setZoom <= WorkspaceModel.ZOOM_MAXIMUM;
+            return setZoom >= WorkspaceViewModel.ZOOM_MINIMUM && setZoom <= WorkspaceViewModel.ZOOM_MAXIMUM;
         }
 
         private bool _fitViewActualZoomToggle = false;
@@ -1084,8 +1154,8 @@ namespace Dynamo.ViewModels
             RaisePropertyChanged("IsHomeSpace");
 
             // New workspace or swapped workspace to follow it offset and zoom
-            this.Model.OnCurrentOffsetChanged(this, new PointEventArgs(new Point2D(Model.X, Model.Y)));
-            this.Model.OnZoomChanged(this, new ZoomEventArgs(Model.Zoom));
+            this.Model.OnCurrentOffsetChanged(this, new PointEventArgs(new Point2D(this.X, this.Y)));
+            this.OnZoomChanged(this, new ZoomEventArgs(this.Zoom));
         }
 
         private void RefreshViewOnSelectionChange()

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -345,7 +345,7 @@ namespace Dynamo.ViewModels
         public WorkspaceViewModel(WorkspaceModel model, DynamoViewModel dynamoViewModel)
         {
             this.DynamoViewModel = dynamoViewModel;
-
+            this.Zoom = 1.0;
             Model = model;
             stateMachine = new StateMachine(this);
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1215,8 +1215,8 @@ namespace Dynamo.Controls
                 if (workspace_index == -1) return;
 
                 var workspace_vm = dynamoViewModel.Workspaces[workspace_index];
-                workspace_vm.Model.OnCurrentOffsetChanged(this, new PointEventArgs(new Point2D(workspace_vm.Model.X, workspace_vm.Model.Y)));
-                workspace_vm.Model.OnZoomChanged(this, new ZoomEventArgs(workspace_vm.Zoom));
+                workspace_vm.Model.OnCurrentOffsetChanged(this, new PointEventArgs(new Point2D(workspace_vm.X, workspace_vm.Y)));
+                workspace_vm.OnZoomChanged(this, new ZoomEventArgs(workspace_vm.Zoom));
 
                 ToggleWorkspaceTabVisibility(WorkspaceTabs.SelectedIndex);
             }

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml.cs
@@ -320,7 +320,7 @@ namespace Dynamo.Views
                 WorkspaceViewModel oldViewModel = (WorkspaceViewModel)e.OldValue;
 
                 oldViewModel.Model.CurrentOffsetChanged -= vm_CurrentOffsetChanged;
-                oldViewModel.Model.ZoomChanged -= vm_ZoomChanged;
+                oldViewModel.ZoomChanged -= vm_ZoomChanged;
                 oldViewModel.RequestZoomToViewportCenter -= vm_ZoomAtViewportCenter;
                 oldViewModel.RequestZoomToViewportPoint -= vm_ZoomAtViewportPoint;
                 oldViewModel.RequestZoomToFitView -= vm_ZoomToFitView;
@@ -335,7 +335,7 @@ namespace Dynamo.Views
             {
                 // Adding registration of event listener
                 ViewModel.Model.CurrentOffsetChanged += vm_CurrentOffsetChanged;
-                ViewModel.Model.ZoomChanged +=vm_ZoomChanged;
+                ViewModel.ZoomChanged +=vm_ZoomChanged;
                 ViewModel.RequestZoomToViewportCenter += vm_ZoomAtViewportCenter;
                 ViewModel.RequestZoomToViewportPoint += vm_ZoomAtViewportPoint;
                 ViewModel.RequestZoomToFitView += vm_ZoomToFitView;
@@ -491,11 +491,11 @@ namespace Dynamo.Views
             double zoom = AdjustZoomForCurrentZoomAmount((e as ZoomEventArgs).Zoom);
 
             // Limit Zoom
-            double resultZoom = ViewModel.Model.Zoom + zoom;
-            if (resultZoom < WorkspaceModel.ZOOM_MINIMUM)
-                resultZoom = WorkspaceModel.ZOOM_MINIMUM;
-            else if (resultZoom > WorkspaceModel.ZOOM_MAXIMUM)
-                resultZoom = WorkspaceModel.ZOOM_MAXIMUM;
+            double resultZoom = ViewModel.Zoom + zoom;
+            if (resultZoom < WorkspaceViewModel.ZOOM_MINIMUM)
+                resultZoom = WorkspaceViewModel.ZOOM_MINIMUM;
+            else if (resultZoom > WorkspaceViewModel.ZOOM_MAXIMUM)
+                resultZoom = WorkspaceViewModel.ZOOM_MAXIMUM;
 
             // Get Viewpoint Center point
             var centerPoint = new Point2D();
@@ -504,8 +504,8 @@ namespace Dynamo.Views
 
             // Get relative point of ZoomBorder child in relates to viewpoint center point
             var relativePoint = new Point2D();
-            relativePoint.X = (centerPoint.X - ViewModel.Model.X) / ViewModel.Model.Zoom;
-            relativePoint.Y = (centerPoint.Y - ViewModel.Model.Y) / ViewModel.Model.Zoom;
+            relativePoint.X = (centerPoint.X - ViewModel.Model.X) / ViewModel.Zoom;
+            relativePoint.Y = (centerPoint.Y - ViewModel.Model.Y) / ViewModel.Zoom;
 
             ZoomAtViewportPoint(zoom, relativePoint);
         }
@@ -519,7 +519,7 @@ namespace Dynamo.Views
             //var adjustedZoom = (lowerLimit + Math.Pow((ViewModel.Model.Zoom / WorkspaceModel.ZOOM_MAXIMUM), 2) * (upperLimit - lowerLimit)) * zoom;
 
             //linear adjustment
-            var adjustedZoom = (lowerLimit + (ViewModel.Model.Zoom / WorkspaceModel.ZOOM_MAXIMUM) * (upperLimit - lowerLimit)) * zoom;
+            var adjustedZoom = (lowerLimit + (ViewModel.Zoom / WorkspaceViewModel.ZOOM_MAXIMUM) * (upperLimit - lowerLimit)) * zoom;
 
             return adjustedZoom;
         }
@@ -535,20 +535,20 @@ namespace Dynamo.Views
         private void ZoomAtViewportPoint(double zoom, Point2D relative)
         {
             // Limit zoom
-            double resultZoom = ViewModel.Model.Zoom + zoom;
-            if (resultZoom < WorkspaceModel.ZOOM_MINIMUM)
-                resultZoom = WorkspaceModel.ZOOM_MINIMUM;
-            else if (resultZoom > WorkspaceModel.ZOOM_MAXIMUM)
-                resultZoom = WorkspaceModel.ZOOM_MAXIMUM;
+            double resultZoom = ViewModel.Zoom + zoom;
+            if (resultZoom < WorkspaceViewModel.ZOOM_MINIMUM)
+                resultZoom = WorkspaceViewModel.ZOOM_MINIMUM;
+            else if (resultZoom > WorkspaceViewModel.ZOOM_MAXIMUM)
+                resultZoom = WorkspaceViewModel.ZOOM_MAXIMUM;
 
             double absoluteX, absoluteY;
-            absoluteX = relative.X * ViewModel.Model.Zoom + ViewModel.Model.X;
-            absoluteY = relative.Y * ViewModel.Model.Zoom + ViewModel.Model.Y;
+            absoluteX = relative.X * ViewModel.Zoom + ViewModel.Model.X;
+            absoluteY = relative.Y * ViewModel.Zoom + ViewModel.Model.Y;
             var resultOffset = new Point2D();
             resultOffset.X = absoluteX - (relative.X * resultZoom);
             resultOffset.Y = absoluteY - (relative.Y * resultZoom);
 
-            ViewModel.Model.Zoom = resultZoom;
+            ViewModel.Zoom = resultZoom;
             ViewModel.Model.X = resultOffset.X;
             ViewModel.Model.Y = resultOffset.Y;
 
@@ -576,10 +576,10 @@ namespace Dynamo.Views
             }
 
             // Limit Zoom
-            if (scaleRequired > WorkspaceModel.ZOOM_MAXIMUM)
-                scaleRequired = WorkspaceModel.ZOOM_MAXIMUM;
-            else if (scaleRequired < WorkspaceModel.ZOOM_MINIMUM)
-                scaleRequired = WorkspaceModel.ZOOM_MINIMUM;
+            if (scaleRequired > WorkspaceViewModel.ZOOM_MAXIMUM)
+                scaleRequired = WorkspaceViewModel.ZOOM_MAXIMUM;
+            else if (scaleRequired < WorkspaceViewModel.ZOOM_MINIMUM)
+                scaleRequired = WorkspaceViewModel.ZOOM_MINIMUM;
 
             // Center position
             double centerOffsetX = viewportPadding + (fitWidth - (zoomArgs.FocusWidth * scaleRequired)) / 2;
@@ -590,7 +590,7 @@ namespace Dynamo.Views
             resultOffset.Y = -(zoomArgs.Offset.Y * scaleRequired) + centerOffsetY;
 
             // Apply on model
-            ViewModel.Model.Zoom = scaleRequired;
+            ViewModel.Zoom = scaleRequired;
             ViewModel.Model.X = resultOffset.X;
             ViewModel.Model.Y = resultOffset.Y;
 

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -102,24 +102,24 @@ namespace DynamoCoreWpfTests
             double zoom;
             
             // Test Zoom in
-            zoom = workspaceModel.Zoom;
+            zoom = workspaceVM.Zoom;
             if ( ViewModel.ZoomInCommand.CanExecute(null) )
                 ViewModel.ZoomInCommand.Execute(null);
-            Assert.Greater(workspaceModel.Zoom, zoom);
+            Assert.Greater(workspaceVM.Zoom, zoom);
 
             // Test Zoom out
-            zoom = workspaceModel.Zoom;
+            zoom = workspaceVM.Zoom;
             if (ViewModel.ZoomOutCommand.CanExecute(null))
                 ViewModel.ZoomOutCommand.Execute(null);
-            Assert.Greater(zoom, workspaceModel.Zoom);
+            Assert.Greater(zoom, workspaceVM.Zoom);
 
             // Test can set zoom (at random zoom for 10 times)
             int testLoop = 10;
             for (int i = 0; i < testLoop; i++)
             {
                 // Get random number for the zoom
-                double upperBound = WorkspaceModel.ZOOM_MAXIMUM;
-                double lowerBound = WorkspaceModel.ZOOM_MINIMUM;
+                double upperBound = WorkspaceViewModel.ZOOM_MAXIMUM;
+                double lowerBound = WorkspaceViewModel.ZOOM_MINIMUM;
                 Random random = new Random();
                 double randomNumber = random.NextDouble() * (upperBound - lowerBound) + lowerBound;
 
@@ -127,41 +127,41 @@ namespace DynamoCoreWpfTests
                     ViewModel.CurrentSpaceViewModel.SetZoomCommand.Execute(randomNumber);
 
                 // Check Zoom is correct
-                Assert.AreEqual(randomNumber, workspaceModel.Zoom);
+                Assert.AreEqual(randomNumber, workspaceVM.Zoom);
             }
 
             // Border Test for Set Zoom
             // Min zoom
-            zoom = WorkspaceModel.ZOOM_MINIMUM;
+            zoom = WorkspaceViewModel.ZOOM_MINIMUM;
             if (workspaceVM.SetZoomCommand.CanExecute(zoom))
                 workspaceVM.SetZoomCommand.Execute(zoom);
-            Assert.AreEqual(zoom, workspaceModel.Zoom);
+            Assert.AreEqual(zoom, workspaceVM.Zoom);
             // Zoom out over limit (check that it does not zoom out)
             if (ViewModel.ZoomOutCommand.CanExecute(null))
                 ViewModel.ZoomOutCommand.Execute(null);
-            Assert.AreEqual(zoom, workspaceModel.Zoom);
+            Assert.AreEqual(zoom, workspaceVM.Zoom);
             
             // Max zoom
-            zoom = WorkspaceModel.ZOOM_MAXIMUM;
+            zoom = WorkspaceViewModel.ZOOM_MAXIMUM;
             if (workspaceVM.SetZoomCommand.CanExecute(zoom))
                 workspaceVM.SetZoomCommand.Execute(zoom);
-            Assert.AreEqual(zoom, workspaceModel.Zoom);
+            Assert.AreEqual(zoom, workspaceVM.Zoom);
             // Zoom in over limit (check that it does not zoom in)
             if (ViewModel.ZoomInCommand.CanExecute(null))
                 ViewModel.ZoomInCommand.Execute(null);
-            Assert.AreEqual(zoom, workspaceModel.Zoom);
+            Assert.AreEqual(zoom, workspaceVM.Zoom);
 
             // Above Max Limit Test
-            zoom = WorkspaceModel.ZOOM_MAXIMUM + 0.1;
+            zoom = WorkspaceViewModel.ZOOM_MAXIMUM + 0.1;
             if (workspaceVM.SetZoomCommand.CanExecute(zoom))
                 workspaceVM.SetZoomCommand.Execute(zoom);
-            Assert.AreNotEqual(zoom, workspaceModel.Zoom);
+            Assert.AreNotEqual(zoom, workspaceVM.Zoom);
 
             // Below Min Limit Test
-            zoom = WorkspaceModel.ZOOM_MINIMUM - 0.1;
+            zoom = WorkspaceViewModel.ZOOM_MINIMUM - 0.1;
             if (workspaceVM.SetZoomCommand.CanExecute(zoom))
                 workspaceVM.SetZoomCommand.Execute(zoom);
-            Assert.AreNotEqual(zoom, workspaceModel.Zoom);
+            Assert.AreNotEqual(zoom, workspaceVM.Zoom);
 
             // Stress Test
             // Zoom in and out repeatly
@@ -190,12 +190,11 @@ namespace DynamoCoreWpfTests
         [Category("DynamoUI")]
         public void CanPanLeft()
         {
-            WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
             WorkspaceViewModel workspaceVM = ViewModel.CurrentSpaceViewModel;
 
             int numOfPanTested = 100;
-            double posX = workspaceModel.X;
-            double posY = workspaceModel.Y;
+            double posX = workspaceVM.X;
+            double posY = workspaceVM.Y;
 
             // Pan left repeatly
             for (int i = 0; i < numOfPanTested; i++)
@@ -204,20 +203,19 @@ namespace DynamoCoreWpfTests
                     ViewModel.PanCommand.Execute("Left");
             }
 
-            Assert.Greater(workspaceModel.X, posX);
-            Assert.AreEqual(workspaceModel.Y, posY);
+            Assert.Greater(workspaceVM.X, posX);
+            Assert.AreEqual(workspaceVM.Y, posY);
         }
 
         [Test, RequiresSTA]
         [Category("DynamoUI")]
         public void CanPanRight()
         {
-            WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
             WorkspaceViewModel workspaceVM = ViewModel.CurrentSpaceViewModel;
 
             int numOfPanTested = 100;
-            double posX = workspaceModel.X;
-            double posY = workspaceModel.Y;
+            double posX = workspaceVM.X;
+            double posY = workspaceVM.Y;
 
             // Pan left repeatly
             for (int i = 0; i < numOfPanTested; i++)
@@ -226,20 +224,19 @@ namespace DynamoCoreWpfTests
                     ViewModel.PanCommand.Execute("Right");
             }
 
-            Assert.Greater(posX, workspaceModel.X);
-            Assert.AreEqual(workspaceModel.Y, posY);
+            Assert.Greater(posX, workspaceVM.X);
+            Assert.AreEqual(workspaceVM.Y, posY);
         }
 
         [Test, RequiresSTA]
         [Category("DynamoUI")]
         public void CanPanUp()
         {
-            WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
             WorkspaceViewModel workspaceVM = ViewModel.CurrentSpaceViewModel;
 
             int numOfPanTested = 100;
-            double posX = workspaceModel.X;
-            double posY = workspaceModel.Y;
+            double posX = workspaceVM.X;
+            double posY = workspaceVM.Y;
 
             // Pan left repeatly
             for (int i = 0; i < numOfPanTested; i++)
@@ -248,20 +245,19 @@ namespace DynamoCoreWpfTests
                     ViewModel.PanCommand.Execute("Up");
             }
 
-            Assert.AreEqual(posX, workspaceModel.X);
-            Assert.Greater(workspaceModel.Y, posY);
+            Assert.AreEqual(posX, workspaceVM.X);
+            Assert.Greater(workspaceVM.Y, posY);
         }
 
         [Test, RequiresSTA]
         [Category("DynamoUI")]
         public void CanPanDown()
         {
-            WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
             WorkspaceViewModel workspaceVM = ViewModel.CurrentSpaceViewModel;
 
             int numOfPanTested = 100;
-            double posX = workspaceModel.X;
-            double posY = workspaceModel.Y;
+            double posX = workspaceVM.X;
+            double posY = workspaceVM.Y;
 
             // Pan left repeatly
             for (int i = 0; i < numOfPanTested; i++)
@@ -270,8 +266,8 @@ namespace DynamoCoreWpfTests
                     ViewModel.PanCommand.Execute("Down");
             }
 
-            Assert.AreEqual(posX, workspaceModel.X);
-            Assert.Greater(posY, workspaceModel.Y);
+            Assert.AreEqual(posX, workspaceVM.X);
+            Assert.Greater(posY, workspaceVM.Y);
         }
 
         #endregion
@@ -282,32 +278,30 @@ namespace DynamoCoreWpfTests
         [Category("DynamoUI")]
         public void FitViewWithNoNodes()
         {
-            WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
             WorkspaceViewModel workspaceVM = ViewModel.CurrentSpaceViewModel;
 
-            double initZoom = workspaceModel.Zoom;
-            double initX = workspaceModel.X;
-            double initY = workspaceModel.Y;
+            double initZoom = workspaceVM.Zoom;
+            double initX = workspaceVM.X;
+            double initY = workspaceVM.Y;
 
             // Zoom to max zoom value
             workspaceVM.FitViewInternal();
             
             // Check for no changes
-            Assert.AreEqual(workspaceModel.Zoom, initZoom);
-            Assert.AreEqual(workspaceModel.X, initX);
-            Assert.AreEqual(workspaceModel.Y, initY);
+            Assert.AreEqual(workspaceVM.Zoom, initZoom);
+            Assert.AreEqual(workspaceVM.X, initX);
+            Assert.AreEqual(workspaceVM.Y, initY);
         }
 
         [Test, RequiresSTA]
         [Category("DynamoUI")]
         public void CanFitView()
         {
-            WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
             WorkspaceViewModel workspaceVM = ViewModel.CurrentSpaceViewModel;
 
-            double initZoom = workspaceModel.Zoom;
-            double initX = workspaceModel.X;
-            double initY = workspaceModel.Y;
+            double initZoom = workspaceVM.Zoom;
+            double initX = workspaceVM.X;
+            double initY = workspaceVM.Y;
 
             CreateNodeOnCurrentWorkspace();
 
@@ -315,9 +309,9 @@ namespace DynamoCoreWpfTests
             workspaceVM.FitViewInternal();
 
             // Check for no changes
-            Assert.AreNotEqual(workspaceModel.Zoom, initZoom);
-            Assert.AreNotEqual(workspaceModel.X, initX);
-            Assert.AreNotEqual(workspaceModel.Y, initY);
+            Assert.AreNotEqual(workspaceVM.Zoom, initZoom);
+            Assert.AreNotEqual(workspaceVM.X, initX);
+            Assert.AreNotEqual(workspaceVM.Y, initY);
 
             ViewModel.CurrentSpaceViewModel.Model.HasUnsavedChanges = false;
         }
@@ -326,12 +320,11 @@ namespace DynamoCoreWpfTests
         [Category("DynamoUI")]
         public void CanFitViewTwiceForActualZoom()
         {
-            WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
             WorkspaceViewModel workspaceVM = ViewModel.CurrentSpaceViewModel;
 
-            double initZoom = workspaceModel.Zoom;
-            double initX = workspaceModel.X;
-            double initY = workspaceModel.Y;
+            double initZoom = workspaceVM.Zoom;
+            double initX = workspaceVM.X;
+            double initY = workspaceVM.Y;
 
             CreateNodeOnCurrentWorkspace();
 
@@ -339,9 +332,9 @@ namespace DynamoCoreWpfTests
             workspaceVM.FitViewInternal();
 
             // Check for no changes
-            Assert.AreNotEqual(workspaceModel.Zoom, initZoom);
-            Assert.AreNotEqual(workspaceModel.X, initX);
-            Assert.AreNotEqual(workspaceModel.Y, initY);
+            Assert.AreNotEqual(workspaceVM.Zoom, initZoom);
+            Assert.AreNotEqual(workspaceVM.X, initX);
+            Assert.AreNotEqual(workspaceVM.Y, initY);
 
             ViewModel.CurrentSpace.HasUnsavedChanges = false;
         }
@@ -350,12 +343,11 @@ namespace DynamoCoreWpfTests
         [Category("DynamoUI")]
         public void FitViewStressTest()
         {
-            WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
             WorkspaceViewModel workspaceVM = ViewModel.CurrentSpaceViewModel;
             
-            double initZoom = workspaceModel.Zoom;
-            double initX = workspaceModel.X;
-            double initY = workspaceModel.Y;
+            double initZoom = workspaceVM.Zoom;
+            double initX = workspaceVM.X;
+            double initY = workspaceVM.Y;
 
             CreateNodeOnCurrentWorkspace();
 
@@ -375,16 +367,15 @@ namespace DynamoCoreWpfTests
         [Category("DynamoUI")]
         public void CanFitViewResetByZoom()
         {
-            WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
             WorkspaceViewModel workspaceVM = ViewModel.CurrentSpaceViewModel;
 
             CreateNodeOnCurrentWorkspace();
 
             workspaceVM.FitViewInternal();
 
-            double curZoom = workspaceModel.Zoom;
-            double curX = workspaceModel.X;
-            double curY = workspaceModel.Y;
+            double curZoom = workspaceVM.Zoom;
+            double curX = workspaceVM.X;
+            double curY = workspaceVM.Y;
 
             // Do some zoom action before FitView again
             ViewModel.ZoomIn(null);
@@ -392,9 +383,9 @@ namespace DynamoCoreWpfTests
             workspaceVM.FitViewInternal();
 
             // Check actual zoom
-            Assert.AreEqual(workspaceModel.Zoom, curZoom);
-            Assert.AreEqual(workspaceModel.X, curX);
-            Assert.AreEqual(workspaceModel.Y, curY);
+            Assert.AreEqual(workspaceVM.Zoom, curZoom);
+            Assert.AreEqual(workspaceVM.X, curX);
+            Assert.AreEqual(workspaceVM.Y, curY);
 
             ViewModel.CurrentSpace.HasUnsavedChanges = false;
         }
@@ -403,16 +394,15 @@ namespace DynamoCoreWpfTests
         [Category("DynamoUI")]
         public void CanFitViewResetByPan()
         {
-            WorkspaceModel workspaceModel = ViewModel.CurrentSpaceViewModel.Model;
             WorkspaceViewModel workspaceVM = ViewModel.CurrentSpaceViewModel;
 
             CreateNodeOnCurrentWorkspace();
 
             workspaceVM.FitViewInternal();
 
-            double curZoom = workspaceModel.Zoom;
-            double curX = workspaceModel.X;
-            double curY = workspaceModel.Y;
+            double curZoom = workspaceVM.Zoom;
+            double curX = workspaceVM.X;
+            double curY = workspaceVM.Y;
 
             // Do some pan action before FitView again
             ViewModel.Pan("Up" as object);
@@ -420,9 +410,9 @@ namespace DynamoCoreWpfTests
             workspaceVM.FitViewInternal();
 
             // Check actual zoom
-            Assert.AreEqual(workspaceModel.Zoom, curZoom);
-            Assert.AreEqual(workspaceModel.X, curX);
-            Assert.AreEqual(workspaceModel.Y, curY);
+            Assert.AreEqual(workspaceVM.Zoom, curZoom);
+            Assert.AreEqual(workspaceVM.X, curX);
+            Assert.AreEqual(workspaceVM.Y, curY);
 
             ViewModel.CurrentSpace.HasUnsavedChanges = false;
         }

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -45,11 +45,6 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DSCoreNodes, Version=2.0.0.4157, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files\Dynamo\Dynamo Core\1.2\DSCoreNodes.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Greg, Version=1.0.6176.18754, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\src\packages\Greg.1.0.6176.18754\lib\net45\Greg.dll</HintPath>
       <Private>True</Private>
@@ -242,6 +237,10 @@
       <Project>{d8262d40-4880-41e4-91e4-af8f480c8637}</Project>
       <Name>CoreNodeModels</Name>
       <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Libraries\CoreNodes\CoreNodes.csproj">
+      <Project>{87550B2B-6CB8-461E-8965-DFAFE3AAFB5C}</Project>
+      <Name>CoreNodes</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Libraries\DynamoConversions\DynamoConversions.csproj">
       <Project>{C5ADC05B-34E8-47BF-8E78-9C7BF96418C2}</Project>

--- a/test/DynamoCoreWpfTests/GraphLayoutTests.cs
+++ b/test/DynamoCoreWpfTests/GraphLayoutTests.cs
@@ -30,9 +30,9 @@ namespace Dynamo.Tests
         [Test]
         public void GraphLayoutEmpty()
         {
-            var x = ViewModel.CurrentSpace.X;
-            var y = ViewModel.CurrentSpace.Y;
-            var zoom = ViewModel.CurrentSpace.Zoom;
+            var x = ViewModel.CurrentSpaceViewModel.X;
+            var y = ViewModel.CurrentSpaceViewModel.Y;
+            var zoom = ViewModel.CurrentSpaceViewModel.Zoom;
 
             ViewModel.DoGraphAutoLayout(null);
 

--- a/test/DynamoCoreWpfTests/WorkspaceOpeningTests.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceOpeningTests.cs
@@ -23,7 +23,8 @@ namespace Dynamo.Tests
         public void OpeningWorkspaceSetsZoom()
         {
             var ws = OpenWorkspaceFromSampleFile();
-            Assert.AreEqual(ws.Zoom, 1.3, .1);
+            var wvm = ViewModel.CurrentSpaceViewModel;
+            Assert.AreEqual(wvm.Zoom, 1.3, .1);
         }
 
         [Test]
@@ -31,9 +32,10 @@ namespace Dynamo.Tests
         {
             var ws = OpenWorkspaceFromSampleFile();
             ws.Clear();
-            Assert.AreEqual(0, ws.X);
-            Assert.AreEqual(0, ws.Y);
-            Assert.AreEqual(1, ws.Zoom);
+            var wvm = ViewModel.CurrentSpaceViewModel;
+            Assert.AreEqual(0, wvm.X);
+            Assert.AreEqual(0, wvm.Y);
+            Assert.AreEqual(1, wvm.Zoom);
         }
 
         [Test]
@@ -41,7 +43,7 @@ namespace Dynamo.Tests
         public void ManipulatingWorkspaceDoesNotAffectZoom()
         {
             var ws = OpenWorkspaceFromSampleFile();
-
+         
             // Pan 
             ViewModel.PanCommand.Execute("Left");
 
@@ -51,7 +53,8 @@ namespace Dynamo.Tests
             ws.Clear();
 
             ws = OpenWorkspaceFromSampleFile();
-            Assert.AreEqual(ws.Zoom, 1.3, .1);
+            var wvm = ViewModel.CurrentSpaceViewModel;
+            Assert.AreEqual(wvm.Zoom, 1.3, .1);
         }
 
         private WorkspaceModel OpenWorkspaceFromSampleFile()


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/QNTM-755
this PR does the following: 
* ~completely removes zoom from the `workspaceModel`~ and places it on the `workspaceViewModel` redirecting events, methods, and tests to use the viewModel.
* It stops serializing the zoom to xml.

* X and Y properties are added to the `WorkspaceViewModel`. as @ikeough 's changes to modelBase during the initial JSON serialization work default to not serializing the x and y properties on most models, the new properties get and set the value on the ws model that this view model owns.

~We could try completely removing these properties from the model though I am not sure of the value vs time. I have not explored it fully- Thoughts?~



### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps 

### FYIs

@QilongTang @ikeough 