### PR TITLE
Add deps

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -413,10 +413,9 @@ namespace Dynamo.Graph.Workspaces
                 //else the workspace is a customnode - and we can add the dependencies directly
                 else
                 {
-                    foreach (var id in (this as CustomNodeWorkspaceModel).CustomNodeDefinition.DirectDependencies.Select(x => x.FunctionId))
-                    {
-                        dependencies.Add(id);
-                    }
+                    var customNodeDirectDependencies = new HashSet<Guid>((this as CustomNodeWorkspaceModel).
+                        CustomNodeDefinition.DirectDependencies.Select(x => x.FunctionId));
+                    dependencies.UnionWith(customNodeDirectDependencies);
                 }
                 return dependencies;
             }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -407,7 +407,7 @@ namespace Dynamo.Graph.Workspaces
                 {
                     foreach (var node in this.Nodes.OfType<Function>())
                     {
-                        dependencies.Add(node.GUID);
+                        dependencies.Add(node.FunctionUuid);
                     }
                 }
                 //else the workspace is a customnode - and we can add the dependencies directly

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -92,6 +92,7 @@ namespace Dynamo.Graph.Workspaces
         private double scaleFactor = 1.0;
         private bool hasNodeInSyncWithDefinition;
         protected Guid guid;
+        private HashSet<Guid> dependencies = new HashSet<Guid>();
 
         /// <summary>
         /// This is set to true after a workspace is added.
@@ -390,6 +391,34 @@ namespace Dynamo.Graph.Workspaces
             {
                 lastSaved = value;
                 RaisePropertyChanged("LastSaved");
+            }
+        }
+
+        /// <summary>
+        /// gathers the direct workspace dependencies of this workspace.
+        /// </summary>
+        /// <returns> a list of workspace IDs in GUID form</returns>
+        public HashSet<Guid> Dependencies
+        {
+            get {
+                dependencies.Clear();
+                //if the workspace is a main workspace then find all functions and their dependencies
+                if (this is HomeWorkspaceModel)
+                {
+                    foreach (var node in this.Nodes.OfType<Function>())
+                    {
+                        dependencies.Add(node.GUID);
+                    }
+                }
+                //else the workspace is a customnode - and we can add the dependencies directly
+                else
+                {
+                    foreach (var id in (this as CustomNodeWorkspaceModel).CustomNodeDefinition.DirectDependencies.Select(x => x.FunctionId))
+                    {
+                        dependencies.Add(id);
+                    }
+                }
+                return dependencies;
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -415,7 +415,7 @@ namespace Dynamo.Graph.Workspaces
                 {
                     var customNodeDirectDependencies = new HashSet<Guid>((this as CustomNodeWorkspaceModel).
                         CustomNodeDefinition.DirectDependencies.Select(x => x.FunctionId));
-                    dependencies.UnionWith(customNodeDirectDependencies);
+                    dependencies = customNodeDirectDependencies;
                 }
                 return dependencies;
             }

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -67,6 +67,9 @@ namespace Dynamo.Tests
             CurrentDynamoModel.AddNodeToCurrentWorkspace(customNode, false);
             Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Dependencies.ToList().Count());
 
+            //assert that guid we have stored is is the custom nodes functionID
+            Assert.AreEqual(customNode.FunctionUuid, CurrentDynamoModel.CurrentWorkspace.Dependencies.First());
+
         }
 
         [Test]

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -51,6 +51,26 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
+        public void WorkspaceModelHasCorrectDependencies()
+        {   
+            var addNode = new DSFunction(CurrentDynamoModel.LibraryServices.GetFunctionDescriptor("+"));
+            var ws = this.CurrentDynamoModel.CustomNodeManager.CreateCustomNode("someNode", "someCategory", "");
+            var csid =  (ws as CustomNodeWorkspaceModel).CustomNodeId;
+            var customNode = this.CurrentDynamoModel.CustomNodeManager.CreateCustomNodeInstance(csid);
+
+            Assert.AreEqual(0, CurrentDynamoModel.CurrentWorkspace.Dependencies.ToList().Count());
+
+            CurrentDynamoModel.AddNodeToCurrentWorkspace(customNode,false);
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(addNode, false);
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Dependencies.ToList().Count());
+            //assert that we still only record one dep even though custom node is in graph twice.
+            CurrentDynamoModel.AddNodeToCurrentWorkspace(customNode, false);
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Dependencies.ToList().Count());
+
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void CanAddANote()
         {
             // Create some test note data


### PR DESCRIPTION
### Purpose
https://jira.autodesk.com/browse/QNTM-691

This PR adds a dependencies property to the workspace model - this property only includes the direct dependencies of a workspace, not the full dependency tree. Today it stores the functionIDs of the custom nodes used inside the workspace to match this description given by @ikeough `An array of identifiers of graphs that are used as functions in this graph.`

#### but 
I think we could interpret the description to mean the full dependency tree @ikeough - can you clarify your initial thoughts? Open to pros/cons.

I used a hashset to avoid duplicate entries, when this is serialized to json it is converted to an array.

There is also a test added that checks the dependencies value is correct with no custom nodes, one custom node, and a repeated custom node inside a workspace.


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@QilongTang 

### FYIs

@ramramps @ikeough @gregmarr 