### PR TITLE
Rename InputPorts and OutputPorts

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -335,7 +335,7 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         ///     Collection of PortModels representing all Input ports.
         /// </summary>
-        [JsonProperty("InputPorts")]
+        [JsonProperty("Inputs")]
         public ObservableCollection<PortModel> InPorts
         {
             get { return inPorts; }
@@ -349,7 +349,7 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         ///     Collection of PortModels representing all Output ports.
         /// </summary>
-        [JsonProperty("OutputPorts")]
+        [JsonProperty("Outputs")]
         public ObservableCollection<PortModel> OutPorts
         {
             get { return outPorts; }

--- a/src/DynamoCore/Graph/Workspaces/Serialiaztion/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/Serialiaztion/SerializationConverters.cs
@@ -59,8 +59,8 @@ namespace Autodesk.Workspaces
             var displayName = obj["DisplayName"].Value<string>();
 
            
-            var inPorts = obj["InputPorts"].ToArray().Select(t => t.ToObject<PortModel>()).ToArray();
-            var outPorts = obj["OutputPorts"].ToArray().Select(t => t.ToObject<PortModel>()).ToArray();
+            var inPorts = obj["Inputs"].ToArray().Select(t => t.ToObject<PortModel>()).ToArray();
+            var outPorts = obj["Outputs"].ToArray().Select(t => t.ToObject<PortModel>()).ToArray();
 
             var resolver = (IdReferenceResolver)serializer.ReferenceResolver;
 


### PR DESCRIPTION
### Purpose

This PR renames InputPorts to Inputs and OutputPorts to Outputs.
https://jira.autodesk.com/browse/QNTM-698

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
 @QilongTang @mjkkirschner 

 
