### PR TITLE
Implement IServiceManager interface

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -117,6 +117,7 @@ limitations under the License.
     <Compile Include="Configuration\Context.cs" />
     <Compile Include="Core\DynamoMigrator.cs" />
     <Compile Include="Exceptions\LibraryLoadFailedException.cs" />
+    <Compile Include="Extensions\IServiceManager.cs" />
     <Compile Include="Graph\Workspaces\Serialiaztion\SerializationConverters.cs" />
     <Compile Include="Graph\Workspaces\Serialiaztion\Workspaces.cs" />
     <Compile Include="Logging\AnalyticsService.cs" />

--- a/src/DynamoCore/Extensions/IExtensionManager.cs
+++ b/src/DynamoCore/Extensions/IExtensionManager.cs
@@ -9,7 +9,7 @@ namespace Dynamo.Extensions
     /// This class handles registration, lookup, and disposal of extensions.  There should only 
     /// be one of these per application instance.
     /// </summary>
-    public interface IExtensionManager : IDisposable
+    public interface IExtensionManager : IServiceManager, IDisposable
     {
         /// <summary>
         /// Add an extension to the current application session.

--- a/src/DynamoCore/Extensions/IServiceManager.cs
+++ b/src/DynamoCore/Extensions/IServiceManager.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace Dynamo.Extensions
+{
+    /// <summary>
+    /// Defines a mechanism for registering and retrieving a service object; 
+    /// that is, an object that provides custom support to other objects.
+    /// </summary>
+    public interface IServiceManager : IServiceProvider
+    {
+        /// <summary>
+        /// Allows extension applications to register some specific service by its type.
+        /// Only one service of a given type can be registered.
+        /// </summary>
+        /// <typeparam name="T">Type of the service</typeparam>
+        /// <param name="service">The service object to register</param>
+        /// <returns>A key for the registered service if registeration is 
+        /// successful else null.</returns>
+        string RegisterService<T>(T service);
+
+        /// <summary>
+        /// Unregisters a service of given type registered with given key. 
+        /// </summary>
+        /// <typeparam name="T">Type of the service</typeparam>
+        /// <param name="serviceKey">The service key to ensure that only authorized
+        /// client is unregistering this service type.</param>
+        /// <returns></returns>
+        bool UnregisterService<T>(string serviceKey);
+
+        /// <summary>
+        /// Gets the service object of the specified type.
+        /// </summary>
+        /// <typeparam name="T">Type of the service</typeparam>
+        /// <returns>The service object if registered else null</returns>
+        T Service<T>();
+    }
+}

--- a/test/DynamoCoreTests/ExtensionTests.cs
+++ b/test/DynamoCoreTests/ExtensionTests.cs
@@ -6,6 +6,8 @@ using Dynamo.Extensions;
 using System.IO;
 using Dynamo.Models;
 using Moq;
+using Dynamo.Logging;
+using System;
 
 namespace Dynamo.Tests
 {
@@ -144,6 +146,93 @@ namespace Dynamo.Tests
         {
             model.Dispose();
             extMock.Verify(ext => ext.Dispose());
+        }
+
+        [Test]
+        public void RegisterService()
+        {
+            var sm = model.ExtensionManager;
+            var id = sm.RegisterService(executive);
+            Assert.IsNotNull(Guid.Parse(id));
+
+            Assert.Throws<ArgumentNullException>(() => sm.RegisterService<ICommandExecutive>(null));
+
+            //Re-registering a service for the same type fails
+            Assert.IsNull(sm.RegisterService(new Mock<ICommandExecutive>().Object));
+
+            var service = sm.Service<ICommandExecutive>();
+            Assert.AreSame(executive, service);
+
+            var status = sm.UnregisterService<ICommandExecutive>(id);
+            Assert.IsTrue(status);
+
+            var obj = sm.GetService(typeof(ICommandExecutive));
+            Assert.IsNull(obj); //Service is already unregistered
+        }
+
+        [Test]
+        public void RegisterAsBaseClassService()
+        {
+            var sm = model.ExtensionManager;
+            var id = sm.RegisterService<ILogSource>(executive);
+            Assert.IsNotNull(System.Guid.Parse(id));
+
+            //Even though we registered ICommandExecutive as ILogSource service,
+            //we can't get ICommandExecutive service from the service manager. The
+            //service was registered as ILogSource service only.
+            var service = sm.Service<ICommandExecutive>();
+            Assert.IsNull(service);
+
+            var logsource = sm.Service<ILogSource>();
+            Assert.AreSame(executive, logsource);
+
+            var status = sm.UnregisterService<ICommandExecutive>(id);
+            Assert.IsFalse(status); //Couldn't find service of type ICommandExecutive
+
+            var obj = sm.GetService(typeof(ILogSource));
+            Assert.IsNotNull(obj); //service is still there
+
+            status = sm.UnregisterService<ILogSource>(id);
+            Assert.IsTrue(status);
+        }
+
+        [Test]
+        public void RegisterSameObjectAsManyServices()
+        {
+            var sm = model.ExtensionManager;
+            var ls = sm.RegisterService<ILogSource>(executive);
+            Assert.IsNotNull(System.Guid.Parse(ls));
+
+            var ce = sm.RegisterService<ICommandExecutive>(executive);
+            Assert.IsNotNull(System.Guid.Parse(ce));
+
+            Assert.AreNotEqual(ls, ce);
+
+            //Get ICommandExecutive service
+            var service = sm.Service<ICommandExecutive>();
+            Assert.AreSame(executive, service);
+
+            //Get ILogSource service
+            var logsource = sm.Service<ILogSource>();
+            Assert.AreSame(executive, logsource);
+
+            var status = sm.UnregisterService<ICommandExecutive>(ls);
+            Assert.IsFalse(status); //The service key didn't match
+
+            var obj = sm.GetService(typeof(ICommandExecutive));
+            Assert.IsNotNull(obj); //service is still there
+
+            status = sm.UnregisterService<ICommandExecutive>(ce);
+            Assert.IsTrue(status); //The service key as type matched
+
+            obj = sm.GetService(typeof(ICommandExecutive));
+            Assert.IsNull(obj); //service is still there
+
+            status = sm.UnregisterService<ILogSource>(ls);
+            Assert.IsTrue(status);
+
+            logsource = sm.Service<ILogSource>();
+            Assert.IsNull(logsource); //service is unregistered and not available any more
         }
     }
 


### PR DESCRIPTION
### Purpose

This PR provides a mechanism to register and retrieve service objects via IExtensionManager interface to provide some custom functions. Implements a new interface IServiceManager and IExtensionManager inherits this interface.

 ```
/// <summary>
/// Defines a mechanism for registering and retrieving a service object; 
/// that is, an object that provides custom support to other objects.
/// </summary>
public interface IServiceManager : IServiceProvider
{
        /// <summary>
        /// Allows extension applications to register some specific service by its type.
        /// Only one service of a given type can be registered.
        /// </summary>
        /// <typeparam name="T">Type of the service</typeparam>
        /// <param name="service">The service object to register</param>
        /// <returns>A key for the registered service if registeration is 
        /// successful else null.</returns>
        string RegisterService<T>(T service);

        /// <summary>
        /// Unregisters a service of given type registered with given key. 
        /// </summary>
        /// <typeparam name="T">Type of the service</typeparam>
        /// <param name="serviceKey">The service key to ensure that only authorized
        /// client is unregistering this service type.</param>
        /// <returns></returns>
        bool UnregisterService<T>(string serviceKey);

        /// <summary>
        /// Gets the service object of the specified type.
        /// </summary>
        /// <typeparam name="T">Type of the service</typeparam>
        /// <returns>The service object if registered else null</returns>
        T Service<T>();
}
```
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs
@ikeough 
@pboyer 