### PR TITLE
Nickname and PortName should be serialized to Name

### DIFF
--- a/src/DynamoCore/Core/CustomNodeDefinition.cs
+++ b/src/DynamoCore/Core/CustomNodeDefinition.cs
@@ -71,7 +71,7 @@ namespace Dynamo
                                 : topNode.OutPorts
                                     .Select(
                                         (port, i) =>
-                                            new {portIndex = i, node = topNode, name = port.PortName})
+                                            new {portIndex = i, node = topNode, name = port.Name})
                                     .Where(x => !topNode.OutPorts[x.portIndex].IsConnected));
 
                 foreach (var rtnAndIndex in rtnPorts.Select((rtn, i) => new {rtn, idx = i}))

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -973,7 +973,7 @@ namespace Dynamo.Core
                             }
                         }
 
-                        node.SetNamePropertyFromAttribute();
+                        node.SetNameFromNodeNameAttribute();
                         node.Y = inputIndex*(50 + node.Height);
 
                         uniqueInputSenders[key] = node;
@@ -1014,7 +1014,7 @@ namespace Dynamo.Core
 
                             node.Y = i*(50 + node.Height);
 
-                            node.SetNamePropertyFromAttribute();
+                            node.SetNameFromNodeNameAttribute();
 
                             newNodes.Add(node);
                             ConnectorModel.Make(outputSenderNode, node, outputSenderData, 0);
@@ -1053,7 +1053,7 @@ namespace Dynamo.Core
                             X = rightMost + 75 - leftShift
                         };
                         node.Y = i*(50 + node.Height);
-                        node.SetNamePropertyFromAttribute();
+                        node.SetNameFromNodeNameAttribute();
 
                         newNodes.Add(node);
                         ConnectorModel.Make(hanging.node, node, hanging.port, 0);

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -932,7 +932,7 @@ namespace Dynamo.Core
 
                         node = new Symbol
                         {
-                            InputSymbol = inputReceiverNode.InPorts[inputReceiverData].PortName,
+                            InputSymbol = inputReceiverNode.InPorts[inputReceiverData].Name,
                             X = 0
                         };
 
@@ -1008,7 +1008,7 @@ namespace Dynamo.Core
                             //Create Symbol Node
                             var node = new Output
                             {
-                                Symbol = outputSenderNode.OutPorts[outputSenderData].PortName,
+                                Symbol = outputSenderNode.OutPorts[outputSenderData].Name,
                                 X = rightMost + 75 - leftShift
                             };
 
@@ -1049,7 +1049,7 @@ namespace Dynamo.Core
                         //Create Symbol Node
                         var node = new Output
                         {
-                            Symbol = hanging.node.OutPorts[hanging.port].PortName,
+                            Symbol = hanging.node.OutPorts[hanging.port].Name,
                             X = rightMost + 75 - leftShift
                         };
                         node.Y = i*(50 + node.Height);

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -125,15 +125,15 @@ namespace Dynamo.Core
         ///     Creates a new Custom Node Instance.
         /// </summary>
         /// <param name="id">Identifier referring to a custom node definition.</param>
-        /// <param name="nickname">
-        ///     Nickname for the custom node to be instantiated, used for error recovery if
+        /// <param name="name">
+        ///     Name for the custom node to be instantiated, used for error recovery if
         ///     the given id could not be found.
         /// </param>
         /// <param name="isTestMode">
         ///     Flag specifying whether or not this should operate in "test mode".
         /// </param>
         public Function CreateCustomNodeInstance(
-            Guid id, string nickname = null, bool isTestMode = false)
+            Guid id, string name = null, bool isTestMode = false)
         {
             CustomNodeWorkspaceModel workspace;
             CustomNodeDefinition def;
@@ -146,15 +146,15 @@ namespace Dynamo.Core
             }
             else
             {
-                // Couldn't get the workspace with the given ID, try a nickname lookup instead.
-                if (nickname != null && TryGetNodeInfo(nickname, out info))
-                    return CreateCustomNodeInstance(info.FunctionId, nickname, isTestMode);
+                // Couldn't get the workspace with the given ID, try a name lookup instead.
+                if (name != null && TryGetNodeInfo(name, out info))
+                    return CreateCustomNodeInstance(info.FunctionId, name, isTestMode);
                 
                 // Couldn't find the workspace at all, prepare for a late initialization.
                 Log(
                     Properties.Resources.UnableToCreateCustomNodeID + id + "\"",
                     WarningLevel.Moderate);
-                info = new CustomNodeInfo(id, nickname ?? "", "", "", "");
+                info = new CustomNodeInfo(id, name ?? "", "", "", "");
             }
 
             if (def == null)
@@ -166,18 +166,18 @@ namespace Dynamo.Core
             if (loadedWorkspaceModels.TryGetValue(id, out workspace))
                 RegisterCustomNodeInstanceForUpdates(node, workspace);
             else
-                RegisterCustomNodeInstanceForLateInitialization(node, id, nickname, isTestMode);
+                RegisterCustomNodeInstanceForLateInitialization(node, id, name, isTestMode);
 
             return node;
         }
 
-        private void RegisterCustomNodeInstanceForLateInitialization(Function node, Guid id, string nickname, bool isTestMode)
+        private void RegisterCustomNodeInstanceForLateInitialization(Function node, Guid id, string name, bool isTestMode)
         {
             var disposed = false;
             Action<CustomNodeInfo> infoUpdatedHandler = null;
             infoUpdatedHandler = newInfo =>
             {
-                if (newInfo.FunctionId == id || newInfo.Name == nickname)
+                if (newInfo.FunctionId == id || newInfo.Name == name)
                 {
                     CustomNodeWorkspaceModel foundWorkspace;
                     if (TryGetFunctionWorkspace(newInfo.FunctionId, isTestMode, out foundWorkspace))
@@ -208,7 +208,7 @@ namespace Dynamo.Core
             Action infoChangedHandler = () =>
             {
                 var info = workspace.CustomNodeInfo;
-                node.NickName = info.Name;
+                node.Name = info.Name;
                 node.Description = info.Description;
                 node.Category = info.Category;
             };
@@ -973,7 +973,7 @@ namespace Dynamo.Core
                             }
                         }
 
-                        node.SetNickNameFromAttribute();
+                        node.SetNamePropertyFromAttribute();
                         node.Y = inputIndex*(50 + node.Height);
 
                         uniqueInputSenders[key] = node;
@@ -1014,7 +1014,7 @@ namespace Dynamo.Core
 
                             node.Y = i*(50 + node.Height);
 
-                            node.SetNickNameFromAttribute();
+                            node.SetNamePropertyFromAttribute();
 
                             newNodes.Add(node);
                             ConnectorModel.Make(outputSenderNode, node, outputSenderData, 0);
@@ -1053,7 +1053,7 @@ namespace Dynamo.Core
                             X = rightMost + 75 - leftShift
                         };
                         node.Y = i*(50 + node.Height);
-                        node.SetNickNameFromAttribute();
+                        node.SetNamePropertyFromAttribute();
 
                         newNodes.Add(node);
                         ConnectorModel.Make(hanging.node, node, hanging.port, 0);

--- a/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
+++ b/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
@@ -63,7 +63,7 @@ namespace Dynamo.Graph.Connectors
                 return new ConnectorModel(start, end, startIndex, endIndex, guid ?? Guid.NewGuid());
             }
 
-            Debug.WriteLine("Could not create a connector between {0} and {1}.", start.NickName, end.NickName);
+            Debug.WriteLine("Could not create a connector between {0} and {1}.", start.Name, end.Name);
 
             return null;
         }
@@ -77,7 +77,7 @@ namespace Dynamo.Graph.Connectors
         public ConnectorModel(PortModel start, PortModel end, Guid guid)
         {
             Debug.WriteLine("Creating a connector between ports {0}(owner:{1}) and {2}(owner:{3}).", 
-                start.GUID, start.Owner == null?"null":start.Owner.NickName, end.GUID, end.Owner == null?"null":end.Owner.NickName);
+                start.GUID, start.Owner == null?"null":start.Owner.Name, end.GUID, end.Owner == null?"null":end.Owner.Name);
             Start = start;
             Start.Connectors.Add(this);
             Connect(end);
@@ -93,7 +93,7 @@ namespace Dynamo.Graph.Connectors
             PortModel endPort = end.InPorts[endIndex];
 
             Debug.WriteLine("Creating a connector between ports {0}(owner:{1}) and {2}(owner:{3}).",
-                start.GUID, Start.Owner == null ? "null" : Start.Owner.NickName, end.GUID, endPort.Owner == null ? "null" : endPort.Owner.NickName);
+                start.GUID, Start.Owner == null ? "null" : Start.Owner.Name, end.GUID, endPort.Owner == null ? "null" : endPort.Owner.Name);
 
             Start.Connectors.Add(this);
             Connect(endPort);

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -353,7 +353,7 @@ namespace Dynamo.Graph.Nodes
             var inPorts = childNodes.Where(node => node.Name.Equals("PortInfo"));
             foreach (var tuple in inPorts.Zip(InPorts, Tuple.Create))
             {
-                tuple.Item1.SetAttribute("name", tuple.Item2.PortName);
+                tuple.Item1.SetAttribute("name", tuple.Item2.Name);
             }
 
             //write output port line number info

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/CustomNodeController.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/CustomNodeController.cs
@@ -37,7 +37,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
 
                 if(model.InPorts.Count > i)
                 {
-                    model.InPorts[i].PortName = input.Item1;
+                    model.InPorts[i].Name = input.Item1;
                     model.InPorts[i].ToolTip = input.Item2;
                     model.InPorts[i].DefaultValue = input.Item3;
                 }
@@ -74,7 +74,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
 
                     if(model.OutPorts.Count > i)
                     {
-                        model.OutPorts[i].PortName = key;
+                        model.OutPorts[i].Name = key;
                         model.OutPorts[i].ToolTip = tooltip;
                     }
                     else
@@ -198,7 +198,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
 
             if (Definition.DisplayParameters != null)
             {
-                var paramNames = model.InPorts.Select(p => p.PortName);
+                var paramNames = model.InPorts.Select(p => p.Name);
                 if (!Definition.DisplayParameters.SequenceEqual(paramNames))
                     return false;
             }
@@ -213,7 +213,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
 
             if (Definition.ReturnKeys != null)
             {
-                var returnKeys = model.OutPorts.Select(p => p.PortName);
+                var returnKeys = model.OutPorts.Select(p => p.Name);
                 if (!Definition.ReturnKeys.SequenceEqual(returnKeys))
                     return false;
             }

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/CustomNodeController.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/CustomNodeController.cs
@@ -157,13 +157,13 @@ namespace Dynamo.Graph.Nodes.CustomNodes
             if (IsInSyncWithNode(model))
             {
                 Debug.WriteLine("Custom node definition is already in sync for: " + 
-                    model.NickName + 
+                    model.Name + 
                     string.Format(", {0} returns, {1} parameters", Definition.Returns.Count(), Definition.Parameters.Count()));
                 return;
             } 
 
             Debug.WriteLine("Syncing custom node with definition for: " + 
-                model.NickName + 
+                model.Name + 
                 string.Format(", {0} returns, {1} parameters", Definition.Returns.Count(), Definition.Parameters.Count()));
 
             base.SyncNodeWithDefinition(model);
@@ -183,7 +183,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
 
             outEl.SetAttribute("value", Definition.FunctionId.ToString());
             nodeElement.AppendChild(outEl);
-            nodeElement.SetAttribute("nickname", NickName);
+            nodeElement.SetAttribute("nickname", Name);
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -26,11 +26,11 @@ namespace Dynamo.Graph.Nodes.CustomNodes
         : FunctionCallBase<CustomNodeController<CustomNodeDefinition>, CustomNodeDefinition>
     {
         [JsonConstructor]
-        private Function(string nickName, string description, string category)
+        private Function(string name, string description, string category)
             : base(new CustomNodeController<CustomNodeDefinition>(null))
         {
             ArgumentLacing = LacingStrategy.Auto;
-            NickName = nickName;
+            Name = name;
             Description = description;
             Category = category;
         }
@@ -39,16 +39,16 @@ namespace Dynamo.Graph.Nodes.CustomNodes
         /// Initializes a new instance of the <see cref="Function"/> class.
         /// </summary>
         /// <param name="def">CustomNode definition.</param>
-        /// <param name="nickName">Nickname.</param>
+        /// <param name="name">Name.</param>
         /// <param name="description">Description.</param>
         /// <param name="category">Category.</param>
         public Function(
-            CustomNodeDefinition def, string nickName, string description, string category)
+            CustomNodeDefinition def, string name, string description, string category)
             : base(new CustomNodeController<CustomNodeDefinition>(def))
         {
             ValidateDefinition(def);
             ArgumentLacing = LacingStrategy.Auto;
-            NickName = nickName;
+            Name = name;
             Description = description;
             Category = category;
         }
@@ -92,7 +92,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
             var xmlDoc = element.OwnerDocument;
 
             var outEl = xmlDoc.CreateElement("Name");
-            outEl.SetAttribute("value", NickName);
+            outEl.SetAttribute("value", Name);
             element.AppendChild(outEl);
 
             outEl = xmlDoc.CreateElement("Description");
@@ -250,7 +250,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
 
             XmlNode nameNode = childNodes.LastOrDefault(subNode => subNode.Name.Equals("Name"));
             if (nameNode != null && nameNode.Attributes != null)
-                NickName = nameNode.Attributes["value"].Value;
+                Name = nameNode.Attributes["value"].Value;
 
             XmlNode descNode = childNodes.LastOrDefault(subNode => subNode.Name.Equals("Description"));
             if (descNode != null && descNode.Attributes != null)
@@ -297,7 +297,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
     public class Symbol : NodeModel
     {
         private string inputSymbol = String.Empty;
-        private string nickName = String.Empty;
+        private string name = String.Empty;
         private ElementResolver workspaceElementResolver;
 
         /// <summary>
@@ -344,7 +344,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
             set
             {
                 inputSymbol = value;
-                nickName = inputSymbol;
+                name = inputSymbol;
                 ClearRuntimeError();
 
                 var type = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var);
@@ -352,7 +352,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
 
                 string comment = null;
 
-                if (!string.IsNullOrEmpty(nickName))
+                if (!string.IsNullOrEmpty(name))
                 {
                     // three cases:
                     //    x = default_value
@@ -361,7 +361,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
                     IdentifierNode identifierNode;
                     if (TryParseInputExpression(inputSymbol, out identifierNode, out defaultValue, out comment))
                     {
-                        nickName = identifierNode.Value;
+                        name = identifierNode.Value;
 
                         if (identifierNode.datatype.UID == Constants.kInvalidIndex)
                         {
@@ -377,7 +377,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
                     }
                 }
 
-                Parameter = new TypedParameter(nickName, type, defaultValue, null, comment);
+                Parameter = new TypedParameter(name, type, defaultValue, null, comment);
 
                 OnNodeModified();
                 RaisePropertyChanged("InputSymbol");
@@ -401,7 +401,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
         {
             return
                 AstFactory.BuildIdentifier(
-                    string.IsNullOrEmpty(nickName) ? AstIdentifierBase : nickName + "__" + AstIdentifierBase);
+                    string.IsNullOrEmpty(name) ? AstIdentifierBase : name + "__" + AstIdentifierBase);
         }
 
         protected override void SerializeCore(XmlElement nodeElement, SaveContext context)

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -100,7 +100,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
             element.AppendChild(outEl);
 
             outEl = xmlDoc.CreateElement("Inputs");
-            foreach (string input in InPorts.Select(x => x.PortName))
+            foreach (string input in InPorts.Select(x => x.Name))
             {
                 XmlElement inputEl = xmlDoc.CreateElement("Input");
                 inputEl.SetAttribute("value", input);
@@ -109,7 +109,7 @@ namespace Dynamo.Graph.Nodes.CustomNodes
             element.AppendChild(outEl);
 
             outEl = xmlDoc.CreateElement("Outputs");
-            foreach (string output in OutPorts.Select(x => x.PortName))
+            foreach (string output in OutPorts.Select(x => x.Name))
             {
                 XmlElement outputEl = xmlDoc.CreateElement("Output");
                 outputEl.SetAttribute("value", output);

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/ICustomNodeSource.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/ICustomNodeSource.cs
@@ -8,9 +8,9 @@ namespace Dynamo.Graph.Nodes.CustomNodes
         ///     Creates a new Custom Node Instance.
         /// </summary>
         /// <param name="id">Identifier referring to a custom node definition.</param>
-        /// <param name="nickname"></param>
+        /// <param name="name"></param>
         /// <param name="isTestMode"></param>
         Function CreateCustomNodeInstance(
-            Guid id, string nickname = null, bool isTestMode = false);
+            Guid id, string name = null, bool isTestMode = false);
     }
 }

--- a/src/DynamoCore/Graph/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Graph/Nodes/DummyNode.cs
@@ -58,7 +58,7 @@ namespace Dynamo.Graph.Nodes
             OutputCount = outputCount;
             LegacyNodeName = legacyName;
             LegacyFullName = legacyName;
-            NickName = legacyName;
+            Name = legacyName;
             OriginalNodeContent = originalElement;
             LegacyAssembly = legacyAssembly;
             NodeNature = nodeNature;

--- a/src/DynamoCore/Graph/Nodes/FunctionCallBase.cs
+++ b/src/DynamoCore/Graph/Nodes/FunctionCallBase.cs
@@ -33,7 +33,7 @@ namespace Dynamo.Graph.Nodes
         {
             get
             {
-                return this.Controller != null ? this.Controller.Definition.MangledName : this.NameAttribute;
+                return this.Controller != null ? this.Controller.Definition.MangledName : this.Name;
             }
         }
     }

--- a/src/DynamoCore/Graph/Nodes/FunctionCallBase.cs
+++ b/src/DynamoCore/Graph/Nodes/FunctionCallBase.cs
@@ -33,7 +33,7 @@ namespace Dynamo.Graph.Nodes
         {
             get
             {
-                return this.Controller != null ? this.Controller.Definition.MangledName : this.Name;
+                return this.Controller != null ? this.Controller.Definition.MangledName : this.NameAttribute;
             }
         }
     }

--- a/src/DynamoCore/Graph/Nodes/FunctionCallNodeController.cs
+++ b/src/DynamoCore/Graph/Nodes/FunctionCallNodeController.cs
@@ -23,9 +23,9 @@ namespace Dynamo.Graph.Nodes
         public T Definition { get; set; }
 
         /// <summary>
-        ///     NickName for nodes using this controller, based on the underlying FunctionDescriptor.
+        ///     Name for nodes using this controller, based on the underlying FunctionDescriptor.
         /// </summary>
-        public string NickName 
+        public string Name 
         {
             get
             {
@@ -189,7 +189,7 @@ namespace Dynamo.Graph.Nodes
             InitializeInputs(model);
             InitializeOutputs(model);
             model.RegisterAllPorts();
-            model.NickName = NickName;
+            model.Name = Name;
             OnSyncWithDefintionEnd(model);
         }
 

--- a/src/DynamoCore/Graph/Nodes/NodeLoaders/CustomNodeLoader.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeLoaders/CustomNodeLoader.cs
@@ -33,20 +33,20 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
 
             string id = idNode.Attributes[0].Value;
 
-            string nickname = nodeElement.Attributes["nickname"].Value;
+            string name = nodeElement.Attributes["nickname"].Value;
 
             Guid funcId;
             if (!Guid.TryParse(id, out funcId))
-                funcId = GuidUtility.Create(GuidUtility.UrlNamespace, nickname);
+                funcId = GuidUtility.Create(GuidUtility.UrlNamespace, name);
 
-            var node = customNodeManager.CreateCustomNodeInstance(funcId, nickname, isTestMode);
+            var node = customNodeManager.CreateCustomNodeInstance(funcId, name, isTestMode);
             node.Deserialize(nodeElement, context);
             return node;
         }
 
-        public Function CreateProxyNode(Guid funcId, string nickname, Guid nodeId, int inputNum, int outputNum)
+        public Function CreateProxyNode(Guid funcId, string name, Guid nodeId, int inputNum, int outputNum)
         {
-            var node = customNodeManager.CreateCustomNodeInstance(funcId, nickname, isTestMode);
+            var node = customNodeManager.CreateCustomNodeInstance(funcId, name, isTestMode);
             // create its definition and add inputs and outputs
             node.LoadNode(nodeId, inputNum, outputNum);
             return node;

--- a/src/DynamoCore/Graph/Nodes/NodeLoaders/NodeFactory.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeLoaders/NodeFactory.cs
@@ -119,14 +119,14 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
         ///     time by means of user uploading the definition.
         /// </summary>
         /// <param name="id">Identifier of the custom node instance.</param>
-        /// <param name="name">The name represents the GUID of the custom node 
+        /// <param name="functionId">The functionId represents the GUID of the custom node 
         /// definition that is used for creating the custom node instance.</param>
-        /// <param name="nickName">The display name of the custom node.</param>
+        /// <param name="name">The display name of the custom node.</param>
         /// <param name="inputs">Number of input ports.</param>
         /// <param name="outputs">Number of output ports.</param>
         /// <returns>Returns the custom node instance if creation was successful, 
         /// or null otherwise.</returns>
-        internal NodeModel CreateProxyNodeInstance(Guid id, string name, string nickName, int inputs, int outputs)
+        internal NodeModel CreateProxyNodeInstance(Guid id, string functionId, string name, int inputs, int outputs)
         {
             Guid guid;
             INodeLoader<NodeModel> data;
@@ -137,7 +137,7 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
 
 
             // create an instance of Function node 
-            var result = (data as CustomNodeLoader).CreateProxyNode(guid, nickName, id, inputs, outputs);
+            var result = (data as CustomNodeLoader).CreateProxyNode(guid, name, id, inputs, outputs);
             return result;
         }
 

--- a/src/DynamoCore/Graph/Nodes/NodeLoaders/ZeroTouchNodeLoader.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeLoaders/ZeroTouchNodeLoader.cs
@@ -27,7 +27,7 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
         {
             string assembly = "";
             string function;
-            var nickname = nodeElement.Attributes["nickname"].Value;
+            var name = nodeElement.Attributes["nickname"].Value;
 
             FunctionDescriptor descriptor;
 
@@ -36,7 +36,7 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
             if (nodeElement.Attributes["assembly"] == null)
             {
                 assembly = DetermineAssemblyName(nodeElement);
-                function = nickname.Replace(".get", ".");
+                function = name.Replace(".get", ".");
             }
             else
             {
@@ -48,7 +48,7 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
                 if (hintedSigniture != null)
                 {
                     nodeElement.Attributes["nickname"].Value =
-                        libraryServices.NicknameFromFunctionSignatureHint(xmlSignature);
+                        libraryServices.NameFromFunctionSignature(xmlSignature);
                     function = hintedSigniture;
 
                     // if the node needs additional parameters, add them here
@@ -80,7 +80,7 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
                 else
                 {
                     // If the desired assembly is not loaded already. Check if it belongs to BuiltInFunctionGroup.
-                    if (libraryServices.IsFunctionBuiltIn(assembly, nickname))
+                    if (libraryServices.IsFunctionBuiltIn(assembly, name))
                     {
                         descriptor = libraryServices.GetFunctionDescriptor(function);
                     }
@@ -111,7 +111,7 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
                 return new DummyNode(
                     inputcount,
                     1,
-                    nickname,
+                    name,
                     nodeElement,
                     assembly,
                     DummyNode.Nature.Unresolved);

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -74,7 +74,7 @@ namespace Dynamo.Graph.Nodes
         /// The unique name that was created the node by
         /// </summary>
         [JsonIgnore]
-        public virtual string CreationName { get { return this.NameAttribute; } }
+        public virtual string CreationName { get { return this.Name; } }
 
         /// <summary>
         /// This property queries all the Upstream Nodes  for a given node, ONLY after the graph is loaded.
@@ -376,26 +376,6 @@ namespace Dynamo.Graph.Nodes
                     // Mark node for update
                     OnNodeModified();
                 }
-            }
-        }
-
-        /// <summary>
-        ///  If the node has a name attribute, return it.  Otherwise return empty string.
-        /// </summary>
-        [JsonIgnore]
-        public string NameAttribute
-        {
-            get
-            {
-                Type type = GetType();
-                object[] attribs = type.GetCustomAttributes(typeof(NodeNameAttribute), false);
-                if (type.Namespace == "Dynamo.Graph.Nodes" && !type.IsAbstract && attribs.Length > 0
-                    && type.IsSubclassOf(typeof(NodeModel)))
-                {
-                    var elCatAttrib = attribs[0] as NodeNameAttribute;
-                    return elCatAttrib.Name;
-                }
-                return "";
             }
         }
 
@@ -1631,7 +1611,7 @@ namespace Dynamo.Graph.Nodes
             if (names.Count != descriptions.Count)
             {
                 Log(String.Concat(
-                        NameAttribute,
+                        Name,
                         ": ",
                         Properties.Resources.PortsNameDescriptionDoNotEqualWarningMessage));
 

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -289,7 +289,7 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         ///  The name that is displayed in the UI for this NodeModel.
         /// </summary>
-        [JsonProperty("Name")]
+        [JsonIgnore()]
         public string Name
         {
             get { return name; }
@@ -1242,7 +1242,7 @@ namespace Dynamo.Graph.Nodes
                                           ArrayDimensions =
                                               new ArrayNode
                                               {
-                                                  Expr = new StringNode { Value = outNode.PortName }
+                                                  Expr = new StringNode { Value = outNode.Name }
                                               }
                                       },
                                       GetAstIdentifierForOutputIndex(index))));
@@ -1832,7 +1832,7 @@ namespace Dynamo.Graph.Nodes
             }
             else
             {
-                s += "(lambda (" + string.Join(" ", InPorts.Where((_, i) => !InPorts[i].IsConnected).Select(x => x.PortName))
+                s += "(lambda (" + string.Join(" ", InPorts.Where((_, i) => !InPorts[i].IsConnected).Select(x => x.Name))
                      + ") (" + nick;
                 foreach (int data in Enumerable.Range(0, InPorts.Count))
                 {
@@ -1841,7 +1841,7 @@ namespace Dynamo.Graph.Nodes
                     if (TryGetInput(data, out input))
                         s += input.Item2.PrintExpression();
                     else
-                        s += InPorts[data].PortName;
+                        s += InPorts[data].Name;
                 }
                 s += "))";
             }

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -74,7 +74,13 @@ namespace Dynamo.Graph.Nodes
         /// The unique name that was created the node by
         /// </summary>
         [JsonIgnore]
-        public virtual string CreationName { get { return this.Name; } }
+        public virtual string CreationName
+        {
+            get
+            {
+                return getNameFromNodeNameAttribute();
+            }
+        }
 
         /// <summary>
         /// This property queries all the Upstream Nodes  for a given node, ONLY after the graph is loaded.
@@ -1060,6 +1066,19 @@ namespace Dynamo.Graph.Nodes
                     break;
             }
             SetNodeStateBasedOnConnectionAndDefaults();
+        }
+
+        private string getNameFromNodeNameAttribute()
+        {
+            Type type = GetType();
+            object[] attribs = type.GetCustomAttributes(typeof(NodeNameAttribute), false);
+            if (type.Namespace == "Dynamo.Graph.Nodes" && !type.IsAbstract && attribs.Length > 0
+                && type.IsSubclassOf(typeof(NodeModel)))
+            {
+                var elCatAttrib = attribs[0] as NodeNameAttribute;
+                return elCatAttrib.Name;
+            }
+            return "";
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -979,7 +979,7 @@ namespace Dynamo.Graph.Nodes
             };
 
             //Fetch the element name from the custom attribute.
-            SetNamePropertyFromAttribute();
+            SetNameFromNodeNameAttribute();
 
             IsSelected = false;
             State = ElementState.Dead;
@@ -1012,7 +1012,7 @@ namespace Dynamo.Graph.Nodes
             };
 
             //Fetch the element name from the custom attribute.
-            SetNamePropertyFromAttribute();
+            SetNameFromNodeNameAttribute();
 
             IsSelected = false;
             State = ElementState.Dead;
@@ -1111,7 +1111,7 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         ///     Sets the name of this node from the attributes on the class definining it.
         /// </summary>
-        public void SetNamePropertyFromAttribute()
+        public void SetNameFromNodeNameAttribute()
         {
             var elNameAttrib = GetType().GetCustomAttributes<NodeNameAttribute>(false).FirstOrDefault();
             if (elNameAttrib != null)

--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -277,7 +277,7 @@ namespace Dynamo.Graph.Nodes
         #endregion
 
         [JsonConstructor]
-        internal PortModel(string nickName, string toolTip)
+        internal PortModel(string name, string toolTip)
         {
             UseLevels = false;
             ShouldKeepListStructure = false;
@@ -287,7 +287,7 @@ namespace Dynamo.Graph.Nodes
             DefaultValue = null;
             LineIndex = -1;
             this.toolTip = toolTip;
-            this.PortName = nickName;
+            this.PortName = name;
 
             MarginThickness = new Thickness(0);
             Height = Math.Abs(Height) < 0.001 ? Configurations.PortHeightInPixels : Height;
@@ -312,7 +312,7 @@ namespace Dynamo.Graph.Nodes
             UsingDefaultValue = DefaultValue != null;
             LineIndex = data.LineIndex;
             toolTip = data.ToolTipString;
-            PortName = data.NickName;
+            PortName = data.Name;
             
             MarginThickness = new Thickness(0);
             Height = Math.Abs(data.Height) < 0.001 ? Configurations.PortHeightInPixels : data.Height;
@@ -356,9 +356,9 @@ namespace Dynamo.Graph.Nodes
     public class PortData
     {
         /// <summary>
-        /// Nickname of the port.
+        /// Name of the port.
         /// </summary>
-        public string NickName { get; set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Tooltip of the port.
@@ -383,20 +383,20 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         /// Creates PortData.
         /// </summary>
-        /// <param name="nickName">Nickname of the port</param>
+        /// <param name="name">name of the port</param>
         /// <param name="toolTipString">Tooltip of the port</param>
-        public PortData(string nickName, string toolTipString) : this(nickName, toolTipString, null) { }
+        public PortData(string name, string toolTipString) : this(name, toolTipString, null) { }
 
         /// <summary>
         /// Creates PortData.
         /// </summary>
-        /// <param name="nickName">Nickname of the port</param>
+        /// <param name="name">name of the port</param>
         /// <param name="toolTipString">Tooltip of the port</param>
         /// <param name="defaultValue">Default value of the port</param>
         [JsonConstructor]
-        public PortData(string nickName, string toolTipString, AssociativeNode defaultValue)
+        public PortData(string name, string toolTipString, AssociativeNode defaultValue)
         {
-            NickName = nickName;
+            Name = name;
             ToolTipString = toolTipString;
             DefaultValue = defaultValue;
             LineIndex = -1;

--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -45,8 +45,7 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         /// Name of the port.
         /// </summary>
-        [JsonProperty("DisplayName")]
-        public string PortName
+        public string Name
         {
             get;
             internal set;
@@ -287,7 +286,7 @@ namespace Dynamo.Graph.Nodes
             DefaultValue = null;
             LineIndex = -1;
             this.toolTip = toolTip;
-            this.PortName = name;
+            this.Name = name;
 
             MarginThickness = new Thickness(0);
             Height = Math.Abs(Height) < 0.001 ? Configurations.PortHeightInPixels : Height;
@@ -312,7 +311,7 @@ namespace Dynamo.Graph.Nodes
             UsingDefaultValue = DefaultValue != null;
             LineIndex = data.LineIndex;
             toolTip = data.ToolTipString;
-            PortName = data.Name;
+            Name = data.Name;
             
             MarginThickness = new Thickness(0);
             Height = Math.Abs(data.Height) < 0.001 ? Configurations.PortHeightInPixels : data.Height;

--- a/src/DynamoCore/Graph/Presets/PresetModel.cs
+++ b/src/DynamoCore/Graph/Presets/PresetModel.cs
@@ -45,7 +45,7 @@ namespace Dynamo.Graph.Presets
         /// <summary>
         /// Name attribute name used during serialization
         /// </summary>
-        public const string NameAttributeName = "Name";
+        public const string StateNameAttributeName = "Name";
 
         /// <summary>
         /// Description attribute name used during serialization
@@ -53,9 +53,9 @@ namespace Dynamo.Graph.Presets
         public const string DescriptionAttributeName = "Description";
 
         /// <summary>
-        /// Nickname attribute name used during serialization
+        /// NodeName attribute name used during serialization
         /// </summary>
-        public const string NicknameAttributeName = "nickname";
+        public const string NodeNameAttributeName = "nickname";
 
         #endregion
 
@@ -122,7 +122,7 @@ namespace Dynamo.Graph.Presets
 
         protected override void SerializeCore(System.Xml.XmlElement element, SaveContext context)
         {
-            element.SetAttribute(NameAttributeName, this.Name);
+            element.SetAttribute(StateNameAttributeName, this.Name);
             element.SetAttribute(DescriptionAttributeName, this.Description);
             element.SetAttribute(GuidAttributeName, this.GUID.ToString());
             //the states are already serialized
@@ -136,7 +136,7 @@ namespace Dynamo.Graph.Presets
 
         protected override void DeserializeCore(XmlElement nodeElement, SaveContext context)
         {
-            var stateName = nodeElement.GetAttribute(NameAttributeName);
+            var stateName = nodeElement.GetAttribute(StateNameAttributeName);
             var stateguidString = nodeElement.GetAttribute(GuidAttributeName);
             var stateDescription = nodeElement.GetAttribute(DescriptionAttributeName);
 
@@ -154,7 +154,7 @@ namespace Dynamo.Graph.Presets
             //iterate each actual saved nodemodel in the state
             foreach (XmlElement node in nodeElement.ChildNodes)
             {
-                var nodename = node.GetAttribute(NicknameAttributeName);
+                var nodename = node.GetAttribute(NodeNameAttributeName);
                 var guidString = node.GetAttribute(GuidAttributeName);
                 Guid nodeID;
                 if (!Guid.TryParse(guidString, out nodeID))

--- a/src/DynamoCore/Graph/Workspaces/Serialiaztion/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/Serialiaztion/SerializationConverters.cs
@@ -111,7 +111,7 @@ namespace Autodesk.Workspaces
             }
 
             node.GUID = guid;
-            node.NickName = displayName;
+            node.Name = displayName;
             //node.X = x;
             //node.Y = y;
 
@@ -291,9 +291,9 @@ namespace Autodesk.Workspaces
             serializer.Serialize(writer, ws.Nodes);
 
             //notes
-            writer.WritePropertyName("Notes");
+           writer.WritePropertyName("Notes");
             serializer.Serialize(writer, ws.Notes);
-
+ 
             //connectors
             writer.WritePropertyName("Connectors");
             serializer.Serialize(writer, ws.Connectors);

--- a/src/DynamoCore/Graph/Workspaces/Serialiaztion/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/Serialiaztion/SerializationConverters.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Dynamo.Core;
@@ -266,7 +266,15 @@ namespace Autodesk.Workspaces
             writer.WriteStartObject();
 
             writer.WritePropertyName("Uuid");
-            writer.WriteValue(ws.Guid.ToString());
+            if (value is CustomNodeWorkspaceModel)
+            {
+                writer.WriteValue((ws as CustomNodeWorkspaceModel).CustomNodeId.ToString());
+            }
+            else
+            {
+                writer.WriteValue(ws.Guid.ToString());
+
+            }
             writer.WritePropertyName("IsCustomNode");
             writer.WriteValue(value is CustomNodeWorkspaceModel ? true : false);
             if(value is CustomNodeWorkspaceModel)

--- a/src/DynamoCore/Graph/Workspaces/Serialiaztion/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/Serialiaztion/SerializationConverters.cs
@@ -54,7 +54,6 @@ namespace Autodesk.Workspaces
             var type = Type.GetType(obj["$type"].Value<string>());
             
             var guid = Guid.Parse(obj["Uuid"].Value<string>());
-            var displayName = obj["DisplayName"].Value<string>();
 
             var inPorts = obj["InputPorts"].ToArray().Select(t => t.ToObject<PortModel>()).ToArray();
             var outPorts = obj["OutputPorts"].ToArray().Select(t => t.ToObject<PortModel>()).ToArray();
@@ -111,9 +110,6 @@ namespace Autodesk.Workspaces
             }
 
             node.GUID = guid;
-            node.Name = displayName;
-            //node.X = x;
-            //node.Y = y;
 
             // Add references to the node and the ports to the reference resolver,
             // so that they are available for entities which are deserialized later.

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -246,7 +246,7 @@ namespace Dynamo.Engine
             }
         }
 
-        internal string NicknameFromFunctionSignatureHint(string functionSignature)
+        internal string NameFromFunctionSignature(string functionSignature)
         {
             string[] splitted = null;
             string newName = null;
@@ -461,14 +461,14 @@ namespace Dynamo.Engine
         /// Checks if a given function is in the builtinFunctionGroups so we do not necessarily look for it's library based on its Assembly tag
         /// </summary>
         /// <param name="library">assembly name</param>
-        /// <param name="nickname">nick name, used for searching as key with default value ""</param>
+        /// <param name="name">name, used for searching as key with default value ""</param>
         /// <returns></returns>
-        internal bool IsFunctionBuiltIn(string library, string nickname = "")
+        internal bool IsFunctionBuiltIn(string library, string name = "")
         {
             // For Nodes with not .dll specific Assembly tag
             if (library == Categories.BuiltIn || library == Categories.Operators)
             {
-                return builtinFunctionGroups.ContainsKey(nickname);
+                return builtinFunctionGroups.ContainsKey(name);
             }
             else
             {

--- a/src/DynamoCore/Logging/Heartbeat.cs
+++ b/src/DynamoCore/Logging/Heartbeat.cs
@@ -172,7 +172,7 @@ namespace Dynamo.Logging
 
             foreach (var node in dynamoModel.Workspaces.SelectMany(ws => ws.Nodes))
             {
-                string fullName = node.NickName;
+                string fullName = node.Name;
                 if (!ret.ContainsKey(fullName))
                     ret[fullName] = 0;
 
@@ -195,7 +195,7 @@ namespace Dynamo.Logging
                 if (node.State != ElementState.Error)
                     continue;
 
-                string fullName = node.NickName;
+                string fullName = node.Name;
                 if (!ret.ContainsKey(fullName))
                     ret[fullName] = 0;
                 

--- a/src/DynamoCore/Migration/Migration.cs
+++ b/src/DynamoCore/Migration/Migration.cs
@@ -573,17 +573,17 @@ namespace Dynamo.Migration
         /// <param name="nodeIndex">Index of the node</param>
         /// <param name="assembly">Name of the assembly that implements this 
         /// function.</param>
-        /// <param name="nickname">The nickname to display on the node.</param>
+        /// <param name="name">The name to display on the node.</param>
         /// <param name="signature">The signature of the function.</param>
         /// <returns>Returns the XmlElement that represents a DSFunction node 
         /// with its basic function information with default attributes.</returns>
         public static XmlElement CreateFunctionNode(XmlDocument document, XmlElement oldNode,
-            int nodeIndex, string assembly, string nickname, string signature)
+            int nodeIndex, string assembly, string name, string signature)
         {
             XmlElement element = document.CreateElement("Dynamo.Graph.Nodes.ZeroTouch.DSFunction");
             element.SetAttribute("type", "Dynamo.Graph.Nodes.ZeroTouch.DSFunction");
             element.SetAttribute("assembly", assembly);
-            element.SetAttribute("nickname", nickname);
+            element.SetAttribute("nickname", name);
             element.SetAttribute("function", signature);
 
             // Attributes with default values (as in DynamoModel.OpenWorkspace).
@@ -611,17 +611,17 @@ namespace Dynamo.Migration
         /// <param name="nodeIndex">Index of the node</param>
         /// <param name="assembly">Name of the assembly that implements this 
         /// function.</param>
-        /// <param name="nickname">The nickname to display on the node.</param>
+        /// <param name="name">The name to display on the node.</param>
         /// <param name="signature">The signature of the function.</param>
         /// <returns>Returns the XmlElement that represents a DSVarArgFunction node 
         /// with its basic function information with default attributes.</returns>
         public static XmlElement CreateVarArgFunctionNode(XmlDocument document, XmlElement oldNode,
-            int nodeIndex, string assembly, string nickname, string signature, string inputcount)
+            int nodeIndex, string assembly, string name, string signature, string inputcount)
         {
             XmlElement element = document.CreateElement("Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction");
             element.SetAttribute("type", "Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction");
             element.SetAttribute("assembly", assembly);
-            element.SetAttribute("nickname", nickname);
+            element.SetAttribute("nickname", name);
             element.SetAttribute("function", signature);
             element.SetAttribute("inputcount", inputcount);
 
@@ -684,16 +684,16 @@ namespace Dynamo.Migration
         /// <param name="document">The XmlDocument to create the node in.</param>
         /// <param name="oldNode">Base node to create a new one</param>
         /// <param name="nodeIndex">Index of the node</param>
-        /// <param name="name">Node name</param>
-        /// <param name="nickname">Name to display on the node</param>
+        /// <param name="type">Node type name</param>
+        /// <param name="name">Name to display on the node</param>
         /// <returns>Returns the XmlElement that represents a NodeModel node 
         /// with its basic function information with default attributes.</returns>
         public static XmlElement CreateNode(XmlDocument document, XmlElement oldNode,
-            int nodeIndex, string name, string nickname)
+            int nodeIndex, string type, string name)
         {
-            XmlElement element = document.CreateElement(name);
-            element.SetAttribute("type", name);
-            element.SetAttribute("nickname", nickname);
+            XmlElement element = document.CreateElement(type);
+            element.SetAttribute("type", type);
+            element.SetAttribute("nickname", name);
 
             // Attributes with default values (as in DynamoModel.OpenWorkspace).
             element.SetAttribute("isVisible", "true");
@@ -894,12 +894,12 @@ namespace Dynamo.Migration
         /// <param name="element">The XmlElement to be cloned and the type name 
         /// updated.</param>
         /// <param name="type">The fully qualified name of the new type.</param>
-        /// <param name="nickname">The new nickname, by which this node is known.</param>
+        /// <param name="name">The new name, by which this node is known.</param>
         /// <param name="cloneInnerXml">Parameter indicating whether the inner xml 
         /// of the original node should be cloned.</param>
         /// <returns>Returns the cloned and updated XmlElement.</returns>
         public static XmlElement CloneAndChangeName(XmlElement element, string type, 
-            string nickname, bool cloneInnerXml = false)
+            string name, bool cloneInnerXml = false)
         {
             XmlDocument document = element.OwnerDocument;
             XmlElement cloned = document.CreateElement(type);
@@ -913,7 +913,7 @@ namespace Dynamo.Migration
             }
 
             cloned.SetAttribute("type", type);
-            cloned.SetAttribute("nickname", nickname);
+            cloned.SetAttribute("nickname", name);
             return cloned;
         }
 
@@ -997,12 +997,12 @@ namespace Dynamo.Migration
         }
 
         /// <summary>
-        /// Sets function data such as assembly, nickname and function name
+        /// Sets function data such as assembly, display name and function signature
         /// </summary>
         /// <param name="element">Xml element where to set data</param>
         /// <param name="assemblyName">Assembly name of the function</param>
-        /// <param name="methodName">Nickname of the function</param>
-        /// <param name="signature">Name of the function</param>
+        /// <param name="methodName">Name of the function</param>
+        /// <param name="signature">FullName of the function</param>
         public static void SetFunctionSignature(XmlElement element,
             string assemblyName, string methodName, string signature)
         {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1798,8 +1798,8 @@ namespace Dynamo.Models
 
                 var lacing = node.ArgumentLacing.ToString();
                 newNode.UpdateValue(new UpdateValueParams("ArgumentLacing", lacing));
-                if (!string.IsNullOrEmpty(node.NickName) && !(node is Symbol) && !(node is Output))
-                    newNode.NickName = node.NickName;
+                if (!string.IsNullOrEmpty(node.Name) && !(node is Symbol) && !(node is Output))
+                    newNode.Name = node.Name;
 
                 newNode.Width = node.Width;
                 newNode.Height = node.Height;

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -142,7 +142,7 @@ namespace Dynamo.Models
             var nodeId = command.ModelGuid;
 
             // find nodes with of the same type with the same GUID
-            var query = CurrentWorkspace.Nodes.Where(n => n.GUID.Equals(nodeId) && n.Name.Equals(name));
+            var query = CurrentWorkspace.Nodes.Where(n => n.GUID.Equals(nodeId) && n.NameAttribute.Equals(name));
 
             // safely ignore a node of the same type with the same GUID
             if (query.Any())

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -142,7 +142,7 @@ namespace Dynamo.Models
             var nodeId = command.ModelGuid;
 
             // find nodes with of the same type with the same GUID
-            var query = CurrentWorkspace.Nodes.Where(n => n.GUID.Equals(nodeId) && n.NameAttribute.Equals(name));
+            var query = CurrentWorkspace.Nodes.Where(n => n.GUID.Equals(nodeId) && n.Name.Equals(name));
 
             // safely ignore a node of the same type with the same GUID
             if (query.Any())

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -931,22 +931,22 @@ namespace Dynamo.Models
             ///
             /// </summary>
             /// <param name="nodeId"></param>
-            /// <param name="nodeName"></param>
+            /// <param name="customnodeFunctionId"></param>
             /// <param name="x"></param>
             /// <param name="y"></param>
             /// <param name="defaultPosition"></param>
             /// <param name="transformCoordinates"></param>
-            /// <param name="nickName"></param>
+            /// <param name="name"></param>
             /// <param name="inputs"></param>
             /// <param name="outputs"></param>
             [JsonConstructor]
-            public CreateProxyNodeCommand(string nodeId, string nodeName,
+            public CreateProxyNodeCommand(string nodeId, string customnodeFunctionId,
                 double x, double y,
                 bool defaultPosition, bool transformCoordinates,
-                string nickName, int inputs, int outputs)
-                : base(nodeId, nodeName, x, y, defaultPosition, transformCoordinates)
+                string name, int inputs, int outputs)
+                : base(nodeId, customnodeFunctionId, x, y, defaultPosition, transformCoordinates)
             {
-                this.NickName = nickName;
+                this.NickName = name;
                 this.Inputs = inputs;
                 this.Outputs = outputs;
             }

--- a/src/DynamoCore/Search/NodeSearchModel.cs
+++ b/src/DynamoCore/Search/NodeSearchModel.cs
@@ -86,7 +86,7 @@ namespace Dynamo.Search
                 {
                     var parameterNode = XmlHelper.AddNode(inputNode, "InputParameter");
 
-                    XmlHelper.AddAttribute(parameterNode, "Name", dynamoNode.InPorts[i].PortName);
+                    XmlHelper.AddAttribute(parameterNode, "Name", dynamoNode.InPorts[i].Name);
 
                     // Case for UI nodes as ColorRange, List.Create etc.
                     // UI nodes  do not have incoming ports in NodeSearchElement, but do have incoming ports in NodeModel.
@@ -118,7 +118,7 @@ namespace Dynamo.Search
                 for (int i = 0; i < dynamoNode.OutPorts.Count; i++)
                 {
                     var parameterNode = XmlHelper.AddNode(outputNode, "OutputParameter");
-                    XmlHelper.AddAttribute(parameterNode, "Name", dynamoNode.OutPorts[i].PortName);
+                    XmlHelper.AddAttribute(parameterNode, "Name", dynamoNode.OutPorts[i].Name);
 
                     // Case for UI nodes as ColorRange.
                     if (dynamoNode.OutPorts.Count == entry.OutputParameters.Count()

--- a/src/DynamoCoreWpf/TestInfrastructure/ConnectorMutator.cs
+++ b/src/DynamoCoreWpf/TestInfrastructure/ConnectorMutator.cs
@@ -37,7 +37,7 @@ namespace Dynamo.TestInfrastructure
                     Guid guid = connector.Start.Owner.GUID;
                     if (!valueMap.ContainsKey(guid))
                     {
-                        String val = connector.Start.Owner.NickName;
+                        String val = connector.Start.Owner.Name;
                         valueMap.Add(guid, val);
                         writer.WriteLine(guid + " :: " + val);
                         writer.Flush();
@@ -48,7 +48,7 @@ namespace Dynamo.TestInfrastructure
                     Guid guid = connector.End.Owner.GUID;
                     if (!valueMap.ContainsKey(guid))
                     {
-                        String val = connector.End.Owner.NickName;
+                        String val = connector.End.Owner.Name;
                         valueMap.Add(guid, val);
                         writer.WriteLine(guid + " :: " + val);
                         writer.Flush();

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:ui="clr-namespace:Dynamo.UI"
         xmlns:p="clr-namespace:Dynamo.Wpf.Properties;assembly=DynamoCoreWpf"
-        Title="{Binding NickName}" Height="480" Width="300">
+        Title="{Binding Name}" Height="480" Width="300">
 
     <Window.Resources>
         <ResourceDictionary>
@@ -31,7 +31,7 @@
             <StackPanel Margin="10" Background="Transparent">
 
                 <TextBlock Name="TitleLabel" FontSize="10" Foreground="#AAA" Margin="0,10,0,10" Text="{x:Static p:Resources.NodeHelpWindowNodeType}"></TextBlock>
-                <TextBlock Name="titleText" FontSize="16" Text="{Binding NickName}" Foreground="#555" TextWrapping="Wrap"></TextBlock>
+                <TextBlock Name="titleText" FontSize="16" Text="{Binding Name}" Foreground="#555" TextWrapping="Wrap"></TextBlock>
 
                 <TextBlock Name="DescriptionLabel" FontSize="10" Foreground="#AAA" Margin="0,20,0,10" Text="{x:Static p:Resources.NodeHelpWindowNodeDescription}"></TextBlock>
                 <TextBlock Name="Description" Text="{Binding Description}" Foreground="#555" TextWrapping="Wrap"></TextBlock>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -55,7 +55,7 @@
     <Color x:Key="SliderTrackDarkColor">#FFC5CBF9</Color>
     <Color x:Key="NavButtonFrameColor">#FF3843C4</Color>
 
-    <clr:Double x:Key="NodeNickNameHeight">27</clr:Double>
+    <clr:Double x:Key="NodeNameHeight">27</clr:Double>
 
     <!--InfoBubble colors-->
     <SolidColorBrush x:Key="InfoBubbleBackNormalBrush"

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -141,6 +141,10 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// The Name of the nodemodel this view points to
+        /// this is the name of the node as it is displayed in the UI.
+        /// </summary>
         public string Name
         {
             get { return nodeLogic.Name; }

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -141,10 +141,10 @@ namespace Dynamo.ViewModels
             }
         }
 
-        public string NickName
+        public string Name
         {
-            get { return nodeLogic.NickName; }
-            set { nodeLogic.NickName = value; }
+            get { return nodeLogic.Name; }
+            set { nodeLogic.Name = value; }
         }
 
         public ElementState State
@@ -600,8 +600,8 @@ namespace Dynamo.ViewModels
         {
             switch (e.PropertyName)
             {
-                case "NickName":
-                    RaisePropertyChanged("NickName");
+                case "Name":
+                    RaisePropertyChanged("Name");
                     break;
                 case "X":
                     RaisePropertyChanged("Left");

--- a/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/PortViewModel.cs
@@ -39,7 +39,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         public string PortName
         {
-            get { return _port.PortName; }
+            get { return _port.Name; }
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml
@@ -22,7 +22,7 @@
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
-            <RowDefinition Height="Auto" MaxHeight="{StaticResource NodeNickNameHeight}"></RowDefinition>
+            <RowDefinition Height="Auto" MaxHeight="{StaticResource NodeNameHeight}"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -200,14 +200,14 @@
             </Rectangle.Fill>
         </Rectangle>
 
-        <Rectangle Name="nickNameBackground"
+        <Rectangle Name="NameBackground"
                    Grid.Row="1"
                    Grid.ColumnSpan="3"
                    StrokeThickness="0,0,0,1"
                    IsHitTestVisible="True"
                    Canvas.ZIndex="11"
                    ToolTipService.ShowDuration="60000"
-                   MouseDown="NickNameBlock_OnMouseDown">
+                   MouseDown="NameBlock_OnMouseDown">
             <Rectangle.Stroke>
                 <Binding Path="State"
                          UpdateSourceTrigger="PropertyChanged"
@@ -264,12 +264,12 @@
         </Border>
 
 
-        <TextBlock Name="nickNameBlock"
+        <TextBlock Name="NameBlock"
                    Grid.Row="1"
                    Grid.ColumnSpan="3"
                    VerticalAlignment="Center"
                    HorizontalAlignment="Stretch"
-                   Text="{Binding NickName, UpdateSourceTrigger=PropertyChanged}"
+                   Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
                    Padding="5"
                    FontSize="13"
                    FontWeight="SemiBold"
@@ -277,7 +277,7 @@
                    TextAlignment="Center"
                    IsHitTestVisible="False"
                    Canvas.ZIndex="12"
-                   Height="{StaticResource NodeNickNameHeight}"
+                   Height="{StaticResource NodeNameHeight}"
                    Background="{x:Null}"
                    Style="{StaticResource SZoomFadeText}">
             <TextBlock.Foreground>

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -309,7 +309,7 @@ namespace Dynamo.Controls
 
             editWindow.Owner = Window.GetWindow(this);
 
-            editWindow.BindToProperty(null, new Binding("NickName")
+            editWindow.BindToProperty(null, new Binding("Name")
             {
                 Mode = BindingMode.TwoWay,
                 NotifyOnValidationError = false,
@@ -418,11 +418,11 @@ namespace Dynamo.Controls
             e.Handled = true;
         }
 
-        private void NickNameBlock_OnMouseDown(object sender, MouseButtonEventArgs e)
+        private void NameBlock_OnMouseDown(object sender, MouseButtonEventArgs e)
         {
             if (e.ClickCount == 2)
             {
-                Debug.WriteLine("Nickname double clicked!");
+                Debug.WriteLine("Name double clicked!");
                 if (ViewModel != null && ViewModel.RenameCommand.CanExecute(null))
                 {
                     ViewModel.RenameCommand.Execute(null);

--- a/src/Libraries/CoreNodeModels/Formula.cs
+++ b/src/Libraries/CoreNodeModels/Formula.cs
@@ -205,7 +205,7 @@ namespace CoreNodeModels
             Func<string, string[], object[], object> backingMethod = DSCore.Formula.Evaluate;
 
             // Format input names to be used as function parameters
-            var inputs = InPorts.Select(x => x.PortName.Replace(' ', '_')).ToList();
+            var inputs = InPorts.Select(x => x.Name.Replace(' ', '_')).ToList();
 
 
             /*  def formula_partial(<params>) {
@@ -237,7 +237,7 @@ namespace CoreNodeModels
                                                 AstFactory.BuildExprList(
                                                     InPorts.Select(
                                                         x =>
-                                                            AstFactory.BuildStringNode(x.PortName) as
+                                                            AstFactory.BuildStringNode(x.Name) as
                                                             AssociativeNode).ToList()),
                                                 AstFactory.BuildExprList(
                                                     inputs.Select(AstFactory.BuildIdentifier)

--- a/src/Libraries/CoreNodeModels/HigherOrder/MapCombineLacing.cs
+++ b/src/Libraries/CoreNodeModels/HigherOrder/MapCombineLacing.cs
@@ -288,14 +288,14 @@ namespace CoreNodeModels.HigherOrder
         private void UpdateReductorPort()
         {
             if (InPorts.Count > 6) 
-                reductorPort.NickName = "f(x1, x2, ... xN, a)";
+                reductorPort.Name = "f(x1, x2, ... xN, a)";
             else
             {
                 if (InPorts.Count == 3) 
-                    reductorPort.NickName = "f(x, a)";
+                    reductorPort.Name = "f(x, a)";
                 else
                 {
-                    reductorPort.NickName = "f("
+                    reductorPort.Name = "f("
                         + string.Join(
                             ", ",
                             Enumerable.Range(0, InPorts.Count - 2).Select(x => "x" + (x + 1)))
@@ -378,14 +378,14 @@ namespace CoreNodeModels.HigherOrder
         private void UpdateReductorPort()
         {
             if (InPorts.Count > 6)
-                reductorPort.NickName = "f(x1, x2, ... xN, a)";
+                reductorPort.Name = "f(x1, x2, ... xN, a)";
             else
             {
                 if (InPorts.Count == 3)
-                    reductorPort.NickName = "f(x, a)";
+                    reductorPort.Name = "f(x, a)";
                 else
                 {
-                    reductorPort.NickName = "f("
+                    reductorPort.Name = "f("
                         + string.Join(
                             ", ",
                             Enumerable.Range(0, InPorts.Count - 2).Select(x => "x" + (x + 1)))

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -370,7 +370,7 @@ namespace CoreNodeModels.Input
 
         internal override IEnumerable<AssociativeNode> BuildAst(List<AssociativeNode> inputAstNodes, CompilationContext context)
         {
-            var paramDict = InPorts.Select(x => x.PortName)
+            var paramDict = InPorts.Select(x => x.Name)
                    .Zip<string, AssociativeNode, Tuple<string, AssociativeNode>>(inputAstNodes, Tuple.Create)
                    .ToDictionary(x => x.Item1, x => x.Item2);
 

--- a/src/Migrations/MigrationHelpers.cs
+++ b/src/Migrations/MigrationHelpers.cs
@@ -7,18 +7,18 @@ namespace Dynamo.Migration
     public class MigrationNode
     {
         protected static NodeMigrationData MigrateToDsFunction(
-            NodeMigrationData data, string nickname, string funcName)
+            NodeMigrationData data, string name, string funcName)
         {
-            return MigrateToDsFunction(data, "", nickname, funcName);
+            return MigrateToDsFunction(data, "", name, funcName);
         }
 
         protected static NodeMigrationData MigrateToDsFunction(
-            NodeMigrationData data, string assembly, string nickname, string funcName)
+            NodeMigrationData data, string assembly, string name, string funcName)
         {
             XmlElement xmlNode = data.MigratedNodes.ElementAt(0);
             var element = MigrationManager.CreateFunctionNodeFrom(xmlNode);
             element.SetAttribute("assembly", assembly);
-            element.SetAttribute("nickname", nickname);
+            element.SetAttribute("nickname", name);
             element.SetAttribute("function", funcName);
 
             var lacingAttribute = xmlNode.Attributes["lacing"];
@@ -33,12 +33,12 @@ namespace Dynamo.Migration
         }
 
         protected static NodeMigrationData MigrateToDsVarArgFunction(
-            NodeMigrationData data, string assembly, string nickname, string funcName)
+            NodeMigrationData data, string assembly, string name, string funcName)
         {
             XmlElement xmlNode = data.MigratedNodes.ElementAt(0);
             var element = MigrationManager.CreateVarArgFunctionNodeFrom(xmlNode);
             element.SetAttribute("assembly", assembly);
-            element.SetAttribute("nickname", nickname);
+            element.SetAttribute("nickname", name);
             element.SetAttribute("function", funcName);
             element.SetAttribute("lacing", xmlNode.Attributes["lacing"].Value);
 

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -430,7 +430,7 @@ namespace WpfVisualizationTests
 
             var ws = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
 
-            var numberOfPlanesNode = ws.Nodes.FirstOrDefault(n => n.NickName == "Number of Planes") as DoubleInput;
+            var numberOfPlanesNode = ws.Nodes.FirstOrDefault(n => n.Name == "Number of Planes") as DoubleInput;
             Assert.NotNull(numberOfPlanesNode);
 
             var numberOfPlanes = int.Parse(numberOfPlanesNode.Value);
@@ -926,14 +926,14 @@ namespace WpfVisualizationTests
         }
 
         private void tagGeometryWhenClickingItem(int[] indexes, int expectedNumberOfLabels, 
-            string nodeNickName, Func<NodeView,NodeModel> getGeometryOwnerNode, bool expandPreviewBubble = false)
+            string nodeName, Func<NodeView,NodeModel> getGeometryOwnerNode, bool expandPreviewBubble = false)
         {
             OpenVisualizationTest("MAGN_3815.dyn");
             RunCurrentModel();
             DispatcherUtil.DoEvents();
             Assert.AreEqual(3, Model.CurrentWorkspace.Nodes.Count());
-            var nodeView = View.ChildrenOfType<NodeView>().First(nv => nv.ViewModel.NickName == nodeNickName);
-            Assert.IsNotNull(nodeView, "NodeView has not been found by given nickname: " + nodeNickName);
+            var nodeView = View.ChildrenOfType<NodeView>().First(nv => nv.ViewModel.Name == nodeName);
+            Assert.IsNotNull(nodeView, "NodeView has not been found by given name: " + nodeName);
 
             if (expandPreviewBubble)
             {

--- a/test/DynamoCoreTests/AstBuilderTest.cs
+++ b/test/DynamoCoreTests/AstBuilderTest.cs
@@ -87,12 +87,12 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSort(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> nickNames = sortedNodes.Select(node => Int32.Parse(node.NickName)).ToList();
+                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
 
                 var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < nickNames.Count; ++idx)
+                for (int idx = 0; idx < names.Count; ++idx)
                 {
-                    nodePosMap[nickNames[idx]] = idx;
+                    nodePosMap[names[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
@@ -126,12 +126,12 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSort(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> nickNames = sortedNodes.Select(node => Int32.Parse(node.NickName)).ToList();
+                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
 
                 var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < nickNames.Count; ++idx)
+                for (int idx = 0; idx < names.Count; ++idx)
                 {
-                    nodePosMap[nickNames[idx]] = idx;
+                    nodePosMap[names[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
@@ -164,12 +164,12 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSort(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 3);
 
-                List<int> nickNames = sortedNodes.Select(node => Int32.Parse(node.NickName)).ToList();
+                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
 
                 var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < nickNames.Count; ++idx)
+                for (int idx = 0; idx < names.Count; ++idx)
                 {
-                    nodePosMap[nickNames[idx]] = idx;
+                    nodePosMap[names[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
@@ -199,12 +199,12 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSort(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> nickNames = sortedNodes.Select(node => Int32.Parse(node.NickName)).ToList();
+                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
 
                 var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < nickNames.Count; ++idx)
+                for (int idx = 0; idx < names.Count; ++idx)
                 {
-                    nodePosMap[nickNames[idx]] = idx;
+                    nodePosMap[names[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
@@ -243,11 +243,11 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSort(nodes).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 9);
 
-                var nickNames = sortedNodes.Select(node => Int32.Parse(node.NickName)).ToList();
+                var names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
                 var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < nickNames.Count; ++idx)
+                for (int idx = 0; idx < names.Count; ++idx)
                 {
-                    nodePosMap[nickNames[idx]] = idx;
+                    nodePosMap[names[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
@@ -295,12 +295,12 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> nickNames = sortedNodes.Select(node => Int32.Parse(node.NickName)).ToList();
+                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
 
                 var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < nickNames.Count; ++idx)
+                for (int idx = 0; idx < names.Count; ++idx)
                 {
-                    nodePosMap[nickNames[idx]] = idx;
+                    nodePosMap[names[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
@@ -334,12 +334,12 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> nickNames = sortedNodes.Select(node => Int32.Parse(node.NickName)).ToList();
+                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
 
                 var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < nickNames.Count; ++idx)
+                for (int idx = 0; idx < names.Count; ++idx)
                 {
-                    nodePosMap[nickNames[idx]] = idx;
+                    nodePosMap[names[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
@@ -375,12 +375,12 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 3);
 
-                List<int> nickNames = sortedNodes.Select(node => Int32.Parse(node.NickName)).ToList();
+                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
 
                 var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < nickNames.Count; ++idx)
+                for (int idx = 0; idx < names.Count; ++idx)
                 {
-                    nodePosMap[nickNames[idx]] = idx;
+                    nodePosMap[names[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
@@ -410,12 +410,12 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> nickNames = sortedNodes.Select(node => Int32.Parse(node.NickName)).ToList();
+                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
 
                 var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < nickNames.Count; ++idx)
+                for (int idx = 0; idx < names.Count; ++idx)
                 {
-                    nodePosMap[nickNames[idx]] = idx;
+                    nodePosMap[names[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
@@ -454,11 +454,11 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(nodes).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 9);
 
-                var nickNames = sortedNodes.Select(node => Int32.Parse(node.NickName)).ToList();
+                var names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
                 var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < nickNames.Count; ++idx)
+                for (int idx = 0; idx < names.Count; ++idx)
                 {
-                    nodePosMap[nickNames[idx]] = idx;
+                    nodePosMap[names[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
@@ -501,8 +501,8 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(nodes).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 13);
 
-                var nickNames = sortedNodes.Select(node => Int32.Parse(node.NickName)).ToList();
-                Assert.IsTrue(nickNames.SequenceEqual(Enumerable.Range(1, 13)));
+                var names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
+                Assert.IsTrue(names.SequenceEqual(Enumerable.Range(1, 13)));
             }
         }
     }

--- a/test/DynamoCoreTests/CallsiteTests.cs
+++ b/test/DynamoCoreTests/CallsiteTests.cs
@@ -111,7 +111,7 @@ namespace Dynamo.Tests
 
             CurrentDynamoModel.TraceReconciliationProcessor = new TestTraceReconciliationProcessor(3);
 
-            var traceNode = ws.Nodes.Where(n=>n is DSFunction).FirstOrDefault(f=>f.NickName == "TraceExampleWrapper.ByString");
+            var traceNode = ws.Nodes.Where(n=>n is DSFunction).FirstOrDefault(f=>f.Name == "TraceExampleWrapper.ByString");
             Assert.NotNull(traceNode);
 
             ws.RemoveAndDisposeNode(traceNode);

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -877,11 +877,11 @@ var06 = g;
             Assert.AreEqual(2, data.Count());
 
             var data0 = data.ElementAt(0);
-            Assert.AreEqual(unboundIdentifiers[0], data0.NickName);
+            Assert.AreEqual(unboundIdentifiers[0], data0.Name);
             Assert.AreEqual(unboundIdentifiers[0], data0.ToolTipString);
 
             var data1 = data.ElementAt(1);
-            Assert.AreEqual("LongerVariableNameTha...", data1.NickName);
+            Assert.AreEqual("LongerVariableNameTha...", data1.Name);
             Assert.AreEqual(unboundIdentifiers[1], data1.ToolTipString);
         }
 

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -467,7 +467,7 @@ namespace Dynamo.Tests
                 node.InputSymbol = label;
 
                 Assert.AreEqual(++currentInPortAmt, instance.InPorts.Count);
-                Assert.AreEqual(label, instance.InPorts.Last().PortName);
+                Assert.AreEqual(label, instance.InPorts.Last().Name);
 
                 return node;
             };
@@ -480,7 +480,7 @@ namespace Dynamo.Tests
                 node.Symbol = label;
 
                 Assert.AreEqual(++currentOutPortAmt, instance.OutPorts.Count);
-                Assert.AreEqual(label, instance.OutPorts.Last().PortName);
+                Assert.AreEqual(label, instance.OutPorts.Last().Name);
 
                 return node;
             };
@@ -490,13 +490,13 @@ namespace Dynamo.Tests
             Action<Symbol, int, string> renameInput = (input, idx, s) =>
             {
                 input.InputSymbol = s;
-                Assert.AreEqual(s, instance.InPorts[idx].PortName);
+                Assert.AreEqual(s, instance.InPorts[idx].Name);
             };
 
             Action<Output, int, string> renameOutput = (output, idx, s) =>
             {
                 output.Symbol = s;
-                Assert.AreEqual(s, instance.OutPorts[idx].PortName);
+                Assert.AreEqual(s, instance.OutPorts[idx].Name);
             };
             #endregion
 
@@ -826,7 +826,7 @@ namespace Dynamo.Tests
 
             customInstance.ResyncWithDefinition(customWorkspace.CustomNodeDefinition);
 
-            Assert.AreEqual("x", customInstance.InPorts.First().PortName);
+            Assert.AreEqual("x", customInstance.InPorts.First().Name);
             Assert.AreEqual("bool", customInstance.InPorts.First().ToolTip);
         }
 
@@ -946,28 +946,28 @@ namespace Dynamo.Tests
             Assert.AreEqual(5, customInstance.InPorts.Count());
             Assert.AreEqual(3, customInstance.OutPorts.Count());
 
-            Assert.AreEqual("", customInstance.InPorts[0].PortName);
+            Assert.AreEqual("", customInstance.InPorts[0].Name);
             Assert.AreEqual(@"var[]..[]", customInstance.InPorts[0].ToolTip);
 
-            Assert.AreEqual("x1", customInstance.InPorts[1].PortName);
+            Assert.AreEqual("x1", customInstance.InPorts[1].Name);
             Assert.AreEqual("x1\n\nvar[]..[]", customInstance.InPorts[1].ToolTip);
 
-            Assert.AreEqual("x2", customInstance.InPorts[2].PortName);
+            Assert.AreEqual("x2", customInstance.InPorts[2].Name);
             Assert.AreEqual("x2:var\n\nvar", customInstance.InPorts[2].ToolTip);
 
-            Assert.AreEqual("x3", customInstance.InPorts[3].PortName);
+            Assert.AreEqual("x3", customInstance.InPorts[3].Name);
             Assert.AreEqual("x3:var\n\nvar[]\nDefault value : {1}", customInstance.InPorts[3].ToolTip);
 
-            Assert.AreEqual("x4", customInstance.InPorts[4].PortName);
+            Assert.AreEqual("x4", customInstance.InPorts[4].Name);
             Assert.AreEqual("comment1\ncomment2\ncomment3\n\nvar[]..[]", customInstance.InPorts[4].ToolTip);
 
-            Assert.AreEqual("", customInstance.OutPorts[0].PortName);
+            Assert.AreEqual("", customInstance.OutPorts[0].Name);
             Assert.AreEqual("return value", customInstance.OutPorts[0].ToolTip);
 
-            Assert.AreEqual("y1", customInstance.OutPorts[1].PortName);
+            Assert.AreEqual("y1", customInstance.OutPorts[1].Name);
             Assert.AreEqual("y1", customInstance.OutPorts[1].ToolTip);
 
-            Assert.AreEqual("y2", customInstance.OutPorts[2].PortName);
+            Assert.AreEqual("y2", customInstance.OutPorts[2].Name);
             Assert.AreEqual("comment1\ncomment2\ncomment3", customInstance.OutPorts[2].ToolTip);
         }
 
@@ -980,10 +980,10 @@ namespace Dynamo.Tests
             var customInstance = CurrentDynamoModel.CurrentWorkspace.Nodes.FirstOrDefault(x => x is Function) as Function;
             Assert.AreEqual(4, customInstance.OutPorts.Count());
 
-            Assert.AreEqual("x", customInstance.OutPorts[0].PortName);
-            Assert.AreEqual("y", customInstance.OutPorts[1].PortName);
-            Assert.AreEqual("def foo() {}", customInstance.OutPorts[2].PortName);
-            Assert.AreEqual("class bar {}", customInstance.OutPorts[3].PortName);
+            Assert.AreEqual("x", customInstance.OutPorts[0].Name);
+            Assert.AreEqual("y", customInstance.OutPorts[1].Name);
+            Assert.AreEqual("def foo() {}", customInstance.OutPorts[2].Name);
+            Assert.AreEqual("class bar {}", customInstance.OutPorts[3].Name);
         }
 
         [Test]
@@ -994,7 +994,7 @@ namespace Dynamo.Tests
 
             var customInstance = CurrentDynamoModel.CurrentWorkspace.Nodes.FirstOrDefault(x => x is Function) as Function;
             Assert.AreEqual("comment", customInstance.OutPorts[0].ToolTip);
-            Assert.AreEqual("Point", customInstance.OutPorts[0].PortName);
+            Assert.AreEqual("Point", customInstance.OutPorts[0].Name);
 
             var previewValue = GetPreviewValue(customInstance.GUID.ToString());
             Assert.AreEqual(21, previewValue);

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -327,7 +327,7 @@ namespace Dynamo.Tests
             var modelsToDelete = new List<ModelBase>();
             var addition = CurrentDynamoModel.CurrentWorkspace.FirstNodeFromWorkspace<DSFunction>();
             Assert.IsNotNull(addition);
-            Assert.AreEqual("+", addition.NickName);
+            Assert.AreEqual("+", addition.Name);
 
             modelsToDelete.Add(addition);
             CurrentDynamoModel.DeleteModelInternal(modelsToDelete);

--- a/test/DynamoCoreTests/DSEvaluationUnitTestBase.cs
+++ b/test/DynamoCoreTests/DSEvaluationUnitTestBase.cs
@@ -49,7 +49,7 @@ namespace Dynamo.Tests
             string logs = string.Empty;
             foreach (var node in dummyNodes)
             {
-                logs += string.Format("{0} is a {1} node\n", node.NickName, node.NodeNature);
+                logs += string.Format("{0} is a {1} node\n", node.Name, node.NodeNature);
             }
 
             double dummyNodesCount = dummyNodes.Count();

--- a/test/DynamoCoreTests/LibraryTests.cs
+++ b/test/DynamoCoreTests/LibraryTests.cs
@@ -265,31 +265,31 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void TestBuiltInFunctionRecognition()
         {
-            string nickName, categoryName;
+            string name, categoryName;
 
-            nickName = "/"; categoryName = LibraryServices.Categories.Operators;
-            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+            name = "/"; categoryName = LibraryServices.Categories.Operators;
+            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, name));
 
-            nickName = "*"; categoryName = LibraryServices.Categories.Operators;
-            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+            name = "*"; categoryName = LibraryServices.Categories.Operators;
+            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, name));
 
-            nickName = "=="; categoryName = "";
-            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+            name = "=="; categoryName = "";
+            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, name));
 
-            nickName = "AllFalse"; categoryName = LibraryServices.Categories.BuiltIn;
-            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+            name = "AllFalse"; categoryName = LibraryServices.Categories.BuiltIn;
+            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, name));
 
-            nickName = "SetUnion"; categoryName = LibraryServices.Categories.BuiltIn;
-            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+            name = "SetUnion"; categoryName = LibraryServices.Categories.BuiltIn;
+            Assert.IsTrue(libraryServices.IsFunctionBuiltIn(categoryName, name));
 
-            nickName = "Reorder"; categoryName = "";
-            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+            name = "Reorder"; categoryName = "";
+            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, name));
 
-            nickName = ""; categoryName = "";
-            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+            name = ""; categoryName = "";
+            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, name));
 
-            nickName = ""; categoryName = LibraryServices.Categories.BuiltIn;
-            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, nickName));
+            name = ""; categoryName = LibraryServices.Categories.BuiltIn;
+            Assert.IsFalse(libraryServices.IsFunctionBuiltIn(categoryName, name));
 
         }
         

--- a/test/DynamoCoreTests/NodeConstructionTests.cs
+++ b/test/DynamoCoreTests/NodeConstructionTests.cs
@@ -80,8 +80,8 @@ namespace Dynamo
             var node = new DummyNodeModel();
             Assert.AreEqual(2, node.InPorts.Count);
 
-            Assert.AreEqual("input1", node.InPorts[0].PortName);
-            Assert.AreEqual("input2", node.InPorts[1].PortName);
+            Assert.AreEqual("input1", node.InPorts[0].Name);
+            Assert.AreEqual("input2", node.InPorts[1].Name);
 
             Assert.AreEqual("This is input1", node.InPorts[0].ToolTip);
             Assert.AreEqual("This is input2", node.InPorts[1].ToolTip);
@@ -99,8 +99,8 @@ namespace Dynamo
             var node = new DummyNodeModel();
             Assert.AreEqual(2, node.InPorts.Count);
 
-            Assert.AreEqual("output1", node.OutPorts[0].PortName);
-            Assert.AreEqual("output2", node.OutPorts[1].PortName);
+            Assert.AreEqual("output1", node.OutPorts[0].Name);
+            Assert.AreEqual("output2", node.OutPorts[1].Name);
 
             Assert.AreEqual("some description", node.OutPorts[0].ToolTip);
             Assert.AreEqual("", node.OutPorts[1].ToolTip);

--- a/test/DynamoCoreTests/NodeMigrationTests.cs
+++ b/test/DynamoCoreTests/NodeMigrationTests.cs
@@ -1971,9 +1971,9 @@ namespace Dynamo.Tests
             // check that no nodes are migrated to dummy nodes
             Assert.AreEqual(0, workspace.Nodes.AsQueryable().Count(x => x is DummyNode));
 
-            // check that the node is migrated to a DSFunction nicknamed "ReferencePoint.ByPoint"
+            // check that the node is migrated to a DSFunction named "ReferencePoint.ByPoint"
             StringAssert.Contains("Reference", workspace.NodeFromWorkspace<DSFunction>(
-                "d615cc73-d32d-4b1f-b519-0b8f9b903ebf").NickName);
+                "d615cc73-d32d-4b1f-b519-0b8f9b903ebf").Name);
         }
 
         [Test]
@@ -1990,9 +1990,9 @@ namespace Dynamo.Tests
             // check that no nodes are migrated to dummy nodes
             Assert.AreEqual(0, workspace.Nodes.AsQueryable().Count(x => x is DummyNode));
 
-            // check that the node is migrated to a DSFunction nicknamed "FamilyInstance.ByPoint"
+            // check that the node is migrated to a DSFunction named "FamilyInstance.ByPoint"
             StringAssert.Contains("Instance", workspace.NodeFromWorkspace<DSFunction>(
-                "fc83b9b2-42c6-4a9f-8f60-a6ee29ef8a34").NickName);
+                "fc83b9b2-42c6-4a9f-8f60-a6ee29ef8a34").Name);
         }
 
         [Test]
@@ -2009,9 +2009,9 @@ namespace Dynamo.Tests
             // check that no nodes are migrated to dummy nodes
             Assert.AreEqual(0, workspace.Nodes.AsQueryable().Count(x => x is DummyNode));
 
-            // check that the node is migrated to a DSFunction nicknamed "ModelCurve.ByCurve"
+            // check that the node is migrated to a DSFunction named "ModelCurve.ByCurve"
             StringAssert.Contains("Model", workspace.NodeFromWorkspace<DSFunction>(
-                "fdea006e-b127-4280-a407-4058b78b93a3").NickName);
+                "fdea006e-b127-4280-a407-4058b78b93a3").Name);
         }
 
         [Test]
@@ -2046,7 +2046,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(0, workspace.Nodes.AsQueryable().Count(x => x is DummyNode));
 
             // check that some of the nodes are Excel nodes
-            Assert.AreEqual(4, workspace.Nodes.AsQueryable().Count(x => x.NickName.Contains("Excel")));
+            Assert.AreEqual(4, workspace.Nodes.AsQueryable().Count(x => x.Name.Contains("Excel")));
         }
 
         [Test]
@@ -2155,7 +2155,7 @@ namespace Dynamo.Tests
                 if (node.NodeNature == DummyNode.Nature.Unresolved)
                 {
                     unresolvedNodeCount++;
-                    str += node.NickName;
+                    str += node.Name;
                     str += "\n";
                 }
             }

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -61,8 +61,8 @@ namespace Dynamo.Tests
             {
                if (group.Count == 2)
                {
-                   Assert.IsNotNull(group.Find(n => n.NickName == "2"));
-                   Assert.IsNotNull(group.Find(n => n.NickName == "3"));
+                   Assert.IsNotNull(group.Find(n => n.Name == "2"));
+                   Assert.IsNotNull(group.Find(n => n.Name == "3"));
                } 
             }
         }
@@ -81,7 +81,7 @@ namespace Dynamo.Tests
             var groups = NodeToCodeCompiler.GetCliques(nodes);
             Assert.AreEqual(2, groups.Count);
             var group = groups.Where(g => g.Count == 2).First();
-            Assert.IsNotNull(group.Find(n => n.NickName == "2"));
+            Assert.IsNotNull(group.Find(n => n.Name == "2"));
         }
 
         [Test]
@@ -98,8 +98,8 @@ namespace Dynamo.Tests
             var groups = NodeToCodeCompiler.GetCliques(nodes);
             Assert.AreEqual(1, groups.Count);
             var group = groups.First();
-            Assert.IsNotNull(group.Find(n => n.NickName == "1"));
-            Assert.IsNotNull(group.Find(n => n.NickName == "2"));
+            Assert.IsNotNull(group.Find(n => n.Name == "1"));
+            Assert.IsNotNull(group.Find(n => n.Name == "2"));
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace Dynamo.Tests
             // 2 ----> x --> 5  
             // 3
             OpenModel(@"core\node2code\partition5.dyn");
-            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.Where(n => n.NickName != "X");
+            var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.Where(n => n.Name != "X");
             var groups = NodeToCodeCompiler.GetCliques(nodes);
             Assert.AreEqual(2, groups.Count);
 
@@ -122,13 +122,13 @@ namespace Dynamo.Tests
             var group2 = groups.Where(g => g.Count == 2).FirstOrDefault();
             Assert.IsNotNull(group2);
 
-            var nickNames = group1.Select(n => Int32.Parse(n.NickName)).ToList();
-            nickNames.Sort();
-            Assert.IsTrue(nickNames.SequenceEqual(new[] { 1, 2, 3 }));
+            var names = group1.Select(n => Int32.Parse(n.Name)).ToList();
+            names.Sort();
+            Assert.IsTrue(names.SequenceEqual(new[] { 1, 2, 3 }));
 
-            nickNames = group2.Select(n => Int32.Parse(n.NickName)).ToList();
-            nickNames.Sort();
-            Assert.IsTrue(nickNames.SequenceEqual(new[] { 4, 5 }));
+            names = group2.Select(n => Int32.Parse(n.Name)).ToList();
+            names.Sort();
+            Assert.IsTrue(names.SequenceEqual(new[] { 4, 5 }));
         }
 
         [Test]

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -233,7 +233,7 @@ namespace Dynamo.Tests
             var dummyNodes = ws1.Nodes.Where(n => n is DummyNode);
             if (dummyNodes.Any())
             {
-                Assert.Inconclusive("The Workspace contains dummy nodes for: " + string.Join(",", dummyNodes.Select(n => n.NickName).ToArray()));
+                Assert.Inconclusive("The Workspace contains dummy nodes for: " + string.Join(",", dummyNodes.Select(n => n.Name).ToArray()));
             }
 
             var cbnErrorNodes = ws1.Nodes.Where(n => n is CodeBlockNodeModel && n.State == ElementState.Error);
@@ -318,7 +318,7 @@ namespace Dynamo.Tests
             dummyNodes = ws2.Nodes.Where(n => n is DummyNode);
             if (dummyNodes.Any())
             {
-                Assert.Inconclusive("The Workspace contains dummy nodes for: " + string.Join(",", dummyNodes.Select(n => n.NickName).ToArray()));
+                Assert.Inconclusive("The Workspace contains dummy nodes for: " + string.Join(",", dummyNodes.Select(n => n.Name).ToArray()));
             }
 
             var wcd2 = new WorkspaceComparisonData(ws2, CurrentDynamoModel.EngineController);

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1542,7 +1542,7 @@ namespace DynamoCoreWpfTests
 
             Assert.IsNotNull(cbn);
 
-            Assert.AreEqual("CBN", cbn.NickName);
+            Assert.AreEqual("CBN", cbn.Name);
         }
 
         [Test, RequiresSTA]
@@ -3992,7 +3992,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(number);
             Assert.IsNotNull(note);
 
-            Assert.AreEqual("Caption 1", number.NickName);
+            Assert.AreEqual("Caption 1", number.Name);
             Assert.AreEqual("Caption 3", note.Text);
 
             //Assert.Inconclusive("Porting : DoubleInput");

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1276,8 +1276,8 @@ namespace DynamoCoreWpfTests
 
             //CBN Input Ports
             //   >PortName stores name of variable
-            Assert.AreEqual("x", cbn.InPorts[0].PortName);
-            Assert.AreEqual("y", cbn.InPorts[1].PortName);
+            Assert.AreEqual("x", cbn.InPorts[0].Name);
+            Assert.AreEqual("y", cbn.InPorts[1].Name);
 
             //Check the connections
             var connectors = workspaceViewModel.Connectors;

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -30,7 +30,7 @@ namespace DynamoCoreWpfTests
             //Assert inital values
             Assert.AreEqual(400, sumNode.X);
             Assert.AreEqual(100, sumNode.Y);
-            Assert.AreEqual("+", sumNode.NickName);
+            Assert.AreEqual("+", sumNode.Name);
             Assert.AreEqual(LacingStrategy.Auto, sumNode.ArgumentLacing);
             Assert.AreEqual(true, sumNode.IsVisible);
             Assert.AreEqual(true, sumNode.IsUpstreamVisible);
@@ -41,7 +41,7 @@ namespace DynamoCoreWpfTests
             XmlElement serializedEl = sumNode.Serialize(xmlDoc, SaveContext.Undo);
             sumNode.X = 250;
             sumNode.Y = 0;
-            sumNode.NickName = "TestNode";
+            sumNode.Name = "TestNode";
             sumNode.UpdateValue(new UpdateValueParams("ArgumentLacing", "CrossProduct"));
             sumNode.UpdateValue(new UpdateValueParams("IsVisible", "false"));
             sumNode.UpdateValue(new UpdateValueParams("IsUpstreamVisible", "false"));
@@ -50,7 +50,7 @@ namespace DynamoCoreWpfTests
             //Assert New Changes
             Assert.AreEqual(250, sumNode.X);
             Assert.AreEqual(0, sumNode.Y);
-            Assert.AreEqual("TestNode", sumNode.NickName);
+            Assert.AreEqual("TestNode", sumNode.Name);
             Assert.AreEqual(LacingStrategy.CrossProduct, sumNode.ArgumentLacing);
             Assert.AreEqual(false, sumNode.IsVisible);
             Assert.AreEqual(false, sumNode.IsUpstreamVisible);
@@ -60,7 +60,7 @@ namespace DynamoCoreWpfTests
             sumNode.Deserialize(serializedEl, SaveContext.Undo);
             Assert.AreEqual(400, sumNode.X);
             Assert.AreEqual(100, sumNode.Y);
-            Assert.AreEqual("+", sumNode.NickName);
+            Assert.AreEqual("+", sumNode.Name);
             Assert.AreEqual(LacingStrategy.Auto, sumNode.ArgumentLacing);
             Assert.AreEqual(true, sumNode.IsVisible);
             Assert.AreEqual(true, sumNode.IsUpstreamVisible);
@@ -250,7 +250,7 @@ namespace DynamoCoreWpfTests
             listNode.Deserialize(serializedEl, SaveContext.Undo);
             Assert.AreEqual(400, listNode.X);
             Assert.AreEqual(3, listNode.InPortData.Count);
-            Assert.AreEqual("index 2", listNode.InPortData.ElementAt(2).NickName);
+            Assert.AreEqual("index 2", listNode.InPortData.ElementAt(2).Name);
 */
             Assert.Inconclusive("Porting : NewList");
 
@@ -308,7 +308,7 @@ namespace DynamoCoreWpfTests
             //Assert initial values
             Assert.AreEqual(534.75, graphNode.X);
             Assert.AreEqual("07e6b150-d902-4abb-8103-79193552eee7", graphNode.Definition.FunctionId.ToString());
-            Assert.AreEqual("GraphFunction", graphNode.NickName);
+            Assert.AreEqual("GraphFunction", graphNode.Name);
             Assert.AreEqual(4, graphNode.InPorts.Count);
             Assert.AreEqual("y", graphNode.InPorts[3].PortName);
 
@@ -316,19 +316,19 @@ namespace DynamoCoreWpfTests
             XmlDocument xmlDoc = new XmlDocument();
             XmlElement serializedEl = graphNode.Serialize(xmlDoc, SaveContext.Undo);
             graphNode.X = 250;
-            graphNode.NickName = "NewNode";
+            graphNode.Name = "NewNode";
             graphNode.InPorts.RemoveAt(graphNode.InPorts.Count - 1);
 
             //Assert new changes
             Assert.AreEqual(250, graphNode.X);
             Assert.AreEqual(3, graphNode.InPorts.Count);
-            Assert.AreEqual("NewNode", graphNode.NickName);
+            Assert.AreEqual("NewNode", graphNode.Name);
 
             //Deserialize and aasert old values
             graphNode.Deserialize(serializedEl, SaveContext.Undo);
             Assert.AreEqual(534.75, graphNode.X);
             Assert.AreEqual(4, graphNode.InPorts.Count);
-            Assert.AreEqual("GraphFunction", graphNode.NickName);
+            Assert.AreEqual("GraphFunction", graphNode.Name);
             Assert.AreEqual("y", graphNode.InPorts[3].PortName);
         }
 
@@ -350,7 +350,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(2, dummyNode.OutputCount);
 
             // Ensure all properties updated data members accordingly.
-            Assert.AreEqual("Point.ByLuck", dummyNode.NickName);
+            Assert.AreEqual("Point.ByLuck", dummyNode.Name);
             Assert.AreEqual(3, dummyNode.InPorts.Count);
             Assert.AreEqual(2, dummyNode.OutPorts.Count);
         }

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -310,7 +310,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual("07e6b150-d902-4abb-8103-79193552eee7", graphNode.Definition.FunctionId.ToString());
             Assert.AreEqual("GraphFunction", graphNode.Name);
             Assert.AreEqual(4, graphNode.InPorts.Count);
-            Assert.AreEqual("y", graphNode.InPorts[3].PortName);
+            Assert.AreEqual("y", graphNode.InPorts[3].Name);
 
             //Serialize node and then change values
             XmlDocument xmlDoc = new XmlDocument();
@@ -329,7 +329,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(534.75, graphNode.X);
             Assert.AreEqual(4, graphNode.InPorts.Count);
             Assert.AreEqual("GraphFunction", graphNode.Name);
-            Assert.AreEqual("y", graphNode.InPorts[3].PortName);
+            Assert.AreEqual("y", graphNode.InPorts[3].Name);
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -830,7 +830,7 @@ namespace Dynamo.Tests
                     .Where(x => x.Definition.FunctionId == nodeWorkspace.CustomNodeId)
                     .ToList();
             Assert.AreEqual(10, funcs.Count);
-            funcs.ForEach(x => Assert.AreEqual(newName, x.NickName));
+            funcs.ForEach(x => Assert.AreEqual(newName, x.Name));
             
         }
 

--- a/test/Libraries/SystemTestServices/TestExtensions.cs
+++ b/test/Libraries/SystemTestServices/TestExtensions.cs
@@ -47,7 +47,7 @@ namespace Dynamo.Tests
         public static NodeModel GetDSFunctionNodeFromWorkspace(this WorkspaceModel model, string nodeName)
         {
             return model.Nodes.FirstOrDefault(node => node is DSFunction &&
-                node.NickName == nodeName);
+                node.Name == nodeName);
         }
     }
 }

--- a/test/core/recorded/TestUpdateNodeCaptions_DS.xml
+++ b/test/core/recorded/TestUpdateNodeCaptions_DS.xml
@@ -5,8 +5,8 @@
   <UpdateModelValueCommand ModelGuid="5cf9dff2-4a3e-428a-a98a-60d0de0d323e" Name="Code" Value="a=10;" />
   <CreateNodeCommand NodeId="5c93c110-bd77-4129-a896-5aec7cba98e0" NodeName="+@," X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
   <SelectModelCommand ModelGuid="5cf9dff2-4a3e-428a-a98a-60d0de0d323e" Modifiers="0" />
-  <UpdateModelValueCommand ModelGuid="5cf9dff2-4a3e-428a-a98a-60d0de0d323e" Name="NickName" Value="CBN" />
+  <UpdateModelValueCommand ModelGuid="5cf9dff2-4a3e-428a-a98a-60d0de0d323e" Name="Name" Value="CBN" />
   <SelectModelCommand ModelGuid="5c93c110-bd77-4129-a896-5aec7cba98e0" Modifiers="0" />
-  <UpdateModelValueCommand ModelGuid="5c93c110-bd77-4129-a896-5aec7cba98e0" Name="NickName" Value="AddNode" />
+  <UpdateModelValueCommand ModelGuid="5c93c110-bd77-4129-a896-5aec7cba98e0" Name="Name" Value="AddNode" />
   <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
 </Commands>

--- a/test/core/recorded/UpdateNodeCaptions.xml
+++ b/test/core/recorded/UpdateNodeCaptions.xml
@@ -1,7 +1,7 @@
 <Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
   <CreateNodeCommand NodeId="a9762506-2ab6-4b50-8166-138de5b0c704" NodeName="Number" X="0" Y="0" DefaultPosition="true" TransformCoordinates="true" />
   <SelectModelCommand ModelGuid="a9762506-2ab6-4b50-8166-138de5b0c704" Modifiers="0" />
-  <UpdateModelValueCommand ModelGuid="a9762506-2ab6-4b50-8166-138de5b0c704" Name="NickName" Value="Caption 1" />
+  <UpdateModelValueCommand ModelGuid="a9762506-2ab6-4b50-8166-138de5b0c704" Name="Name" Value="Caption 1" />
   <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
   <CreateNodeCommand NodeId="cdada95d-fd36-4945-aba5-a41416cc3ca5" NodeName="Code Block" X="307" Y="393" DefaultPosition="false" TransformCoordinates="true" />
   <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
@@ -10,7 +10,7 @@
   <UpdateModelValueCommand ModelGuid="cdada95d-fd36-4945-aba5-a41416cc3ca5" Name="Code" Value="&quot;String&quot;;" />
   <SelectModelCommand ModelGuid="cdada95d-fd36-4945-aba5-a41416cc3ca5" Modifiers="0" />
   <SelectModelCommand ModelGuid="cdada95d-fd36-4945-aba5-a41416cc3ca5" Modifiers="0" />
-  <UpdateModelValueCommand ModelGuid="cdada95d-fd36-4945-aba5-a41416cc3ca5" Name="NickName" Value="Caption 2" />
+  <UpdateModelValueCommand ModelGuid="cdada95d-fd36-4945-aba5-a41416cc3ca5" Name="Name" Value="Caption 2" />
   <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
   <CreateNoteCommand NodeId="21c66403-d102-42bd-97ae-9e7b9c0b6e7d" NoteText="" X="0" Y="0" DefaultPosition="true" />
   <SelectModelCommand ModelGuid="21c66403-d102-42bd-97ae-9e7b9c0b6e7d" Modifiers="0" />


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/QNTM-694

This PR does a few things:

* get rid of original `Name` Property on `NodeModel` which usually returned the value of the `[NodeNameAttribute]` - @gregmarr has detailed notes of the output for this. Instead this attribute value is gathered from a private method on `NodeModel`.

* `Nickname` is now the `Name` property.

* `PortName` is renamed to `Name` 

* `PortModel.Name` and `NodeModel.Name` both serialize to `Name` - but `NodeModel.Name` does **Not** serialize into the graph block, it should only serialize when the nodeViewModel is serialized. `Name` exists on the `NodeViewModel` and grabs a value off the `NodeModel`

* Fixes an issue when the workspace is serialized, if the `WorkspaceModel` is a CustomNode, it will serialize the CustomNodeId or functionId as the Uuid.

* updates some recorded tests to use the new Name property instead of Nickname when setting the name.


### Declarations

There will be two related PRs in other repos.

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps 

### FYIs

@ikeough @QilongTang @gregmarr 