### PR TITLE
Remove C# 6.0 language feature.

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -201,7 +201,10 @@ namespace Dynamo.Graph.Workspaces
             return typeof(WorkspaceModel).IsAssignableFrom(objectType);
         }
 
-        public override bool CanWrite => false;
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
@@ -277,7 +280,10 @@ namespace Dynamo.Graph.Workspaces
             return typeof(WorkspaceModel).IsAssignableFrom(objectType);
         }
 
-        public override bool CanRead => false;
+        public override bool CanRead
+        {
+            get { return false; }
+        }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {


### PR DESCRIPTION
### Purpose

This  PR removes   the C# 6.0 language feature to fix  Reach mono build.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### FYIs

@ikeough 
