### PR TITLE
Graph.JSON CleanUp

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -334,21 +334,12 @@ namespace Dynamo.Graph.Workspaces
             serializer.Serialize(writer, ws.Nodes);
 
             //notes
-           writer.WritePropertyName("Notes");
+            writer.WritePropertyName("Notes");
             serializer.Serialize(writer, ws.Notes);
  
             //connectors
             writer.WritePropertyName("Connectors");
             serializer.Serialize(writer, ws.Connectors);
-
-            //annotations
-            writer.WritePropertyName("Annotations");
-            serializer.Serialize(writer, ws.Annotations);
-
-            //cameras
-            writer.WritePropertyName("Cameras");
-            writer.WriteStartArray();
-            writer.WriteEndArray();
 
             // Dependencies
             writer.WritePropertyName("Dependencies");

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -228,6 +228,7 @@ namespace Dynamo.ViewModels
         public ObservableCollection<ConnectorViewModel> Connectors { get { return _connectors; } }
 
         ObservableCollection<NodeViewModel> _nodes = new ObservableCollection<NodeViewModel>();
+        [JsonProperty("NodeViews")]
         public ObservableCollection<NodeViewModel> Nodes { get { return _nodes; } }
 
         ObservableCollection<NoteViewModel> _notes = new ObservableCollection<NoteViewModel>();
@@ -239,7 +240,6 @@ namespace Dynamo.ViewModels
         public ObservableCollection<InfoBubbleViewModel> Errors { get { return _errors; } }
 
         ObservableCollection<AnnotationViewModel> _annotations = new ObservableCollection<AnnotationViewModel>();
-        [JsonIgnore]
         public ObservableCollection<AnnotationViewModel> Annotations { get { return _annotations; } }
 
         [JsonIgnore]


### PR DESCRIPTION
### Purpose

This PR aim to clean up the difference between current saved format of json and defined graph.json in https://github.com/DynamoDS/Dynamo/issues/7747.

1. Removed `Annotations` and `Cameras` from workspaceModel serialization
2. Add `Annotations` Json property in View block
3. **TBD** Either we rename `nodes` in workspaceViewModel or use json property like this PR did so we have `NodeViews` block
4. **TODO** add node id to `NodeViews` block
5. **TODO** reach agreement about `IsCustomNode`, `LastModified`, `LastModifiedBy`, `ElementResolver`, `Notes`, format within `Cameras`
6. **TODO** Adding `FunctionSignature` property for just ZeroTouchNode, nodeType should be `FunctionNode` in this case

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers



### FYIs

@mjkkirschner @ramramps @gregmarr @ikeough 
