### PR TITLE
Provides support for default icon when resource not found

### DIFF
--- a/src/LibraryViewExtension/Handlers/IconResourceProvider.cs
+++ b/src/LibraryViewExtension/Handlers/IconResourceProvider.cs
@@ -22,9 +22,9 @@ namespace Dynamo.LibraryUI.Handlers
         private string defaultIconName;
 
         /// <summary>
-        /// Defaaault constructor for the IconResourceProvider
+        /// Default constructor for the IconResourceProvider
         /// </summary>
-        /// <param name="pathManager">Path maanager instance to resolve the 
+        /// <param name="pathManager">Path manager instance to resolve the 
         /// customization resource path</param>
         /// <param name="defaultIcon">Name of the default icon (including 
         /// extension) to be used when it can't find the requested icon</param>

--- a/src/LibraryViewExtension/Handlers/IconResourceProvider.cs
+++ b/src/LibraryViewExtension/Handlers/IconResourceProvider.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Resources;
 using CefSharp;
 using Dynamo.Engine;
@@ -17,17 +18,75 @@ namespace Dynamo.LibraryUI.Handlers
     {
         private const string imagesSuffix = "Images";
         private IPathManager pathManager;
+        private Stream defaultIconStream;
+        private string defaultIconName;
 
-        public IconResourceProvider(IPathManager pathManager) : base(true)
+        /// <summary>
+        /// Defaaault constructor for the IconResourceProvider
+        /// </summary>
+        /// <param name="pathManager">Path maanager instance to resolve the 
+        /// customization resource path</param>
+        /// <param name="defaultIcon">Name of the default icon (including 
+        /// extension) to be used when it can't find the requested icon</param>
+        public IconResourceProvider(IPathManager pathManager, string defaultIcon = "default-icon.svg") : base(true)
         {
             this.pathManager = pathManager;
+            defaultIconName = defaultIcon;
         }
 
+        /// <summary>
+        /// Gets the stream for the given icon resource request.
+        /// </summary>
+        /// <param name="request">Request object for the icon resource.</param>
+        /// <param name="extension">Returns the extension to describe the type of resource.</param>
+        /// <returns>A valid Stream if the icon resource found successfully else null.</returns>
         public override Stream GetResource(IRequest request, out string extension)
         {
-            extension = "png";
             //Create IconUrl to parse the request.Url to icon name and path.
             var icon = new IconUrl(new Uri(request.Url));
+            
+            var stream = GetIconStream(icon, out extension);
+            if (stream == null)
+                stream = GetDefaultIconStream(out extension);
+
+            return stream;
+        }
+
+        /// <summary>
+        /// Gets the stream for a default icon, to be used when no icon found 
+        /// for a given request. This keeps a cache of the stream to reuse next
+        /// time.
+        /// </summary>
+        /// <param name="extension"></param>
+        /// <param name="extension">Returns the extension to describe the type of resource.</param>
+        /// <returns>A valid Stream if the icon resource found successfully else null.</returns>
+        private Stream GetDefaultIconStream(out string extension)
+        {
+            extension = Path.GetExtension(defaultIconName);
+            if (defaultIconStream == null)
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+                var resource = assembly.GetManifestResourceNames().FirstOrDefault(s => s.Contains(defaultIconName));
+
+                if (string.IsNullOrEmpty(resource)) return null;
+
+                defaultIconName = resource;
+                defaultIconStream = assembly.GetManifestResourceStream(defaultIconName);
+            }
+
+            return defaultIconStream;
+        }
+
+        /// <summary>
+        /// Gets the stream for the given icon resource
+        /// </summary>
+        /// <param name="icon">Icon Url</param>
+        /// <param name="extension">Returns the extension to describe the type of resource.</param>
+        /// <returns>A valid Stream if the icon resource found successfully else null.</returns>
+        private Stream GetIconStream(IconUrl icon, out string extension)
+        {
+            extension = "png";
+
             var path = Path.GetFullPath(icon.Path); //Get full path if it's a relative path.
             var libraryCustomization = LibraryCustomizationServices.GetForAssembly(path, pathManager, true);
             if (libraryCustomization == null)
@@ -36,7 +95,7 @@ namespace Dynamo.LibraryUI.Handlers
             var assembly = libraryCustomization.ResourceAssembly;
             if (assembly == null)
                 return null;
-            
+
             // "Name" can be "Some.Assembly.Name.customization" with multiple dots, 
             // we are interested in removal of the "customization" part and the middle dots.
             var temp = assembly.GetName().Name.Split('.');

--- a/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
+++ b/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
@@ -9,6 +9,7 @@ using CefSharp;
 using Dynamo;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes.CustomNodes;
+using Dynamo.Interfaces;
 using Dynamo.LibraryUI;
 using Dynamo.LibraryUI.Handlers;
 using Dynamo.Search;
@@ -501,6 +502,27 @@ namespace ViewExtensionLibraryTests
             disposable.Dispose();
             disposable.Dispose();
             controller.Verify(c => c.RaiseEvent("Disposed"), Times.Once);
+        }
+
+        [Test, Category("UnitTests")]
+        public void ConcurrentIconRequest()
+        {
+            var resetevent = new AutoResetEvent(false);
+            var requests = (new[] { "A", "B", "C", "D", "E" })
+                .Select(s => new IconUrl(s, s))
+                .Select(icon => {
+                    var req = new Mock<IRequest>();
+                    req.Setup(r => r.Url).Returns(icon.Url);
+                    return req;
+                }).ToList();
+
+            var pathmanager = new Mock<IPathManager>();
+            var provider = new IconResourceProvider(pathmanager.Object);
+            string ext;
+            var result = Parallel.ForEach(requests, r => Assert.IsNotNull(provider.GetResource(r.Object, out ext)));
+
+            resetevent.WaitOne(250);
+            Assert.IsTrue(result.IsCompleted);
         }
 
         private static Mock<NodeSearchElement> MockNodeSearchElement(string fullname, string creationName)


### PR DESCRIPTION
### Purpose

This PR fixes performance issue due to missing icons. When an icon is requested by library UI and LibraryController is not able to serve it, CEF takes a long time to resolve it. As a resolution, we need to return a default icon if the requested icon resource is not available.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs

@Randy-Ma 