### PR TITLE
serialize usingDefaultValue for portModels

### DIFF
--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -179,7 +179,6 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         /// Controls whether this port is set to use it's default value (true) or yield a closure (false).
         /// </summary>
-        [JsonIgnore]
         public bool UsingDefaultValue
         {
             get { return usingDefaultValue; }


### PR DESCRIPTION
### Purpose

After discussion with @ikeough and @pboyer we decided this property should become part of the `portModel` spec inside the serialized JSON graph.

In our discussion it seemed the state of this property should effect the generated DS code and @pboyer discussed this as a possible principle for determining if a field should be serialized into the json format.

@gregmarr let's follow up on related work off github.

I will post a new version of the latest version of the graph json after this is merged to the github JSON issue.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@QilongTang 
