### PR TITLE
Updates for AnnotationViewModel

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -240,10 +240,11 @@ namespace Dynamo.Graph.Workspaces
             // relevant ports.
             var connectors = obj["Connectors"].ToObject<IEnumerable<ConnectorModel>>(serializer);
 
-            // annotations
-            var annotations = obj["Annotations"].ToObject<IEnumerable<AnnotationModel>>(serializer);
-
             var info = new WorkspaceInfo(guid.ToString(), name, description, Dynamo.Models.RunType.Automatic);
+
+            //Build an empty annotations. Annotations are defined in the view block. If the file has View block
+            //serialize view block first and build the annotations.
+            var annotations = new List<AnnotationModel>();
 
             WorkspaceModel ws;
             if (isCustomNode)
@@ -404,68 +405,6 @@ namespace Dynamo.Graph.Workspaces
         }
     }
 
-    /// <summary>
-    /// The AnnotationConverter is used to serialize and deserialize AnnotationModels.
-    /// The SelectedModels property on AnnotationModel is a list of references
-    /// to ModelBase objects. During serialization we want to refer to these objects
-    /// by their ids. During deserialization, we use the ReferenceResolver to
-    /// find the correct ModelBase instances to reference.
-    /// </summary>
-    public class AnnotationConverter : JsonConverter
-    {
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(AnnotationModel);
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            var obj = JObject.Load(reader);
-            var title = obj["Title"].Value<string>();
-            //if the id is not a guid, makes a guid based on the id of the model
-            Guid annotationId =  GuidUtility.tryParseOrCreateGuid(obj["Id"].Value<string>());
-
-            // This is a collection of string Guids, which
-            // should be accessible in the ReferenceResolver.
-            var models = obj["Nodes"].Values<JValue>();
-
-            var existing = models.Select(m => {
-                Guid modelId = GuidUtility.tryParseOrCreateGuid(m.Value<string>());
-              
-                return serializer.ReferenceResolver.ResolveReference(serializer.Context, modelId.ToString());
-                });
-
-            var nodes = existing.Where(m => typeof(NodeModel).IsAssignableFrom(m.GetType())).Cast<NodeModel>();
-            var notes = existing.Where(m => typeof(NoteModel).IsAssignableFrom(m.GetType())).Cast<NoteModel>();
-
-            var anno = new AnnotationModel(nodes, notes);
-            anno.AnnotationText = title;
-            anno.GUID = annotationId;
-
-            return anno;
-        }
-
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            var anno = (AnnotationModel)value;
-
-            writer.WriteStartObject();
-
-            writer.WritePropertyName("Title");
-            writer.WriteValue(anno.AnnotationText);
-            writer.WritePropertyName("Nodes");
-            writer.WriteStartArray();
-            foreach (var m in anno.Nodes)
-            {
-                writer.WriteValue(m.GUID.ToString());
-            }
-            writer.WriteEndArray();
-            writer.WritePropertyName("Id");
-            writer.WriteValue(anno.GUID.ToString());
-
-            writer.WriteEndObject();
-        }
-    }
 
     /// <summary>
     /// The ConnectorConverter is used to serialize and deserialize ConnectorModels.

--- a/src/DynamoCore/Graph/Workspaces/SerializationExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationExtensions.cs
@@ -28,8 +28,7 @@ namespace Dynamo.Graph.Workspaces
                 TypeNameHandling = TypeNameHandling.Auto,
                 Formatting = Formatting.Indented,
                 Converters = new List<JsonConverter>{
-                        new ConnectorConverter(),
-                        new AnnotationConverter(),
+                        new ConnectorConverter(),                        
                         new WorkspaceWriteConverter(engine)
                     },
                 ReferenceResolverProvider = () => { return new IdReferenceResolver(); }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1480,7 +1480,6 @@ namespace Dynamo.Graph.Workspaces
                 Formatting = Newtonsoft.Json.Formatting.Indented,
                 Converters = new List<JsonConverter>{
                         new ConnectorConverter(),
-                        new AnnotationConverter(),
                         new WorkspaceReadConverter(engineController, scheduler, factory, isTestMode, verboseLogging),
                         new NodeReadConverter(manager, libraryServices),
                     },

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -293,6 +293,7 @@
     <Compile Include="ViewModels\Core\AnnotationExtension.cs" />
     <Compile Include="ViewModels\Core\AnnotationViewModel.cs" />
     <Compile Include="Utilities\ResourceUtilities.cs" />
+    <Compile Include="ViewModels\Core\Converters\SerializationConverters.cs" />
     <Compile Include="ViewModels\Core\DynamoViewModelBranding.cs" />
     <Compile Include="ViewModels\Core\GalleryViewModel.cs" />
     <Compile Include="ViewModels\Core\HomeWorkspaceViewModel.cs" />

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -13,6 +13,7 @@ using Dynamo.Selection;
 using Dynamo.UI.Commands;
 using Dynamo.Utilities;
 using Dynamo.Views;
+using Newtonsoft.Json;
 using Color = System.Windows.Media.Color;
 
 namespace Dynamo.ViewModels
@@ -32,11 +33,13 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public Double Width
         {
             get { return annotationModel.Width; }
         }
 
+        [JsonIgnore]
         public Double Height
         {
             get { return annotationModel.Height; }
@@ -46,6 +49,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public Double Top
         {
             get { return annotationModel.Y; }
@@ -54,19 +58,22 @@ namespace Dynamo.ViewModels
                 annotationModel.Y = value;                
             }
         }
-       
+
+        [JsonIgnore]
         public Double Left
         {
             get { return annotationModel.X; }
             set { annotationModel.X = value; }
         }
 
+        [JsonIgnore]
         public double ZIndex
         {
             get { return 1; }
             
         }
 
+        [JsonIgnore]
         public String AnnotationText
         {
             get { return annotationModel.AnnotationText; }
@@ -77,6 +84,7 @@ namespace Dynamo.ViewModels
         }
        
         private Color _background;
+        [JsonIgnore]
         public Color Background
         {
             get
@@ -92,7 +100,8 @@ namespace Dynamo.ViewModels
                 annotationModel.Background = value.ToString();                
             }
         }
-        
+
+        [JsonIgnore]
         public PreviewState PreviewState
         {
             get
@@ -107,6 +116,7 @@ namespace Dynamo.ViewModels
         }
 
         private DelegateCommand _changeFontSize;
+        [JsonIgnore]
         public DelegateCommand ChangeFontSize
         {
             get
@@ -120,6 +130,7 @@ namespace Dynamo.ViewModels
         }
 
         private DelegateCommand _addToGroupCommand;
+        [JsonIgnore]
         public DelegateCommand AddToGroupCommand
         {
              get
@@ -151,7 +162,8 @@ namespace Dynamo.ViewModels
                 }
             }
         }
-      
+
+        [JsonIgnore]
         public Double FontSize
         {
             get
@@ -164,6 +176,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public IEnumerable<ModelBase> Nodes
         {
             get { return annotationModel.Nodes; }

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -22,7 +22,8 @@ namespace Dynamo.ViewModels
     {
         private AnnotationModel annotationModel;
         public readonly WorkspaceViewModel WorkspaceViewModel;        
-      
+        
+        [JsonIgnore]
         public AnnotationModel AnnotationModel
         {
             get { return annotationModel; }

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Linq;
+using Dynamo.Graph.Annotations;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Notes;
+using Dynamo.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Type = System.Type;
+
+namespace Dynamo.Wpf.ViewModels.Core.Converters
+{
+    /// <summary>
+    /// The AnnotationConverter is used to serialize and deserialize AnnotationModels.
+    /// The SelectedModels property on AnnotationModel is a list of references
+    /// to ModelBase objects. During serialization we want to refer to these objects
+    /// by their ids. During deserialization, we use the ReferenceResolver to
+    /// find the correct ModelBase instances to reference.
+    /// </summary>
+    public class AnnotationConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(AnnotationModel);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var obj = JObject.Load(reader);
+            var title = obj["Title"].Value<string>();
+            //if the id is not a guid, makes a guid based on the id of the model
+            Guid annotationId = GuidUtility.tryParseOrCreateGuid(obj["Id"].Value<string>());
+
+            // This is a collection of string Guids, which
+            // should be accessible in the ReferenceResolver.
+            var models = obj["Nodes"].Values<JValue>();
+
+            var existing = models.Select(m =>
+            {
+                Guid modelId = GuidUtility.tryParseOrCreateGuid(m.Value<string>());
+
+                return serializer.ReferenceResolver.ResolveReference(serializer.Context, modelId.ToString());
+            });
+
+            var nodes = existing.Where(m => typeof(NodeModel).IsAssignableFrom(m.GetType())).Cast<NodeModel>();
+            var notes = existing.Where(m => typeof(NoteModel).IsAssignableFrom(m.GetType())).Cast<NoteModel>();
+
+            var anno = new AnnotationModel(nodes, notes);
+            anno.AnnotationText = title;
+            anno.GUID = annotationId;
+            anno.X = obj["Left"].Value<double>();
+            anno.Y = obj["Top"].Value<double>();
+            anno.Width = obj["Width"].Value<double>();
+            anno.Height = obj["Height"].Value<double>();
+            anno.FontSize = obj["FontSize"].Value<double>();
+            anno.InitialTop = obj["InitialTop"].Value<double>();
+            anno.InitialHeight = obj["InitialHeight"].Value<double>();
+            anno.TextBlockHeight = obj["TextblockHeight"].Value<double>();
+            anno.Background = obj["Background"].Value<string>();
+            return anno;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var anno = (AnnotationModel)value;
+
+            writer.WriteStartObject();
+
+            writer.WritePropertyName("Id");
+            writer.WriteValue(anno.GUID.ToString());
+            writer.WritePropertyName("Title");
+            writer.WriteValue(anno.AnnotationText);
+            writer.WritePropertyName("Nodes");
+            writer.WriteStartArray();
+            foreach (var m in anno.Nodes)
+            {
+                writer.WriteValue(m.GUID.ToString());
+            }
+            writer.WriteEndArray();
+            writer.WritePropertyName("Left");
+            writer.WriteValue(anno.X.ToString());
+            writer.WritePropertyName("Top");
+            writer.WriteValue(anno.Y);
+            writer.WritePropertyName("Width");
+            writer.WriteValue(anno.Width);
+            writer.WritePropertyName("Height");
+            writer.WriteValue(anno.Height);
+            writer.WritePropertyName("FontSize");
+            writer.WriteValue(anno.FontSize);
+            writer.WritePropertyName("InitialTop");
+            writer.WriteValue(anno.InitialTop);
+            writer.WritePropertyName("InitialHeight");
+            writer.WriteValue(anno.InitialHeight);
+            writer.WritePropertyName("TextblockHeight");
+            writer.WriteValue(anno.TextBlockHeight);
+            writer.WritePropertyName("Background");
+            writer.WriteValue(anno.Background != null ? anno.Background : "");
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -3,7 +3,9 @@ using System.Linq;
 using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Notes;
+using Dynamo.Nodes;
 using Dynamo.Utilities;
+using Dynamo.ViewModels;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Type = System.Type;
@@ -17,11 +19,11 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
     /// by their ids. During deserialization, we use the ReferenceResolver to
     /// find the correct ModelBase instances to reference.
     /// </summary>
-    public class AnnotationConverter : JsonConverter
+    public class AnnotationViewModelConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(AnnotationModel);
+            return objectType == typeof(AnnotationViewModel);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
@@ -62,7 +64,9 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            var anno = (AnnotationModel)value;
+            var annoVM = (AnnotationViewModel)value;
+            var anno = annoVM.AnnotationModel;
+
 
             writer.WriteStartObject();
 
@@ -78,7 +82,7 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
             }
             writer.WriteEndArray();
             writer.WritePropertyName("Left");
-            writer.WriteValue(anno.X.ToString());
+            writer.WriteValue(anno.X);
             writer.WritePropertyName("Top");
             writer.WriteValue(anno.Y);
             writer.WritePropertyName("Width");

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -33,7 +33,7 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
             //if the id is not a guid, makes a guid based on the id of the model
             Guid annotationId = GuidUtility.tryParseOrCreateGuid(obj["Id"].Value<string>());
 
-            // This is a collection of string Guids, which
+            // This is a string id, which
             // should be accessible in the ReferenceResolver.
             var models = obj["Nodes"].Values<JValue>();
 

--- a/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using Dynamo.ViewModels;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
+using Dynamo.Wpf.ViewModels.Core.Converters;
 
 namespace Dynamo.Wpf.ViewModels.Core
 {
@@ -25,7 +27,10 @@ namespace Dynamo.Wpf.ViewModels.Core
                 },
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
                 TypeNameHandling = TypeNameHandling.Auto,
-                Formatting = Formatting.Indented
+                Formatting = Formatting.Indented,
+                Converters = new List<JsonConverter>{
+                        new AnnotationConverter(),                        
+                    },
             };
 
             var json = JsonConvert.SerializeObject(viewModel, settings);

--- a/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
@@ -29,7 +29,7 @@ namespace Dynamo.Wpf.ViewModels.Core
                 TypeNameHandling = TypeNameHandling.Auto,
                 Formatting = Formatting.Indented,
                 Converters = new List<JsonConverter>{
-                        new AnnotationConverter(),                        
+                        new AnnotationViewModelConverter(),                        
                     },
             };
 

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -63,8 +63,7 @@ namespace Dynamo.Tests
         {
             public Guid Guid { get; set; }
             public int NodeCount { get; set; }
-            public int ConnectorCount { get; set; }
-            public int GroupCount { get; set; }
+            public int ConnectorCount { get; set; }            
             public int NoteCount { get; set; }
             public Dictionary<Guid,Type> NodeTypeMap { get; set; }
             public Dictionary<Guid,List<object>> NodeDataMap { get; set; }
@@ -76,8 +75,7 @@ namespace Dynamo.Tests
             {
                 Guid = workspace.Guid;
                 NodeCount = workspace.Nodes.Count();
-                ConnectorCount = workspace.Connectors.Count();
-                GroupCount = workspace.Annotations.Count();
+                ConnectorCount = workspace.Connectors.Count();               
                 NoteCount = workspace.Notes.Count();
                 NodeTypeMap = new Dictionary<Guid, Type>();
                 NodeDataMap = new Dictionary<Guid, List<object>>();
@@ -127,7 +125,6 @@ namespace Dynamo.Tests
             }
             Assert.AreEqual(a.NodeCount, b.NodeCount, "The workspaces don't have the same number of nodes.");
             Assert.AreEqual(a.ConnectorCount, b.ConnectorCount, "The workspaces don't have the same number of connectors.");
-            Assert.AreEqual(a.GroupCount, b.GroupCount, "The workspaces don't have the same number of groups.");
             Assert.AreEqual(a.NoteCount, b.NoteCount, "The workspaces don't have the same number of notes.");
             foreach (var kvp in a.InportCountMap)
             {
@@ -180,7 +177,8 @@ namespace Dynamo.Tests
             }
             Assert.AreEqual(a.NodeCount, b.NodeCount, "The workspaces don't have the same number of nodes.");
             Assert.AreEqual(a.ConnectorCount, b.ConnectorCount, "The workspaces don't have the same number of connectors.");
-            Assert.AreEqual(a.GroupCount, b.GroupCount, "The workspaces don't have the same number of groups.");
+            //TODO: Annotations tests should be in viewmodel serialization tests.
+           // Assert.AreEqual(a.GroupCount, b.GroupCount, "The workspaces don't have the same number of groups.");
             Assert.AreEqual(a.NoteCount, b.NoteCount, "The workspaces don't have the same number of notes.");
             foreach(var kvp in a.InportCountMap)
             {


### PR DESCRIPTION
### Purpose

This PR `removes AnnotationConverter` from `Dynamo.Core` and adds it to `Dynamo.Core.wpf.ViewModel`.

`Annotations` are view parameters and it should get serialized inside the ViewModel.  

The Annotation tests are removed from  `Core SerializationTests`.

``` 
"Annotations": [
      {
        "Id": "5afbee39-d216-4540-90e6-cb3d41dece3e",
        "Title": "<Click here to edit the group title>",
        "Nodes": [
          "ed9eb983-1136-41fa-986a-b75847489d75"
        ],
        "Left": 76.0,
        "Top": -13.800000000000011,
        "Width": 185.6,
        "Height": 275.4,
        "FontSize": 36.0,
        "InitialTop": 169.0,
        "InitialHeight": 122.6,
        "TextblockHeight": 172.8,
        "Background": "#FFC1D676"
      }
    ] 
```

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @mjkkirschner 

### FYIs

@ColinDayOrg 
