### PR TITLE
NoteModel Conversion

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -222,14 +222,15 @@ namespace Dynamo.Graph.Workspaces
             var nodes = obj["Nodes"].ToObject<IEnumerable<NodeModel>>(serializer);
             
             // notes
-            var notes = obj["Notes"].ToObject<IEnumerable<NoteModel>>(serializer);
-            if (notes.Any())
-            {
-                foreach(var n in notes)
-                {
-                    serializer.ReferenceResolver.AddReference(serializer.Context, n.GUID.ToString(), n);
-                }
-            }
+            //TODO: Check this when implementing ReadJSON in ViewModel.
+            //var notes = obj["Notes"].ToObject<IEnumerable<NoteModel>>(serializer);
+            //if (notes.Any())
+            //{
+            //    foreach(var n in notes)
+            //    {
+            //        serializer.ReferenceResolver.AddReference(serializer.Context, n.GUID.ToString(), n);
+            //    }
+            //}
 
             // connectors
             // Although connectors are not used in the construction of the workspace
@@ -242,6 +243,10 @@ namespace Dynamo.Graph.Workspaces
             //Build an empty annotations. Annotations are defined in the view block. If the file has View block
             //serialize view block first and build the annotations.
             var annotations = new List<AnnotationModel>();
+
+            //Build an empty notes. Notes are defined in the view block. If the file has View block
+            //serialize view block first and build the notes.
+            var notes = new List<NoteModel>();
 
             WorkspaceModel ws;
             if (isCustomNode)
@@ -327,10 +332,6 @@ namespace Dynamo.Graph.Workspaces
             writer.WritePropertyName("Nodes");
             serializer.Serialize(writer, ws.Nodes);
 
-            //notes
-            writer.WritePropertyName("Notes");
-            serializer.Serialize(writer, ws.Notes);
- 
             //connectors
             writer.WritePropertyName("Connectors");
             serializer.Serialize(writer, ws.Connectors);

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -143,4 +143,39 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
             throw new NotImplementedException();
         }
     }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class NoteViewModelConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(NoteViewModel);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+            JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var noteViewModel = (NoteViewModel)value;
+            var notes = noteViewModel.Model;
+
+            // For each noteViewModel, start a new object
+            writer.WriteStartObject();
+            writer.WritePropertyName("Id");
+            writer.WriteValue(notes.GUID);
+            writer.WritePropertyName("X");
+            writer.WriteValue(notes.X);
+            writer.WritePropertyName("Y");
+            writer.WriteValue(notes.Y);
+            writer.WritePropertyName("Text");
+            writer.WriteValue(notes.Text);
+            writer.WriteEndObject();
+        }
+    }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -145,7 +145,7 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
     }
 
     /// <summary>
-    /// 
+    /// Serialize NoteViewModel.
     /// </summary>
     public class NoteViewModelConverter : JsonConverter
     {

--- a/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
@@ -30,6 +30,7 @@ namespace Dynamo.Wpf.ViewModels.Core
                 Formatting = Formatting.Indented,
                 Converters = new List<JsonConverter>{
                     new AnnotationViewModelConverter(),
+                    new NoteViewModelConverter(),
                     new NodeViewModelConverter(),
                 },
             };

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -232,7 +232,7 @@ namespace Dynamo.ViewModels
         public ObservableCollection<NodeViewModel> Nodes { get { return _nodes; } }
 
         ObservableCollection<NoteViewModel> _notes = new ObservableCollection<NoteViewModel>();
-        [JsonIgnore]
+        [JsonProperty("Notes")]
         public ObservableCollection<NoteViewModel> Notes { get { return _notes; } }
 
         ObservableCollection<InfoBubbleViewModel> _errors = new ObservableCollection<InfoBubbleViewModel>();

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -63,8 +63,7 @@ namespace Dynamo.Tests
         {
             public Guid Guid { get; set; }
             public int NodeCount { get; set; }
-            public int ConnectorCount { get; set; }            
-            public int NoteCount { get; set; }
+            public int ConnectorCount { get; set; }           
             public Dictionary<Guid,Type> NodeTypeMap { get; set; }
             public Dictionary<Guid,List<object>> NodeDataMap { get; set; }
             public Dictionary<Guid,int> InportCountMap { get; set; }
@@ -76,7 +75,6 @@ namespace Dynamo.Tests
                 Guid = workspace.Guid;
                 NodeCount = workspace.Nodes.Count();
                 ConnectorCount = workspace.Connectors.Count();               
-                NoteCount = workspace.Notes.Count();
                 NodeTypeMap = new Dictionary<Guid, Type>();
                 NodeDataMap = new Dictionary<Guid, List<object>>();
                 InportCountMap = new Dictionary<Guid, int>();
@@ -125,7 +123,7 @@ namespace Dynamo.Tests
             }
             Assert.AreEqual(a.NodeCount, b.NodeCount, "The workspaces don't have the same number of nodes.");
             Assert.AreEqual(a.ConnectorCount, b.ConnectorCount, "The workspaces don't have the same number of connectors.");
-            Assert.AreEqual(a.NoteCount, b.NoteCount, "The workspaces don't have the same number of notes.");
+            
             foreach (var kvp in a.InportCountMap)
             {
                 var countA = kvp.Value;
@@ -177,9 +175,9 @@ namespace Dynamo.Tests
             }
             Assert.AreEqual(a.NodeCount, b.NodeCount, "The workspaces don't have the same number of nodes.");
             Assert.AreEqual(a.ConnectorCount, b.ConnectorCount, "The workspaces don't have the same number of connectors.");
-            //TODO: Annotations tests should be in viewmodel serialization tests.
+            //TODO: Annotations / Note tests should be in viewmodel serialization tests.
            // Assert.AreEqual(a.GroupCount, b.GroupCount, "The workspaces don't have the same number of groups.");
-            Assert.AreEqual(a.NoteCount, b.NoteCount, "The workspaces don't have the same number of notes.");
+           // Assert.AreEqual(a.NoteCount, b.NoteCount, "The workspaces don't have the same number of notes.");
             foreach(var kvp in a.InportCountMap)
             {
                 var countA = kvp.Value;


### PR DESCRIPTION
### Purpose

This PR moves the NoteModel to View block.

```
 "Notes": [
      {
        "Id": "e4e28b97-c8b0-47b6-97da-513708cadb93",
        "X": 243.59999999999985,
        "Y": 71.999999999999972,
        "Text": "New Note"
      },
      {
        "Id": "2b01f9b4-f5cb-4b34-bd87-f206df9d385d",
        "X": 428.40000000000003,
        "Y": 160.79999999999998,
        "Text": "New Note1"
      },
      {
        "Id": "00ea8787-c47a-42a6-b44d-b5922fde1200",
        "X": 612.4,
        "Y": 276.0,
        "Text": "New Note2"
      }
    ]
```
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@QilongTang  @mjkkirschner 

### FYIs

@gregmarr 