### PR TITLE
[ Tech Debt ] Remove NodeViewModelConverter

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -104,43 +104,6 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
     }
 
     /// <summary>
-    /// The NodeViewModelConverter is used to serialize and deserialize NodeViewModels.
-    /// </summary>
-    public class NodeViewModelConverter : JsonConverter
-    {
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(NodeViewModel);
-        }
-
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            var nodeViewModel = (NodeViewModel)value;
-            // For each nodeViewModel, start a new object
-            writer.WriteStartObject();
-            writer.WritePropertyName("Id");
-            writer.WriteValue(nodeViewModel.Id.ToString());
-            writer.WritePropertyName("Name");
-            writer.WriteValue(nodeViewModel.Name);
-            writer.WritePropertyName("X");
-            writer.WriteValue(nodeViewModel.X);
-            writer.WritePropertyName("Y");
-            writer.WriteValue(nodeViewModel.Y);
-            writer.WritePropertyName("IsVisible");
-            writer.WriteValue(nodeViewModel.IsVisible);
-            writer.WritePropertyName("IsUpstreamVisible");
-            writer.WriteValue(nodeViewModel.IsUpstreamVisible);
-            writer.WriteEndObject();
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
-            JsonSerializer serializer)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    /// <summary>
     /// Serialize NoteViewModel.
     /// </summary>
     public class NoteViewModelConverter : JsonConverter

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -37,6 +37,7 @@ namespace Dynamo.ViewModels
         public event SnapInputEventHandler SnapInputEvent;
         #endregion
 
+        [JsonIgnore]
         public Action OnMouseLeave;
 
         #region private members
@@ -52,15 +53,27 @@ namespace Dynamo.ViewModels
 
         #region public members
 
+        /// <summary>
+        /// Returns NodeModel ID
+        /// </summary>
+        public Guid Id
+        {
+            get { return NodeModel.GUID; }
+        }
+
+        [JsonIgnore]
         public readonly DynamoViewModel DynamoViewModel;
 
+        [JsonIgnore]
         public readonly WorkspaceViewModel WorkspaceViewModel;
 
+        [JsonIgnore]
         public readonly Size? PreferredSize;
 
         private bool previewPinned;
-
-        public bool PreviewPinned {
+        [JsonIgnore]
+        public bool PreviewPinned
+        {
             get { return previewPinned; }
             set
             {
@@ -68,30 +81,36 @@ namespace Dynamo.ViewModels
                 previewPinned = value;
 
                 DynamoViewModel.ExecuteCommand(
-              new DynamoModel.UpdateModelValueCommand(
+                    new DynamoModel.UpdateModelValueCommand(
                         System.Guid.Empty, NodeModel.GUID, "PreviewPinned", previewPinned.ToString()));
             }
         }
 
+        [JsonIgnore]
         public NodeModel NodeModel { get { return nodeLogic; } private set { nodeLogic = value; } }
 
+        [JsonIgnore]
         public LacingStrategy ArgumentLacing
         {
             get { return nodeLogic.ArgumentLacing; }
         }
 
+        [JsonIgnore]
         public NodeModel NodeLogic
         {
             get { return nodeLogic; }
         }
 
+        [JsonIgnore]
         public InfoBubbleViewModel ErrorBubble { get; set; }
 
+        [JsonIgnore]
         public string ToolTipText
         {
             get { return nodeLogic.ToolTipText; }
         }
 
+        [JsonIgnore]
         public ObservableCollection<PortViewModel> InPorts
         {
             get { return inPorts; }
@@ -102,6 +121,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public ObservableCollection<PortViewModel> OutPorts
         {
             get { return outPorts; }
@@ -112,6 +132,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public bool IsSelected
         {
             get
@@ -120,6 +141,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public bool IsInput
         {
             get
@@ -128,6 +150,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public bool IsSetAsInput
         {
             get
@@ -154,16 +177,19 @@ namespace Dynamo.ViewModels
             set { nodeLogic.Name = value; }
         }
 
+        [JsonIgnore]
         public ElementState State
         {
             get { return nodeLogic.State; }
         }
 
+        [JsonIgnore]
         public string Description
         {
             get { return nodeLogic.Description; }
         }
 
+        [JsonIgnore]
         public bool IsCustomFunction
         {
             get { return nodeLogic.IsCustomFunction ? true : false; }
@@ -172,6 +198,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Element's left position is two-way bound to this value
         /// </summary>
+        [JsonIgnore]
         public double Left
         {
             get { return nodeLogic.X; }
@@ -185,6 +212,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Element's top position is two-way bound to this value
         /// </summary>
+        [JsonIgnore]
         public double Top
         {
             get { return nodeLogic.Y; }
@@ -208,6 +236,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// ZIndex represents the order on the z-plane in which nodes appear.
         /// </summary>
+        [JsonIgnore]
         public int ZIndex
         {
             get { return zIndex; }
@@ -222,6 +251,7 @@ namespace Dynamo.ViewModels
         /// Input grid's enabled state is now bound to this property
         /// which tracks the node model's InteractionEnabled property
         /// </summary>
+        [JsonIgnore]
         public bool IsInteractionEnabled
         {
             get { return true; }
@@ -243,6 +273,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public Visibility PeriodicUpdateVisibility
         {
             get
@@ -253,22 +284,26 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public bool EnablePeriodicUpdate
         {
             get { return nodeLogic.CanUpdatePeriodically; }
             set { nodeLogic.CanUpdatePeriodically = value; }
         }
 
+        [JsonIgnore]
         public bool ShowsVisibilityToggles
         {
             get { return true; }
         }
 
+        [JsonIgnore]
         public bool IsPreviewInsetVisible
         {
             get { return WorkspaceViewModel.Model is HomeWorkspaceModel && nodeLogic.ShouldDisplayPreview; }
         }
 
+        [JsonIgnore]
         public bool ShouldShowGlyphBar
         {
             get { return IsPreviewInsetVisible || ArgumentLacing != LacingStrategy.Disabled; }
@@ -277,6 +312,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Enable or disable text labels on nodes.
         /// </summary>
+        [JsonIgnore]
         public bool IsDisplayingLabels
         {
             get { return nodeLogic.DisplayLabels; }
@@ -287,6 +323,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public bool CanDisplayLabels
         {
             get
@@ -300,6 +337,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public string ASTText
         {
             get { return astText; }
@@ -310,6 +348,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public bool ShowDebugASTs
         {
             get { return DynamoViewModel.Model.DebugSettings.ShowDebugASTs; }
@@ -319,6 +358,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public bool WillForceReExecuteOfNode
         {
             get
@@ -328,7 +368,7 @@ namespace Dynamo.ViewModels
         }
 
         private bool showExectionPreview;
-
+        [JsonIgnore]
         public bool ShowExecutionPreview
         {
             get
@@ -343,6 +383,7 @@ namespace Dynamo.ViewModels
             }
         }
 
+        [JsonIgnore]
         public PreviewState PreviewState
         {
             get
@@ -362,7 +403,7 @@ namespace Dynamo.ViewModels
         }
 
         private bool isNodeNewlyAdded;
-
+        [JsonIgnore]
         public bool IsNodeAddedRecently
         {
             get
@@ -381,6 +422,7 @@ namespace Dynamo.ViewModels
         /// <value>
         ///   <c>true</c> if this instance is frozen; otherwise, <c>false</c>.
         /// </value>
+        [JsonIgnore]
         public bool IsFrozen
         {
             get
@@ -391,7 +433,7 @@ namespace Dynamo.ViewModels
             }
             set
             {
-                NodeModel.IsFrozen = value;                    
+                NodeModel.IsFrozen = value;
             }
         }
 
@@ -400,20 +442,21 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <value>
         ///  Returns true if the node has been frozen explicitly by the user, otherwise false.
-        /// </value>
+        /// </value>  
+        [JsonIgnore]
         public bool IsFrozenExplicitly
         {
             get
-            {    
+            {
                 //if the node is freeze by the user, then always
                 //check the Freeze property     
                 if (this.NodeLogic.isFrozenExplicitly)
-                {                   
+                {
                     return true;
                 }
-                
+
                 return false;
-            }             
+            }
         }
 
         /// <summary>
@@ -423,6 +466,7 @@ namespace Dynamo.ViewModels
         ///  This will return false if this node is not the root of the freeze operation, otherwise it will return 
         ///  true.
         /// </value>
+        [JsonIgnore]
         public bool CanToggleFrozen
         {
             get
@@ -453,14 +497,6 @@ namespace Dynamo.ViewModels
             {
                 NodeModel.Y = value;
             }
-        }
-
-        /// <summary>
-        /// Returns NodeModel ID
-        /// </summary>
-        public Guid Id
-        {
-            get { return NodeModel.GUID; }
         }
 
         #endregion
@@ -535,9 +571,9 @@ namespace Dynamo.ViewModels
             ZIndex = ++StaticZIndex;
             ++NoteViewModel.StaticZIndex;
         }
- 
+
         public NodeViewModel(WorkspaceViewModel workspaceViewModel, NodeModel logic, Size preferredSize)
-            :this(workspaceViewModel, logic)
+            : this(workspaceViewModel, logic)
         {
             // preferredSize is set when a node needs to have a fixed size
             PreferredSize = preferredSize;
@@ -545,12 +581,12 @@ namespace Dynamo.ViewModels
 
         private void SelectionOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-           CreateGroupCommand.RaiseCanExecuteChanged();
-           AddToGroupCommand.RaiseCanExecuteChanged();
-           UngroupCommand.RaiseCanExecuteChanged();
-           ToggleIsFrozenCommand.RaiseCanExecuteChanged();
-           RaisePropertyChanged("IsFrozenExplicitly");
-           RaisePropertyChanged("CanToggleFrozen");
+            CreateGroupCommand.RaiseCanExecuteChanged();
+            AddToGroupCommand.RaiseCanExecuteChanged();
+            UngroupCommand.RaiseCanExecuteChanged();
+            ToggleIsFrozenCommand.RaiseCanExecuteChanged();
+            RaisePropertyChanged("IsFrozenExplicitly");
+            RaisePropertyChanged("CanToggleFrozen");
         }
 
         void DebugSettings_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -606,18 +642,18 @@ namespace Dynamo.ViewModels
         {
             foreach (var item in nodeLogic.InPorts)
             {
-                PortViewModel inportViewModel = SubscribePortEvents(item);               
+                PortViewModel inportViewModel = SubscribePortEvents(item);
                 InPorts.Add(inportViewModel);
             }
 
             foreach (var item in nodeLogic.OutPorts)
             {
-                PortViewModel outportViewModel = SubscribePortEvents(item);              
+                PortViewModel outportViewModel = SubscribePortEvents(item);
                 OutPorts.Add(outportViewModel);
             }
         }
 
-        
+
         /// <summary>
         /// Respond to property changes on the model
         /// </summary>
@@ -658,7 +694,7 @@ namespace Dynamo.ViewModels
                     break;
                 case "IsSelected":
                     RaisePropertyChanged("IsSelected");
-                    RaisePropertyChanged("PreviewState");                    
+                    RaisePropertyChanged("PreviewState");
                     break;
                 case "State":
                     RaisePropertyChanged("State");
@@ -692,7 +728,7 @@ namespace Dynamo.ViewModels
                     break;
                 case "ForceReExecuteOfNode":
                     RaisePropertyChanged("WillForceReExecuteOfNode");
-                    break;             
+                    break;
                 case "CanUpdatePeriodically":
                     RaisePropertyChanged("EnablePeriodicUpdate");
                     RaisePropertyChanged("PeriodicUpdateVisibility");
@@ -781,9 +817,9 @@ namespace Dynamo.ViewModels
         }
 
         private void SetLacingType(object param)
-        {           
+        {
             DynamoViewModel.ExecuteCommand(
-              new DynamoModel.UpdateModelValueCommand(
+                new DynamoModel.UpdateModelValueCommand(
                     Guid.Empty, NodeModel.GUID, "ArgumentLacing", param.ToString()));
 
             DynamoViewModel.RaiseCanExecuteUndoRedo();
@@ -798,7 +834,7 @@ namespace Dynamo.ViewModels
         private void ViewCustomNodeWorkspace(object parameter)
         {
             var f = (nodeLogic as Function);
-            if(f!= null)
+            if (f != null)
                 DynamoViewModel.FocusCustomNodeWorkspace(f.Definition.FunctionId);
         }
 
@@ -817,8 +853,8 @@ namespace Dynamo.ViewModels
                 //create a new port view model
                 foreach (var item in e.NewItems)
                 {
-                    PortViewModel inportViewModel = SubscribePortEvents(item as PortModel);                   
-                    InPorts.Add(inportViewModel);                    
+                    PortViewModel inportViewModel = SubscribePortEvents(item as PortModel);
+                    InPorts.Add(inportViewModel);
                 }
             }
             else if (e.Action == NotifyCollectionChangedAction.Remove)
@@ -827,13 +863,13 @@ namespace Dynamo.ViewModels
                 //is the one passed in
                 foreach (var item in e.OldItems)
                 {
-                    PortViewModel portToRemove = UnSubscribePortEvents(InPorts.ToList().First(x => x.PortModel == item)); ;                   
+                    PortViewModel portToRemove = UnSubscribePortEvents(InPorts.ToList().First(x => x.PortModel == item)); ;
                     InPorts.Remove(portToRemove);
                 }
             }
-            else if(e.Action == NotifyCollectionChangedAction.Reset)
+            else if (e.Action == NotifyCollectionChangedAction.Reset)
             {
-                foreach(var p in InPorts)
+                foreach (var p in InPorts)
                 {
                     UnSubscribePortEvents(p);
                 }
@@ -851,7 +887,7 @@ namespace Dynamo.ViewModels
                 //create a new port view model
                 foreach (var item in e.NewItems)
                 {
-                    PortViewModel outportViewModel = SubscribePortEvents(item as PortModel);                    
+                    PortViewModel outportViewModel = SubscribePortEvents(item as PortModel);
                     OutPorts.Add(outportViewModel);
                 }
             }
@@ -883,7 +919,7 @@ namespace Dynamo.ViewModels
         /// <returns></returns>
         private PortViewModel SubscribePortEvents(PortModel item)
         {
-            PortViewModel portViewModel = new PortViewModel(this, item);            
+            PortViewModel portViewModel = new PortViewModel(this, item);
             portViewModel.MouseEnter += OnRectangleMouseEnter;
             portViewModel.MouseLeave += OnRectangleMouseLeave;
             portViewModel.MouseLeftButtonDown += OnMouseLeftButtonDown;
@@ -1111,7 +1147,7 @@ namespace Dynamo.ViewModels
         }
 
         private void RaiseFrozenPropertyChanged()
-        {            
+        {
             RaisePropertyChanged("IsFrozen");
             RaisePropertyChangedOnDownStreamNodes();
         }
@@ -1156,7 +1192,7 @@ namespace Dynamo.ViewModels
         }
 
         private bool CanAddToGroup(object parameters)
-        {          
+        {
             var groups = WorkspaceViewModel.Model.Annotations;
             if (groups.Any(x => x.IsSelected))
             {
@@ -1188,6 +1224,5 @@ namespace Dynamo.ViewModels
             Model = model;
             Handled = false;
         }
-    }   
+    }
 }
-

--- a/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
@@ -31,7 +31,6 @@ namespace Dynamo.Wpf.ViewModels.Core
                 Converters = new List<JsonConverter>{
                     new AnnotationViewModelConverter(),
                     new NoteViewModelConverter(),
-                    new NodeViewModelConverter(),
                 },
             };
 


### PR DESCRIPTION
### Purpose

Since we verified that nested structure is no longer needed for nodeView serialization. Removing the use of  `NodeViewModelConverter` and use serialization from Json.Net. The result Graph.Json format remain unchanged.

Example Graph:
```json
{
  "Uuid": "c88ae17d-f74f-43a3-98db-cef4785e9d7a",
  "IsCustomNode": false,
  "Description": "",
  "Name": "Home",
  "ElementResolver": {
    "ResolutionMap": {}
  },
  "Nodes": [
    {
      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
      "NodeType": "FunctionNode",
      "FunctionSignature": "Autodesk.DesignScript.Geometry.Sphere.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double",
      "Id": "d61e3b04-542e-474a-b661-738820d7634c",
      "Inputs": [
        {
          "Id": "8199a7cf-8a07-4640-ad27-8a2b31ca5419",
          "Name": "centerPoint",
          "Description": "Point\nDefault value : Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0)",
          "Level": 2,
          "UseLevels": false,
          "KeepListStructure": false
        },
        {
          "Id": "1f51b6a2-8168-4574-8f67-e672e800217b",
          "Name": "radius",
          "Description": "double\nDefault value : 1",
          "Level": 2,
          "UseLevels": false,
          "KeepListStructure": false
        }
      ],
      "Outputs": [
        {
          "Id": "ecc82e26-17e2-4434-97c9-0ab845108020",
          "Name": "Sphere",
          "Description": "Sphere",
          "Level": 2,
          "UseLevels": false,
          "KeepListStructure": false
        }
      ],
      "Replication": "Auto",
      "Description": "Create a Solid Sphere cetered at the input Point, with given radius.\n\nSphere.ByCenterPointRadius (centerPoint: Point = Autodesk.DesignScript.Geometry.Point.ByCoordinates(0, 0, 0), radius: double = 1): Sphere"
    }
  ],
  "Connectors": [],
  "Dependencies": [],
  "Bindings": [],
  "View": {
    "Cameras": {
      "EyePosition": "-17,24,50",
      "UpDirection": "0,1,0",
      "LookDirection": "12,-13,-58",
      "Name": "Background Preview"
    },
    "NodeViews": [
      {
        "Id": "d61e3b04-542e-474a-b661-738820d7634c",
        "Name": "Sphere.ByCenterPointRadius",
        "IsVisible": true,
        "IsUpstreamVisible": true,
        "X": 201.5,
        "Y": 159.5
      }
    ],
    "Notes": [],
    "Annotations": [],
    "X": -328.0,
    "Y": -48.0,
    "Zoom": 1.0
  }
}
```

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps @mjkkirschner 

### FYIs

@gregmarr @ikeough 
