### PR TITLE
DynamoModel.Version

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -196,7 +196,7 @@ namespace Dynamo.Models
         /// </summary>
         public string Version
         {
-            get { return UpdateManager.ProductVersion.ToString(); }
+            get { return DefaultUpdateManager.GetProductVersion().ToString(); }
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

This PR removes the dependency of DynamoModel.Version property on UpdateManager instance, rather use the static method to return the product version. This was causing crash at start up due to #8000, now fixed with this PR.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs

@Racel 