### PR TITLE
Implement Resource registration and app shutdown notification mechanism

### DIFF
--- a/src/DynamoCoreWpf/Interfaces/ILibraryViewCustomization.cs
+++ b/src/DynamoCoreWpf/Interfaces/ILibraryViewCustomization.cs
@@ -62,5 +62,21 @@ namespace Dynamo.Wpf.Interfaces
         /// <param name="sectionText">The name of the section to be updated</param>
         /// <returns>True if the operation was successful</returns>
         bool AddIncludeInfo(IEnumerable<LayoutIncludeInfo> includes, string sectionText = "");
+
+        /// <summary>
+        /// Registers a given resource stream for a given url. If registered 
+        /// successfully the requested resource is returned from the given stream.
+        /// </summary>
+        /// <param name="urlpath">relative path of url including 
+        /// extension of the resource, e.g. /myicons/xicon.png</param>
+        /// <param name="resource">resource data stream</param>
+        /// <returns>True if the operation was successful</returns>
+        bool RegisterResourceStream(string urlpath, Stream resource);
+
+        /// <summary>
+        /// This method can be called by host application to notify the aplication
+        /// shutdown so that the customization service can do the cleanup of resources.
+        /// </summary>
+        void OnAppShutdown();
     }
 }

--- a/src/LibraryViewExtension/Handlers/IconUrl.cs
+++ b/src/LibraryViewExtension/Handlers/IconUrl.cs
@@ -20,9 +20,15 @@ namespace Dynamo.LibraryUI.Handlers
         public IconUrl(Uri url)
         {
             Url = url.AbsoluteUri;
-
-            var assemblyPath = url.Query.Substring(query.Length);
-            Path = WebUtility.UrlDecode(assemblyPath); //Decode the path to normal path
+            if(string.IsNullOrEmpty(url.Query))
+            {
+                Path = DefaultPath;
+            }
+            else
+            {
+                var assemblyPath = url.Query.Substring(query.Length);
+                Path = WebUtility.UrlDecode(assemblyPath); //Decode the path to normal path
+            }
 
             Name = url.Segments.Last();
         }

--- a/src/LibraryViewExtension/LibraryViewController.cs
+++ b/src/LibraryViewExtension/LibraryViewController.cs
@@ -91,7 +91,7 @@ namespace Dynamo.LibraryUI
         /// </summary>
         /// <param name="dynamoView">DynamoView hosting library component</param>
         /// <param name="commandExecutive">Command executive to run dynamo commands</param>
-        public LibraryViewController(Window dynamoView, ICommandExecutive commandExecutive, LibraryViewCustomization customization)
+        internal LibraryViewController(Window dynamoView, ICommandExecutive commandExecutive, LibraryViewCustomization customization)
         {
             this.dynamoWindow = dynamoView;
             dynamoViewModel = dynamoView.DataContext as DynamoViewModel;

--- a/src/LibraryViewExtension/LibraryViewCustomization.cs
+++ b/src/LibraryViewExtension/LibraryViewCustomization.cs
@@ -6,10 +6,16 @@ using Dynamo.Wpf.Interfaces;
 
 namespace Dynamo.LibraryUI
 {
-    class LibraryViewCustomization : ILibraryViewCustomization
+    public class LibraryViewCustomization : ILibraryViewCustomization, IDisposable
     {
         public const string DefaultSectionName = "default";
         private LayoutSpecification root = new LayoutSpecification();
+        private Dictionary<string, Stream> resources = new Dictionary<string, Stream>();
+
+        /// <summary>
+        /// Returns a list of key value pair of all the registered resources
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, Stream>> Resources { get { return resources; } }
 
         private void RaiseSepcificationUpdated()
         {
@@ -126,6 +132,60 @@ namespace Dynamo.LibraryUI
         public Stream ToJSONStream()
         {
             return root.ToJSONStream();
+        }
+
+        /// <summary>
+        /// Notifies when a resource stream is registered
+        /// </summary>
+        public event Action<string, Stream> ResourceStreamRegistered;
+
+        /// <summary>
+        /// Registers a given resource stream for a given url. If registered 
+        /// successfully the requested resource is returned from the given stream.
+        /// </summary>
+        /// <param name="urlpath">relative path of url including 
+        /// extension of the resource, e.g. /myicons/xicon.png</param>
+        /// <param name="resource">resource data stream</param>
+        /// <returns>True if the operation was successful</returns>
+        public bool RegisterResourceStream(string urlpath, Stream resource)
+        {
+            var handler = ResourceStreamRegistered;
+            if(handler != null)
+            {
+                handler(urlpath, resource);
+            }
+
+            var extension = Path.GetExtension(urlpath);
+            if (string.IsNullOrEmpty(extension)) return false;
+
+            resources.Add(urlpath, resource);
+            return true;
+        }
+
+        public void OnAppShutdown()
+        {
+            if (CefSharp.Cef.IsInitialized)
+            {
+                CefSharp.Cef.Shutdown();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                foreach (var item in resources)
+                {
+                    item.Value.Dispose();
+                }
+                resources.Clear();
+            }
         }
     }
 }

--- a/src/LibraryViewExtension/LibraryViewCustomization.cs
+++ b/src/LibraryViewExtension/LibraryViewCustomization.cs
@@ -6,7 +6,7 @@ using Dynamo.Wpf.Interfaces;
 
 namespace Dynamo.LibraryUI
 {
-    public class LibraryViewCustomization : ILibraryViewCustomization, IDisposable
+    class LibraryViewCustomization : ILibraryViewCustomization, IDisposable
     {
         public const string DefaultSectionName = "default";
         private LayoutSpecification root = new LayoutSpecification();
@@ -135,7 +135,9 @@ namespace Dynamo.LibraryUI
         }
 
         /// <summary>
-        /// Notifies when a resource stream is registered
+        /// Notifies when a resource stream is registered. This event is
+        /// used by ResourceHandlerFactory to register the resource handler
+        /// for provided url path.
         /// </summary>
         public event Action<string, Stream> ResourceStreamRegistered;
 
@@ -149,19 +151,22 @@ namespace Dynamo.LibraryUI
         /// <returns>True if the operation was successful</returns>
         public bool RegisterResourceStream(string urlpath, Stream resource)
         {
-            var handler = ResourceStreamRegistered;
-            if(handler != null)
-            {
-                handler(urlpath, resource);
-            }
-
             var extension = Path.GetExtension(urlpath);
             if (string.IsNullOrEmpty(extension)) return false;
 
             resources.Add(urlpath, resource);
+
+            var handler = ResourceStreamRegistered;
+            if (handler != null)
+            {
+                handler(urlpath, resource);
+            }
             return true;
         }
 
+        /// <summary>
+        /// To be called by host application to request CEF shutdown
+        /// </summary>
         public void OnAppShutdown()
         {
             if (CefSharp.Cef.IsInitialized)
@@ -170,6 +175,9 @@ namespace Dynamo.LibraryUI
             }
         }
 
+        /// <summary>
+        /// IDisposable implementation
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);

--- a/src/LibraryViewExtension/LibraryViewExtension.cs
+++ b/src/LibraryViewExtension/LibraryViewExtension.cs
@@ -1,17 +1,6 @@
-﻿using System;
-using System.IO;
-using System.Reflection;
-using System.Windows.Controls;
-using CefSharp;
-using CefSharp.Wpf;
-using Dynamo.LibraryUI.ViewModels;
-using Dynamo.LibraryUI.Views;
-using Dynamo.Wpf.Extensions;
+﻿using Dynamo.Models;
 using Dynamo.PackageManager;
-using Dynamo.Models;
-using System.Linq;
-using Dynamo.Controls;
-using Dynamo.ViewModels;
+using Dynamo.Wpf.Extensions;
 using Dynamo.Wpf.Interfaces;
 
 namespace Dynamo.LibraryUI
@@ -20,7 +9,7 @@ namespace Dynamo.LibraryUI
     {
         private ViewLoadedParams viewLoadedParams;
         private ViewStartupParams viewStartupParams;
-        private ILibraryViewCustomization customization = new LibraryViewCustomization();
+        private LibraryViewCustomization customization = new LibraryViewCustomization();
         private LibraryViewController controller;
 
         public string UniqueId
@@ -38,7 +27,7 @@ namespace Dynamo.LibraryUI
         public void Startup(ViewStartupParams p)
         {
             viewStartupParams = p;
-            p.ExtensionManager.RegisterService(customization);
+            p.ExtensionManager.RegisterService<ILibraryViewCustomization>(customization);
         }
 
         public void Loaded(ViewLoadedParams p)
@@ -58,7 +47,9 @@ namespace Dynamo.LibraryUI
 
         public void Dispose()
         {
-
+            if (controller != null) controller.Dispose();
+            customization = null;
+            controller = null;
         }
     }
 

--- a/src/LibraryViewExtension/LibraryViewExtension.cs
+++ b/src/LibraryViewExtension/LibraryViewExtension.cs
@@ -47,10 +47,21 @@ namespace Dynamo.LibraryUI
 
         public void Dispose()
         {
+            Dispose(true);
+            System.GC.SuppressFinalize(this);
+        }
+
+        protected void Dispose(bool disposing)
+        {
+            if (!disposing) return;
+
             if (controller != null) controller.Dispose();
+            if (customization != null) customization.Dispose();
+
             customization = null;
             controller = null;
         }
+        
     }
 
     public static class DynamoModelExtensions

--- a/src/LibraryViewExtension/Views/LibraryView.xaml.cs
+++ b/src/LibraryViewExtension/Views/LibraryView.xaml.cs
@@ -26,7 +26,7 @@ namespace Dynamo.LibraryUI.Views
                 var settings = new CefSettings { RemoteDebuggingPort = 8088 };
                 //to fix Fickering set disable-gpu to true
                 settings.CefCommandLineArgs.Add("disable-gpu", "1");
-                Cef.Initialize(settings);
+                Cef.Initialize(settings, true, false);
             }
             
             InitializeComponent();


### PR DESCRIPTION
### Purpose

This PR updates the `ILibraryViewCustomization` interface to provide additional methods to register resources and to notify when host application is shutting down to shut down the CEF instance. This PR also provides the IDisposable implementation for LibraryViewCustomization and LibraryController class.

```cs
        /// <summary>
        /// Registers a given resource stream for a given url. If registered 
        /// successfully the requested resource is returned from the given stream.
        /// </summary>
        /// <param name="urlpath">relative path of url including 
        /// extension of the resource, e.g. /myicons/xicon.png</param>
        /// <param name="resource">resource data stream</param>
        /// <returns>True if the operation was successful</returns>
        bool RegisterResourceStream(string urlpath, Stream resource);

        /// <summary>
        /// This method can be called by host application to notify the aplication
        /// shutdown so that the customization service can do the cleanup of resources.
        /// </summary>
        void OnAppShutdown();
```

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@Benglin 
