### PR TITLE
Keep the version based on 1/1/16

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
@@ -70,5 +70,5 @@ using System.Runtime.InteropServices;
 int MajorVersion = 2;
 int MinorVersion = 0;
 int BuildNumber = 0;
-int RevisionNumber = ((int)(DateTime.UtcNow - new DateTime(2017,1,1)).TotalDays)*10+((int)DateTime.UtcNow.Hour)/3;
+int RevisionNumber = ((int)(DateTime.UtcNow - new DateTime(2016,1,1)).TotalDays)*10+((int)DateTime.UtcNow.Hour)/3;
 #>


### PR DESCRIPTION
### Purpose

The base date for version should be changed only when the version numbers are changed. We have been posting NuGet packages based on 2016 based version, changing it to 2017 caused the newer packages with lower beta version. Reverting back the base date to 2016 so that the Revision number in version string is in continuation with the old packages.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### FYIs

@mjkkirschner 
@QilongTang 