### PR TITLE
added node to append to file

### DIFF
--- a/src/Libraries/CoreNodes/Files.cs
+++ b/src/Libraries/CoreNodes/Files.cs
@@ -185,6 +185,18 @@ namespace DSCore.IO
             var fullpath = AbsolutePath(filePath);
             System.IO.File.WriteAllText(fullpath, text);
         }
+        
+        /// <summary>
+        ///     Append the text content to a file specified by the path
+        /// </summary>
+        /// <param name="filePath">Path to write to</param>
+        /// <param name="text">Text content</param>
+        /// <search>append file,text,file,filepath</search>
+        public static void AppendText(string filePath, string text)
+        {
+            var fullpath = AbsolutePath(filePath);
+            System.IO.File.AppendAllText(fullpath, text);
+        }
 
         #region Obsolete Methods
 

--- a/test/Libraries/CoreNodesTests/FileTests.cs
+++ b/test/Libraries/CoreNodesTests/FileTests.cs
@@ -212,6 +212,18 @@ namespace Dynamo.Tests
             Assert.IsTrue(System.IO.File.Exists(fn));
             Assert.AreEqual(contents, System.IO.File.ReadAllText(fn));
         }
+        
+        [Test, Category("UnitTests")]
+        public void File_AppendText()
+        {
+            const string contents = "test";
+            var fn = GetNewFileNameOnTempPath(".txt");
+            Assert.IsFalse(System.IO.File.Exists(fn));
+            File.WriteText(fn, contents);
+            File.AppendText(fn, contents);
+            Assert.IsTrue(System.IO.File.Exists(fn));
+            Assert.AreEqual(contents+contents, System.IO.File.ReadAllText(fn));
+        }
         #endregion
 
         #region Directories


### PR DESCRIPTION
fixes #7977

### Purpose

adds a node allowing users to append to files instead of write, as requested by community :

- https://forum.dynamobim.com/t/wish-add-append-option-to-writetext-node/12489
- https://forum.dynamobim.com/t/append-new-data-to-end-of-text-file/10919?source_topic_id=12489

This this is a much safer option than adding a boolean switch to control write/append behaviour as it removes the possibility of accidentally overwriting files (by forgetting or not understanding what the switch does).

Have also added a test for the new `AppendText` method.

![append text](https://user-images.githubusercontent.com/11439624/28115270-154fe7e4-66fc-11e7-870e-841a11a60abd.PNG)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ke-yu 
@QilongTang 

### FYIs

@DavePlumb

