### PR TITLE
Update the type of custom node instance

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -54,15 +54,6 @@ namespace Dynamo.Graph.Nodes.CustomNodes
         }
 
         /// <summary>
-        /// A flag used during serialization to indicate
-        /// that the node is a custom node.
-        /// </summary>
-        public bool IsCustomNode
-        {
-            get { return true; }
-        }
-
-        /// <summary>
         /// The unique id of the underlying function.
         /// </summary>
         public Guid FunctionUuid

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -71,6 +71,17 @@ namespace Dynamo.Graph.Nodes.CustomNodes
         }
 
         /// <summary>
+        /// The type of node.
+        /// </summary>
+        public override string NodeType
+        {
+            get
+            {
+                return "CustomFunctionNode";
+            }
+        }
+
+        /// <summary>
         /// Returns customNode definition.
         /// </summary>
         [JsonIgnore]


### PR DESCRIPTION
### Purpose

Change the type of custom node instance from `ExtensionNode` to `CustomFunctionNode`.

Remove `IsCustomNode` property.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner PTAL
