### PR TITLE
Ensure CBN output port descriptions match after serialization

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -41,6 +41,7 @@ namespace Dynamo.Graph.Nodes
         private readonly List<string> tempVariables = new List<string>();
         private string previewVariable;
         private readonly LibraryServices libraryServices;
+        private const string ReachTempVarForNonAssignment = "temp6BBA4B28C5E54CF89F300D510499A11E_";
 
         private bool shouldFocus = true;
 
@@ -801,6 +802,19 @@ namespace Dynamo.Graph.Nodes
                 string tooltip = def.Key;
                 if (tempVariables.Contains(def.Key))
                     tooltip = Formatting.TOOL_TIP_FOR_TEMP_VARIABLE;
+
+                // there's hardcoded prefix tooltip for all non unassigned variables on CBN.
+                // but also there's a delta between 0.9 and 1.0 versions prefixes.
+                // to overcome it we cast dynamo prefix to universal pre-defined one.
+                var tooltip_guid = ProtoCore.DSASM.Constants.kTempVarForNonAssignment;
+
+                if (tooltip.IndexOf(tooltip_guid) != -1)
+                {
+                    var tempArray = tooltip.Split(new string[] { tooltip_guid }, System.StringSplitOptions.None);
+                    tooltip = (tempArray.Length > 1)
+                        ? ReachTempVarForNonAssignment + tempArray[1]
+                        : tooltip;
+                }
 
                 OutPorts.Add(new PortModel(PortType.Output, this, new PortData(string.Empty, tooltip)
                 {


### PR DESCRIPTION
### Purpose

The purpose of this PR is to ensure the output port descriptions of CBN's remain the same after serialization.  Previously the output port descriptions did not match if a CB output was not explicitly assigned to a variable.  In this scenario a GUID is generated and assigned to the output port description.  The fix outline in the comments below ensures the GUID is the same after serialization.  The reason this data is stored in the the `port.Description` as opposed to the `port.Name` is because any `port.Name` content will be displayed on the nodes output UI.  If the output has a GUID `port.Name` the node becomes significantly expanded due to the string length.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner  @QilongTang 

### FYIs
