### PR TITLE
 Serialization small updates

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -180,7 +180,6 @@ namespace Dynamo.Graph.Nodes
         ///     Returns whether the node is to be included in visualizations.
         /// </summary>
         [JsonIgnore]
-        [JsonProperty("ShowGeometry")]
         public bool IsVisible
         {
             get

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -180,6 +180,7 @@ namespace Dynamo.Graph.Nodes
         ///     Returns whether the node is to be included in visualizations.
         /// </summary>
         [JsonIgnore]
+        [JsonProperty("ShowGeometry")]
         public bool IsVisible
         {
             get

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -53,7 +53,7 @@ namespace Dynamo.Graph.Workspaces
         public string Name;
         public double X;
         public double Y;
-        public bool IsVisible;
+        public bool ShowGeometry;
         public bool IsUpstreamVisible;
     }
 
@@ -1581,7 +1581,7 @@ namespace Dynamo.Graph.Workspaces
 
                     // Note: These parameters are not directly accessible due to undo/redo considerations
                     //       which should not be used during deserialization (see "ArgumentLacing" for details)
-                    nodeModel.UpdateValue(new UpdateValueParams("IsVisible", nodeViewInfo.IsVisible.ToString()));
+                    nodeModel.UpdateValue(new UpdateValueParams("IsVisible", nodeViewInfo.ShowGeometry.ToString()));
                     nodeModel.UpdateValue(new UpdateValueParams("IsUpstreamVisible", nodeViewInfo.IsUpstreamVisible.ToString()));
                 }
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -257,6 +257,7 @@ namespace Dynamo.ViewModels
             get { return true; }
         }
 
+        [JsonProperty("ShowGeometry")]
         public bool IsVisible
         {
             get

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -62,6 +62,15 @@ namespace Dynamo.Tests
             public bool UseLevels { get; set; }
             public bool KeepListStructure { get; set; }
             public int Level { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                var other = (obj as portComparisonData);
+                return ID == other.ID &&
+                    other.KeepListStructure == this.KeepListStructure && 
+                    other.Level == this.Level && 
+                    other.UseLevels == this.UseLevels;
+            }
         }
 
         /// <summary>
@@ -180,8 +189,12 @@ namespace Dynamo.Tests
             {
                 //convert the old guid to the new guid
                 var newGuid = GuidUtility.Create(GuidUtility.UrlNamespace, this.modelsGuidToIdMap[portkvp.Key]);
-                Assert.IsTrue(b.PortDataMap.ContainsKey(portkvp.Key));
-                Assert.AreEqual(a.PortDataMap[portkvp.Key], b.PortDataMap[newGuid]);
+                Assert.IsTrue(b.PortDataMap.ContainsKey(newGuid));
+                var aPort = a.PortDataMap[portkvp.Key];
+                var bPort= b.PortDataMap[newGuid];
+                Assert.AreEqual(aPort.UseLevels,bPort.UseLevels);
+                Assert.AreEqual(aPort.KeepListStructure, bPort.KeepListStructure);
+                Assert.AreEqual(aPort.Level, bPort.Level);
             }
 
             foreach (var kvp in a.NodeDataMap)

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -84,6 +84,7 @@ namespace Dynamo.Tests
             public int ConnectorCount { get; set; }
             public Dictionary<Guid, Type> NodeTypeMap { get; set; }
             public Dictionary<Guid, List<object>> NodeDataMap { get; set; }
+            public Dictionary<Guid,string> NodeReplicationMap { get; set; }
             public Dictionary<Guid, int> InportCountMap { get; set; }
             public Dictionary<Guid, int> OutportCountMap { get; set; }
             public Dictionary<Guid, portComparisonData> PortDataMap { get; set; }
@@ -100,10 +101,12 @@ namespace Dynamo.Tests
                 InportCountMap = new Dictionary<Guid, int>();
                 OutportCountMap = new Dictionary<Guid, int>();
                 PortDataMap = new Dictionary<Guid, portComparisonData>();
+                NodeReplicationMap = new Dictionary<Guid, string>();
 
                 foreach (var n in workspace.Nodes)
                 {
                     NodeTypeMap.Add(n.GUID, n.GetType());
+                    NodeReplicationMap.Add(n.GUID,n.ArgumentLacing.ToString());
 
                     var portvalues = n.OutPorts.Select(p =>
                         GetDataOfValue(n.GetValue(p.Index, controller))).ToList<object>();
@@ -197,6 +200,14 @@ namespace Dynamo.Tests
                 Assert.AreEqual(aPort.Level, bPort.Level);
             }
 
+            foreach(var kvp in a.NodeReplicationMap)
+            {
+                var newGuid = GuidUtility.Create(GuidUtility.UrlNamespace, this.modelsGuidToIdMap[kvp.Key]);
+                var valueA = kvp.Value;
+                var valueB = b.NodeReplicationMap[newGuid];
+                Assert.AreEqual(valueA, valueB);
+            }
+
             foreach (var kvp in a.NodeDataMap)
             {
                 var valueA = kvp.Value;
@@ -252,6 +263,13 @@ namespace Dynamo.Tests
             {
                 Assert.IsTrue(b.PortDataMap.ContainsKey(portkvp.Key));
                 Assert.AreEqual(a.PortDataMap[portkvp.Key], b.PortDataMap[portkvp.Key]);
+            }
+
+            foreach (var kvp in a.NodeReplicationMap)
+            {
+                var valueA = kvp.Value;
+                var valueB = b.NodeReplicationMap[kvp.Key];
+                Assert.AreEqual(valueA, valueB);
             }
 
             foreach (var kvp in a.NodeDataMap)

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -56,7 +56,7 @@ namespace Dynamo.Tests
             lastExecutionDuration = (TimeSpan)session.GetParameterValue(Session.ParameterKeys.LastExecutionDuration);
         }
 
-        internal class portComparisonData
+        internal class PortComparisonData
         {
             public string ID { get; set; }
             public bool UseLevels { get; set; }
@@ -65,7 +65,7 @@ namespace Dynamo.Tests
 
             public override bool Equals(object obj)
             {
-                var other = (obj as portComparisonData);
+                var other = (obj as PortComparisonData);
                 return ID == other.ID &&
                     other.KeepListStructure == this.KeepListStructure && 
                     other.Level == this.Level && 
@@ -87,7 +87,7 @@ namespace Dynamo.Tests
             public Dictionary<Guid,string> NodeReplicationMap { get; set; }
             public Dictionary<Guid, int> InportCountMap { get; set; }
             public Dictionary<Guid, int> OutportCountMap { get; set; }
-            public Dictionary<Guid, portComparisonData> PortDataMap { get; set; }
+            public Dictionary<Guid, PortComparisonData> PortDataMap { get; set; }
             public string DesignScript { get; set; }
 
             public WorkspaceComparisonData(WorkspaceModel workspace, EngineController controller)
@@ -100,7 +100,7 @@ namespace Dynamo.Tests
                 NodeDataMap = new Dictionary<Guid, List<object>>();
                 InportCountMap = new Dictionary<Guid, int>();
                 OutportCountMap = new Dictionary<Guid, int>();
-                PortDataMap = new Dictionary<Guid, portComparisonData>();
+                PortDataMap = new Dictionary<Guid, PortComparisonData>();
                 NodeReplicationMap = new Dictionary<Guid, string>();
 
                 foreach (var n in workspace.Nodes)
@@ -114,25 +114,24 @@ namespace Dynamo.Tests
                     n.InPorts.ToList().ForEach(p =>
                     {
                         PortDataMap.Add(p.GUID,
-    new portComparisonData
-    {
-        ID = p.GUID.ToString(),
-        UseLevels = p.UseLevels,
-        KeepListStructure = p.KeepListStructure,
-        Level = p.Level
-    });
+                            new PortComparisonData
+                            {
+                                ID = p.GUID.ToString(),
+                                UseLevels = p.UseLevels,
+                                KeepListStructure = p.KeepListStructure,
+                                Level = p.Level
+                            });
                     });
 
                     n.OutPorts.ToList().ForEach(p =>
                     {
                         PortDataMap.Add(p.GUID,
-    new portComparisonData
-    {
-        ID = p.GUID.ToString(),
+                            new PortComparisonData
+                            {
+                                ID = p.GUID.ToString(),
 
-    });
+                            });
                     });
-
 
                     NodeDataMap.Add(n.GUID, portvalues);
                     InportCountMap.Add(n.GUID, n.InPorts.Count);
@@ -200,7 +199,7 @@ namespace Dynamo.Tests
                 Assert.AreEqual(aPort.Level, bPort.Level);
             }
 
-            foreach(var kvp in a.NodeReplicationMap)
+            foreach (var kvp in a.NodeReplicationMap)
             {
                 var newGuid = GuidUtility.Create(GuidUtility.UrlNamespace, this.modelsGuidToIdMap[kvp.Key]);
                 var valueA = kvp.Value;
@@ -259,7 +258,7 @@ namespace Dynamo.Tests
                 Assert.AreEqual(countA, countB, string.Format("One {0} node has {1} outports, while the other has {2}", a.NodeTypeMap[kvp.Key], countA, countB));
             }
 
-            foreach(var portkvp in a.PortDataMap)
+            foreach (var portkvp in a.PortDataMap)
             {
                 Assert.IsTrue(b.PortDataMap.ContainsKey(portkvp.Key));
                 Assert.AreEqual(a.PortDataMap[portkvp.Key], b.PortDataMap[portkvp.Key]);


### PR DESCRIPTION
This PR updates json serialization in dynamo to serialize and deserialize the NodeView property `IsVisible` as `ShowGeometry`, as defined in the schema.

 also starts deserializing `Replication` - looks like this was not done previously when using the node read converter, now it is done as part of node deserialization in the node read converter... I find it odd that this was not caught as part of the workspace data comparison but it was not being set on save before this change.

last, this PR sets some data on portModels for nodes from the deserialized portModels, this was not being done so graphs were losing their port guids and other list@level settings.

Tests are added for the portModel and replication properties as part of workspace comparison.

really Last! I've used this branch to generate a new `serialization.dyn` file which I will include in my other PR.

**Reviewers**:
@QilongTang @ColinDayOrg 
