### PR TITLE
QNTM-1074 Dynamo should serialize all number and slider nodes as 'NumberInputNode'

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -41,6 +41,7 @@ namespace Dynamo.Graph.Nodes
         private readonly List<string> tempVariables = new List<string>();
         private string previewVariable;
         private readonly LibraryServices libraryServices;
+        private const string ReachTempVarForNonAssignment = "temp6BBA4B28C5E54CF89F300D510499A11E_";
 
         private bool shouldFocus = true;
 
@@ -801,6 +802,19 @@ namespace Dynamo.Graph.Nodes
                 string tooltip = def.Key;
                 if (tempVariables.Contains(def.Key))
                     tooltip = Formatting.TOOL_TIP_FOR_TEMP_VARIABLE;
+
+                // there's hardcoded prefix tooltip for all non unassigned variables on CBN.
+                // but also there's a delta between 0.9 and 1.0 versions prefixes.
+                // to overcome it we cast dynamo prefix to universal pre-defined one.
+                var tooltip_guid = ProtoCore.DSASM.Constants.kTempVarForNonAssignment;
+
+                if (tooltip.IndexOf(tooltip_guid) != -1)
+                {
+                    var tempArray = tooltip.Split(new string[] { tooltip_guid }, System.StringSplitOptions.None);
+                    tooltip = (tempArray.Length > 1)
+                        ? ReachTempVarForNonAssignment + tempArray[1]
+                        : tooltip;
+                }
 
                 OutPorts.Add(new PortModel(PortType.Output, this, new PortData(string.Empty, tooltip)
                 {

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -41,7 +41,6 @@ namespace Dynamo.Graph.Nodes
         private readonly List<string> tempVariables = new List<string>();
         private string previewVariable;
         private readonly LibraryServices libraryServices;
-        private const string ReachTempVarForNonAssignment = "temp6BBA4B28C5E54CF89F300D510499A11E_";
 
         private bool shouldFocus = true;
 
@@ -802,19 +801,6 @@ namespace Dynamo.Graph.Nodes
                 string tooltip = def.Key;
                 if (tempVariables.Contains(def.Key))
                     tooltip = Formatting.TOOL_TIP_FOR_TEMP_VARIABLE;
-
-                // there's hardcoded prefix tooltip for all non unassigned variables on CBN.
-                // but also there's a delta between 0.9 and 1.0 versions prefixes.
-                // to overcome it we cast dynamo prefix to universal pre-defined one.
-                var tooltip_guid = ProtoCore.DSASM.Constants.kTempVarForNonAssignment;
-
-                if (tooltip.IndexOf(tooltip_guid) != -1)
-                {
-                    var tempArray = tooltip.Split(new string[] { tooltip_guid }, System.StringSplitOptions.None);
-                    tooltip = (tempArray.Length > 1)
-                        ? ReachTempVarForNonAssignment + tempArray[1]
-                        : tooltip;
-                }
 
                 OutPorts.Add(new PortModel(PortType.Output, this, new PortData(string.Empty, tooltip)
                 {

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -131,14 +131,7 @@ namespace CoreNodeModels.Input
         {
             get
             {
-                if(this.GetType().ToString() == "CoreNodeModels.Input.DoubleInput")
-                {
-                    return "Double";
-                }
-                else
-                {
-                    return this.GetType().ToString();
-                }
+                return "Double";
             }
         }
 

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -114,19 +114,6 @@ namespace CoreNodeModels.Input
     [AlsoKnownAs("Dynamo.Nodes.DoubleInput", "Dynamo.Nodes.dynDoubleInput", "DSCoreNodesUI.Input.DoubleInput")]
     public class DoubleInput : NodeModel
     {
-        private string numberType;
-
-        [JsonProperty("NumberType")]
-        public string NumberType
-        {
-            get { return numberType; }
-            set
-            {
-                numberType = value;
-                RaisePropertyChanged("NumberType");
-            }
-        }
-
         /// <summary>
         /// The NodeType property provides a name which maps to the 
         /// server type for the node. This property should only be
@@ -140,12 +127,26 @@ namespace CoreNodeModels.Input
             }
         }
 
+        public string NumberType
+        {
+            get
+            {
+                if(this.GetType().ToString() == "CoreNodeModels.Input.DoubleInput")
+                {
+                    return "Double";
+                }
+                else
+                {
+                    return this.GetType().ToString();
+                }
+            }
+        }
+
         [JsonConstructor]
         private DoubleInput(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
         {
             InPorts.AddRange(inPorts);
             OutPorts.AddRange(outPorts);
-            NumberType = "Double";
             ShouldDisplayPreviewCore = false;
             ConvertToken = Convert;
             Value = "0";
@@ -156,7 +157,6 @@ namespace CoreNodeModels.Input
             OutPorts.Add(new PortModel(PortType.Output, this, new PortData("", "")));
             RegisterAllPorts();
 
-            NumberType = "Double";
             ShouldDisplayPreviewCore = false;
             ConvertToken = Convert;
             Value = "0";

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -114,6 +114,19 @@ namespace CoreNodeModels.Input
     [AlsoKnownAs("Dynamo.Nodes.DoubleInput", "Dynamo.Nodes.dynDoubleInput", "DSCoreNodesUI.Input.DoubleInput")]
     public class DoubleInput : NodeModel
     {
+        private string numberType;
+
+        [JsonProperty("NumberType")]
+        public string NumberType
+        {
+            get { return numberType; }
+            set
+            {
+                numberType = value;
+                RaisePropertyChanged("NumberType");
+            }
+        }
+
         /// <summary>
         /// The NodeType property provides a name which maps to the 
         /// server type for the node. This property should only be
@@ -123,7 +136,7 @@ namespace CoreNodeModels.Input
         {
             get
             {
-                return "FloatInputNode";
+                return "NumberInputNode";
             }
         }
 
@@ -132,6 +145,7 @@ namespace CoreNodeModels.Input
         {
             InPorts.AddRange(inPorts);
             OutPorts.AddRange(outPorts);
+            NumberType = "Double";
             ShouldDisplayPreviewCore = false;
             ConvertToken = Convert;
             Value = "0";
@@ -142,6 +156,7 @@ namespace CoreNodeModels.Input
             OutPorts.Add(new PortModel(PortType.Output, this, new PortData("", "")));
             RegisterAllPorts();
 
+            NumberType = "Double";
             ShouldDisplayPreviewCore = false;
             ConvertToken = Convert;
             Value = "0";

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -38,14 +38,7 @@ namespace CoreNodeModels.Input
         {
             get
             {
-                if (this.GetType().ToString() == "CoreNodeModels.Input.DoubleSlider")
-                {
-                    return "Double";
-                }
-                else
-                {
-                    return this.GetType().ToString();
-                }
+                return "Double";
             }
         }
 

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -31,7 +31,7 @@ namespace CoreNodeModels.Input
         {
             get
             {
-                return "FloatRangeInputNode";
+                return "NumberInputNode";
             }
         }
 
@@ -39,6 +39,7 @@ namespace CoreNodeModels.Input
         private DoubleSlider(IEnumerable<PortModel> inPorts,
             IEnumerable<PortModel> outPorts): base(inPorts, outPorts)
         {
+            NumberType = "Double";
             Min = 0;
             Max = 100;
             Step = 0.1;
@@ -48,6 +49,7 @@ namespace CoreNodeModels.Input
 
         public DoubleSlider()
         {
+            NumberType = "Double";
             Min = 0;
             Max = 100;
             Step = 0.1;

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -34,12 +34,25 @@ namespace CoreNodeModels.Input
                 return "NumberInputNode";
             }
         }
+        public string NumberType
+        {
+            get
+            {
+                if (this.GetType().ToString() == "CoreNodeModels.Input.DoubleSlider")
+                {
+                    return "Double";
+                }
+                else
+                {
+                    return this.GetType().ToString();
+                }
+            }
+        }
 
         [JsonConstructor]
         private DoubleSlider(IEnumerable<PortModel> inPorts,
             IEnumerable<PortModel> outPorts): base(inPorts, outPorts)
         {
-            NumberType = "Double";
             Min = 0;
             Max = 100;
             Step = 0.1;
@@ -49,7 +62,6 @@ namespace CoreNodeModels.Input
 
         public DoubleSlider()
         {
-            NumberType = "Double";
             Min = 0;
             Max = 100;
             Step = 0.1;

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -37,11 +37,26 @@ namespace CoreNodeModels.Input
             }
         }
 
+        public string NumberType
+        {
+            get
+            {
+                if (this.GetType().ToString() == "CoreNodeModels.Input.IntegerSlider")
+                {
+                    return "Integer";
+                }
+                else
+                {
+                    return this.GetType().ToString();
+                }
+            }
+        }
+
+
         [JsonConstructor]
         private IntegerSlider(IEnumerable<PortModel> inPorts,
             IEnumerable<PortModel> outPorts): base(inPorts, outPorts)
         {
-            NumberType = "Integer";
             Min = 0;
             Max = 100;
             Step = 1;
@@ -53,7 +68,6 @@ namespace CoreNodeModels.Input
         {
             RegisterAllPorts();
 
-            NumberType = "Integer";
             Min = 0;
             Max = 100;
             Step = 1;

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -41,14 +41,7 @@ namespace CoreNodeModels.Input
         {
             get
             {
-                if (this.GetType().ToString() == "CoreNodeModels.Input.IntegerSlider")
-                {
-                    return "Integer";
-                }
-                else
-                {
-                    return this.GetType().ToString();
-                }
+                return "Integer";
             }
         }
 

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -33,7 +33,7 @@ namespace CoreNodeModels.Input
         {
             get
             {
-                return "IntegerRangeInputNode";
+                return "NumberInputNode";
             }
         }
 
@@ -41,6 +41,7 @@ namespace CoreNodeModels.Input
         private IntegerSlider(IEnumerable<PortModel> inPorts,
             IEnumerable<PortModel> outPorts): base(inPorts, outPorts)
         {
+            NumberType = "Integer";
             Min = 0;
             Max = 100;
             Step = 1;
@@ -52,6 +53,7 @@ namespace CoreNodeModels.Input
         {
             RegisterAllPorts();
 
+            NumberType = "Integer";
             Min = 0;
             Max = 100;
             Step = 1;

--- a/src/Libraries/CoreNodeModels/Input/SliderBase.cs
+++ b/src/Libraries/CoreNodeModels/Input/SliderBase.cs
@@ -8,11 +8,23 @@ namespace CoreNodeModels.Input
 {
     public abstract class SliderBase<T> : BasicInteractive<T> where T : IComparable<T>
     {
+        private string numberType;
         private T max;
         private T min;
         private T step;
 
-        [JsonProperty("RangeMax")]
+        [JsonProperty("NumberType")]
+        public string NumberType
+        {
+            get { return numberType; }
+            set
+            {
+                numberType = value;
+                RaisePropertyChanged("NumberType");
+            }
+        }
+
+        [JsonProperty("MaximumValue")]
         public T Max
         {
             get { return max; }
@@ -34,7 +46,7 @@ namespace CoreNodeModels.Input
             }
         }
 
-        [JsonProperty("RangeMin")]
+        [JsonProperty("MinimumValue")]
         public T Min
         {
             get { return min; }
@@ -56,7 +68,7 @@ namespace CoreNodeModels.Input
             }
         }
 
-        [JsonProperty("RangeStep")]
+        [JsonProperty("StepValue")]
         public T Step
         {
             get { return step; }

--- a/src/Libraries/CoreNodeModels/Input/SliderBase.cs
+++ b/src/Libraries/CoreNodeModels/Input/SliderBase.cs
@@ -8,7 +8,6 @@ namespace CoreNodeModels.Input
 {
     public abstract class SliderBase<T> : BasicInteractive<T> where T : IComparable<T>
     {
-        private string numberType;
         private T max;
         private T min;
         private T step;

--- a/src/Libraries/CoreNodeModels/Input/SliderBase.cs
+++ b/src/Libraries/CoreNodeModels/Input/SliderBase.cs
@@ -13,17 +13,6 @@ namespace CoreNodeModels.Input
         private T min;
         private T step;
 
-        [JsonProperty("NumberType")]
-        public string NumberType
-        {
-            get { return numberType; }
-            set
-            {
-                numberType = value;
-                RaisePropertyChanged("NumberType");
-            }
-        }
-
         [JsonProperty("MaximumValue")]
         public T Max
         {


### PR DESCRIPTION
### Purpose

The purpose of this PR is to reduced specific node types so that all number and slider nodes are now of the type 'NumberInputNode' with various parameters.  Dynamo will serialize all number nodes like this with the intention of matching the CoGS schema.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs
