### PR TITLE
No hyphen for GUIDs during serialization

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -722,7 +722,7 @@ namespace Dynamo.Graph.Nodes
         {
             get
             {
-                return GUID.ToString().Replace("-", string.Empty).ToLower();
+                return GUID.ToString("N");
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -469,11 +469,11 @@ namespace Dynamo.Graph.Workspaces
 
             writer.WriteStartObject();
             writer.WritePropertyName("Start");
-            writer.WriteValue(connector.Start.GUID.ToString());
+            writer.WriteValue(connector.Start.GUID.ToString("N"));
             writer.WritePropertyName("End");
-            writer.WriteValue(connector.End.GUID.ToString());
+            writer.WriteValue(connector.End.GUID.ToString("N"));
             writer.WritePropertyName("Id");
-            writer.WriteValue(connector.GUID.ToString());
+            writer.WriteValue(connector.GUID.ToString("N"));
             writer.WriteEndObject();
         }
     }
@@ -504,15 +504,7 @@ namespace Dynamo.Graph.Workspaces
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
-        }
-
-        public override bool CanWrite
-        {
-            get
-            {
-                return false;
-            }
+            writer.WriteValue(((Guid)value).ToString("N"));
         }
     }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -78,7 +78,7 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
             writer.WriteStartArray();
             foreach (var m in anno.Nodes)
             {
-                writer.WriteValue(m.GUID.ToString());
+                writer.WriteValue(m.GUID.ToString("N"));
             }
             writer.WriteEndArray();
             writer.WritePropertyName("Left");

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -71,7 +71,7 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
             writer.WriteStartObject();
 
             writer.WritePropertyName("Id");
-            writer.WriteValue(anno.GUID.ToString());
+            writer.WriteValue(anno.GUID.ToString("N"));
             writer.WritePropertyName("Title");
             writer.WriteValue(anno.AnnotationText);
             writer.WritePropertyName("Nodes");
@@ -127,7 +127,7 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
             // For each noteViewModel, start a new object
             writer.WriteStartObject();
             writer.WritePropertyName("Id");
-            writer.WriteValue(notes.GUID);
+            writer.WriteValue(notes.GUID.ToString("N"));
             writer.WritePropertyName("X");
             writer.WriteValue(notes.X);
             writer.WritePropertyName("Y");

--- a/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NodeViewModel.cs
@@ -56,6 +56,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Returns NodeModel ID
         /// </summary>
+        [JsonConverter(typeof(IdToGuidConverter))]
         public Guid Id
         {
             get { return NodeModel.GUID; }

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -592,7 +592,7 @@ namespace Dynamo.Tests
             foreach (var nodeId in model.CurrentWorkspace.Nodes.Select(x => x.GUID))
             {
                 modelsGuidToIdMap.Add(nodeId, idcount.ToString());
-                json = json.Replace(nodeId.ToString(), idcount.ToString());
+                json = json.Replace(nodeId.ToString("N"), idcount.ToString());
                 idcount = idcount + 1;
             }
 
@@ -602,14 +602,14 @@ namespace Dynamo.Tests
                 foreach (var port in node.InPorts)
                 {
                     modelsGuidToIdMap.Add(port.GUID, idcount.ToString());
-                    json = json.Replace(port.GUID.ToString(), idcount.ToString());
+                    json = json.Replace(port.GUID.ToString("N"), idcount.ToString());
                     idcount = idcount + 1;
                 }
 
                 foreach (var port in node.OutPorts)
                 {
                     modelsGuidToIdMap.Add(port.GUID, idcount.ToString());
-                    json = json.Replace(port.GUID.ToString(), idcount.ToString());
+                    json = json.Replace(port.GUID.ToString("N"), idcount.ToString());
                     idcount = idcount + 1;
                 }
             }
@@ -617,14 +617,14 @@ namespace Dynamo.Tests
             foreach (var connector in model.CurrentWorkspace.Connectors)
             {
                 modelsGuidToIdMap.Add(connector.GUID, idcount.ToString());
-                json = json.Replace(connector.GUID.ToString(), idcount.ToString());
+                json = json.Replace(connector.GUID.ToString("N"), idcount.ToString());
                 idcount = idcount + 1;
             }
             //alter the output json so that all annotationModel ids are not guids
             foreach (var annotation in model.CurrentWorkspace.Annotations)
             {
                 modelsGuidToIdMap.Add(annotation.GUID, idcount.ToString());
-                json = json.Replace(annotation.GUID.ToString(), idcount.ToString());
+                json = json.Replace(annotation.GUID.ToString("N"), idcount.ToString());
                 idcount = idcount + 1;
             }
 


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[QNTM-1123](https://jira.autodesk.com/browse/QNTM-1123)  As a Dynamo Dev, I want Dynamo Id json serialized with no dashes

Internally, we are still using Default GUID formats with hyphens. The GUID constructor is tolerant enough. But to be consistent with AVP and CoGs in terms of Id serialization, we plan to unify all the serialization in 32 digits string format without hyphens. There will be another PR in AVP to change Guids serialization as well.

This PR:
1. Use GUIDs without hyphens for Node, Notes, Connectors, Groups, Ports
2. Modify Serialization Tests
3. Works together with the AVP part PR: https://github.com/DynamoDS/AutodeskVisualProgramming/pull/271

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@mjkkirschner 

### FYIs
@ColinDayOrg @alfarok @smangarole 
