### PR TITLE
QNTM-1228: Some nodes do not de-serialize from JSON correctly

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -959,6 +959,11 @@ namespace Dynamo.Graph.Nodes
             inputNodes = new Dictionary<int, Tuple<int, NodeModel>>();
             outputNodes = new Dictionary<int, HashSet<Tuple<int, NodeModel>>>();
 
+            // Initialize the port events
+            // Note; It is important that this occurs before the ports are added next
+            InPorts.CollectionChanged += PortsCollectionChanged;
+            OutPorts.CollectionChanged += PortsCollectionChanged;
+
             // Set the ports from the deserialized data
             InPorts.AddRange(inPorts);
             OutPorts.AddRange(outPorts);
@@ -986,9 +991,6 @@ namespace Dynamo.Graph.Nodes
             ArgumentLacing = LacingStrategy.Disabled;
 
             RaisesModificationEvents = true;
-
-            InPorts.CollectionChanged += PortsCollectionChanged;
-            OutPorts.CollectionChanged += PortsCollectionChanged;
         }
 
         protected NodeModel()

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -960,7 +960,7 @@ namespace Dynamo.Graph.Nodes
             outputNodes = new Dictionary<int, HashSet<Tuple<int, NodeModel>>>();
 
             // Initialize the port events
-            // Note; It is important that this occurs before the ports are added next
+            // Note: It is important that this occurs before the ports are added next
             InPorts.CollectionChanged += PortsCollectionChanged;
             OutPorts.CollectionChanged += PortsCollectionChanged;
 

--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -88,6 +88,12 @@ namespace CoreNodeModels
             PopulateItems();
         }
 
+        [JsonConstructor]
+        protected DSDropDownBase(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+            PopulateItems();
+        }
+
         protected override void SerializeCore(XmlElement nodeElement, SaveContext context)
         {
             base.SerializeCore(nodeElement, context);

--- a/src/Libraries/CoreNodeModels/Enum.cs
+++ b/src/Libraries/CoreNodeModels/Enum.cs
@@ -5,6 +5,8 @@ using System.Linq;
 
 using Dynamo.Utilities;
 using ProtoCore.AST.AssociativeAST;
+using Newtonsoft.Json;
+using Dynamo.Graph.Nodes;
 
 namespace CoreNodeModels
 {
@@ -56,6 +58,11 @@ namespace CoreNodeModels
         protected AllChildrenOfType() : base("Types")
         {
             RegisterAllPorts();
+        }
+
+        [JsonConstructor]
+        protected AllChildrenOfType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
         }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)

--- a/src/Libraries/CoreNodeModels/HigherOrder/MapCombineLacing.cs
+++ b/src/Libraries/CoreNodeModels/HigherOrder/MapCombineLacing.cs
@@ -51,10 +51,8 @@ namespace CoreNodeModels.HigherOrder
     {
         private readonly int minPorts;
 
-        protected CombinatorNode(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        protected CombinatorNode(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
-            InPorts.AddRange(inPorts);
-            OutPorts.AddRange(outPorts);
         }
 
         protected CombinatorNode() : this(3)
@@ -99,9 +97,13 @@ namespace CoreNodeModels.HigherOrder
     public class Combine : CombinatorNode
     {
         [JsonConstructor]
-        private Combine(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts):base(inPorts, outPorts) { }
+        private Combine(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+        }
 
-        public Combine() : base() { }
+        public Combine() : base()
+        {
+        }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
@@ -130,9 +132,13 @@ namespace CoreNodeModels.HigherOrder
     public class ForEach : CombinatorNode
     {
         [JsonConstructor]
-        private ForEach(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts):base(inPorts, outPorts) { }
+        private ForEach(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+        }
   
-        public ForEach() : base(2) { }
+        public ForEach() : base(2)
+        {
+        }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
@@ -162,9 +168,13 @@ namespace CoreNodeModels.HigherOrder
     public class LaceShortest : CombinatorNode
     {
         [JsonConstructor]
-        private LaceShortest(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) :base(inPorts, outPorts) { }
+        private LaceShortest(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+        }
 
-        public LaceShortest() : base() { }
+        public LaceShortest() : base()
+        {
+        }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
@@ -194,9 +204,13 @@ namespace CoreNodeModels.HigherOrder
     public class LaceLongest : CombinatorNode
     {
         [JsonConstructor]
-        private LaceLongest(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) :base(inPorts, outPorts) { }
+        private LaceLongest(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+        }
 
-        public LaceLongest() : base() { }
+        public LaceLongest() : base()
+        {
+        }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
@@ -227,9 +241,13 @@ namespace CoreNodeModels.HigherOrder
     public class CartesianProduct : CombinatorNode
     {
         [JsonConstructor]
-        private CartesianProduct(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) :base(inPorts, outPorts) { }
+        private CartesianProduct(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+        }
 
-        public CartesianProduct() : base() { }
+        public CartesianProduct() : base()
+        {
+        }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -128,10 +128,8 @@ namespace CoreNodeModels.Input
         }
 
         [JsonConstructor]
-        private DoubleInput(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        private DoubleInput(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
-            InPorts.AddRange(inPorts);
-            OutPorts.AddRange(outPorts);
             ShouldDisplayPreviewCore = false;
             ConvertToken = Convert;
             Value = "0";

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -38,7 +38,8 @@ namespace CoreNodeModels.Input
         }
 
         [JsonConstructor]
-        private StringInput(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts):base(inPorts, outPorts) {
+        private StringInput(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
             Value = "";
             ShouldDisplayPreviewCore = false;
         }

--- a/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
+++ b/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
@@ -43,12 +43,9 @@ namespace CoreNodeModels.Input
         protected abstract T DeserializeValue(string val);
         protected abstract string SerializeValue();
 
-        protected BasicInteractive(IEnumerable<PortModel> inPorts,
-            IEnumerable<PortModel> outPorts)
+        protected BasicInteractive(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             Type type = typeof(T);
-            InPorts.AddRange(inPorts);
-            OutPorts.AddRange(outPorts);
         }
 
         protected BasicInteractive()

--- a/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
+++ b/src/Libraries/CoreNodeModels/Input/BoolSelector.cs
@@ -10,9 +10,13 @@ namespace CoreNodeModels.Input
     public abstract class Bool : BasicInteractive<bool>
     {
         [JsonConstructor]
-        protected Bool(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
+        protected Bool(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+        }
 
-        protected Bool() : base() { }
+        protected Bool() : base()
+        {
+        }
 
         protected override bool DeserializeValue(string val)
         {

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -36,8 +36,7 @@ namespace CoreNodeModels.Input
         }
 
         [JsonConstructor]
-        private DoubleSlider(IEnumerable<PortModel> inPorts,
-            IEnumerable<PortModel> outPorts): base(inPorts, outPorts)
+        private DoubleSlider(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             Min = 0;
             Max = 100;

--- a/src/Libraries/CoreNodeModels/Input/SliderBase.cs
+++ b/src/Libraries/CoreNodeModels/Input/SliderBase.cs
@@ -79,8 +79,7 @@ namespace CoreNodeModels.Input
             }
         }
 
-        protected SliderBase(IEnumerable<PortModel> inPorts,
-            IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        protected SliderBase(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             base.PropertyChanged += SliderBase_PropertyChanged;
         }

--- a/src/Libraries/CoreNodeModels/Input/String.cs
+++ b/src/Libraries/CoreNodeModels/Input/String.cs
@@ -7,9 +7,13 @@ namespace CoreNodeModels.Input
 {
     public abstract class String : BasicInteractive<string>
     {
-        protected String() { }
+        protected String()
+        {
+        }
 
-        protected String(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
+        protected String(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+        }
 
         public override string PrintExpression()
         {

--- a/src/Libraries/UnitsUI/UnitsUI.cs
+++ b/src/Libraries/UnitsUI/UnitsUI.cs
@@ -350,6 +350,15 @@ namespace UnitsUI
     [IsDesignScriptCompatible]
     public class UnitTypes : AllChildrenOfType<SIUnit>
     {
+        public UnitTypes() : base()
+        {
+        }
+
+        [JsonConstructor]
+        private UnitTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+        }
+
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             AssociativeNode node;


### PR DESCRIPTION
### Purpose
This PR addresses an issue found with deserialization from JSON format where the order of hooking uop events and adding ports was incorrect. There are two main aspects to this PR; first altering the base NodeModel class so that the order of operations enables correct node functionality, and second removing any previous work-arounds that were added to hide the base issue.
 
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [n/a] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [wip] The level of testing this PR includes is appropriate
- [n/a] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [n/a] Snapshot of UI changes, if any.
- [n/a] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@alfarok @jnealb 