### PR TITLE
Save InputNodes to the Inputs property during JSON serialization

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -118,6 +118,7 @@ limitations under the License.
     <Compile Include="Configuration\Context.cs" />
     <Compile Include="Core\DynamoMigrator.cs" />
     <Compile Include="Exceptions\LibraryLoadFailedException.cs" />
+    <Compile Include="Graph\Nodes\NodeInputData.cs" />
     <Compile Include="Graph\Workspaces\LayoutExtensions.cs" />
     <Compile Include="Graph\Workspaces\NodesToCodeExtensions.cs" />
     <Compile Include="Graph\Workspaces\PresetExtensions.cs" />

--- a/src/DynamoCore/Graph/Nodes/NodeInputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeInputData.cs
@@ -42,26 +42,32 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         /// If this input is a selection type a list of choices a user can select.
         /// </summary>
+        [JsonProperty(NullValueHandling=NullValueHandling.Ignore)]
         public List<string> Choices { get; set; }
         /// <summary>
         /// if this input is a Number, the max value of that number.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public double? MaximumValue { get; set; }
         /// <summary>
         /// if this input is a Number, the min value of that number.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public double? MinimumValue { get; set; }
         /// <summary>
         /// if this input is a Number, the step value of that number when it acts as a slider.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public double? StepValue { get; set; }
         /// <summary>
         /// if this input is a Number, the number type Double or Integer that the number returns.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string NumberType { get; set; }
         /// <summary>
         /// Description displayed to user of this input node.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; set; }
 
         private static Dictionary<Type, NodeInputTypes> dotNetTypeToNodeInputType = new Dictionary<Type, NodeInputTypes>

--- a/src/DynamoCore/Graph/Nodes/NodeInputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeInputData.cs
@@ -1,0 +1,144 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dynamo.Graph.Nodes
+{
+    public enum NodeInputTypes
+    {
+        numberInput, booleanInput, stringInput, colorInput, dateInput, selectionInput
+    };
+
+
+
+    /// <summary>
+    /// Represents a node which acts as a UI input for the graph
+    /// - may also hold a value for that input
+    /// </summary>
+    public class NodeInputData
+    {
+        /// <summary>
+        /// The id of the node.
+        /// </summary>
+        public string Id { get; set; }
+        /// <summary>
+        /// Display name of the input node.
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// The type of input this node is.
+        /// </summary>
+        [JsonConverter(typeof(NodeInputTypeConverter))]
+        public NodeInputTypes Type { get; set; }
+        /// <summary>
+        /// The value of the input when the graph was saved.
+        /// </summary>
+        public string Value { get; set; }
+
+        //optional properties, might be null
+        /// <summary>
+        /// If this input is a selection type a list of choices a user can select.
+        /// </summary>
+        public List<string> Choices { get; set; }
+        /// <summary>
+        /// if this input is a Number, the max value of that number.
+        /// </summary>
+        public double? MaximumValue { get; set; }
+        /// <summary>
+        /// if this input is a Number, the min value of that number.
+        /// </summary>
+        public double? MinimumValue { get; set; }
+        /// <summary>
+        /// if this input is a Number, the step value of that number when it acts as a slider.
+        /// </summary>
+        public double? StepValue { get; set; }
+        /// <summary>
+        /// if this input is a Number, the number type Double or Integer that the number returns.
+        /// </summary>
+        public string NumberType { get; set; }
+        /// <summary>
+        /// Description displayed to user of this input node.
+        /// </summary>
+        public string Description { get; set; }
+
+        //TODO... or give up and just encode this in the different NodeModel types...
+        private static Dictionary<Type, NodeInputTypes> dotNetTypeToNodeInputType = new Dictionary<Type, NodeInputTypes>
+        {
+            {typeof(String),NodeInputTypes.stringInput},
+            { typeof(Boolean),NodeInputTypes.booleanInput},
+            { typeof(DateTime),NodeInputTypes.dateInput},
+            { typeof(double),NodeInputTypes.numberInput},
+            { typeof(int),NodeInputTypes.numberInput},
+            {typeof(float),NodeInputTypes.numberInput},
+        };
+
+        private static Dictionary<NodeInputTypes, string> enumToStringMap = new Dictionary<NodeInputTypes, string>
+        {
+            {NodeInputTypes.stringInput,"string"},
+            {NodeInputTypes.selectionInput,"selection"},
+            {NodeInputTypes.colorInput,"color"},
+            {NodeInputTypes.booleanInput,"boolean"},
+            {NodeInputTypes.numberInput,"number"},
+            {NodeInputTypes.dateInput,"date"}
+        };
+
+
+        public static NodeInputTypes getNodeInputTypeFromType(Type type)
+        {
+            NodeInputTypes output;
+            if (dotNetTypeToNodeInputType.TryGetValue(type, out output))
+            {
+                return output;
+            }
+            else
+            {//TODO maybe return string as default?
+
+                throw new ArgumentException("could not find an inputType for this type");
+            }
+        }
+        public static string getStringName(NodeInputTypes type)
+        {
+            string output;
+            if (enumToStringMap.TryGetValue(type, out output))
+            {
+                return output;
+            }
+            else
+            {
+                throw new ArgumentException("could not find a string name for this type");
+            }
+        }
+    }
+
+    public class NodeInputTypeConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return (objectType == typeof(NodeInputTypes));
+        }
+        public override bool CanRead
+        {
+            get { return false; }
+        }
+        public override bool CanWrite
+        {
+            get { return true; }
+        }
+
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var name = NodeInputData.getStringName((NodeInputTypes)value);
+            serializer.Serialize(writer, name);
+        }
+    }
+
+}

--- a/src/DynamoCore/Graph/Nodes/NodeInputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeInputData.cs
@@ -64,7 +64,6 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         public string Description { get; set; }
 
-        //TODO... or give up and just encode this in the different NodeModel types...
         private static Dictionary<Type, NodeInputTypes> dotNetTypeToNodeInputType = new Dictionary<Type, NodeInputTypes>
         {
             {typeof(String),NodeInputTypes.stringInput},
@@ -94,8 +93,7 @@ namespace Dynamo.Graph.Nodes
                 return output;
             }
             else
-            {//TODO maybe return string as default?
-
+            {
                 throw new ArgumentException("could not find an inputType for this type");
             }
         }

--- a/src/DynamoCore/Graph/Nodes/NodeInputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeInputData.cs
@@ -1,17 +1,30 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace Dynamo.Graph.Nodes
 {
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum NodeInputTypes
     {
-        numberInput, booleanInput, stringInput, colorInput, dateInput, selectionInput
+        [EnumMember(Value = "number")]
+        numberInput,
+        [EnumMember(Value = "boolean")]
+        booleanInput,
+        [EnumMember(Value = "string")]
+        stringInput,
+        [EnumMember(Value = "color")]
+        colorInput,
+        [EnumMember(Value = "date")]
+        dateInput,
+        [EnumMember(Value = "selection")]
+        selectionInput
     };
-
 
 
     /// <summary>
@@ -31,7 +44,6 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         /// The type of input this node is.
         /// </summary>
-        [JsonConverter(typeof(NodeInputTypeConverter))]
         public NodeInputTypes Type { get; set; }
         /// <summary>
         /// The value of the input when the graph was saved.
@@ -79,18 +91,6 @@ namespace Dynamo.Graph.Nodes
             { typeof(int),NodeInputTypes.numberInput},
             {typeof(float),NodeInputTypes.numberInput},
         };
-
-        private static Dictionary<NodeInputTypes, string> enumToStringMap = new Dictionary<NodeInputTypes, string>
-        {
-            {NodeInputTypes.stringInput,"string"},
-            {NodeInputTypes.selectionInput,"selection"},
-            {NodeInputTypes.colorInput,"color"},
-            {NodeInputTypes.booleanInput,"boolean"},
-            {NodeInputTypes.numberInput,"number"},
-            {NodeInputTypes.dateInput,"date"}
-        };
-
-
         public static NodeInputTypes getNodeInputTypeFromType(Type type)
         {
             NodeInputTypes output;
@@ -103,45 +103,20 @@ namespace Dynamo.Graph.Nodes
                 throw new ArgumentException("could not find an inputType for this type");
             }
         }
-        public static string getStringName(NodeInputTypes type)
-        {
-            string output;
-            if (enumToStringMap.TryGetValue(type, out output))
-            {
-                return output;
-            }
-            else
-            {
-                throw new ArgumentException("could not find a string name for this type");
-            }
-        }
-    }
 
-    public class NodeInputTypeConverter : JsonConverter
-    {
-        public override bool CanConvert(Type objectType)
+        public override bool Equals(object obj)
         {
-            return (objectType == typeof(NodeInputTypes));
-        }
-        public override bool CanRead
-        {
-            get { return false; }
-        }
-        public override bool CanWrite
-        {
-            get { return true; }
-        }
-
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            var name = NodeInputData.getStringName((NodeInputTypes)value);
-            serializer.Serialize(writer, name);
+            var converted = obj as NodeInputData;
+            return obj is NodeInputData && this.Id == converted.Id &&
+                this.Description == converted.Description &&
+                this.Choices == converted.Choices &&
+                this.MaximumValue == converted.MaximumValue &&
+                this.MinimumValue == converted.MinimumValue &&
+                this.Name == converted.Name &&
+                this.NumberType == converted.NumberType &&
+                this.StepValue == converted.StepValue &&
+                this.Type == converted.Type &&
+                this.Value == converted.Value;
         }
     }
 

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -852,9 +852,10 @@ namespace Dynamo.Graph.Nodes
             return false;
         }
 
-        public virtual NodeInputData InputData()
+        [JsonIgnore]
+        public virtual NodeInputData InputData
         {
-            return null;
+           get { return null; }
         }
 
         #endregion

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -852,6 +852,11 @@ namespace Dynamo.Graph.Nodes
             return false;
         }
 
+        public virtual NodeInputData InputData()
+        {
+            return null;
+        }
+
         #endregion
 
         #region freeze execution

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -346,8 +346,9 @@ namespace Dynamo.Graph.Workspaces
 
             //inputs
             writer.WritePropertyName("Inputs");
-            //find nodes which are inputs and get their inputData
-            var inputNodeDatas = ws.Nodes.Where((node) => node.IsSetAsInput == true).Select(inputNode => inputNode.InputData()).ToList();
+            //find nodes which are inputs and get their inputData if its not null.
+            var inputNodeDatas = ws.Nodes.Where((node) => node.IsSetAsInput == true && node.InputData != null)
+                .Select(inputNode => inputNode.InputData).ToList();
             serializer.Serialize(writer, inputNodeDatas);
 
             //nodes

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -346,7 +346,7 @@ namespace Dynamo.Graph.Workspaces
 
             //inputs
             writer.WritePropertyName("Inputs");
-            //we'll loop over all nodes, getting inputs and only serialize this nodes
+            //find nodes which are inputs and get their inputData
             var inputNodeDatas = ws.Nodes.Where((node) => node.IsSetAsInput == true).Select(inputNode => inputNode.InputData()).ToList();
             serializer.Serialize(writer, inputNodeDatas);
 

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -344,6 +344,12 @@ namespace Dynamo.Graph.Workspaces
             writer.WritePropertyName("ElementResolver");
             serializer.Serialize(writer, ws.ElementResolver);
 
+            //inputs
+            writer.WritePropertyName("Inputs");
+            //we'll loop over all nodes, getting inputs and only serialize this nodes
+            var inputNodeDatas = ws.Nodes.Where((node) => node.IsSetAsInput == true).Select(inputNode => inputNode.InputData()).ToList();
+            serializer.Serialize(writer, inputNodeDatas);
+
             //nodes
             writer.WritePropertyName("Nodes");
             serializer.Serialize(writer, ws.Nodes);

--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -65,18 +65,11 @@ namespace CoreNodeModels
 
         public override NodeInputData InputData()
         {
-
-            return new NodeInputData()
-            {
-                Id = this.GUID.ToString("N"),
-                Name = this.Name,
-
-                Type = NodeInputTypes.selectionInput,
-                Description = this.Description,
-                //TODO investigate if this node type also needs to serialize it's selected index.
-                Value = this.Items[this.selectedIndex].Name,
-                Choices = this.items.Select(x => x.Name).ToList(),
-            };
+            //TODO There is not yet an appropriate input type
+            //defined in the cogs graph schema to support dropdowns
+            //which return arbitrary objects at some index - implement this
+            //when that exists.
+            return null;
         }
 
         private int selectedIndex = 0;

--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -62,14 +62,13 @@ namespace CoreNodeModels
                 RaisePropertyChanged("Items");
             }
         }
-
-        public override NodeInputData InputData()
+        public override NodeInputData InputData
         {
             //TODO There is not yet an appropriate input type
             //defined in the cogs graph schema to support dropdowns
             //which return arbitrary objects at some index - implement this
             //when that exists.
-            return null;
+            get { return null; }
         }
 
         private int selectedIndex = 0;

--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -73,8 +73,8 @@ namespace CoreNodeModels
 
                 Type = NodeInputTypes.selectionInput,
                 Description = this.Description,
-                //TODO should this be the selected item to string or the index?
-                Value = this.SelectedIndex.ToString(),
+                //TODO investigate if this node type also needs to serialize it's selected index.
+                Value = this.Items[this.selectedIndex].Name,
                 Choices = this.items.Select(x => x.Name).ToList(),
             };
         }

--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -63,6 +63,22 @@ namespace CoreNodeModels
             }
         }
 
+        public override NodeInputData InputData()
+        {
+
+            return new NodeInputData()
+            {
+                Id = this.GUID.ToString("N"),
+                Name = this.Name,
+
+                Type = NodeInputTypes.selectionInput,
+                Description = this.Description,
+                //TODO should this be the selected item to string or the index?
+                Value = this.SelectedIndex.ToString(),
+                Choices = this.items.Select(x => x.Name).ToList(),
+            };
+        }
+
         private int selectedIndex = 0;
         public int SelectedIndex
         {

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -126,6 +126,20 @@ namespace CoreNodeModels.Input
                 return "NumberInputNode";
             }
         }
+        public override NodeInputData InputData()
+        {
+            return new NodeInputData()
+            {
+                Id = this.GUID.ToString("N"),
+                Name = this.Name,
+                Type = NodeInputTypes.numberInput,
+                Description = this.Description,
+                Value = Value.ToString(),
+
+                NumberType = this.NumberType,
+
+            };
+        }
 
         public string NumberType
         {

--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -126,19 +126,21 @@ namespace CoreNodeModels.Input
                 return "NumberInputNode";
             }
         }
-        public override NodeInputData InputData()
+        public override NodeInputData InputData
         {
-            return new NodeInputData()
-            {
-                Id = this.GUID.ToString("N"),
-                Name = this.Name,
-                Type = NodeInputTypes.numberInput,
-                Description = this.Description,
-                Value = Value.ToString(),
+           get {
+                return new NodeInputData()
+                {
+                    Id = this.GUID.ToString("N"),
+                    Name = this.Name,
+                    Type = NodeInputTypes.numberInput,
+                    Description = this.Description,
+                    Value = Value.ToString(),
 
-                NumberType = this.NumberType,
+                    NumberType = this.NumberType,
 
-            };
+                };
+            }
         }
 
         public string NumberType

--- a/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
+++ b/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
@@ -37,6 +37,20 @@ namespace CoreNodeModels.Input
                 }               
             }
         }
+        public override NodeInputData InputData()
+        {
+           
+            return new NodeInputData()
+            {
+                Id = this.GUID.ToString("N"),
+                Name = this.Name,
+                //use the <T> type to convert to the correct nodeTypeString defined by
+                //the schema
+                Type = NodeInputData.getNodeInputTypeFromType(typeof(T)),
+                Description = this.Description,
+                Value = Value.ToString(),
+            };
+        }
 
         // Making these abstract so that derived classes are forced to come up 
         // with their implementations rather than default silently taking over.

--- a/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
+++ b/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
@@ -37,19 +37,22 @@ namespace CoreNodeModels.Input
                 }               
             }
         }
-        public override NodeInputData InputData()
+        public override NodeInputData InputData
         {
            
-            return new NodeInputData()
+            get
             {
-                Id = this.GUID.ToString("N"),
-                Name = this.Name,
-                //use the <T> type to convert to the correct nodeTypeString defined by
-                //the schema
-                Type = NodeInputData.getNodeInputTypeFromType(typeof(T)),
-                Description = this.Description,
-                Value = Value.ToString(),
-            };
+                return new NodeInputData()
+                {
+                    Id = this.GUID.ToString("N"),
+                    Name = this.Name,
+                    //use the <T> type to convert to the correct nodeTypeString defined by
+                    //the schema
+                    Type = NodeInputData.getNodeInputTypeFromType(typeof(T)),
+                    Description = this.Description,
+                    Value = Value.ToString(),
+                };
+            }
         }
 
         // Making these abstract so that derived classes are forced to come up 

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -17,7 +17,8 @@ using DSColor = DSCore.Color;
 
 using Autodesk.DesignScript.Runtime;
 using Dynamo.Graph.Workspaces;
-
+using Newtonsoft.Json;
+using System.IO;
 
 namespace CoreNodeModels.Input
 {
@@ -41,6 +42,21 @@ namespace CoreNodeModels.Input
                 OnNodeModified();
                 RaisePropertyChanged("DsColor");
             }
+        }
+        public override NodeInputData InputData()
+        {
+            //this object which we'll convert to a json string matches the format the schema expects for colors
+            var colorObj = new { Red = Convert.ToInt32(DsColor.Red), Blue = Convert.ToInt32(DsColor.Blue), Green = Convert.ToInt32(DsColor.Green), Alpha = Convert.ToInt32(DsColor.Alpha) };
+
+            return new NodeInputData()
+            {
+                Id = this.GUID.ToString("N"),
+                Name = this.Name,
+
+                Type = NodeInputTypes.colorInput,
+                Description = this.Description,
+                Value = JsonConvert.SerializeObject(colorObj),
+            };
         }
         /// <summary>
         ///     Node constructor.

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -43,20 +43,23 @@ namespace CoreNodeModels.Input
                 RaisePropertyChanged("DsColor");
             }
         }
-        public override NodeInputData InputData()
+        public override NodeInputData InputData
         {
-            //this object which we'll convert to a json string matches the format the schema expects for colors
-            var colorObj = new { Red = Convert.ToInt32(DsColor.Red), Blue = Convert.ToInt32(DsColor.Blue), Green = Convert.ToInt32(DsColor.Green), Alpha = Convert.ToInt32(DsColor.Alpha) };
-
-            return new NodeInputData()
+            get
             {
-                Id = this.GUID.ToString("N"),
-                Name = this.Name,
+                //this object which we'll convert to a json string matches the format the schema expects for colors
+                var colorObj = new { Red = Convert.ToInt32(DsColor.Red), Blue = Convert.ToInt32(DsColor.Blue), Green = Convert.ToInt32(DsColor.Green), Alpha = Convert.ToInt32(DsColor.Alpha) };
 
-                Type = NodeInputTypes.colorInput,
-                Description = this.Description,
-                Value = JsonConvert.SerializeObject(colorObj),
-            };
+                return new NodeInputData()
+                {
+                    Id = this.GUID.ToString("N"),
+                    Name = this.Name,
+
+                    Type = NodeInputTypes.colorInput,
+                    Description = this.Description,
+                    Value = JsonConvert.SerializeObject(colorObj),
+                };
+            }
         }
         /// <summary>
         ///     Node constructor.

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -41,22 +41,25 @@ namespace CoreNodeModels.Input
                 return "Double";
             }
         }
-        public override NodeInputData InputData()
+        public override NodeInputData InputData
         {
-            return new NodeInputData()
+            get
             {
-                Id = this.GUID.ToString("N"),
-                Name = this.Name,
-                Type = NodeInputTypes.numberInput,
-                Description = this.Description,
-                Value = Value.ToString(),
+                return new NodeInputData()
+                {
+                    Id = this.GUID.ToString("N"),
+                    Name = this.Name,
+                    Type = NodeInputTypes.numberInput,
+                    Description = this.Description,
+                    Value = Value.ToString(),
 
-                MinimumValue = this.Min,
-                MaximumValue = this.Max,
-                StepValue = this.Step,
-                NumberType = this.NumberType,
+                    MinimumValue = this.Min,
+                    MaximumValue = this.Max,
+                    StepValue = this.Step,
+                    NumberType = this.NumberType,
 
-            };
+                };
+            }
         }
 
 

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -43,8 +43,6 @@ namespace CoreNodeModels.Input
         }
         public override NodeInputData InputData()
         {
-            //TODO nodeModel should actually return null here
-            //as we don't know this is an input node
             return new NodeInputData()
             {
                 Id = this.GUID.ToString("N"),

--- a/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/DoubleSlider.cs
@@ -41,6 +41,26 @@ namespace CoreNodeModels.Input
                 return "Double";
             }
         }
+        public override NodeInputData InputData()
+        {
+            //TODO nodeModel should actually return null here
+            //as we don't know this is an input node
+            return new NodeInputData()
+            {
+                Id = this.GUID.ToString("N"),
+                Name = this.Name,
+                Type = NodeInputTypes.numberInput,
+                Description = this.Description,
+                Value = Value.ToString(),
+
+                MinimumValue = this.Min,
+                MaximumValue = this.Max,
+                StepValue = this.Step,
+                NumberType = this.NumberType,
+
+            };
+        }
+
 
         [JsonConstructor]
         private DoubleSlider(IEnumerable<PortModel> inPorts,

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -44,22 +44,25 @@ namespace CoreNodeModels.Input
                 return "Integer";
             }
         }
-        public override NodeInputData InputData()
+        public override NodeInputData InputData
         {
-            return new NodeInputData()
+           get
             {
-                Id = this.GUID.ToString("N"),
-                Name = this.Name,
-                Type = NodeInputTypes.numberInput,
-                Description = this.Description,
-                Value = Value.ToString(),
+                return new NodeInputData()
+                {
+                    Id = this.GUID.ToString("N"),
+                    Name = this.Name,
+                    Type = NodeInputTypes.numberInput,
+                    Description = this.Description,
+                    Value = Value.ToString(),
 
-                MinimumValue = this.Min,
-                MaximumValue = this.Max,
-                StepValue = this.Step,
-                NumberType = this.NumberType,
+                    MinimumValue = this.Min,
+                    MaximumValue = this.Max,
+                    StepValue = this.Step,
+                    NumberType = this.NumberType,
 
-            };
+                };
+            }
         }
 
 

--- a/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
+++ b/src/Libraries/CoreNodeModels/Input/IntegerSlider.cs
@@ -44,6 +44,23 @@ namespace CoreNodeModels.Input
                 return "Integer";
             }
         }
+        public override NodeInputData InputData()
+        {
+            return new NodeInputData()
+            {
+                Id = this.GUID.ToString("N"),
+                Name = this.Name,
+                Type = NodeInputTypes.numberInput,
+                Description = this.Description,
+                Value = Value.ToString(),
+
+                MinimumValue = this.Min,
+                MaximumValue = this.Max,
+                StepValue = this.Step,
+                NumberType = this.NumberType,
+
+            };
+        }
 
 
         [JsonConstructor]

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -13,6 +13,7 @@ using Dynamo.Engine;
 using Dynamo.Events;
 using System.Text.RegularExpressions;
 using Dynamo.Utilities;
+using Newtonsoft.Json.Linq;
 
 namespace Dynamo.Tests
 {
@@ -491,6 +492,14 @@ namespace Dynamo.Tests
                 Assert.True(ws2.Nodes.Contains(c.Start.Owner));
                 Assert.True(ws2.Nodes.Contains(c.End.Owner));
             }
+
+            //assert that the inputs in the saved json file are the same as those we can gather from the 
+            //grah at runtime - because we don't deserialize these directly we check the json itself.
+            var jObject = JObject.Parse(json);
+            var jToken = jObject["Inputs"];
+            var inputs = jToken.ToArray().Select(x => x.ToObject<NodeInputData>()).ToList();
+            var inputs2 = ws1.Nodes.Where(x => x.IsSetAsInput == true).Select(input => input.InputData()).ToList();
+            Assert.IsTrue(inputs.SequenceEqual(inputs2));
         }
 
         private static void SaveWorkspaceComparisonData(WorkspaceComparisonData wcd1, string filePathBase, TimeSpan executionDuration)

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -498,7 +498,7 @@ namespace Dynamo.Tests
             var jObject = JObject.Parse(json);
             var jToken = jObject["Inputs"];
             var inputs = jToken.ToArray().Select(x => x.ToObject<NodeInputData>()).ToList();
-            var inputs2 = ws1.Nodes.Where(x => x.IsSetAsInput == true).Select(input => input.InputData()).ToList();
+            var inputs2 = ws1.Nodes.Where(x => x.IsSetAsInput == true).Select(input => input.InputData).ToList();
             Assert.IsTrue(inputs.SequenceEqual(inputs2));
         }
 


### PR DESCRIPTION
### Purpose

This PR saves UI input nodes which are set as inputs to the inputs property of the graph schema.
A new class which mirrors the `InputData` type in the schema is created so json serialization is straightforward in most cases.

a new virtual method `InputData` is added to `NodeModel` - this property is only a getter and constructs an inputData which represents this node at the current time - so theres no reason to deserialize inputs at this time.

value types on this class are made nullable and marked as null handling ignore so they don't serialize unless they are set to a value by a node Type.

There will be a related AVP pr to update serialization file and the converters.

output looks like this 
``` javascript
 "Inputs": [
    {
      "Id": "02cc931008e74a8a884c02798fc9169c",
      "Name": "Date Time",
      "Type": "date",
      "Value": "11/2/2016 4:31:00 PM",
      "Description": "Create a DateTime object from a formatted date and time string. Date and time must be of the format \"April 12, 1977 12:00 PM\""
    },
    {
      "Id": "4d923f1d065c4b1f8d8c914f85104bf2",
      "Name": "String",
      "Type": "string",
      "Value": "",
      "Description": "Creates a string."
    },
    {
      "Id": "270bb4994369490297bdf554a66c33fe",
      "Name": "Number",
      "Type": "number",
      "Value": "12.5",
      "NumberType": "Double",
      "Description": "Creates a number."
    },
    {
      "Id": "99af95516b854b9a998088880437f078",
      "Name": "Number Slider",
      "Type": "number",
      "Value": "50.5",
      "MaximumValue": 75.5,
      "MinimumValue": 25.5,
      "StepValue": 0.25,
      "NumberType": "Double",
      "Description": "A slider that produces numeric values."
    },
    {
      "Id": "8742eba874ec4027817658d9d20c3a16",
      "Name": "Directory Path",
      "Type": "string",
      "Value": "C:\\Go",
      "Description": "Allows you to select a directory on the system to get its path"
    },
    {
      "Id": "2b6b3855a35342b6b8091f306087c54c",
      "Name": "Boolean",
      "Type": "boolean",
      "Value": "False",
      "Description": "Selection between a true and false."
    },
    {
      "Id": "ef5dc6c30ff44c79bf559751c66ac666",
      "Name": "Integer Slider",
      "Type": "number",
      "Value": "50",
      "MaximumValue": 75.0,
      "MinimumValue": 25.0,
      "StepValue": 1.0,
      "NumberType": "Integer",
      "Description": "A slider that produces integer values."
    }
  ],
```


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@alfarok @ColinDayOrg 