### PR TITLE
QNTM-1544: Dynamo Sandbox crashes when users tries to create a new custom node

### DIFF
--- a/src/LibraryViewExtension/Handlers/IconUrl.cs
+++ b/src/LibraryViewExtension/Handlers/IconUrl.cs
@@ -42,11 +42,18 @@ namespace Dynamo.LibraryUI.Handlers
             Name = iconName + ".Small";
             if (customNode)
             {
-                string customizationPath = System.IO.Path.GetDirectoryName(Path);
-                customizationPath = Directory.GetParent(customizationPath).FullName;
+                string customizationPath = null;
+                if (Path != null && Path != String.Empty)
+                {
+                  customizationPath = System.IO.Path.GetDirectoryName(Path);
+                  customizationPath = Directory.GetParent(customizationPath).FullName;
+                }
+
                 Path = DefaultPath;
                 Name = DefaultIcon;
-                if (File.Exists(System.IO.Path.Combine(customizationPath, "bin", "Package.customization.dll")))
+
+                if (customizationPath != null &&
+                    File.Exists(System.IO.Path.Combine(customizationPath, "bin", "Package.customization.dll")))
                 {
                     Path = System.IO.Path.Combine(customizationPath, "bin", "Package.dll");
                 }


### PR DESCRIPTION
### Purpose

This PR fixes an issue that was making creation of new custom nodes in Dynamo fail (by crashing).

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [n/a] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [n/a] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [n/a] Snapshot of UI changes, if any.
- [n/a] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@smangarole 
