### PR TITLE
Revit element selection nodes should serialize and deserialize properly in Json

### DIFF
--- a/src/Libraries/CoreNodeModels/CoreNodeModels.csproj
+++ b/src/Libraries/CoreNodeModels/CoreNodeModels.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -26,7 +26,7 @@ namespace CoreNodeModels
         private readonly string selectionMessage;
         private List<TResult> selectionResults = new List<TResult>();
         private List<TSelection> selection = new List<TSelection>();
-        private IEnumerable<string> selectionIdentifier;
+        private List<string> selectionIdentifier;
         private readonly SelectionType selectionType;
         private readonly SelectionObjectType selectionObjectType;
         
@@ -70,12 +70,18 @@ namespace CoreNodeModels
         }
 
         [JsonProperty("InstanceId")]
-        public IEnumerable<string> SelectionIdentifier
+        public List<string> SelectionIdentifier
         {
             get
             {
-                return selection.Select(GetIdentifierFromModelObject).Where(x => x != null).ToList();
+                if (selectionIdentifier == null || selectionIdentifier.Count == 0)
+                {
+                    selectionIdentifier = selection.Select(GetIdentifierFromModelObject).Where(x => x != null).ToList();
+                }
+
+                return selectionIdentifier;
             }
+
             set
             {
                 selectionIdentifier = value;
@@ -147,7 +153,7 @@ namespace CoreNodeModels
             SelectionObjectType selectionObjectType,
             string message,
             string prefix,
-            IEnumerable<string> selectionIdentifier,
+            List<string> selectionIdentifier,
             IEnumerable<PortModel> inPorts,
             IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
@@ -161,6 +167,9 @@ namespace CoreNodeModels
             State = ElementState.Warning;
 
             ShouldDisplayPreviewCore = true;
+
+            SelectionIdentifier = selectionIdentifier;
+            ResetSelectionFromIds(SelectionIdentifier);
         }
 
         #endregion

--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -26,7 +26,7 @@ namespace CoreNodeModels
         private readonly string selectionMessage;
         private List<TResult> selectionResults = new List<TResult>();
         private List<TSelection> selection = new List<TSelection>();
-        private List<string> selectionIdentifier;
+        private IEnumerable<string> selectionIdentifier;
         private readonly SelectionType selectionType;
         private readonly SelectionObjectType selectionObjectType;
         
@@ -70,11 +70,11 @@ namespace CoreNodeModels
         }
 
         [JsonProperty("InstanceId")]
-        public List<string> SelectionIdentifier
+        public IEnumerable<string> SelectionIdentifier
         {
             get
             {
-                if (selectionIdentifier == null || selectionIdentifier.Count == 0)
+                if (selectionIdentifier == null || selectionIdentifier.Count() == 0)
                 {
                     selectionIdentifier = selection.Select(GetIdentifierFromModelObject).Where(x => x != null).ToList();
                 }
@@ -153,7 +153,7 @@ namespace CoreNodeModels
             SelectionObjectType selectionObjectType,
             string message,
             string prefix,
-            List<string> selectionIdentifier,
+            IEnumerable<string> selectionIdentifier,
             IEnumerable<PortModel> inPorts,
             IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
@@ -169,7 +169,7 @@ namespace CoreNodeModels
             ShouldDisplayPreviewCore = true;
 
             SelectionIdentifier = selectionIdentifier;
-            ResetSelectionFromIds(SelectionIdentifier);
+            ResetSelectionFromIds(SelectionIdentifier.ToList());
         }
 
         #endregion

--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -74,9 +74,10 @@ namespace CoreNodeModels
         {
             get
             {
-                if (selectionIdentifier == null || selectionIdentifier.Count() == 0)
+                IEnumerable<String> updatedSelection = selection.Select(GetIdentifierFromModelObject).Where(x => x != null).ToList();
+                if (updatedSelection.Count() > 0)
                 {
-                    selectionIdentifier = selection.Select(GetIdentifierFromModelObject).Where(x => x != null).ToList();
+                    selectionIdentifier = updatedSelection;
                 }
 
                 return selectionIdentifier;

--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Xml;
 using CoreNodeModels.Properties;
 using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Logging;
+using Newtonsoft.Json;
 
 namespace CoreNodeModels
 {
@@ -17,12 +19,14 @@ namespace CoreNodeModels
     /// </summary>
     /// <typeparam name="TSelection">The type which is used to constrain the selection.</typeparam>
     /// <typeparam name="TResult">The type which is returned from the selection or subselection.</typeparam>
+    [DataContract]
     public abstract class SelectionBase<TSelection, TResult> : NodeModel
     {
         private bool canSelect = true;
         private readonly string selectionMessage;
         private List<TResult> selectionResults = new List<TResult>();
         private List<TSelection> selection = new List<TSelection>();
+        private IEnumerable<string> selectionIdentifier;
         private readonly SelectionType selectionType;
         private readonly SelectionObjectType selectionObjectType;
         
@@ -53,6 +57,28 @@ namespace CoreNodeModels
 
                 RaisePropertyChanged("SelectionResults");
                 RaisePropertyChanged("Text");
+            }
+        }
+
+        [JsonProperty("NodeType")]
+        public string NodeType
+        {
+            get
+            {
+                return "ExtensionNode";
+            }
+        }
+
+        [JsonProperty("InstanceId")]
+        public IEnumerable<string> SelectionIdentifier
+        {
+            get
+            {
+                return selection.Select(GetIdentifierFromModelObject).Where(x => x != null).ToList();
+            }
+            set
+            {
+                selectionIdentifier = value;
             }
         }
 
@@ -112,6 +138,28 @@ namespace CoreNodeModels
 
             State = ElementState.Warning; 
             
+            ShouldDisplayPreviewCore = true;
+        }
+
+        [JsonConstructor]
+        protected SelectionBase(
+            SelectionType selectionType,
+            SelectionObjectType selectionObjectType,
+            string message,
+            string prefix,
+            IEnumerable<string> selectionIdentifier,
+            IEnumerable<PortModel> inPorts,
+            IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+            selectionMessage = message;
+
+            this.selectionType = selectionType;
+            this.selectionObjectType = selectionObjectType;
+
+            Prefix = prefix;
+
+            State = ElementState.Warning;
+
             ShouldDisplayPreviewCore = true;
         }
 


### PR DESCRIPTION
### Purpose

 [QNTM-1284](https://jira.autodesk.com/browse/QNTM-1284)

The purpose of this PR is to enable the serialization and deserialization of Revit element selection nodes in Json.  Previously Revit/Dynamo would freeze when attempting save a graph containing Revit selection nodes and the Json file is never written.  The selection node should also maintain the Revit element id that is referenced so it will automatically be recognized when reopening a graph.

Supplemental to [D4R PR #1768](https://github.com/DynamoDS/DynamoRevit/pull/1768)

![giphy](https://user-images.githubusercontent.com/13341935/29972605-aa48e9a6-8efa-11e7-8db0-e2b844948d1b.gif)

### Updated Json Output

``` json
{
  "Uuid": "ac033b17-4df4-4c56-bc42-533f7bad27fe",
  "IsCustomNode": false,
  "Description": null,
  "Name": "Home",
  "ElementResolver": {
    "ResolutionMap": {}
  },
  "Inputs": [],
  "Nodes": [
    {
      "ConcreteType": "Dynamo.Nodes.SelectFaces, DSRevitNodesUI",
      "NodeType": "ExtensionNode",
      "InstanceId": [
        "3a376239-8db9-4f12-8dbb-774857dd156f-0000097b:5:SURFACE",
        "3a376239-8db9-4f12-8dbb-774857dd156f-0000097b:6:SURFACE",
        "3a376239-8db9-4f12-8dbb-774857dd156f-0000097b:10:SURFACE",
        "3a376239-8db9-4f12-8dbb-774857dd156f-0000097b:18:SURFACE"
      ],
      "Id": "4d90c28040f247ef8cc0a3d0e6eed4d7",
      "Inputs": [],
      "Outputs": [
        {
          "Id": "4953c930ce1040ea828e6f8a94328d8a",
          "Name": "Surfaces",
          "Description": "The selected elements.",
          "Level": 2,
          "UseLevels": false,
          "KeepListStructure": false
        }
      ],
      "Replication": "Disabled"
    }
  ],
  "Connectors": [],
  "Dependencies": [],
  "Bindings": [],
  "View": {
    "Camera": {
      "Name": "Background Preview",
      "EyeX": -17.0,
      "EyeY": 24.0,
      "EyeZ": 50.0,
      "LookX": 12.0,
      "LookY": -13.0,
      "LookZ": -58.0,
      "UpX": 0.0,
      "UpY": 1.0,
      "UpZ": 0.0
    },
    "NodeViews": [
      {
        "ShowGeometry": true,
        "Name": "Select Faces",
        "Id": "4d90c28040f247ef8cc0a3d0e6eed4d7",
        "IsUpstreamVisible": true,
        "Excluded": false,
        "X": 135.60000000000002,
        "Y": 128.79999999999993
      }
    ],
    "Notes": [],
    "Annotations": [],
    "X": 0.0,
    "Y": 0.0,
    "Zoom": 1.0
  }
}
```

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@QilongTang 

### FYIs
