### PR TITLE
Make '=' in return statement be optional 

### DIFF
--- a/src/Engine/ProtoCore/Parser/GenerateParser.bat
+++ b/src/Engine/ProtoCore/Parser/GenerateParser.bat
@@ -2,4 +2,7 @@ copy/b atg\Start.atg+atg\Associative.atg+atg\Imperative.atg+atg\End.atg DesignSc
 Coco.exe -namespace ProtoCore.DesignScriptParser DesignScript.atg
 copy DesignScript.atg DS.DesignScript.atg.temp
 del DesignScript.atg
+del DS.DesignScript.atg.temp
+del Parser.cs.old
+del Scanner.cs.old
 PAUSE

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -62,8 +62,8 @@ public class Parser {
 	public const int _inlinecomment = 65;
 	public const int _blockcomment = 66;
 
-	const bool T = true;
-	const bool x = false;
+	const bool _T = true;
+	const bool _x = false;
 	const int minErrDist = 2;
 	
 	public Scanner scanner;
@@ -492,6 +492,20 @@ public Node root { get; set; }
         }
         scanner.ResetPeek();        
         return true;    
+    }
+
+    private bool IsReturn(ProtoCore.AST.Node ident) {
+        ProtoCore.AST.AssociativeAST.IdentifierNode assocIdent = ident as ProtoCore.AST.AssociativeAST.IdentifierNode;
+        if (assocIdent != null) {
+            return assocIdent.Value == "return";
+        }
+
+        ProtoCore.AST.ImperativeAST.IdentifierNode impIdent = ident as ProtoCore.AST.ImperativeAST.IdentifierNode;
+        if (impIdent != null) {
+            return impIdent.Value == "return";
+        }
+
+        return false;
     }
 
     private AssociativeNode GenerateBinaryOperatorMethodCallNode(Operator op, ProtoCore.AST.AssociativeAST.AssociativeNode op1, ProtoCore.AST.AssociativeAST.AssociativeNode op2)
@@ -1058,8 +1072,14 @@ public Node root { get; set; }
 			   node = expressionNode;
 			}
 			
-		} else if (la.kind == 51) {
-			Get();
+		} else if (StartOf(9)) {
+			if (IsReturn(leftNode)) {
+				if (la.kind == 51) {
+					Get();
+				}
+			} else {
+				Get();
+			}
 			ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
 			bool isLeftMostNode = false; 
 			if (leftVar == null) 
@@ -1125,7 +1145,7 @@ public Node root { get; set; }
 			   isLeftVarIdentList = false;                                  
 			}  
 			
-		} else if (StartOf(9)) {
+		} else if (StartOf(10)) {
 			SynErr(Resources.SemiColonExpected); 
 		} else SynErr(75);
 	}
@@ -1175,7 +1195,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 					Get();
 					Expect(45);
 					break; 
-				} else if (StartOf(9)) {
+				} else if (StartOf(10)) {
 					Get(); 
 				} else SynErr(77);
 			}
@@ -1197,7 +1217,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_StatementList(out List<ProtoCore.AST.AssociativeAST.AssociativeNode> nodelist) {
 		nodelist = new List<ProtoCore.AST.AssociativeAST.AssociativeNode>(); 
-		while (StartOf(10)) {
+		while (StartOf(11)) {
 			ProtoCore.AST.AssociativeAST.AssociativeNode node = null; 
 			Associative_Statement(out node);
 			if (null != node) nodelist.Add(node); 
@@ -1320,7 +1340,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		ProtoCore.AST.ImperativeAST.CodeBlockNode codeblock = new ProtoCore.AST.ImperativeAST.CodeBlockNode();
 		NodeUtils.SetNodeStartLocation(codeblock, t);
 		
-		while (StartOf(11)) {
+		while (StartOf(12)) {
 			Imperative_stmt(out node);
 			if (null != node)   
 			   codeblock.Body.Add(node); 
@@ -1397,11 +1417,6 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		   errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
 		}
 		int ltype = (0 == String.Compare(t.val, "return")) ? (int)ProtoCore.PrimitiveType.Return : (int)ProtoCore.PrimitiveType.Var;
-		if (ltype == (int)ProtoCore.PrimitiveType.Return && la.val != "=")
-		{
-		    SynErr(String.Format(Resources.InvalidReturnStatement, la.val));
-		}
-		
 		var identNode = AstFactory.BuildIdentifier(t.val);
 		identNode.datatype = TypeSystem.BuildPrimitiveTypeObject((ProtoCore.PrimitiveType)ltype);
 		node = identNode;
@@ -1417,7 +1432,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.AssociativeAST.AssociativeNode t; 
 			Associative_Expression(out t);
 			nodes.Add(t); 
-			while (WeakSeparator(50,4,12) ) {
+			while (WeakSeparator(50,4,13) ) {
 				Associative_Expression(out t);
 				nodes.Add(t); 
 			}
@@ -1478,7 +1493,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			argumentSignature.AddArgument(arg as ProtoCore.AST.AssociativeAST.VarDeclNode); 
 			while (la.kind == 50) {
 				if (NotDefaultArg()) { 
-				ExpectWeak(50, 13);
+				ExpectWeak(50, 14);
 				Associative_ArgDecl(out arg);
 				argumentSignature.AddArgument(arg as ProtoCore.AST.AssociativeAST.VarDeclNode); 
 				} else break; 
@@ -1852,7 +1867,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_UnaryExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		node = null; 
-		if (StartOf(14)) {
+		if (StartOf(15)) {
 			Associative_NegExpression(out node);
 		} else if (la.kind == 14 || la.kind == 59) {
 			Associative_BitUnaryExpression(out node);
@@ -1917,7 +1932,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Associative_String(out node);
 		} else if (la.kind == 1 || la.kind == 12 || la.kind == 44) {
 			Associative_IdentifierList(out node);
-		} else if (StartOf(15)) {
+		} else if (StartOf(16)) {
 			Associative_UnaryExpression(out node);
 		} else SynErr(84);
 	}
@@ -1933,7 +1948,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_ComparisonExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		Associative_RangeExpr(out node);
-		while (StartOf(16)) {
+		while (StartOf(17)) {
 			Operator op; 
 			Associative_ComparisonOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
@@ -2599,7 +2614,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 					Get();
 					Expect(45);
 					break; 
-				} else if (StartOf(9)) {
+				} else if (StartOf(10)) {
 					Get(); 
 				} else SynErr(97);
 			}
@@ -2629,7 +2644,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Imperative_stmtlist(out body);
 			ifStmtNode.IfBody = body; 
 			Expect(45);
-		} else if (StartOf(11)) {
+		} else if (StartOf(12)) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt; 
 			Imperative_stmt(out singleStmt);
 			ifStmtNode.IfBody.Add(singleStmt); 
@@ -2653,7 +2668,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				Imperative_stmtlist(out body);
 				elseifBlock.Body = body; 
 				Expect(45);
-			} else if (StartOf(11)) {
+			} else if (StartOf(12)) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				elseifBlock.Body.Add(singleStmt); 
@@ -2669,7 +2684,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				Imperative_stmtlist(out body);
 				ifStmtNode.ElseBody = body; 
 				Expect(45);
-			} else if (StartOf(11)) {
+			} else if (StartOf(12)) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				ifStmtNode.ElseBody.Add(singleStmt); 
@@ -2722,7 +2737,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			loopNode.Body = body; 
 			Expect(45);
 			NodeUtils.SetNodeEndLocation(loopNode, t); 
-		} else if (StartOf(11)) {
+		} else if (StartOf(12)) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 			Imperative_stmt(out singleStmt);
 			loopNode.Body.Add(singleStmt); 
@@ -2747,8 +2762,14 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			NodeUtils.SetNodeEndLocation(bNode, t);
 			node = bNode; 
 			
-		} else if (la.kind == 51) {
-			Get();
+		} else if (StartOf(9)) {
+			if (IsReturn(lhsNode)) {
+				if (la.kind == 51) {
+					Get();
+				}
+			} else {
+				Get();
+			}
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode = null; 
 			if (HasMoreAssignmentStatements()) {
 				Imperative_assignstmt(out rhsNode);
@@ -2767,7 +2788,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			NodeUtils.SetNodeEndLocation(bNode, t);
 			node = bNode;       
 			
-		} else if (StartOf(9)) {
+		} else if (StartOf(10)) {
 			SynErr("';' is expected"); 
 		} else SynErr(104);
 	}
@@ -2782,7 +2803,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Imperative_stmtlist(out List<ProtoCore.AST.ImperativeAST.ImperativeNode> nodelist) {
 		nodelist = new List<ProtoCore.AST.ImperativeAST.ImperativeNode>(); 
-		while (StartOf(11)) {
+		while (StartOf(12)) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode node = null; 
 			Imperative_stmt(out node);
 			if (node != null) nodelist.Add(node); 
@@ -2944,10 +2965,6 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		   errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
 		}
 		int ltype = (0 == String.Compare(t.val, "return")) ? (int)ProtoCore.PrimitiveType.Return : (int)ProtoCore.PrimitiveType.Var;
-		if (ltype == (int)ProtoCore.PrimitiveType.Return && la.val != "=")
-		{
-		   SynErr(String.Format(Resources.InvalidReturnStatement, la.val)); 
-		}        
 		node = BuildImperativeIdentifier(t.val, (ProtoCore.PrimitiveType)ltype);
 		NodeUtils.SetNodeLocation(node, t);
 		
@@ -3175,7 +3192,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	void Imperative_logicalexpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null;
 		Imperative_RangeExpr(out node);
-		while (StartOf(16)) {
+		while (StartOf(17)) {
 			Operator op; 
 			Imperative_relop(out op);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode = null; 
@@ -3528,23 +3545,24 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	}
 	
 	static readonly bool[,] set = {
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,T,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,T,T, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,T, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{T,T,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,T,x,T, x,T,T,T, T,T,x,x, x,T,T,x, x,T,T,T, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,T,x,x, T,T,x,x, x,T,T,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,x,x, T,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,T,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x}
+		{_T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_T,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_T,_x,_T, _x,_T,_T,_T, _T,_T,_x,_x, _x,_T,_T,_x, _x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_T,_x,_x, _T,_T,_x,_x, _x,_T,_T,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x}
 
 	};
 } // end Parser

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -228,6 +228,9 @@ public Node root { get; set; }
 		if (IsTypedVariable())
             return false;
 
+        if (la.val == "return")
+            return false;
+
         Token pt = la;
         while (pt.kind != _EOF)
         {
@@ -251,8 +254,12 @@ public Node root { get; set; }
         return true;
     }
 
-    private bool IsAssignmentStatement()
+    private bool IsAssignmentOrReturnStatement()
     {
+		if (la.val == "return") {
+		    return true;
+		}
+
         Token pt = la;
         while (pt.kind != _EOF)
         {
@@ -2553,7 +2560,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			
 			Expect(23);
 			node = new ProtoCore.AST.ImperativeAST.ContinueNode(); NodeUtils.SetNodeLocation(node, t); 
-		} else if (IsAssignmentStatement() || IsVariableDeclaration()) {
+		} else if (IsAssignmentOrReturnStatement() || IsVariableDeclaration()) {
 			Imperative_assignstmt(out node);
 		} else if (StartOf(4)) {
 			Imperative_expr(out node);

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -980,7 +980,14 @@ Associative_FunctionalStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode
                                 .)
         |
         (
-            '='                 
+            (
+                (
+                IF(IsReturn(leftNode))
+                    ['=']
+                )
+                |
+                '='
+            )
                                 (. 
                                     ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
                                     bool isLeftMostNode = false; 

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1502,11 +1502,6 @@ Associative_Ident<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
                     errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
                 }
                 int ltype = (0 == String.Compare(t.val, "return")) ? (int)ProtoCore.PrimitiveType.Return : (int)ProtoCore.PrimitiveType.Var;
-                if (ltype == (int)ProtoCore.PrimitiveType.Return && la.val != "=")
-                {
-                     SynErr(String.Format(Resources.InvalidReturnStatement, la.val));
-                }
-                
                 var identNode = AstFactory.BuildIdentifier(t.val);
                 identNode.datatype = TypeSystem.BuildPrimitiveTypeObject((ProtoCore.PrimitiveType)ltype);
                 node = identNode;

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -299,7 +299,14 @@ Imperative_assignstmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                         .)
         |
         (
-            '='     
+            (
+                (
+                IF(IsReturn(lhsNode))
+                    ['=']
+                )
+                |
+                '='     
+            )
             (. ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode = null; .)
             (   
                 ( 
@@ -800,10 +807,6 @@ Imperative_Ident<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                         errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
                     }
                     int ltype = (0 == String.Compare(t.val, "return")) ? (int)ProtoCore.PrimitiveType.Return : (int)ProtoCore.PrimitiveType.Var;
-                    if (ltype == (int)ProtoCore.PrimitiveType.Return && la.val != "=")
-                    {
-                        SynErr(String.Format(Resources.InvalidReturnStatement, la.val)); 
-                    }        
                     node = BuildImperativeIdentifier(t.val, (ProtoCore.PrimitiveType)ltype);
                     NodeUtils.SetNodeLocation(node, t);
                 .)

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -111,7 +111,7 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
             endline
         )  (. node = new ProtoCore.AST.ImperativeAST.ContinueNode(); NodeUtils.SetNodeLocation(node, t); .)
         |
-        (IF(IsAssignmentStatement() || IsVariableDeclaration())
+        (IF(IsAssignmentOrReturnStatement() || IsVariableDeclaration())
             Imperative_assignstmt<out node>
         )
         |

--- a/src/Engine/ProtoCore/Parser/atg/Start.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Start.atg
@@ -154,7 +154,7 @@ COMPILER DesignScriptParser
 		if (IsTypedVariable())
             return false;
 
-        if (la.value == "return")
+        if (la.val == "return")
             return false;
 
         Token pt = la;
@@ -180,8 +180,12 @@ COMPILER DesignScriptParser
         return true;
     }
 
-    private bool IsAssignmentStatement()
+    private bool IsAssignmentOrReturnStatement()
     {
+		if (la.val == "return") {
+		    return true;
+		}
+
         Token pt = la;
         while (pt.kind != _EOF)
         {

--- a/src/Engine/ProtoCore/Parser/atg/Start.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Start.atg
@@ -420,6 +420,20 @@ COMPILER DesignScriptParser
         return true;    
     }
 
+    private bool IsReturn(ProtoCore.AST.Node ident) {
+        ProtoCore.AST.AssociativeAST.IdentifierNode assocIdent = ident as ProtoCore.AST.AssociativeAST.IdentifierNode;
+        if (assocIdent != null) {
+            return assocIdent.Value == "return";
+        }
+
+        ProtoCore.AST.ImperativeAST.IdentifierNode impIdent = ident as ProtoCore.AST.ImperativeAST.IdentifierNode;
+        if (impIdent != null) {
+            return impIdent.Value == "return";
+        }
+
+        return false;
+    }
+
     private AssociativeNode GenerateBinaryOperatorMethodCallNode(Operator op, ProtoCore.AST.AssociativeAST.AssociativeNode op1, ProtoCore.AST.AssociativeAST.AssociativeNode op2)
     {
         FunctionCallNode funCallNode = new FunctionCallNode();

--- a/src/Engine/ProtoCore/Parser/atg/Start.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Start.atg
@@ -154,6 +154,9 @@ COMPILER DesignScriptParser
 		if (IsTypedVariable())
             return false;
 
+        if (la.value == "return")
+            return false;
+
         Token pt = la;
         while (pt.kind != _EOF)
         {

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -971,24 +971,6 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Return statement is invalid. Do you mean: return = {0} ?.
-        /// </summary>
-        public static string InvalidReturnStatement {
-            get {
-                return ResourceManager.GetString("InvalidReturnStatement", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Syntax Error: invalid symbol &apos;{0}&apos;. (Did you mean to use Modifier Stack \&quot; =&gt; \&quot;).
-        /// </summary>
-        public static string InvalidSymbol {
-            get {
-                return ResourceManager.GetString("InvalidSymbol", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to File : &apos;{0}&apos; is already imported.
         /// </summary>
         public static string kAlreadyImported {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -186,12 +186,6 @@
   <data name="InvalidLanguageBlockIdentifier" xml:space="preserve">
     <value>\"{0}\" is not a valid language block identifier, do you mean \"Associative\" or \"Imperative\"?</value>
   </data>
-  <data name="InvalidReturnStatement" xml:space="preserve">
-    <value>Return statement is invalid. Do you mean: return = {0} ?</value>
-  </data>
-  <data name="InvalidSymbol" xml:space="preserve">
-    <value>Syntax Error: invalid symbol '{0}'. (Did you mean to use Modifier Stack \" =&gt; \")</value>
-  </data>
   <data name="kAlreadyImported" xml:space="preserve">
     <value>File : '{0}' is already imported</value>
   </data>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -189,12 +189,6 @@
   <data name="InvalidLanguageBlockIdentifier" xml:space="preserve">
     <value>\"{0}\" is not a valid language block identifier, do you mean \"Associative\" or \"Imperative\"?</value>
   </data>
-  <data name="InvalidReturnStatement" xml:space="preserve">
-    <value>Return statement is invalid. Do you mean: return = {0} ?</value>
-  </data>
-  <data name="InvalidSymbol" xml:space="preserve">
-    <value>Syntax Error: invalid symbol '{0}'. (Did you mean to use Modifier Stack \" =&gt; \")</value>
-  </data>
   <data name="kAlreadyImported" xml:space="preserve">
     <value>File : '{0}' is already imported</value>
   </data>

--- a/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
@@ -3526,5 +3526,33 @@ b = TestThisOverload.Mul(obj, 4);
             // Here we shouldn't generate an overloaded one.
             thisTest.Verify("b", 24);
         }
+
+        [Test]
+        public void TestReturnStatement01()
+        {
+            string code = @"
+def foo() {
+    return 21;
+}
+r = foo();
+";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+            thisTest.Verify("r", 21);
+        }
+
+
+        [Test]
+        public void TestReturnStatement02()
+        {
+            string code = @"
+r = [Imperative] {
+    return 21;
+}
+";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+            thisTest.Verify("r", 21);
+        }
     }
 }


### PR DESCRIPTION
### Purpose

That said, we should allow the following syntax:
```
def foo() {
    return 21;
}
x = [Imperative] {
    return 42;
}
```

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap PTAL
@pboyer FYI