### PR TITLE
QNTM-711: Serialize/Deserialize Dynamo Preferences from JSON

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -73,7 +73,7 @@ namespace Dynamo.Graph.Workspaces
         /// how execution is carried out.
         /// </summary>
         [JsonIgnore]
-        public readonly RunSettings RunSettings;
+        public RunSettings RunSettings { get; set; }
 
         /// <summary>
         /// Evaluation count is incremented whenever the graph is evaluated. 

--- a/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/HomeWorkspaceModel.cs
@@ -54,7 +54,7 @@ namespace Dynamo.Graph.Workspaces
         ///     are not left in run-auto upon reopening.  
         /// </summary>
         [JsonIgnore]
-        public bool HasRunWithoutCrash { get; private set; }
+        public bool HasRunWithoutCrash { get; set; }
 
         /// <summary>
         ///     Before the Workspace has been built the first time, we do not respond to 

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1566,6 +1566,9 @@ namespace Dynamo.Graph.Workspaces
         /// <param name="workspaceViewInfo">The extra view information from the workspace to update the model with.</param>
         public void UpdateWithExtraWorkspaceViewInfo(ExtraWorkspaceViewInfo workspaceViewInfo)
         {
+            if (workspaceViewInfo == null)
+              return;
+
             X = workspaceViewInfo.X;
             Y = workspaceViewInfo.Y;
             Zoom = workspaceViewInfo.Zoom; 

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1570,6 +1570,10 @@ namespace Dynamo.Graph.Workspaces
             Y = workspaceViewInfo.Y;
             Zoom = workspaceViewInfo.Zoom; 
 
+            OnCurrentOffsetChanged(
+                this,
+                new PointEventArgs(new Point2D(X, Y)));
+
             foreach (ExtraNodeViewInfo nodeViewInfo in workspaceViewInfo.NodeViews)
             {
                 var guidValue = IdToGuidConverter(nodeViewInfo.Id);

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -57,15 +57,18 @@ namespace Dynamo.Models
       public double ScaleFactor { get; internal set; }
       public bool HasRunWithoutCrash { get; internal set; }
       public bool IsVisibleInDynamoLibrary { get; internal set; }
+      public string Version { get; internal set; }
 
       public DynamoPreferencesData(
         double scaleFactor,
         bool hasRunWithoutCrash,
-        bool isVisibleInDynamoLibrary)
+        bool isVisibleInDynamoLibrary,
+        string version)
       {
         ScaleFactor = scaleFactor;
         HasRunWithoutCrash = hasRunWithoutCrash;
         IsVisibleInDynamoLibrary = isVisibleInDynamoLibrary;
+        Version = version;
       }
     }
 
@@ -1487,6 +1490,13 @@ namespace Dynamo.Models
 
             workspace.FileName = filePath;
             workspace.ScaleFactor = dynamoPreferences.ScaleFactor;
+
+            // NOTE: This is to handle the case of opening a JSON file that does not have a version string
+            //       This logic may not be correct, need to decide the importance of versioning early JSON files
+            string versionString = dynamoPreferences.Version;
+            if (versionString == null)
+              versionString = AssemblyHelper.GetDynamoVersion().ToString();
+            workspace.WorkspaceVersion = new System.Version(versionString);
 
             HomeWorkspaceModel homeWorkspace = workspace as HomeWorkspaceModel;
             if (homeWorkspace != null)

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -81,10 +81,10 @@ namespace Dynamo.Models
       {
         return new DynamoPreferencesData(
           1.0,
-          false,
+          true,
           true,
           AssemblyHelper.GetDynamoVersion().ToString(),
-          Models.RunType.Manual.ToString(),
+          Models.RunType.Automatic.ToString(),
           RunSettings.DefaultRunPeriod.ToString());
       }
     }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -54,12 +54,15 @@ namespace Dynamo.Models
     /// </summary>
     public class DynamoPreferencesData
     {
-      public double ScaleFactor;
+      public double ScaleFactor { get; internal set; }
+      public bool HasRunWithoutCrash { get; internal set; }
 
       public DynamoPreferencesData(
-        double scaleFactor)
+        double scaleFactor,
+        bool hasRunWithoutCrash)
       {
         ScaleFactor = scaleFactor;
+        HasRunWithoutCrash = hasRunWithoutCrash;
       }
     }
 
@@ -1481,6 +1484,10 @@ namespace Dynamo.Models
 
             workspace.FileName = filePath;
             workspace.ScaleFactor = dynamoPreferences.ScaleFactor;
+
+            HomeWorkspaceModel homeWorkspace = workspace as HomeWorkspaceModel;
+            if (homeWorkspace != null)
+              homeWorkspace.HasRunWithoutCrash = dynamoPreferences.HasRunWithoutCrash;
 
             return true;
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -76,6 +76,17 @@ namespace Dynamo.Models
         RunType = runType;
         RunPeriod = runPeriod;
       }
+
+      public static DynamoPreferencesData Default()
+      {
+        return new DynamoPreferencesData(
+          1.0,
+          false,
+          true,
+          AssemblyHelper.GetDynamoVersion().ToString(),
+          Models.RunType.Manual.ToString(),
+          RunSettings.DefaultRunPeriod.ToString());
+      }
     }
 
     /// <summary>
@@ -1333,7 +1344,9 @@ namespace Dynamo.Models
             JsonReader reader = new JsonTextReader(new StringReader(json));
             var obj = JObject.Load(reader);
             var viewBlock = obj["View"];
-            var dynamoBlock = viewBlock["Dynamo"];
+            var dynamoBlock = viewBlock == null ? null : viewBlock["Dynamo"];
+            if (dynamoBlock == null)
+              return DynamoPreferencesData.Default();
            
             var settings = new JsonSerializerSettings
             {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -44,11 +44,25 @@ using DefaultUpdateManager = Dynamo.Updates.UpdateManager;
 using FunctionGroup = Dynamo.Engine.FunctionGroup;
 using Utils = Dynamo.Graph.Nodes.Utilities;
 
-// NOTE, QNTM-1101: For WorkspaceInfo deserialization
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Dynamo.Models
 {
+    /// <summary>
+    /// This class contains the extra Dynamo-specific preferences data
+    /// </summary>
+    public class DynamoPreferencesData
+    {
+      public double ScaleFactor;
+
+      public DynamoPreferencesData(
+        double scaleFactor)
+      {
+        ScaleFactor = scaleFactor;
+      }
+    }
+
     /// <summary>
     /// This class creates an interface for Engine controller.
     /// </summary>
@@ -1299,6 +1313,28 @@ namespace Dynamo.Models
             Logger.LogError("Could not open workspace at: " + filePath);
         }
 
+        static private DynamoPreferencesData DynamoPreferencesDataFromJson(string json)
+        {
+            JsonReader reader = new JsonTextReader(new StringReader(json));
+            var obj = JObject.Load(reader);
+            var viewBlock = obj["View"];
+            var dynamoBlock = viewBlock["Dynamo"];
+           
+            var settings = new JsonSerializerSettings
+            {
+                Error = (sender, args) =>
+                {
+                    args.ErrorContext.Handled = true;
+                    Console.WriteLine(args.ErrorContext.Error);
+                },
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                TypeNameHandling = TypeNameHandling.Auto,
+                Formatting = Newtonsoft.Json.Formatting.Indented
+            };
+
+            return JsonConvert.DeserializeObject<DynamoPreferencesData>(dynamoBlock.ToString(), settings);
+        }
+
         /// <summary>
         /// Opens a Dynamo workspace from a path to an JSON file on disk.
         /// </summary>
@@ -1313,24 +1349,14 @@ namespace Dynamo.Models
             {
                 string fileContents = File.ReadAllText(filePath);
 
-                // TODO, QNTM-1101: Figure out the plan for WorkspaceInfoin JSON files
-                // NOTE, short-term fix, QNTM-1100: Either implicit or explicit default WorkspaceInfo values 
-                // are being used for now, long-term fix is being tracked by QNTM-1101
-                WorkspaceInfo workspaceInfo = JsonConvert.DeserializeObject<WorkspaceInfo>(fileContents);
-                if (workspaceInfo != null)
+                DynamoPreferencesData dynamoPreferences = DynamoPreferencesDataFromJson(fileContents);
+                if (dynamoPreferences != null)
                 {
-                    // NOTE, short-term fix, QNTM-1100: Default the FileName property here to show the file name in the view tab
-                    workspaceInfo.FileName = filePath;
-
-                    // NOTE, short-term fix, QNTM-1100: Default The scale factor to 1 (instead of 0) to enable 
-                    // proper geometry display when loading JSON
-                    workspaceInfo.ScaleFactor = 1;
-
                     // TODO, QNTM-1101: Figure out JSON migration strategy
-                    if (true) //MigrationManager.ProcessWorkspace(workspaceInfo, xmlDoc, IsTestMode, NodeFactory))
+                    if (true) //MigrationManager.ProcessWorkspace(dynamoPreferences.Version, xmlDoc, IsTestMode, NodeFactory))
                     {
                         WorkspaceModel ws;
-                        if (OpenJsonFile(workspaceInfo, fileContents, out ws))
+                        if (OpenJsonFile(filePath, fileContents, dynamoPreferences, out ws))
                         {
                             OpenWorkspace(ws);
                             SetPeriodicEvaluation(ws);
@@ -1431,10 +1457,14 @@ namespace Dynamo.Models
             }
         }
 
-        private bool OpenJsonFile(WorkspaceInfo workspaceInfo, string fileContents, out WorkspaceModel workspace)
+        private bool OpenJsonFile(
+          string filePath, 
+          string fileContents, 
+          DynamoPreferencesData dynamoPreferences, 
+          out WorkspaceModel workspace)
         {
             CustomNodeManager.AddUninitializedCustomNodesInPath(
-                Path.GetDirectoryName(workspaceInfo.FileName),
+                Path.GetDirectoryName(filePath),
                 IsTestMode);
 
             // TODO, QNTM-1108: WorkspaceModel.FromJson does not check a schema and so will not fail as long
@@ -1449,13 +1479,8 @@ namespace Dynamo.Models
                 false,
                 CustomNodeManager);
 
-            workspace.FileName = workspaceInfo.FileName;
-
-            workspace.OnCurrentOffsetChanged(
-                this,
-                new PointEventArgs(new Point2D(workspaceInfo.X, workspaceInfo.Y)));
-
-            workspace.ScaleFactor = workspaceInfo.ScaleFactor;
+            workspace.FileName = filePath;
+            workspace.ScaleFactor = dynamoPreferences.ScaleFactor;
 
             return true;
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -56,13 +56,16 @@ namespace Dynamo.Models
     {
       public double ScaleFactor { get; internal set; }
       public bool HasRunWithoutCrash { get; internal set; }
+      public bool IsVisibleInDynamoLibrary { get; internal set; }
 
       public DynamoPreferencesData(
         double scaleFactor,
-        bool hasRunWithoutCrash)
+        bool hasRunWithoutCrash,
+        bool isVisibleInDynamoLibrary)
       {
         ScaleFactor = scaleFactor;
         HasRunWithoutCrash = hasRunWithoutCrash;
+        IsVisibleInDynamoLibrary = isVisibleInDynamoLibrary;
       }
     }
 
@@ -1488,6 +1491,10 @@ namespace Dynamo.Models
             HomeWorkspaceModel homeWorkspace = workspace as HomeWorkspaceModel;
             if (homeWorkspace != null)
               homeWorkspace.HasRunWithoutCrash = dynamoPreferences.HasRunWithoutCrash;
+
+            CustomNodeWorkspaceModel customNodeWorkspace = workspace as CustomNodeWorkspaceModel;
+            if (customNodeWorkspace != null)
+              customNodeWorkspace.IsVisibleInDynamoLibrary = dynamoPreferences.IsVisibleInDynamoLibrary;
 
             return true;
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -58,17 +58,23 @@ namespace Dynamo.Models
       public bool HasRunWithoutCrash { get; internal set; }
       public bool IsVisibleInDynamoLibrary { get; internal set; }
       public string Version { get; internal set; }
+      public string RunType { get; internal set; }
+      public string RunPeriod { get; internal set; }
 
       public DynamoPreferencesData(
         double scaleFactor,
         bool hasRunWithoutCrash,
         bool isVisibleInDynamoLibrary,
-        string version)
+        string version,
+        string runType,
+        string runPeriod)
       {
         ScaleFactor = scaleFactor;
         HasRunWithoutCrash = hasRunWithoutCrash;
         IsVisibleInDynamoLibrary = isVisibleInDynamoLibrary;
         Version = version;
+        RunType = runType;
+        RunPeriod = runPeriod;
       }
     }
 
@@ -1500,7 +1506,17 @@ namespace Dynamo.Models
 
             HomeWorkspaceModel homeWorkspace = workspace as HomeWorkspaceModel;
             if (homeWorkspace != null)
+            {
               homeWorkspace.HasRunWithoutCrash = dynamoPreferences.HasRunWithoutCrash;
+
+              RunType runType;
+              if (!homeWorkspace.HasRunWithoutCrash || !Enum.TryParse(dynamoPreferences.RunType, false, out runType))
+                  runType = RunType.Manual;
+              int runPeriod;
+              if (!Int32.TryParse(dynamoPreferences.RunPeriod, out runPeriod))
+                  runPeriod = RunSettings.DefaultRunPeriod;
+              homeWorkspace.RunSettings = new RunSettings(runType, runPeriod);
+            }
 
             CustomNodeWorkspaceModel customNodeWorkspace = workspace as CustomNodeWorkspaceModel;
             if (customNodeWorkspace != null)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -29,7 +29,6 @@ using Dynamo.Engine;
 
 namespace Dynamo.ViewModels
 {
-
     public delegate void NoteEventHandler(object sender, EventArgs e);
     public delegate void ViewEventHandler(object sender, EventArgs e);
     public delegate void SelectionEventHandler(object sender, SelectionBoxUpdateArgs e);
@@ -180,6 +179,20 @@ namespace Dynamo.ViewModels
 
         [JsonIgnore]
         public bool IsSnapping { get; set; }
+
+        /// <summary>
+        /// Gets the collection of Dynamo-specific preferences.
+        /// This is used when serializing Dynamo preferences in the View block of Graph.Json.
+        /// </summary>
+        [JsonProperty("Dynamo")]
+        public DynamoPreferencesData DynamoPreferences
+        {
+            get
+            {
+              return new DynamoPreferencesData(
+                Model.ScaleFactor);
+            }
+        }
 
         /// <summary>
         /// Gets the Camera Data. This is used when serializing Camera Data in the View block

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -202,7 +202,8 @@ namespace Dynamo.ViewModels
               return new DynamoPreferencesData(
                 Model.ScaleFactor,
                 hasRunWithoutCrash,
-                isVisibleInDynamoLibrary);
+                isVisibleInDynamoLibrary,
+                Model.WorkspaceVersion.ToString());
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -190,9 +190,15 @@ namespace Dynamo.ViewModels
             get
             {
               bool hasRunWithoutCrash = false;
+              string runType = RunType.Manual.ToString();
+              string runPeriod = RunSettings.DefaultRunPeriod.ToString();
               HomeWorkspaceModel homeWorkspace = Model as HomeWorkspaceModel;
               if (homeWorkspace != null)
+              {
                 hasRunWithoutCrash = homeWorkspace.HasRunWithoutCrash;
+                runType = homeWorkspace.RunSettings.RunType.ToString();
+                runPeriod = homeWorkspace.RunSettings.RunPeriod.ToString();
+              }
 
               bool isVisibleInDynamoLibrary = true;
               CustomNodeWorkspaceModel customNodeWorkspace = Model as CustomNodeWorkspaceModel;
@@ -203,7 +209,9 @@ namespace Dynamo.ViewModels
                 Model.ScaleFactor,
                 hasRunWithoutCrash,
                 isVisibleInDynamoLibrary,
-                Model.WorkspaceVersion.ToString());
+                Model.WorkspaceVersion.ToString(),
+                runType,
+                runPeriod);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -194,9 +194,15 @@ namespace Dynamo.ViewModels
               if (homeWorkspace != null)
                 hasRunWithoutCrash = homeWorkspace.HasRunWithoutCrash;
 
+              bool isVisibleInDynamoLibrary = true;
+              CustomNodeWorkspaceModel customNodeWorkspace = Model as CustomNodeWorkspaceModel;
+              if (customNodeWorkspace != null)
+                isVisibleInDynamoLibrary = customNodeWorkspace.IsVisibleInDynamoLibrary;
+
               return new DynamoPreferencesData(
                 Model.ScaleFactor,
-                hasRunWithoutCrash);
+                hasRunWithoutCrash,
+                isVisibleInDynamoLibrary);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -189,8 +189,14 @@ namespace Dynamo.ViewModels
         {
             get
             {
+              bool hasRunWithoutCrash = false;
+              HomeWorkspaceModel homeWorkspace = Model as HomeWorkspaceModel;
+              if (homeWorkspace != null)
+                hasRunWithoutCrash = homeWorkspace.HasRunWithoutCrash;
+
               return new DynamoPreferencesData(
-                Model.ScaleFactor);
+                Model.ScaleFactor,
+                hasRunWithoutCrash);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -531,6 +531,8 @@ namespace Dynamo.ViewModels
             JsonReader reader = new JsonTextReader(new StringReader(json));
             var obj = JObject.Load(reader);
             var viewBlock = obj["View"];
+            if (viewBlock == null)
+              return null;
            
             var settings = new JsonSerializerSettings
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -209,7 +209,7 @@ namespace Dynamo.ViewModels
                 Model.ScaleFactor,
                 hasRunWithoutCrash,
                 isVisibleInDynamoLibrary,
-                Model.WorkspaceVersion.ToString(),
+                AssemblyHelper.GetDynamoVersion().ToString(),
                 runType,
                 runPeriod);
             }


### PR DESCRIPTION
### Purpose

This PR serializes/deserializes Dynamo-specific preferences from JSON

The Dynamo preferences addressed in this PR are;
- ScaleFactor
- HasRunWithoutCrash
- IsVisibleInDynamoLibrary
- Version
- RunType
- RunPeriod

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [n/a] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [n/a] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [n/a] Snapshot of UI changes, if any.
- [n/a] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
