### PR TITLE
Using default vals

### DIFF
--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -8,6 +8,7 @@ using Dynamo.Utilities;
 using Newtonsoft.Json;
 using ProtoCore.AST.AssociativeAST;
 using Dynamo.Graph.Workspaces;
+using System.ComponentModel;
 
 namespace Dynamo.Graph.Nodes
 {
@@ -179,6 +180,8 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         /// Controls whether this port is set to use it's default value (true) or yield a closure (false).
         /// </summary>
+        [DefaultValue(true)]            
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public bool UsingDefaultValue
         {
             get { return usingDefaultValue; }

--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -179,7 +179,6 @@ namespace Dynamo.Graph.Nodes
         /// <summary>
         /// Controls whether this port is set to use it's default value (true) or yield a closure (false).
         /// </summary>
-        [JsonIgnore]
         public bool UsingDefaultValue
         {
             get { return usingDefaultValue; }

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -109,6 +109,7 @@ namespace Dynamo.Graph.Workspaces
             }
             else
             {
+                //we don't need to remap ports for any nodes with json constructors which pass ports
                 node = (NodeModel)obj.ToObject(type);
             }
             //cannot set Lacing directly as property is protected
@@ -164,6 +165,7 @@ namespace Dynamo.Graph.Workspaces
             newPort.UseLevels = deserializedPort.UseLevels;
             newPort.Level = deserializedPort.Level;
             newPort.KeepListStructure = deserializedPort.KeepListStructure;
+            newPort.UsingDefaultValue = deserializedPort.UsingDefaultValue;
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -63,6 +63,7 @@ namespace Dynamo.Tests
             public bool UseLevels { get; set; }
             public bool KeepListStructure { get; set; }
             public int Level { get; set; }
+            public bool UsingDefaultValue { get; set; }
 
             public override bool Equals(object obj)
             {
@@ -70,7 +71,8 @@ namespace Dynamo.Tests
                 return ID == other.ID &&
                     other.KeepListStructure == this.KeepListStructure &&
                     other.Level == this.Level &&
-                    other.UseLevels == this.UseLevels;
+                    other.UseLevels == this.UseLevels &&
+                    other.UsingDefaultValue == this.UsingDefaultValue;
             }
         }
 
@@ -127,7 +129,8 @@ namespace Dynamo.Tests
                                 ID = p.GUID.ToString(),
                                 UseLevels = p.UseLevels,
                                 KeepListStructure = p.KeepListStructure,
-                                Level = p.Level
+                                Level = p.Level,
+                                UsingDefaultValue = p.UsingDefaultValue
                             });
                     });
 


### PR DESCRIPTION

### Purpose

Function passing requires serializing `UsingDefaultValue` so let's do that.
This property defaults to true in Dynamo -  for graphs where we did not serialize this / if it's missing.

It's added to the portComparisons in the serialization tests and there is a related PR


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@QilongTang 

### FYIs

@gregmarr 