### PR TITLE
Revert "Revert "Make '=' be optional in return statement""

### DIFF
--- a/src/Engine/ProtoCore/Parser/GenerateParser.bat
+++ b/src/Engine/ProtoCore/Parser/GenerateParser.bat
@@ -2,4 +2,6 @@ copy/b atg\Start.atg+atg\Associative.atg+atg\Imperative.atg+atg\End.atg DesignSc
 Coco.exe -namespace ProtoCore.DesignScriptParser DesignScript.atg
 copy DesignScript.atg DS.DesignScript.atg.temp
 del DesignScript.atg
-PAUSE
+del DS.DesignScript.atg.temp
+del Parser.cs.old
+del Scanner.cs.old

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -58,12 +58,12 @@ public class Parser {
 	public const int _literal_true = 41;
 	public const int _literal_false = 42;
 	public const int _literal_null = 43;
-	public const int maxT = 64;
-	public const int _inlinecomment = 65;
-	public const int _blockcomment = 66;
+	public const int maxT = 65;
+	public const int _inlinecomment = 66;
+	public const int _blockcomment = 67;
 
-	const bool T = true;
-	const bool x = false;
+	const bool _T = true;
+	const bool _x = false;
 	const int minErrDist = 2;
 	
 	public Scanner scanner;
@@ -639,11 +639,11 @@ public Node root { get; set; }
 			t = la;
 			la = scanner.Scan();
 			if (la.kind <= maxT) { ++errDist; break; }
-				if (la.kind == 65) {
+				if (la.kind == 66) {
 				CommentNode cNode = new CommentNode(la.col, la.line, la.val, CommentNode.CommentType.Inline); 
 				commentNode.Body.Add(cNode); 
 				}
-				if (la.kind == 66) {
+				if (la.kind == 67) {
 				CommentNode cNode = new CommentNode(la.col, la.line, la.val, CommentNode.CommentType.Block); 
 				commentNode.Body.Add(cNode); 
 				}
@@ -786,7 +786,7 @@ public Node root { get; set; }
 	}
 
 	void Import_Statement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		while (!(la.kind == 0 || la.kind == 34)) {SynErr(65); Get();}
+		while (!(la.kind == 0 || la.kind == 34)) {SynErr(66); Get();}
 		string moduleName = "", typeName = "", alias = "";
 		
 		Expect(34);
@@ -801,7 +801,7 @@ public Node root { get; set; }
 			Expect(36);
 			Expect(4);
 			moduleName = t.val; 
-		} else SynErr(66);
+		} else SynErr(67);
 		Expect(13);
 		if (la.kind == 35) {
 			Get();
@@ -841,14 +841,16 @@ public Node root { get; set; }
 	}
 
 	void Associative_Statement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		while (!(StartOf(2))) {SynErr(67); Get();}
+		while (!(StartOf(2))) {SynErr(68); Get();}
 		if (!IsFullClosure()) SynErr(Resources.CloseBracketExpected); 
 		node = null; 
-		if (IsNonAssignmentStatement()) {
+		if (la.kind == 44) {
+			Associative_ReturnStatement(out node);
+		} else if (IsNonAssignmentStatement()) {
 			Associative_NonAssignmentStatement(out node);
 		} else if (IsFunctionCallStatement()) {
 			Associative_FunctionCallStatement(out node);
-		} else if (la.kind == 1 || la.kind == 12 || la.kind == 44) {
+		} else if (la.kind == 1 || la.kind == 12 || la.kind == 46) {
 			Associative_FunctionalStatement(out node);
 		} else if (la.kind == 10) {
 			Associative_LanguageBlock(out node);
@@ -864,7 +866,7 @@ public Node root { get; set; }
 				
 				Get();
 			}
-		} else SynErr(68);
+		} else SynErr(69);
 	}
 
 	void Associative_functiondecl(out ProtoCore.AST.AssociativeAST.AssociativeNode node, ProtoCore.CompilerDefinitions.AccessModifier access = ProtoCore.CompilerDefinitions.AccessModifier.Public, bool isStatic = false) {
@@ -923,10 +925,10 @@ public Node root { get; set; }
 			classnode.BaseClass = baseClass;
 			
 		}
-		Expect(44);
+		Expect(46);
 		while (StartOf(5)) {
 			ProtoCore.CompilerDefinitions.AccessModifier access = ProtoCore.CompilerDefinitions.AccessModifier.Public; 
-			if (la.kind == 47 || la.kind == 48 || la.kind == 49) {
+			if (la.kind == 49 || la.kind == 50 || la.kind == 51) {
 				Associative_AccessSpecifier(out access);
 			}
 			if (la.kind == 26) {
@@ -959,16 +961,43 @@ public Node root { get; set; }
 					NodeUtils.SetNodeEndLocation(varnode, t); 
 				} else if (la.kind == 23) {
 					Get();
-				} else SynErr(69);
-			} else SynErr(70);
+				} else SynErr(70);
+			} else SynErr(71);
 		}
-		Expect(45);
+		Expect(47);
 		isInClass = false; classnode.endLine = t.line; classnode.endCol = t.col; 
 		node = classnode; 
 	}
 
+	void Associative_ReturnStatement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
+		var bNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
+		NodeUtils.SetNodeLocation(bNode, la);
+		
+		Expect(44);
+		if (la.kind == 45) {
+			Get();
+		}
+		var lhs = AstFactory.BuildIdentifier("return");
+		lhs.datatype = TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.Return);
+		bNode.LeftNode = lhs;
+		
+		ProtoCore.AST.AssociativeAST.AssociativeNode rhs = null;
+		
+		if (la.kind == 10) {
+			Associative_LanguageBlock(out rhs);
+		} else if (StartOf(4)) {
+			Associative_Expression(out rhs);
+			Expect(23);
+		} else SynErr(72);
+		bNode.RightNode = rhs;
+		bNode.Optr = Operator.assign;
+		
+		node = bNode;
+		
+	}
+
 	void Associative_NonAssignmentStatement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		while (!(StartOf(7))) {SynErr(71); Get();}
+		while (!(StartOf(7))) {SynErr(73); Get();}
 		node = null; 
 		ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
 		 
@@ -998,7 +1027,7 @@ public Node root { get; set; }
 	}
 
 	void Associative_FunctionCallStatement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		while (!(StartOf(7))) {SynErr(72); Get();}
+		while (!(StartOf(7))) {SynErr(74); Get();}
 		node = null; 
 		ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
 		 
@@ -1009,7 +1038,6 @@ public Node root { get; set; }
 		if (rightNode is ProtoCore.AST.AssociativeAST.FunctionDotCallNode 
 		   || rightNode is ProtoCore.AST.AssociativeAST.FunctionCallNode
 		   || allowIdentList)
-		
 		{
 		ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
 		ProtoCore.AST.AssociativeAST.IdentifierNode leftNode = new ProtoCore.AST.AssociativeAST.IdentifierNode();
@@ -1037,7 +1065,7 @@ public Node root { get; set; }
 	}
 
 	void Associative_FunctionalStatement(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		while (!(StartOf(8))) {SynErr(73); Get();}
+		while (!(StartOf(8))) {SynErr(75); Get();}
 		node = null; 
 		ProtoCore.AST.AssociativeAST.AssociativeNode leftNode = null; 
 		ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode(); 
@@ -1058,7 +1086,7 @@ public Node root { get; set; }
 			   node = expressionNode;
 			}
 			
-		} else if (la.kind == 51) {
+		} else if (la.kind == 45) {
 			Get();
 			ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
 			bool isLeftMostNode = false; 
@@ -1112,7 +1140,7 @@ public Node root { get; set; }
 				
 				Expect(23);
 				NodeUtils.SetNodeEndLocation(expressionNode, t); node = expressionNode; 
-			} else SynErr(74);
+			} else SynErr(76);
 			if (isLeftMostNode) 
 			{
 			   leftVar = null;
@@ -1127,7 +1155,7 @@ public Node root { get; set; }
 			
 		} else if (StartOf(9)) {
 			SynErr(Resources.SemiColonExpected); 
-		} else SynErr(75);
+		} else SynErr(77);
 	}
 
 	void Associative_LanguageBlock(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -1149,14 +1177,14 @@ public Node root { get; set; }
 		}
 		
 		Expect(11);
-		Expect(44);
+		Expect(46);
 		Node codeBlockNode = null; 
 		if (langblock.codeblock.Language == ProtoCore.Language.Associative ||
 langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Hydrogen(out codeBlockNode);
 		} else if (langblock.codeblock.Language == ProtoCore.Language.Imperative ) {
 			Imperative(out codeBlockNode);
-		} else SynErr(76);
+		} else SynErr(78);
 		if (langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			int openCurlyBraceCount = 0, closeCurlyBraceCount = 0; 
 			ProtoCore.AST.AssociativeAST.CodeBlockNode codeBlockInvalid = new ProtoCore.AST.AssociativeAST.CodeBlockNode(); 
@@ -1165,24 +1193,24 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				if (la.kind == 10) {
 					Associative_LanguageBlock(out validBlockInInvalid);
 					codeBlockInvalid.Body.Add(validBlockInInvalid); 
-				} else if (la.kind == 44) {
+				} else if (la.kind == 46) {
 					Get();
 					openCurlyBraceCount++; 
-				} else if (la.kind == 45) {
+				} else if (la.kind == 47) {
 					Get();
 					closeCurlyBraceCount++; 
 				} else if (la.kind == 0) {
 					Get();
-					Expect(45);
+					Expect(47);
 					break; 
 				} else if (StartOf(9)) {
 					Get(); 
-				} else SynErr(77);
+				} else SynErr(79);
 			}
 			codeBlockNode = codeBlockInvalid; 
-		} else if (la.kind == 45) {
+		} else if (la.kind == 47) {
 			Get();
-		} else SynErr(78);
+		} else SynErr(80);
 		langblock.CodeBlockNode = codeBlockNode; 
 		node = langblock; 
 	}
@@ -1190,7 +1218,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	void Associative_Expression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		node = null; 
 		Associative_LogicalExpression(out node);
-		while (la.kind == 52) {
+		while (la.kind == 53) {
 			Associative_TernaryOp(ref node);
 		}
 	}
@@ -1211,15 +1239,15 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_AccessSpecifier(out ProtoCore.CompilerDefinitions.AccessModifier access) {
 		access = ProtoCore.CompilerDefinitions.AccessModifier.Public; 
-		if (la.kind == 47) {
+		if (la.kind == 49) {
 			Get();
-		} else if (la.kind == 48) {
+		} else if (la.kind == 50) {
 			Get();
 			access = ProtoCore.CompilerDefinitions.AccessModifier.Private; 
-		} else if (la.kind == 49) {
+		} else if (la.kind == 51) {
 			Get();
 			access = ProtoCore.CompilerDefinitions.AccessModifier.Protected; 
-		} else SynErr(79);
+		} else SynErr(81);
 	}
 
 	void Associative_constructordecl(out ProtoCore.AST.AssociativeAST.AssociativeNode constrNode, ProtoCore.CompilerDefinitions.AccessModifier access) {
@@ -1238,7 +1266,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		constr.Access = access; 
 		ProtoCore.AST.AssociativeAST.AssociativeNode functionBody = null; 
 		
-		if (la.kind == 46) {
+		if (la.kind == 48) {
 			Get();
 			ProtoCore.AST.AssociativeAST.AssociativeNode bnode; 
 			Associative_BaseConstructorCall(out bnode);
@@ -1266,7 +1294,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		NodeUtils.SetNodeLocation(tNode, t);
 		varDeclNode.NameNode = tNode;
 		
-		if (la.kind == 46) {
+		if (la.kind == 48) {
 			Get();
 			Expect(1);
 			ProtoCore.Type argtype = new ProtoCore.Type(); argtype.Name = t.val; argtype.rank = 0; 
@@ -1382,10 +1410,10 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		List<ProtoCore.AST.AssociativeAST.AssociativeNode> body = new List<ProtoCore.AST.AssociativeAST.AssociativeNode>(); 
 		NodeUtils.SetNodeStartLocation(functionBody, la);
 		
-		Expect(44);
+		Expect(46);
 		Associative_StatementList(out body);
 		functionBody.Body =body;  
-		Expect(45);
+		Expect(47);
 		NodeUtils.SetNodeEndLocation(functionBody, t); 
 		funcBody = functionBody; 
 	}
@@ -1396,14 +1424,8 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		{
 		   errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
 		}
-		int ltype = (0 == String.Compare(t.val, "return")) ? (int)ProtoCore.PrimitiveType.Return : (int)ProtoCore.PrimitiveType.Var;
-		if (ltype == (int)ProtoCore.PrimitiveType.Return && la.val != "=")
-		{
-		    SynErr(String.Format(Resources.InvalidReturnStatement, la.val));
-		}
-		
 		var identNode = AstFactory.BuildIdentifier(t.val);
-		identNode.datatype = TypeSystem.BuildPrimitiveTypeObject((ProtoCore.PrimitiveType)ltype);
+		identNode.datatype = TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.Var);
 		node = identNode;
 		NodeUtils.SetNodeLocation(node, t);
 		
@@ -1417,7 +1439,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.AssociativeAST.AssociativeNode t; 
 			Associative_Expression(out t);
 			nodes.Add(t); 
-			while (WeakSeparator(50,4,12) ) {
+			while (WeakSeparator(52,4,12) ) {
 				Associative_Expression(out t);
 				nodes.Add(t); 
 			}
@@ -1435,7 +1457,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		ProtoCore.AST.AssociativeAST.AssociativeNode argumentSignature = null;
 		returnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank);
 		
-		if (la.kind == 46) {
+		if (la.kind == 48) {
 			Associative_TypeRestriction(out returnType);
 		}
 		Associative_ArgumentSignatureDefinition(out argumentSignature);
@@ -1443,7 +1465,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	}
 
 	void Associative_TypeRestriction(out ProtoCore.Type type) {
-		Expect(46);
+		Expect(48);
 		Associative_ClassReference(out type);
 		type.rank = 0; 
 		if (la.kind == 10) {
@@ -1476,22 +1498,22 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			if (NotDefaultArg()) { 
 			Associative_ArgDecl(out arg);
 			argumentSignature.AddArgument(arg as ProtoCore.AST.AssociativeAST.VarDeclNode); 
-			while (la.kind == 50) {
+			while (la.kind == 52) {
 				if (NotDefaultArg()) { 
-				ExpectWeak(50, 13);
+				ExpectWeak(52, 13);
 				Associative_ArgDecl(out arg);
 				argumentSignature.AddArgument(arg as ProtoCore.AST.AssociativeAST.VarDeclNode); 
 				} else break; 
 			}
 			} 
 		}
-		if (la.kind == 1 || la.kind == 50) {
-			if (la.kind == 50) {
+		if (la.kind == 1 || la.kind == 52) {
+			if (la.kind == 52) {
 				Get();
 			}
 			Associative_DefaultArgDecl(out arg);
 			argumentSignature.AddArgument(arg as ProtoCore.AST.AssociativeAST.VarDeclNode); 
-			while (la.kind == 50) {
+			while (la.kind == 52) {
 				Get();
 				Associative_DefaultArgDecl(out arg);
 				argumentSignature.AddArgument(arg as ProtoCore.AST.AssociativeAST.VarDeclNode); 
@@ -1517,7 +1539,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		NodeUtils.CopyNodeLocation(varDeclNode, tNode);
 		
 		ProtoCore.Type argtype = new ProtoCore.Type(); argtype.Name = "var"; argtype.rank = 0; argtype.UID = 0; 
-		if (la.kind == 46) {
+		if (la.kind == 48) {
 			Get();
 			Expect(1);
 			argtype.Name = t.val; 
@@ -1548,7 +1570,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	void Associative_DefaultArgDecl(out ProtoCore.AST.AssociativeAST.AssociativeNode node, ProtoCore.CompilerDefinitions.AccessModifier access = ProtoCore.CompilerDefinitions.AccessModifier.Public) {
 		Associative_ArgDecl(out node);
 		ProtoCore.AST.AssociativeAST.VarDeclNode varDeclNode = node as ProtoCore.AST.AssociativeAST.VarDeclNode; 
-		Expect(51);
+		Expect(45);
 		ProtoCore.AST.AssociativeAST.AssociativeNode rhsNode; 
 		Associative_Expression(out rhsNode);
 		ProtoCore.AST.AssociativeAST.BinaryExpressionNode bNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
@@ -1601,7 +1623,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			typedVar.Name = typedVar.Value = t.val;
 			NodeUtils.SetNodeLocation(typedVar, t);
 			
-			Expect(46);
+			Expect(48);
 			Expect(40);
 			typedVar.IsLocal = true;
 			
@@ -1651,7 +1673,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			identNode.Name = identNode.Value = t.val;
 			NodeUtils.SetNodeLocation(identNode, t);
 			
-			Expect(46);
+			Expect(48);
 			Expect(40);
 			identNode.IsLocal = true;
 			
@@ -1666,7 +1688,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			typedVar.Name = typedVar.Value = t.val;
 			NodeUtils.SetNodeLocation(typedVar, t);
 			
-			Expect(46);
+			Expect(48);
 			string strIdent = string.Empty;
 			int type = ProtoCore.DSASM.Constants.kInvalidIndex;
 			
@@ -1676,7 +1698,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			} else if (la.kind == 1) {
 				Get();
 				strIdent = t.val; 
-			} else SynErr(80);
+			} else SynErr(82);
 			type = core.TypeSystem.GetType(strIdent);
 			typedVar.TypeAlias = strIdent;
 			if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
@@ -1713,9 +1735,9 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				typedVar.datatype = datatype; 
 			}
 			node = typedVar; 
-		} else if (la.kind == 1 || la.kind == 12 || la.kind == 44) {
+		} else if (la.kind == 1 || la.kind == 12 || la.kind == 46) {
 			Associative_IdentifierList(out node);
-		} else SynErr(81);
+		} else SynErr(83);
 	}
 
 	void Associative_IdentifierList(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -1825,7 +1847,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_LogicalExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		Associative_ComparisonExpression(out node);
-		while (la.kind == 57 || la.kind == 58) {
+		while (la.kind == 58 || la.kind == 59) {
 			Operator op;
 			Associative_LogicalOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
@@ -1837,11 +1859,11 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_TernaryOp(ref ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		ProtoCore.AST.AssociativeAST.InlineConditionalNode inlineConNode = new ProtoCore.AST.AssociativeAST.InlineConditionalNode(); 
-		Expect(52);
+		Expect(53);
 		inlineConNode.ConditionExpression = node; node = null; 
 		Associative_Expression(out node);
 		inlineConNode.TrueExpression = node; 
-		Expect(46);
+		Expect(48);
 		node = null; 
 		Associative_Expression(out node);
 		inlineConNode.FalseExpression = node;
@@ -1854,9 +1876,9 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		node = null; 
 		if (StartOf(14)) {
 			Associative_NegExpression(out node);
-		} else if (la.kind == 14 || la.kind == 59) {
+		} else if (la.kind == 14 || la.kind == 60) {
 			Associative_BitUnaryExpression(out node);
-		} else SynErr(82);
+		} else SynErr(84);
 	}
 
 	void Associative_NegExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -1885,11 +1907,11 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Get();
 			op = UnaryOperator.Not;    
 			#if ENABLE_BIT_OP          
-		} else if (la.kind == 59) {
+		} else if (la.kind == 60) {
 			Get();
 			op = UnaryOperator.Negate; 
 			#endif                     
-		} else SynErr(83);
+		} else SynErr(85);
 	}
 
 	void Associative_Factor(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -1915,20 +1937,20 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Associative_Char(out node);
 		} else if (la.kind == 4) {
 			Associative_String(out node);
-		} else if (la.kind == 1 || la.kind == 12 || la.kind == 44) {
+		} else if (la.kind == 1 || la.kind == 12 || la.kind == 46) {
 			Associative_IdentifierList(out node);
 		} else if (StartOf(15)) {
 			Associative_UnaryExpression(out node);
-		} else SynErr(84);
+		} else SynErr(86);
 	}
 
 	void Associative_negop(out UnaryOperator op) {
 		op = UnaryOperator.None; 
-		if (la.kind == 1 || la.kind == 12 || la.kind == 44) {
+		if (la.kind == 1 || la.kind == 12 || la.kind == 46) {
 		} else if (la.kind == 15) {
 			Get();
 			op = UnaryOperator.Neg; 
-		} else SynErr(85);
+		} else SynErr(87);
 	}
 
 	void Associative_ComparisonExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -1945,12 +1967,12 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_LogicalOp(out Operator op) {
 		op = Operator.and; 
-		if (la.kind == 57) {
+		if (la.kind == 58) {
 			Get();
-		} else if (la.kind == 58) {
+		} else if (la.kind == 59) {
 			Get();
 			op = Operator.or; 
-		} else SynErr(86);
+		} else SynErr(88);
 	}
 
 	void Associative_ComparisonOp(out Operator op) {
@@ -1986,7 +2008,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			op = Operator.nq; 
 			break;
 		}
-		default: SynErr(87); break;
+		default: SynErr(89); break;
 		}
 	}
 
@@ -1998,7 +2020,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			bool hasRangeAmountOperator = false;
 			
 			Get();
-			if (la.kind == 60) {
+			if (la.kind == 61) {
 				Associative_rangeAmountOperator(out hasRangeAmountOperator);
 			}
 			rnode.HasRangeAmountOperator = hasRangeAmountOperator; 
@@ -2022,7 +2044,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_ArithmeticExpression(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		Associative_Term(out node);
-		while (la.kind == 15 || la.kind == 53) {
+		while (la.kind == 15 || la.kind == 54) {
 			Operator op; 
 			Associative_AddOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
@@ -2034,14 +2056,14 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_rangeAmountOperator(out bool hasRangeAmountOperator) {
 		hasRangeAmountOperator = false; 
-		Expect(60);
+		Expect(61);
 		hasRangeAmountOperator = true; 
 	}
 
 	void Associative_rangeStepOperator(out RangeStepOperator op) {
 		op = RangeStepOperator.StepSize; 
-		if (la.kind == 59 || la.kind == 60) {
-			if (la.kind == 60) {
+		if (la.kind == 60 || la.kind == 61) {
+			if (la.kind == 61) {
 				Get();
 				op = RangeStepOperator.Number; 
 			} else {
@@ -2053,30 +2075,30 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Associative_AddOp(out Operator op) {
 		op = Operator.add; 
-		if (la.kind == 53) {
+		if (la.kind == 54) {
 			Get();
 		} else if (la.kind == 15) {
 			Get();
 			op = Operator.sub; 
-		} else SynErr(88);
+		} else SynErr(90);
 	}
 
 	void Associative_MulOp(out Operator op) {
 		op = Operator.mul; 
-		if (la.kind == 54) {
+		if (la.kind == 55) {
 			Get();
-		} else if (la.kind == 55) {
-			Get();
-			op = Operator.div; 
 		} else if (la.kind == 56) {
 			Get();
+			op = Operator.div; 
+		} else if (la.kind == 57) {
+			Get();
 			op = Operator.mod; 
-		} else SynErr(89);
+		} else SynErr(91);
 	}
 
 	void Associative_Term(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
 		Associative_Factor(out node);
-		while (la.kind == 54 || la.kind == 55 || la.kind == 56) {
+		while (la.kind == 55 || la.kind == 56 || la.kind == 57) {
 			Operator op; 
 			Associative_MulOp(out op);
 			ProtoCore.AST.AssociativeAST.AssociativeNode expr2; 
@@ -2128,7 +2150,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			
 			NodeUtils.SetNodeLocation(node, t);
 			
-		} else SynErr(90);
+		} else SynErr(92);
 	}
 
 	void Associative_Number(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -2189,7 +2211,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			   node.line = line; node.col = col;
 			}
 			
-		} else SynErr(91);
+		} else SynErr(93);
 	}
 
 	void Associative_Char(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
@@ -2220,19 +2242,19 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	}
 
 	void Associative_ArrayExprList(out ProtoCore.AST.AssociativeAST.AssociativeNode node) {
-		Expect(44);
+		Expect(46);
 		ProtoCore.AST.AssociativeAST.ExprListNode exprlist = new ProtoCore.AST.AssociativeAST.ExprListNode(); 
 		NodeUtils.SetNodeStartLocation(exprlist, t); 
 		if (StartOf(4)) {
 			Associative_Expression(out node);
 			exprlist.Exprs.Add(node); 
-			while (la.kind == 50) {
+			while (la.kind == 52) {
 				Get();
 				Associative_Expression(out node);
 				exprlist.Exprs.Add(node); 
 			}
 		}
-		Expect(45);
+		Expect(47);
 		NodeUtils.SetNodeEndLocation(exprlist, t); 
 		node = exprlist; 
 	}
@@ -2269,11 +2291,11 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Associative_Ident(out node);
 			nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode; 
 			
-		} else if (la.kind == 44) {
+		} else if (la.kind == 46) {
 			Associative_ArrayExprList(out node);
 			nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode;
 			
-		} else SynErr(92);
+		} else SynErr(94);
 		if (la.kind == 10) {
 			ProtoCore.AST.AssociativeAST.ArrayNode array = new ProtoCore.AST.AssociativeAST.ArrayNode(); 
 			
@@ -2415,7 +2437,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			} else if (la.kind == 2) {
 				Get();
 				isLongest = false; 
-			} else SynErr(93);
+			} else SynErr(95);
 			repguide = t.val;
 			if (isLongest)
 			{
@@ -2437,7 +2459,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				} else if (la.kind == 2) {
 					Get();
 					isLongest = false; 
-				} else SynErr(94);
+				} else SynErr(96);
 				repguide = t.val;
 				if (isLongest)
 				{
@@ -2538,6 +2560,8 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			
 			Expect(23);
 			node = new ProtoCore.AST.ImperativeAST.ContinueNode(); NodeUtils.SetNodeLocation(node, t); 
+		} else if (la.kind == 44) {
+			Imperative_returnstmt(out node);
 		} else if (IsAssignmentStatement() || IsVariableDeclaration()) {
 			Imperative_assignstmt(out node);
 		} else if (StartOf(4)) {
@@ -2551,7 +2575,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			  SynErr(Resources.SemiColonExpected);
 			
 			Get();
-		} else SynErr(95);
+		} else SynErr(97);
 	}
 
 	void Imperative_languageblock(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -2573,14 +2597,14 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		}
 		
 		Expect(11);
-		Expect(44);
+		Expect(46);
 		Node codeBlockNode = null; 
 		if (langblock.codeblock.Language == ProtoCore.Language.Associative ||
 langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Hydrogen(out codeBlockNode);
 		} else if (langblock.codeblock.Language == ProtoCore.Language.Imperative ) {
 			Imperative(out codeBlockNode);
-		} else SynErr(96);
+		} else SynErr(98);
 		if (langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			int openCurlyBraceCount = 0, closeCurlyBraceCount = 0; 
 			ProtoCore.AST.ImperativeAST.CodeBlockNode codeBlockInvalid = new ProtoCore.AST.ImperativeAST.CodeBlockNode(); 
@@ -2589,24 +2613,24 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				if (la.kind == 10) {
 					Imperative_languageblock(out validBlockInInvalid);
 					codeBlockInvalid.Body.Add(validBlockInInvalid); 
-				} else if (la.kind == 44) {
+				} else if (la.kind == 46) {
 					Get();
 					openCurlyBraceCount++; 
-				} else if (la.kind == 45) {
+				} else if (la.kind == 47) {
 					Get();
 					closeCurlyBraceCount++; 
 				} else if (la.kind == 0) {
 					Get();
-					Expect(45);
+					Expect(47);
 					break; 
 				} else if (StartOf(9)) {
 					Get(); 
-				} else SynErr(97);
+				} else SynErr(99);
 			}
 			codeBlockNode = codeBlockInvalid; 
-		} else if (la.kind == 45) {
+		} else if (la.kind == 47) {
 			Get();
-		} else SynErr(98);
+		} else SynErr(100);
 		langblock.CodeBlockNode = codeBlockNode; 
 		node = langblock; 
 	}
@@ -2624,16 +2648,16 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		NodeUtils.SetNodeEndLocation(ifStmtNode.IfExprNode, t);
 		NodeUtils.SetNodeStartLocation(ifStmtNode.IfBodyPosition, la);
 		
-		if (la.kind == 44) {
+		if (la.kind == 46) {
 			Get();
 			Imperative_stmtlist(out body);
 			ifStmtNode.IfBody = body; 
-			Expect(45);
+			Expect(47);
 		} else if (StartOf(11)) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt; 
 			Imperative_stmt(out singleStmt);
 			ifStmtNode.IfBody.Add(singleStmt); 
-		} else SynErr(99);
+		} else SynErr(101);
 		NodeUtils.SetNodeEndLocation(ifStmtNode.IfBodyPosition, t); 
 		while (la.kind == 30) {
 			ProtoCore.AST.ImperativeAST.ElseIfBlock elseifBlock = new ProtoCore.AST.ImperativeAST.ElseIfBlock(); 
@@ -2648,32 +2672,32 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			NodeUtils.SetNodeEndLocation(elseifBlock.Expr, t);
 			NodeUtils.SetNodeStartLocation(elseifBlock.ElseIfBodyPosition, la);
 			
-			if (la.kind == 44) {
+			if (la.kind == 46) {
 				Get();
 				Imperative_stmtlist(out body);
 				elseifBlock.Body = body; 
-				Expect(45);
+				Expect(47);
 			} else if (StartOf(11)) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				elseifBlock.Body.Add(singleStmt); 
-			} else SynErr(100);
+			} else SynErr(102);
 			NodeUtils.SetNodeEndLocation(elseifBlock.ElseIfBodyPosition, t); 
 			ifStmtNode.ElseIfList.Add(elseifBlock); 
 		}
 		if (la.kind == 31) {
 			Get();
 			NodeUtils.SetNodeStartLocation(ifStmtNode.ElseBodyPosition, la); 
-			if (la.kind == 44) {
+			if (la.kind == 46) {
 				Get();
 				Imperative_stmtlist(out body);
 				ifStmtNode.ElseBody = body; 
-				Expect(45);
+				Expect(47);
 			} else if (StartOf(11)) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				ifStmtNode.ElseBody.Add(singleStmt); 
-			} else SynErr(101);
+			} else SynErr(103);
 			NodeUtils.SetNodeEndLocation(ifStmtNode.ElseBodyPosition, t); 
 		}
 		node = ifStmtNode; 
@@ -2691,10 +2715,10 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		NodeUtils.SetNodeStartLocation(whileStmtNode.Expr, whileStmtNode);
 		NodeUtils.SetNodeEndLocation(whileStmtNode.Expr, t);
 		
-		Expect(44);
+		Expect(46);
 		Imperative_stmtlist(out body);
 		whileStmtNode.Body = body; 
-		Expect(45);
+		Expect(47);
 		NodeUtils.SetNodeEndLocation(whileStmtNode, t);
 		node = whileStmtNode;
 		
@@ -2711,23 +2735,53 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		int idLine = la.line; int idCol = la.col; 
 		Imperative_Ident(out node);
 		loopNode.LoopVariable = node; loopNode.LoopVariable.line = idLine; loopNode.LoopVariable.col = idCol; 
-		Expect(61);
+		Expect(62);
 		loopNode.KwInLine = t.line; loopNode.KwInCol = t.col; int exprLine = la.line; int exprCol = la.col; 
 		Imperative_expr(out node);
 		loopNode.Expression = node; if (loopNode.Expression != null) {  loopNode.Expression.line = exprLine; loopNode.Expression.col = exprCol; } 
 		Expect(13);
-		if (la.kind == 44) {
+		if (la.kind == 46) {
 			Get();
 			Imperative_stmtlist(out body);
 			loopNode.Body = body; 
-			Expect(45);
+			Expect(47);
 			NodeUtils.SetNodeEndLocation(loopNode, t); 
 		} else if (StartOf(11)) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 			Imperative_stmt(out singleStmt);
 			loopNode.Body.Add(singleStmt); 
-		} else SynErr(102);
+		} else SynErr(104);
 		forloop = loopNode;
+		
+	}
+
+	void Imperative_returnstmt(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
+		node = null;
+		     var bNode = new ProtoCore.AST.ImperativeAST.BinaryExpressionNode();
+		     NodeUtils.SetNodeLocation(bNode, la);
+		
+		Expect(44);
+		if (la.kind == 45) {
+			Get();
+		}
+		var lhs = BuildImperativeIdentifier("return", ProtoCore.PrimitiveType.Return);
+		bNode.LeftNode = lhs;
+		
+		ProtoCore.AST.ImperativeAST.ImperativeNode rhs = null;
+		
+		if (la.kind == 10) {
+			Imperative_languageblock(out rhs);
+		} else if (StartOf(4)) {
+			Imperative_expr(out rhs);
+			if (la.kind != _endline)
+			   SynErr(Resources.SemiColonExpected);
+			
+			Expect(23);
+		} else SynErr(105);
+		bNode.RightNode = rhs;
+		bNode.Optr = Operator.assign;
+		
+		node = bNode;
 		
 	}
 
@@ -2747,7 +2801,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			NodeUtils.SetNodeEndLocation(bNode, t);
 			node = bNode; 
 			
-		} else if (la.kind == 51) {
+		} else if (la.kind == 45) {
 			Get();
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode = null; 
 			if (HasMoreAssignmentStatements()) {
@@ -2760,7 +2814,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				Expect(23);
 			} else if (la.kind == 10) {
 				Imperative_languageblock(out rhsNode);
-			} else SynErr(103);
+			} else SynErr(106);
 			bNode.LeftNode = lhsNode;
 			bNode.RightNode = rhsNode;
 			bNode.Optr = Operator.assign;
@@ -2769,13 +2823,13 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			
 		} else if (StartOf(9)) {
 			SynErr("';' is expected"); 
-		} else SynErr(104);
+		} else SynErr(107);
 	}
 
 	void Imperative_expr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null; 
 		Imperative_binexpr(out node);
-		while (la.kind == 52) {
+		while (la.kind == 53) {
 			Imperative_TernaryOp(ref node);
 		}
 	}
@@ -2801,7 +2855,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			typedVar.Name = typedVar.Value = t.val;
 			NodeUtils.SetNodeLocation(typedVar, t);
 			
-			Expect(46);
+			Expect(48);
 			Expect(40);
 			typedVar.IsLocal = true;
 			
@@ -2851,7 +2905,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			identNode.Name = identNode.Value = t.val;
 			NodeUtils.SetNodeLocation(identNode, t);
 			
-			Expect(46);
+			Expect(48);
 			Expect(40);
 			identNode.IsLocal = true;
 			
@@ -2866,7 +2920,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			typedVar.Name = typedVar.Value = t.val;
 			NodeUtils.SetNodeLocation(typedVar, t);
 			
-			Expect(46);
+			Expect(48);
 			Expect(1);
 			int type = core.TypeSystem.GetType(t.val); 
 			if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
@@ -2903,9 +2957,9 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				typedVar.DataType = datatype; 
 			}
 			node = typedVar; 
-		} else if (la.kind == 1 || la.kind == 12 || la.kind == 44) {
+		} else if (la.kind == 1 || la.kind == 12 || la.kind == 46) {
 			Imperative_IdentifierList(out node);
-		} else SynErr(105);
+		} else SynErr(108);
 	}
 
 	void Imperative_IdentifierList(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -2943,12 +2997,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		{
 		   errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
 		}
-		int ltype = (0 == String.Compare(t.val, "return")) ? (int)ProtoCore.PrimitiveType.Return : (int)ProtoCore.PrimitiveType.Var;
-		if (ltype == (int)ProtoCore.PrimitiveType.Return && la.val != "=")
-		{
-		   SynErr(String.Format(Resources.InvalidReturnStatement, la.val)); 
-		}        
-		node = BuildImperativeIdentifier(t.val, (ProtoCore.PrimitiveType)ltype);
+		node = BuildImperativeIdentifier(t.val, ProtoCore.PrimitiveType.Var);
 		NodeUtils.SetNodeLocation(node, t);
 		
 	}
@@ -2956,7 +3005,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	void Imperative_binexpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null;
 		Imperative_logicalexpr(out node);
-		while (la.kind == 57 || la.kind == 58) {
+		while (la.kind == 58 || la.kind == 59) {
 			Operator op; 
 			Imperative_logicalop(out op);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode = null; 
@@ -2973,11 +3022,11 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Imperative_TernaryOp(ref ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		ProtoCore.AST.ImperativeAST.InlineConditionalNode inlineConNode = new ProtoCore.AST.ImperativeAST.InlineConditionalNode(); 
-		Expect(52);
+		Expect(53);
 		inlineConNode.ConditionExpression = node; node = null; 
 		Imperative_expr(out node);
 		inlineConNode.TrueExpression = node; 
-		Expect(46);
+		Expect(48);
 		node = null; 
 		Imperative_expr(out node);
 		inlineConNode.FalseExpression = node; 
@@ -3011,11 +3060,11 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Imperative_Ident(out node);
 			nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
 			
-		} else if (la.kind == 44) {
+		} else if (la.kind == 46) {
 			Imperative_ExprList(out node);
 			nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
 			
-		} else SynErr(106);
+		} else SynErr(109);
 		if (la.kind == 10) {
 			ProtoCore.AST.ImperativeAST.ArrayNode array = new ProtoCore.AST.ImperativeAST.ArrayNode();
 			
@@ -3090,9 +3139,9 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		node = null; 
 		if (la.kind == 15) {
 			Imperative_negexpr(out node);
-		} else if (la.kind == 14 || la.kind == 59) {
+		} else if (la.kind == 14 || la.kind == 60) {
 			Imperative_bitunaryexpr(out node);
-		} else SynErr(107);
+		} else SynErr(110);
 	}
 
 	void Imperative_negexpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3130,11 +3179,11 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Get();
 			op = UnaryOperator.Not; 
 			#if ENABLE_BIT_OP       
-		} else if (la.kind == 59) {
+		} else if (la.kind == 60) {
 			Get();
 			op = UnaryOperator.Negate; 
 			#endif                     
-		} else SynErr(108);
+		} else SynErr(111);
 	}
 
 	void Imperative_factor(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3160,11 +3209,11 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			node = new ProtoCore.AST.ImperativeAST.NullNode(); 
 			NodeUtils.SetNodeLocation(node, t); 
 			
-		} else if (la.kind == 1 || la.kind == 12 || la.kind == 44) {
+		} else if (la.kind == 1 || la.kind == 12 || la.kind == 46) {
 			Imperative_IdentifierList(out node);
-		} else if (la.kind == 14 || la.kind == 15 || la.kind == 59) {
+		} else if (la.kind == 14 || la.kind == 15 || la.kind == 60) {
 			Imperative_unaryexpr(out node);
-		} else SynErr(109);
+		} else SynErr(112);
 	}
 
 	void Imperative_negop(out UnaryOperator op) {
@@ -3192,13 +3241,13 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Imperative_logicalop(out Operator op) {
 		op = Operator.none; 
-		if (la.kind == 57) {
+		if (la.kind == 58) {
 			Get();
 			op = Operator.and; 
-		} else if (la.kind == 58) {
+		} else if (la.kind == 59) {
 			Get();
 			op = Operator.or; 
-		} else SynErr(110);
+		} else SynErr(113);
 	}
 
 	void Imperative_RangeExpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3210,7 +3259,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			bool hasAmountOperator = false;
 			
 			Get();
-			if (la.kind == 60) {
+			if (la.kind == 61) {
 				Imperative_rangeAmountOperator(out hasAmountOperator);
 			}
 			rnode.HasRangeAmountOperator = hasAmountOperator; 
@@ -3265,14 +3314,14 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			op = Operator.nq; 
 			break;
 		}
-		default: SynErr(111); break;
+		default: SynErr(114); break;
 		}
 	}
 
 	void Imperative_rel(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null;
 		Imperative_term(out node);
-		while (la.kind == 15 || la.kind == 53) {
+		while (la.kind == 15 || la.kind == 54) {
 			Operator op; 
 			Imperative_addop(out op);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode; 
@@ -3289,14 +3338,14 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Imperative_rangeAmountOperator(out bool hasAmountOperator) {
 		hasAmountOperator = false; 
-		Expect(60);
+		Expect(61);
 		hasAmountOperator = true; 
 	}
 
 	void Imperative_rangeStepOperator(out RangeStepOperator op) {
 		op = RangeStepOperator.StepSize; 
-		if (la.kind == 59 || la.kind == 60) {
-			if (la.kind == 60) {
+		if (la.kind == 60 || la.kind == 61) {
+			if (la.kind == 61) {
 				Get();
 				op = RangeStepOperator.Number; 
 			} else {
@@ -3313,7 +3362,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		#else             
 		Imperative_factor(out node);
 		#endif            
-		while (la.kind == 54 || la.kind == 55 || la.kind == 56) {
+		while (la.kind == 55 || la.kind == 56 || la.kind == 57) {
 			Operator op; 
 			Imperative_mulop(out op);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode; 
@@ -3334,19 +3383,19 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Imperative_addop(out Operator op) {
 		op = Operator.none; 
-		if (la.kind == 53) {
+		if (la.kind == 54) {
 			Get();
 			op = Operator.add; 
 		} else if (la.kind == 15) {
 			Get();
 			op = Operator.sub; 
-		} else SynErr(112);
+		} else SynErr(115);
 	}
 
 	void Imperative_interimfactor(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null;
 		Imperative_factor(out node);
-		while (la.kind == 16 || la.kind == 62 || la.kind == 63) {
+		while (la.kind == 16 || la.kind == 63 || la.kind == 64) {
 			Operator op; 
 			Imperative_bitop(out op);
 			ProtoCore.AST.ImperativeAST.ImperativeNode rhsNode; 
@@ -3363,30 +3412,30 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Imperative_mulop(out Operator op) {
 		op = Operator.none; 
-		if (la.kind == 54) {
+		if (la.kind == 55) {
 			Get();
 			op = Operator.mul; 
-		} else if (la.kind == 55) {
-			Get();
-			op = Operator.div; 
 		} else if (la.kind == 56) {
 			Get();
+			op = Operator.div; 
+		} else if (la.kind == 57) {
+			Get();
 			op = Operator.mod; 
-		} else SynErr(113);
+		} else SynErr(116);
 	}
 
 	void Imperative_bitop(out Operator op) {
 		op = Operator.none; 
-		if (la.kind == 62) {
+		if (la.kind == 63) {
 			Get();
 			op = Operator.bitwiseand; 
 		} else if (la.kind == 16) {
 			Get();
 			op = Operator.bitwiseor; 
-		} else if (la.kind == 63) {
+		} else if (la.kind == 64) {
 			Get();
 			op = Operator.bitwisexor; 
-		} else SynErr(114);
+		} else SynErr(117);
 	}
 
 	void Imperative_Char(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3467,7 +3516,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			else{
 			   NodeUtils.SetNodeLocation(node, t); }
 			
-		} else SynErr(115);
+		} else SynErr(118);
 	}
 
 	void Imperative_functioncall(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3480,7 +3529,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode argNode; 
 			Imperative_expr(out argNode);
 			arglist.Add(argNode); 
-			while (la.kind == 50) {
+			while (la.kind == 52) {
 				Get();
 				Imperative_expr(out argNode);
 				arglist.Add(argNode); 
@@ -3497,20 +3546,20 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	}
 
 	void Imperative_ExprList(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
-		Expect(44);
+		Expect(46);
 		ProtoCore.AST.ImperativeAST.ExprListNode exprlist = new ProtoCore.AST.ImperativeAST.ExprListNode();
 		NodeUtils.SetNodeStartLocation(exprlist, t);
 		
 		if (StartOf(4)) {
 			Imperative_expr(out node);
 			exprlist.Exprs.Add(node); 
-			while (la.kind == 50) {
+			while (la.kind == 52) {
 				Get();
 				Imperative_expr(out node);
 				exprlist.Exprs.Add(node); 
 			}
 		}
-		Expect(45);
+		Expect(47);
 		NodeUtils.SetNodeEndLocation(exprlist, t);
 		node = exprlist;
 		
@@ -3528,23 +3577,23 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 	}
 	
 	static readonly bool[,] set = {
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,T,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,T,T, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,T, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{T,T,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,T,x,T, x,T,T,T, T,T,x,x, x,T,T,x, x,T,T,T, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,T,x,x, T,T,x,x, x,T,T,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{T,T,T,T, T,T,x,x, x,x,T,x, T,x,T,T, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,T,T,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,x,x, T,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x},
-		{x,T,x,x, x,x,x,x, x,x,x,x, T,x,T,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x},
-		{x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,T,T, T,T,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x}
+		{_T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x},
+		{_x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_T,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x},
+		{_T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x},
+		{_x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x},
+		{_x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
+		{_T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_x,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x},
+		{_T,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
+		{_T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_T,_x,_T, _x,_T,_T,_T, _T,_T,_x,_x, _x,_T,_T,_x, _x,_T,_T,_T, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x},
+		{_x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x},
+		{_x,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_T,_x,_x, _T,_T,_x,_x, _x,_T,_T,_x, _x,_T,_T,_T, _T,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
+		{_T,_T,_T,_T, _T,_T,_x,_x, _x,_x,_T,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x},
+		{_x,_T,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_T,_T, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _T,_x,_x,_x, _x,_x,_x},
+		{_x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_T,_T,_T, _T,_T,_T,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x,_x, _x,_x,_x}
 
 	};
 } // end Parser
@@ -3604,78 +3653,81 @@ public class Errors {
 			case 41: s = "literal_true expected"; break;
 			case 42: s = "literal_false expected"; break;
 			case 43: s = "literal_null expected"; break;
-			case 44: s = "\"{\" expected"; break;
-			case 45: s = "\"}\" expected"; break;
-			case 46: s = "\":\" expected"; break;
-			case 47: s = "\"public\" expected"; break;
-			case 48: s = "\"private\" expected"; break;
-			case 49: s = "\"protected\" expected"; break;
-			case 50: s = "\",\" expected"; break;
-			case 51: s = "\"=\" expected"; break;
-			case 52: s = "\"?\" expected"; break;
-			case 53: s = "\"+\" expected"; break;
-			case 54: s = "\"*\" expected"; break;
-			case 55: s = "\"/\" expected"; break;
-			case 56: s = "\"%\" expected"; break;
-			case 57: s = "\"&&\" expected"; break;
-			case 58: s = "\"||\" expected"; break;
-			case 59: s = "\"~\" expected"; break;
-			case 60: s = "\"#\" expected"; break;
-			case 61: s = "\"in\" expected"; break;
-			case 62: s = "\"&\" expected"; break;
-			case 63: s = "\"^\" expected"; break;
-			case 64: s = "??? expected"; break;
-			case 65: s = "this symbol not expected in Import_Statement"; break;
-			case 66: s = "invalid Import_Statement"; break;
-			case 67: s = "this symbol not expected in Associative_Statement"; break;
-			case 68: s = "invalid Associative_Statement"; break;
-			case 69: s = "invalid Associative_classdecl"; break;
+			case 44: s = "\"return\" expected"; break;
+			case 45: s = "\"=\" expected"; break;
+			case 46: s = "\"{\" expected"; break;
+			case 47: s = "\"}\" expected"; break;
+			case 48: s = "\":\" expected"; break;
+			case 49: s = "\"public\" expected"; break;
+			case 50: s = "\"private\" expected"; break;
+			case 51: s = "\"protected\" expected"; break;
+			case 52: s = "\",\" expected"; break;
+			case 53: s = "\"?\" expected"; break;
+			case 54: s = "\"+\" expected"; break;
+			case 55: s = "\"*\" expected"; break;
+			case 56: s = "\"/\" expected"; break;
+			case 57: s = "\"%\" expected"; break;
+			case 58: s = "\"&&\" expected"; break;
+			case 59: s = "\"||\" expected"; break;
+			case 60: s = "\"~\" expected"; break;
+			case 61: s = "\"#\" expected"; break;
+			case 62: s = "\"in\" expected"; break;
+			case 63: s = "\"&\" expected"; break;
+			case 64: s = "\"^\" expected"; break;
+			case 65: s = "??? expected"; break;
+			case 66: s = "this symbol not expected in Import_Statement"; break;
+			case 67: s = "invalid Import_Statement"; break;
+			case 68: s = "this symbol not expected in Associative_Statement"; break;
+			case 69: s = "invalid Associative_Statement"; break;
 			case 70: s = "invalid Associative_classdecl"; break;
-			case 71: s = "this symbol not expected in Associative_NonAssignmentStatement"; break;
-			case 72: s = "this symbol not expected in Associative_FunctionCallStatement"; break;
-			case 73: s = "this symbol not expected in Associative_FunctionalStatement"; break;
-			case 74: s = "invalid Associative_FunctionalStatement"; break;
-			case 75: s = "invalid Associative_FunctionalStatement"; break;
-			case 76: s = "invalid Associative_LanguageBlock"; break;
-			case 77: s = "invalid Associative_LanguageBlock"; break;
+			case 71: s = "invalid Associative_classdecl"; break;
+			case 72: s = "invalid Associative_ReturnStatement"; break;
+			case 73: s = "this symbol not expected in Associative_NonAssignmentStatement"; break;
+			case 74: s = "this symbol not expected in Associative_FunctionCallStatement"; break;
+			case 75: s = "this symbol not expected in Associative_FunctionalStatement"; break;
+			case 76: s = "invalid Associative_FunctionalStatement"; break;
+			case 77: s = "invalid Associative_FunctionalStatement"; break;
 			case 78: s = "invalid Associative_LanguageBlock"; break;
-			case 79: s = "invalid Associative_AccessSpecifier"; break;
-			case 80: s = "invalid Associative_DecoratedIdentifier"; break;
-			case 81: s = "invalid Associative_DecoratedIdentifier"; break;
-			case 82: s = "invalid Associative_UnaryExpression"; break;
-			case 83: s = "invalid Associative_unaryop"; break;
-			case 84: s = "invalid Associative_Factor"; break;
-			case 85: s = "invalid Associative_negop"; break;
-			case 86: s = "invalid Associative_LogicalOp"; break;
-			case 87: s = "invalid Associative_ComparisonOp"; break;
-			case 88: s = "invalid Associative_AddOp"; break;
-			case 89: s = "invalid Associative_MulOp"; break;
-			case 90: s = "invalid Associative_Level"; break;
-			case 91: s = "invalid Associative_Number"; break;
-			case 92: s = "invalid Associative_NameReference"; break;
-			case 93: s = "invalid Associative_NameReference"; break;
+			case 79: s = "invalid Associative_LanguageBlock"; break;
+			case 80: s = "invalid Associative_LanguageBlock"; break;
+			case 81: s = "invalid Associative_AccessSpecifier"; break;
+			case 82: s = "invalid Associative_DecoratedIdentifier"; break;
+			case 83: s = "invalid Associative_DecoratedIdentifier"; break;
+			case 84: s = "invalid Associative_UnaryExpression"; break;
+			case 85: s = "invalid Associative_unaryop"; break;
+			case 86: s = "invalid Associative_Factor"; break;
+			case 87: s = "invalid Associative_negop"; break;
+			case 88: s = "invalid Associative_LogicalOp"; break;
+			case 89: s = "invalid Associative_ComparisonOp"; break;
+			case 90: s = "invalid Associative_AddOp"; break;
+			case 91: s = "invalid Associative_MulOp"; break;
+			case 92: s = "invalid Associative_Level"; break;
+			case 93: s = "invalid Associative_Number"; break;
 			case 94: s = "invalid Associative_NameReference"; break;
-			case 95: s = "invalid Imperative_stmt"; break;
-			case 96: s = "invalid Imperative_languageblock"; break;
-			case 97: s = "invalid Imperative_languageblock"; break;
+			case 95: s = "invalid Associative_NameReference"; break;
+			case 96: s = "invalid Associative_NameReference"; break;
+			case 97: s = "invalid Imperative_stmt"; break;
 			case 98: s = "invalid Imperative_languageblock"; break;
-			case 99: s = "invalid Imperative_ifstmt"; break;
-			case 100: s = "invalid Imperative_ifstmt"; break;
+			case 99: s = "invalid Imperative_languageblock"; break;
+			case 100: s = "invalid Imperative_languageblock"; break;
 			case 101: s = "invalid Imperative_ifstmt"; break;
-			case 102: s = "invalid Imperative_forloop"; break;
-			case 103: s = "invalid Imperative_assignstmt"; break;
-			case 104: s = "invalid Imperative_assignstmt"; break;
-			case 105: s = "invalid Imperative_decoratedIdentifier"; break;
-			case 106: s = "invalid Imperative_NameReference"; break;
-			case 107: s = "invalid Imperative_unaryexpr"; break;
-			case 108: s = "invalid Imperative_unaryop"; break;
-			case 109: s = "invalid Imperative_factor"; break;
-			case 110: s = "invalid Imperative_logicalop"; break;
-			case 111: s = "invalid Imperative_relop"; break;
-			case 112: s = "invalid Imperative_addop"; break;
-			case 113: s = "invalid Imperative_mulop"; break;
-			case 114: s = "invalid Imperative_bitop"; break;
-			case 115: s = "invalid Imperative_num"; break;
+			case 102: s = "invalid Imperative_ifstmt"; break;
+			case 103: s = "invalid Imperative_ifstmt"; break;
+			case 104: s = "invalid Imperative_forloop"; break;
+			case 105: s = "invalid Imperative_returnstmt"; break;
+			case 106: s = "invalid Imperative_assignstmt"; break;
+			case 107: s = "invalid Imperative_assignstmt"; break;
+			case 108: s = "invalid Imperative_decoratedIdentifier"; break;
+			case 109: s = "invalid Imperative_NameReference"; break;
+			case 110: s = "invalid Imperative_unaryexpr"; break;
+			case 111: s = "invalid Imperative_unaryop"; break;
+			case 112: s = "invalid Imperative_factor"; break;
+			case 113: s = "invalid Imperative_logicalop"; break;
+			case 114: s = "invalid Imperative_relop"; break;
+			case 115: s = "invalid Imperative_addop"; break;
+			case 116: s = "invalid Imperative_mulop"; break;
+			case 117: s = "invalid Imperative_bitop"; break;
+			case 118: s = "invalid Imperative_num"; break;
 
 			default: s = "error " + n; break;
 		}

--- a/src/Engine/ProtoCore/Parser/Parser.frame
+++ b/src/Engine/ProtoCore/Parser/Parser.frame
@@ -39,8 +39,8 @@ using ProtoCore.Properties;
 
 public class Parser {
 -->constants
-	const bool T = true;
-	const bool x = false;
+	const bool _T = true;
+	const bool _x = false;
 	const int minErrDist = 2;
 	
 	public Scanner scanner;

--- a/src/Engine/ProtoCore/Parser/Scanner.cs
+++ b/src/Engine/ProtoCore/Parser/Scanner.cs
@@ -203,8 +203,8 @@ public class UTF8Buffer: Buffer {
 public class Scanner {
 	const char EOL = '\n';
 	const int eofSym = 0; /* pdt */
-	const int maxT = 64;
-	const int noSym = 64;
+	const int maxT = 65;
+	const int noSym = 65;
 
 
 	public Buffer buffer; // scanner buffer
@@ -713,10 +713,11 @@ public class Scanner {
 			case "true": t.kind = 41; break;
 			case "false": t.kind = 42; break;
 			case "null": t.kind = 43; break;
-			case "public": t.kind = 47; break;
-			case "private": t.kind = 48; break;
-			case "protected": t.kind = 49; break;
-			case "in": t.kind = 61; break;
+			case "return": t.kind = 44; break;
+			case "public": t.kind = 49; break;
+			case "private": t.kind = 50; break;
+			case "protected": t.kind = 51; break;
+			case "in": t.kind = 62; break;
 			default: break;
 		}
 	}
@@ -810,15 +811,15 @@ public class Scanner {
 			case 24:
 				{t.kind = 24; break;}
 			case 25:
-				recEnd = pos; recKind = 65;
+				recEnd = pos; recKind = 66;
 				if (ch <= 9 || ch >= 11 && ch <= 65535) {AddCh(); goto case 25;}
-				else {t.kind = 65; break;}
+				else {t.kind = 66; break;}
 			case 26:
 				if (ch <= ')' || ch >= '+' && ch <= 65535) {AddCh(); goto case 26;}
 				else if (ch == '*') {AddCh(); goto case 36;}
 				else {goto case 0;}
 			case 27:
-				{t.kind = 66; break;}
+				{t.kind = 67; break;}
 			case 28:
 				recEnd = pos; recKind = 2;
 				if (ch >= '0' && ch <= '9') {AddCh(); goto case 28;}
@@ -862,48 +863,48 @@ public class Scanner {
 				if (ch == 39) {AddCh(); goto case 11;}
 				else {t.kind = 5; break;}
 			case 38:
-				{t.kind = 44; break;}
-			case 39:
-				{t.kind = 45; break;}
-			case 40:
 				{t.kind = 46; break;}
+			case 39:
+				{t.kind = 47; break;}
+			case 40:
+				{t.kind = 48; break;}
 			case 41:
-				{t.kind = 50; break;}
-			case 42:
 				{t.kind = 52; break;}
-			case 43:
+			case 42:
 				{t.kind = 53; break;}
-			case 44:
+			case 43:
 				{t.kind = 54; break;}
+			case 44:
+				{t.kind = 55; break;}
 			case 45:
-				{t.kind = 56; break;}
-			case 46:
 				{t.kind = 57; break;}
-			case 47:
+			case 46:
 				{t.kind = 58; break;}
-			case 48:
+			case 47:
 				{t.kind = 59; break;}
-			case 49:
+			case 48:
 				{t.kind = 60; break;}
+			case 49:
+				{t.kind = 61; break;}
 			case 50:
-				{t.kind = 63; break;}
+				{t.kind = 64; break;}
 			case 51:
 				recEnd = pos; recKind = 16;
 				if (ch == '|') {AddCh(); goto case 47;}
 				else {t.kind = 16; break;}
 			case 52:
-				recEnd = pos; recKind = 51;
+				recEnd = pos; recKind = 45;
 				if (ch == '=') {AddCh(); goto case 21;}
-				else {t.kind = 51; break;}
+				else {t.kind = 45; break;}
 			case 53:
-				recEnd = pos; recKind = 55;
+				recEnd = pos; recKind = 56;
 				if (ch == '/') {AddCh(); goto case 25;}
 				else if (ch == '*') {AddCh(); goto case 26;}
-				else {t.kind = 55; break;}
+				else {t.kind = 56; break;}
 			case 54:
-				recEnd = pos; recKind = 62;
+				recEnd = pos; recKind = 63;
 				if (ch == '&') {AddCh(); goto case 46;}
-				else {t.kind = 62; break;}
+				else {t.kind = 63; break;}
 
 		}
 		t.val = new String(tval, 0, tlen);

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -160,6 +160,8 @@ Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 =  SYNC                     (. if (!IsFullClosure()) SynErr(Resources.CloseBracketExpected); .)
                             (. node = null; .)
 (
+		Associative_ReturnStatement<out node>
+	|
 	IF(IsNonAssignmentStatement())
 		Associative_NonAssignmentStatement<out node>
 	|
@@ -189,6 +191,37 @@ Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
             )      
         )
 )
+.
+
+Associative_ReturnStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
+=
+	(.
+        var bNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
+		NodeUtils.SetNodeLocation(bNode, la);
+	.)
+	"return"
+	[
+		'='
+	]
+	(.
+		var lhs = AstFactory.BuildIdentifier("return");
+		lhs.datatype = TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.Return);
+		bNode.LeftNode = lhs;
+
+		ProtoCore.AST.AssociativeAST.AssociativeNode rhs = null;
+	.)
+	(
+		    Associative_LanguageBlock<out rhs>
+		|
+			Associative_Expression<out rhs>
+			endline
+	)
+	(.
+        bNode.RightNode = rhs;
+        bNode.Optr = Operator.assign;
+
+		node = bNode;
+	.)
 .
 
 Associative_StatementList<.out List<ProtoCore.AST.AssociativeAST.AssociativeNode> nodelist.> 
@@ -872,7 +905,7 @@ Associative_NonAssignmentStatement<out ProtoCore.AST.AssociativeAST.AssociativeN
 	(
 		Associative_Expression<out rightNode>
 					(.
-                        //Try to make a false binary expression node.					    
+						//Try to make a false binary expression node.					    
 						ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
 						ProtoCore.AST.AssociativeAST.IdentifierNode leftNode = new ProtoCore.AST.AssociativeAST.IdentifierNode();
 						leftNode.Value = leftNode.Name = Constants.kTempProcLeftVar;
@@ -918,25 +951,24 @@ Associative_FunctionCallStatement<out ProtoCore.AST.AssociativeAST.AssociativeNo
 					    if (rightNode is ProtoCore.AST.AssociativeAST.FunctionDotCallNode 
                             || rightNode is ProtoCore.AST.AssociativeAST.FunctionCallNode
                             || allowIdentList)
+						{
+							ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
+							ProtoCore.AST.AssociativeAST.IdentifierNode leftNode = new ProtoCore.AST.AssociativeAST.IdentifierNode();
+							leftNode.Value = leftNode.Name = Constants.kTempProcLeftVar;
 
-							{
-								ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
-								ProtoCore.AST.AssociativeAST.IdentifierNode leftNode = new ProtoCore.AST.AssociativeAST.IdentifierNode();
-								leftNode.Value = leftNode.Name = Constants.kTempProcLeftVar;
+							var unknownType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0);
+							leftNode.datatype = unknownType;
+							leftNode.line = rightNode.line;
+							leftNode.col = rightNode.col;
+							leftNode.endLine = rightNode.endLine;
+							leftNode.endCol = rightNode.endCol;
 
-								var unknownType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0);
-								leftNode.datatype = unknownType;
-								leftNode.line = rightNode.line;
-								leftNode.col = rightNode.col;
-								leftNode.endLine = rightNode.endLine;
-								leftNode.endCol = rightNode.endCol;
-
-								expressionNode.LeftNode = leftNode;
-								expressionNode.RightNode = rightNode;
-								expressionNode.Optr = Operator.assign;
-								NodeUtils.UpdateBinaryExpressionLocation(expressionNode);
-								node = expressionNode;
-							}
+							expressionNode.LeftNode = leftNode;
+							expressionNode.RightNode = rightNode;
+							expressionNode.Optr = Operator.assign;
+							NodeUtils.UpdateBinaryExpressionLocation(expressionNode);
+							node = expressionNode;
+						}
 					.)			
                     
                     (. 
@@ -1494,14 +1526,8 @@ Associative_Ident<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
                 {
                     errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
                 }
-                int ltype = (0 == String.Compare(t.val, "return")) ? (int)ProtoCore.PrimitiveType.Return : (int)ProtoCore.PrimitiveType.Var;
-                if (ltype == (int)ProtoCore.PrimitiveType.Return && la.val != "=")
-                {
-                     SynErr(String.Format(Resources.InvalidReturnStatement, la.val));
-                }
-                
                 var identNode = AstFactory.BuildIdentifier(t.val);
-                identNode.datatype = TypeSystem.BuildPrimitiveTypeObject((ProtoCore.PrimitiveType)ltype);
+                identNode.datatype = TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.Var);
                 node = identNode;
                 NodeUtils.SetNodeLocation(node, t);
             .)

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -111,6 +111,8 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
             endline
         )  (. node = new ProtoCore.AST.ImperativeAST.ContinueNode(); NodeUtils.SetNodeLocation(node, t); .)
         |
+		Imperative_returnstmt<out node>
+		|
         (IF(IsAssignmentStatement() || IsVariableDeclaration())
             Imperative_assignstmt<out node>
         )
@@ -132,6 +134,42 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
             endline 
         )
     )   
+.
+
+Imperative_returnstmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
+=
+    (.
+		node = null;
+        var bNode = new ProtoCore.AST.ImperativeAST.BinaryExpressionNode();
+        NodeUtils.SetNodeLocation(bNode, la);
+	.)
+	"return"
+	[
+		'='
+	]
+	(.
+		var lhs = BuildImperativeIdentifier("return", ProtoCore.PrimitiveType.Return);
+		bNode.LeftNode = lhs;
+
+		ProtoCore.AST.ImperativeAST.ImperativeNode rhs = null;
+	.)
+
+	(
+	Imperative_languageblock<out rhs>
+	|
+	Imperative_expr<out rhs>
+    (.
+        if (la.kind != _endline)
+            SynErr(Resources.SemiColonExpected);
+    .)
+    endline
+	)
+	(.
+        bNode.RightNode = rhs;
+        bNode.Optr = Operator.assign;
+
+		node = bNode;
+	.)
 .
 
 Imperative_stmtlist<.out List<ProtoCore.AST.ImperativeAST.ImperativeNode> nodelist.> 
@@ -799,12 +837,7 @@ Imperative_Ident<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                     {
                         errors.SemErr(t.line, t.col, String.Format(Resources.keywordCantBeUsedAsIdentifier, t.val));
                     }
-                    int ltype = (0 == String.Compare(t.val, "return")) ? (int)ProtoCore.PrimitiveType.Return : (int)ProtoCore.PrimitiveType.Var;
-                    if (ltype == (int)ProtoCore.PrimitiveType.Return && la.val != "=")
-                    {
-                        SynErr(String.Format(Resources.InvalidReturnStatement, la.val)); 
-                    }        
-                    node = BuildImperativeIdentifier(t.val, (ProtoCore.PrimitiveType)ltype);
+                    node = BuildImperativeIdentifier(t.val, ProtoCore.PrimitiveType.Var);
                     NodeUtils.SetNodeLocation(node, t);
                 .)
 .

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -971,15 +971,6 @@ namespace ProtoCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Return statement is invalid. Do you mean: return = {0} ?.
-        /// </summary>
-        public static string InvalidReturnStatement {
-            get {
-                return ResourceManager.GetString("InvalidReturnStatement", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Syntax Error: invalid symbol &apos;{0}&apos;. (Did you mean to use Modifier Stack \&quot; =&gt; \&quot;).
         /// </summary>
         public static string InvalidSymbol {

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -186,9 +186,6 @@
   <data name="InvalidLanguageBlockIdentifier" xml:space="preserve">
     <value>\"{0}\" is not a valid language block identifier, do you mean \"Associative\" or \"Imperative\"?</value>
   </data>
-  <data name="InvalidReturnStatement" xml:space="preserve">
-    <value>Return statement is invalid. Do you mean: return = {0} ?</value>
-  </data>
   <data name="InvalidSymbol" xml:space="preserve">
     <value>Syntax Error: invalid symbol '{0}'. (Did you mean to use Modifier Stack \" =&gt; \")</value>
   </data>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -189,9 +189,6 @@
   <data name="InvalidLanguageBlockIdentifier" xml:space="preserve">
     <value>\"{0}\" is not a valid language block identifier, do you mean \"Associative\" or \"Imperative\"?</value>
   </data>
-  <data name="InvalidReturnStatement" xml:space="preserve">
-    <value>Return statement is invalid. Do you mean: return = {0} ?</value>
-  </data>
   <data name="InvalidSymbol" xml:space="preserve">
     <value>Syntax Error: invalid symbol '{0}'. (Did you mean to use Modifier Stack \" =&gt; \")</value>
   </data>

--- a/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Associative/MicroFeatureTests.cs
@@ -3526,5 +3526,193 @@ b = TestThisOverload.Mul(obj, 4);
             // Here we shouldn't generate an overloaded one.
             thisTest.Verify("b", 24);
         }
+
+        [Test]
+        public void TestReturnStatement01()
+        {
+            string code = @"
+x = [Imperative] {
+    return 6;
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+            thisTest.Verify("x", 6);
+        }
+
+        [Test]
+        public void TestReturnStatement02()
+        {
+            string code = @"
+x = [Imperative] {
+    return {2, 3, 5};
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+            thisTest.Verify("x", new object[] { 2, 3, 5 } );
+        }
+
+        [Test]
+        public void TestReturnStatement03()
+        {
+            string code = @"
+def foo(x) {
+    return x * 2;
+}
+
+x = [Imperative] {
+    return foo(3);
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+            thisTest.Verify("x", 6);
+        }
+
+        [Test]
+        public void TestReturnStatement04()
+        {
+            string code = @"
+[Imperative] {
+    return 6;
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+        }
+
+        [Test]
+        public void TestReturnStatement05()
+        {
+            string code = @"
+[Imperative] {
+    return {2, 3, 5};
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+        }
+
+        [Test]
+        public void TestReturnStatement06()
+        {
+            string code = @"
+def foo(x) {
+    return x * 2;
+}
+
+[Imperative] {
+    return foo(3);
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+        }
+
+        [Test]
+        public void TestReturnStatement07()
+        {
+            string code = @"
+def foo(x) {
+    return [Imperative] {
+        return x * 2;
+    }
+}
+
+r = foo(3);
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+            thisTest.Verify("x", 6);
+        }
+
+        [Test]
+        public void TestReturnStatement08()
+        {
+            string code = @"
+x = [Associative] {
+    return 6;
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+            thisTest.Verify("x", 6);
+        }
+
+        [Test]
+        public void TestReturnStatement09()
+        {
+            string code = @"
+x = [Associative] {
+    return {2, 3, 5};
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+            thisTest.Verify("x", new object[] { 2, 3, 5 });
+        }
+
+        [Test]
+        public void TestReturnStatement10()
+        {
+            string code = @"
+def foo(x) {
+    return x * 2;
+}
+
+x = [Associative] {
+    return foo(3);
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+            thisTest.Verify("x", 6);
+        }
+
+        [Test]
+        public void TestReturnStatement11()
+        {
+            string code = @"
+[Associative] {
+    return 6;
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+        }
+
+        [Test]
+        public void TestReturnStatement12()
+        {
+            string code = @"
+[Associative] {
+    return {2, 3, 5};
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+        }
+
+        [Test]
+        public void TestReturnStatement13()
+        {
+            string code = @"
+def foo(x) {
+    return x * 2;
+}
+
+[Associative] {
+    return foo(3);
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+        }
+
+        [Test]
+        public void TestReturnStatement14()
+        {
+            string code = @"
+def foo(x) {
+    return [Associative] {
+        return x * 2;
+    }
+}
+
+r = foo(3);
+}";
+            thisTest.RunScriptSource(code);
+            thisTest.VerifyBuildWarningCount(0);
+            thisTest.Verify("x", 6);
+        }
     }
 }

--- a/test/Engine/ProtoTest/DebugTests/RunEqualityTests.cs
+++ b/test/Engine/ProtoTest/DebugTests/RunEqualityTests.cs
@@ -11746,20 +11746,6 @@ t = x;
         }
 
         [Test]
-        public void DebugEQT63_Dynamic_array_onthefly_function_return()
-        {
-            string code = @"
-def foo()
-{
-return =b[0]=5;
-}
-a = foo();
-c = {100};
-";
-            DebugTestFx.CompareDebugAndRunResults(code);
-        }
-
-        [Test]
         public void DebugEQT63_Dynamic_array_onthefly_update()
         {
             string code = @"
@@ -12997,11 +12983,11 @@ def foo : int ( a = 5, b = 5 )
             string code = @"
 def foo  ( a : int = 5, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 def foo  ( a : double = 5, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 [Imperative]
 {
@@ -13020,11 +13006,11 @@ def foo  ( a : double = 5, b : double = 5.5, c : bool = true )
             string code = @"
 def foo  ( a : int, b : double = 5, c : bool = true)
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 def foo2  ( a , b = 5, c = true)
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 d1 = foo2 (  );
 d2 = foo2 ( 1 );
@@ -13049,11 +13035,11 @@ d5 =
             string code = @"
 def foo  ( a : int = 5, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 def foo  ( a : double = 6, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 [Imperative]
 {

--- a/test/Engine/ProtoTest/DebugTests/RunWatchTestsIncluded.cs
+++ b/test/Engine/ProtoTest/DebugTests/RunWatchTestsIncluded.cs
@@ -9978,22 +9978,6 @@ t = x;
 
         [Test]
         [Category("WatchFx Tests")]
-        public void DebugWatch1083_T63_Dynamic_array_onthefly_function_return()
-        {
-            Dictionary<int, List<string>> map = new Dictionary<int, List<string>>();
-            string src = @"def foo()
-{
-return =b[0]=5;
-}
-a = foo();
-c = {100};
-";
-            WatchTestFx.GeneratePrintStatements(src, ref map);
-            WatchTestFx fx = new WatchTestFx(); fx.CompareRunAndWatchResults(null, src, map);
-        }
-
-        [Test]
-        [Category("WatchFx Tests")]
         public void DebugWatch1084_T63_Dynamic_array_onthefly_update()
         {
             Dictionary<int, List<string>> map = new Dictionary<int, List<string>>();
@@ -11566,11 +11550,11 @@ c1;c2;c3;c4;
             Dictionary<int, List<string>> map = new Dictionary<int, List<string>>();
             string src = @"def foo  ( a : int = 5, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 def foo  ( a : double = 5, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 c1;c2;c3;c4;
 [Imperative]
@@ -11592,11 +11576,11 @@ c1;c2;c3;c4;
             Dictionary<int, List<string>> map = new Dictionary<int, List<string>>();
             string src = @"def foo  ( a : int, b : double = 5, c : bool = true)
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 def foo2  ( a , b = 5, c = true)
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 c1;c3;c3;c4;
 d1 = foo2 (  );
@@ -11624,11 +11608,11 @@ d5 =
             Dictionary<int, List<string>> map = new Dictionary<int, List<string>>();
             string src = @"def foo  ( a : int = 5, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 def foo  ( a : double = 6, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 c1;c2;c3;c4;
 [Imperative]

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestFunction.cs
@@ -2979,11 +2979,11 @@ c1;c2;c3;c4;
             string code = @"
 def foo  ( a : int = 5, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 def foo  ( a : double = 5, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 c1;c2;c3;c4;
 [Imperative]
@@ -3009,11 +3009,11 @@ c1;c2;c3;c4;
             string code = @"
 def foo  ( a : int, b : double = 5, c : bool = true)
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 def foo2  ( a , b = 5, c = true)
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 c1;c3;c3;c4;
 d1 = foo2 (  );
@@ -3045,11 +3045,11 @@ d5 =
             string code = @"
 def foo  ( a : int = 5, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 def foo  ( a : double = 6, b : double = 5.5, c : bool = true )
 {
-	return = x = c == true ? a  : b;
+	return = c == true ? a  : b;
 }
 c1;c2;c3;c4;
 [Imperative]

--- a/test/Engine/ProtoTest/TD/MultiLangTests/TestUpdate.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/TestUpdate.cs
@@ -1909,41 +1909,6 @@ z2 = z;
         }
 
         [Test]
-        [Category("SmokeTest")]
-        public void T51_Defect_1461388()
-        {
-            // Tracked by: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4094
-            String code =
- @"
-b = 2;
-a = { 0, 1, 2 };
-c = 0;
-[Imperative]
-{
-    d = a + 1;
-    [Associative]
-    {
-        b = a  + 1;
-        a = { c, c } ;
-        [Imperative]
-        {
-            for ( i in a )
-            {
-                a[c] = i + 1;
-                c = c + 1;
-            }            
-        }
-    }
-}
-c = 10;
-";
-            string errmsg = "MAGN-4094 Runtime Cyclic Dependency not detected";
-            ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code, errmsg);
-            TestFrameWork.VerifyRuntimeWarning(ProtoCore.Runtime.WarningID.CyclicDependency);
-            
-        }
-
-        [Test]
         [Category("DSDefinedClass_Ported")]
         [Category("SmokeTest")]
         public void T52_Defect_1459478()


### PR DESCRIPTION
Reverts DynamoDS/Dynamo#8156 => #8153 

@mjkkirschner I'm reverting your revert, will fix the tests immediately after this. I tried rewinding back to @ke-yu 's commit and making the test fix on top of his changes but all the changes didn't reflect in my new PR; only the test changes did. I find this really weird.