### PR TITLE
Ensure empty selection nodes serialize/deserialize properly

### DIFF
--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -80,6 +80,13 @@ namespace CoreNodeModels
                     selectionIdentifier = updatedSelection;
                 }
 
+                // if instanceId is still null we have a selection node in the graph with no active selection
+                // in this scenario we return an empty list to ensure proper serialization/deserialization
+                if (selectionIdentifier == null)
+                {
+                    selectionIdentifier = new List<string>();
+                }
+
                 return selectionIdentifier;
             }
 

--- a/src/Libraries/CoreNodeModels/Selection.cs
+++ b/src/Libraries/CoreNodeModels/Selection.cs
@@ -26,7 +26,7 @@ namespace CoreNodeModels
         private readonly string selectionMessage;
         private List<TResult> selectionResults = new List<TResult>();
         private List<TSelection> selection = new List<TSelection>();
-        private IEnumerable<string> selectionIdentifier;
+        private IEnumerable<string> selectionIdentifier = new List<string>();
         private readonly SelectionType selectionType;
         private readonly SelectionObjectType selectionObjectType;
         
@@ -78,13 +78,6 @@ namespace CoreNodeModels
                 if (updatedSelection.Count() > 0)
                 {
                     selectionIdentifier = updatedSelection;
-                }
-
-                // if instanceId is still null we have a selection node in the graph with no active selection
-                // in this scenario we return an empty list to ensure proper serialization/deserialization
-                if (selectionIdentifier == null)
-                {
-                    selectionIdentifier = new List<string>();
                 }
 
                 return selectionIdentifier;


### PR DESCRIPTION
### Purpose

This should have been included w/ [PR-8131](https://github.com/DynamoDS/Dynamo/pull/8131).  I realized the bug when testing D4R UI node deserilazation in the current task.

If a selection node is added to the graph with no selection that graph would serialize the `InstanceID` property as `null`.  This would cause the node to not deserialization properly due to the missing property and it would never be added to the graph when reopening.  This PR initializes `InstanceID` w/ an empty list to avoid the `null` value.

I also verified all the RTF selection tests still pass with this change but we may want to add additional testing to catch this behavior in the future.

To reproduce:
- add a selection node to the graph (without selecting anything)
- save and close the graph
- reopen and verify the node is missing

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@smangarole 