### PR TITLE
As a D4R dev, I want D4R UI nodes to deserialize w/o adding duplicate ports

### DIFF
--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -97,7 +97,7 @@ namespace CoreNodeModels
         }
 
         [JsonConstructor]
-        protected DSDropDownBase(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        protected DSDropDownBase(string outputName, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             PopulateItems();
         }

--- a/src/Libraries/CoreNodeModels/Enum.cs
+++ b/src/Libraries/CoreNodeModels/Enum.cs
@@ -63,13 +63,15 @@ namespace CoreNodeModels
     /// </summary>
     public abstract class AllChildrenOfType<T> : DSDropDownBase
     {
-        protected AllChildrenOfType() : base("Types")
+        private const string outputName = "Types";
+
+        protected AllChildrenOfType() : base(outputName)
         {
             RegisterAllPorts();
         }
 
         [JsonConstructor]
-        protected AllChildrenOfType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Types", inPorts, outPorts)
+        protected AllChildrenOfType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(outputName, inPorts, outPorts)
         {
         }
 

--- a/src/Libraries/CoreNodeModels/Enum.cs
+++ b/src/Libraries/CoreNodeModels/Enum.cs
@@ -12,6 +12,11 @@ namespace CoreNodeModels
 {
     public abstract class EnumAsInt<T> : EnumBase<T>
     {
+        protected EnumAsInt() { }
+
+        [JsonConstructor]
+        protected EnumAsInt(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
+
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             var rhs = AstFactory.BuildIntNode(SelectedIndex);
@@ -35,6 +40,9 @@ namespace CoreNodeModels
     public abstract class EnumBase<T> : DSDropDownBase
     {
         protected EnumBase() : base(typeof(T).ToString()) { }
+
+        [JsonConstructor]
+        protected EnumBase(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(typeof(T).ToString(), inPorts, outPorts) { }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {
@@ -61,7 +69,7 @@ namespace CoreNodeModels
         }
 
         [JsonConstructor]
-        protected AllChildrenOfType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        protected AllChildrenOfType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Types", inPorts, outPorts)
         {
         }
 


### PR DESCRIPTION
### Purpose

[Task: QNTM-1708](https://jira.autodesk.com/browse/QNTM-1708)

[CoincidingD4R Changes ](https://github.com/DynamoDS/DynamoRevit/pull/1783)
(Dynamo Beta NuGet packages must be updated for successful Jenkins build of D4R)

This PR addresses the duplicate port issue during deserialization.  This is related to the recent changes in the node model base class affecting all the Revit UI nodes that inherent from this base.  Json constructors must be added throughout the inheritance chain to prevent this from occurring.

### Testing
Added new regression testing to verify no nodes are lost in translation after saving/reopening and that port counts are consistent.  The tests:
- iterate through specified assemblies in the library, adding all those nodes to the canvas
- store specific data (active node count, port count, etc)
- save temp file, close, reopen
- verify data is consistent with original state after serialization/deserialization
- close/delete temp file

No corresponding dyn is required reducing testing maintenance.

### Affected Nodes (49):
**[Elements.cs]**
- All Elements of Family Type
- All Elements of Type
- All Elements of Category
- All Elements at Level
- All Elements in Active View

**[RevitDropDown.cs]**
- Family Types
- Get Family Parameter
- Floor Types
- Wall Types
- Performance Adviser Rules
- Categories
- Levels
- Structural Framing Types
- Spacing Rule Layout
- Element Types
- Views

**[RevitTypes.cs]**
- Select Phase
- Select Revision
- Select Filled Region Type
- Select Rule Type
- Select Revision Numbering
- Select Revision Numbering Type
- Select Parameter Type
- Select BuiltIn Parameter Group
- Select Revision Visibility
- Select Direct Shape Room Bounding Option
- Detail Level
- Select Horizontal Text Alignment
- Select Vertical Text Alignment
- Wall Location
- Schedule Type
- Export Column Headers
- Export Text Qualifier
- Fill Patterns
- FIll Pattern Targets
- Line Patterns
- Schedule Filter Type

**[Selection.cs]** (these were addressed in [1768](https://github.com/DynamoDS/DynamoRevit/pull/1768))
- Select Model Element
- Select Face
-  Select Edge
- Select Point on Face
- Select UV on Face
- Select Divided Surface Families
- Select Model Elements
- Select Faces
- Select Edges

**[SiteLocation.cs]**
- Site Location

**[SunPath.cs]**
- SunSettings Current

### Outstanding Issues
- Resolve `SiteLocation` Deserialization Issues (verified this is old behavior in 1.3 and filed [QNTM-1903](https://jira.autodesk.com/browse/QNTM-1903))
- Node State is inconsistent pre/post save (verified this is also old behavior in 1.3 and the behavior is consistent with the existing 2.0 core custom UI nodes(filed [QNTM-1902](https://jira.autodesk.com/browse/QNTM-1902) with more info/examples)
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

