### PR TITLE
Node save issue

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1411,28 +1411,7 @@ namespace Dynamo.ViewModels
             }
         }
 
-        /// <summary>
-        /// Save the specified workspace to a file. If the file path is null or empty, an
-        /// exception is written to the console.
-        /// </summary>
-        /// <param name="path">The path to the file.</param>
-        /// <param name="workspace">The Workspace to save.</param>
-        internal void SaveAs(string path, WorkspaceModel workspace)
-        {
-            try
-            {
-                workspace.Save(path, false, EngineController);
-            }
-            catch (Exception ex)
-            {
-                Model.Logger.Log(ex.Message);
-                Model.Logger.Log(ex.StackTrace);
-
-                if (ex is IOException || ex is UnauthorizedAccessException)
-                    System.Windows.MessageBox.Show(String.Format(ex.Message, MessageBoxButtons.OK, MessageBoxIcon.Warning));
-            }
-        }
-
+        
         /// <summary>
         ///     Attempts to save a given workspace.  Shows a save as dialog if the 
         ///     workspace does not already have a path associated with it
@@ -1444,7 +1423,7 @@ namespace Dynamo.ViewModels
             // crash should always allow save as
             if (!String.IsNullOrEmpty(workspace.FileName) && !DynamoModel.IsCrashing)
             {
-                SaveAs(workspace.FileName, workspace);
+                SaveAs(workspace.FileName);
                 return true;
             }
             else
@@ -1458,7 +1437,7 @@ namespace Dynamo.ViewModels
                 fd.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
                 if (fd.ShowDialog() == DialogResult.OK)
                 {
-                    SaveAs(fd.FileName, workspace);
+                    SaveAs(fd.FileName);
                     return true;
                 }
             }


### PR DESCRIPTION
### Purpose

This PR fix'es node jumbling issue. There are two SaveAs method with different parameters. Apparently one of those method had the right implementation. Removed the other SaveAs method.

TODO: Have to check the tests.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@ColinDayOrg  @mjkkirschner 

### FYIs

@jnealb @smangarole @alfarok @QilongTang 
