### PR TITLE
LayoutSpecs Comparison

### DIFF
--- a/src/Libraries/Analysis/Label.cs
+++ b/src/Libraries/Analysis/Label.cs
@@ -22,6 +22,7 @@ namespace Analysis
         /// <param name="point"></param>
         /// <param name="label"></param>
         /// <returns></returns>
+        [IsVisibleInDynamoLibrary(false)]
         public static Label ByPointAndString(Point point, string label)
         {
             if (point == null)

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -213,42 +213,33 @@
                 },
                 {
                   "path": "DSCoreNodes.DSCore.List.SortIndexByValue"
+                },
+                {
+                  "path": "BuiltIn.List.GetKeys"
+                },
+                {
+                  "path": "BuiltIn.List.GetValues"
+                },
+                {
+                  "path": "BuiltIn.List.MaximumItemByKey"
+                },
+                {
+                  "path": "BuiltIn.List.MinimumItemByKey"
+                },
+                {
+                  "path": "BuiltIn.List.ContainsKey"
+                },
+                {
+                  "path": "BuiltIn.List.RemoveKey"
+                },
+                {
+                  "path": "DSCoreNodes.DSCore.List.GroupByKey"
+                },
+                {
+                  "path": "DSCoreNodes.DSCore.List.SortByKey"
                 }
               ],
-              "childElements": [
-                {
-                  "text": "Keys",
-                  "iconUrl": "./dist/resources/Category.Keys.svg",
-                  "elementType": "category",
-                  "include": [
-                    {
-                      "path": "BuiltIn.List.GetKeys"
-                    },
-                    {
-                      "path": "BuiltIn.List.GetValues"
-                    },
-                    {
-                      "path": "BuiltIn.List.MaximumItemByKey"
-                    },
-                    {
-                      "path": "BuiltIn.List.MinimumItemByKey"
-                    },
-                    {
-                      "path": "BuiltIn.List.ContainsKey"
-                    },
-                    {
-                      "path": "BuiltIn.List.RemoveKey"
-                    },
-                    {
-                      "path": "DSCoreNodes.DSCore.List.GroupByKey"
-                    },
-                    {
-                      "path": "DSCoreNodes.DSCore.List.SortByKey"
-                    }
-                  ],
-                  "childItems": []
-                }
-              ]
+              "childElements": [ ]
             },
             {
               "text": "Generate",

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -213,33 +213,42 @@
                 },
                 {
                   "path": "DSCoreNodes.DSCore.List.SortIndexByValue"
-                },
-                {
-                  "path": "BuiltIn.List.GetKeys"
-                },
-                {
-                  "path": "BuiltIn.List.GetValues"
-                },
-                {
-                  "path": "BuiltIn.List.MaximumItemByKey"
-                },
-                {
-                  "path": "BuiltIn.List.MinimumItemByKey"
-                },
-                {
-                  "path": "BuiltIn.List.ContainsKey"
-                },
-                {
-                  "path": "BuiltIn.List.RemoveKey"
-                },
-                {
-                  "path": "DSCoreNodes.DSCore.List.GroupByKey"
-                },
-                {
-                  "path": "DSCoreNodes.DSCore.List.SortByKey"
                 }
               ],
-              "childElements": [ ]
+              "childElements": [
+                {
+                  "text": "Keys",
+                  "iconUrl": "./dist/resources/Category.Keys.svg",
+                  "elementType": "category",
+                  "include": [
+                    {
+                      "path": "BuiltIn.List.GetKeys"
+                    },
+                    {
+                      "path": "BuiltIn.List.GetValues"
+                    },
+                    {
+                      "path": "BuiltIn.List.MaximumItemByKey"
+                    },
+                    {
+                      "path": "BuiltIn.List.MinimumItemByKey"
+                    },
+                    {
+                      "path": "BuiltIn.List.ContainsKey"
+                    },
+                    {
+                      "path": "BuiltIn.List.RemoveKey"
+                    },
+                    {
+                      "path": "DSCoreNodes.DSCore.List.GroupByKey"
+                    },
+                    {
+                      "path": "DSCoreNodes.DSCore.List.SortByKey"
+                    }
+                  ],
+                  "childItems": []
+                }
+              ]
             },
             {
               "text": "Generate",

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -794,11 +794,7 @@
           "text": "Display",
           "iconUrl": "./dist/resources/Category.Display.svg",
           "elementType": "category",
-          "include": [
-            {
-              "path":  "Analysis.Analysis.Label"
-            }
-          ],
+          "include": [],
           "childElements": [
             {
               "text": "Color",


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

I finished the comparison between the layoutSpecs.json in Librarie.js repo and the one in Dynamo Repo. And found a few differences:
1. There is a `Keys` sub category in Librarie.js which is not there in Dynamo
![image](https://user-images.githubusercontent.com/3942418/30572394-4d9e41aa-9cbb-11e7-91b6-ca840563869d.png)
**It turned out Dynamo is correct.**

2. There is a Label sub category which got deleted in Librarie.js but still there in Dynamo. What should we do there? **That sub-category is hidden in this PR**
3. All resource icons and node paths are different in both json which makes it pretty hard to maintain both. What is the reasons behind it? @sharadkjaiswal 
4. A few icons for category is removed but I assume for good purpose. E.g. Geometry->Modifiers->Geometry
5. We really need to stop syncing this json everywhere and create guidlines for whichever client willing to add new nodes. Hope this PR could be the discussion point of a new baseline.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @ramramps 

### FYIs

@Racel 
