### PR TITLE
Changes to Workspace BackUp Saving

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -96,7 +96,7 @@ namespace Dynamo.Models
     {
         /// <summary>
         /// A controller to coordinate the interactions between some DesignScript
-        /// sub components like library managment, live runner and so on.
+        /// sub components like library management, live runner and so on.
         /// </summary>
         EngineController EngineController { get; }
     }
@@ -141,6 +141,18 @@ namespace Dynamo.Models
             if (WorkspaceSaved != null)
             {
                 WorkspaceSaved(workspace);
+            }
+        }
+
+        /// <summary>
+        /// Occurs when a workspace is scheduled to be saved to a backup file.
+        /// </summary>
+        public event Action<string, bool> RequestWorkspaceBackUpSave;
+        internal void OnRequestWorkspaceBackUpSave(string path, bool isBackUp)
+        {
+            if (RequestWorkspaceBackUpSave != null)
+            {
+                RequestWorkspaceBackUpSave(path, isBackUp);
             }
         }
 
@@ -1628,11 +1640,7 @@ namespace Dynamo.Models
                     }
 
                     var savePath = pathManager.GetBackupFilePath(workspace);
-                    var oldFileName = workspace.FileName;
-                    var oldName = workspace.Name;
-                    workspace.Save(savePath, true, EngineController);
-                    workspace.FileName = oldFileName;
-                    workspace.Name = oldName;
+                    OnRequestWorkspaceBackUpSave(savePath, true);
                     backupFilesDict[workspace.Guid] = savePath;
                     Logger.Log("Backup file is saved: " + savePath);
                 }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -537,6 +537,7 @@ namespace Dynamo.ViewModels
             SubscribeModelCleaningUpEvent();
             SubscribeModelUiEvents();
             SubscribeModelChangedHandlers();
+            SubscribeModelBackupFileSaveEvent();
             SubscribeUpdateManagerHandlers();
 
             InitializeAutomationSettings(startConfiguration.CommandFilePath);
@@ -631,6 +632,7 @@ namespace Dynamo.ViewModels
             UnsubscribeUpdateManagerEvents();
             UnsubscribeLoggerEvents();
             UnsubscribeModelCleaningUpEvent();
+            UnsubscribeModelBackupFileSaveEvent();
 
             model.WorkspaceAdded -= WorkspaceAdded;
             model.WorkspaceRemoved -= WorkspaceRemoved;
@@ -689,6 +691,16 @@ namespace Dynamo.ViewModels
         private void UnsubscribeModelCleaningUpEvent()
         {
             model.CleaningUp -= CleanUp;
+        }
+
+        private void SubscribeModelBackupFileSaveEvent()
+        {
+            model.RequestWorkspaceBackUpSave += SaveAs;
+        }
+
+        private void UnsubscribeModelBackupFileSaveEvent()
+        {
+            model.RequestWorkspaceBackUpSave -= SaveAs;
         }
 
         private void SubscribeModelChangedHandlers()
@@ -1391,15 +1403,15 @@ namespace Dynamo.ViewModels
         /// <param name="path">The path to the file.</param>
         /// <exception cref="IOException"></exception>
         /// <exception cref="UnauthorizedAccessException"></exception>
-        internal void SaveAs(string path)
+        internal void SaveAs(string path, bool isBackup = false)
         {
             try
             {
                 Model.Logger.Log(String.Format(Properties.Resources.SavingInProgress, path));
 
-                CurrentSpaceViewModel.Save(path, Model.EngineController);
-                
-                AddToRecentFiles(path);
+                CurrentSpaceViewModel.Save(path, isBackup, Model.EngineController);
+
+                if(!isBackup) AddToRecentFiles(path);
             }
             catch (Exception ex)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -492,7 +492,7 @@ namespace Dynamo.ViewModels
         /// <param name="filePath"></param>
         /// <param name="engine"></param>
         /// <exception cref="ArgumentNullException">Thrown when the file path is null.</exception>
-        internal void Save(string filePath, EngineController engine = null)
+        internal void Save(string filePath, bool isBackup = false, EngineController engine = null)
         {
             if (String.IsNullOrEmpty(filePath))
             {
@@ -512,8 +512,13 @@ namespace Dynamo.ViewModels
                 // Stage 3: Save
                 File.WriteAllText(filePath, jo.ToString());
 
-                Model.FileName = filePath;
-                Model.OnSaved();
+                // Handle Workspace or CustomNodeWorkspace related non-serialization internal logic
+                // Only for actual save, update file path and recent file list
+                if (!isBackup)
+                {
+                    Model.FileName = filePath;
+                    Model.OnSaved();
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[QNTM-2078](https://jira.autodesk.com/browse/QNTM-2078) JSON backup files don't have a view block

This PR:
1. Changed how backup file is saved, it was previous saved on DynamoModel layer directly which will result in that no `View` blocking existing. It is now raising an event with `BackUpPath` and `isBackUp` = true` as arguments and actual save is called on DynamoViewModel layer.
2. Also added `bool isBackUp` parameter to `Save` function so that it could handle backup saving.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@ColinDayOrg 
### FYIs
@ramramps @nealb @smangarole 