### PR TITLE
Deserialize json element binding data 

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -315,6 +315,28 @@ namespace Dynamo.Graph.Workspaces
             //serialize view block first and build the notes.
             var notes = new List<NoteModel>();
 
+            // Restore Bindings
+            Dictionary<Guid, List<CallSite.RawTraceData>> loadedTraceData = new Dictionary<Guid, List<CallSite.RawTraceData>>();
+            JEnumerable<JToken> bindings = obj["Bindings"].Children();
+
+            // Iterate through bindings to extract nodeID's and bindingData (callsiteId & traceData)
+            foreach (JToken entity in bindings)
+            {
+                Guid nodeId = Guid.Parse(entity["NodeId"].ToString());
+                string bindingString = entity["Binding"].ToString();
+
+                // Key(callsiteId) : Value(traceData)
+                Dictionary<string, string> bindingData = JsonConvert.DeserializeObject<Dictionary<string, string>>(bindingString);
+                List<CallSite.RawTraceData> callsiteTraceData = new List<CallSite.RawTraceData>();
+
+                foreach (KeyValuePair<string, string> pair in bindingData)
+                {
+                    callsiteTraceData.Add(new CallSite.RawTraceData(pair.Key, pair.Value));
+                }
+
+                loadedTraceData.Add(nodeId, callsiteTraceData);
+            }
+
             WorkspaceModel ws;
             if (isCustomNode)
             {
@@ -323,8 +345,8 @@ namespace Dynamo.Graph.Workspaces
             }
             else
             {
-                ws = new HomeWorkspaceModel(guid, engine, scheduler, factory, 
-                    Enumerable.Empty<KeyValuePair<Guid, List<CallSite.RawTraceData>>>(), nodes, notes, annotations, 
+                ws = new HomeWorkspaceModel(guid, engine, scheduler, factory,
+                    loadedTraceData, nodes, notes, annotations, 
                     Enumerable.Empty<PresetModel>(), elementResolver, 
                     info, verboseLogging, isTestMode);
             }


### PR DESCRIPTION
### Purpose

[QNTM-1734](https://jira.autodesk.com/browse/QNTM-1734)

Currently we only serialize element binding data so relationships that depend on this trace data are broken when opening a previously saved dyn file.  The purpose of this PR is to properly deserialize and restore element bindings.

### Testing

New RTF testing has been added in [D4R PR-1803](https://github.com/DynamoDS/DynamoRevit/pull/1803)
These tests compare element counts and element Id's to verify no duplicate elements have been created and original element Id's have been restored after saving to Json and rerunning the graph.   Previously to this PR a new element would be created every time the file was run, this test verifies this is no longer the case.  MultipleCustomNodeInstance (recursive custom nodes) failure is a previously known issue and has never worked in 2.0.

![elementbinding_rtf_results](https://user-images.githubusercontent.com/13341935/30928160-c9c1a064-a388-11e7-9001-40174a9fccda.jpg)

### Outstanding Issues

Initially I thought the trace data was not being restored because any modifications upon reopening a json graph containing trace data were not reflected in the Revit viewport.  However, after some digging I realized the Revit viewport loses all communication with Dynamo after loading a Json graph (even with simple Core geometry - not D4R related).  This issue is outside the scope of this deserialization task and has been filed as [QNTM-2124](https://jira.autodesk.com/browse/QNTM-2124)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@mjkkirschner @smangarole 