### PR TITLE
QNTM-908

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1641,43 +1641,55 @@ namespace Dynamo.Graph.Workspaces
 
             foreach (ExtraAnnotationViewInfo annotationViewInfo in workspaceViewInfo.Annotations)
             {
-                
+                var annotationGuidValue = IdToGuidConverter(annotationViewInfo.Id);
+                var text = annotationViewInfo.Title;
+
+                if (annotationViewInfo.Nodes == null)
+                {
+                    var noteModel = new NoteModel(
+                        annotationViewInfo.Left, 
+                        annotationViewInfo.Top, 
+                        text, 
+                        annotationGuidValue);
+                    this.AddNote(noteModel);
+
+                    continue;
+                }
 
                 // Create a collection of nodes in the given annotation
                 var nodes = new List<NodeModel>();
                 foreach (string nodeId in annotationViewInfo.Nodes)
                 {
-                  var guidValue = IdToGuidConverter(nodeId);
-                  if (guidValue == null)
-                    continue;
+                    var guidValue = IdToGuidConverter(nodeId);
+                    if (guidValue == null)
+                      continue;
 
-                  // NOTE: Some nodes may be annotations and not be found here
-                  var nodeModel = Nodes.FirstOrDefault(node => node.GUID == guidValue);
-                  if (nodeModel == null)
-                    continue;
+                    // NOTE: Some nodes may be annotations and not be found here
+                    var nodeModel = Nodes.FirstOrDefault(node => node.GUID == guidValue);
+                    if (nodeModel == null)
+                      continue;
 
-                  nodes.Add(nodeModel);
+                    nodes.Add(nodeModel);
                 }
 
                 // Create a collection of notes in the given annotation
                 var notes = new List<NoteModel>();
                 foreach (string noteId in annotationViewInfo.Nodes)
                 {
-                  var guidValue = IdToGuidConverter(noteId);
-                  if (guidValue == null)
-                    continue;
+                    var guidValue = IdToGuidConverter(noteId);
+                    if (guidValue == null)
+                      continue;
 
-                  // NOTE: Some nodes may not be annotations and not be found here
-                  var noteModel = Notes.FirstOrDefault(note => note.GUID == guidValue);
-                  if (noteModel == null)
-                    continue;
+                    // NOTE: Some nodes may not be annotations and not be found here
+                    var noteModel = Notes.FirstOrDefault(note => note.GUID == guidValue);
+                    if (noteModel == null)
+                      continue;
 
-                  notes.Add(noteModel);
+                    notes.Add(noteModel);
                 }
 
-                var annotationGuidValue = IdToGuidConverter(annotationViewInfo.Id);
                 var annotationModel = new AnnotationModel(nodes, notes);
-                annotationModel.AnnotationText = annotationViewInfo.Title;
+                annotationModel.AnnotationText = text;
                 annotationModel.FontSize = annotationViewInfo.FontSize;
                 annotationModel.Background = annotationViewInfo.Background;
                 annotationModel.GUID = annotationGuidValue;

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1606,15 +1606,23 @@ namespace Dynamo.Graph.Workspaces
                 this,
                 new PointEventArgs(new Point2D(X, Y)));
 
+            // This function loads standard nodes
             LoadNodes(workspaceViewInfo.NodeViews);
 
+            // This function loads notes from the Notes array in the JSON format
             // NOTE: This is here to support early JSON graphs
+            // IMPORTANT: All notes must be loaded before annotations are loaded to
+            //            ensure that any contained notes are contained properly
             LoadLegacyNotes(workspaceViewInfo.Notes);
 
+            // This function loads notes from the Annotations array in the JSON format
+            // that have an empty nodes collection
+            // IMPORTANT: All notes must be loaded before annotations are loaded to
+            //            ensure that any contained notes are contained properly
             LoadNotesFromAnnotations(workspaceViewInfo.Annotations);
 
-            // All notes must be loaded/created before annotations to be 
-            // included in a containing annotation
+            // This function loads annotations from the Annotations array in the JSON format
+            // that have a non-empty nodes collection
             LoadAnnotations(workspaceViewInfo.Annotations);
 
             // TODO, QNTM-1099: These items are not in the extra view info

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1626,13 +1626,17 @@ namespace Dynamo.Graph.Workspaces
                 }
             }
 
-            foreach (ExtraNoteViewInfo noteViewInfo in workspaceViewInfo.Notes)
+            // NOTE: This is here to support early JSON graphs
+            if (workspaceViewInfo.Notes != null)
             {
-                var guidValue = IdToGuidConverter(noteViewInfo.Id);
+                foreach (ExtraNoteViewInfo noteViewInfo in workspaceViewInfo.Notes)
+                {
+                    var guidValue = IdToGuidConverter(noteViewInfo.Id);
 
-                // TODO, QNTM-1099: Figure out if ZIndex needs to be set here as well
-                var noteModel = new NoteModel(noteViewInfo.X, noteViewInfo.Y, noteViewInfo.Text, guidValue);
-                this.AddNote(noteModel);
+                    // TODO, QNTM-1099: Figure out if ZIndex needs to be set here as well
+                    var noteModel = new NoteModel(noteViewInfo.X, noteViewInfo.Y, noteViewInfo.Text, guidValue);
+                    this.AddNote(noteModel);
+                }
             }
 
             foreach (ExtraAnnotationViewInfo annotationViewInfo in workspaceViewInfo.Annotations)

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -12,6 +12,73 @@ using Type = System.Type;
 namespace Dynamo.Wpf.ViewModels.Core.Converters
 {
     /// <summary>
+    /// WorkspaceWriteConverter is used for serializing Workspaces to JSON.
+    /// </summary>
+    public class WorkspaceViewWriteConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(WorkspaceViewModel).IsAssignableFrom(objectType);
+        }
+
+        public override bool CanRead
+        {
+            get { return false; }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var workspaceView = (WorkspaceViewModel)value;
+
+            writer.WriteStartObject();
+
+            writer.WritePropertyName("Dynamo");
+            serializer.Serialize(writer, workspaceView.DynamoPreferences);
+
+            writer.WritePropertyName("Camera");
+            serializer.Serialize(writer, workspaceView.Camera);
+
+            writer.WritePropertyName("NodeViews");
+            writer.WriteStartArray();
+            foreach (var nodeView in workspaceView.Nodes)
+                serializer.Serialize(writer, nodeView);
+            writer.WriteEndArray();
+
+            writer.WritePropertyName("Annotations");
+            writer.WriteStartArray();
+            foreach (var annotation in workspaceView.Annotations)
+                serializer.Serialize(writer, annotation);
+            foreach (var note in workspaceView.Notes)
+            {
+                AnnotationModel convertedNote = new AnnotationModel(new NodeModel[0], new NoteModel[0]);
+                convertedNote.GUID = note.Model.GUID;
+                convertedNote.X = note.Left;
+                convertedNote.Y = note.Top;
+                convertedNote.AnnotationText = note.Text;
+
+                serializer.Serialize(writer, new AnnotationViewModel(workspaceView, convertedNote));
+            }
+            writer.WriteEndArray();
+
+            writer.WritePropertyName("X");
+            writer.WriteValue(workspaceView.X);
+
+            writer.WritePropertyName("Y");
+            writer.WriteValue(workspaceView.Y);
+
+            writer.WritePropertyName("Zoom");
+            writer.WriteValue(workspaceView.Zoom);
+
+            writer.WriteEndObject();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
     /// The AnnotationViewModelConverter is used to serialize AnnotationViewModels.
     /// </summary>
     public class AnnotationViewModelConverter : JsonConverter

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -12,11 +12,7 @@ using Type = System.Type;
 namespace Dynamo.Wpf.ViewModels.Core.Converters
 {
     /// <summary>
-    /// The AnnotationConverter is used to serialize and deserialize AnnotationModels.
-    /// The SelectedModels property on AnnotationModel is a list of references
-    /// to ModelBase objects. During serialization we want to refer to these objects
-    /// by their ids. During deserialization, we use the ReferenceResolver to
-    /// find the correct ModelBase instances to reference.
+    /// The AnnotationViewModelConverter is used to serialize AnnotationViewModels.
     /// </summary>
     public class AnnotationViewModelConverter : JsonConverter
     {
@@ -27,37 +23,7 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var obj = JObject.Load(reader);
-            var title = obj["Title"].Value<string>();
-
-            // If the id is not a guid, makes a guid based on the id of the model
-            Guid annotationId = GuidUtility.tryParseOrCreateGuid(obj["Id"].Value<string>());
-
-            // This is a string id, which should be accessible in the ReferenceResolver.
-            var models = obj["Nodes"].Values<JValue>();
-
-            var existing = models.Select(m =>
-            {
-                Guid modelId = GuidUtility.tryParseOrCreateGuid(m.Value<string>());
-                return serializer.ReferenceResolver.ResolveReference(serializer.Context, modelId.ToString());
-            });
-
-            var nodes = existing.Where(m => typeof(NodeModel).IsAssignableFrom(m.GetType())).Cast<NodeModel>();
-            var notes = existing.Where(m => typeof(NoteModel).IsAssignableFrom(m.GetType())).Cast<NoteModel>();
-
-            var anno = new AnnotationModel(nodes, notes);
-            anno.AnnotationText = title;
-            anno.GUID = annotationId;
-            anno.X = obj["Left"].Value<double>();
-            anno.Y = obj["Top"].Value<double>();
-            anno.Width = obj["Width"].Value<double>();
-            anno.Height = obj["Height"].Value<double>();
-            anno.FontSize = obj["FontSize"].Value<double>();
-            anno.InitialTop = obj["InitialTop"].Value<double>();
-            anno.InitialHeight = obj["InitialHeight"].Value<double>();
-            anno.TextBlockHeight = obj["TextblockHeight"].Value<double>();
-            anno.Background = obj["Background"].Value<string>();
-            return anno;
+            throw new NotImplementedException();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Notes;
-using Dynamo.Nodes;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Newtonsoft.Json;
@@ -30,17 +29,16 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
         {
             var obj = JObject.Load(reader);
             var title = obj["Title"].Value<string>();
-            //if the id is not a guid, makes a guid based on the id of the model
+
+            // If the id is not a guid, makes a guid based on the id of the model
             Guid annotationId = GuidUtility.tryParseOrCreateGuid(obj["Id"].Value<string>());
 
-            // This is a string id, which
-            // should be accessible in the ReferenceResolver.
+            // This is a string id, which should be accessible in the ReferenceResolver.
             var models = obj["Nodes"].Values<JValue>();
 
             var existing = models.Select(m =>
             {
                 Guid modelId = GuidUtility.tryParseOrCreateGuid(m.Value<string>());
-
                 return serializer.ReferenceResolver.ResolveReference(serializer.Context, modelId.ToString());
             });
 
@@ -66,7 +64,6 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
         {
             var annoVM = (AnnotationViewModel)value;
             var anno = annoVM.AnnotationModel;
-
 
             writer.WriteStartObject();
 
@@ -99,41 +96,6 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
             writer.WriteValue(anno.TextBlockHeight);
             writer.WritePropertyName("Background");
             writer.WriteValue(anno.Background != null ? anno.Background : "");
-            writer.WriteEndObject();
-        }
-    }
-
-    /// <summary>
-    /// Serialize NoteViewModel.
-    /// </summary>
-    public class NoteViewModelConverter : JsonConverter
-    {
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(NoteViewModel);
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
-            JsonSerializer serializer)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            var noteViewModel = (NoteViewModel)value;
-            var notes = noteViewModel.Model;
-
-            // For each noteViewModel, start a new object
-            writer.WriteStartObject();
-            writer.WritePropertyName("Id");
-            writer.WriteValue(notes.GUID.ToString("N"));
-            writer.WritePropertyName("X");
-            writer.WriteValue(notes.X);
-            writer.WritePropertyName("Y");
-            writer.WriteValue(notes.Y);
-            writer.WritePropertyName("Text");
-            writer.WriteValue(notes.Text);
             writer.WriteEndObject();
         }
     }

--- a/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
@@ -29,15 +29,12 @@ namespace Dynamo.Wpf.ViewModels.Core
                 TypeNameHandling = TypeNameHandling.Auto,
                 Formatting = Formatting.Indented,
                 Converters = new List<JsonConverter>{
+                    new WorkspaceViewWriteConverter(),
                     new AnnotationViewModelConverter()
                 }
             };
 
-            viewModel.ConvertNotesToAnnotations();
-            var json = JsonConvert.SerializeObject(viewModel, settings);
-            viewModel.RemoveConvertedNotesFromAnnotations();
-
-            return json;
+            return JsonConvert.SerializeObject(viewModel, settings);
         }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
@@ -34,7 +34,9 @@ namespace Dynamo.Wpf.ViewModels.Core
                 },
             };
 
+            viewModel.ConvertNotesToAnnotations();
             var json = JsonConvert.SerializeObject(viewModel, settings);
+            viewModel.RemoveConvertedNotesFromAnnotations();
 
             return json;
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/SerializationExtensions.cs
@@ -29,9 +29,8 @@ namespace Dynamo.Wpf.ViewModels.Core
                 TypeNameHandling = TypeNameHandling.Auto,
                 Formatting = Formatting.Indented,
                 Converters = new List<JsonConverter>{
-                    new AnnotationViewModelConverter(),
-                    new NoteViewModelConverter(),
-                },
+                    new AnnotationViewModelConverter()
+                }
             };
 
             viewModel.ConvertNotesToAnnotations();

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -550,25 +550,6 @@ namespace Dynamo.ViewModels
             return JsonConvert.DeserializeObject<ExtraWorkspaceViewInfo>(viewBlock.ToString(), settings);
         }
 
-        public void ConvertNotesToAnnotations()
-        {
-            foreach (var note in _notes)
-            {
-                AnnotationModel model = new AnnotationModel(new NodeModel[0], new NoteModel[0]);
-                model.GUID = note.Model.GUID;
-                model.X = note.Left;
-                model.Y = note.Top;
-                model.AnnotationText = note.Text;
-                _annotations.Add(new AnnotationViewModel(this, model));
-            }
-        }
-
-        public void RemoveConvertedNotesFromAnnotations()
-        {
-            foreach (var note in _notes)
-                _annotations.RemoveAll(annotation => annotation.AnnotationModel.GUID == note.Model.GUID);
-        }
-
         void CopyPasteChanged(object sender, EventArgs e)
         {
             RaisePropertyChanged("CanPaste", "CanCopy", "CanCopyOrPaste");

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -558,7 +558,7 @@ namespace Dynamo.ViewModels
                 model.GUID = note.Model.GUID;
                 model.X = note.Left;
                 model.Y = note.Top;
-                model.Text = note.Text;
+                model.AnnotationText = note.Text;
                 _annotations.Add(new AnnotationViewModel(this, model));
             }
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -265,8 +265,9 @@ namespace Dynamo.ViewModels
         [JsonProperty("NodeViews")]
         public ObservableCollection<NodeViewModel> Nodes { get { return _nodes; } }
 
+        // Do not serialize notes, they will be converted to annotations during serialization
         ObservableCollection<NoteViewModel> _notes = new ObservableCollection<NoteViewModel>();
-        [JsonProperty("Notes")]
+        [JsonIgnore]
         public ObservableCollection<NoteViewModel> Notes { get { return _notes; } }
 
         ObservableCollection<InfoBubbleViewModel> _errors = new ObservableCollection<InfoBubbleViewModel>();
@@ -547,6 +548,25 @@ namespace Dynamo.ViewModels
             };
 
             return JsonConvert.DeserializeObject<ExtraWorkspaceViewInfo>(viewBlock.ToString(), settings);
+        }
+
+        public void ConvertNotesToAnnotations()
+        {
+            foreach (var note in _notes)
+            {
+                AnnotationModel model = new AnnotationModel(new NodeModel[0], new NoteModel[0]);
+                model.GUID = note.Model.GUID;
+                model.X = note.Left;
+                model.Y = note.Top;
+                model.Text = note.Text;
+                _annotations.Add(new AnnotationViewModel(this, model));
+            }
+        }
+
+        public void RemoveConvertedNotesFromAnnotations()
+        {
+            foreach (var note in _notes)
+                _annotations.RemoveAll(annotation => annotation.AnnotationModel.GUID == note.Model.GUID);
         }
 
         void CopyPasteChanged(object sender, EventArgs e)


### PR DESCRIPTION
### Purpose

This PR implements the change for notes to be stored as annotations. The distinction between notes and annotations is made by querying if there are nodes contained in the annotation or not, if not the annotation will become a note.

This PR implements the Dynamo part of QNTM-908 only, the AVP parto will be in a future PR.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [n/a] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [WIP] The level of testing this PR includes is appropriate
- [n/a] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [n/a] Snapshot of UI changes, if any.
- [n/a] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps 
@QilongTang 

### FYIs


