### PR TITLE
verify bindings exist before deserializing

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -315,26 +315,31 @@ namespace Dynamo.Graph.Workspaces
             //serialize view block first and build the notes.
             var notes = new List<NoteModel>();
 
-            // Restore Bindings
+            // Trace Data
             Dictionary<Guid, List<CallSite.RawTraceData>> loadedTraceData = new Dictionary<Guid, List<CallSite.RawTraceData>>();
-            JEnumerable<JToken> bindings = obj["Bindings"].Children();
 
-            // Iterate through bindings to extract nodeID's and bindingData (callsiteId & traceData)
-            foreach (JToken entity in bindings)
+            // Restore trace data if bindings are present in json
+            if (obj["Bindings"] != null && obj["Bindings"].Children().Count() > 0)
             {
-                Guid nodeId = Guid.Parse(entity["NodeId"].ToString());
-                string bindingString = entity["Binding"].ToString();
+                JEnumerable<JToken> bindings = obj["Bindings"].Children();
 
-                // Key(callsiteId) : Value(traceData)
-                Dictionary<string, string> bindingData = JsonConvert.DeserializeObject<Dictionary<string, string>>(bindingString);
-                List<CallSite.RawTraceData> callsiteTraceData = new List<CallSite.RawTraceData>();
-
-                foreach (KeyValuePair<string, string> pair in bindingData)
+                // Iterate through bindings to extract nodeID's and bindingData (callsiteId & traceData)
+                foreach (JToken entity in bindings)
                 {
-                    callsiteTraceData.Add(new CallSite.RawTraceData(pair.Key, pair.Value));
-                }
+                    Guid nodeId = Guid.Parse(entity["NodeId"].ToString());
+                    string bindingString = entity["Binding"].ToString();
 
-                loadedTraceData.Add(nodeId, callsiteTraceData);
+                    // Key(callsiteId) : Value(traceData)
+                    Dictionary<string, string> bindingData = JsonConvert.DeserializeObject<Dictionary<string, string>>(bindingString);
+                    List<CallSite.RawTraceData> callsiteTraceData = new List<CallSite.RawTraceData>();
+
+                    foreach (KeyValuePair<string, string> pair in bindingData)
+                    {
+                        callsiteTraceData.Add(new CallSite.RawTraceData(pair.Key, pair.Value));
+                    }
+
+                    loadedTraceData.Add(nodeId, callsiteTraceData);
+                }
             }
 
             WorkspaceModel ws;


### PR DESCRIPTION
### Purpose

This PR fixes a regression introduced in [PR-8198](https://github.com/DynamoDS/Dynamo/pull/8198) caught by the unit tests.  If trace data does not exist or exists and is empty in json we skip this deserialization step.  Failing regressions now pass.

![regression_tests](https://user-images.githubusercontent.com/13341935/31018864-8cd46744-a4fb-11e7-903d-a53633230a17.jpg)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@smangarole 
