### PR TITLE
Add adequate json constructor for color palette UI node

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -18,6 +18,7 @@ using DSColor = DSCore.Color;
 using Autodesk.DesignScript.Runtime;
 using Dynamo.Graph.Workspaces;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System.IO;
 
 namespace CoreNodeModels.Input
@@ -33,6 +34,7 @@ namespace CoreNodeModels.Input
     public class ColorPalette : NodeModel
     {
         private DSColor dscolor = DSColor.ByARGB(255, 0, 0, 0);
+
         public DSColor DsColor
         {
             get { return dscolor; }
@@ -43,6 +45,7 @@ namespace CoreNodeModels.Input
                 RaisePropertyChanged("DsColor");
             }
         }
+
         public override NodeInputData InputData
         {
             get
@@ -67,6 +70,22 @@ namespace CoreNodeModels.Input
         public ColorPalette()
         {
             RegisterAllPorts();
+        }
+        
+        [JsonConstructor]
+        public ColorPalette(JObject DsColor, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+            // RGBA to ARGB
+            try
+            {
+                this.DsColor = DSColor.ByARGB((int)DsColor["Alpha"], (int)DsColor["Red"], (int)DsColor["Green"], (int)DsColor["Blue"]);
+            }
+
+            catch
+            {
+                this.DsColor = DSColor.ByARGB(255, 0, 0, 0);
+            }
+
         }
 
         protected override bool UpdateValueCore(UpdateValueParams updateValueParams)


### PR DESCRIPTION
### Purpose

[QNTM-1932](https://jira.autodesk.com/browse/QNTM-1932)

This PR adds a json constructor for the color palette UI node that maintains knowledge of the last saved color.  If the color cannot be properly deserialized we return a black as the default.  The addition of the json constructor also eliminates the duplicate ports issue as outlined in the original task.

![color_palette](https://user-images.githubusercontent.com/13341935/31087154-f87bcc10-a769-11e7-9f9e-bcd8282f7310.gif)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of