### PR TITLE
Serialize ColorPalette node type as ColorInputNode

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -35,6 +35,7 @@ namespace CoreNodeModels.Input
     {
         private DSColor dscolor = DSColor.ByARGB(255, 0, 0, 0);
 
+        [JsonProperty(PropertyName = "InputValue")]
         public DSColor DsColor
         {
             get { return dscolor; }
@@ -82,12 +83,12 @@ namespace CoreNodeModels.Input
         }
         
         [JsonConstructor]
-        public ColorPalette(JObject DsColor, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        public ColorPalette(JObject InputValue, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             // RGBA to ARGB
             try
             {
-                this.DsColor = DSColor.ByARGB((int)DsColor["Alpha"], (int)DsColor["Red"], (int)DsColor["Green"], (int)DsColor["Blue"]);
+                this.DsColor = DSColor.ByARGB((int)InputValue["Alpha"], (int)InputValue["Red"], (int)InputValue["Green"], (int)InputValue["Blue"]);
             }
 
             catch
@@ -105,6 +106,9 @@ namespace CoreNodeModels.Input
             switch (name)
             {
                 case "DsColor":
+                    this.DsColor = this.DeserializeValue(value);
+                    return true;
+                case "InputValue":
                     this.DsColor = this.DeserializeValue(value);
                     return true;
             }

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -88,7 +88,7 @@ namespace CoreNodeModels.Input
             // RGBA to ARGB
             try
             {
-                this.DsColor = DSColor.ByARGB((int)InputValue["Alpha"], (int)InputValue["Red"], (int)InputValue["Green"], (int)InputValue["Blue"]);
+                this.DsColor = DSColor.ByARGB((int)InputValue["A"], (int)InputValue["R"], (int)InputValue["G"], (int)InputValue["B"]);
             }
 
             catch
@@ -106,9 +106,6 @@ namespace CoreNodeModels.Input
             switch (name)
             {
                 case "DsColor":
-                    this.DsColor = this.DeserializeValue(value);
-                    return true;
-                case "InputValue":
                     this.DsColor = this.DeserializeValue(value);
                     return true;
             }

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -46,6 +46,15 @@ namespace CoreNodeModels.Input
             }
         }
 
+        //override ExtensionNode
+        public override string NodeType
+        {
+            get
+            {
+                return "ColorInputNode";
+            }
+        }
+
         public override NodeInputData InputData
         {
             get

--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -46,7 +46,7 @@ namespace CoreNodeModels.Input
             }
         }
 
-        //override ExtensionNode
+        //override ExtensionNode NodeType from NodeModel base class
         public override string NodeType
         {
             get

--- a/src/Libraries/CoreNodes/Color.cs
+++ b/src/Libraries/CoreNodes/Color.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using Autodesk.DesignScript.Geometry;
 using Autodesk.DesignScript.Runtime;
 
+using Newtonsoft.Json;
+
 namespace DSCore
 {
     public class Color
@@ -19,6 +21,7 @@ namespace DSCore
         ///     Find the red component of a color, 0 to 255.
         /// </summary>
         /// <returns name="red">int between 0 and 255 inclusive.</returns>
+        [JsonProperty(PropertyName = "R")]
         public byte Red
         {
             get { return color.R; }
@@ -28,6 +31,7 @@ namespace DSCore
         ///     Find the green component of a color, 0 to 255.
         /// </summary>
         /// <returns name="green">int between 0 and 255 inclusive.</returns>
+        [JsonProperty(PropertyName = "G")]
         public byte Green
         {
             get { return color.G; }
@@ -37,6 +41,7 @@ namespace DSCore
         ///     Find the blue component of a color, 0 to 255.
         /// </summary>
         /// <returns name="blue">int between 0 and 255 inclusive.</returns>
+        [JsonProperty(PropertyName = "B")]
         public byte Blue
         {
             get { return color.B; }
@@ -46,6 +51,7 @@ namespace DSCore
         ///     Find the alpha component of a color, 0 to 255.
         /// </summary>
         /// <returns name="alpha">int between 0 and 255 inclusive.</returns>
+        [JsonProperty(PropertyName = "A")]
         public byte Alpha
         {
             get { return color.A; }

--- a/src/Libraries/CoreNodes/CoreNodes.csproj
+++ b/src/Libraries/CoreNodes/CoreNodes.csproj
@@ -49,6 +49,10 @@
       <HintPath>..\..\..\extern\NCalc\NCalc.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/test/DynamoCoreWpfTests/ColorPaletteTests.cs
+++ b/test/DynamoCoreWpfTests/ColorPaletteTests.cs
@@ -1,4 +1,5 @@
-﻿using SystemTestServices;
+﻿using System.IO;
+using SystemTestServices;
 using CoreNodeModels.Input;
 using Dynamo.Graph;
 using Dynamo.Graph.Workspaces;
@@ -32,7 +33,30 @@ namespace DynamoCoreWpfTests
             Assert.DoesNotThrow(DispatcherUtil.DoEvents);
             Assert.AreEqual(colorPalette.DsColor, DSColor.ByARGB(255,0,0,0));
             Assert.Pass();
+
+            // Verify same results in JSON
+
+            // Change from default color to red
+            homespace.UpdateModelValue(new List<System.Guid>() { colorPalette.GUID }, "DsColor", DSColor.ByARGB(255, 255, 0, 0).ToString());
+            homespace.Run();
+            Assert.AreEqual(DSColor.ByARGB(255, 255, 0, 0), colorPalette.DsColor);
+            // Save in temp location
+            var tempPath = Path.GetTempPath() + "ColorPaletteTest_temp.dyn";
+            ViewModel.SaveAs(tempPath);
+            // Close workspace
+            Assert.IsTrue(ViewModel.CloseHomeWorkspaceCommand.CanExecute(null));
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+            // Open JSON temp file
+            OpenDynamoDefinition(tempPath);
+            // Run
+            RunCurrentModel();
+            // Verify xml results against json
+            Assert.DoesNotThrow(DispatcherUtil.DoEvents);
+            Assert.AreEqual(colorPalette.DsColor, DSColor.ByARGB(255, 255, 0, 0));
+            // Delete temp file
+            File.Delete(tempPath);
         }
+
         [Test]
         public void ColorPalette_Undo()
         {


### PR DESCRIPTION
### Purpose

[QNTM-1907](https://jira.autodesk.com/browse/QNTM-1907)

The purpose of this PR is to update the ColorPalette node type to align with the CoGS schema.
From `ExtensionNode` To `ColorInputNode`

Example Schema:
```Json
{
      "ConcreteType": "CoreNodeModels.Input.ColorPalette, CoreNodeModels",
      "InputValue": {
        "R": 255,
        "G": 140,
        "B": 0,
        "A": 255
      },
      "NodeType": "ColorInputNode",
      "Id": "92e4e321bde949eb92c6e6e37f1754c7",
      "Inputs": [],
      "Outputs": [
        {
          "Id": "67d142d694304236a0e189fad5fcb8c8",
          "Name": "Color",
          "Description": "Selected Color.",
          "UsingDefaultValue": false,
          "Level": 2,
          "UseLevels": false,
          "KeepListStructure": false
        }
      ],
      "Replication": "Disabled",
      "Description": "Select a Color from the palette"
}
```

### AVP PR

[PR-315](https://github.com/DynamoDS/AutodeskVisualProgramming/pull/315)

### Testing
Extended existing unit test to assert storing and updating of color values against JSON schema

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@ramramps  @QilongTang 