### PR TITLE
Opening a Json dyf should add custom node in library

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.0.0.2121")]
+[assembly: AssemblyVersion("2.0.0.2821")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.0.0.2121")]
+[assembly: AssemblyFileVersion("2.0.0.2821")]

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -575,7 +575,7 @@ namespace Dynamo.Core
         }
 
         /// <summary>
-        ///     Returns a guid from a specific path, internally this first calls GetDefinitionFromPath
+        ///     Returns a boolean indicating if successfully get a CustomNodeInfo object from a workspace path
         /// </summary>
         /// <param name="path">The path from which to get the guid</param>
         /// <param name="isTestMode">
@@ -766,7 +766,7 @@ namespace Dynamo.Core
                 }
                 else if (DynamoUtilities.PathHelper.isValidJson(path, out strInput))
                 {
-                    // Skip Json migration for now
+                    // TODO: Skip Json migration for now
                     WorkspaceInfo.FromJsonDocument(strInput, path, isTestMode, false, AsLogger(), out info);
                     info.ID = functionId.ToString();
                     return InitializeCustomNode(info, out workspace, libraryServices);

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -164,6 +164,7 @@ namespace Dynamo.Core
         /// <param name="info">
         ///     Custom node information data
         /// </param>
+        /// <param name="libraryServices">LibraryServices used for code block node initialization.</param>
         public bool TryGetCustomNodeData(
             Guid id, 
             string name,

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -560,15 +560,23 @@ namespace Dynamo.Core
             {
                 XmlDocument xmlDoc;
                 string jsonDoc;
-                DynamoUtilities.PathHelper.isValidXML(path, out xmlDoc);
-                DynamoUtilities.PathHelper.isValidJson(path, out jsonDoc);
-
-                if (!WorkspaceInfo.FromXmlDocument(xmlDoc, path, isTestMode, false, AsLogger(), out header)
-                && !WorkspaceInfo.FromJsonDocument(jsonDoc, path, isTestMode, false, AsLogger(), out header))
+                if (DynamoUtilities.PathHelper.isValidXML(path, out xmlDoc))
                 {
-                    Log(String.Format(Properties.Resources.FailedToLoadHeader, path));
-                    info = null;
-                    return false;
+                    if (!WorkspaceInfo.FromXmlDocument(xmlDoc, path, isTestMode, false, AsLogger(), out header))
+                    {
+                        Log(String.Format(Properties.Resources.FailedToLoadHeader, path));
+                        info = null;
+                        return false;
+                    }
+                }
+                else if (DynamoUtilities.PathHelper.isValidJson(path, out jsonDoc))
+                {
+                    if (!WorkspaceInfo.FromJsonDocument(jsonDoc, path, isTestMode, false, AsLogger(), out header))
+                    {
+                        Log(String.Format(Properties.Resources.FailedToLoadHeader, path));
+                        info = null;
+                        return false;
+                    }
                 }
                 info = new CustomNodeInfo(
                     Guid.Parse(header.ID),

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -683,6 +683,7 @@ namespace Dynamo.Core
             else if(DynamoUtilities.PathHelper.isValidJson(workspaceInfo.FileName, out jsonDoc))
             {
                 newWorkspace = (CustomNodeWorkspaceModel)WorkspaceModel.FromJson(jsonDoc, libraryServices, null, null, nodeFactory, false, true, this);
+                newWorkspace.FileName = workspaceInfo.FileName;
             }
 
             RegisterCustomNodeWorkspace(newWorkspace);

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/ICustomNodeManager.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/ICustomNodeManager.cs
@@ -9,5 +9,6 @@ namespace Dynamo.Graph.Nodes.CustomNodes
     {
         IEnumerable<CustomNodeInfo> AddUninitializedCustomNodesInPath(string path, bool isTestMode, bool isPackageMember = false);
         Guid GuidFromPath(string path);
+        bool TryGetFunctionWorkspace(Guid id, bool isTestMode, out ICustomNodeWorkspaceModel ws, Engine.LibraryServices libraryServices = null);
     }
 }

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/ICustomNodeManager.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/ICustomNodeManager.cs
@@ -9,6 +9,5 @@ namespace Dynamo.Graph.Nodes.CustomNodes
     {
         IEnumerable<CustomNodeInfo> AddUninitializedCustomNodesInPath(string path, bool isTestMode, bool isPackageMember = false);
         Guid GuidFromPath(string path);
-        bool TryGetFunctionWorkspace(Guid id, bool isTestMode, out ICustomNodeWorkspaceModel ws);
     }
 }

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/ICustomNodeSource.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/ICustomNodeSource.cs
@@ -10,7 +10,8 @@ namespace Dynamo.Graph.Nodes.CustomNodes
         /// <param name="id">Identifier referring to a custom node definition.</param>
         /// <param name="name"></param>
         /// <param name="isTestMode"></param>
+        /// <param name="libraryServices">LibraryServices used for code block node initialization.</param>
         Function CreateCustomNodeInstance(
-            Guid id, string name = null, bool isTestMode = false);
+            Guid id, string name = null, bool isTestMode = false, Engine.LibraryServices libraryServices = null);
     }
 }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
@@ -111,7 +111,6 @@ namespace Dynamo.Graph.Workspaces
                 // we have a dyf and it lacks an ID field, we need to assign it
                 // a deterministic guid based on its name.  By doing it deterministically,
                 // files remain compatible
-                if (string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(funName) && funName != "Home")
                 {
                     id = GuidUtility.Create(GuidUtility.UrlNamespace, funName).ToString();
                 }
@@ -150,6 +149,16 @@ namespace Dynamo.Graph.Workspaces
             }
         }
 
+        /// <summary>
+        /// Return a boolean indicating if successfully deserialized workspace info object from Json file
+        /// </summary>
+        /// <param name="jsonDoc">Target Josn</param>
+        /// <param name="path">Target path</param>
+        /// <param name="isTestMode">Boolean indicating if Dynamo is running in Test Mode</param>
+        /// <param name="forceManualExecutionMode">Boolean indicating if forcing manual mode</param>
+        /// <param name="logger">Dynamo logger</param>
+        /// <param name="workspaceInfo">Return object</param>
+        /// <returns>A boolean indicating success</returns>
         internal static bool FromJsonDocument(String jsonDoc, string path, bool isTestMode,
             bool forceManualExecutionMode, ILogger logger, out WorkspaceInfo workspaceInfo)
         {
@@ -190,7 +199,7 @@ namespace Dynamo.Graph.Workspaces
                 // we have a dyf and it lacks an ID field, we need to assign it
                 // a deterministic guid based on its name.  By doing it deterministically,
                 // files remain compatible
-                if (string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(funName) && funName != "Home")
+                if (string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(funName) && funName != Properties.Resources.DefaultHomeWorkspaceName)
                 {
                     id = GuidUtility.Create(GuidUtility.UrlNamespace, funName).ToString();
                 }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
@@ -111,6 +111,7 @@ namespace Dynamo.Graph.Workspaces
                 // we have a dyf and it lacks an ID field, we need to assign it
                 // a deterministic guid based on its name.  By doing it deterministically,
                 // files remain compatible
+                if (string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(funName) && funName != Properties.Resources.DefaultHomeWorkspaceName)
                 {
                     id = GuidUtility.Create(GuidUtility.UrlNamespace, funName).ToString();
                 }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1342,14 +1342,14 @@ namespace Dynamo.Models
         /// execution mode specified in the file and set manual mode</param>
         public void OpenFileFromPath(string filePath, bool forceManualExecutionMode = false)
         {
-            var xmlDoc = new XmlDocument();
+            XmlDocument xmlDoc;
             if (DynamoUtilities.PathHelper.isValidXML(filePath, out xmlDoc))
             {
                 OpenXmlFileFromPath(xmlDoc, filePath, forceManualExecutionMode);
                 return;
             }
 
-            var fileContents = "";
+            string fileContents;
             if (DynamoUtilities.PathHelper.isValidJson(filePath, out fileContents))
             {
                 OpenJsonFileFromPath(fileContents, filePath, forceManualExecutionMode);
@@ -1386,13 +1386,13 @@ namespace Dynamo.Models
         /// <summary>
         /// Opens a Dynamo workspace from a path to an JSON file on disk.
         /// </summary>
+        /// <param name="fileContents">Json file contents</param>
         /// <param name="filePath">Path to file</param>
         /// <param name="forceManualExecutionMode">Set this to true to discard
         /// execution mode specified in the file and set manual mode</param>
         /// <returns>True if workspace was opened successfully</returns>
         private bool OpenJsonFileFromPath(string fileContents, string filePath, bool forceManualExecutionMode)
         {
-            bool success = true;
             try
             {
                 DynamoPreferencesData dynamoPreferences = DynamoPreferencesDataFromJson(fileContents);
@@ -1413,13 +1413,12 @@ namespace Dynamo.Models
                         }
                     }
                 }
+                return true;
             }
             catch (Exception)
             {
-                success = false;
+                return false;
             }
-
-            return success;
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1860,7 +1860,7 @@ namespace Dynamo.Models
         public bool OpenCustomNodeWorkspace(Guid guid)
         {
             CustomNodeWorkspaceModel customNodeWorkspace;
-            if (CustomNodeManager.TryGetFunctionWorkspace(guid, IsTestMode, out customNodeWorkspace))
+            if (CustomNodeManager.TryGetFunctionWorkspace(guid, IsTestMode, out customNodeWorkspace, this.LibraryServices))
             {
                 if (!Workspaces.OfType<CustomNodeWorkspaceModel>().Contains(customNodeWorkspace))
                     AddWorkspace(customNodeWorkspace);

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -169,7 +169,7 @@ namespace Dynamo.Models
             // And if that didn't work, then it must be a custom node.
             if (Guid.TryParse(name, out customNodeId))
             {
-                node = CustomNodeManager.CreateCustomNodeInstance(customNodeId);
+                node = CustomNodeManager.CreateCustomNodeInstance(customNodeId, null, false, LibraryServices);
                 node.GUID = nodeId;
                 return node;
             }

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -322,6 +322,15 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Home.
+        /// </summary>
+        public static string DefaultHomeWorkspaceName {
+            get {
+                return ResourceManager.GetString("DefaultHomeWorkspaceName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Default value.
         /// </summary>
         public static string DefaultValue {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -649,4 +649,8 @@ value : bool = false</value>
   <data name="NoneString" xml:space="preserve">
     <value>none</value>
   </data>
+  <data name="DefaultHomeWorkspaceName" xml:space="preserve">
+    <value>Home</value>
+    <comment>The default name of home workspace</comment>
+  </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -658,4 +658,8 @@ value : bool = false</value>
   <data name="PythonTemplateUserFile" xml:space="preserve">
     <value>Python template set to user file</value>
   </data>
+  <data name="DefaultHomeWorkspaceName" xml:space="preserve">
+    <value>Home</value>
+    <comment>The default name of home workspace</comment>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1109,6 +1109,14 @@ namespace Dynamo.ViewModels
             else
             {
                 var newVm = new WorkspaceViewModel(item, this);
+
+                // For Json Workspaces, workspace view info need to be read agin from file
+                string fileContents;
+                if (DynamoUtilities.PathHelper.isValidJson(newVm.Model.FileName, out fileContents))
+                {
+                    ExtraWorkspaceViewInfo viewInfo = WorkspaceViewModel.ExtraWorkspaceViewInfoFromJson(fileContents);
+                    newVm.Model.UpdateWithExtraWorkspaceViewInfo(viewInfo);
+                }
                 workspaces.Add(newVm);
             }
         }

--- a/src/DynamoPackages/Interfaces/CustomNodePathRemapper.cs
+++ b/src/DynamoPackages/Interfaces/CustomNodePathRemapper.cs
@@ -41,7 +41,7 @@ namespace Dynamo.PackageManager
             var id = customNodeManager.GuidFromPath(originalPath);
 
             ICustomNodeWorkspaceModel def;
-            var res = customNodeManager.TryGetFunctionWorkspace(id, this.isTestMode, out def);
+            var res = customNodeManager.TryGetFunctionWorkspace(id, this.isTestMode, out def, null);
 
             if (!res) return false;
 

--- a/src/DynamoUtilities/DynamoUtilities.csproj
+++ b/src/DynamoUtilities/DynamoUtilities.csproj
@@ -44,7 +44,7 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Reach\src\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/DynamoUtilities/DynamoUtilities.csproj
+++ b/src/DynamoUtilities/DynamoUtilities.csproj
@@ -42,6 +42,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\extern\avalonEdit\ICSharpCode.AvalonEdit.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\Reach\src\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Security.AccessControl;
+using System.Xml;
+using Newtonsoft.Json;
 
 namespace DynamoUtilities
 {
@@ -87,6 +89,65 @@ namespace DynamoUtilities
             }
 
             return writeAllow && !writeDeny;
+        }
+
+        /// <summary>
+        /// This is a utility method for checking if given path contains valid XML document.
+        /// </summary>
+        /// <param name="path">path to the target xml file</param>
+        /// <param name="xmlDoc">System.Xml.XmlDocument repensentation of target xml file</param>
+        /// <returns></returns>
+        public static bool isValidXML(string path, out XmlDocument xmlDoc)
+        {
+            // Based on https://msdn.microsoft.com/en-us/library/875kz807(v=vs.110).aspx
+            // Exception thrown indicate invalid XML document path 
+            try
+            {
+                xmlDoc = new XmlDocument();
+                xmlDoc.Load(path);
+                return true;
+            }
+            catch
+            {
+                xmlDoc = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// This is a utility method for checking if given path contains valid Json document.
+        /// </summary>
+        /// <param name="path">path to the target json file</param>
+        /// <param name="fileContents"> string contents of target json file</param>
+        /// <returns></returns>
+        public static bool isValidJson(string path, out string fileContents)
+        {
+            fileContents = File.ReadAllText(path);
+            fileContents = fileContents.Trim();
+            if ((fileContents.StartsWith("{") && fileContents.EndsWith("}")) || //For object
+                (fileContents.StartsWith("[") && fileContents.EndsWith("]"))) //For array
+            {
+                try
+                {
+                    var obj = Newtonsoft.Json.Linq.JToken.Parse(fileContents);
+                    return true;
+                }
+                catch (JsonReaderException jex)
+                {
+                    //Exception in parsing Json
+                    Console.WriteLine(jex.Message);
+                    return false;
+                }
+                catch (Exception ex) //some other exception
+                {
+                    Console.WriteLine(ex.ToString());
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
         }
     }
 }

--- a/src/Engine/ProtoCore/Utils/FileUtils.cs
+++ b/src/Engine/ProtoCore/Utils/FileUtils.cs
@@ -16,7 +16,7 @@ namespace ProtoCore.Utils
         /// is null it will search only in the executing assembly path or the
         /// current directory.</param>
         /// <returns>Full path for the file if located successfully else the 
-        /// file name when failed to loate the given file</returns>
+        /// file name when failed to locate the given file</returns>
         public static string GetDSFullPathName(string fileName, Options options = null)
         {
             // trim white space chars

--- a/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
+++ b/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
@@ -62,7 +62,7 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void CanOpenCustomNodeWorkspace()
+        public void CanOpenXmlCustomNodeWorkspace()
         {
             OpenTestFile(@"core\combine", "Sequence2.dyf");
 
@@ -72,10 +72,29 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void CustomNodeWorkspaceIsAddedToSearchOnOpening()
+        public void XmlCustomNodeWorkspaceIsAddedToSearchOnOpening()
         {
             OpenTestFile(@"core\combine", "Sequence2.dyf");
             
+            var res = CurrentDynamoModel.SearchModel.Search("Sequence2");
+            Assert.AreEqual("Sequence2", res.First().Name);
+        }
+
+        [Test]
+        public void CanOpenJsonCustomNodeWorkspace()
+        {
+            OpenTestFile(@"core\combine", "Sequence_Json.dyf");
+
+            var nodeWorkspace = CurrentDynamoModel.Workspaces.FirstOrDefault(x => x is CustomNodeWorkspaceModel);
+            Assert.IsNotNull(nodeWorkspace);
+            Assert.AreEqual(CurrentDynamoModel.CurrentWorkspace.Name, "Sequence2");
+        }
+
+        [Test]
+        public void JsonCustomNodeWorkspaceIsAddedToSearchOnOpening()
+        {
+            OpenTestFile(@"core\combine", "Sequence_Json.dyf");
+
             var res = CurrentDynamoModel.SearchModel.Search("Sequence2");
             Assert.AreEqual("Sequence2", res.First().Name);
         }

--- a/test/core/combine/Sequence_Json.dyf
+++ b/test/core/combine/Sequence_Json.dyf
@@ -1,0 +1,291 @@
+{
+  "Uuid": "6aecda57-7679-4afb-aa02-05a75cc3433e",
+  "IsCustomNode": true,
+  "Category": "Misc",
+  "Description": "",
+  "Name": "Sequence2",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Range, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "5399c352d22945f18c5973c55cd3574e",
+      "Inputs": [
+        {
+          "Id": "e00a6c94b25148d1abdfc428831e3861",
+          "Name": "start",
+          "Description": "Number or letter to start the sequence at\r\nDefault value: 0 (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "de086a19e8754a07b31ba4980ecee5b8",
+          "Name": "end",
+          "Description": "Number or letter to end the sequence at\r\nDefault value: 9 (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b48f9a1d015b46ee97e44eab6741d028",
+          "Name": "step",
+          "Description": "Space between numbers or letters\r\nDefault value: 1 (disabled)",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b84f6a3271064f5781b3c42596c66b8e",
+          "Name": "seq",
+          "Description": "New sequence",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a sequence of numbers or letters in the specified range."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Symbol, DynamoCore",
+      "NodeType": "InputNode",
+      "Parameter": {
+        "Name": "start",
+        "TypeName": "var",
+        "TypeRank": -1,
+        "DefaultValue": null
+      },
+      "Id": "c1e4f3cc6d4048c483ceaee56d646c98",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "2e578dd7cd6543719ffb5833e941f02b",
+          "Name": "",
+          "Description": "Symbol",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A function parameter, use with custom nodes.\r\n\r\nYou can specify the type and default value for parameter. E.g.,\r\n\r\ninput : var[]..[]\r\nvalue : bool = false"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Symbol, DynamoCore",
+      "NodeType": "InputNode",
+      "Parameter": {
+        "Name": "end",
+        "TypeName": "var",
+        "TypeRank": -1,
+        "DefaultValue": null
+      },
+      "Id": "f5906773647143a0b1fcce12f61d461d",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "842bcc23f4c94cbd880a416e9e539dd0",
+          "Name": "",
+          "Description": "Symbol",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A function parameter, use with custom nodes.\r\n\r\nYou can specify the type and default value for parameter. E.g.,\r\n\r\ninput : var[]..[]\r\nvalue : bool = false"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Symbol, DynamoCore",
+      "NodeType": "InputNode",
+      "Parameter": {
+        "Name": "step",
+        "TypeName": "var",
+        "TypeRank": -1,
+        "DefaultValue": null
+      },
+      "Id": "8f47fb7e43c7415f87ef5d564bb68191",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "431ddbd96d184d0e907115428abef2a2",
+          "Name": "",
+          "Description": "Symbol",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A function parameter, use with custom nodes.\r\n\r\nYou can specify the type and default value for parameter. E.g.,\r\n\r\ninput : var[]..[]\r\nvalue : bool = false"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Formula, CoreNodeModels",
+      "Formula": "x-1",
+      "NodeType": "FormulaNode",
+      "Id": "dab29ca0f01346c0b2a33bcb5c7745c2",
+      "Inputs": [
+        {
+          "Id": "f5214325101149388056914b4b09b2d9",
+          "Name": "x",
+          "Description": "variable",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "48b0eeec709242b4a61dac3cc13b7bfe",
+          "Name": "",
+          "Description": "Result of math computation",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Evaluates mathematical formulas. Uses NCalc: http://ncalc.codeplex.com/"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
+      "NodeType": "OutputNode",
+      "ElementResolver": null,
+      "Symbol": "",
+      "Id": "28a960447dee4da299f970c2f350e622",
+      "Inputs": [
+        {
+          "Id": "78807c4ba8034576b07e12e6e9b2c885",
+          "Name": "",
+          "Description": "",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "A function output, use with custom nodes"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "b84f6a3271064f5781b3c42596c66b8e",
+      "End": "78807c4ba8034576b07e12e6e9b2c885",
+      "Id": "3f2deabd1dff48d8a3ff291a1122ea21"
+    },
+    {
+      "Start": "2e578dd7cd6543719ffb5833e941f02b",
+      "End": "e00a6c94b25148d1abdfc428831e3861",
+      "Id": "805ce74a9f1945748e336753f440c70e"
+    },
+    {
+      "Start": "842bcc23f4c94cbd880a416e9e539dd0",
+      "End": "f5214325101149388056914b4b09b2d9",
+      "Id": "54c7eb9e13834a2abc5bb5455de0b5a2"
+    },
+    {
+      "Start": "431ddbd96d184d0e907115428abef2a2",
+      "End": "b48f9a1d015b46ee97e44eab6741d028",
+      "Id": "462d335a0fd3484f95ad88c9f56eb018"
+    },
+    {
+      "Start": "48b0eeec709242b4a61dac3cc13b7bfe",
+      "End": "de086a19e8754a07b31ba4980ecee5b8",
+      "Id": "90b11ea0846b4ef6860386a3ef50264d"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": false,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.0.2806",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "Id": "5399c352d22945f18c5973c55cd3574e",
+        "Name": "Range",
+        "ShowGeometry": true,
+        "Excluded": false,
+        "X": 323.383122001953,
+        "Y": 208.824760256458
+      },
+      {
+        "Id": "c1e4f3cc6d4048c483ceaee56d646c98",
+        "Name": "Input",
+        "ShowGeometry": true,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 154.577959398747
+      },
+      {
+        "Id": "f5906773647143a0b1fcce12f61d461d",
+        "Name": "Input",
+        "ShowGeometry": true,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 230.871432466577
+      },
+      {
+        "Id": "8f47fb7e43c7415f87ef5d564bb68191",
+        "Name": "Input",
+        "ShowGeometry": true,
+        "Excluded": false,
+        "X": 0.0,
+        "Y": 311.641216267404
+      },
+      {
+        "Id": "dab29ca0f01346c0b2a33bcb5c7745c2",
+        "Name": "Formula",
+        "ShowGeometry": true,
+        "Excluded": false,
+        "X": 113.533651647406,
+        "Y": 228.546463130036
+      },
+      {
+        "Id": "28a960447dee4da299f970c2f350e622",
+        "Name": "Output",
+        "ShowGeometry": true,
+        "Excluded": false,
+        "X": 490.991600088771,
+        "Y": 207.689005153314
+      }
+    ],
+    "Annotations": [],
+    "X": 124.0,
+    "Y": -2.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[QNTM-1746](https://jira.autodesk.com/browse/QNTM-1746) Dynamo: Opening a Json dyf does not add custom node in library 

Various factors contributed to the broken state of custom nodes in Dynamo 2.0 right now, but most of them are related to that the code to grab FunctionDefination of custom nodes are all expecting XML file format. This PR is trying to address as much as I can since we still do not have Json File regression results from Dynamo 2.0 to compare. So I could only fix based on exceptions and callstacks I've seen.



### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
Waiting for Unit test results
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning]
Additional param LibraryServices are optional

(https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

Create a new simple Custom Node creating some geometry:
![image](https://user-images.githubusercontent.com/3942418/31201817-1cd1c248-a92e-11e7-997f-009f72a002eb.png)

The new node is added to the library and searchable. After user place the custom node in canvas, graph runs and geometry displays.
![image](https://user-images.githubusercontent.com/3942418/31201872-4df0a07e-a92e-11e7-8759-fa4daed11980.png)



### Reviewers

@mjkkirschner @ramramps 

### FYIs

@phliberato @ricardoperucci 
