### PR TITLE
Register HomeWorkspace events upon JSON deserialization

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1557,6 +1557,8 @@ namespace Dynamo.Models
               homeWorkspace.RunSettings = new RunSettings(runType, runPeriod);
             }
 
+            RegisterHomeWorkspace(homeWorkspace);
+
             CustomNodeWorkspaceModel customNodeWorkspace = workspace as CustomNodeWorkspaceModel;
             if (customNodeWorkspace != null)
               customNodeWorkspace.IsVisibleInDynamoLibrary = dynamoPreferences.IsVisibleInDynamoLibrary;

--- a/test/DynamoCoreWpfTests/WorkspaceOpeningTests.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceOpeningTests.cs
@@ -38,7 +38,7 @@ namespace Dynamo.Tests
             
             // Verify events handlers have been registered
             bool openXmlFired = false;
-            EventHandler<EvaluationCompletedEventArgs> testXmlEvent = (sender, e) => openXmlFired = true;
+            EventHandler<EvaluationCompletedEventArgs> testXmlEvent = (sender, e) => { openXmlFired = true; };
             ViewModel.Model.EvaluationCompleted += testXmlEvent;
             RunCurrentModel();
             Assert.IsTrue(openXmlFired);
@@ -64,7 +64,7 @@ namespace Dynamo.Tests
 
             // Verify events handlers have been registered
             bool openJsonFired = false;
-            EventHandler<EvaluationCompletedEventArgs> testJsonEvent = (sender, e) => openJsonFired = true;
+            EventHandler<EvaluationCompletedEventArgs> testJsonEvent = (sender, e) => { openJsonFired = true; };
             ViewModel.Model.EvaluationCompleted += testJsonEvent;
             RunCurrentModel();
             Assert.IsTrue(openJsonFired);

--- a/test/DynamoCoreWpfTests/WorkspaceOpeningTests.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceOpeningTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Dynamo.Events;
 using Dynamo.Graph;
 using Dynamo.Graph.Workspaces;
@@ -37,12 +38,13 @@ namespace Dynamo.Tests
             
             // Verify events handlers have been registered
             bool openXmlFired = false;
-            ViewModel.Model.EvaluationCompleted += (sender, e) => openXmlFired = true;
+            EventHandler<EvaluationCompletedEventArgs> testXmlEvent = (sender, e) => openXmlFired = true;
+            ViewModel.Model.EvaluationCompleted += testXmlEvent;
             RunCurrentModel();
             Assert.IsTrue(openXmlFired);
 
             //Unsubscribe
-            ViewModel.Model.EvaluationCompleted -= ViewModel.Model.OnEvaluationCompleted;
+            ViewModel.Model.EvaluationCompleted -= testXmlEvent;
 
             // Save to json in temp location
             string tempPath = Path.Combine(Dynamo.UnitTestBase.TestDirectory, @"core\serialization\serialization_temp.dyn");
@@ -62,7 +64,8 @@ namespace Dynamo.Tests
 
             // Verify events handlers have been registered
             bool openJsonFired = false;
-            ViewModel.Model.EvaluationCompleted += (sender, e) => openJsonFired = true;
+            EventHandler<EvaluationCompletedEventArgs> testJsonEvent = (sender, e) => openJsonFired = true;
+            ViewModel.Model.EvaluationCompleted += testJsonEvent;
             RunCurrentModel();
             Assert.IsTrue(openJsonFired);
 
@@ -74,7 +77,7 @@ namespace Dynamo.Tests
             File.Delete(tempPath);
 
             //Unsubscribe
-            ViewModel.Model.EvaluationCompleted -= ViewModel.Model.OnEvaluationCompleted;
+            ViewModel.Model.EvaluationCompleted -= testJsonEvent;
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

[QNTM-2124](https://jira.autodesk.com/browse/QNTM-2124)

The purpose of this PR is to register the `HomeWorkspace` with the `OnEvaluationCompleted` and `OnRefreshCompleted` events.  This has always been the case previously with XML and was accidentally omitted when JSON deserilaization was added.  This also caused some buggy behavior, such as Dynamo not properly communicating/updating with Revit.

### Testing

Added a unit test for verifying the  `OnEvaluationCompleted` and `OnRefreshCompleted` events are registered with the homeworkspace upon xml and json deserialization.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner  @QilongTang 

### FYIs

@smangarole 
