### PR TITLE
Prevent registering of HomeWorkspace events with CustomNodeWorkspaces

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1557,11 +1557,17 @@ namespace Dynamo.Models
               homeWorkspace.RunSettings = new RunSettings(runType, runPeriod);
             }
 
-            RegisterHomeWorkspace(homeWorkspace);
-
             CustomNodeWorkspaceModel customNodeWorkspace = workspace as CustomNodeWorkspaceModel;
             if (customNodeWorkspace != null)
-              customNodeWorkspace.IsVisibleInDynamoLibrary = dynamoPreferences.IsVisibleInDynamoLibrary;
+            {
+                customNodeWorkspace.IsVisibleInDynamoLibrary = dynamoPreferences.IsVisibleInDynamoLibrary;
+            }
+
+            // Only RegisterHomeWorkspace if not a CustomNodeWorkspace
+            else
+            {
+                RegisterHomeWorkspace(homeWorkspace);
+            }
 
             return true;
         }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1555,19 +1555,13 @@ namespace Dynamo.Models
               if (!Int32.TryParse(dynamoPreferences.RunPeriod, out runPeriod))
                   runPeriod = RunSettings.DefaultRunPeriod;
               homeWorkspace.RunSettings = new RunSettings(runType, runPeriod);
+
+              RegisterHomeWorkspace(homeWorkspace);
             }
 
             CustomNodeWorkspaceModel customNodeWorkspace = workspace as CustomNodeWorkspaceModel;
             if (customNodeWorkspace != null)
-            {
                 customNodeWorkspace.IsVisibleInDynamoLibrary = dynamoPreferences.IsVisibleInDynamoLibrary;
-            }
-
-            // Only RegisterHomeWorkspace if not a CustomNodeWorkspace
-            else
-            {
-                RegisterHomeWorkspace(homeWorkspace);
-            }
 
             return true;
         }


### PR DESCRIPTION
### Purpose

This PR prevents CustomNodeWorkspaces from attempting to register to HomeWorkspace events.

In xml we had functions for `OpenXmlFile` and `OpenXmlHomeWorkspace` but in json this has been consolidated into `OpenJsonFile` and therefore we must perform this check to determine if we are dealing with a `HomeWorkspace` or `CustomNodeWorkspace`.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @mjkkirschner 

### FYIs

@smangarole 
