### PR TITLE
fix crash by checking for null

### DIFF
--- a/src/LibraryViewExtension/LibraryViewController.cs
+++ b/src/LibraryViewExtension/LibraryViewController.cs
@@ -107,18 +107,22 @@ namespace Dynamo.LibraryUI
         //if the window is resized toggle visibility of browser to force redraw
         private void DynamoWindow_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            this.browser.Visibility = Visibility.Hidden;
-            this.browser.Visibility = Visibility.Visible;
+            toggleBrowserVisibility(this.browser);
+        }
+
+        private void toggleBrowserVisibility(ChromiumWebBrowser browser)
+        {
+            if (browser != null)
+            {
+                browser.Visibility = Visibility.Hidden;
+                browser.Visibility = Visibility.Visible;
+            }
         }
 
         //if the dynamo window is minimized and then restored, force a layout update.
         private void DynamoWindowStateChanged(object sender, EventArgs e)
         {
-            if (this.dynamoWindow.WindowState == WindowState.Normal)
-            {
-                this.browser.Visibility = Visibility.Hidden;
-                this.browser.Visibility = Visibility.Visible;
-            }
+            toggleBrowserVisibility(this.browser);
         }
 
 
@@ -172,13 +176,13 @@ namespace Dynamo.LibraryUI
         {
             System.Diagnostics.Trace.WriteLine("*****Chromium Browser Messages******");
             System.Diagnostics.Trace.Write(e.ErrorText);
+            this.dynamoViewModel.Model.Logger.LogError(e.ErrorText);
         }
 
         //if the browser window itself is resized, toggle visibility to force redraw.
         private void Browser_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            this.browser.Visibility = Visibility.Hidden;
-            this.browser.Visibility = Visibility.Visible;
+            toggleBrowserVisibility(this.browser);
         }
 
         #region Tooltip


### PR DESCRIPTION

### Purpose

When Cef fails to start the browser can be null and needs to be checked for null before we try to resize it or change any properties on it.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@smangarole @jnealb 