### PR TITLE
no longer throw exception when xml is null (if we opened a json file)

### DIFF
--- a/src/DynamoCore/Graph/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Graph/Nodes/DummyNode.cs
@@ -161,6 +161,13 @@ namespace Dynamo.Graph.Nodes
                 if (legacyFullName != null)
                     LegacyFullName = legacyFullName.Value;
             }
+            else if (nodeElement.Attributes["OriginalNodeContent"] != null)
+            {
+                //we have some json, so lets parse it.
+               this.OriginalNodeContent = JObject.Parse(nodeElement.Attributes["OriginalNodeContent"].Value);
+            }
+
+
 
             var legacyAsm = nodeElement.Attributes["legacyAssembly"];
             if (legacyAsm != null)
@@ -172,6 +179,7 @@ namespace Dynamo.Graph.Nodes
                 var nature = Enum.Parse(typeof(Nature), nodeNature.Value);
                 NodeNature = ((Nature)nature);
             }
+
 
             UpdatePorts();
         }
@@ -226,6 +234,12 @@ namespace Dynamo.Graph.Nodes
 
                     originalNode.AppendChild(nodeContent);
                     nodeElement.AppendChild(originalNode);
+                }
+                //if the node actually came from JSON we need to
+                //still preserve that incase this node was copied or undo/redone
+                else if (OriginalNodeContent is JObject)
+                {
+                    nodeElement.SetAttribute("OriginalNodeContent", OriginalNodeContent.ToString());
                 }
             }
 
@@ -361,6 +375,9 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         public object OriginalNodeContent { get; private set; }
 
+        /// <summary>
+        /// This property returns the originalXmlContent if it exists or returns null.
+        /// </summary>
         private XmlElement OriginalXmlNodeContent
         {
             get
@@ -370,8 +387,10 @@ namespace Dynamo.Graph.Nodes
 
               XmlElement originalXmlElement = OriginalNodeContent as XmlElement;
               if (originalXmlElement == null)
-                  throw new InvalidOperationException("OriginalNodeContent is not an XmlElement.");
-
+                {
+                    return null;
+                }
+              
               return originalXmlElement;
             }
         }

--- a/src/DynamoCore/Graph/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Graph/Nodes/DummyNode.cs
@@ -12,7 +12,7 @@ namespace Dynamo.Graph.Nodes
     /// DummyNode is used for tests or in case if node couldn't be loaded.
     /// </summary>
     [NodeName("Legacy Node")]
-    [NodeDescription("DummyNodeDescription",typeof(Dynamo.Properties.Resources))]
+    [NodeDescription("DummyNodeDescription", typeof(Dynamo.Properties.Resources))]
     [IsMetaNode]
     [IsVisibleInDynamoLibrary(false)]
     [IsDesignScriptCompatible]
@@ -54,11 +54,11 @@ namespace Dynamo.Graph.Nodes
         /// <param name="legacyAssembly">Assembly of the node</param>
         /// <param name="nodeNature">Node can be Deprecated or Unresolved</param>
         public DummyNode(
-            int inputCount, 
-            int outputCount, 
-            string legacyName, 
-            XmlElement originalElement, 
-            string legacyAssembly, 
+            int inputCount,
+            int outputCount,
+            string legacyName,
+            XmlElement originalElement,
+            string legacyAssembly,
             Nature nodeNature)
         {
             InputCount = inputCount;
@@ -102,9 +102,9 @@ namespace Dynamo.Graph.Nodes
         /// <param name="legacyAssembly">Assembly of the node</param>
         /// <param name="originalElement">Original JSON description of the node</param>
         public DummyNode(
-            string id, 
-            int inputCount, 
-            int outputCount, 
+            string id,
+            int inputCount,
+            int outputCount,
             string legacyAssembly,
             JObject originalElement)
         {
@@ -128,9 +128,9 @@ namespace Dynamo.Graph.Nodes
 
             if (originalElement != null)
             {
-              var legacyFullName = originalElement["FunctionSignature"];
-              if (legacyFullName != null)
-                LegacyFullName = legacyFullName.ToString();
+                var legacyFullName = originalElement["FunctionSignature"];
+                if (legacyFullName != null)
+                    LegacyFullName = legacyFullName.ToString();
             }
 
             UpdatePorts();
@@ -164,7 +164,11 @@ namespace Dynamo.Graph.Nodes
             else if (nodeElement.Attributes["OriginalNodeContent"] != null)
             {
                 //we have some json, so lets parse it.
-               this.OriginalNodeContent = JObject.Parse(nodeElement.Attributes["OriginalNodeContent"].Value);
+                var jsonObject = JObject.Parse(nodeElement.Attributes["OriginalNodeContent"].Value);
+                if (jsonObject != null)
+                {
+                    this.OriginalNodeContent = jsonObject;
+                }
             }
 
 
@@ -339,7 +343,7 @@ namespace Dynamo.Graph.Nodes
             const string message = "Unhandled 'DummyNode.NodeNature' value: {0}";
             throw new InvalidOperationException(string.Format(message, NodeNature));
         }
-        
+
         /// <summary>
         /// Returns the number of input ports
         /// </summary>
@@ -382,16 +386,16 @@ namespace Dynamo.Graph.Nodes
         {
             get
             {
-              if (OriginalNodeContent == null)
-                  return null;
+                if (OriginalNodeContent == null)
+                    return null;
 
-              XmlElement originalXmlElement = OriginalNodeContent as XmlElement;
-              if (originalXmlElement == null)
+                XmlElement originalXmlElement = OriginalNodeContent as XmlElement;
+                if (originalXmlElement == null)
                 {
                     return null;
                 }
-              
-              return originalXmlElement;
+
+                return originalXmlElement;
             }
         }
     }

--- a/src/DynamoCore/Logging/Heartbeat.cs
+++ b/src/DynamoCore/Logging/Heartbeat.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
+using Dynamo.Graph.Workspaces;
 
 namespace Dynamo.Logging
 {
@@ -100,8 +101,7 @@ namespace Dynamo.Logging
                         () =>
                         {
                             string workspace = dynamoModel.CurrentWorkspace == null ? string.Empty :
-                                dynamoModel.CurrentWorkspace
-                                    .GetStringRepOfWorkspace();
+                                dynamoModel.CurrentWorkspace.ToJson(dynamoModel.EngineController);
                             Analytics.LogPiiInfo("Workspace", workspace);
                         });
 

--- a/src/DynamoCore/Logging/Heartbeat.cs
+++ b/src/DynamoCore/Logging/Heartbeat.cs
@@ -101,7 +101,7 @@ namespace Dynamo.Logging
                         () =>
                         {
                             string workspace = dynamoModel.CurrentWorkspace == null ? string.Empty :
-                                dynamoModel.CurrentWorkspace.ToJson(dynamoModel.EngineController);
+                                dynamoModel.CurrentWorkspace.GetStringRepOfWorkspace();
                             Analytics.LogPiiInfo("Workspace", workspace);
                         });
 

--- a/test/DynamoCoreTests/DummyNodeTests.cs
+++ b/test/DynamoCoreTests/DummyNodeTests.cs
@@ -1,0 +1,76 @@
+﻿using Dynamo.Graph.Nodes;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static Dynamo.Models.DynamoModel;
+
+namespace Dynamo.Tests
+{
+    internal class DummyNodeTests : DynamoModelTestBase
+    {
+        string testFileWithDummyNode = @"core\dummy_node\2080_JSONTESTCRASH undo_redo.dyn";
+
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("ProtoGeometry.dll");
+            libraries.Add("VMDataBridge.dll");
+            libraries.Add("DSCoreNodes.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        [Test]
+        public void CanCopyPasteJSONDummyNodeAndRetainsOriginalJSON()
+        {
+            string openPath = Path.Combine(TestDirectory, testFileWithDummyNode);
+            OpenModel(openPath);
+
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DummyNode>().Count());
+            //select the dummy node
+            CurrentDynamoModel.AddToSelection(CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DummyNode>().First());
+            CurrentDynamoModel.Copy();
+            CurrentDynamoModel.Paste();
+            //get both dummyNodes
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DummyNode>().Count());
+            var dummies = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DummyNode>().ToList();
+
+            var oc1 = (dummies[0].OriginalNodeContent as JObject).ToString();
+            var oc2 = (dummies[1].OriginalNodeContent as JObject).ToString();
+
+            Console.WriteLine(oc1);
+            Console.WriteLine(oc2);
+            //assert that originalData are the same string
+            Assert.AreEqual(oc1, oc2);
+
+        }
+
+        [Test]
+        public void CanMoveAndUndoJSONDummyNodeAndRetainsOriginalJSON()
+        {
+            string openPath = Path.Combine(TestDirectory, testFileWithDummyNode);
+            OpenModel(openPath);
+
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DummyNode>().Count());
+            var dummyNode = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DummyNode>().First();
+            var originalPos = dummyNode.X;
+            var contentPreMove = (dummyNode.OriginalNodeContent as JObject).ToString();
+            //move the node.
+            CurrentDynamoModel.ExecuteCommand(new UpdateModelValueCommand(dummyNode.GUID, "Position", "12.0;34.1"));
+            //assert we moved.
+            Assert.AreEqual(12, dummyNode.X);
+            //assert same content after move.
+            Assert.AreEqual(contentPreMove, (dummyNode.OriginalNodeContent as JObject).ToString());
+
+            //undo the move.
+            CurrentDynamoModel.CurrentWorkspace.Undo();
+            Assert.AreEqual(originalPos, dummyNode.X);
+
+            //assert the content is the same as when we started.
+            Assert.AreEqual(contentPreMove, (dummyNode.OriginalNodeContent as JObject).ToString());
+        }
+    }
+}

--- a/test/DynamoCoreTests/DummyNodeTests.cs
+++ b/test/DynamoCoreTests/DummyNodeTests.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static Dynamo.Models.DynamoModel;
+using Dynamo.Models;
 
 namespace Dynamo.Tests
 {
@@ -59,7 +59,7 @@ namespace Dynamo.Tests
             var originalPos = dummyNode.X;
             var contentPreMove = (dummyNode.OriginalNodeContent as JObject).ToString();
             //move the node.
-            CurrentDynamoModel.ExecuteCommand(new UpdateModelValueCommand(dummyNode.GUID, "Position", "12.0;34.1"));
+            CurrentDynamoModel.ExecuteCommand(new DynamoModel.UpdateModelValueCommand(dummyNode.GUID, "Position", "12.0;34.1"));
             //assert we moved.
             Assert.AreEqual(12, dummyNode.X);
             //assert same content after move.

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="AnalyticsTests.cs" />
     <Compile Include="AtLevelTest.cs" />
     <Compile Include="AttributeTest.cs" />
+    <Compile Include="DummyNodeTests.cs" />
     <Compile Include="ImperativeClodeBlockTest.cs" />
     <Compile Include="ListAtLevelTests.cs" />
     <Compile Include="MultiOutputNodeTest.cs" />

--- a/test/core/dummy_node/2080_JSONTESTCRASH undo_redo.dyn
+++ b/test/core/dummy_node/2080_JSONTESTCRASH undo_redo.dyn
@@ -1,0 +1,107 @@
+{
+  "Uuid": "edd9e95c-26a5-4ec2-bd1b-ca2a80bc827b",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "Home",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.UNKNOWNTYPE, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "4;",
+      "Id": "158f8f25ddb746c88323ae262e87611e",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "cddfa508b4a246fd94f79792d303cbf5",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "5;",
+      "Id": "6cbd0760736f4235a03b38fb359e9957",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "8234ec6cc018433da0605ddfb17cdc2b",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.0.2841",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "158f8f25ddb746c88323ae262e87611e",
+        "Excluded": false,
+        "X": 76.8,
+        "Y": 65.3999999999999
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "6cbd0760736f4235a03b38fb359e9957",
+        "Excluded": false,
+        "X": 76.8,
+        "Y": 162.4
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "da2bfb84f2fc4de1a08d0e7aedfb29a3",
+        "Excluded": false,
+        "X": 78.4,
+        "Y": 259.2
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/dummy_node/2080_JSONTESTCRASH undo_redo.dyn
+++ b/test/core/dummy_node/2080_JSONTESTCRASH undo_redo.dyn
@@ -89,14 +89,6 @@
         "Excluded": false,
         "X": 76.8,
         "Y": 162.4
-      },
-      {
-        "ShowGeometry": true,
-        "Name": "Code Block",
-        "Id": "da2bfb84f2fc4de1a08d0e7aedfb29a3",
-        "Excluded": false,
-        "X": 78.4,
-        "Y": 259.2
       }
     ],
     "Annotations": [],


### PR DESCRIPTION
https://jira.autodesk.com/browse/QNTM-2122

### Purpose

This PR attempts to deal with a crash which occurs when opening any file which has unresolved nodes which do not contain XML. So in effect any JSON file which contains dummy nodes as of master branch. (that might change after the PR for 2080)...

This occurs because of an assertion that is made in the getter for `OriginalXMLcontent` if the content was not xml an exception was raised. 

This getter is invoked very frequently upon any node property change, undo, redo, analytics upload, node move, node click etc.

What happens now is that null is simply returned instead, I investigated converting the JSON to xml etc and this turned out to be a big pain, things got very complex fast.

If we simply return null though, copy paste and undo/redo will not work correctly, as the JSON content of the dummy node will be lost... I had to modify the deserialize and serialize methods of dummy node to save the JSON content as a string and then parse it back if it existed... I believe this is the simplest fix possible until we actually refactor undo/redo copy/paste to stop using XML... hopefully this is sooner rather than later. ⚠️ 😢 🔜 

I've added some tests that assert the JSON content exists after copy paste and undo... I think we need more tests, any suggestions for good ones?

I also noticed that analytics heart beat is converting the WS to XML quite frequently, I found this quite odd, and switched it to JSON conversion, note that this WS will be missing the view block, there is no way around that without moving this code to the DynamoViewModel, I didn't know enough about what it does to do that in this PR.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
@ColinDayOrg 
### FYIs

@ramramps ~~@saintentropy~~(sorry for the ping) @jnealb @smangarole 