### PR TITLE
handle XML graphs with unresolved nodes.

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeLoaders/NodeFactory.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeLoaders/NodeFactory.cs
@@ -334,8 +334,13 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
             {
                 return node;
             }
+            //when we create a dummy node make sure to set the lacing accurately, as we want
+            //migration to be performed - this will ensure the generated json has the correct replication type.
+            //TODO check for null try parse.
+            var replicationFromXml = elNode.GetAttribute("lacing");
+            var argumentLacing = (LacingStrategy)Enum.Parse(typeof(LacingStrategy), replicationFromXml);
 
-            node = new DummyNode(1, 1, typeName, elNode, "", DummyNode.Nature.Deprecated);
+            node = new DummyNode(1, 1, typeName, elNode, "", DummyNode.Nature.Deprecated, argumentLacing);
             return node;
         }
 

--- a/src/DynamoCore/Graph/Nodes/NodeLoaders/ZeroTouchNodeLoader.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeLoaders/ZeroTouchNodeLoader.cs
@@ -108,13 +108,20 @@ namespace Dynamo.Graph.Nodes.NodeLoaders
             {
                 var inputcount = DetermineFunctionInputCount(nodeElement);
 
+                //when we create a dummy node make sure to set the lacing accurately, as we want
+                //migration to be performed - this will ensure the generated json has the correct replication type.
+                //TODO move to function, check for null.
+                var replicationFromXml = nodeElement.GetAttribute("lacing");
+                var argumentLacing = (LacingStrategy)Enum.Parse(typeof(LacingStrategy), replicationFromXml);
+
                 return new DummyNode(
                     inputcount,
                     1,
                     name,
                     nodeElement,
                     assembly,
-                    DummyNode.Nature.Unresolved);
+                    DummyNode.Nature.Unresolved,
+                    argumentLacing);
             }
 
             DSFunctionBase result;

--- a/src/DynamoCore/Graph/Workspaces/SerializationExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationExtensions.cs
@@ -23,6 +23,8 @@ namespace Dynamo.Graph.Workspaces
                 {
                     args.ErrorContext.Handled = true;
                     Console.WriteLine(args.ErrorContext.Error);
+                    //log any errors during serialization to the dynamo console as well.
+                    engine.AsLogger().Log(args.ErrorContext.Error);
                 },
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
                 TypeNameHandling = TypeNameHandling.Auto,

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1575,7 +1575,7 @@ namespace Dynamo.Graph.Workspaces
                 Converters = new List<JsonConverter>{
                         new ConnectorConverter(),
                         new WorkspaceReadConverter(engineController, scheduler, factory, isTestMode, verboseLogging),
-                        new NodeReadConverter(manager, libraryServices),
+                        new NodeReadConverter(manager, libraryServices,factory),
                         new TypedParameterConverter()
                     },
                 ReferenceResolverProvider = () => { return new IdReferenceResolver(); }


### PR DESCRIPTION
### Purpose
https://jira.autodesk.com/browse/QNTM-2080

This PR investigates what to do about the case where an XML based graph contains an unresolved node at the time we attempt to save it to JSON.

Currently Dynamo will do an odd thing:
 * when these graphs are saved these nodes are simply ignored.

I've tried to handle this in the following way though I am not convinced it is worth the tech debt:
 
When we open an XML file containing a node we cannot resolve we serialize this node to JSON as an `extensionNode` of concreteType ~ `DummyNode, DynamoCore` with a property `OriginalNodeContent` which contains the original XML content as a string.

When this node type gets deserialized later (lets say the next time we open this JSON graph, we can resolve this node) - then we deserialize this node using XML deserialization using the nodeFactory. This works pretty well except for some issues around ports and migrations.
 To make sure that lacing attributes are migrated correctly for instance we need to correctly set the lacing data on the dummy node, something that was never done before. Then it will be correct later. A similar thing happens for ports where we essentially want to combine properties from the XML and JSON representations of the node to produce a correct version.

 I feel this is prone to errors... 🐞  and requires keeping XML deserialization around a bit longer than we had planned for a use case we are not sure of the frequency of. (opening XML files with unresolved nodes) - but I think the current implementation will do a pretty good job in most cases if the dummy node is not interacted with (properties altered in dummy node state) Position changes work though ;)

I'm looking for feedback if this solution with it's cons is acceptable vs our other solution of simply refusing to save XML graphs with unresolved nodes to json without using saveAs - AND when saveAs is used simply deleting the nodes with some popup message.

I am writing tests for this PR and will fix the todos depending on feedback.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
@ColinDayOrg 
@ramramps 
### FYIs

@Racel @smangarole @jnealb 