### PR TITLE
Fix Revit/Advance Steel crash on Python dialogs

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -424,6 +424,7 @@
     <Compile Include="ViewModels\Preview\Watch3DFullscreenViewModel.cs" />
     <Compile Include="ViewModels\Preview\WatchViewModel.cs" />
     <Compile Include="ViewModels\Core\WorkspaceViewModel.cs" />
+    <Compile Include="Windows\ModelessChildWindow.cs" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="Controls\GraphUpdateNotificationControl.xaml">

--- a/src/DynamoCoreWpf/Windows/ModelessChildWindow.cs
+++ b/src/DynamoCoreWpf/Windows/ModelessChildWindow.cs
@@ -1,0 +1,40 @@
+﻿using Dynamo.Controls;
+using Dynamo.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media;
+
+namespace Dynamo.Wpf.Windows
+{
+    // <summary>
+    //  Display a modeless child window that is parented on the Dynamo window
+    //  and will close when the Dynamo window is closed.
+    // </summary>
+    public class ModelessChildWindow : Window
+    {
+        /// <summary>
+        /// Construct a ModelessChildWindow.
+        /// </summary>
+        /// <param name="viewParent">A UI object in the Dynamo visual tree.</param>
+        public ModelessChildWindow(DependencyObject viewParent)
+        {
+            Owner = WpfUtilities.FindUpVisualTree<DynamoView>(viewParent);
+            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            Owner.Closing += OwnerWindow_Closing;
+        }
+
+        private void OwnerWindow_Closing(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+
+        private void ChildWindow_Closing(object sender, EventArgs e)
+        {
+            Owner.Closing -= OwnerWindow_Closing;
+        }
+    }
+}

--- a/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
+++ b/src/Libraries/PythonNodeModelsWpf/PythonNode.cs
@@ -14,6 +14,7 @@ namespace PythonNodeModelsWpf
     {
         private DynamoViewModel dynamoViewModel;
         private PythonNode model;
+        private NodeView view;
         private ScriptEditorWindow editWindow;
 
         public void CustomizeView(PythonNode nodeModel, NodeView nodeView)
@@ -21,6 +22,7 @@ namespace PythonNodeModelsWpf
             base.CustomizeView(nodeModel, nodeView);
 
             model = nodeModel;
+            view = nodeView;
             dynamoViewModel = nodeView.ViewModel.DynamoViewModel;
 
             var editWindowItem = new MenuItem { Header = PythonNodeModels.Properties.Resources.EditHeader, IsCheckable = false };
@@ -40,7 +42,7 @@ namespace PythonNodeModelsWpf
             }
         }
 
-        public void view_EditWindowClosed(object sender, EventArgs e)
+        public void editWindow_Closed(object sender, EventArgs e)
         {
             editWindow = null;
         }
@@ -55,20 +57,11 @@ namespace PythonNodeModelsWpf
                 }
                 else
                 {
-                    editWindow = new ScriptEditorWindow(dynamoViewModel, model);
+                    editWindow = new ScriptEditorWindow(dynamoViewModel, model, view);
                     editWindow.Initialize(model.GUID, "ScriptContent", model.Script);
-                    editWindow.Closed += this.view_EditWindowClosed;
-                    System.Windows.Application.Current.MainWindow.Closing += delegate { Application_Exit(); };
+                    editWindow.Closed += editWindow_Closed;
                     editWindow.Show();
                 }
-            }
-        }
-
-        private void Application_Exit()
-        {
-            if (editWindow != null)
-            {
-                editWindow.Close();
             }
         }
     }

--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml
@@ -1,8 +1,9 @@
-﻿<Window x:Class="PythonNodeModelsWpf.ScriptEditorWindow"
+﻿<dww:ModelessChildWindow x:Class="PythonNodeModelsWpf.ScriptEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:avalonedit="clr-namespace:ICSharpCode.AvalonEdit;assembly=ICSharpCode.AvalonEdit"
         xmlns:ui1="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
+        xmlns:dww="clr-namespace:Dynamo.Wpf.Windows;assembly=DynamoCoreWpf"
         xmlns:p="clr-namespace:PythonNodeModels.Properties;assembly=PythonNodeModels"
         Title="{Binding nodeModel.Name, Mode=OneWay, RelativeSource={RelativeSource Self}}" Height="500" Width="600">
 
@@ -44,4 +45,4 @@
         </Grid>
     </Grid>
 
-</Window>
+</dww:ModelessChildWindow>

--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Media;
 using System.Xml;
 using Dynamo.Controls;
 using Dynamo.Models;
@@ -12,13 +11,14 @@ using ICSharpCode.AvalonEdit.CodeCompletion;
 using ICSharpCode.AvalonEdit.Highlighting;
 using ICSharpCode.AvalonEdit.Highlighting.Xshd;
 using PythonNodeModels;
+using Dynamo.Wpf.Windows;
 
 namespace PythonNodeModelsWpf
 {
     /// <summary>
     /// Interaction logic for ScriptEditorWindow.xaml
     /// </summary>
-    public partial class ScriptEditorWindow : Window
+    public partial class ScriptEditorWindow : ModelessChildWindow
     {
         private string propertyName = string.Empty;
         private Guid boundNodeId = Guid.Empty;
@@ -29,17 +29,20 @@ namespace PythonNodeModelsWpf
         private bool nodeWasModified = false;
         private string originalScript;
 
-        public ScriptEditorWindow(DynamoViewModel dynamoViewModel, PythonNode nodeModel)
+        public ScriptEditorWindow(
+            DynamoViewModel dynamoViewModel, 
+            PythonNode nodeModel, 
+            NodeView nodeView
+            ) : base(nodeView)
         {
             this.dynamoViewModel = dynamoViewModel;
             this.nodeModel = nodeModel;
+
             completionProvider = new IronPythonCompletionProvider();
             completionProvider.MessageLogged += dynamoViewModel.Model.Logger.Log;
 
             InitializeComponent();
-            var view = FindUpVisualTree<DynamoView>(this);
-            Owner = view;
-            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+
             Dynamo.Logging.Analytics.TrackScreenView("Python");
         }
 
@@ -158,16 +161,6 @@ namespace PythonNodeModelsWpf
 
         #endregion
 
-        // walk up the visual tree to find object of type T, starting from initial object
-        private static T FindUpVisualTree<T>(DependencyObject initial) where T : DependencyObject
-        {
-            DependencyObject current = initial;
 
-            while (current != null && current.GetType() != typeof(T))
-            {
-                current = VisualTreeHelper.GetParent(current);
-            }
-            return current as T;
-        }
     }
 }


### PR DESCRIPTION

### Purpose

* Move modeless dialog plumbing to separate class
* Fix crash when the execution environment is not Sandbox (e.g. Revit, Advance Steel)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap @mjkkirschner 
