### PR TITLE
Do not save files when xmlDummyNodes are present

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -597,7 +597,7 @@ namespace Dynamo.Graph.Workspaces
                 return new ConnectorModel(startPort, endPort, connectorId);
             }
             else
-            {   //TODO should we log a notification to alert user that graph is missing nodes?
+            {
                 this.logger.LogWarning(
                     string.Format("connector {0} could not be created, start or end port does not exist", connectorId),
                     Logging.WarningLevel.Moderate);

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -547,6 +547,17 @@ namespace Dynamo.Graph.Workspaces
     /// </summary>
     public class ConnectorConverter : JsonConverter
     {
+        private Logging.ILogger logger;
+        
+        /// <summary>
+        /// Constructs a ConnectorConverter.
+        /// </summary>
+        /// <param name="logger"></param>
+        public ConnectorConverter(Logging.ILogger logger)
+        {
+            this.logger = logger;
+        }
+
         public override bool CanConvert(Type objectType)
         {
             return objectType == typeof(ConnectorModel);
@@ -581,8 +592,17 @@ namespace Dynamo.Graph.Workspaces
 
             //if the id is not a guid, makes a guid based on the id of the model
             Guid connectorId = GuidUtility.tryParseOrCreateGuid(obj["Id"].Value<string>());
-
-            return new ConnectorModel(startPort, endPort, connectorId);
+            if(startPort != null && endPort != null)
+            {
+                return new ConnectorModel(startPort, endPort, connectorId);
+            }
+            else
+            {   //TODO should we log a notification to alert user that graph is missing nodes?
+                this.logger.LogWarning(
+                    string.Format("connector {0} could not be created, start or end port does not exist", connectorId),
+                    Logging.WarningLevel.Moderate);
+                return null;
+            }
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/DynamoCore/Graph/Workspaces/SerializationExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationExtensions.cs
@@ -28,7 +28,7 @@ namespace Dynamo.Graph.Workspaces
                 TypeNameHandling = TypeNameHandling.Auto,
                 Formatting = Formatting.Indented,
                 Converters = new List<JsonConverter>{
-                        new ConnectorConverter(),                        
+                        new ConnectorConverter(engine.AsLogger()),                        
                         new WorkspaceWriteConverter(engine),
                         new DummyNodeWriteConverter(),
                         new TypedParameterConverter()

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -531,8 +531,9 @@ namespace Dynamo.Graph.Workspaces
         /// Returns if current workspace is readonly.
         /// </summary>
         public bool IsReadOnly
-        {
-            get { return isReadOnly; }
+        {   
+            //if the workspace contains xmlDummyNodes it's effectively a readonly graph.
+            get { return isReadOnly || this.containsXmlDummyNodes(); }
             set
             {
                 isReadOnly = value;
@@ -1320,6 +1321,16 @@ namespace Dynamo.Graph.Workspaces
         #endregion
 
         #region private/internal methods
+        /// <summary>
+        /// Returns true if the graph currently contains dummy node which point to XML content.
+        /// These nodes cannot be serialized to json correctly.
+        /// </summary>
+        /// <returns></returns>
+        internal bool containsXmlDummyNodes()
+        {
+            //if the workspace being added has dummy nodes which contain XML, log a notification.
+            return this.Nodes.OfType<DummyNode>().Where(node => node.OriginalNodeContent is XmlElement).Count()> 0;
+        }
 
         private void SerializeElementResolver(XmlDocument xmlDoc)
         {
@@ -1573,7 +1584,7 @@ namespace Dynamo.Graph.Workspaces
                 TypeNameHandling = TypeNameHandling.Auto,
                 Formatting = Newtonsoft.Json.Formatting.Indented,
                 Converters = new List<JsonConverter>{
-                        new ConnectorConverter(),
+                        new ConnectorConverter(engineController.AsLogger()),
                         new WorkspaceReadConverter(engineController, scheduler, factory, isTestMode, verboseLogging),
                         new NodeReadConverter(manager, libraryServices),
                         new TypedParameterConverter()
@@ -1651,6 +1662,12 @@ namespace Dynamo.Graph.Workspaces
                     // NOTE: These parameters are not directly accessible due to undo/redo considerations
                     //       which should not be used during deserialization (see "ArgumentLacing" for details)
                     nodeModel.UpdateValue(new UpdateValueParams("IsVisible", nodeViewInfo.ShowGeometry.ToString()));
+                }
+                else
+                {   //TODO we may want to raise an event which logs a notification.
+                    this.Log(string.Format("This graph has a nodeview with id:{0} and name:{1}, but does not contain a matching nodeModel", 
+                        guidValue.ToString(),nodeViewInfo.Name)
+                        , WarningLevel.Moderate);
                 }
             }
         }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1328,7 +1328,6 @@ namespace Dynamo.Graph.Workspaces
         /// <returns></returns>
         internal bool containsXmlDummyNodes()
         {
-            //if the workspace being added has dummy nodes which contain XML, log a notification.
             return this.Nodes.OfType<DummyNode>().Where(node => node.OriginalNodeContent is XmlElement).Count()> 0;
         }
 
@@ -1664,7 +1663,7 @@ namespace Dynamo.Graph.Workspaces
                     nodeModel.UpdateValue(new UpdateValueParams("IsVisible", nodeViewInfo.ShowGeometry.ToString()));
                 }
                 else
-                {   //TODO we may want to raise an event which logs a notification.
+                {   
                     this.Log(string.Format("This graph has a nodeview with id:{0} and name:{1}, but does not contain a matching nodeModel", 
                         guidValue.ToString(),nodeViewInfo.Name)
                         , WarningLevel.Moderate);

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1407,7 +1407,7 @@ namespace Dynamo.Models
                             OpenWorkspace(ws);
                             //Raise an event to deserialize the view parameters before
                             //setting the graph to run
-                            OnComputeModelDeSerialized();
+                            OnComputeModelDeserialized();
  
                             SetPeriodicEvaluation(ws);
                         }
@@ -2265,7 +2265,42 @@ namespace Dynamo.Models
             };
 
             _workspaces.Add(workspace);
+            //TODO move this to some handler for the event...
+            CheckForXMLDummyNodes(workspace);
             OnWorkspaceAdded(workspace);
+        }
+
+        private void CheckForXMLDummyNodes(WorkspaceModel workspace)
+        {
+            //if the graph that is opened contains xml dummynodes log a notification 
+            if (workspace.containsXmlDummyNodes())
+            {
+                this.Logger.LogNotification("DynamoViewModel",
+                  Resources.UnresolvedNodesWarningTitle,
+                  Resources.UnresolvedNodesWarningShortMessage,
+                  Resources.UnresolvedNodesWarningMessage);
+
+                //raise a window as well so the user is clearly alerted to this state.
+                DisplayXmlDummyNodeWarning();
+            }
+        }
+        private void DisplayXmlDummyNodeWarning()
+        {
+           var xmlDummyNodeCount = this.CurrentWorkspace.Nodes.OfType<DummyNode>().
+                Where(node => node.OriginalNodeContent is XmlElement).Count();
+
+           Logging.Analytics.LogPiiInfo("XmlDummyNodeWarning",
+               xmlDummyNodeCount.ToString());
+
+            string summary = Resources.UnresolvedNodesWarningShortMessage;
+            var description = Resources.UnresolvedNodesWarningMessage;
+            const string imageUri = "/DynamoCoreWpf;component/UI/Images/task_dialog_future_file.png";
+            var args = new TaskDialogEventArgs(
+               new Uri(imageUri, UriKind.Relative),
+               Resources.UnresolvedNodesWarningTitle, summary, description);
+
+            args.AddRightAlignedButton((int)ButtonId.Proceed, Resources.OKButton);
+            OnRequestTaskDialog(null, args);
         }
 
         enum ButtonId
@@ -2364,7 +2399,7 @@ namespace Dynamo.Models
 
             Logging.Analytics.LogPiiInfo("FutureFileMessage", fullFilePath +
                 " :: fileVersion:" + fileVer + " :: currVersion:" + currVer);
-
+            
             string summary = Resources.FutureFileSummary;
             var description = string.Format(Resources.FutureFileDescription, fullFilePath, fileVersion, currVersion);
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2264,7 +2264,6 @@ namespace Dynamo.Models
             };
 
             _workspaces.Add(workspace);
-            //TODO move this to some handler for the event...
             CheckForXMLDummyNodes(workspace);
             OnWorkspaceAdded(workspace);
         }

--- a/src/DynamoCore/Models/DynamoModelEvents.cs
+++ b/src/DynamoCore/Models/DynamoModelEvents.cs
@@ -331,17 +331,17 @@ namespace Dynamo.Models
         }
 
         /// <summary>
-        /// Occurs after compute section of the workspace is serialized
+        /// This Event is raised after the compute section of the workspace is deserialized
         /// </summary>
-        internal event Action ComputeModelDeSerialized;
+        internal event Action ComputeModelDeserialized;
 
         /// <summary>
         /// Triggers ComputeModelSerialized event
         /// </summary>
-        internal virtual void OnComputeModelDeSerialized()
+        internal virtual void OnComputeModelDeserialized()
         {
-            if (ComputeModelDeSerialized != null)
-                ComputeModelDeSerialized();
+            if (ComputeModelDeserialized != null)
+                ComputeModelDeserialized();
         }
 
         #endregion

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -1476,6 +1476,33 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This graph currently contains some unresolved nodes, and cannot be saved until the nodes are resolved. If the graph is saved using SaveAs - the unresolved nodes will be removed from the file..
+        /// </summary>
+        public static string UnresolvedNodesWarningMessage {
+            get {
+                return ResourceManager.GetString("UnresolvedNodesWarningMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This graph cannot be saved until unresolved nodes are removed or resolved..
+        /// </summary>
+        public static string UnresolvedNodesWarningShortMessage {
+            get {
+                return ResourceManager.GetString("UnresolvedNodesWarningShortMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Graph Contains Unresolved Nodes and Cannot Be Saved..
+        /// </summary>
+        public static string UnresolvedNodesWarningTitle {
+            get {
+                return ResourceManager.GetString("UnresolvedNodesWarningTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Update available: {0}.
         /// </summary>
         public static string UpdateAvailable {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -653,4 +653,13 @@ value : bool = false</value>
     <value>Home</value>
     <comment>The default name of home workspace</comment>
   </data>
+  <data name="UnresolvedNodesWarningShortMessage" xml:space="preserve">
+    <value>This graph cannot be saved until unresolved nodes are removed or resolved.</value>
+  </data>
+  <data name="UnresolvedNodesWarningTitle" xml:space="preserve">
+    <value>Graph Contains Unresolved Nodes and Cannot Be Saved.</value>
+  </data>
+  <data name="UnresolvedNodesWarningMessage" xml:space="preserve">
+    <value>This graph currently contains some unresolved nodes, and cannot be saved until the nodes are resolved. If the graph is saved using SaveAs - the unresolved nodes will be removed from the file.</value>
+  </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -662,4 +662,13 @@ value : bool = false</value>
     <value>Home</value>
     <comment>The default name of home workspace</comment>
   </data>
+  <data name="UnresolvedNodesWarningMessage" xml:space="preserve">
+    <value>This graph currently contains some unresolved nodes, and cannot be saved until the nodes are resolved. If the graph is saved using SaveAs - the unresolved nodes will be removed from the file.</value>
+  </data>
+  <data name="UnresolvedNodesWarningShortMessage" xml:space="preserve">
+    <value>This graph cannot be saved until unresolved nodes are removed or resolved.</value>
+  </data>
+  <data name="UnresolvedNodesWarningTitle" xml:space="preserve">
+    <value>Graph Contains Unresolved Nodes and Cannot Be Saved.</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -37,7 +37,6 @@ using System.Windows.Forms;
 using System.Windows.Threading;
 using ISelectable = Dynamo.Selection.ISelectable;
 
-
 namespace Dynamo.ViewModels
 {
     public interface IDynamoViewModel : INotifyPropertyChanged
@@ -562,7 +561,7 @@ namespace Dynamo.ViewModels
             BackgroundPreviewViewModel.PropertyChanged += Watch3DViewModelPropertyChanged;
             WatchHandler.RequestSelectGeometry += BackgroundPreviewViewModel.AddLabelForPath;
             RegisterWatch3DViewModel(BackgroundPreviewViewModel, RenderPackageFactoryViewModel.Factory);
-            model.ComputeModelDeSerialized += model_ComputeModelDeSerialized;
+            model.ComputeModelDeserialized += model_ComputeModelDeserialized;
         }
 
         /// <summary>
@@ -1276,7 +1275,7 @@ namespace Dynamo.ViewModels
         /// <summary>
         /// Read the contents of the file and set the view parameters for that current workspace
         /// </summary>
-        private void model_ComputeModelDeSerialized()
+        private void model_ComputeModelDeserialized()
         {
             if (filePath == String.Empty) return;
             string fileContents = File.ReadAllText(filePath);

--- a/test/DynamoCoreTests/DummyNodeTests.cs
+++ b/test/DynamoCoreTests/DummyNodeTests.cs
@@ -14,6 +14,9 @@ namespace Dynamo.Tests
     internal class DummyNodeTests : DynamoModelTestBase
     {
         string testFileWithDummyNode = @"core\dummy_node\2080_JSONTESTCRASH undo_redo.dyn";
+        string testFileWithXmlDummyNode = @"core\dummy_node\dummyNode.dyn";
+        string testFileWithMultipleXmlDummyNode = @"core\dummy_node\dummyNodeXMLMultiple.dyn";
+
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
@@ -71,6 +74,21 @@ namespace Dynamo.Tests
 
             //assert the content is the same as when we started.
             Assert.AreEqual(contentPreMove, (dummyNode.OriginalNodeContent as JObject).ToString());
+        }
+
+        [Test]
+        public void WorkspaceIsReadonly_IfXmlDummyNodePresent()
+        {
+            string openPath = Path.Combine(TestDirectory, testFileWithXmlDummyNode);
+            OpenModel(openPath);
+
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DummyNode>().Count());
+            var dummyNode = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DummyNode>().First();
+            Assert.IsTrue(this.CurrentDynamoModel.CurrentWorkspace.IsReadOnly);
+
+            //delete the dummy node
+            this.CurrentDynamoModel.CurrentWorkspace.RemoveAndDisposeNode(dummyNode);
+            Assert.IsFalse(this.CurrentDynamoModel.CurrentWorkspace.IsReadOnly);
         }
     }
 }

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -554,6 +554,30 @@ namespace Dynamo.Tests
             Assert.IsFalse(def.HasUnsavedChanges);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void WorkspaceWithDummyXmlNodesSavesAndOpensWithoutThrowing()
+        {
+            //openPath
+            var testFileWithMultipleXmlDummyNode = @"core\dummy_node\dummyNodeXMLMultiple.dyn";
+            string openPath = Path.Combine(TestDirectory, testFileWithMultipleXmlDummyNode);
+            ViewModel.OpenCommand.Execute(openPath);
+            var nodeCount1 = ViewModel.CurrentSpace.Nodes.Count();
+
+            //try saving this graph
+            var newPath = GetNewFileNameOnTempPath("dyn");
+            Assert.DoesNotThrow(()=> { this.ViewModel.SaveAs(newPath); }) ;
+
+            //try to open the file we just saved.
+            Assert.DoesNotThrow(() => { ViewModel.OpenCommand.Execute(newPath); });
+            var nodeCount2 = ViewModel.CurrentSpace.Nodes.Count();
+            //assert we are missing the dummy nodes after opening
+            Assert.Less(nodeCount2, nodeCount1);
+            Assert.IsNotNull(this.ViewModel);
+            Assert.DoesNotThrow(() => { ViewModel.Model.ClearCurrentWorkspace(); });
+            System.IO.File.Delete(newPath);
+        }
+
         #region CustomNodeWorkspaceModel SaveAs side effects
 
         [Test]

--- a/test/core/dummy_node/dummyNodeXMLMultiple.dyn
+++ b/test/core/dummy_node/dummyNodeXMLMultiple.dyn
@@ -1,0 +1,10 @@
+<Workspace Version="0.7.6.3912" X="99.1977448010291" Y="167.824962319859" zoom="0.342081630871005" Name="Home">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="6a5b9043-a953-4909-913d-5616609f8e3c" type="Dynamo.Nodes.DSFunction" nickname="Foo" x="0" y="0" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="FooBar.dll" function="Foo@int" />
+    <Dynamo.Nodes.DSFunction guid="6a5b9043-a953-4909-913d-5616609f8e3b" type="Dynamo.Nodes.DSFunction" nickname="Foo" x="0" y="0" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="FooBar.dll" function="Foo@int" />
+    <Dynamo.Nodes.DSFunction guid="6a5b9043-a953-4909-913d-5616609f8e3d" type="Dynamo.Nodes.DSFunction" nickname="Foo" x="0" y="0" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="FooBar.dll" function="Foo@int" />
+  </Elements>
+  <Connectors>
+  </Connectors>
+</Workspace>


### PR DESCRIPTION



### Purpose
If a graph is opened that contains xml based DummyNodes, a notification and message box are both displayed with a similar message about the state of the graph - alerting the user that saving the file will activate SaveAs and that saving the graph in the current state will lose the unresolved nodes.
https://jira.autodesk.com/browse/QNTM-2080

if a user hits the save button or save menuitem in this state, a saveAs dialog box will appear letting them save over the original file or create a new file.

if a user opens the JSON file which is now missing unresolved nodes messages are logged to the console for the missing connectors and nodes. I'm thinking we may also want to log notifications so this state is clear without checking the console.

I have not been able to reproduce the crash from opening a graph in this state any longer.

I need to add tests.

<img width="1429" alt="screen shot 2017-10-17 at 1 31 32 am" src="https://user-images.githubusercontent.com/508936/31648464-df773fe2-b2db-11e7-8a5d-32e86568a6f5.png">
<img width="1488" alt="screen shot 2017-10-17 at 1 31 21 am" src="https://user-images.githubusercontent.com/508936/31648465-df8c40b8-b2db-11e7-8b70-20752d76c423.png">

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
@ColinDayOrg 
### FYIs

@smangarole @Racel 