### PR TITLE
Add Default Value when deserialize Dynamo Nodes

### DIFF
--- a/src/Libraries/CoreNodeModels/Range.cs
+++ b/src/Libraries/CoreNodeModels/Range.cs
@@ -24,7 +24,14 @@ namespace CoreNodeModels
         [JsonConstructor]
         private Range(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
+            if (inPorts.Count() == 3)
+            {
+                inPorts.ElementAt(0).DefaultValue = startPortDefaultValue;
+                inPorts.ElementAt(1).DefaultValue = endPortDefaultValue;
+                inPorts.ElementAt(2).DefaultValue = stepPortDefaultValue;
+            }
             ArgumentLacing = LacingStrategy.Auto;
+            SetNodeStateBasedOnConnectionAndDefaults();
         }
 
         public Range()
@@ -103,7 +110,14 @@ namespace CoreNodeModels
         [JsonConstructor]
         private Sequence(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
+            if (inPorts.Count() == 3)
+            {
+                inPorts.ElementAt(0).DefaultValue = startPortDefaultValue;
+                inPorts.ElementAt(1).DefaultValue = amountPortDefaultValue;
+                inPorts.ElementAt(2).DefaultValue = stepPortDefaultValue;
+            }
             ArgumentLacing = LacingStrategy.Auto;
+            SetNodeStateBasedOnConnectionAndDefaults();
         }
 
         public Sequence()

--- a/src/Libraries/CoreNodeModels/Range.cs
+++ b/src/Libraries/CoreNodeModels/Range.cs
@@ -21,6 +21,11 @@ namespace CoreNodeModels
         private readonly IntNode endPortDefaultValue = new IntNode(9);
         private readonly IntNode stepPortDefaultValue = new IntNode(1);
 
+        /// <summary>
+        /// Json Constructor for Range Node
+        /// </summary>
+        /// <param name="inPorts"></param>
+        /// <param name="outPorts"></param>
         [JsonConstructor]
         private Range(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
@@ -30,10 +35,21 @@ namespace CoreNodeModels
                 inPorts.ElementAt(1).DefaultValue = endPortDefaultValue;
                 inPorts.ElementAt(2).DefaultValue = stepPortDefaultValue;
             }
+            else
+            {
+                // If information from json does not look correct, clear the default ports and add ones with default value
+                InPorts.Clear();
+                InPorts.Add(new PortModel(PortType.Input, this, new PortData("start", Resources.RangePortDataStartToolTip, startPortDefaultValue)));
+                InPorts.Add(new PortModel(PortType.Input, this, new PortData("end", Resources.RangePortDataEndToolTip, endPortDefaultValue)));
+                InPorts.Add(new PortModel(PortType.Input, this, new PortData("step", Resources.RangePortDataStepToolTip, stepPortDefaultValue)));
+            }
             ArgumentLacing = LacingStrategy.Auto;
             SetNodeStateBasedOnConnectionAndDefaults();
         }
 
+        /// <summary>
+        /// Default constructor for Range Node
+        /// </summary>
         public Range()
         {
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("start", Resources.RangePortDataStartToolTip, startPortDefaultValue)));

--- a/src/Libraries/CoreNodeModels/Range.cs
+++ b/src/Libraries/CoreNodeModels/Range.cs
@@ -133,6 +133,15 @@ namespace CoreNodeModels
                 inPorts.ElementAt(1).DefaultValue = amountPortDefaultValue;
                 inPorts.ElementAt(2).DefaultValue = stepPortDefaultValue;
             }
+            else
+            {
+                // If information from json does not look correct, clear the default ports and add ones with default value
+                InPorts.Clear();
+                InPorts.Add(new PortModel(PortType.Input, this, new PortData("start", Resources.RangePortDataStartToolTip, startPortDefaultValue)));
+                InPorts.Add(new PortModel(PortType.Input, this, new PortData("amount", Resources.RangePortDataAmountToolTip, amountPortDefaultValue)));
+                InPorts.Add(new PortModel(PortType.Input, this, new PortData("step", Resources.RangePortDataStepToolTip, stepPortDefaultValue)));
+            }
+            if (outPorts.Count() == 0) OutPorts.Add(new PortModel(PortType.Output, this, new PortData("seq", Resources.RangePortDataSeqToolTip)));
             ArgumentLacing = LacingStrategy.Auto;
             SetNodeStateBasedOnConnectionAndDefaults();
         }

--- a/src/Libraries/CoreNodeModels/Range.cs
+++ b/src/Libraries/CoreNodeModels/Range.cs
@@ -43,6 +43,7 @@ namespace CoreNodeModels
                 InPorts.Add(new PortModel(PortType.Input, this, new PortData("end", Resources.RangePortDataEndToolTip, endPortDefaultValue)));
                 InPorts.Add(new PortModel(PortType.Input, this, new PortData("step", Resources.RangePortDataStepToolTip, stepPortDefaultValue)));
             }
+            if(outPorts.Count() == 0) OutPorts.Add(new PortModel(PortType.Output, this, new PortData("seq", Resources.RangePortDataSeqToolTip)));
             ArgumentLacing = LacingStrategy.Auto;
             SetNodeStateBasedOnConnectionAndDefaults();
         }


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[QNTM-2123](https://jira.autodesk.com/browse/QNTM-2123) Use Defaults right click is disabled for Range Node

It turns out `Range` and `Sequence` nodes are the only two instances of built-in Dynamo nodes missing default port values so I am adding them in their json constructor. Ideally there should be some magic on nodeModel level to handle this free for all nodes. But I failed to find a way to do this magic in base class because we will need nodetype to call child constructor then base constructor is invoked first but by that time default port values are still defined in the child class. Let me know if you have any suggestions. My current plan is to create a wiki page educating how 3rd party devs can define default port values and use it when deserialization.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
I found there are XML tests covering this, e.g. `RangeSyntax` so this should be covered once we enable tests to run on JSON DYNs. I am hesitated to add new json tests since the new one will be dup of work after that.
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps @mjkkirschner 

### FYIs


