### PR TITLE
Fix for calling List methods inside imperative blocks

### DIFF
--- a/src/Engine/ProtoCore/ClassTable.cs
+++ b/src/Engine/ProtoCore/ClassTable.cs
@@ -204,24 +204,24 @@ namespace ProtoCore.DSASM
         //    1.3 Return member function whose access == kPublic
         //
         // 2. In global scope, classScope == kInvalidIndex;
-        public ProtoCore.DSASM.ProcedureNode GetMemberFunction(string procName, List<ProtoCore.Type> argTypeList, int classScope, out bool isAccessible, out int functionHostClassIndex, bool isStaticOrConstructor = false)
+        public ProcedureNode GetMemberFunction(string procName, List<ProtoCore.Type> argTypeList, int classScope, out bool isAccessible, out int functionHostClassIndex, bool isStaticOrConstructor = false)
         {
             isAccessible = false;
-            functionHostClassIndex = ProtoCore.DSASM.Constants.kInvalidIndex;
+            functionHostClassIndex = Constants.kInvalidIndex;
 
             if (ProcTable == null)
                 return null;
 
-            ProtoCore.DSASM.ProcedureNode procNode = null;
+            ProcedureNode procNode = null;
 
             int functionIndex = ProcTable.IndexOf(procName, argTypeList, isStaticOrConstructor);
-            if (functionIndex != ProtoCore.DSASM.Constants.kInvalidIndex)
+            if (functionIndex != Constants.kInvalidIndex)
             {
                 int myClassIndex = TypeSystem.classTable.IndexOf(Name);
                 functionHostClassIndex = myClassIndex;
                 procNode = ProcTable.Procedures[functionIndex];
 
-                if (classScope == ProtoCore.DSASM.Constants.kInvalidIndex)
+                if (classScope == Constants.kInvalidIndex)
                 {
                     isAccessible = (procNode.AccessModifier == CompilerDefinitions.AccessModifier.Public);
                 }

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -278,10 +278,8 @@ namespace ProtoImperative
                 arglist.Add(paramType);
             }
 
-            ProtoCore.DSASM.ProcedureNode procNode = null;
-            int type = ProtoCore.DSASM.Constants.kInvalidIndex;
-            bool isConstructor = false;
-            bool isStatic = false;
+            ProcedureNode procNode = null;
+            int type = Constants.kInvalidIndex;
             bool hasLogError = false;
 
             int refClassIndex = Constants.kInvalidIndex;
@@ -295,18 +293,18 @@ namespace ProtoImperative
             }
 
             // If lefttype is a valid class then check if calling a constructor
-            if ((int)ProtoCore.PrimitiveType.InvalidType != inferedType.UID && (int)ProtoCore.PrimitiveType.Void != inferedType.UID)
+            if ((int)PrimitiveType.InvalidType != inferedType.UID && (int)PrimitiveType.Void != inferedType.UID)
             {
-                bool isAccessible;
-                int realType;
-
                 if (procName != Constants.kFunctionPointerCall)
                 {
                     bool isStaticOrConstructor = refClassIndex != Constants.kInvalidIndex;
                     var classNode = core.ClassTable.ClassNodes[inferedType.UID];
+
+                    bool isAccessible;
+                    int realType;
                     procNode = classNode.GetMemberFunction(procName, arglist, globalClassIndex, out isAccessible, out realType, isStaticOrConstructor);
 
-                    if (isStaticOrConstructor)
+                    if (isStaticOrConstructor && procNode == null)
                     {
                         procNode = classNode.GetFirstConstructorBy(procName, arglist.Count);
                         if (procNode == null)
@@ -323,8 +321,6 @@ namespace ProtoImperative
 
                     if (procNode != null)
                     {
-                        isConstructor = procNode.IsConstructor;
-                        isStatic = procNode.IsStatic;
                         type = lefttype = realType;
 
                         if (!isAccessible)

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -22,7 +22,7 @@ namespace DSCore
     public static class List
     {
         /// <summary>
-        ///     An Empty List.
+        ///     Returns an Empty List.
         /// </summary>
         /// <returns name="list">Empty list.</returns>
         /// <search>empty list, emptylist,[]</search>

--- a/test/Engine/ProtoTest/Imperative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Imperative/MicroFeatureTests.cs
@@ -1077,6 +1077,30 @@ def fac : int( n : int )
         }
 
         [Test]
+        public void ListMethod_Imperative()
+        {
+            var code =
+@"
+import(""DSCoreNodes.dll"");
+import(""BuiltIn.ds"");
+a = [Imperative]
+{
+counter = 0;
+lst = {};
+while(counter < 10)
+{
+lst = List.AddItemToEnd(counter, lst);
+counter = counter + 1;
+}
+return = lst;
+};
+  ";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("a", new object[] { 0,1,2,3,4,5,6,7,8,9 }
+);
+        }
+
+        [Test]
         public void NegativeIndexOnCollection003()
         {
             String code =


### PR DESCRIPTION
### Purpose

This fixes a regression caused by #7819 when calling List methods inside imperative blocks.
JIRA Link: https://jira.autodesk.com/browse/QNTM-2356

As part of #7819 we introduced a new DS class by name `List` that wrapped calls to the list builtins and derived from the ZT class `DSCore.List` in `DSCoreNodes`. The reason for doing this was to fold all List methods, both builtins as well as zero touch, under a single `List` class in order to make them work nicely with autocomplete in CBN's plus align with the new Library structure, i.e. have them all arranged under one `List` category.

The bug (described in JIRA) appeared as a result of the above change because in imperative codegen, the procedure node for a List method, although it was returned properly by looking it up from the class hierarchy, the class index was still pointing to the derived class, namely, `List` and not `DSCore.List`. The fix is to point the class index to the class ID contained within the procedure node that is returned correctly.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

<img width="407" alt="screen shot 2017-10-19 at 11 40 12 am" src="https://user-images.githubusercontent.com/5710686/31780027-97ff4d24-b4c2-11e7-9d32-54351cc35886.png">

### FYIs
@mjkkirschner @mrahmaniasl 
