### PR TITLE
QNTM-1965: Fix for zipped lacing post list promotion changes

### DIFF
--- a/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
@@ -397,7 +397,10 @@ namespace ProtoCore.Lang.Replication
                     if (ri.Zipped)
                     {
                         foreach (int idx in ri.ZipIndecies)
-                            maxReductionDepths[idx] = maxReductionDepths[idx] - 1;
+                        {
+                            if(maxReductionDepths[idx] > 0)
+                                maxReductionDepths[idx] = maxReductionDepths[idx] - 1;
+                        }
                     }
                     else
                     {

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -35,7 +35,7 @@ namespace Dynamo.Tests
         public void Regress561()
         {
             // 1; ----> x
-            // 2; ----> y .ByCoordinates(x, y, z);
+            // 2; ----> y Point.ByCoordinates(x, y, z);
             // 3; ----> z
             RunModel(@"core\dsevaluation\regress561.dyn");
             AssertClassName("8774296c-5269-450b-959d-ce4020ddbf80", "Autodesk.DesignScript.Geometry.Point");

--- a/test/DynamoCoreTests/DSEvaluationModelTest.cs
+++ b/test/DynamoCoreTests/DSEvaluationModelTest.cs
@@ -35,7 +35,7 @@ namespace Dynamo.Tests
         public void Regress561()
         {
             // 1; ----> x
-            // 2; ----> y Point.ByCoordinates(x, y, z);
+            // 2; ----> y .ByCoordinates(x, y, z);
             // 3; ----> z
             RunModel(@"core\dsevaluation\regress561.dyn");
             AssertClassName("8774296c-5269-450b-959d-ce4020ddbf80", "Autodesk.DesignScript.Geometry.Point");
@@ -664,6 +664,46 @@ namespace Dynamo.Tests
 
             AssertPreviewValue("d9b9d0a9-1fec-4b20-82c4-2d1665306509", new int[] { 4, 6, 7 });
             AssertPreviewValue("c35f1c6d-b955-4638-802f-208f93112078", new object[] { new int[] { 4, 5, 6 }, new int[] { 5, 6, 7 } });
+        }
+
+        [Test]
+        public void Test_Longest_Lacing()
+        {
+            RunModel(@"core\dsevaluation\longest_lacing.dyn");
+
+            AssertPreviewValue("c9476b21a972476788e184982918700e", new object[]
+            {
+                new[] {3, 4, 5}, new[] {7, 8, 9}, new[] {8, 9, 10}
+            });
+        }
+
+        [Test]
+        public void Test_Auto_Lacing()
+        {
+            RunModel(@"core\dsevaluation\auto_lacing.dyn");
+
+            AssertPreviewValue("c9476b21a972476788e184982918700e",
+                new object[] {new[] {3, 4, 5}, new[] {7, 8, 9}});
+        }
+
+        [Test]
+        public void Test_Cross_Lacing()
+        {
+            RunModel(@"core\dsevaluation\cross_lacing.dyn");
+
+            AssertPreviewValue("c9476b21a972476788e184982918700e", new object[]
+            {
+                new object[] {new[] {3, 4, 5}, new[] {4, 5, 6}, new[] {5, 6, 7}},
+                new object[] {new[] {6, 7, 8}, new[] {7, 8, 9}, new[] {8, 9, 10}}
+            });
+        }
+
+        [Test]
+        public void Test_Shortest_Lacing()
+        {
+            RunModel(@"core\dsevaluation\shortest_lacing.dyn");
+
+            AssertPreviewValue("c9476b21a972476788e184982918700e", new object[] {new[] {3, 4, 5}});
         }
 
         [Test]

--- a/test/core/dsevaluation/auto_lacing.dyn
+++ b/test/core/dsevaluation/auto_lacing.dyn
@@ -1,0 +1,161 @@
+{
+  "Uuid": "5f171e29-cba2-47b6-a0df-b3cceb606241",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "Home",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "{1..3, 4..6};\n1..3;\n1;",
+      "Id": "e50c1c999df84755ad4f64ffc35b6bb3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4d48a90869e244a3b58298b20427dfff",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cf34473beb4d4bad98e515513264ffd1",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3de0ea03b44c49fa8819a29825576f24",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "def foo(x, y, z)\n{\n\treturn x+y+z;\n}\nfoo(a, b, c);",
+      "Id": "c9476b21a972476788e184982918700e",
+      "Inputs": [
+        {
+          "Id": "754f2312c87b4e759d69f3787b0a74e0",
+          "Name": "a",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "652f2ad56fec40c39c69e85eba1a3021",
+          "Name": "b",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5c4a96023b9c492fa73fdb545b00fc67",
+          "Name": "c",
+          "Description": "c",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b12e98cb063545898f880e4b9dbefdc6",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "4d48a90869e244a3b58298b20427dfff",
+      "End": "754f2312c87b4e759d69f3787b0a74e0",
+      "Id": "3189905a81d24d899f2d329afe985a7b"
+    },
+    {
+      "Start": "cf34473beb4d4bad98e515513264ffd1",
+      "End": "652f2ad56fec40c39c69e85eba1a3021",
+      "Id": "444f5653a2c14336ba5bfe0b6d9decf6"
+    },
+    {
+      "Start": "3de0ea03b44c49fa8819a29825576f24",
+      "End": "5c4a96023b9c492fa73fdb545b00fc67",
+      "Id": "6885d597e53343909d4f22229c53dc52"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.0.2967",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -4.0812240985643733,
+      "EyeY": 19.0894291853785,
+      "EyeZ": 11.061506781679528,
+      "LookX": 13.440191730132705,
+      "LookY": -14.872155307949512,
+      "LookZ": -14.570419692502922,
+      "UpX": 0.28117168088060362,
+      "UpY": 0.90996127087654344,
+      "UpZ": -0.30481629119114106
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "e50c1c999df84755ad4f64ffc35b6bb3",
+        "Excluded": false,
+        "X": 69.0,
+        "Y": 8.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "c9476b21a972476788e184982918700e",
+        "Excluded": false,
+        "X": 575.0,
+        "Y": 48.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/dsevaluation/cross_lacing.dyn
+++ b/test/core/dsevaluation/cross_lacing.dyn
@@ -1,0 +1,161 @@
+{
+  "Uuid": "5f171e29-cba2-47b6-a0df-b3cceb606241",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "Home",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "{1..3, 4..6};\n1..3;\n1;",
+      "Id": "e50c1c999df84755ad4f64ffc35b6bb3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4d48a90869e244a3b58298b20427dfff",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cf34473beb4d4bad98e515513264ffd1",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3de0ea03b44c49fa8819a29825576f24",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "def foo(x, y, z)\n{\n\treturn x+y+z;\n}\nfoo(a<1>, b<2>, c<3>);",
+      "Id": "c9476b21a972476788e184982918700e",
+      "Inputs": [
+        {
+          "Id": "64ea6a36f678486fb5c0532c81ebe50f",
+          "Name": "a",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e9c915227f8d45eeba939b878d120a76",
+          "Name": "b",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "ed8c7c2616784678b4e4aaf46567e32f",
+          "Name": "c",
+          "Description": "c",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "56d4416565714e8c9dcfe3964f55a1da",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "4d48a90869e244a3b58298b20427dfff",
+      "End": "64ea6a36f678486fb5c0532c81ebe50f",
+      "Id": "6b3159ff93cb4d9bb7e1efc0b29a40d9"
+    },
+    {
+      "Start": "cf34473beb4d4bad98e515513264ffd1",
+      "End": "e9c915227f8d45eeba939b878d120a76",
+      "Id": "fff2ca84a61249c29c816ef5c68ccdf6"
+    },
+    {
+      "Start": "3de0ea03b44c49fa8819a29825576f24",
+      "End": "ed8c7c2616784678b4e4aaf46567e32f",
+      "Id": "269d3a34ae9741d6ba48b1718f6e8c4c"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.0.2967",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -4.0812240985643733,
+      "EyeY": 19.0894291853785,
+      "EyeZ": 11.061506781679528,
+      "LookX": 13.440191730132705,
+      "LookY": -14.872155307949512,
+      "LookZ": -14.570419692502922,
+      "UpX": 0.28117168088060362,
+      "UpY": 0.90996127087654344,
+      "UpZ": -0.30481629119114106
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "e50c1c999df84755ad4f64ffc35b6bb3",
+        "Excluded": false,
+        "X": 69.0,
+        "Y": 8.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "c9476b21a972476788e184982918700e",
+        "Excluded": false,
+        "X": 575.0,
+        "Y": 48.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/dsevaluation/longest_lacing.dyn
+++ b/test/core/dsevaluation/longest_lacing.dyn
@@ -1,0 +1,161 @@
+{
+  "Uuid": "5f171e29-cba2-47b6-a0df-b3cceb606241",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "Home",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "{1..3, 4..6};\n1..3;\n1;",
+      "Id": "e50c1c999df84755ad4f64ffc35b6bb3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4d48a90869e244a3b58298b20427dfff",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cf34473beb4d4bad98e515513264ffd1",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3de0ea03b44c49fa8819a29825576f24",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "def foo(x, y, z)\n{\n\treturn x+y+z;\n}\nfoo(a<1L>, b<1L>, c<1L>);",
+      "Id": "c9476b21a972476788e184982918700e",
+      "Inputs": [
+        {
+          "Id": "7afd634f93c24082b0a020b42e09e49b",
+          "Name": "a",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "50700351c68c465dbd5b6a497bd11463",
+          "Name": "b",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "ea8730a918874ea3bfa9254d953f1a08",
+          "Name": "c",
+          "Description": "c",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "297c7d924e3d462496bc2d5e49a2c573",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "4d48a90869e244a3b58298b20427dfff",
+      "End": "7afd634f93c24082b0a020b42e09e49b",
+      "Id": "63f193a1435e47dc81ee736431e8172b"
+    },
+    {
+      "Start": "cf34473beb4d4bad98e515513264ffd1",
+      "End": "50700351c68c465dbd5b6a497bd11463",
+      "Id": "7dfae4232bef48bcb729d2585a1d2d22"
+    },
+    {
+      "Start": "3de0ea03b44c49fa8819a29825576f24",
+      "End": "ea8730a918874ea3bfa9254d953f1a08",
+      "Id": "fbf5f94a5f544c138f86bb547b384606"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.0.2967",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -4.0812240985643733,
+      "EyeY": 19.0894291853785,
+      "EyeZ": 11.061506781679528,
+      "LookX": 13.440191730132705,
+      "LookY": -14.872155307949512,
+      "LookZ": -14.570419692502922,
+      "UpX": 0.28117168088060362,
+      "UpY": 0.90996127087654344,
+      "UpZ": -0.30481629119114106
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "e50c1c999df84755ad4f64ffc35b6bb3",
+        "Excluded": false,
+        "X": 69.0,
+        "Y": 8.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "c9476b21a972476788e184982918700e",
+        "Excluded": false,
+        "X": 575.0,
+        "Y": 48.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/dsevaluation/shortest_lacing.dyn
+++ b/test/core/dsevaluation/shortest_lacing.dyn
@@ -1,0 +1,161 @@
+{
+  "Uuid": "5f171e29-cba2-47b6-a0df-b3cceb606241",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "Home",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "{1..3, 4..6};\n1..3;\n1;",
+      "Id": "e50c1c999df84755ad4f64ffc35b6bb3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4d48a90869e244a3b58298b20427dfff",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cf34473beb4d4bad98e515513264ffd1",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3de0ea03b44c49fa8819a29825576f24",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "def foo(x, y, z)\n{\n\treturn x+y+z;\n}\nfoo(a<1>, b<1>, c<1>);",
+      "Id": "c9476b21a972476788e184982918700e",
+      "Inputs": [
+        {
+          "Id": "d8c1bb6236f44db4adc96dd87d80ac76",
+          "Name": "a",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c526981909c9437f93349520c3f4042d",
+          "Name": "b",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a6a9dda723814591bc577d1e1c879cb4",
+          "Name": "c",
+          "Description": "c",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "010a5080e7f64b9aa69355810e7e7780",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "4d48a90869e244a3b58298b20427dfff",
+      "End": "d8c1bb6236f44db4adc96dd87d80ac76",
+      "Id": "cb0c22e300f042148c78855dbf14d36f"
+    },
+    {
+      "Start": "cf34473beb4d4bad98e515513264ffd1",
+      "End": "c526981909c9437f93349520c3f4042d",
+      "Id": "8b88ea229c274bd0bd9af77e16171243"
+    },
+    {
+      "Start": "3de0ea03b44c49fa8819a29825576f24",
+      "End": "a6a9dda723814591bc577d1e1c879cb4",
+      "Id": "1158713993df4a3fba2f5e0fec13a336"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.0.2967",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -4.0812240985643733,
+      "EyeY": 19.0894291853785,
+      "EyeZ": 11.061506781679528,
+      "LookX": 13.440191730132705,
+      "LookY": -14.872155307949512,
+      "LookZ": -14.570419692502922,
+      "UpX": 0.28117168088060362,
+      "UpY": 0.90996127087654344,
+      "UpZ": -0.30481629119114106
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "e50c1c999df84755ad4f64ffc35b6bb3",
+        "Excluded": false,
+        "X": 69.0,
+        "Y": 8.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "c9476b21a972476788e184982918700e",
+        "Excluded": false,
+        "X": 575.0,
+        "Y": 48.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

This is a fix for regressions caused by changes in #8073 to disable list promotion of arguments when passed into nodes with lacing. 
JIRA Link: https://jira.autodesk.com/browse/QNTM-1965

**Note:** There is a pending defect with differences of behaviour found with the use of default argument as described below. This bug has also been referred to in #7773 and does not surface so glaringly in 1.3 and earlier as older versions precede the introduction of the "shortest lacing" option that has been added to nodes in 2.0:

![image](https://user-images.githubusercontent.com/5710686/31870866-2c431ae8-b77e-11e7-9795-67b2d513880f.png)

![image](https://user-images.githubusercontent.com/5710686/31870891-5084055c-b77e-11e7-8365-6c75cfcd5fb2.png)

Both the scenarios are expected to return the same result but as can be seen in the second example, the reason for the difference is that in the case of a default argument, the replication guide (lacing) is not applied to the default argument, which explains the difference in behaviour. This needs to be addressed by generating the correct DS code that applies the relevant lacing options to the default argument as well.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate - adding unit tests in progress ...
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### FYIs

@Racel @QilongTang @jnealb @smangarole 
