### PR TITLE
crash when passing null engine to workspaceConverter

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -598,9 +598,14 @@ namespace Dynamo.Graph.Workspaces
             }
             else
             {
-                this.logger.LogWarning(
-                    string.Format("connector {0} could not be created, start or end port does not exist", connectorId),
-                    Logging.WarningLevel.Moderate);
+                if (this.logger!=null)
+                {
+                    this.logger.LogWarning(
+                       string.Format("connector {0} could not be created, start or end port does not exist", connectorId),
+                       Logging.WarningLevel.Moderate);
+
+                }
+                
                 return null;
             }
         }

--- a/src/DynamoCore/Graph/Workspaces/SerializationExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationExtensions.cs
@@ -17,6 +17,8 @@ namespace Dynamo.Graph.Workspaces
         /// <returns>A string representing the serialized WorkspaceModel.</returns>
         internal static string ToJson(this WorkspaceModel workspace, EngineController engine)
         {
+            var logger = engine != null ? engine.AsLogger() : null;
+
             var settings = new JsonSerializerSettings
             {
                 Error = (sender, args) =>
@@ -28,7 +30,7 @@ namespace Dynamo.Graph.Workspaces
                 TypeNameHandling = TypeNameHandling.Auto,
                 Formatting = Formatting.Indented,
                 Converters = new List<JsonConverter>{
-                        new ConnectorConverter(engine.AsLogger()),                        
+                        new ConnectorConverter(logger),                        
                         new WorkspaceWriteConverter(engine),
                         new DummyNodeWriteConverter(),
                         new TypedParameterConverter()

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -2277,9 +2277,11 @@ namespace Dynamo.Models
                   Resources.UnresolvedNodesWarningTitle,
                   Resources.UnresolvedNodesWarningShortMessage,
                   Resources.UnresolvedNodesWarningMessage);
-
+                if (!IsTestMode)
+                {
+                    DisplayXmlDummyNodeWarning();
+                }
                 //raise a window as well so the user is clearly alerted to this state.
-                DisplayXmlDummyNodeWarning();
             }
         }
         private void DisplayXmlDummyNodeWarning()

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -507,6 +507,13 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void ConverterDoesNotThrowWithNullEngine()
+        {
+            CurrentDynamoModel.AddHomeWorkspace();
+            Assert.DoesNotThrow(()=>{ CurrentDynamoModel.CurrentWorkspace.ToJson(null); });
+        }
+
+        [Test]
         public void CustomNodeSerializationTest()
         {
             var customNodeTestPath = Path.Combine(TestDirectory, @"core\CustomNodes\TestAdd.dyn");


### PR DESCRIPTION
### Purpose

* Check for null on logger and engine.
* Don't display unresolved node warning when in test mode.

https://jira.autodesk.com/browse/QNTM-2080

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@smangarole 