### PR TITLE
[WIP] QNTM-1636: Add a package path if needed when importing a library.

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -763,6 +763,11 @@ namespace Dynamo.Models
             }
         }
 
+        /// <summary>
+        /// Adds a new path to the list of custom package folders, but only if the path
+        /// does not already exist in the list.
+        /// </summary>
+        /// <param name="path"> The path to add.</param>
         public bool AddPackagePath(string path)
         {
             if (!Directory.Exists(path))

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -637,10 +637,7 @@ namespace Dynamo.Models
 
             // Make sure that the default package folder is added in the list if custom packages folder.
             var userDataFolder = pathManager.GetUserDataFolder(); // Get the default user data path
-            if (Directory.Exists(userDataFolder) && !PreferenceSettings.CustomPackageFolders.Contains(userDataFolder))
-            {
-                PreferenceSettings.CustomPackageFolders.Add(userDataFolder);
-            }
+            AddPackagePath(userDataFolder);
 
             // Check if the Python template file specified in the settings file exists & it's not empty
             // If not, check the default filepath for the Python template (userDataFolder\PythonTemplate.py).
@@ -764,6 +761,19 @@ namespace Dynamo.Models
                     Logger.Log(ex.Message);
                 }
             }
+        }
+
+        public bool AddPackagePath(string path)
+        {
+            if (!Directory.Exists(path))
+                return false;
+          
+            if (PreferenceSettings.CustomPackageFolders.Contains(path))
+                return false;
+
+            PreferenceSettings.CustomPackageFolders.Add(path);
+
+            return true;
         }
 
         private IEnumerable<IExtension> LoadExtensions()

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -3696,6 +3696,33 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The import path &quot;{0}&quot; was added to &quot;Manage Node and Package Paths&quot;. If you want to update or remove this path, please open &quot;Settings &gt; Manage Node and Package Paths...&quot;.
+        /// </summary>
+        public static string PackagePathAutoAddNotificationDetailedDescription {
+            get {
+                return ResourceManager.GetString("PackagePathAutoAddNotificationDetailedDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to &quot;Settings &gt; Manage Node and Package Paths...&quot;.
+        /// </summary>
+        public static string PackagePathAutoAddNotificationShortDescription {
+            get {
+                return ResourceManager.GetString("PackagePathAutoAddNotificationShortDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package Path Added.
+        /// </summary>
+        public static string PackagePathAutoAddNotificationTitle {
+            get {
+                return ResourceManager.GetString("PackagePathAutoAddNotificationTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Accept Changes.
         /// </summary>
         public static string PackagePathViewAccept {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1611,6 +1611,15 @@ Next assemblies were loaded several times:
     <value>Move the selected path upward</value>
     <comment>Tool-tip for up arrow</comment>
   </data>
+  <data name="PackagePathAutoAddNotificationTitle" xml:space="preserve">
+    <value>Package Path Added</value>
+  </data>
+  <data name="PackagePathAutoAddNotificationShortDescription" xml:space="preserve">
+    <value>A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to "Settings > Manage Node and Package Paths..."</value>
+  </data>
+  <data name="PackagePathAutoAddNotificationDetailedDescription" xml:space="preserve">
+    <value>The import path "{0}" was added to "Manage Node and Package Paths". If you want to update or remove this path, please open "Settings > Manage Node and Package Paths..."</value>
+  </data>
   <data name="PackageSearchStateNoResult" xml:space="preserve">
     <value>Search returned no results!</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1960,6 +1960,15 @@ Do you want to install the latest Dynamo update?</value>
     <value>Move the selected path upward</value>
     <comment>Tool-tip for up arrow</comment>
   </data>
+  <data name="PackagePathAutoAddNotificationTitle" xml:space="preserve">
+    <value>Package Path Added</value>
+  </data>
+  <data name="PackagePathAutoAddNotificationShortDescription" xml:space="preserve">
+    <value>A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to "Settings > Manage Node and Package Paths..."</value>
+  </data>
+  <data name="PackagePathAutoAddNotificationDetailedDescription" xml:space="preserve">
+    <value>The import path "{0}" was added to "Manage Node and Package Paths". If you want to update or remove this path, please open "Settings > Manage Node and Package Paths..."</value>
+  </data>
   <data name="NodeContextMenuIsInput" xml:space="preserve">
     <value>Is Input</value>
   </data>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2248,6 +2248,15 @@ namespace Dynamo.ViewModels
                     foreach (var file in openFileDialog.FileNames)
                     {
                         EngineController.ImportLibrary(file);
+                        string path = new FileInfo(file).Directory.FullName;
+                        if (this.Model.AddPackagePath(path))
+                        {
+                            this.Model.Logger.LogNotification(
+                                "Dynamo", 
+                                "Package Path Added", 
+                                "Due to importing a library a package path has been added to the \"Manage Node and Package Paths\" options.", 
+                                "The import path \"" + path + "\" has been added to the \"Manage Node and Package Paths\" options.");
+                        }
                     }
                     SearchViewModel.SearchAndUpdateResults();
                 }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2251,9 +2251,9 @@ namespace Dynamo.ViewModels
                         string path = new FileInfo(file).Directory.FullName;
                         if (this.Model.AddPackagePath(path))
                         {
-                            string title = "Package Path Added";
-                            string shortMessage = "A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to \"Settings > Manage Node and Package Paths...\"";
-                            string detailedMessage = "The import path \"{0}\" was added to \"Manage Node and Package Paths\". If you want to update or remove this path, please open \"Settings > Manage Node and Package Paths...\"";
+                            string title = Resources.PackagePathAutoAddNotificationTitle;
+                            string shortMessage = Resources.PackagePathAutoAddNotificationShortDescription;
+                            string detailedMessage = Resources.PackagePathAutoAddNotificationDetailedDescription;
                             this.Model.Logger.LogNotification(
                                 "Dynamo", 
                                 title,

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2253,12 +2253,12 @@ namespace Dynamo.ViewModels
                         {
                             string title = "Package Path Added";
                             string shortMessage = "A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to \"Settings > Manage Node and Package Paths...\"";
-                            string detailedMessage = "The import path \"" + path + "\" was added to \"Manage Node and Package Paths\". If you want to update or remove this path, please open \"Settings > Manage Node and Package Paths...\"";
+                            string detailedMessage = "The import path \"{0}\" was added to \"Manage Node and Package Paths\". If you want to update or remove this path, please open \"Settings > Manage Node and Package Paths...\"";
                             this.Model.Logger.LogNotification(
                                 "Dynamo", 
                                 title,
                                 shortMessage, 
-                                detailedMessage);
+                                string.Format(detailedMessage, path));
                         }
                     }
                     SearchViewModel.SearchAndUpdateResults();

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2251,11 +2251,14 @@ namespace Dynamo.ViewModels
                         string path = new FileInfo(file).Directory.FullName;
                         if (this.Model.AddPackagePath(path))
                         {
+                            string title = "Package Path Added";
+                            string shortMessage = "A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to \"Settings > Manage Node and Package Paths...\"";
+                            string detailedMessage = "The import path \"" + path + "\" was added to \"Manage Node and Package Paths\". If you want to update or remove this path, please open \"Settings > Manage Node and Package Paths...\"";
                             this.Model.Logger.LogNotification(
                                 "Dynamo", 
-                                "Package Path Added", 
-                                "Due to importing a library a package path has been added to the \"Manage Node and Package Paths\" options.", 
-                                "The import path \"" + path + "\" has been added to the \"Manage Node and Package Paths\" options.");
+                                title,
+                                shortMessage, 
+                                detailedMessage);
                         }
                     }
                     SearchViewModel.SearchAndUpdateResults();


### PR DESCRIPTION
Note: This PR is WIP pending unit tests being created.

### Purpose

This PR adds a path to the "Manage Node and Package Paths" options automatically when a library is imported. (If the path has already been added it is not duplicated.) A notification is added to the Notification Center to alert the user to the change.

![image](https://user-images.githubusercontent.com/10959111/32011558-18e90ea6-b983-11e7-9ea4-5d3db8c378e4.png)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [not yet] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [n/a] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@QilongTang 

### FYIs

@Racel
