### PR TITLE
Save xml test files as json files w/ identical folder structure

### DIFF
--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -578,13 +578,13 @@ namespace DynamoCoreWpfTests
 
         }
 
-        private static string SaveJsonTempWithFolderStructure(DynamoViewModel viewModel, string originalPath, JObject jo)
+        private static string SaveJsonTempWithFolderStructure(DynamoViewModel viewModel, string filePath, JObject jo)
         {   
             // Get all folder structure following "\\test"
-            var expectedStructure = originalPath.Split(new string[] { "\\test" }, StringSplitOptions.None).Last();
+            var expectedStructure = filePath.Split(new string[] { "\\test" }, StringSplitOptions.None).Last();
 
             // Current test fileName
-            var fileName = Path.GetFileName(originalPath);
+            var fileName = Path.GetFileName(filePath);
 
             // Get temp folder path
             var tempPath = Path.GetTempPath();

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -593,7 +593,6 @@ namespace DynamoCoreWpfTests
             // Get temp folder path
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, "DynamoTestJSON");
-            var thing = Path.GetDirectoryName(expectedStructure);
             jsonFolder += Path.GetDirectoryName(expectedStructure);
 
             if (!System.IO.Directory.Exists(jsonFolder))
@@ -902,7 +901,6 @@ namespace DynamoCoreWpfTests
         public object[] FindWorkspaces()
         {
             var di = new DirectoryInfo(TestDirectory);
-            //var fis = di.GetFiles("*.dyn", SearchOption.AllDirectories);
             var fis = new string[] { "*.dyn", "*.dyf" }
             .SelectMany(i => di.GetFiles(i, SearchOption.AllDirectories));
             return fis.Select(fi => fi.FullName).ToArray();

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -542,12 +542,8 @@ namespace DynamoCoreWpfTests
             lastExecutionDuration = new TimeSpan();
 
             // Open JSON .dyn or .dyf
-            var fileName = Path.GetFileName(filePath);
-            string folderPath = Path.GetFullPath(Path.Combine(filePath, @".."));
-
-            // Determine required exntension (dyn or dyf)
-            var fileExtension = filePath.Split('.');
-            this.ViewModel.OpenCommand.Execute(filePathBase + '.' + fileExtension[fileExtension.Length - 1]);
+            var fileExtension = Path.GetExtension(filePath);
+            this.ViewModel.OpenCommand.Execute(filePathBase + fileExtension);
 
             var ws2 = ViewModel.CurrentSpaceViewModel;
             Assert.NotNull(ws2);

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -514,7 +514,7 @@ namespace DynamoCoreWpfTests
         }
 
         private void DoWorkspaceOpenAndCompareView(string filePath, string dirName,
-           Func<DynamoViewModel, string, string, string> saveFunction,
+           Func<DynamoViewModel, string, string> saveFunction,
            Action<WorkspaceViewComparisonData, WorkspaceViewComparisonData> workspaceViewCompareFunction,
            Action<WorkspaceViewComparisonData, string, TimeSpan,Dictionary<Guid,string>> workspaceViewDataSaveFunction)
         {
@@ -535,7 +535,7 @@ namespace DynamoCoreWpfTests
             //no longer do this, as its done in model serialization tests.
             //ConvertCurrentWorkspaceToDesignScriptAndSave(filePathBase);
 
-            string json = saveFunction(this.ViewModel, filePathBase, filePath);
+            string json = saveFunction(this.ViewModel, filePath);
 
             workspaceViewDataSaveFunction(wcd1, filePathBase, lastExecutionDuration,this.modelsGuidToIdMap);
 
@@ -609,7 +609,7 @@ namespace DynamoCoreWpfTests
             return jo.ToString();
         }
 
-        private static string ConvertCurrentWorkspaceViewToJsonAndSave(DynamoViewModel viewModel, string filePathBase, string filePath)
+        private static string ConvertCurrentWorkspaceViewToJsonAndSave(DynamoViewModel viewModel, string filePath)
         {
             // Stage 1: Serialize the workspace.
             var jsonModel = viewModel.Model.CurrentWorkspace.ToJson(viewModel.Model.EngineController);
@@ -645,7 +645,7 @@ namespace DynamoCoreWpfTests
             return jo.ToString();
         }
 
-        private string ConvertCurrentWorkspaceViewToNonGuidJsonAndSave(DynamoViewModel viewModel, string filePathBase, string filePath)
+        private string ConvertCurrentWorkspaceViewToNonGuidJsonAndSave(DynamoViewModel viewModel, string filePath)
         {
             // Stage 1: Serialize the workspace.
             var jsonModel = viewModel.Model.CurrentWorkspace.ToJson(viewModel.Model.EngineController);

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -514,7 +514,7 @@ namespace DynamoCoreWpfTests
         }
 
         private void DoWorkspaceOpenAndCompareView(string filePath, string dirName,
-           Func<DynamoViewModel, string, string> saveFunction,
+           Func<DynamoViewModel, string, string, string> saveFunction,
            Action<WorkspaceViewComparisonData, WorkspaceViewComparisonData> workspaceViewCompareFunction,
            Action<WorkspaceViewComparisonData, string, TimeSpan,Dictionary<Guid,string>> workspaceViewDataSaveFunction)
         {
@@ -535,14 +535,20 @@ namespace DynamoCoreWpfTests
             //no longer do this, as its done in model serialization tests.
             //ConvertCurrentWorkspaceToDesignScriptAndSave(filePathBase);
 
-            string json = saveFunction(this.ViewModel, filePathBase);
+            string json = saveFunction(this.ViewModel, filePathBase, filePath);
 
             workspaceViewDataSaveFunction(wcd1, filePathBase, lastExecutionDuration,this.modelsGuidToIdMap);
 
             lastExecutionDuration = new TimeSpan();
 
-            //make sure we're opening the json here
-            this.ViewModel.OpenCommand.Execute(filePathBase + ".dyn");
+            // Open JSON .dyn or .dyf
+            var fileName = Path.GetFileName(filePath);
+            string folderPath = Path.GetFullPath(Path.Combine(filePath, @".."));
+
+            // Determine required exntension (dyn or dyf)
+            var fileExtension = filePath.Split('.');
+            this.ViewModel.OpenCommand.Execute(filePathBase + '.' + fileExtension[fileExtension.Length - 1]);
+
             var ws2 = ViewModel.CurrentSpaceViewModel;
             Assert.NotNull(ws2);
 
@@ -576,9 +582,40 @@ namespace DynamoCoreWpfTests
 
         }
 
-        private static string ConvertCurrentWorkspaceViewToJsonAndSave(DynamoViewModel viewModel, string filePathBase)
-        {
+        private static string SaveJsonTempWithFolderStructure(DynamoViewModel viewModel, string originalPath, JObject jo)
+        {   
+            // Get all folder structure following "\\test"
+            var expectedStructure = originalPath.Split(new string[] { "\\test" }, StringSplitOptions.None).Last();
 
+            // Current test fileName
+            var fileName = Path.GetFileName(originalPath);
+
+            // Get temp folder path
+            var tempPath = Path.GetTempPath();
+            var jsonFolder = Path.Combine(tempPath, "DynamoTestJSON");
+            var thing = Path.GetDirectoryName(expectedStructure);
+            jsonFolder += Path.GetDirectoryName(expectedStructure);
+
+            if (!System.IO.Directory.Exists(jsonFolder))
+            {
+                System.IO.Directory.CreateDirectory(jsonFolder);
+            }
+
+            // Combine directory with test file name
+            var jsonPath = jsonFolder + "\\" + fileName;
+
+            if (File.Exists(jsonPath))
+            {
+                File.Delete(jsonPath);
+            }
+
+            File.WriteAllText(jsonPath, jo.ToString());
+
+            return jo.ToString();
+        }
+
+        private static string ConvertCurrentWorkspaceViewToJsonAndSave(DynamoViewModel viewModel, string filePathBase, string filePath)
+        {
             // Stage 1: Serialize the workspace.
             var jsonModel = viewModel.Model.CurrentWorkspace.ToJson(viewModel.Model.EngineController);
 
@@ -590,6 +627,9 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNullOrEmpty(jsonModel);
             Assert.IsNotNullOrEmpty(jo.ToString());
 
+            // Call new structured copy function
+            SaveJsonTempWithFolderStructure(viewModel, filePath, jo);
+
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonFolderName);
 
@@ -598,7 +638,9 @@ namespace DynamoCoreWpfTests
                 System.IO.Directory.CreateDirectory(jsonFolder);
             }
 
-            var jsonPath = filePathBase + ".dyn";
+            var fileName = Path.GetFileName(filePath);
+            var jsonPath = Path.Combine(jsonFolder, fileName);
+
             if (File.Exists(jsonPath))
             {
                 File.Delete(jsonPath);
@@ -608,7 +650,7 @@ namespace DynamoCoreWpfTests
             return jo.ToString();
         }
 
-        private string ConvertCurrentWorkspaceViewToNonGuidJsonAndSave(DynamoViewModel viewModel, string filePathBase)
+        private string ConvertCurrentWorkspaceViewToNonGuidJsonAndSave(DynamoViewModel viewModel, string filePathBase, string filePath)
         {
             // Stage 1: Serialize the workspace.
             var jsonModel = viewModel.Model.CurrentWorkspace.ToJson(viewModel.Model.EngineController);
@@ -623,6 +665,9 @@ namespace DynamoCoreWpfTests
 
             Assert.IsNotNullOrEmpty(json);
 
+            // Call new structured copy function
+            SaveJsonTempWithFolderStructure(viewModel, filePath, jo);
+
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonNonGuidFolderName);
 
@@ -631,7 +676,9 @@ namespace DynamoCoreWpfTests
                 System.IO.Directory.CreateDirectory(jsonFolder);
             }
 
-            var jsonPath = filePathBase + ".dyn";
+            var fileName = Path.GetFileName(filePath);
+            var jsonPath = Path.Combine(jsonFolder, fileName);
+
             if (File.Exists(jsonPath))
             {
                 File.Delete(jsonPath);
@@ -855,7 +902,9 @@ namespace DynamoCoreWpfTests
         public object[] FindWorkspaces()
         {
             var di = new DirectoryInfo(TestDirectory);
-            var fis = di.GetFiles("*.dyn", SearchOption.AllDirectories);
+            //var fis = di.GetFiles("*.dyn", SearchOption.AllDirectories);
+            var fis = new string[] { "*.dyn", "*.dyf" }
+            .SelectMany(i => di.GetFiles(i, SearchOption.AllDirectories));
             return fis.Select(fi => fi.FullName).ToArray();
         }
 


### PR DESCRIPTION
### Purpose

[QNTM-1892](https://jira.autodesk.com/browse/QNTM-1892)

The purpose of this PR is to save all the existing core XML test files in JSON with an identical folder structure allowing us to run the unit tests against both file formats without modifying the test behavior.  This procedure should not only copy/convert all the .dyn files but .dyf dependencies as well.

JSON test files will be saved to:
```C:\Users\UserName\AppData\Local\Temp\DynamoTestJSON\```

![serialization_tests_results](https://user-images.githubusercontent.com/13341935/32109042-8decf0e4-bb01-11e7-95a2-9e42e2d9f602.JPG)

![copied_json_files](https://user-images.githubusercontent.com/13341935/32109052-9330d796-bb01-11e7-8ce0-2d2f5f927ca2.JPG)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@mjkkirschner 
