### PR TITLE
QNTM-2447 Import/Export File Refactor to Import/Export FileSystem

### DIFF
--- a/src/Libraries/CoreNodeModels/CoreNodeModels.csproj
+++ b/src/Libraries/CoreNodeModels/CoreNodeModels.csproj
@@ -60,7 +60,7 @@
     <Compile Include="Input\Double.cs" />
     <Compile Include="Input\BaseTypes.cs" />
     <Compile Include="Input\DoubleSlider.cs" />
-    <Compile Include="Input\File.cs" />
+    <Compile Include="Input\FileSystem.cs" />
     <Compile Include="Input\Integer.cs" />
     <Compile Include="Input\String.cs" />
     <Compile Include="..\..\AssemblySharedInfoGenerator\AssemblySharedInfo.cs">

--- a/src/Libraries/CoreNodeModels/Input/FileSystem.cs
+++ b/src/Libraries/CoreNodeModels/Input/FileSystem.cs
@@ -61,7 +61,7 @@ namespace CoreNodeModels.Input
                 yield return
                     AstFactory.BuildAssignment(
                         GetAstIdentifierForOutputIndex(0),
-                        AstFactory.BuildFunctionCall<string,string,string>(DSCore.IO.File.AbsolutePath, ast));
+                        AstFactory.BuildFunctionCall<string,string,string>(DSCore.IO.FileSystem.AbsolutePath, ast));
             }
         }
 
@@ -259,7 +259,7 @@ namespace CoreNodeModels.Input
         }
     }
 
-    [NodeName("File.FromPath")]
+    [NodeName("File From Path")]
     [NodeCategory(BuiltinNodeCategories.CORE_IO)]
     [NodeDescription("FileObjectNodeDescription", typeof(Resources))]
     [NodeSearchTags("FilePathSearchTags", typeof(Resources))]
@@ -272,10 +272,10 @@ namespace CoreNodeModels.Input
 
         [JsonConstructor]
         private FileObject(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : 
-            base(DSCore.IO.File.FromPath, inPorts, outPorts) { }
+            base(DSCore.IO.FileSystem.FileFromPath, inPorts, outPorts) { }
 
         public FileObject()
-            : base(DSCore.IO.File.FromPath)
+            : base(DSCore.IO.FileSystem.FileFromPath)
         {
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("path", Resources.FileObjectPortDataPathToolTip)));
             OutPorts.Add(new PortModel(PortType.Output, this, new PortData("file", Resources.FileObjectPortDataResultToolTip)));
@@ -321,7 +321,7 @@ namespace CoreNodeModels.Input
         }
     }
 
-    [NodeName("DirectoryFromPath")]
+    [NodeName("Directory From Path")]
     [NodeCategory("Core.File")]
     [NodeDescription("DirectoryObjectNodeDescription",typeof(Resources))]
     [NodeSearchTags("DirectoryPathSearchTags", typeof(Resources))]
@@ -332,10 +332,10 @@ namespace CoreNodeModels.Input
     {
         [JsonConstructor]
         private DirectoryObject(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : 
-            base(DSCore.IO.File.DirectoryFromPath, inPorts, outPorts) { }
+            base(DSCore.IO.FileSystem.DirectoryFromPath, inPorts, outPorts) { }
 
         public DirectoryObject()
-            : base(DSCore.IO.File.DirectoryFromPath)
+            : base(DSCore.IO.FileSystem.DirectoryFromPath)
         {
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("path", Resources.DirectoryObjectPortDataPathToolTip)));
             OutPorts.Add(new PortModel(PortType.Output, this, new PortData("directory", Resources.DirectoryObjectPortDataResultToolTip)));

--- a/src/Libraries/CoreNodes/CoreNodes.csproj
+++ b/src/Libraries/CoreNodes/CoreNodes.csproj
@@ -73,7 +73,7 @@
     <Compile Include="Color.cs" />
     <Compile Include="Compare.cs" />
     <Compile Include="DateTime.cs" />
-    <Compile Include="Files.cs" />
+    <Compile Include="FileSystem.cs" />
     <Compile Include="List.cs" />
     <Compile Include="Math.cs" />
     <Compile Include="Object.cs" />

--- a/src/Libraries/CoreNodes/DSCoreNodes.Migrations.xml
+++ b/src/Libraries/CoreNodes/DSCoreNodes.Migrations.xml
@@ -162,4 +162,89 @@
     <oldName>DSCore.Logic.Or</oldName>
     <newName>DSCore.Math.Or</newName>
   </priorNameHint>
+  <!-- NEW ADDITIONS -->
+  <!-- Many of these nodes are already remapped above.
+       Since these changes were introduced for 2.0 the
+       'newNames' can just be replaced if we don't need to support
+       any existing 2.0 graphs otherwise we need to remap twice-->
+  <priorNameHint>
+    <oldName>File.File.FromPath</oldName>
+    <newName>File.File From Path</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>File.DirectoryFromPath</oldName>
+    <newName>File.Directory From Path</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.CombinePath</oldName>
+    <newName>DSCore.IO.FileSystem.CombinePath</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.FileExtension</oldName>
+    <newName>DSCore.IO.FileSystem.FileExtension</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.ChangePathExtension</oldName>
+    <newName>DSCore.IO.FileSystem.ChangePathExtension</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.DirectoryName</oldName>
+    <newName>DSCore.IO.FileSystem.DirectoryName</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.FileName</oldName>
+    <newName>DSCore.IO.FileSystem.FileName</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.FileHasExtension</oldName>
+    <newName>DSCore.IO.FileSystem.FileHasExtension</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.ReadText</oldName>
+    <newName>DSCore.IO.FileSystem.ReadText</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.Move</oldName>
+    <newName>DSCore.IO.FileSystem.MoveFile</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.Delete</oldName>
+    <newName>DSCore.IO.FileSystem.DeleteFile</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.Copy</oldName>
+    <newName>DSCore.IO.FileSystem.CopyFile</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.Exists</oldName>
+    <newName>DSCore.IO.FileSystem.FileExists</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.WriteText</oldName>
+    <newName>DSCore.IO.FileSystem.WriteText</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.AppendText</oldName>
+    <newName>DSCore.IO.FileSystem.AppendText</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.MoveDirectory</oldName>
+    <newName>DSCore.IO.FileSystem.MoveDirectory</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.CopyDirectory</oldName>
+    <newName>DSCore.IO.FileSystem.CopyDirectory</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.DeleteDirectory</oldName>
+    <newName>DSCore.IO.FileSystem.DeleteDirectory</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.GetDirectoryContents</oldName>
+    <newName>DSCore.IO.FileSystem.GetDirectoryContents</newName>
+  </priorNameHint>
+  <priorNameHint>
+    <oldName>DSCore.IO.File.DirectoryExists</oldName>
+    <newName>DSCore.IO.FileSystem.DirectoryExists</newName>
+  </priorNameHint>
 </migrations>

--- a/src/Libraries/CoreNodes/DSCoreNodes.Migrations.xml
+++ b/src/Libraries/CoreNodes/DSCoreNodes.Migrations.xml
@@ -162,11 +162,6 @@
     <oldName>DSCore.Logic.Or</oldName>
     <newName>DSCore.Math.Or</newName>
   </priorNameHint>
-  <!-- NEW ADDITIONS -->
-  <!-- Many of these nodes are already remapped above.
-       Since these changes were introduced for 2.0 the
-       'newNames' can just be replaced if we don't need to support
-       any existing 2.0 graphs otherwise we need to remap twice-->
   <priorNameHint>
     <oldName>File.File.FromPath</oldName>
     <newName>File.File From Path</newName>
@@ -176,27 +171,27 @@
     <newName>File.Directory From Path</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.File.CombinePath</oldName>
+    <oldName>DSCore.IO.FilePath.Combine</oldName>
     <newName>DSCore.IO.FileSystem.CombinePath</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.File.FileExtension</oldName>
+    <oldName>DSCore.IO.FilePath.Extension</oldName>
     <newName>DSCore.IO.FileSystem.FileExtension</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.File.ChangePathExtension</oldName>
+    <oldName>DSCore.IO.FilePath.ChangeExtension</oldName>
     <newName>DSCore.IO.FileSystem.ChangePathExtension</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.File.DirectoryName</oldName>
+    <oldName>DSCore.IO.FilePath.DirectoryName</oldName>
     <newName>DSCore.IO.FileSystem.DirectoryName</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.File.FileName</oldName>
+    <oldName>DSCore.IO.FilePath.FileName</oldName>
     <newName>DSCore.IO.FileSystem.FileName</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.File.FileHasExtension</oldName>
+    <oldName>DSCore.IO.FilePath.HasExtension</oldName>
     <newName>DSCore.IO.FileSystem.FileHasExtension</newName>
   </priorNameHint>
   <priorNameHint>
@@ -228,23 +223,23 @@
     <newName>DSCore.IO.FileSystem.AppendText</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.File.MoveDirectory</oldName>
+    <oldName>DSCore.IO.Directory.Move</oldName>
     <newName>DSCore.IO.FileSystem.MoveDirectory</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.File.CopyDirectory</oldName>
+    <oldName>DSCore.IO.Directory.Copy</oldName>
     <newName>DSCore.IO.FileSystem.CopyDirectory</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.File.DeleteDirectory</oldName>
+    <oldName>DSCore.IO.Directory.Delete</oldName>
     <newName>DSCore.IO.FileSystem.DeleteDirectory</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.File.GetDirectoryContents</oldName>
+    <oldName>DSCore.IO.Directory.Contents</oldName>
     <newName>DSCore.IO.FileSystem.GetDirectoryContents</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.File.DirectoryExists</oldName>
+    <oldName>DSCore.IO.Directory.Exists</oldName>
     <newName>DSCore.IO.FileSystem.DirectoryExists</newName>
   </priorNameHint>
 </migrations>

--- a/src/Libraries/CoreNodes/DSCoreNodes.Migrations.xml
+++ b/src/Libraries/CoreNodes/DSCoreNodes.Migrations.xml
@@ -65,26 +65,6 @@
     </additionalAttributes>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.IO.Directory.Contents</oldName>
-    <newName>DSCore.IO.File.GetDirectoryContents</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>DSCore.IO.Directory.Copy</oldName>
-    <newName>DSCore.IO.File.CopyDirectory</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>DSCore.IO.Directory.Delete</oldName>
-    <newName>DSCore.IO.File.DeleteDirectory</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>DSCore.IO.Directory.Exists</oldName>
-    <newName>DSCore.IO.File.DirectoryExists</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>DSCore.IO.Directory.Move</oldName>
-    <newName>DSCore.IO.File.MoveDirectory</newName>
-  </priorNameHint>
-  <priorNameHint>
     <oldName>DSCore.Display.ByGeometryColor</oldName>
     <newName>Modifiers.GeometryColor.ByGeometryColor</newName>
     <additionalAttributes>
@@ -121,30 +101,6 @@
         <value>GeometryColor.dll</value>
       </attribute>
     </additionalAttributes>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>DSCore.IO.FilePath.HasExtension</oldName>
-    <newName>DSCore.IO.File.FileHasExtension</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>DSCore.IO.FilePath.ChangeExtension</oldName>
-    <newName>DSCore.IO.File.ChangePathExtension</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>DSCore.IO.FilePath.DirectoryName</oldName>
-    <newName>DSCore.IO.File.DirectoryName</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>DSCore.IO.FilePath.Combine</oldName>
-    <newName>DSCore.IO.File.CombinePath</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>DSCore.IO.FilePath.FileName</oldName>
-    <newName>DSCore.IO.File.FileName</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>DSCore.IO.FilePath.Extension</oldName>
-    <newName>DSCore.IO.File.FileExtension</newName>
   </priorNameHint>
   <priorNameHint>
     <oldName>DSCore.Formula.Evaluate</oldName>

--- a/src/Libraries/CoreNodes/DSCoreNodesImages.resx
+++ b/src/Libraries/CoreNodes/DSCoreNodesImages.resx
@@ -5297,7 +5297,7 @@
         AAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.GetDirectoryContents.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.GetDirectoryContents.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAALISURBVHhe7dbRaVRhFATglGAJlmAJeRUsIqXYiSVY
@@ -5315,7 +5315,7 @@
         wdSIiIiIiIiIiIiIiIiIiIjo6e7uNwtoxDYwWX9KAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.GetDirectoryContents.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.GetDirectoryContents.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAACBSURBVFhHYxgFo2AUjAJC4KCPpwMQ/8eDG6BKaQOA
@@ -5323,7 +5323,7 @@
         1AFUcQAlYHg4AFvQEis26gCqOIASMLQdQC0MNXIUjIJRMNgAAwMAGKNwYBJr1BAAAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.CopyDirectory.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.CopyDirectory.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAMvSURBVHhe7Zg9blNREIW9BGoqlkBH6xaJjhahLIEl
@@ -5343,7 +5343,7 @@
         LrDZPAAu3a4YyJNHyQAAAABJRU5ErkJggg==
 </value>
   </data>
-  <data name="DSCore.IO.File.CopyDirectory.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.CopyDirectory.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADISURBVFhH7ZJBCsIwEEVzDle9hdtuBY8gnsULeAbX
@@ -5372,7 +5372,7 @@
         IiIiIiIiIluz2/0De2vEJpk//isAAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.DeleteDirectory.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.DeleteDirectory.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAEASURBVFhH7ZXRDYMwDEQZgREYoSP0t1I/GKEjMAKb
@@ -5383,7 +5383,7 @@
         TkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.DirectoryExists.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.DirectoryExists.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAALvSURBVHhe7ZvRbeJAFEUpgRJSAiXkd6X92BIoISWk
@@ -5402,7 +5402,7 @@
         AOp8FY/X12JTAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.DirectoryExists.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.DirectoryExists.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADfSURBVFhH7ZXRDYMwDEQzAiMwAiPwW6kfHaEjZAQ2
@@ -5412,7 +5412,7 @@
         DvD24wFno2EYf4hzX/qGzXDKy57QAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.Directory.FromPath.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FileFromPath.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAJKSURBVHhe7drRTetAEIXhlEAJt4SUwDvSrSGl0Akl
@@ -5428,7 +5428,7 @@
         AAAAAAAAAAAAAADWabf7ApUimLXZZbmGAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.Directory.FromPath.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FileFromPath.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAACPSURBVFhH7ZHRDUBAEESvBCVcKf4latKBEpTiRwX4
@@ -5437,7 +5437,7 @@
         KAAAAABJRU5ErkJggg==
 </value>
   </data>
-  <data name="DSCore.IO.File.MoveDirectory.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.MoveDirectory.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAOHSURBVHhe7ZoxbttAEEV1BNepfAR3ad0GSOc2CHwE
@@ -5458,7 +5458,7 @@
         1SddBdcmWPVJV8G1CVaFEEIIIYQQQgghhBBCCD+sVv8AQkgWwzNa1YQAAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.MoveDirectory.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.MoveDirectory.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADtSURBVFhHYxgFo2DQgoM+ngZA/B/KxqCBuADEphkA
@@ -5468,7 +5468,7 @@
         QFJpGKZ7CKDjUQcMbQdQC0ONHAWjYLAABgYArMwSK49hWaIAAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.Copy.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.CopyFile.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAKHSURBVHhe7Z27bRtAEERZh6tQEwoEqAR/IsHd2CUw
@@ -5485,7 +5485,7 @@
         bKHkeZ7neZ7neZ7n5d9m8wL6aYYMRzTZYgAAAABJRU5ErkJggg==
 </value>
   </data>
-  <data name="DSCore.IO.File.Copy.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.CopyFile.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAC1SURBVFhH7ZIxCsMwDAD9BM99gb9S6BNKCf2o6ZRu
@@ -5494,7 +5494,7 @@
         GqABGqAB/xeQCwtg8bdWBVBwvgDlPgJqxVXKL2HMCzw8BSHwi+jwAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.Delete.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.DeleteFile.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAANeSURBVHhe7Z3rjRpBEIQJgRAcwqVhyT8cwoVwIZAJ
@@ -5515,7 +5515,7 @@
         AAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.Delete.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.DeleteFile.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAEOSURBVFhH7ZTRDYMwDEQZgRE6AiP0t1I/GIERGIFN
@@ -5526,7 +5526,7 @@
         dpasmxVTjV0AAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.Exists.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FileExists.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAMTSURBVHhe7Z3dTetAEIVTQkqgBErI65V4SAkpgRLS
@@ -5545,7 +5545,7 @@
         gy0AYgNKg8T7f+AARW7AffzDB0IIIYQQQgghhBBCCCFts9v9B74Mb15fPVluAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.Exists.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FileExists.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADwSURBVFhH7ZXhDcIgEIU7giM4Qkfgr4lDOEJH6AaO
@@ -5555,7 +5555,7 @@
         nIq0dEA2YXv+Qm0HzRz4G9IB5NIxzGvGTmfHDMMbPBrfBDKSPd0AAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.FromPath.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FromPath.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAI8SURBVHhe7Z3RaRxBEAUvBIVyeRgUg0JRJorGCUj6
@@ -5571,7 +5571,7 @@
         yy9LmiAJvOw9nwAAAABJRU5ErkJggg==
 </value>
   </data>
-  <data name="DSCore.IO.File.FromPath.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FromPath.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAACTSURBVFhH7ZFhCoAgDEY9gvcKOlM36FT9Fqr7mJNP
@@ -5580,7 +5580,7 @@
         KX3lNd8AAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.Move.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.MoveFile.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAMmSURBVHhe7Z09blNBFIWzDiqWwBJoUiDR0fKzF0RN
@@ -5600,7 +5600,7 @@
         ki8jLwAAAABJRU5ErkJggg==
 </value>
   </data>
-  <data name="DSCore.IO.File.Move.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.MoveFile.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADfSURBVFhH7ZIxCsJAEEX3CNaewGOkFexsxUa8iHgP
@@ -5610,7 +5610,7 @@
         gOTfKGA1R7m+SSE8APXA8bsfLqezAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.WriteText.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.WriteText.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAMxSURBVHhe7Z1NahRRFIV7CVlClpAlOBUcZCA4dS6I
@@ -5630,7 +5630,7 @@
         CCHEHavVP6Nyc5/z0pzyAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.WriteText.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.WriteText.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAD2SURBVFhH7ZPNDYJAEEYpgVJsw8QiLIFOPBgTb5Tg
@@ -5640,7 +5640,7 @@
         A7LaMpnowPX1tU8hkHJtuBYY6jC6gAov4ETAttDK45kjQfABjiWja7SqwSQAAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.ChangePathExtension.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.ChangePathExtension.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAKXSURBVHhe7Z1NahRRFIV7SYHWmJggiiYaEacOnboG
@@ -5657,7 +5657,7 @@
         hDVeiYsyONo/cPjf3HolIYQQQgghhBBCCCGEEIKL3e4Psyr/u5Ik1YUAAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.ChangePathExtension.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.ChangePathExtension.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADPSURBVFhH7ZJNCsIwFIRzhN4lC92KIgjiyTyDWxG8
@@ -5667,7 +5667,7 @@
         CzPdl6sAAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.CombinePath.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.CombinePath.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAQASURBVHhe7Z3hTeNAEIUpISVQAiXw96T7cSVQAiXQ
@@ -5690,7 +5690,7 @@
         ZDUrKRdIfG3/wGGq5f3DfUIIIYQQQgghhBBCCCEum6ur/979vR3ckXtSAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.CombinePath.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.CombinePath.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAEISURBVFhH7ZTdCYMwFIUdwRE6giP0tdAHR+gIjuAG
@@ -5701,7 +5701,7 @@
         pZYAAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.DirectoryName.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.DirectoryName.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAMNSURBVHhe7Z0xahxBEEX3CIodKXSozOmmBmdOjVFi
@@ -5720,7 +5720,7 @@
         Y1Gko/dByaB36eh9UDLoXTo6IYQQQgghhBD/rFb/AcZSoWXqztWEAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.DirectoryName.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.DirectoryName.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAD2SURBVFhH7ZK9DcIwEEYzQupUlJTpaGmRGAExA5tk
@@ -5730,7 +5730,7 @@
         fXlcLzTopggUgSKQJWCHG3HTmGQJfBP7BUxEBVKDFoUtUVUfJ4k3xkfT7GYAAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="DSCore.IO.File.FileExtension.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FileExtension.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAI+SURBVHhe7Z3hSVxREIW3hJSQEizBv4EUYSnpxBJS
@@ -5746,7 +5746,7 @@
         F6fTP9BJ3wYyH2VmAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.FileExtension.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FileExtension.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAACySURBVFhH7ZLBCcMwDEU9QkbICB2h10B260ilE2SU
@@ -5755,7 +5755,7 @@
         AhZSIFTgdMCIcVIgBbSABe/8HALeYlSSzEgpF8uNOnQ5dJ8HAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.FileName.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FileName.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAKqSURBVHhe7ZzhTeNAFIRTAiVcCZTAX6QrglLo4Eqg
@@ -5773,7 +5773,7 @@
         AAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.FileName.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FileName.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADKSURBVFhH7ZTtCcJADIZvBEdwBEfwr+AQbuQIjiJO
@@ -5783,7 +5783,7 @@
         AAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.FileHasExtension.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FileHasExtension.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAOQSURBVHhe7Z0xTiNBEEU5wh5hj4DEBZyuBAdwRsQF
@@ -5805,7 +5805,7 @@
         YII=
 </value>
   </data>
-  <data name="DSCore.IO.File.FileHasExtension.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.FileHasExtension.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAEISURBVFhH7ZLJDYMwEEUpgRJSQkrwNVJogwZogA5y
@@ -7074,7 +7074,7 @@
         7CNagAACCCCAAAIIpAhEoyqAHSnlAYNR5+bRJ0lUAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.ReadText.var.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.ReadText.var.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAASiSURBVHhe7Z3NahRBFIXzCHkEHyGP4FZQcCHoMuBS
@@ -7100,7 +7100,7 @@
         wzAMwzAMwzAMwzB6MTHxD4vmd4bveirUAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.ReadText.var.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.ReadText.var.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAFXSURBVFhH7ZQ9SgQxHMXnCHMEjzKtoJ2gpScQO9HK
@@ -7558,7 +7558,7 @@
         gg==
 </value>
   </data>
-  <data name="DSCore.IO.File.AppendText.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.AppendText.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAMxSURBVHhe7Z1NahRRFIV7CVlClpAlOBUcZCA4dS6I
@@ -7578,7 +7578,7 @@
         CCHEHavVP6Nyc5/z0pzyAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.IO.File.AppendText.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="DSCore.IO.FileSystem.AppendText.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAD2SURBVFhH7ZPNDYJAEEYpgVJsw8QiLIFOPBgTb5Tg

--- a/src/Libraries/CoreNodes/FileSystem.cs
+++ b/src/Libraries/CoreNodes/FileSystem.cs
@@ -16,7 +16,7 @@ namespace DSCore.IO
     /// <summary>
     ///     Methods for working with Files.
     /// </summary>
-    public static class File
+    public static class FileSystem
     {
         #region file methods
 
@@ -42,7 +42,7 @@ namespace DSCore.IO
                 var filepath = Path.Combine(parent, path);
                 //If hint path is null or file exists at this location return the computed path
                 //If hint path doesn't exist then the relative path might be for write operation.
-                if (File.Exists(filepath) || string.IsNullOrEmpty(hintPath) || !File.Exists(hintPath))
+                if (FileSystem.FileExists(filepath) || string.IsNullOrEmpty(hintPath) || !FileSystem.FileExists(hintPath))
                     return Path.GetFullPath(filepath);
             }
 
@@ -55,7 +55,7 @@ namespace DSCore.IO
         /// <param name="path"></param>
         /// <returns></returns>
         [IsVisibleInDynamoLibrary(false)]
-        public static FileInfo FromPath(string path)
+        public static FileInfo FileFromPath(string path)
         {
             return new FileInfo(AbsolutePath(path));
         }
@@ -76,10 +76,10 @@ namespace DSCore.IO
         /// <param name="path"></param>
         /// <param name="newPath"></param>
         /// <param name="overwrite"></param>
-        public static void Move(string path, string newPath, bool overwrite = false)
+        public static void MoveFile(string path, string newPath, bool overwrite = false)
         {
-            if (overwrite && Exists(newPath))
-                Delete(newPath);
+            if (overwrite && FileExists(newPath))
+                DeleteFile(newPath);
             System.IO.File.Move(path, newPath);
         }
 
@@ -87,7 +87,7 @@ namespace DSCore.IO
         ///   Deletes the specified file.
         /// </summary>
         /// <param name="path"></param>
-        public static void Delete(string path)
+        public static void DeleteFile(string path)
         {
             System.IO.File.Delete(path);
         }
@@ -98,7 +98,7 @@ namespace DSCore.IO
         /// <param name="file"></param>
         /// <param name="destinationPath"></param>
         /// <param name="overwrite"></param>
-        public static void Copy(FileInfo file, string destinationPath, bool overwrite = false)
+        public static void CopyFile(FileInfo file, string destinationPath, bool overwrite = false)
         {
             file.CopyTo(destinationPath, overwrite);
         }
@@ -108,7 +108,7 @@ namespace DSCore.IO
         /// </summary>
         /// <param name="path"></param>
         /// <search>filepath</search>
-        public static bool Exists(string path)
+        public static bool FileExists(string path)
         {
             return System.IO.File.Exists(path);
         }
@@ -223,13 +223,13 @@ namespace DSCore.IO
         /// <param name="overwriteFiles"></param>
         public static void CopyDirectory(DirectoryInfo directory, string destinationPath, bool overwriteFiles = false)
         {
-            if (!Exists(destinationPath))
+            if (!FileExists(destinationPath))
                 System.IO.Directory.CreateDirectory(destinationPath);
 
             foreach (var file in directory.EnumerateFiles())
             {
                 var newFilePath = Path.Combine(destinationPath, file.Name);
-                Copy(file, newFilePath, overwriteFiles);
+                CopyFile(file, newFilePath, overwriteFiles);
             }
 
             foreach (var dir in directory.EnumerateDirectories())
@@ -284,7 +284,7 @@ namespace DSCore.IO
             foreach (var file in info.EnumerateFiles())
             {
                 var newFilePath = Path.Combine(newPath, file.Name);
-                Move(file.FullName, newFilePath, overwriteFiles);
+                MoveFile(file.FullName, newFilePath, overwriteFiles);
             }
 
             foreach (var dir in info.EnumerateDirectories())
@@ -301,7 +301,7 @@ namespace DSCore.IO
         [NodeObsolete("ReadImageObsolete", typeof(Properties.Resources))]
         public static Color[] ReadImage(string path, int xSamples, int ySamples)
         {
-            var info = FromPath(path);
+            var info = FileFromPath(path);
             var image = Image.ReadFromFile(info);
             return Image.Pixels(image, xSamples, ySamples).SelectMany(x => x).ToArray();
         }
@@ -309,13 +309,13 @@ namespace DSCore.IO
         [NodeObsolete("LoadImageFromPathObsolete", typeof(Properties.Resources))]
         public static Bitmap LoadImageFromPath(string path)
         {
-            return Image.ReadFromFile(FromPath(path));
+            return Image.ReadFromFile(FileFromPath(path));
         }
 
         [NodeObsolete("ReadTextObsolete", typeof(Properties.Resources))]
         public static string ReadText(string path)
         {
-            return ReadText(FromPath(path));
+            return ReadText(FileFromPath(path));
         }
 
         [NodeObsolete("WriteImageObsolete", typeof(Properties.Resources))]
@@ -451,7 +451,7 @@ namespace DSCore.IO
         /// <search>write image,image,file,filepath</search>
         public static void WriteToFile(string path, Bitmap image)
         {
-            image.Save(File.AbsolutePath(path));
+            image.Save(FileSystem.AbsolutePath(path));
         }
     }
 }

--- a/src/Libraries/DSOffice/Excel.cs
+++ b/src/Libraries/DSOffice/Excel.cs
@@ -710,7 +710,7 @@ namespace DSOffice
         /// <search>write,text,file</search>
         public static void ExportCSV(string filePath, object[][] data)
         {
-            using (var writer = new StreamWriter(DSCore.IO.File.AbsolutePath(filePath)))
+            using (var writer = new StreamWriter(DSCore.IO.FileSystem.AbsolutePath(filePath)))
             {
                 foreach (var line in data)
                 {
@@ -736,7 +736,7 @@ namespace DSOffice
         /// <search>import,csv,comma,file,list,separate,transpose</search>
         public static IList ImportCSV(string filePath, bool transpose = false)
         {
-            if (string.IsNullOrEmpty(filePath) || !DSCore.IO.File.Exists(filePath))
+            if (string.IsNullOrEmpty(filePath) || !DSCore.IO.FileSystem.FileExists(filePath))
             {
                 // File not existing.
                 throw new FileNotFoundException();

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -909,7 +909,7 @@
               "childElements": [ ]
             },
             {
-              "text": "File",
+              "text": "File System",
               "iconUrl": "",
               "elementType": "group",
               "include": [
@@ -920,64 +920,64 @@
                   "path": "Core.Input.Directory Path"
                 },
                 {
-                  "path": "Core.File.File.FromPath"
+                  "path": "Core.File.File From Path"
                 },
                 {
-                  "path": "Core.File.DirectoryFromPath"
+                  "path": "Core.File.Directory From Path"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.CombinePath"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.CombinePath"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.FileExtension"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.FileExtension"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.ChangePathExtension"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.ChangePathExtension"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.DirectoryName"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.DirectoryName"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.FileName"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.FileName"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.FileHasExtension"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.FileHasExtension"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.ReadText"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.ReadText"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.Move"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.MoveFile"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.Delete"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.DeleteFile"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.Copy"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.CopyFile"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.Exists"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.FileExists"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.WriteText"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.WriteText"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.AppendText"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.AppendText"
                 },
 								{
-                  "path": "DSCoreNodes.DSCore.IO.File.MoveDirectory"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.MoveDirectory"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.CopyDirectory"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.CopyDirectory"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.DeleteDirectory"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.DeleteDirectory"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.GetDirectoryContents"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.GetDirectoryContents"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.IO.File.DirectoryExists"
+                  "path": "DSCoreNodes.DSCore.IO.FileSystem.DirectoryExists"
                 }
               ],
               "childElements": [ ]

--- a/test/DynamoCoreTests/NodeMigrationTests.cs
+++ b/test/DynamoCoreTests/NodeMigrationTests.cs
@@ -146,6 +146,12 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void TestMigration_FileSystem()
+        {
+            TestMigration("TestMigration_Core_FileSystem.dyn");
+        }
+
+        [Test]
         [Category("Failure")]
         public void TestMigration_InputOutput_Hardware()
         {

--- a/test/Libraries/CoreNodesTests/FileTests.cs
+++ b/test/Libraries/CoreNodesTests/FileTests.cs
@@ -11,7 +11,7 @@ using Moq;
 using NUnit.Framework;
 using Color = DSCore.Color;
 using Directory = System.IO.Directory;
-using File = DSCore.IO.File;
+using FileSystem = DSCore.IO.FileSystem;
 using Image = DSCore.IO.Image;
 
 namespace Dynamo.Tests
@@ -28,28 +28,28 @@ namespace Dynamo.Tests
         [Test, Category("UnitTests")]
         public void SimpleWrappers()
         {
-            Assert.AreEqual(Path.Combine("test"), File.CombinePath("test"));
-            Assert.AreEqual(Path.Combine("test", "1"), File.CombinePath("test", "1"));
-            Assert.AreEqual(Path.Combine("test/", @"1\"), File.CombinePath("test/", @"1\"));
+            Assert.AreEqual(Path.Combine("test"), FileSystem.CombinePath("test"));
+            Assert.AreEqual(Path.Combine("test", "1"), FileSystem.CombinePath("test", "1"));
+            Assert.AreEqual(Path.Combine("test/", @"1\"), FileSystem.CombinePath("test/", @"1\"));
 
             const string aFilePath = @"hello\there.txt";
             const string aFileName = "hello";
 
-            Assert.AreEqual(Path.GetExtension(aFilePath), File.FileExtension(aFilePath));
-            Assert.AreEqual(Path.GetExtension(aFileName), File.FileExtension(aFileName));
+            Assert.AreEqual(Path.GetExtension(aFilePath), FileSystem.FileExtension(aFilePath));
+            Assert.AreEqual(Path.GetExtension(aFileName), FileSystem.FileExtension(aFileName));
 
             Assert.AreEqual(
                 Path.ChangeExtension(aFilePath, ".png"),
-                File.ChangePathExtension(aFilePath, ".png"));
+                FileSystem.ChangePathExtension(aFilePath, ".png"));
             Assert.AreEqual(
                 Path.ChangeExtension(aFileName, ".txt"),
-                File.ChangePathExtension(aFileName, ".txt"));
+                FileSystem.ChangePathExtension(aFileName, ".txt"));
 
-            Assert.AreEqual(Path.GetDirectoryName(aFilePath), File.DirectoryName(aFilePath));
-            Assert.AreEqual(Path.GetDirectoryName(aFileName), File.DirectoryName(aFileName));
+            Assert.AreEqual(Path.GetDirectoryName(aFilePath), FileSystem.DirectoryName(aFilePath));
+            Assert.AreEqual(Path.GetDirectoryName(aFileName), FileSystem.DirectoryName(aFileName));
 
-            Assert.AreEqual(Path.HasExtension(aFilePath), File.FileHasExtension(aFilePath));
-            Assert.AreEqual(Path.HasExtension(aFileName), File.FileHasExtension(aFileName));
+            Assert.AreEqual(Path.HasExtension(aFilePath), FileSystem.FileHasExtension(aFilePath));
+            Assert.AreEqual(Path.HasExtension(aFileName), FileSystem.FileHasExtension(aFileName));
         }
 
         [Test, Category("UnitTests")]
@@ -57,10 +57,10 @@ namespace Dynamo.Tests
         {
             const string aFilePath = @"hello\there.txt";
 
-            Assert.AreEqual(Path.GetFileName(aFilePath), File.FileName(aFilePath));
+            Assert.AreEqual(Path.GetFileName(aFilePath), FileSystem.FileName(aFilePath));
             Assert.AreEqual(
                 Path.GetFileNameWithoutExtension(aFilePath),
-                File.FileName(aFilePath, withExtension: false));
+                FileSystem.FileName(aFilePath, withExtension: false));
         }
         #endregion
 
@@ -76,7 +76,7 @@ namespace Dynamo.Tests
             SetActiveSession(session.Object);
             var relativepath = @"images\testImage.jpg";
             var expectedpath = Path.Combine(TestDirectory, @"core\files", relativepath);
-            Assert.AreEqual(expectedpath, File.AbsolutePath(relativepath));
+            Assert.AreEqual(expectedpath, FileSystem.AbsolutePath(relativepath));
             SetActiveSession(null);
         }
 
@@ -91,7 +91,7 @@ namespace Dynamo.Tests
             SetActiveSession(session.Object);
             var relativepath = @"do not exist\no file.txt";
             var expectedpath = Path.Combine(TestDirectory, @"core\files", relativepath);
-            Assert.AreEqual(expectedpath, File.AbsolutePath(relativepath));
+            Assert.AreEqual(expectedpath, FileSystem.AbsolutePath(relativepath));
             SetActiveSession(null);
         }
 
@@ -106,7 +106,7 @@ namespace Dynamo.Tests
             SetActiveSession(session.Object);
             var relativepath = @"excel\ascending.xlsx";
             var hintpath = Path.Combine(TestDirectory, "core", relativepath);
-            Assert.AreEqual(hintpath, File.AbsolutePath(relativepath, hintpath));
+            Assert.AreEqual(hintpath, FileSystem.AbsolutePath(relativepath, hintpath));
             SetActiveSession(null);
         }
 
@@ -117,7 +117,7 @@ namespace Dynamo.Tests
             string wspath = Path.Combine(TestDirectory, @"core\files\dummy.dyn");
             var relativepath = @"excel\ascending.xlsx";
             var hintpath = Path.Combine(TestDirectory, "core", relativepath);
-            Assert.AreEqual(wspath, File.AbsolutePath(wspath, hintpath));
+            Assert.AreEqual(wspath, FileSystem.AbsolutePath(wspath, hintpath));
         }
 
         [Test, Category("UnitTests")]
@@ -126,14 +126,14 @@ namespace Dynamo.Tests
             Assert.IsNull(ExecutionEvents.ActiveSession);
             var relativepath = @"excel\ascending.xlsx";
             var hintpath = Path.Combine(TestDirectory, @"do not exist\no file.txt");
-            Assert.AreEqual(hintpath, File.AbsolutePath(relativepath, hintpath));
+            Assert.AreEqual(hintpath, FileSystem.AbsolutePath(relativepath, hintpath));
         }
 
         [Test, Category("UnitTests")]
         public void File_FromPath()
         {
             var fn = GetNewFileNameOnTempPath(".txt");
-            Assert.AreEqual(new FileInfo(fn).FullName, File.FromPath(fn).FullName);
+            Assert.AreEqual(new FileInfo(fn).FullName, FileSystem.FileFromPath(fn).FullName);
         }
 
         [Test, Category("UnitTests")]
@@ -142,8 +142,8 @@ namespace Dynamo.Tests
             const string contents = "test";
             var fn = GetNewFileNameOnTempPath(".txt");
             System.IO.File.WriteAllText(fn, contents);
-            var fnInfo = File.FromPath(fn);
-            Assert.AreEqual(contents, File.ReadText(fnInfo));
+            var fnInfo = FileSystem.FileFromPath(fn);
+            Assert.AreEqual(contents, FileSystem.ReadText(fnInfo));
         }
 
         [Test, Category("UnitTests")]
@@ -155,11 +155,11 @@ namespace Dynamo.Tests
             Assert.IsTrue(System.IO.File.Exists(fn));
 
             var dest = GetNewFileNameOnTempPath(".txt");
-            var destInfo = File.FromPath(dest);
-            File.Move(fn, dest);
+            var destInfo = FileSystem.FileFromPath(dest);
+            FileSystem.MoveFile(fn, dest);
             Assert.IsTrue(System.IO.File.Exists(dest));
             Assert.IsFalse(System.IO.File.Exists(fn));
-            Assert.AreEqual(contents, File.ReadText(destInfo));
+            Assert.AreEqual(contents, FileSystem.ReadText(destInfo));
         }
 
         [Test, Category("UnitTests")]
@@ -170,7 +170,7 @@ namespace Dynamo.Tests
             System.IO.File.WriteAllText(fn, contents);
             Assert.IsTrue(System.IO.File.Exists(fn));
 
-            File.Delete(fn);
+            FileSystem.DeleteFile(fn);
             Assert.IsFalse(System.IO.File.Exists(fn));
         }
 
@@ -179,17 +179,17 @@ namespace Dynamo.Tests
         {
             const string contents = "test";
             var fn = GetNewFileNameOnTempPath(".txt");
-            var fnInfo = File.FromPath(fn);
+            var fnInfo = FileSystem.FileFromPath(fn);
             System.IO.File.WriteAllText(fn, contents);
             Assert.IsTrue(System.IO.File.Exists(fn));
 
             var dest = GetNewFileNameOnTempPath(".txt");
-            var destInfo = File.FromPath(dest);
-            File.Copy(fnInfo, dest);
+            var destInfo = FileSystem.FileFromPath(dest);
+            FileSystem.CopyFile(fnInfo, dest);
             Assert.IsTrue(System.IO.File.Exists(dest));
             Assert.IsTrue(System.IO.File.Exists(fn));
-            Assert.AreEqual(contents, File.ReadText(fnInfo));
-            Assert.AreEqual(contents, File.ReadText(destInfo));
+            Assert.AreEqual(contents, FileSystem.ReadText(fnInfo));
+            Assert.AreEqual(contents, FileSystem.ReadText(destInfo));
         }
 
         [Test, Category("UnitTests")]
@@ -208,7 +208,7 @@ namespace Dynamo.Tests
             const string contents = "test";
             var fn = GetNewFileNameOnTempPath(".txt");
             Assert.IsFalse(System.IO.File.Exists(fn));
-            File.WriteText(fn, contents);
+            FileSystem.WriteText(fn, contents);
             Assert.IsTrue(System.IO.File.Exists(fn));
             Assert.AreEqual(contents, System.IO.File.ReadAllText(fn));
         }
@@ -219,9 +219,9 @@ namespace Dynamo.Tests
             const string contents = "test";
             var fn = GetNewFileNameOnTempPath(".txt");
             Assert.IsFalse(System.IO.File.Exists(fn));
-            File.AppendText(fn, contents);
+            FileSystem.AppendText(fn, contents);
             Assert.IsTrue(System.IO.File.Exists(fn));
-            File.AppendText(fn, contents);
+            FileSystem.AppendText(fn, contents);
             Assert.AreEqual(contents + contents, System.IO.File.ReadAllText(fn));
         }
         #endregion
@@ -232,12 +232,12 @@ namespace Dynamo.Tests
         {
             var tmp = GetNewFileNameOnTempPath("");
             Assert.IsFalse(Directory.Exists(tmp));
-            var info = File.DirectoryFromPath(tmp);
+            var info = FileSystem.DirectoryFromPath(tmp);
             Assert.AreEqual(tmp, info.FullName);
             Assert.IsTrue(info.Exists);
 
             //Make again now that it already exists
-            var info2 = File.DirectoryFromPath(tmp);
+            var info2 = FileSystem.DirectoryFromPath(tmp);
             Assert.AreEqual(tmp, info2.FullName);
             Assert.IsTrue(info2.Exists);
         }
@@ -248,34 +248,34 @@ namespace Dynamo.Tests
             var tmpSrc = GetNewFileNameOnTempPath("");
             Directory.CreateDirectory(tmpSrc);
             const string fileName = @"temp.txt";
-            File.WriteText(File.CombinePath(tmpSrc, fileName), "test");
+            FileSystem.WriteText(FileSystem.CombinePath(tmpSrc, fileName), "test");
 
             var tmpDest = GetNewFileNameOnTempPath("");
-            File.MoveDirectory(tmpSrc, tmpDest);
-            Assert.IsFalse(File.DirectoryExists(tmpSrc));
-            Assert.IsTrue(File.DirectoryExists(tmpDest));
+            FileSystem.MoveDirectory(tmpSrc, tmpDest);
+            Assert.IsFalse(FileSystem.DirectoryExists(tmpSrc));
+            Assert.IsTrue(FileSystem.DirectoryExists(tmpDest));
 
-            var destFileName = File.CombinePath(tmpDest, fileName);
-            Assert.IsTrue(File.Exists(destFileName));
-            Assert.AreEqual("test", File.ReadText(File.FromPath(destFileName)));
+            var destFileName = FileSystem.CombinePath(tmpDest, fileName);
+            Assert.IsTrue(FileSystem.FileExists(destFileName));
+            Assert.AreEqual("test", FileSystem.ReadText(FileSystem.FileFromPath(destFileName)));
         }
 
         [Test, Category("UnitTests")]
         public void Directory_Copy()
         {
             var tmpSrc = GetNewFileNameOnTempPath("");
-            var tmpSrcInfo = File.DirectoryFromPath(tmpSrc);
+            var tmpSrcInfo = FileSystem.DirectoryFromPath(tmpSrc);
             const string fileName = @"temp.txt";
-            File.WriteText(File.CombinePath(tmpSrc, fileName), "test");
+            FileSystem.WriteText(FileSystem.CombinePath(tmpSrc, fileName), "test");
 
             var tmpDest = GetNewFileNameOnTempPath("");
-            File.CopyDirectory(tmpSrcInfo, tmpDest);
-            Assert.IsTrue(File.DirectoryExists(tmpSrc));
-            Assert.IsTrue(File.DirectoryExists(tmpDest));
+            FileSystem.CopyDirectory(tmpSrcInfo, tmpDest);
+            Assert.IsTrue(FileSystem.DirectoryExists(tmpSrc));
+            Assert.IsTrue(FileSystem.DirectoryExists(tmpDest));
 
-            var destFileName = File.CombinePath(tmpDest, fileName);
-            Assert.IsTrue(File.Exists(destFileName));
-            Assert.AreEqual("test", File.ReadText(File.FromPath(destFileName)));
+            var destFileName = FileSystem.CombinePath(tmpDest, fileName);
+            Assert.IsTrue(FileSystem.FileExists(destFileName));
+            Assert.AreEqual("test", FileSystem.ReadText(FileSystem.FileFromPath(destFileName)));
         }
 
         [Test, Category("UnitTests")]
@@ -284,32 +284,32 @@ namespace Dynamo.Tests
             var tmpSrc = GetNewFileNameOnTempPath("");
             Directory.CreateDirectory(tmpSrc);
             const string fileName = @"temp.txt";
-            File.WriteText(File.CombinePath(tmpSrc, fileName), "test");
+            FileSystem.WriteText(FileSystem.CombinePath(tmpSrc, fileName), "test");
 
-            Assert.Throws<IOException>(() => File.DeleteDirectory(tmpSrc));
-            File.DeleteDirectory(tmpSrc, recursive: true);
-            Assert.IsFalse(File.DirectoryExists(tmpSrc));
+            Assert.Throws<IOException>(() => FileSystem.DeleteDirectory(tmpSrc));
+            FileSystem.DeleteDirectory(tmpSrc, recursive: true);
+            Assert.IsFalse(FileSystem.DirectoryExists(tmpSrc));
 
             var tmpSrc2 = GetNewFileNameOnTempPath("");
             Directory.CreateDirectory(tmpSrc2);
-            File.DeleteDirectory(tmpSrc2);
-            Assert.IsFalse(File.DirectoryExists(tmpSrc2));
+            FileSystem.DeleteDirectory(tmpSrc2);
+            Assert.IsFalse(FileSystem.DirectoryExists(tmpSrc2));
         }
 
         [Test, Category("UnitTests")]
         public void Directory_Contents()
         {
             var tmpSrc = GetNewFileNameOnTempPath("");
-            var tmpSrcInfo = File.DirectoryFromPath(tmpSrc);
+            var tmpSrcInfo = FileSystem.DirectoryFromPath(tmpSrc);
             const string fileName = @"temp.txt";
-            var newFile = File.CombinePath(tmpSrc, fileName);
-            File.WriteText(newFile, "test");
+            var newFile = FileSystem.CombinePath(tmpSrc, fileName);
+            FileSystem.WriteText(newFile, "test");
 
             const string dirName = @"subDir";
-            var newDir = File.CombinePath(tmpSrc, dirName);
+            var newDir = FileSystem.CombinePath(tmpSrc, dirName);
             Directory.CreateDirectory(newDir);
 
-            var contents = File.GetDirectoryContents(tmpSrcInfo);
+            var contents = FileSystem.GetDirectoryContents(tmpSrcInfo);
             Assert.AreEqual(new[] { newFile }, contents["files"]);
             Assert.AreEqual(new[] { newDir }, contents["directories"]);
         }
@@ -318,24 +318,24 @@ namespace Dynamo.Tests
         public void Directory_ContentsRecursive()
         {
             var tmpSrc = GetNewFileNameOnTempPath("");
-            var tmpSrcInfo = File.DirectoryFromPath(tmpSrc);
+            var tmpSrcInfo = FileSystem.DirectoryFromPath(tmpSrc);
 
             // make test file
             const string fileName = @"temp.txt";
-            var newFile = File.CombinePath(tmpSrc, fileName);
-            File.WriteText(newFile, "test");
+            var newFile = FileSystem.CombinePath(tmpSrc, fileName);
+            FileSystem.WriteText(newFile, "test");
 
             // make subdirectory
             const string dirName = @"subDir";
-            var newDir = File.CombinePath(tmpSrc, dirName);
+            var newDir = FileSystem.CombinePath(tmpSrc, dirName);
             Directory.CreateDirectory(newDir);
 
             // make another test file in subdirectory
             const string subdirFileName = @"tempSubdir.txt";
-            var newSubdirFile = File.CombinePath(newDir, subdirFileName);
-            File.WriteText(newSubdirFile, "testSubdir");
+            var newSubdirFile = FileSystem.CombinePath(newDir, subdirFileName);
+            FileSystem.WriteText(newSubdirFile, "testSubdir");
 
-            var contents = File.GetDirectoryContents(tmpSrcInfo, "*.*", true);
+            var contents = FileSystem.GetDirectoryContents(tmpSrcInfo, "*.*", true);
             Assert.AreEqual(new[] { newFile, newSubdirFile }, contents["files"]);
             Assert.AreEqual(new[] { newDir }, contents["directories"]);
         }
@@ -345,9 +345,9 @@ namespace Dynamo.Tests
         public void Directory_Exists()
         {
             var tmp = GetNewFileNameOnTempPath("");
-            Assert.IsFalse(File.DirectoryExists(tmp), "Directory hasn't been created yet.");
+            Assert.IsFalse(FileSystem.DirectoryExists(tmp), "Directory hasn't been created yet.");
             Directory.CreateDirectory(tmp);
-            Assert.IsTrue(File.DirectoryExists(tmp), "Directory has been created.");
+            Assert.IsTrue(FileSystem.DirectoryExists(tmp), "Directory has been created.");
         }
         #endregion
 
@@ -364,7 +364,7 @@ namespace Dynamo.Tests
         {
             foreach (var file in GetTestImageFiles())
             {
-                Image.ReadFromFile(File.FromPath(file));
+                Image.ReadFromFile(FileSystem.FileFromPath(file));
                 Assert.DoesNotThrow(
                     () =>
                     {

--- a/test/core/migration/TestMigration_Core_FileSystem.dyn
+++ b/test/core/migration/TestMigration_Core_FileSystem.dyn
@@ -1,0 +1,51 @@
+<Workspace Version="0.9.1.4062" X="385.6" Y="92" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e2c895bb-aefc-4b30-929a-af377c11b82d" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Directory.Contents" x="31.6000000000002" y="6.40000000000001" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.Directory.Contents@var,string">
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="59b1cd70-0949-4841-9a63-291354ee2cd9" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Directory.Copy" x="52.4" y="113.6" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.Directory.Copy@var,string,bool">
+      <PortInfo index="2" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="5724100d-beb0-4562-a9c1-72317c91368a" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Directory.Delete" x="67.6" y="253.6" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.Directory.Delete@string,bool">
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="80de7c9c-e2eb-4259-a49c-6e88bc58fb91" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Directory.Exists" x="74.0000000000001" y="369.6" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.Directory.Exists@string" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="c4306990-93d8-4235-b952-89a274816063" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Directory.Move" x="38" y="461.6" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.Directory.Move@string,string,bool">
+      <PortInfo index="2" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="033f228a-d359-46b9-85e6-292f226cf5a1" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="File.Copy" x="262" y="600" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.File.Copy@var,string,bool">
+      <PortInfo index="2" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="d664d920-8e33-4ac2-9c4b-36707dbf7ca0" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="File.Delete" x="294.8" y="-41.6000000000001" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.File.Delete@string" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="f3aec853-2a00-407f-b0eb-074517c22661" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="File.Exists" x="291.6" y="80.8" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.File.Exists@string" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="2fcbe204-9735-4e97-9101-c1cdb3a18c70" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="File.Move" x="281.2" y="197.6" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.File.Move@string,string,bool">
+      <PortInfo index="2" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="e63ea1af-839f-4eab-bf08-3e06d28651ba" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="File.ReadText" x="301.2" y="360.8" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.File.ReadText@var" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="3dd79899-ddbd-4a8c-acf8-cd45b30db759" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="File.WriteText" x="288.4" y="473.6" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.File.WriteText@string,string" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="0bc3b05f-c20a-47ed-b5cc-9e86bfc3bc70" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="FilePath.ChangeExtension" x="461.2" y="167.2" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.FilePath.ChangeExtension@string,string" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="bf35a282-45ba-4bc6-826e-6e6364ac792e" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="FilePath.Combine" x="481.2" y="280.8" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.FilePath.Combine@string[]" inputcount="1" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="0a4e3bc3-1203-4445-a2d8-c74633f31ef5" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="FilePath.DirectoryName" x="478.8" y="371.2" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.FilePath.DirectoryName@string" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="72b40f68-ac66-487f-8dad-a1ba8b779c58" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="FilePath.Extension" x="497.2" y="458.4" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.FilePath.Extension@string" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="10f54985-a184-4c9d-9c24-cd483c413dda" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="FilePath.FileName" x="469.2" y="49.5999999999999" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.FilePath.FileName@string,bool">
+      <PortInfo index="1" default="True" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="de7087dd-810c-4aee-a5fa-82ee18a64b94" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="FilePath.HasExtension" x="494" y="-37.6000000000001" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.IO.FilePath.HasExtension@string" />
+    <CoreNodeModels.Input.DirectoryObject guid="4408214d-da58-448e-91af-8437118fcfde" type="CoreNodeModels.Input.DirectoryObject" nickname="Directory.FromPath" x="686.8" y="282.4" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" />
+    <CoreNodeModels.Input.FileObject guid="7b82ad75-a822-4057-bdd6-d96502ea0ed7" type="CoreNodeModels.Input.FileObject" nickname="File.FromPath" x="708.4" y="404.8" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" />
+    <CoreNodeModels.Input.Filename guid="63ef1405-214a-444c-9f91-2d4677f70cc4" type="CoreNodeModels.Input.Filename" nickname="File Path" x="702" y="49.5999999999999" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
+      <System.String>No file selected.</System.String>
+    </CoreNodeModels.Input.Filename>
+    <CoreNodeModels.Input.Directory guid="470d70bb-631b-4e6e-abec-3b11bab825e1" type="CoreNodeModels.Input.Directory" nickname="Directory Path" x="699.6" y="153.6" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
+      <System.String>No file selected.</System.String>
+    </CoreNodeModels.Input.Directory>
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

[QNTM-2447](https://jira.autodesk.com/browse/QNTM-2447) 

The purpose of this PR is to rename `File` to `FileSystem` and to be more explicit with node naming within this category.  For example `Copy` becomes `CopyFile` to avoid confusion with similar nodes such as `CopyDirectory`.  All nodes that can be invoked via DesignScript use `FileSystem.NodeName` and display this convention on the node name.  There are also 4 NodeModel nodes that do not include this naming convention since they cannot be called from DesignScript (see image below).  Icons have been re-associated as well.

### Changes

![filesystem_library](https://user-images.githubusercontent.com/13341935/32344936-dea916d4-bfde-11e7-9c7c-e081cc673bf6.JPG)

ImportExport/File (Now - FileSystem)

- AppendText
- ChangePathExtension
- CombinePath
- Copy (Now - CopyFile)
- CopyDirectory
- Delete (Now - DeleteFile)
- DeleteDirectory
- Directoy Path
- DirectoryExists
- DirectoryFromPath
- DirectoryName
- Exists (Now - FileExists)
- File Path
- FileExtension
- FileHasExtension
- FileName
- FromPath (Now - FileFromPath)
- GetDirectoryContents
- Move (Now - MoveFile)
- MoveDirectory
- ReadText
- WriteText

### Testing

- All existing `FileLibraryTests`, `FileReadingTests`, and `FileWritingTests` pass
- Tested migration from 0.9 and 1.3 XML files containing all the nodes listed above to 2.0
- Added a Migration Unit Test (using 0.9 dyn)

![filesystem_tests](https://user-images.githubusercontent.com/13341935/32344929-d7fe8b34-bfde-11e7-95f0-18333dda3a81.JPG)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@QilongTang 
