### PR TITLE
Deprecate DayOfWeek Enum node

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -664,6 +664,8 @@ namespace ProtoFFI
             func.IsExternLib = true;
             func.ExternLibName = Module.Name;
             func.IsStatic = f.IsStatic;
+            //Set the method attribute for Enum properties.
+            func.MethodAttributes = new FFIMethodAttributes(f);
 
             return func;
         }
@@ -1247,6 +1249,32 @@ namespace ProtoFFI
         }
         public bool AllowRankReduction { get; protected set; }
         public bool RequireTracing { get; protected set; }
+
+        //Set the MethodAttributes for Enum fields.
+        public FFIMethodAttributes(FieldInfo f)
+        {
+            var atts = f.GetCustomAttributes(false).Cast<Attribute>();
+
+            foreach (var attr in atts)
+            {
+                //Set the obsolete message for enum fields.
+                if (attr is IsObsoleteAttribute)
+                {
+                    HiddenInLibrary = true;
+                    ObsoleteMessage = (attr as IsObsoleteAttribute).Message;
+                    if (string.IsNullOrEmpty(ObsoleteMessage))
+                        ObsoleteMessage = "Obsolete";
+                }
+                else if (attr is ObsoleteAttribute)
+                {
+                    HiddenInLibrary = true;
+                    ObsoleteMessage = (attr as ObsoleteAttribute).Message;
+                    if (string.IsNullOrEmpty(ObsoleteMessage))
+                        ObsoleteMessage = "Obsolete";
+                }
+
+            }
+        }
 
         public FFIMethodAttributes(MethodInfo method, Dictionary<MethodInfo, Attribute[]> getterAttributes)
         {

--- a/src/Libraries/CoreNodes/DateTime.cs
+++ b/src/Libraries/CoreNodes/DateTime.cs
@@ -232,14 +232,22 @@ namespace DSCore
     /// <summary>
     ///     Days of the Week
     /// </summary>
+    [IsVisibleInDynamoLibrary(false)]
     public enum DayOfWeek
     {
+        [Obsolete("This node is deprecated")]
         [EnumDescription("EnumDateOfWeekSunday", typeof(Properties.Resources))]Sunday,
+        [Obsolete("This node is deprecated")]
         [EnumDescription("EnumDateOfWeekMonday", typeof(Properties.Resources))]Monday,
+        [Obsolete("This node is deprecated")]
         [EnumDescription("EnumDateOfWeekTuesday", typeof(Properties.Resources))]Tuesday,
+        [Obsolete("This node is deprecated")]
         [EnumDescription("EnumDateOfWeekWednesday", typeof(Properties.Resources))]Wednesday,
+        [Obsolete("This node is deprecated")]
         [EnumDescription("EnumDateOfWeekThursday", typeof(Properties.Resources))]Thursday,
+        [Obsolete("This node is deprecated")]
         [EnumDescription("EnumDateOfWeekFriday", typeof(Properties.Resources))]Friday,
+        [Obsolete("This node is deprecated")]
         [EnumDescription("EnumDateOfWeekSaturday", typeof(Properties.Resources))]Saturday
     }
 

--- a/test/DynamoCoreWpfTests/DateTimeTests.cs
+++ b/test/DynamoCoreWpfTests/DateTimeTests.cs
@@ -1,7 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Dynamo;
 using Dynamo.Configuration;
+using Dynamo.Engine;
+using Dynamo.Graph.Nodes;
 using Dynamo.Tests;
 using NUnit.Framework;
 using DateTime = CoreNodeModels.Input.DateTime;
@@ -60,6 +63,19 @@ namespace DynamoCoreWpfTests
             var dt = (System.DateTime)GetPreviewValue(node.GUID.ToString());
 
             Assert.AreEqual(string.Format("{0:" + PreferenceSettings.DefaultDateFormat + "}", dt), testDate.ToString(PreferenceSettings.DefaultDateFormat));
+        }
+
+        [Test]
+
+        public void DateTimeNodeDeprecated_Test()
+        {
+            var path = Path.Combine(TestDirectory, "core", "dateTime", "DateTimeDeprecated.dyn");
+            CurrentDynamoModel.OpenFileFromPath(path);
+
+            var node = CurrentDynamoModel.CurrentWorkspace.Nodes.FirstOrDefault();
+            Assert.IsNotNull(node);
+            Assert.AreEqual(ElementState.PersistentWarning, node.State);
+            Assert.AreEqual("This node is deprecated", node.ToolTipText);
         }
 
         [TearDown]

--- a/test/core/dateTime/DateTimeDeprecated.dyn
+++ b/test/core/dateTime/DateTimeDeprecated.dyn
@@ -1,0 +1,13 @@
+<Workspace Version="1.3.0.875" X="0" Y="0" zoom="1" ScaleFactor="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="67f8b695-d664-4d2e-8005-e262048511c5" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="DayOfWeek.Friday" x="337.5" y="326" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.DayOfWeek.Friday" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose
This PR sets the DayOfWeek node as deprecated in Dynamo.  DayOfWeek node is enum, and hence a new constructor is added to check for obsolete property on Enum fields.

Samplegraph
```
{
  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
  "IsCustomNode": false,
  "Description": "",
  "Name": "Home",
  "ElementResolver": {
    "ResolutionMap": {}
  },
  "Inputs": [],
  "Nodes": [
    {
      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
      "NodeType": "FunctionNode",
      "FunctionSignature": "DSCore.DayOfWeek.Friday",
      "Id": "e299fd0add574ff99a87e642983dbc9f",
      "Inputs": [],
      "Outputs": [
        {
          "Id": "d9ca877201d04441bb12f6dcd3548ac8",
          "Name": "DayOfWeek",
          "Description": "DayOfWeek",
          "UsingDefaultValue": false,
          "Level": 2,
          "UseLevels": false,
          "KeepListStructure": false
        }
      ],
      "Replication": "Auto",
      "Description": "DayOfWeek.Friday: DayOfWeek"
    }
  ],
  "Connectors": [],
  "Dependencies": [],
  "Bindings": [],
  "View": {
    "Dynamo": {
      "ScaleFactor": 1.0,
      "HasRunWithoutCrash": true,
      "IsVisibleInDynamoLibrary": true,
      "Version": "2.0.0.3064",
      "RunType": "Automatic",
      "RunPeriod": "1000"
    },
    "Camera": {
      "Name": "Background Preview",
      "EyeX": -17.0,
      "EyeY": 24.0,
      "EyeZ": 50.0,
      "LookX": 12.0,
      "LookY": -13.0,
      "LookZ": -58.0,
      "UpX": 0.0,
      "UpY": 1.0,
      "UpZ": 0.0
    },
    "NodeViews": [
      {
        "Id": "e299fd0add574ff99a87e642983dbc9f",
        "Name": "DayOfWeek.Friday",
        "ShowGeometry": true,
        "Excluded": false,
        "X": 294.0,
        "Y": 232.75
      }
    ],
    "Annotations": [],
    "X": 0.0,
    "Y": 0.0,
    "Zoom": 1.0
  }
}
```


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
