### PR TITLE
Update obsolete read/write image migration

### DIFF
--- a/src/Libraries/CoreNodes/DSCoreNodes.Migrations.xml
+++ b/src/Libraries/CoreNodes/DSCoreNodes.Migrations.xml
@@ -5,8 +5,8 @@
     <newName>DSCore.List.Contains</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.File.ReadImage</oldName>
-    <newName>DSCore.IO.File.ReadImage</newName>
+    <oldName>DSCore.IO.File.ReadImage</oldName>
+    <newName>DSCore.IO.Image.ReadFromFile</newName>
   </priorNameHint>
   <priorNameHint>
     <oldName>DSCore.File.LoadImageFromPath</oldName>
@@ -17,8 +17,8 @@
     <newName>DSCore.IO.File.ReadText</newName>
   </priorNameHint>
   <priorNameHint>
-    <oldName>DSCore.File.WriteImage</oldName>
-    <newName>DSCore.IO.File.WriteImage</newName>
+    <oldName>DSCore.IO.File.WriteImage</oldName>
+    <newName>DSCore.IO.Image.WriteToFile</newName>
   </priorNameHint>
   <priorNameHint>
     <oldName>DSCore.File.WriteText</oldName>


### PR DESCRIPTION
### Purpose

This is an addition to [8308](https://github.com/DynamoDS/Dynamo/pull/8308).

`ReadImage` and `WriteImage` were at one point part of the `File` class which was recently renamed to `FileSystem`.  These nodes were marked obsolete a while ago when these nodes became part of the `Image` class however  `DSCoreNodes.Migrations.xml` included a migration attempting to migrate `DSCore.File.ReadImage` to `DSCore.IO.File.ReadImage` which actually doesn't migrate to the new `Image` class node but allows the obsolete node to still be added to the graph (which allowed the tests to still pass).  Renaming the `File` class caused this migration to break.  My solution in this PR is to migrate the obsolete node to the latest version in the `Image` class.

### Testing

Verified `File.ReadImage` and `File.WriteImage` (now `Image.ReadFile` and `Image.WriteFile`) are properly migrated properly from at a minimum from Dynamo 0.9 forward.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
