### PR TITLE
Add a try catch to catch errors getting the extension of the path.

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1142,7 +1142,12 @@ namespace Dynamo.Models
             foreach (var path in pathManager.DefinitionDirectories)
             {
                 // NOTE: extension will only be null if path is null
-                string extension = Path.GetExtension(path);
+                string extension = null;
+                try
+                {
+                    extension = Path.GetExtension(path);
+                }
+                catch (ArgumentException) { }
                 if (extension == null)
                     continue;
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1147,7 +1147,10 @@ namespace Dynamo.Models
                 {
                     extension = Path.GetExtension(path);
                 }
-                catch (ArgumentException) { }
+                catch (ArgumentException e)
+                {
+                    Logger.Log(e.Message);
+                }
                 if (extension == null)
                     continue;
 


### PR DESCRIPTION
### Purpose

This PR addresses an issue with the LoadFromMultipleLocationTest. This test passes in an invalid path and there was an exception being thrown by a call to Path.GetExtension, so the call needed to be wrapped in a try catch block.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [not run yet] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@alfarok 