### PR TITLE
don't fail to load custom node if engine is null

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -672,6 +672,7 @@ namespace Dynamo.Core
             }
             else if(DynamoUtilities.PathHelper.isValidJson(workspaceInfo.FileName, out jsonDoc))
             {
+                //we pass null for engine and scheduler as apparently the custom node constructor doesnt need them.
                 newWorkspace = (CustomNodeWorkspaceModel)WorkspaceModel.FromJson(jsonDoc, this.libraryServices, null, null, nodeFactory, false, true, this);
                 newWorkspace.FileName = workspaceInfo.FileName;
             }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1572,6 +1572,8 @@ namespace Dynamo.Graph.Workspaces
             EngineController engineController, DynamoScheduler scheduler, NodeFactory factory,
             bool isTestMode, bool verboseLogging, CustomNodeManager manager)
         {
+            var logger = engineController != null ? engineController.AsLogger() : null;
+
             var settings = new JsonSerializerSettings
             {
                 Error = (sender, args) =>
@@ -1583,7 +1585,7 @@ namespace Dynamo.Graph.Workspaces
                 TypeNameHandling = TypeNameHandling.Auto,
                 Formatting = Newtonsoft.Json.Formatting.Indented,
                 Converters = new List<JsonConverter>{
-                        new ConnectorConverter(engineController.AsLogger()),
+                        new ConnectorConverter(logger),
                         new WorkspaceReadConverter(engineController, scheduler, factory, isTestMode, verboseLogging),
                         new NodeReadConverter(manager, libraryServices),
                         new TypedParameterConverter()

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -30,7 +30,7 @@ namespace Dynamo.Tests
         /// <param name="model"> the workspace the json represents</param>
         /// <param name="modelsGuidToIdMap"> a map of the old guids to the new ids we are replacing them with </param>
         /// <returns> returns a new json string without guids where applicable </returns>
-        public static string replaceModelIdsWithNonGuids(string json, WorkspaceModel model, Dictionary<Guid,string> modelsGuidToIdMap)
+        public static string replaceModelIdsWithNonGuids(string json, WorkspaceModel model, Dictionary<Guid, string> modelsGuidToIdMap)
         {
             var idcount = 0;
 
@@ -179,7 +179,7 @@ namespace Dynamo.Tests
         /// </summary>
         /// <param name="a"> first workspace data to compare</param>
         /// <param name="b">second workspace data to compare</param>
-        public static void CompareWorkspaceModels(serializationTestUtils.WorkspaceComparisonData a, serializationTestUtils.WorkspaceComparisonData b, Dictionary<Guid,string> c = null)
+        public static void CompareWorkspaceModels(serializationTestUtils.WorkspaceComparisonData a, serializationTestUtils.WorkspaceComparisonData b, Dictionary<Guid, string> c = null)
         {
             var nodeDiff = a.NodeTypeMap.Except(b.NodeTypeMap);
             if (nodeDiff.Any())
@@ -189,7 +189,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(a.Description, b.Description, "The workspaces don't have the same description.");
             Assert.AreEqual(a.NodeCount, b.NodeCount, "The workspaces don't have the same number of nodes.");
             Assert.AreEqual(a.ConnectorCount, b.ConnectorCount, "The workspaces don't have the same number of connectors.");
-          
+
             foreach (var kvp in a.InportCountMap)
             {
                 var countA = kvp.Value;
@@ -248,7 +248,7 @@ namespace Dynamo.Tests
 
         public static void CompareWorkspacesDifferentGuids(serializationTestUtils.WorkspaceComparisonData a,
             serializationTestUtils.WorkspaceComparisonData b,
-            Dictionary<Guid,string> modelGuidsToIDmap)
+            Dictionary<Guid, string> modelGuidsToIDmap)
         {
             var nodeDiff = a.NodeTypeMap.Select(x => x.Value).Except(b.NodeTypeMap.Select(x => x.Value));
             if (nodeDiff.Any())
@@ -330,7 +330,7 @@ namespace Dynamo.Tests
         public static void SaveWorkspaceComparisonData(serializationTestUtils.WorkspaceComparisonData wcd1,
             string filePathBase,
             TimeSpan executionDuration,
-            Dictionary<Guid,string> modelGuidToIDMap = null)
+            Dictionary<Guid, string> modelGuidToIDMap = null)
         {
             var nodeData = new Dictionary<string, Dictionary<string, object>>();
             foreach (var d in wcd1.NodeDataMap)
@@ -371,7 +371,7 @@ namespace Dynamo.Tests
         public static void SaveWorkspaceComparisonDataWithNonGuidIds(serializationTestUtils.WorkspaceComparisonData wcd1,
             string filePathBase,
             TimeSpan executionDuration,
-            Dictionary<Guid,string> modelsGuidToIdMap)
+            Dictionary<Guid, string> modelsGuidToIdMap)
         {
             var nodeData = new Dictionary<string, Dictionary<string, object>>();
             foreach (var d in wcd1.NodeDataMap)
@@ -460,7 +460,7 @@ namespace Dynamo.Tests
         public void FixtureSetup()
         {
             ExecutionEvents.GraphPostExecution += ExecutionEvents_GraphPostExecution;
-            
+
             //Clear Temp directory folders before start of the new serialization test run
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonFolderName);
@@ -475,7 +475,7 @@ namespace Dynamo.Tests
                     Console.WriteLine("Deleting JSON directory from temp");
                     Directory.Delete(jsonFolder, true);
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     Console.WriteLine(e.Message);
                 }
@@ -510,7 +510,26 @@ namespace Dynamo.Tests
         public void ConverterDoesNotThrowWithNullEngine()
         {
             CurrentDynamoModel.AddHomeWorkspace();
-            Assert.DoesNotThrow(()=>{ CurrentDynamoModel.CurrentWorkspace.ToJson(null); });
+            Assert.DoesNotThrow(() => { CurrentDynamoModel.CurrentWorkspace.ToJson(null); });
+        }
+
+        [Test]
+        public void ReadConverterDoesNotThrowWithNullEngineAndScheduler()
+        {
+            CurrentDynamoModel.AddHomeWorkspace();
+            var json = CurrentDynamoModel.CurrentWorkspace.ToJson(null);
+
+            Assert.DoesNotThrow(() =>
+            {
+                WorkspaceModel.FromJson(
+                json, this.CurrentDynamoModel.LibraryServices,
+                null,
+                null,
+                this.CurrentDynamoModel.NodeFactory,
+                true,
+                true,
+                this.CurrentDynamoModel.CustomNodeManager);
+            });
         }
 
         [Test]
@@ -518,7 +537,7 @@ namespace Dynamo.Tests
         {
             var customNodeTestPath = Path.Combine(TestDirectory, @"core\CustomNodes\TestAdd.dyn");
             DoWorkspaceOpenAndCompare(customNodeTestPath, "json", ConvertCurrentWorkspaceToJsonAndSave,
-                serializationTestUtils.CompareWorkspaceModels, 
+                serializationTestUtils.CompareWorkspaceModels,
                 serializationTestUtils.SaveWorkspaceComparisonData);
         }
 
@@ -527,7 +546,7 @@ namespace Dynamo.Tests
         {
             var customNodeTestPath = Path.Combine(TestDirectory, @"core\serialization\serialization.dyn");
             DoWorkspaceOpenAndCompare(customNodeTestPath, "json", ConvertCurrentWorkspaceToJsonAndSave,
-                serializationTestUtils.CompareWorkspaceModels, 
+                serializationTestUtils.CompareWorkspaceModels,
                 serializationTestUtils.SaveWorkspaceComparisonData);
         }
 
@@ -548,7 +567,7 @@ namespace Dynamo.Tests
         [Test, TestCaseSource("FindWorkspaces")]
         public void SerializationTest(string filePath)
         {
-            DoWorkspaceOpenAndCompare(filePath, jsonFolderName, ConvertCurrentWorkspaceToJsonAndSave, 
+            DoWorkspaceOpenAndCompare(filePath, jsonFolderName, ConvertCurrentWorkspaceToJsonAndSave,
                 serializationTestUtils.CompareWorkspaceModels,
                 serializationTestUtils.SaveWorkspaceComparisonData);
         }
@@ -566,7 +585,7 @@ namespace Dynamo.Tests
         public void SerializationNonGuidIdsTest(string filePath)
         {
             modelsGuidToIdMap.Clear();
-            DoWorkspaceOpenAndCompare(filePath,jsonNonGuidFolderName, 
+            DoWorkspaceOpenAndCompare(filePath, jsonNonGuidFolderName,
                 ConvertCurrentWorkspaceToNonGuidJsonAndSave,
                 serializationTestUtils.CompareWorkspacesDifferentGuids,
                 serializationTestUtils.SaveWorkspaceComparisonDataWithNonGuidIds);
@@ -595,8 +614,8 @@ namespace Dynamo.Tests
 
         private void DoWorkspaceOpenAndCompare(string filePath, string dirName,
             Func<DynamoModel, string, string> saveFunction,
-            Action<serializationTestUtils.WorkspaceComparisonData, serializationTestUtils.WorkspaceComparisonData, Dictionary<Guid,String>> workspaceCompareFunction,
-            Action<serializationTestUtils.WorkspaceComparisonData, string, TimeSpan,Dictionary<Guid,string>> workspaceDataSaveFunction)
+            Action<serializationTestUtils.WorkspaceComparisonData, serializationTestUtils.WorkspaceComparisonData, Dictionary<Guid, String>> workspaceCompareFunction,
+            Action<serializationTestUtils.WorkspaceComparisonData, string, TimeSpan, Dictionary<Guid, string>> workspaceDataSaveFunction)
         {
             var openPath = filePath;
 
@@ -643,7 +662,7 @@ namespace Dynamo.Tests
 
             string json = saveFunction(model, filePathBase);
 
-            workspaceDataSaveFunction(wcd1, filePathBase, lastExecutionDuration,modelsGuidToIdMap);
+            workspaceDataSaveFunction(wcd1, filePathBase, lastExecutionDuration, modelsGuidToIdMap);
 
             lastExecutionDuration = new TimeSpan();
 
@@ -704,7 +723,7 @@ namespace Dynamo.Tests
 
             var wcd2 = new serializationTestUtils.WorkspaceComparisonData(ws2, CurrentDynamoModel.EngineController);
 
-            workspaceCompareFunction(wcd1, wcd2,modelsGuidToIdMap);
+            workspaceCompareFunction(wcd1, wcd2, modelsGuidToIdMap);
 
             var functionNodes = ws2.Nodes.Where(n => n is Function).Cast<Function>();
             if (functionNodes.Any())
@@ -738,7 +757,7 @@ namespace Dynamo.Tests
             Assert.IsTrue(inputs.SequenceEqual(inputs2));
         }
 
-     
+
 
         private static string ConvertCurrentWorkspaceToJsonAndSave(DynamoModel model, string filePathBase)
         {
@@ -767,7 +786,7 @@ namespace Dynamo.Tests
         {
             var json = model.CurrentWorkspace.ToJson(model.EngineController);
 
-           json = serializationTestUtils.replaceModelIdsWithNonGuids(json, model.CurrentWorkspace, modelsGuidToIdMap);
+            json = serializationTestUtils.replaceModelIdsWithNonGuids(json, model.CurrentWorkspace, modelsGuidToIdMap);
 
             Assert.IsNotNullOrEmpty(json);
 

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -911,9 +911,13 @@ namespace DynamoCoreWpfTests
             var nodeingraph = this.ViewModel.CurrentSpace.Nodes.FirstOrDefault();
             Assert.NotNull(nodeingraph);
             Assert.IsTrue(nodeingraph.State == ElementState.Active);
+            //remove custom node from definitions folder
+            var savePath = Path.Combine(this.ViewModel.Model.PathManager.DefinitionDirectories.FirstOrDefault(), "NewCustomNodeSaveAndLoad.dyf");
+            File.Delete(savePath);
+
         }
 
-        
+
         [Test]
         public void AllTypesSerialize()
         {

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -26,6 +26,7 @@ using Dynamo.Wpf.ViewModels.Watch3D;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Dynamo.Utilities;
+using Dynamo.Graph.Connectors;
 
 namespace DynamoCoreWpfTests
 {
@@ -864,6 +865,55 @@ namespace DynamoCoreWpfTests
                 serializationTestUtils.SaveWorkspaceComparisonData);
         }
 
+        [Test]
+        public void NewCustomNodeSaveAndLoadPt1()
+        {
+
+            var funcguid = GuidUtility.Create(GuidUtility.UrlNamespace, "NewCustomNodeSaveAndLoad");
+            //first create a new custom node.
+            this.ViewModel.ExecuteCommand(new DynamoModel.CreateCustomNodeCommand(funcguid, "testnode", "testcategory", "atest", true));
+            var outnode1 = new Output();
+            outnode1.Symbol = "out1";
+            var outnode2 = new Output();
+            outnode1.Symbol = "out2";
+
+            var numberNode = new DoubleInput();
+            numberNode.Value = "5";
+          
+
+            this.ViewModel.CurrentSpace.AddAndRegisterNode(numberNode);
+            this.ViewModel.CurrentSpace.AddAndRegisterNode(outnode1);
+            this.ViewModel.CurrentSpace.AddAndRegisterNode(outnode2);
+
+            new ConnectorModel(numberNode.OutPorts.FirstOrDefault(), outnode1.InPorts.FirstOrDefault(), Guid.NewGuid());
+            new ConnectorModel(numberNode.OutPorts.FirstOrDefault(), outnode2.InPorts.FirstOrDefault(), Guid.NewGuid());
+
+
+            var savePath = Path.Combine(this.ViewModel.Model.PathManager.DefinitionDirectories.FirstOrDefault(), "NewCustomNodeSaveAndLoad.dyf");
+            //save it to the definitions folder so it gets loaded at startup.
+            this.ViewModel.CurrentSpace.Save(savePath);
+
+            //assert the filesaved
+            Assert.IsTrue(File.Exists(savePath));
+            Assert.IsFalse(string.IsNullOrEmpty(File.ReadAllText(savePath)));
+        }
+
+        [Test]
+        public void NewCustomNodeSaveAndLoadPt2()
+        {
+            var funcguid = GuidUtility.Create(GuidUtility.UrlNamespace, "NewCustomNodeSaveAndLoad");
+            var functionnode = this.ViewModel.Model.CustomNodeManager.CreateCustomNodeInstance(funcguid,"testnode",true);
+            Assert.IsTrue(functionnode.IsCustomFunction);
+            Assert.IsFalse(functionnode.IsInErrorState);
+            Assert.AreEqual(functionnode.OutPorts.Count, 2);
+
+            this.ViewModel.CurrentSpace.AddAndRegisterNode(functionnode);
+            var nodeingraph = this.ViewModel.CurrentSpace.Nodes.FirstOrDefault();
+            Assert.NotNull(nodeingraph);
+            Assert.IsTrue(nodeingraph.State == ElementState.Active);
+        }
+
+        
         [Test]
         public void AllTypesSerialize()
         {


### PR DESCRIPTION
reported by @phliberato 

### Purpose
a very limited check, which does not throw when creating customnodes.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@phliberato @kronz