### PR TITLE
QNTM-2737: Add categories for exclusion

### DIFF
--- a/test/DynamoCoreTests/MigrationManagerTests.cs
+++ b/test/DynamoCoreTests/MigrationManagerTests.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 namespace Dynamo.Tests
 {
     [TestFixture]
+    [Category("JsonTestExclude")]
     internal class MigrationManagerTests
     {
         private XmlDocument xmlDocument = null;

--- a/test/DynamoCoreTests/MigrationTestFramework.cs
+++ b/test/DynamoCoreTests/MigrationTestFramework.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 namespace Dynamo.Tests
 {
     [TestFixture]
+    [Category("JsonTestExclude")]
     class MigrationTestFramework : DynamoModelTestBase
     {
         protected override void GetLibrariesToPreload(List<string> libraries)

--- a/test/DynamoCoreTests/NodeMigrationTests.cs
+++ b/test/DynamoCoreTests/NodeMigrationTests.cs
@@ -12,6 +12,7 @@ using PythonNodeModels;
 
 namespace Dynamo.Tests
 {
+    [Category("JsonTestExclude")]
     public class NodeMigrationTests : DynamoModelTestBase
     {
         protected override void GetLibrariesToPreload(List<string> libraries)

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -532,7 +532,7 @@ namespace Dynamo.Tests
             });
         }
 
-        [Test]
+        [Test, Category("JsonTestExclude")]
         public void CustomNodeSerializationTest()
         {
             var customNodeTestPath = Path.Combine(TestDirectory, @"core\CustomNodes\TestAdd.dyn");
@@ -541,7 +541,7 @@ namespace Dynamo.Tests
                 serializationTestUtils.SaveWorkspaceComparisonData);
         }
 
-        [Test]
+        [Test, Category("JsonTestExclude")]
         public void AllTypesSerialize()
         {
             var customNodeTestPath = Path.Combine(TestDirectory, @"core\serialization\serialization.dyn");
@@ -564,7 +564,7 @@ namespace Dynamo.Tests
         /// </summary>
         /// <param name="filePath">The path to a .dyn file. This parameter is supplied
         /// by the test framework.</param>
-        [Test, TestCaseSource("FindWorkspaces")]
+        [Test, TestCaseSource("FindWorkspaces"), Category("JsonTestExclude")]
         public void SerializationTest(string filePath)
         {
             DoWorkspaceOpenAndCompare(filePath, jsonFolderName, ConvertCurrentWorkspaceToJsonAndSave,
@@ -581,7 +581,7 @@ namespace Dynamo.Tests
         /// </summary>
         /// <param name="filePath">The path to a .dyn file. This parameter is supplied
         /// by the test framework.</param>
-        [Test, TestCaseSource("FindWorkspaces")]
+        [Test, TestCaseSource("FindWorkspaces"), Category("JsonTestExclude")]
         public void SerializationNonGuidIdsTest(string filePath)
         {
             modelsGuidToIdMap.Clear();

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -824,7 +824,7 @@ namespace DynamoCoreWpfTests
         /// </summary>
         /// <param name="filePath">The path to a .dyn file. This parameter is supplied
         /// by the test framework.</param>
-        [Test, TestCaseSource("FindWorkspaces")]
+        [Test, TestCaseSource("FindWorkspaces"), Category("JsonTestExclude")]
         public void SerializationTest(string filePath)
         {
             DoWorkspaceOpenAndCompareView(filePath,
@@ -843,7 +843,7 @@ namespace DynamoCoreWpfTests
         /// </summary>
         /// <param name="filePath">The path to a .dyn file. This parameter is supplied
         /// by the test framework.</param>
-        [Test, TestCaseSource("FindWorkspaces")]
+        [Test, TestCaseSource("FindWorkspaces"), Category("JsonTestExclude")]
         public void SerializationNonGuidIdsTest(string filePath)
         {
             modelsGuidToIdMap.Clear();


### PR DESCRIPTION
### Purpose
The purpose of this PR is to add categories to migration and serialization tests so that we can exclude migration and serialization tests from JSON test run

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate

### Reviewers

@QilongTang 

### FYIs

@mjkkirschner 
