### PR TITLE
[WIP] QNTM-2631: Watch3D node should display geometry only from connected port

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -284,6 +284,7 @@ limitations under the License.
     </Compile>
     <Compile Include="Search\SearchDictionary.cs" />
     <Compile Include="Utilities\ResourceLoader.cs" />
+    <Compile Include="Visualization\RenderPackageCache.cs" />
     <EmbeddedResource Include="BuiltInAndOperators\BuiltInImages.resx">
       <LastGenOutput>OperatorsImages.Designer.cs</LastGenOutput>
     </EmbeddedResource>

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2308,8 +2308,6 @@ namespace Dynamo.Graph.Nodes
             var task = asyncTask as UpdateRenderPackageAsyncTask;
             var packages = new RenderPackageCache();
 
-            // TODO, QNTM-2631: Determine why OnRequestRenderPackages should not be called
-            // if the task render package cache is empty
             if (!task.RenderPackages.IsEmpty())
             {
                 packages.Add(task.RenderPackages);

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2283,7 +2283,7 @@ namespace Dynamo.Graph.Nodes
                 Node = this,
                 RenderPackageFactory = factory,
                 EngineController = engine,
-                DrawableIds = GetDrawableIds(),
+                DrawableIds = GetDrawableIdMap(),
                 PreviewIdentifierName = AstIdentifierForPreview.Name,
                 ForceUpdate = forceUpdate
             };
@@ -2338,21 +2338,24 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
-        /// Returns list of drawable Ids as registered with visualization manager
-        /// for all the output port of the given node.
+        /// Returns a map of output port GUIDs and drawable Ids as registered 
+        /// with visualization manager for all the output ports of the given node.
         /// </summary>
         /// <returns>List of Drawable Ids</returns>
-        private IEnumerable<string> GetDrawableIds()
+        private IEnumerable<KeyValuePair<Guid, string>> GetDrawableIdMap()
         {
-            var drawables = new List<String>();
-            for (int i = 0; i < OutPorts.Count; ++i)
+            var idMap = new Dictionary<Guid, string>();
+            for (int index = 0; index < OutPorts.Count; ++index)
             {
-                string id = GetDrawableId(i);
+                string id = GetDrawableId(index);
                 if (!string.IsNullOrEmpty(id))
-                    drawables.Add(id);
+                {
+                    Guid originId = OutPorts[index].GUID;
+                    idMap[originId] = id;
+                }
             }
 
-            return drawables;
+            return idMap;
         }
 
         /// <summary>

--- a/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
@@ -81,7 +81,7 @@ namespace Dynamo.Scheduler
             if (initParams.EngineController == null)
                 throw new ArgumentNullException("initParams.EngineController");
             if (initParams.DrawableIdMap == null)
-                throw new ArgumentNullException("initParams.DrawableIds");
+                throw new ArgumentNullException("initParams.DrawableIdMap");
 
             var nodeModel = initParams.Node;
             if (nodeModel.WasRenderPackageUpdatedAfterExecution && !initParams.ForceUpdate)

--- a/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateRenderPackageAsyncTask.cs
@@ -130,11 +130,19 @@ namespace Dynamo.Scheduler
                 if (mirrorData == null)
                     continue;
 
-                GetRenderPackagesFromMirrorData(mirrorData.GetData(), previewIdentifierName, displayLabels);
+                GetRenderPackagesFromMirrorData(
+                    idEnum.Current.Key,
+                    mirrorData.GetData(), 
+                    previewIdentifierName, 
+                    displayLabels);
             }
         }
 
-        private void GetRenderPackagesFromMirrorData(MirrorData mirrorData, string tag, bool displayLabels)
+        private void GetRenderPackagesFromMirrorData(
+            Guid outputPortId,
+            MirrorData mirrorData, 
+            string tag, 
+            bool displayLabels)
         {
             if (mirrorData.IsNull)
             {
@@ -149,7 +157,7 @@ namespace Dynamo.Scheduler
                     if (el.IsCollection || el.Data is IGraphicItem)
                     {
                         string newTag = tag + ":" + count;
-                        GetRenderPackagesFromMirrorData(el, newTag, displayLabels);
+                        GetRenderPackagesFromMirrorData(outputPortId, el, newTag, displayLabels);
                     }
                     count = count + 1;
                 }
@@ -301,7 +309,7 @@ namespace Dynamo.Scheduler
                 package.DisplayLabels = displayLabels;
                 package.IsSelected = isNodeSelected;
 
-                renderPackageCache.Add(package);
+                renderPackageCache.Add(package, outputPortId);
             }
         }
 

--- a/src/DynamoCore/Visualization/IRenderPackageSource.cs
+++ b/src/DynamoCore/Visualization/IRenderPackageSource.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using Autodesk.DesignScript.Interfaces;
 
 namespace Dynamo.Visualization
 {
@@ -13,6 +11,6 @@ namespace Dynamo.Visualization
         /// <summary>
         /// An event raised then the source has updated IRenderPackages.
         /// </summary>
-        event Action<T, IEnumerable<IRenderPackage>> RenderPackagesUpdated;
+        event Action<T, RenderPackageCache> RenderPackagesUpdated;
     }
 }

--- a/src/DynamoCore/Visualization/RenderPackageCache.cs
+++ b/src/DynamoCore/Visualization/RenderPackageCache.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using Autodesk.DesignScript.Interfaces;
+
+namespace Dynamo.Visualization
+{
+    public class RenderPackageCache
+    {
+        private List<IRenderPackage> packages;
+
+        // TODO, QNTM-2631: The packages list returned should take into account the
+        // output port they were created by if needed
+        public IEnumerable<IRenderPackage> Packages
+        {
+            get
+            {
+                return packages;
+            }
+        }
+
+        public RenderPackageCache()
+        {
+            packages = new List<IRenderPackage>();
+        }
+
+        // TODO, QNTM-2631: This should include the GUIDs of the output ports that the packages came from
+        public RenderPackageCache(IEnumerable<IRenderPackage> otherPackages)
+        {
+            packages = new List<IRenderPackage>();
+            foreach (var package in otherPackages)
+            {
+                packages.Add(package);
+            }
+        }
+
+        public bool IsEmpty()
+        {
+            return packages.Count == 0;
+        }
+
+        public void Add(RenderPackageCache other)
+        {
+            foreach (var package in other.packages)
+            {
+                packages.Add(package);
+            }
+        }
+
+        // TODO, QNTM-2631: This should include the GUID of the output port the package came from
+        public void Add(IRenderPackage package)
+        {
+            packages.Add(package);
+        }
+    }
+}

--- a/src/DynamoCore/Visualization/RenderPackageCache.cs
+++ b/src/DynamoCore/Visualization/RenderPackageCache.cs
@@ -42,6 +42,18 @@ namespace Dynamo.Visualization
             packages.AddRange(otherPackages);
         }
 
+        public RenderPackageCache GetPortPackages(Guid portId)
+        {
+            List<IRenderPackage> portPackages;
+            if (!portMap.TryGetValue(portId, out portPackages))
+                return null;
+
+            if (portPackages == null)
+                return null;
+
+            return new RenderPackageCache(portPackages);
+        }
+
         public bool IsEmpty()
         {
             return packages.Count == 0;

--- a/src/DynamoCore/Visualization/RenderPackageCache.cs
+++ b/src/DynamoCore/Visualization/RenderPackageCache.cs
@@ -19,27 +19,24 @@ namespace Dynamo.Visualization
             portMap[outputPortId].Add(package);
         }
 
-        // TODO, QNTM-2631: The packages list returned should take into account the
-        // output port they were created by if needed
-        public IEnumerable<IRenderPackage> Packages
-        {
-            get
-            {
-                return packages;
-            }
-        }
-
         public RenderPackageCache()
         {
             packages = new List<IRenderPackage>();
             portMap = new Dictionary<Guid, RenderPackageCache>();
         }
 
-        // TODO, QNTM-2631: This should include the GUIDs of the output ports that the packages came from
         public RenderPackageCache(IEnumerable<IRenderPackage> otherPackages)
         : this()
         {
             packages.AddRange(otherPackages);
+        }
+
+        public IEnumerable<IRenderPackage> Packages
+        {
+            get
+            {
+                return packages;
+            }
         }
 
         public RenderPackageCache GetPortPackages(Guid portId)

--- a/src/DynamoCore/Visualization/RenderPackageCache.cs
+++ b/src/DynamoCore/Visualization/RenderPackageCache.cs
@@ -7,13 +7,13 @@ namespace Dynamo.Visualization
     public class RenderPackageCache
     {
         private List<IRenderPackage> packages;
-        private Dictionary<Guid, List<IRenderPackage>> portMap;
+        private Dictionary<Guid, RenderPackageCache> portMap;
 
         private void AddPort(IRenderPackage package, Guid outputPortId)
         {
             if (!portMap.ContainsKey(outputPortId))
             {
-                portMap[outputPortId] = new List<IRenderPackage>();
+                portMap[outputPortId] = new RenderPackageCache();
             }
 
             portMap[outputPortId].Add(package);
@@ -32,7 +32,7 @@ namespace Dynamo.Visualization
         public RenderPackageCache()
         {
             packages = new List<IRenderPackage>();
-            portMap = new Dictionary<Guid, List<IRenderPackage>>();
+            portMap = new Dictionary<Guid, RenderPackageCache>();
         }
 
         // TODO, QNTM-2631: This should include the GUIDs of the output ports that the packages came from
@@ -44,14 +44,14 @@ namespace Dynamo.Visualization
 
         public RenderPackageCache GetPortPackages(Guid portId)
         {
-            List<IRenderPackage> portPackages;
+            RenderPackageCache portPackages;
             if (!portMap.TryGetValue(portId, out portPackages))
                 return null;
 
             if (portPackages == null)
                 return null;
 
-            return new RenderPackageCache(portPackages);
+            return portPackages;
         }
 
         public bool IsEmpty()
@@ -64,7 +64,7 @@ namespace Dynamo.Visualization
             packages.AddRange(other.packages);
             foreach(var port in other.portMap)
             {
-                foreach(var item in port.Value)
+                foreach(var item in port.Value.Packages)
                 {
                     AddPort(item, port.Key);
                 }

--- a/src/DynamoCore/Visualization/RenderPackageCache.cs
+++ b/src/DynamoCore/Visualization/RenderPackageCache.cs
@@ -64,14 +64,20 @@ namespace Dynamo.Visualization
         public RenderPackageCache GetPortPackages(Guid portId)
         {
             if (portMap == null)
+            {
                 return null;
+            }
 
             RenderPackageCache portPackages;
             if (!portMap.TryGetValue(portId, out portPackages))
+            {
                 return null;
+            }
 
             if (portPackages == null)
+            {
                 return null;
+            }
 
             return portPackages;
         }
@@ -93,7 +99,9 @@ namespace Dynamo.Visualization
             packages.AddRange(other.packages);
 
             if (other.portMap == null)
+            {
                 return;
+            }
 
             foreach (var port in other.portMap)
             {

--- a/src/DynamoCore/Visualization/RenderPackageCache.cs
+++ b/src/DynamoCore/Visualization/RenderPackageCache.cs
@@ -64,7 +64,7 @@ namespace Dynamo.Visualization
             packages.AddRange(other.packages);
             foreach(var port in other.portMap)
             {
-                foreach(var item in port.Value.Packages)
+                foreach(var item in port.Value.packages)
                 {
                     AddPort(item, port.Key);
                 }

--- a/src/DynamoCore/Visualization/RenderPackageCache.cs
+++ b/src/DynamoCore/Visualization/RenderPackageCache.cs
@@ -4,6 +4,9 @@ using Autodesk.DesignScript.Interfaces;
 
 namespace Dynamo.Visualization
 {
+    /// <summary>
+    /// This class controls the collection and distribution of render packages
+    /// </summary>
     public class RenderPackageCache
     {
         private List<IRenderPackage> packages;
@@ -24,18 +27,28 @@ namespace Dynamo.Visualization
             portMap[outputPortId].Add(package);
         }
 
+        /// <summary>
+        /// Create an empty RenderPackageCache object
+        /// </summary>
         public RenderPackageCache()
         {
             packages = new List<IRenderPackage>();
             portMap = null;
         }
 
+        /// <summary>
+        /// Create a RenderPackageCache object containing the given render packages
+        /// </summary>
+        /// <param name="otherPackages">The packages to fill the new cache object.</param>
         public RenderPackageCache(IEnumerable<IRenderPackage> otherPackages)
         : this()
         {
             packages.AddRange(otherPackages);
         }
 
+        /// <summary>
+        /// Get the render packages in this cache
+        /// </summary>
         public IEnumerable<IRenderPackage> Packages
         {
             get
@@ -44,6 +57,10 @@ namespace Dynamo.Visualization
             }
         }
 
+        /// <summary>
+        /// Get the RenderPackageCache object for the given port ID
+        /// </summary>
+        /// <param name="portId">The port ID used to get the sub-cache.</param>
         public RenderPackageCache GetPortPackages(Guid portId)
         {
             if (portMap == null)
@@ -59,11 +76,18 @@ namespace Dynamo.Visualization
             return portPackages;
         }
 
+        /// <summary>
+        /// Returns true if the cache is empty
+        /// </summary>
         public bool IsEmpty()
         {
             return packages.Count == 0;
         }
 
+        /// <summary>
+        /// Concatenates the other cache into this cache
+        /// </summary>
+        /// <param name="other">The cache to add to this cache.</param>
         public void Add(RenderPackageCache other)
         {
             packages.AddRange(other.packages);
@@ -80,11 +104,21 @@ namespace Dynamo.Visualization
             }
         }
 
+        /// <summary>
+        /// Adds a render package to this cache
+        /// </summary>
+        /// <param name="package">The package to add to this cache.</param>
         public void Add(IRenderPackage package)
         {
             packages.Add(package);
         }
 
+        /// <summary>
+        /// Adds a render package to this cache, including a reference to 
+        /// the output port that the package originated from
+        /// </summary>
+        /// <param name="package">The package to add to this cache.</param>
+        /// <param name="outputPortId">The output port to associate the package with.</param>
         public void Add(IRenderPackage package, Guid outputPortId)
         {
             Add(package);

--- a/src/DynamoCore/Visualization/RenderPackageCache.cs
+++ b/src/DynamoCore/Visualization/RenderPackageCache.cs
@@ -11,6 +11,11 @@ namespace Dynamo.Visualization
 
         private void AddPort(IRenderPackage package, Guid outputPortId)
         {
+            if (portMap == null)
+            {
+                portMap = new Dictionary<Guid, RenderPackageCache>();
+            }
+
             if (!portMap.ContainsKey(outputPortId))
             {
                 portMap[outputPortId] = new RenderPackageCache();
@@ -22,7 +27,7 @@ namespace Dynamo.Visualization
         public RenderPackageCache()
         {
             packages = new List<IRenderPackage>();
-            portMap = new Dictionary<Guid, RenderPackageCache>();
+            portMap = null;
         }
 
         public RenderPackageCache(IEnumerable<IRenderPackage> otherPackages)
@@ -41,6 +46,9 @@ namespace Dynamo.Visualization
 
         public RenderPackageCache GetPortPackages(Guid portId)
         {
+            if (portMap == null)
+                return null;
+
             RenderPackageCache portPackages;
             if (!portMap.TryGetValue(portId, out portPackages))
                 return null;
@@ -59,7 +67,11 @@ namespace Dynamo.Visualization
         public void Add(RenderPackageCache other)
         {
             packages.AddRange(other.packages);
-            foreach(var port in other.portMap)
+
+            if (other.portMap == null)
+                return;
+
+            foreach (var port in other.portMap)
             {
                 foreach(var item in port.Value.packages)
                 {

--- a/src/DynamoCore/Visualization/RenderPackageCache.cs
+++ b/src/DynamoCore/Visualization/RenderPackageCache.cs
@@ -100,9 +100,15 @@ namespace Dynamo.Visualization
 
             foreach (var port in other.portMap)
             {
-                foreach(var item in port.Value.packages)
+                Guid portId = port.Key;
+                if (portMap != null && portMap.ContainsKey(portId))
                 {
-                    AddPort(item, port.Key);
+                    throw new ArgumentException("The given port already exists in this render cache.");
+                }
+
+                foreach (var item in port.Value.packages)
+                {
+                    AddPort(item, portId);
                 }
             }
         }

--- a/src/DynamoCore/Visualization/RenderPackageCache.cs
+++ b/src/DynamoCore/Visualization/RenderPackageCache.cs
@@ -74,11 +74,6 @@ namespace Dynamo.Visualization
                 return null;
             }
 
-            if (portPackages == null)
-            {
-                return null;
-            }
-
             return portPackages;
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -495,8 +495,11 @@ namespace Dynamo.ViewModels
 
             if (startConfiguration.Watch3DViewModel == null)
             {
-                startConfiguration.Watch3DViewModel = HelixWatch3DViewModel.TryCreateHelixWatch3DViewModel(
-                    new Watch3DViewModelStartupParams(startConfiguration.DynamoModel), startConfiguration.DynamoModel.Logger);
+                startConfiguration.Watch3DViewModel = 
+                    HelixWatch3DViewModel.TryCreateHelixWatch3DViewModel(
+                        null,
+                        new Watch3DViewModelStartupParams(startConfiguration.DynamoModel), 
+                        startConfiguration.DynamoModel.Logger);
             }
 
             return new DynamoViewModel(startConfiguration);

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -603,23 +603,43 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             if (packages.IsEmpty())
                 return;
 
-            // If no attached model update for all render packages
+            // If there is no attached model update for all render packages
             if (watchModel == null)
             {
                 AddGeometryForRenderPackages(packages);
                 return;
             }
 
+            // If there are no input ports update for all render packages
+            var inPorts = watchModel.InPorts;
+            if (inPorts == null || inPorts.Count() < 1)
+            {
+                AddGeometryForRenderPackages(packages);
+                return;
+            }
+
+            // If there are no connectors connected to the first (only) input port update for all render packages
+            var inConnectors = inPorts[0].Connectors;
+            if (inConnectors == null || inConnectors.Count() < 1 || inConnectors[0].Start == null)
+            {
+                AddGeometryForRenderPackages(packages);
+                return;
+            }
+
             // Only update for render packages from the connected output port
-            var inputId = watchModel.InPorts[0].Connectors[0].Start.GUID;
+            var inputId = inConnectors[0].Start.GUID;
             foreach (var port in node.OutPorts)
             {
                 if (port.GUID != inputId)
+                {
                     continue;
+                }
 
                 RenderPackageCache portPackages = packages.GetPortPackages(inputId);
                 if (portPackages == null)
+                {
                     continue;
+                }
 
                 AddGeometryForRenderPackages(portPackages);
             }

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -600,9 +600,24 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         protected virtual void OnRenderPackagesUpdated(NodeModel node, RenderPackageCache packages)
         {
             RemoveGeometryForNode(node);
-            if (!packages.IsEmpty())
+            if (packages.IsEmpty())
+                return;
+
+            // If no attached model update for all render packages
+            if (watchModel == null)
             {
                 AddGeometryForRenderPackages(packages);
+                return;
+            }
+
+            // Only update for render packages from the connected output port
+            var inputId = watchModel.InPorts[0].Connectors[0].Start.GUID;
+            foreach (var port in node.OutPorts)
+            {
+                if (port.GUID == inputId)
+                {
+                    //AddGeometryForRenderPackages(packages.GetPortPackages(port.GUID));
+                }
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -55,7 +55,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
     /// </summary>
     public class DefaultWatch3DViewModel : NotificationObject, IWatch3DViewModel, IDisposable, IWatchPreferenceProperties
     {
-        protected readonly IDynamoModel model;
+        protected readonly NodeModel watchModel;
+
+        protected readonly IDynamoModel dynamoModel;
         protected readonly IScheduler scheduler;
         protected readonly IPreferences preferences;
         protected readonly ILogger logger;
@@ -198,7 +200,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         {
             get
             {
-                return viewModel.Workspaces.FirstOrDefault(vm => vm.Model == model.CurrentWorkspace);
+                return viewModel.Workspaces.FirstOrDefault(vm => vm.Model == dynamoModel.CurrentWorkspace);
             }
         }
 
@@ -233,10 +235,12 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// cannot be established. Typically, this is machines that do not have GPUs, or do not
         /// support DirectX 10 feature levels. For most purposes, you will want to use a <see cref="HelixWatch3DViewModel"/>
         /// </summary>
+        /// <param name="model">The NodeModel that this watch is displaying.</param>
         /// <param name="parameters">A Watch3DViewModelStartupParams object.</param>
-        public DefaultWatch3DViewModel(Watch3DViewModelStartupParams parameters)
+        public DefaultWatch3DViewModel(NodeModel model, Watch3DViewModelStartupParams parameters)
         {
-            model = parameters.Model;
+            watchModel = model;
+            dynamoModel = parameters.Model;
             scheduler = parameters.Scheduler;
             preferences = parameters.Preferences;
             logger = parameters.Logger;
@@ -295,9 +299,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
             LogVisualizationCapabilities();
 
-            RegisterModelEventhandlers(model);
+            RegisterModelEventhandlers(dynamoModel);
 
-            RegisterWorkspaceEventHandlers(model);
+            RegisterWorkspaceEventHandlers(dynamoModel);
         }
 
         /// <summary>
@@ -332,9 +336,9 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         {
             DynamoSelection.Instance.Selection.CollectionChanged -= SelectionChangedHandler;
 
-            UnregisterModelEventHandlers(model);
+            UnregisterModelEventHandlers(dynamoModel);
 
-            UnregisterWorkspaceEventHandlers(model);
+            UnregisterWorkspaceEventHandlers(dynamoModel);
         }
 
         private void OnModelShutdownStarted(IDynamoModel dynamoModel)
@@ -420,7 +424,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         public void RegenerateAllPackages()
         {
             foreach (var node in
-                model.CurrentWorkspace.Nodes)
+                dynamoModel.CurrentWorkspace.Nodes)
             {
                 node.RequestVisualUpdateAsync(scheduler, engineManager.EngineController,
                         renderPackageFactory, true);

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -614,10 +614,14 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             var inputId = watchModel.InPorts[0].Connectors[0].Start.GUID;
             foreach (var port in node.OutPorts)
             {
-                if (port.GUID == inputId)
-                {
-                    //AddGeometryForRenderPackages(packages.GetPortPackages(port.GUID));
-                }
+                if (port.GUID != inputId)
+                    continue;
+
+                RenderPackageCache portPackages = packages.GetPortPackages(inputId);
+                if (portPackages == null)
+                    continue;
+
+                AddGeometryForRenderPackages(portPackages);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/DefaultWatch3DViewModel.cs
@@ -8,7 +8,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Media3D;
 using System.Xml;
-using Autodesk.DesignScript.Interfaces;
 using Dynamo.Core;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
@@ -500,7 +499,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// </summary>
         /// <param name="packages"></param>
         /// <param name="forceAsyncCall"></param>
-        public virtual void AddGeometryForRenderPackages(IEnumerable<IRenderPackage> packages, bool forceAsyncCall = false)
+        public virtual void AddGeometryForRenderPackages(RenderPackageCache packages, bool forceAsyncCall = false)
         {
             // Override in inherited classes.
         }
@@ -594,10 +593,10 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             // Override in derived classes
         }
 
-        protected virtual void OnRenderPackagesUpdated(NodeModel node, IEnumerable<IRenderPackage> packages)
+        protected virtual void OnRenderPackagesUpdated(NodeModel node, RenderPackageCache packages)
         {
             RemoveGeometryForNode(node);
-            if(packages.Any())
+            if (!packages.IsEmpty())
             {
                 AddGeometryForRenderPackages(packages);
             }
@@ -610,7 +609,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// <param name="taskPackages">A collection of packages from which to 
         /// create render geometry.</param>
         public virtual void GenerateViewGeometryFromRenderPackagesAndRequestUpdate(
-            IEnumerable<IRenderPackage> taskPackages)
+            RenderPackageCache taskPackages)
         {
             // Override in derived classes
         }

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -771,13 +771,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 #if DEBUG
             renderTimer.Start();
 #endif
-            var packages = taskPackages.Packages
-                .Cast<HelixRenderPackage>().Where(rp => rp.MeshVertexCount % 3 == 0);
+            var packages = taskPackages.Packages;
+            var meshPackages = packages.Cast<HelixRenderPackage>().Where(rp => rp.MeshVertexCount % 3 == 0);
 
-            RemoveGeometryForUpdatedPackages(packages);
-
-            AggregateRenderPackages(packages);
-
+            RemoveGeometryForUpdatedPackages(meshPackages);
+            AggregateRenderPackages(meshPackages);
 #if DEBUG
             renderTimer.Stop();
             Debug.WriteLine(string.Format("RENDER: {0} ellapsed for compiling assets for rendering.", renderTimer.Elapsed));

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -24,6 +24,7 @@ using Dynamo.Selection;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Properties;
 using Dynamo.Wpf.Rendering;
+using Dynamo.Visualization;
 using DynamoUtilities;
 using HelixToolkit.Wpf;
 using HelixToolkit.Wpf.SharpDX;
@@ -196,8 +197,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// <summary>
         /// An envent requesting to create geometries from render packages.
         /// </summary>
-        public event Action<IEnumerable<IRenderPackage>, bool> RequestCreateModels;
-        private void OnRequestCreateModels(IEnumerable<IRenderPackage> packages, bool forceAsyncCall = false)
+        public event Action<RenderPackageCache, bool> RequestCreateModels;
+        private void OnRequestCreateModels(RenderPackageCache packages, bool forceAsyncCall = false)
         {
             if (RequestCreateModels != null)
             {
@@ -557,7 +558,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
         }
 
-        public override void AddGeometryForRenderPackages(IEnumerable<IRenderPackage> packages, bool forceAsyncCall = false)
+        public override void AddGeometryForRenderPackages(RenderPackageCache packages, bool forceAsyncCall = false)
         {
             if (Active)
             {
@@ -757,7 +758,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             }
         }
 
-        public override void GenerateViewGeometryFromRenderPackagesAndRequestUpdate(IEnumerable<IRenderPackage> taskPackages)
+        public override void GenerateViewGeometryFromRenderPackagesAndRequestUpdate(RenderPackageCache taskPackages)
         {
             /*foreach (var p in taskPackages)
             {
@@ -769,7 +770,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 #if DEBUG
             renderTimer.Start();
 #endif
-            var packages = taskPackages
+            var packages = taskPackages.Packages
                 .Cast<HelixRenderPackage>().Where(rp => rp.MeshVertexCount % 3 == 0);
 
             RemoveGeometryForUpdatedPackages(packages);

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -430,11 +430,11 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// <param name="parameters">A Watch3DViewModelStartupParams object.</param>
         /// <param name="logger">A logger to be used to log the exception.</param>
         /// <returns></returns>
-        public static DefaultWatch3DViewModel TryCreateHelixWatch3DViewModel(Watch3DViewModelStartupParams parameters, DynamoLogger logger)
+        public static DefaultWatch3DViewModel TryCreateHelixWatch3DViewModel(NodeModel model, Watch3DViewModelStartupParams parameters, DynamoLogger logger)
         {
             try
             {
-                var vm = new HelixWatch3DViewModel(parameters);
+                var vm = new HelixWatch3DViewModel(model, parameters);
                 return vm;
             }
             catch (Exception ex)
@@ -442,7 +442,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 logger.Log(Resources.BackgroundPreviewCreationFailureMessage, LogLevel.Console);
                 logger.Log(ex.Message, LogLevel.File);
 
-                var vm = new DefaultWatch3DViewModel(parameters)
+                var vm = new DefaultWatch3DViewModel(model, parameters)
                 {
                     Active = false,
                     CanBeActivated = false
@@ -460,7 +460,8 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         {
         }
 
-        protected HelixWatch3DViewModel(Watch3DViewModelStartupParams parameters) : base(parameters)
+        protected HelixWatch3DViewModel(NodeModel model, Watch3DViewModelStartupParams parameters) 
+        : base(model, parameters)
         {
             Name = Resources.BackgroundPreviewName;
             IsResizable = false;
@@ -859,7 +860,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     // This will need to be adapted when multiple home workspaces are supported,
                     // so that a specific workspace can be selected to act as the preview context.
 
-                    var hs = model.Workspaces.FirstOrDefault(i => i is HomeWorkspaceModel);
+                    var hs = dynamoModel.Workspaces.FirstOrDefault(i => i is HomeWorkspaceModel);
                     if (hs != null)
                     {
                         nodesToRender = hs.Nodes;
@@ -920,7 +921,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         {
             IEnumerable<string> idents = null;
 
-            var hs = model.Workspaces.OfType<HomeWorkspaceModel>().FirstOrDefault();
+            var hs = dynamoModel.Workspaces.OfType<HomeWorkspaceModel>().FirstOrDefault();
             if (hs == null)
             {
                 return idents;
@@ -1357,7 +1358,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
         private bool InCustomNode()
         {
-            return model.CurrentWorkspace is CustomNodeWorkspaceModel;
+            return dynamoModel.CurrentWorkspace is CustomNodeWorkspaceModel;
         }
 
         /// <summary>
@@ -1503,7 +1504,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
             IEnumerable<string> customNodeIdents = null;
             if (InCustomNode())
             {
-                var hs = model.Workspaces.OfType<HomeWorkspaceModel>().FirstOrDefault();
+                var hs = dynamoModel.Workspaces.OfType<HomeWorkspaceModel>().FirstOrDefault();
                 if (hs != null)
                 {
                     customNodeIdents = FindIdentifiersForCustomNodes(hs);
@@ -2124,7 +2125,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
 
             using (TextWriter tw = new StreamWriter(path))
             {
-                tw.WriteLine("solid {0}", model.CurrentWorkspace.Name);
+                tw.WriteLine("solid {0}", dynamoModel.CurrentWorkspace.Name);
                 foreach (var g in geoms)
                 {
                     var n = ((MeshGeometry3D) g.Geometry).Normals.ToList();
@@ -2142,7 +2143,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                         tw.WriteLine("\tendfacet");
                     }
                 }
-                tw.WriteLine("endsolid {0}", model.CurrentWorkspace.Name);
+                tw.WriteLine("endsolid {0}", dynamoModel.CurrentWorkspace.Name);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -427,6 +427,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// Attempt to create a HelixWatch3DViewModel. If one cannot be created,
         /// fall back to creating a DefaultWatch3DViewModel and log the exception.
         /// </summary>
+        /// <param name="model">The NodeModel to associate with the returned view model.</param>
         /// <param name="parameters">A Watch3DViewModelStartupParams object.</param>
         /// <param name="logger">A logger to be used to log the exception.</param>
         /// <returns></returns>

--- a/src/DynamoCoreWpf/ViewModels/Watch3D/IWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/IWatch3DViewModel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media.Media3D;
-using Autodesk.DesignScript.Interfaces;
+using Dynamo.Visualization;
 using Dynamo.Graph.Nodes;
 
 namespace Dynamo.Wpf.ViewModels.Watch3D
@@ -95,7 +95,7 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
         /// <param name="packages">render packages to be drawn</param>
         /// <param name="forceAsyncCall">set to 'true' if calling from UI thread and still need to queue 
         /// the creation of display geometry for asynchronous execution</param>
-        void AddGeometryForRenderPackages(IEnumerable<IRenderPackage> packages, bool forceAsyncCall = false);
+        void AddGeometryForRenderPackages(RenderPackageCache packages, bool forceAsyncCall = false);
 
         /// <summary>
         /// Finds a geometry corresponding to a string identifier

--- a/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/Watch3DView.xaml.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Media3D;
 using System.Windows.Threading;
-using Autodesk.DesignScript.Interfaces;
+using Dynamo.Visualization;
 using Dynamo.Wpf.ViewModels.Watch3D;
 using HelixToolkit.Wpf.SharpDX;
 using SharpDX;
@@ -172,7 +170,7 @@ namespace Dynamo.Controls
             runUpdateClipPlane = true;
         }
 
-        private void RequestCreateModelsHandler(IEnumerable<IRenderPackage> packages, bool forceAsyncCall = false)
+        private void RequestCreateModelsHandler(RenderPackageCache packages, bool forceAsyncCall = false)
         {
             if (!forceAsyncCall && CheckAccess())
             {

--- a/src/DynamoManipulation/Gizmo.cs
+++ b/src/DynamoManipulation/Gizmo.cs
@@ -46,9 +46,9 @@ namespace Dynamo.Manipulation
         /// Returns render package for all the drawables of this Gizmo.
         /// </summary>
         /// <returns>List of render packages.</returns>
-        IEnumerable<IRenderPackage> GetDrawables();
+        RenderPackageCache GetDrawables();
 
-        IEnumerable<IRenderPackage> GetDrawablesForTransientGraphics();
+        RenderPackageCache GetDrawablesForTransientGraphics();
 
         /// <summary>
         /// Delete any transient graphics associated with the Gizmo
@@ -186,9 +186,9 @@ namespace Dynamo.Manipulation
 
         public abstract Vector GetOffset(Point newPosition, Vector viewDirection);
 
-        public abstract IEnumerable<IRenderPackage> GetDrawables();
+        public abstract RenderPackageCache GetDrawables();
 
-        public abstract IEnumerable<IRenderPackage> GetDrawablesForTransientGraphics();
+        public abstract RenderPackageCache GetDrawablesForTransientGraphics();
 
         public abstract void UpdateGizmoGraphics();
 

--- a/src/DynamoManipulation/INodeManipulator.cs
+++ b/src/DynamoManipulation/INodeManipulator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Autodesk.DesignScript.Interfaces;
+using Dynamo.Visualization;
 using Dynamo.Graph.Nodes;
 
 namespace Dynamo.Manipulation
@@ -26,6 +26,6 @@ namespace Dynamo.Manipulation
     /// </summary>
     public interface INodeManipulator : IDisposable
     {
-        IEnumerable<IRenderPackage> BuildRenderPackage();
+        RenderPackageCache BuildRenderPackage();
     }
 }

--- a/src/DynamoManipulation/NodeManipulator.cs
+++ b/src/DynamoManipulation/NodeManipulator.cs
@@ -1,15 +1,11 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media.Media3D;
 using Autodesk.DesignScript.Geometry;
-using Autodesk.DesignScript.Interfaces;
 using CoreNodeModels.Input;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes;
@@ -20,7 +16,6 @@ using Dynamo.Wpf.ViewModels.Watch3D;
 using ProtoCore.AST.AssociativeAST;
 using ProtoCore.Mirror;
 using Point = Autodesk.DesignScript.Geometry.Point;
-using String = System.String;
 using Vector = Autodesk.DesignScript.Geometry.Vector;
 
 namespace Dynamo.Manipulation
@@ -422,9 +417,9 @@ namespace Dynamo.Manipulation
         /// called on the scheduler thread if there's a node update
         /// </summary>
         /// <returns>List of render packages</returns>
-        private IEnumerable<IRenderPackage> GenerateRenderPackages()
+        private RenderPackageCache GenerateRenderPackages()
         {
-            var packages = new List<IRenderPackage>();
+            var packages = new RenderPackageCache();
 
             // This can happen only when the node is updating along with the manipulator
             // and meanwhile it is deselected in the UI before the manipulator is killed
@@ -450,7 +445,7 @@ namespace Dynamo.Manipulation
             // to avoid race condition with gizmo members b/w scheduler and UI threads.
             // Race condition can occur if say one gizmo is moving due to another gizmo
             // and it is highlighted when it comes near the mouse pointer.
-            IEnumerable<IRenderPackage> result = null;
+            RenderPackageCache result = null;
             BackgroundPreviewViewModel.Invoke(() => result = BuildRenderPackage());
             return result;
         }
@@ -535,23 +530,24 @@ namespace Dynamo.Manipulation
         /// Builds render packages as required for rendering this manipulator.
         /// </summary>
         /// <returns>List of render packages</returns>
-        public IEnumerable<IRenderPackage> BuildRenderPackage()
+        public RenderPackageCache BuildRenderPackage()
         {
             Debug.Assert(IsMainThread());
 
-            var packages = new List<IRenderPackage>();
+            var packages = new RenderPackageCache();
             try
             {
                 var gizmos = GetGizmos(true);
                 foreach (var item in gizmos)
                 {
-                    packages.AddRange(item.GetDrawables());
+                    packages.Add(item.GetDrawables());
                 }
             }
             catch (Exception e)
             {
                 Node.Warning(Properties.Resources.DirectManipulationError +": " + e.Message);
             }
+
             return packages;
         }
 
@@ -649,13 +645,14 @@ namespace Dynamo.Manipulation
             subManipulators.ForEach(x => x.Dispose());
         }
 
-        public IEnumerable<IRenderPackage> BuildRenderPackage()
+        public RenderPackageCache BuildRenderPackage()
         {
-            var packages = new List<IRenderPackage>();
+            var packages = new RenderPackageCache();
             foreach (var subManipulator in subManipulators)
             {
-                packages.AddRange(subManipulator.BuildRenderPackage());
+                packages.Add(subManipulator.BuildRenderPackage());
             }
+
             return packages;
         }
 

--- a/src/DynamoManipulation/TranslationGizmo.cs
+++ b/src/DynamoManipulation/TranslationGizmo.cs
@@ -5,6 +5,7 @@ using System.Windows.Media;
 using Autodesk.DesignScript.Geometry;
 using Autodesk.DesignScript.Interfaces;
 using Dynamo.Wpf.ViewModels.Watch3D;
+using Dynamo.Visualization;
 
 namespace Dynamo.Manipulation
 {
@@ -334,9 +335,9 @@ namespace Dynamo.Manipulation
         /// Returns drawables to render this Gizmo
         /// </summary>
         /// <returns>List of render package</returns>
-        public override IEnumerable<IRenderPackage> GetDrawables()
+        public override RenderPackageCache GetDrawables()
         {
-            var drawables = new List<IRenderPackage>();
+            var drawables = new RenderPackageCache();
             foreach (Vector axis in axes)
             {
                 IRenderPackage package = RenderPackageFactory.CreateRenderPackage();
@@ -351,7 +352,7 @@ namespace Dynamo.Manipulation
                 DrawPlane(ref package, plane, p++);
                 drawables.Add(package);
             }
-            drawables.AddRange(GetDrawablesForTransientGraphics());
+            drawables.Add(GetDrawablesForTransientGraphics());
 
             return drawables;
         }
@@ -382,9 +383,9 @@ namespace Dynamo.Manipulation
         /// Returns drawables for transient geometry associated with Gizmo
         /// </summary>
         /// <returns></returns>
-        public override IEnumerable<IRenderPackage> GetDrawablesForTransientGraphics()
+        public override RenderPackageCache GetDrawablesForTransientGraphics()
         {
-            var drawables = new List<IRenderPackage>();
+            var drawables = new RenderPackageCache();
             if (null != hitAxis)
             {
                 IRenderPackage package = RenderPackageFactory.CreateRenderPackage();
@@ -401,6 +402,7 @@ namespace Dynamo.Manipulation
                 DrawAxisLine(ref package, hitPlane.YAxis, "yAxisLine");
                 drawables.Add(package);
             }
+
             return drawables;
         }
 

--- a/src/DynamoSandbox/DynamoCoreSetup.cs
+++ b/src/DynamoSandbox/DynamoCoreSetup.cs
@@ -44,7 +44,11 @@ namespace DynamoSandbox
                     {
                         CommandFilePath = commandFilePath,
                         DynamoModel = model,
-                        Watch3DViewModel = HelixWatch3DViewModel.TryCreateHelixWatch3DViewModel(new Watch3DViewModelStartupParams(model), model.Logger),
+                        Watch3DViewModel = 
+                            HelixWatch3DViewModel.TryCreateHelixWatch3DViewModel(
+                                null,
+                                new Watch3DViewModelStartupParams(model), 
+                                model.Logger),
                         ShowLogin = true
                     });
 

--- a/src/Libraries/Watch3DNodeModelsWpf/HelixWatch3DNodeViewModel.cs
+++ b/src/Libraries/Watch3DNodeModelsWpf/HelixWatch3DNodeViewModel.cs
@@ -13,30 +13,31 @@ namespace Watch3DNodeModelsWpf
 {
     public class HelixWatch3DNodeViewModel : HelixWatch3DViewModel
     {
-        private readonly Watch3D watchNode;
-
         public override bool IsBackgroundPreview
         {
             get { return false; }
         }
 
-        public HelixWatch3DNodeViewModel(Watch3D node, Watch3DViewModelStartupParams parameters):
-            base(parameters)
+        public HelixWatch3DNodeViewModel(Watch3D node, Watch3DViewModelStartupParams parameters)
+        : base(node, parameters)
         {
-            watchNode = node;
             IsResizable = true;
 
             RegisterPortEventHandlers(node);
 
-            watchNode.Serialized += SerializeCamera;
-            watchNode.Deserialized += watchNode_Deserialized;
+            node.Serialized += SerializeCamera;
+            node.Deserialized += watchNode_Deserialized;
 
             Name = string.Format("{0} Preview", node.GUID);
         }
 
         protected override void OnWatchExecution()
         {
-            watchNode.WasExecuted = true;
+            var watch3D = watchModel as Watch3D;
+            if (watch3D != null)
+            {
+                watch3D.WasExecuted = true;
+            }
         }
 
         void watchNode_Deserialized(XmlNode obj)
@@ -56,7 +57,7 @@ namespace Watch3DNodeModelsWpf
             OnClear();
 
             var gathered = new List<NodeModel>();
-            watchNode.VisibleUpstreamNodes(gathered);
+            watchModel.VisibleUpstreamNodes(gathered);
 
             gathered.ForEach(n => n.WasRenderPackageUpdatedAfterExecution = false);
             gathered.ForEach(n => n.RequestVisualUpdateAsync(scheduler, engineManager.EngineController, renderPackageFactory));
@@ -81,11 +82,11 @@ namespace Watch3DNodeModelsWpf
         protected override void OnRenderPackagesUpdated(NodeModel node,
             RenderPackageCache renderPackages)
         {
-            var updatedNode = model.CurrentWorkspace.Nodes.FirstOrDefault(n => n.GUID == node.GUID);
+            var updatedNode = dynamoModel.CurrentWorkspace.Nodes.FirstOrDefault(n => n.GUID == node.GUID);
             if (updatedNode == null) return;
 
             var visibleUpstream = new List<NodeModel>();
-            watchNode.VisibleUpstreamNodes(visibleUpstream);
+            watchModel.VisibleUpstreamNodes(visibleUpstream);
 
             if (!visibleUpstream.Contains(updatedNode))
             {

--- a/src/Libraries/Watch3DNodeModelsWpf/HelixWatch3DNodeViewModel.cs
+++ b/src/Libraries/Watch3DNodeModelsWpf/HelixWatch3DNodeViewModel.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Xml;
-using Autodesk.DesignScript.Interfaces;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
 using Dynamo.Wpf.ViewModels.Watch3D;
 using Watch3DNodeModels;
+using Dynamo.Visualization;
 
 namespace Watch3DNodeModelsWpf
 {
@@ -79,7 +79,7 @@ namespace Watch3DNodeModelsWpf
 
         
         protected override void OnRenderPackagesUpdated(NodeModel node,
-            IEnumerable<IRenderPackage> renderPackages)
+            RenderPackageCache renderPackages)
         {
             var updatedNode = model.CurrentWorkspace.Nodes.FirstOrDefault(n => n.GUID == node.GUID);
             if (updatedNode == null) return;

--- a/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeViewCustomization.cs
+++ b/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeViewCustomization.cs
@@ -13,6 +13,7 @@ using Dynamo.Controls;
 using Dynamo.Wpf;
 using Dynamo.Wpf.Rendering;
 using Dynamo.Wpf.ViewModels.Watch3D;
+using Dynamo.Visualization;
 using VMDataBridge;
 using Watch3DNodeModels;
 using Watch3DNodeModelsWpf.Properties;
@@ -137,7 +138,8 @@ namespace Watch3DNodeModelsWpf
 
         private void RenderData(object data)
         {
-            watch3DViewModel.AddGeometryForRenderPackages(UnpackRenderData(data).Select(CreateRenderPackageFromGraphicItem));
+            IEnumerable<IRenderPackage> packages = UnpackRenderData(data).Select(CreateRenderPackageFromGraphicItem);
+            watch3DViewModel.AddGeometryForRenderPackages(new RenderPackageCache(packages));
         }
 
         void mi_Click(object sender, RoutedEventArgs e)
@@ -164,7 +166,6 @@ namespace Watch3DNodeModelsWpf
 
         public void Dispose()
         {
-
         }
     }
 }

--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -95,7 +95,11 @@ namespace WpfVisualizationTests
                 new DynamoViewModel.StartConfiguration()
                 {
                     DynamoModel = Model,
-                    Watch3DViewModel = HelixWatch3DViewModel.TryCreateHelixWatch3DViewModel(new Watch3DViewModelStartupParams(Model), Model.Logger)
+                    Watch3DViewModel = 
+                        HelixWatch3DViewModel.TryCreateHelixWatch3DViewModel(
+                            null,
+                            new Watch3DViewModelStartupParams(Model), 
+                            Model.Logger)
                 });
 
             //create the view

--- a/test/DynamoCoreWpfTests/DynamoViewModelUnitTest.cs
+++ b/test/DynamoCoreWpfTests/DynamoViewModelUnitTest.cs
@@ -133,7 +133,7 @@ namespace Dynamo.Tests
                 new DynamoViewModel.StartConfiguration()
                 {
                     DynamoModel = model,
-                    Watch3DViewModel = new DefaultWatch3DViewModel(watch3DViewParams)
+                    Watch3DViewModel = new DefaultWatch3DViewModel(null, watch3DViewParams)
                 });
 
             this.ViewModel.RequestUserSaveWorkflow += RequestUserSaveWorkflow;


### PR DESCRIPTION
### Purpose

This PR addresses the issue with Watch3D nodes displaying all geometry when connected to any node with multiple output ports instead of only displaying the geometry from the connected port.

Note that this PR is WIP pending looking into unit tests only, the functionality is fully implemented.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [n/a] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [n/a] Snapshot of UI changes, if any.
- [n/a] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@QilongTang 
@ramramps 
@alfarok 