### PR TITLE
QNTM-2117: Fix multiple definition warnings for inherited classes

### DIFF
--- a/src/Engine/ProtoCore/ClassTable.cs
+++ b/src/Engine/ProtoCore/ClassTable.cs
@@ -533,7 +533,7 @@ namespace ProtoCore.DSASM
 
         /// <summary>
         /// Returns all matching classes for the given name from this ClassTable.
-        /// If the classes have a common base class, this simply returns the base class.
+        /// If the classes have a common base class, this simply returns the given name of the class.
         /// </summary>
         /// <param name="name">Partial name of the class for lookup</param>
         /// <returns>Array of fully qualified name of all matching symbols</returns>
@@ -549,7 +549,7 @@ namespace ProtoCore.DSASM
 
                 if (baseClass != null)
                 {
-                    classes.Add(baseClass.Name);
+                    classes.Add(name);
                     return classes.ToArray();
                 }
             }

--- a/src/Engine/ProtoCore/ClassTable.cs
+++ b/src/Engine/ProtoCore/ClassTable.cs
@@ -7,6 +7,8 @@ using ProtoCore.AST.AssociativeAST;
 using ProtoCore.Properties;
 using ProtoCore.Utils;
 using System.Linq;
+using System.Runtime.InteropServices;
+using ProtoCore.Namespace;
 
 namespace ProtoCore.DSASM
 {
@@ -386,19 +388,49 @@ namespace ProtoCore.DSASM
 
     public class ClassTable
     {
+        
+        private List<ClassNode> classNodes = new List<ClassNode>();
+
+        //Symbol table to manage symbols with namespace
+        private Namespace.SymbolTable symbolTable = new Namespace.SymbolTable();
+        
+        private List<ClassNode> GetClassHierarchy(ClassNode node)
+        {
+            var cNodes = new List<ClassNode> {node};
+            
+            while (node.Base != Constants.kInvalidIndex)
+            {
+                node = ClassNodes[node.Base];
+                cNodes.Add(node);
+            }
+            return cNodes;
+        }
+
+        private ClassNode GetCommonBaseClass(IEnumerable<Symbol> symbols)
+        {
+            var cNodes = ClassNodes.Where(node => symbols.Any(s => s.Id == node.ID));
+            var baseLists = new List<List<ClassNode>>();
+            foreach (var classNode in cNodes)
+            {
+                var baseNodes = GetClassHierarchy(classNode);
+                baseLists.Add(baseNodes);
+            }
+            var arr = baseLists.ToArray();
+
+            if (!arr.Any()) return null;
+
+            var baseClass = ArrayUtils.GetCommonItems(arr);
+            return baseClass.FirstOrDefault();
+        }
+
         // Don't directly modify class table list.
-        public ReadOnlyCollection<ClassNode> ClassNodes 
+        public ReadOnlyCollection<ClassNode> ClassNodes
         {
             get
             {
                 return classNodes.AsReadOnly();
             }
         }
-
-        private List<ClassNode> classNodes = new List<ClassNode>();
-
-        //Symbol table to manage symbols with namespace
-        private Namespace.SymbolTable symbolTable = new Namespace.SymbolTable();
 
         public ClassTable()
         {
@@ -500,19 +532,29 @@ namespace ProtoCore.DSASM
         }
 
         /// <summary>
-        /// Returns all matching classes for the given name from this ClassTable
+        /// Returns all matching classes for the given name from this ClassTable.
+        /// If the classes have a common base class, this simply returns the base class.
         /// </summary>
         /// <param name="name">Partial name of the class for lookup</param>
         /// <returns>Array of fully qualified name of all matching symbols</returns>
         public string[] GetAllMatchingClasses(string name)
         {
-            Namespace.Symbol[] symbols = symbolTable.TryGetSymbols(name, (Namespace.Symbol s) => s.Matches(name));
-            int size = symbols.Length;
-            string[] classes = new string[size];
-            for (int i = 0; i < size; ++i)
-                classes[i] = symbols[i].FullName;
+            var symbols = symbolTable.TryGetSymbols(name, s => s.Matches(name));
 
-            return classes;
+            var classes = new List<string>();
+
+            if (symbols.Length > 1)
+            {
+                var baseClass = GetCommonBaseClass(symbols);
+
+                if (baseClass != null)
+                {
+                    classes.Add(baseClass.Name);
+                    return classes.ToArray();
+                }
+            }
+            classes.AddRange(symbols.Select(t => t.FullName));
+            return classes.ToArray();
         }
 
         public string GetTypeName(int UID)
@@ -545,6 +587,13 @@ namespace ProtoCore.DSASM
                 var symbols = symbolTable.GetAllSymbols(name);
                 if (symbols.Count > 1)
                 {
+                    var baseClass = GetCommonBaseClass(symbols);
+
+                    if (baseClass != null)
+                    {
+                        continue;
+                    }
+
                     string message = string.Format(Resources.kMultipleSymbolFound, name, "");
                     foreach (var symbol in symbols)
                     {

--- a/src/Engine/ProtoCore/Utils/ArrayUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ArrayUtils.cs
@@ -157,7 +157,7 @@ namespace ProtoCore.Utils
                 return ret;
             }
 
-            Dictionary<ClassNode, int> usageFreq = new Dictionary<ClassNode,int>();
+            Dictionary<ClassNode, int> usageFreq = new Dictionary<ClassNode, int>();
 
             //This is the element on the heap that manages the data structure
             var dsArray = runtimeCore.Heap.ToHeapObject<DSArray>(array);
@@ -390,7 +390,7 @@ namespace ProtoCore.Utils
         {
             List<StackValue[]> allFlattenValues = new List<StackValue[]>();
 
-            int zipLength = System.Int32.MaxValue;
+            int zipLength = Int32.MaxValue;
             foreach (var index in indices)
             {
                 int length = 1;
@@ -471,5 +471,13 @@ namespace ProtoCore.Utils
             var array = runtimeCore.Heap.ToHeapObject<DSArray>(arrayPointer);
             return array.Values.All(v => IsEmpty(v, runtimeCore));
         }
-   }
+
+        public static IEnumerable<T> GetCommonItems<T>(IEnumerable<T>[] lists)
+        {
+            HashSet<T> hs = new HashSet<T>(lists.First());
+            for (int i = 1; i < lists.Length; i++)
+                hs.IntersectWith(lists[i]);
+            return hs;
+        }
+    }
 }

--- a/src/Engine/ProtoCore/Utils/ArrayUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ArrayUtils.cs
@@ -472,6 +472,12 @@ namespace ProtoCore.Utils
             return array.Values.All(v => IsEmpty(v, runtimeCore));
         }
 
+        /// <summary>
+        /// Returns the list of common items from a given collection of generic lists 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="lists"></param>
+        /// <returns>list of common items from multiple lists</returns>
         public static IEnumerable<T> GetCommonItems<T>(IEnumerable<T>[] lists)
         {
             HashSet<T> hs = new HashSet<T>(lists.First());

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -1093,6 +1093,26 @@ var06 = g;
             AssertPreviewValue("ebb49227-2e2b-4861-b824-1574ba89b455", 6);
         }
 
+        [Test]
+        public void TestWarningsWithListMethods()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\sorting\sorting.dyn");
+            OpenModel(openPath);
+
+            var node1 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace
+                ("14fae78b-b009-4503-afe9-b714e08db1ec");
+            var node2 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace
+                ("9e2c84e6-b9b8-4bdf-b82e-868b2436b865");
+
+            Assert.IsTrue(string.IsNullOrEmpty(node1.ToolTipText));
+            Assert.IsTrue(string.IsNullOrEmpty(node2.ToolTipText));
+
+            BeginRun();
+
+            Assert.IsTrue(string.IsNullOrEmpty(node1.ToolTipText));
+            Assert.IsTrue(string.IsNullOrEmpty(node2.ToolTipText));
+        }
+
         #endregion
 
 


### PR DESCRIPTION
### Purpose

This fixes multiple definition warnings found with the `List` class when using List methods in CBN's. 

On adding a new [DS class for builtin List methods](https://github.com/DynamoDS/Dynamo/pull/7819) called `List`, which derived from `DSCore.List` we introduced a duplicate name in the class table, which then started complaining of class conflicts. The fix is to prevent class conflicts arising out of duplicate class names in the same class hierarchy.
JIRA: https://jira.autodesk.com/browse/QNTM-2117

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs

@mjkkirschner 
