### PR TITLE
QNTM-2446 Rename select UI nodes to provide distinction from ZT nodes

### DIFF
--- a/src/Libraries/CoreNodeModels/CreateList.cs
+++ b/src/Libraries/CoreNodeModels/CreateList.cs
@@ -8,12 +8,12 @@ using Newtonsoft.Json;
 
 namespace CoreNodeModels
 {
-    [NodeName("List.Create")]
+    [NodeName("List Create")]
     [NodeDescription("ListCreateDescription", typeof(Resources))]
     [NodeSearchTags("ListCreateSearchTags", typeof(Resources))]
     [NodeCategory(BuiltinNodeCategories.CORE_LISTS_CREATE)]
     [IsDesignScriptCompatible]
-    [AlsoKnownAs("DSCoreNodesUI.CreateList")]
+    [AlsoKnownAs("DSCoreNodesUI.CreateList", "List.Create")]
     public class CreateList : VariableInputNode
     {
         /// <summary>

--- a/src/Libraries/CoreNodeModels/HigherOrder/Apply.cs
+++ b/src/Libraries/CoreNodeModels/HigherOrder/Apply.cs
@@ -8,11 +8,11 @@ using Newtonsoft.Json;
 
 namespace CoreNodeModels.HigherOrder
 {
-    [NodeName("Function.Apply")]
+    [NodeName("Function Apply")]
     [NodeCategory(BuiltinNodeCategories.CORE_EVALUATE)]
     [NodeDescription("FunctionApplyDescription", typeof(Resources))]
     [IsDesignScriptCompatible]
-    [AlsoKnownAs("DSCoreNodesUI.HigherOrder.ApplyFunction")]
+    [AlsoKnownAs("DSCoreNodesUI.HigherOrder.ApplyFunction", "Function.Apply")]
     public class ApplyFunction : VariableInputNode
     {
         [JsonConstructor]
@@ -71,11 +71,11 @@ namespace CoreNodeModels.HigherOrder
         }
     }
 
-    [NodeName("Function.Compose")]
+    [NodeName("Function Compose")]
     [NodeCategory(BuiltinNodeCategories.CORE_EVALUATE)]
     [NodeDescription("FunctionComposeDescription", typeof(Resources))]
     [IsDesignScriptCompatible]
-    [AlsoKnownAs("DSCoreNodesUI.HigherOrder.ComposeFunctions")]
+    [AlsoKnownAs("DSCoreNodesUI.HigherOrder.ComposeFunctions", "Function.Compose")]
     public class ComposeFunctions : VariableInputNode
     {
         [JsonConstructor]

--- a/test/DynamoCoreTests/NodeMigrationTests.cs
+++ b/test/DynamoCoreTests/NodeMigrationTests.cs
@@ -2056,6 +2056,21 @@ namespace Dynamo.Tests
             TestMigration("TestMigrateBuiltIn.dyn");
         }
 
+        [Test]
+        public void TestFunctionApplyAndCompose()
+        {
+            OpenModel(GetDynPath("TestMigration_FunctionApplyAndCompose.dyn"));
+
+            RunCurrentModel();
+
+            var workspace = CurrentDynamoModel.CurrentWorkspace;
+
+            AssertPreviewValue("95c607e2-7f1b-4ec7-ba1c-a34f9dcf23bc", 14);
+
+            Assert.AreEqual(6, workspace.Nodes.Count());
+            Assert.AreEqual(6, workspace.Connectors.Count());
+        }
+
         #endregion
 
         #region Dynamo Libraries Node Migration Tests

--- a/test/core/migration/TestMigration_FunctionApplyAndCompose.dyn
+++ b/test/core/migration/TestMigration_FunctionApplyAndCompose.dyn
@@ -1,0 +1,25 @@
+<Workspace Version="0.9.1.4062" X="-130.767344516049" Y="-204.739110696326" zoom="1.16438980805626" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <CoreNodeModels.HigherOrder.ComposeFunctions guid="b217c1fd-dff4-43dc-97e4-c7fcd423f33f" type="CoreNodeModels.HigherOrder.ComposeFunctions" nickname="Function.Compose" x="624.155410611482" y="272.634483219073" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" inputcount="2" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="d654f4f5-4155-4812-a7a8-a878d4a66891" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="+" x="453.254812774113" y="224.776140844841" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="Operators" function="+@var[]..[],var[]..[]" />
+    <CoreNodeModels.HigherOrder.ApplyFunction guid="95c607e2-7f1b-4ec7-ba1c-a34f9dcf23bc" type="CoreNodeModels.HigherOrder.ApplyFunction" nickname="Function.Apply" x="809.875427967806" y="321.057369762583" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" inputcount="2" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="273e1579-8f2f-4737-8e59-5753916fafd5" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="*" x="454.343982337992" y="332.22868257543" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="Operators" function="*@var[]..[],var[]..[]" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="5e10799e-dcf0-45f9-bc57-012e9a5b7f38" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="328.321390959745" y="308.808057662487" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="2;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="608f3e81-1fb4-438c-951d-4b742314cd50" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="673.375438577504" y="383.293157920369" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" CodeText="5;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="b217c1fd-dff4-43dc-97e4-c7fcd423f33f" start_index="0" end="95c607e2-7f1b-4ec7-ba1c-a34f9dcf23bc" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="d654f4f5-4155-4812-a7a8-a878d4a66891" start_index="0" end="b217c1fd-dff4-43dc-97e4-c7fcd423f33f" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="273e1579-8f2f-4737-8e59-5753916fafd5" start_index="0" end="b217c1fd-dff4-43dc-97e4-c7fcd423f33f" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5e10799e-dcf0-45f9-bc57-012e9a5b7f38" start_index="0" end="d654f4f5-4155-4812-a7a8-a878d4a66891" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="5e10799e-dcf0-45f9-bc57-012e9a5b7f38" start_index="0" end="273e1579-8f2f-4737-8e59-5753916fafd5" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="608f3e81-1fb4-438c-951d-4b742314cd50" start_index="0" end="95c607e2-7f1b-4ec7-ba1c-a34f9dcf23bc" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

[QNTM-2446](https://jira.autodesk.com/browse/QNTM-2446)

This PR renames:
- List.Create -->  List Create
- Function.Apply --> Apply Function
- Function.Compose --> Compose Function

The purpose of doing this is so that they appear visually and syntactically distinct from other ZT nodes that can be called via DesignScript.  Old graphs abiding by the old naming convention will be migrated but will still appear with the old name on the node due to the recent consolidation of name & nickname, however this is a known issue.  The library will only display the newest naming convention.

### Testing

I have added 1 new unit test verifying a successful migration of `Function.Apply`  and `Function.Compose` from 0.9 to 2.0.  There was already an existing test verifying this for `List.Create` that can be view [here](https://github.com/DynamoDS/Dynamo/blob/master/test/DynamoCoreTests/NodeMigrationTests.cs#L1173).

![image](https://user-images.githubusercontent.com/13341935/33667820-e3b2ad28-da6b-11e7-83e2-cd9d4abc9e58.png)


### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
