### PR TITLE
check for null if the watch3dnode is not created correctly

### DIFF
--- a/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeViewCustomization.cs
+++ b/src/Libraries/Watch3DNodeModelsWpf/Watch3DNodeViewCustomization.cs
@@ -168,9 +168,12 @@ namespace Watch3DNodeModelsWpf
 
         public void Dispose()
         {
-            watch3DViewModel.ViewCameraChanged -= onCameraChanged;
+            if (watch3DViewModel != null)
+            {
+                watch3DViewModel.ViewCameraChanged -= onCameraChanged;
+                watch3DViewModel.Dispose();
+            }
             DataBridge.Instance.UnregisterCallback(watch3dModel.GUID.ToString());
-            watch3DViewModel.Dispose();
         }
     }
 }


### PR DESCRIPTION
@smangarole 
during testing the watch3dview is sometimes not a helix view - we should check for null in these cases.