### PR TITLE
Readonly tab

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -396,17 +396,19 @@ namespace Dynamo.Controls
         }
     }
 
-    public class PathToFileNameConverter : IValueConverter
+    public class WorkspaceToFileNameConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (value is string && !string.IsNullOrEmpty(value as string))
+
+            var wsvm = value as WorkspaceViewModel;
+            if (wsvm != null && !string.IsNullOrEmpty(wsvm.FileName))
             {
                 // Convert to path, get file name. If read-only file, append [Read-Only].
-                if (DynamoUtilities.PathHelper.IsReadOnlyPath((string)value))
-                    return Resources.TabFileNameReadOnlyPrefix + Path.GetFileName((string)value);
+                if (wsvm.Model.IsReadOnly)
+                    return Resources.TabFileNameReadOnlyPrefix + Path.GetFileName(wsvm.FileName);
                 else
-                    return Path.GetFileName((string)value);
+                    return Path.GetFileName(wsvm.FileName);
             }
 
             return "Unsaved";

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -84,7 +84,7 @@
     <controls:PortNameConverter x:Key="PortNameConverter" />
     <controls:NodeSearchElementVMToBoolConverter x:Key="NodeSearchElementVMToBoolConverter" />
     <controls:FilePathDisplayConverter x:Key="FilePathDisplayConverter" />
-    <controls:PathToFileNameConverter x:Key="PathToFileNameConverter" />
+    <controls:WorkspaceToFileNameConverter x:Key="WorkspaceToFileNameConverter" />
     <controls:PathToSaveStateConverter x:Key="PathToSaveStateConverter" />
     <controls:InverseBooleanConverter x:Key="InverseBooleanConverter" />
     <controls:ShowHideConsoleMenuItemConverter x:Key="ShowHideConsoleMenuConverter" />

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1134,8 +1134,9 @@
                                                                     </DataTrigger>
                                                                     <DataTrigger Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
                                                                                  Value="Saved">
+                                                                        <!--TODO find out what is up with this binding did it ever do anything?-->
                                                                         <Setter Property="Header"
-                                                                                Value="{Binding FileName, Converter={StaticResource PathToFileNameConverter}}" />
+                                                                                Value="{Binding Path=CurrentSpaceViewModel, Converter={StaticResource WorkspaceToFileNameConverter}}" />
                                                                     </DataTrigger>
 
                                                                     <DataTrigger Binding="{Binding HasUnsavedChanges}"
@@ -1390,7 +1391,7 @@
                                                                        Value="Saved" />
                                                         </MultiDataTrigger.Conditions>
                                                         <Setter Property="Text"
-                                                                Value="{Binding Path=FileName, Converter={StaticResource PathToFileNameConverter}}" />
+                                                                Value="{Binding Converter={StaticResource WorkspaceToFileNameConverter}}" />
                                                     </MultiDataTrigger>
 
                                                     <MultiDataTrigger>
@@ -1412,7 +1413,7 @@
                                                                        Value="Saved" />
                                                         </MultiDataTrigger.Conditions>
                                                         <Setter Property="Text"
-                                                                Value="{Binding Path=FileName, Converter={StaticResource PathToFileNameConverter}}" />
+                                                                Value="{Binding Converter={StaticResource WorkspaceToFileNameConverter}}" />
                                                     </MultiDataTrigger>
 
                                                 </Style.Triggers>

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1136,7 +1136,7 @@
                                                                                  Value="Saved">
                                                                         <!--TODO find out what is up with this binding did it ever do anything?-->
                                                                         <Setter Property="Header"
-                                                                                Value="{Binding Path=CurrentSpaceViewModel, Converter={StaticResource WorkspaceToFileNameConverter}}" />
+                                                                                Value="{Binding Converter={StaticResource WorkspaceToFileNameConverter}}" />
                                                                     </DataTrigger>
 
                                                                     <DataTrigger Binding="{Binding HasUnsavedChanges}"

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -12,6 +12,8 @@ using Dynamo.Wpf.ViewModels;
 
 using NUnit.Framework;
 using Dynamo.ViewModels;
+using Dynamo.Controls;
+using Dynamo.Wpf.Properties;
 
 namespace Dynamo.Tests
 {
@@ -578,6 +580,39 @@ namespace Dynamo.Tests
             System.IO.File.Delete(newPath);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void WorkspaceToFileNameConverterTest()
+        {
+            //openPath
+            var testFileWithMultipleXmlDummyNode = @"core\dummy_node\dummyNodeXMLMultiple.dyn";
+            string openPath = Path.Combine(TestDirectory, testFileWithMultipleXmlDummyNode);
+            ViewModel.OpenCommand.Execute(openPath);
+
+            var converter = new WorkspaceToFileNameConverter();
+            var result = converter.Convert(ViewModel.CurrentSpaceViewModel, null, null, null);
+            //assert the filename is correct for readonly workspace
+            Assert.IsTrue(ViewModel.CurrentSpaceViewModel.Model.IsReadOnly);
+            Assert.AreEqual(Resources.TabFileNameReadOnlyPrefix + Path.GetFileName(ViewModel.CurrentSpaceViewModel.FileName), result);
+
+            //try saving this graph
+            var newPath = GetNewFileNameOnTempPath("dyn");
+            Assert.DoesNotThrow(() => { this.ViewModel.SaveAs(newPath); });
+
+            //try to open the file we just saved.
+            Assert.DoesNotThrow(() => { ViewModel.OpenCommand.Execute(newPath); });
+
+            //assert that we no longer have a readonly filename
+            result = converter.Convert(ViewModel.CurrentSpaceViewModel, null, null, null);
+            //assert the filename is correct for readonly workspace
+            Assert.False(ViewModel.CurrentSpaceViewModel.Model.IsReadOnly);
+            Assert.AreEqual(Path.GetFileName(ViewModel.CurrentSpaceViewModel.FileName), result);
+
+            System.IO.File.Delete(newPath);
+
+
+
+        }
         #region CustomNodeWorkspaceModel SaveAs side effects
 
         [Test]


### PR DESCRIPTION
### Purpose

Workspaces which have their readonly properties set to `true`, should show as readonly in the view tab- even if that path on disk is not truly readonly.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs
  