### PR TITLE
Square bracket list initialization syntax

### DIFF
--- a/src/Engine/ProtoCore/ExtendedLibraries/BuiltIn.ds
+++ b/src/Engine/ProtoCore/ExtendedLibraries/BuiltIn.ds
@@ -4,62 +4,62 @@ class List extends DSCore.List
 {
 	public static def RemoveIfNot(list: var[]..[], type: string)
 	{		
-		return = __RemoveIfNot(list, type);
+		return __RemoveIfNot(list, type);
 	}
 
 	public static def Equals: bool(objectA: var[]..[], objectB: var[]..[])
     {
-        return = __Equals(objectA, objectB);
+        return __Equals(objectA, objectB);
 	}
 
 	public static def GroupByFunction(list: var[]..[], func: Function)
 	{
-		return = __GroupByFunction(list, func);
+		return __GroupByFunction(list, func);
 	}
 
 	public static def SortByFunction(list: var[]..[], func: Function)
 	{
-		return = __SortByFunction(list, func);
+		return __SortByFunction(list, func);
 	}
 
 	public static def MaximumItemByKey(list: var[]..[], keyProjector: Function)
 	{
-		return = __MaximumItemByKey(list, keyProjector);
+		return __MaximumItemByKey(list, keyProjector);
 	}
 
 	public static def MinimumItemByKey(list: var[]..[], keyProjector: Function)
 	{
-		return = __MinimumItemByKey(list, keyProjector);
+		return __MinimumItemByKey(list, keyProjector);
 	}
 
 	public static def TrueForAll: bool(list: var[]..[], predicate: Function)
 	{
-		return = __TrueForAll(list, predicate);
+		return __TrueForAll(list, predicate);
 	}
 
 	public static def TrueForAny: bool(list: var[]..[], predicate: Function)
 	{
-		return = __TrueForAny(list, predicate);
+		return __TrueForAny(list, predicate);
 	}
 
 	public static def RemoveKey(list: var[]..[], key: var)
 	{
-		return = __RemoveKey(list, key);
+		return __RemoveKey(list, key);
 	}
 
 	public static def GetValues(list: var[]..[])
 	{
-		return = __GetValues(list);
+		return __GetValues(list);
 	}
 
 	public static def GetKeys(list: var[]..[])
 	{
-		return = __GetKeys(list);
+		return __GetKeys(list);
 	}
 
 	public static def ContainsKey: bool(list: var[]..[], key: var)
 	{
-		return = __ContainsKey(list, key);
+		return __ContainsKey(list, key);
 	}
 }
 

--- a/src/Engine/ProtoCore/ExtendedLibraries/FunctionObject.ds
+++ b/src/Engine/ProtoCore/ExtendedLibraries/FunctionObject.ds
@@ -32,42 +32,42 @@ def __CreateFunctionObject(
 	fo = Function();
 	imp = { "__funcobj" : fobj };
 	fo.imp = imp;
-    return = fo;
+    return fo;
 }
 
 def __CreateComposedFunctionObject(fobjs: Function[])
 {
-    return = [Imperative] {
+    return [Imperative] {
         for (fobj in fobjs) {
             if (fobj.imp["__funcobj"] == null && fobj.imp["__funcobjs"] == null) {
-                return = null;
+                return null;
             }
         }
 
         composedObj = Function();
 		imp = { "__funcobjs" : fobjs };
 		composedObj.imp = imp;
-        return = composedObj;
+        return composedObj;
     }
 }
 
 def __GetNextParamPos(hasParamAt: bool[])
 {
-    return = [Imperative] {
+    return [Imperative] {
         for(i in 0..Count(hasParamAt) - 1) {
             if (!hasParamAt[i])
-                return = i;
+                return i;
         }
-        return = -1;
+        return -1;
     }
 }
 
 def __EvaluateComposedFunctionObjects(fos: Function, arg:var[]..[])
 {
-    return = [Imperative] {
+    return [Imperative] {
         fobjs = fos.imp["__funcobjs"];
 		if (fobjs == null) {
-			return = null;
+			return null;
 		}
         count = Count(fobjs);
 
@@ -77,37 +77,37 @@ def __EvaluateComposedFunctionObjects(fos: Function, arg:var[]..[])
             v = __EvaluateFunctionObject(f, v);
         }
 
-        return = v;
+        return v;
     }
 }
 
 def __EvaluateFunctionObject(fo: Function, arg: var[]..[])
 {      
-    return = [Imperative]
+    return [Imperative]
     {           
         fobjs = fo.imp["__funcobjs"];
         if (fobjs != null) {
-            return = __EvaluateComposedFunctionObjects(fo, arg); 
+            return __EvaluateComposedFunctionObjects(fo, arg); 
         }
 
         fobj = fo.imp["__funcobj"];
         if (fobj == null) {
-            return = null;
+            return null;
         }
 
         arginfo = fobj["__arginfo"];
         if (arginfo == null) {
-            return = null;
+            return null;
         }
 
         func = fobj["__func"];
         if (func == null) {
-            return = null;
+            return null;
         }
 
         nextParamPosition = __GetNextParamPos(arginfo["__argflags"]);
         if (nextParamPosition < 0) {
-            return = null;
+            return null;
         }
         else
         {
@@ -120,11 +120,11 @@ def __EvaluateFunctionObject(fo: Function, arg: var[]..[])
             nextParamPosition = __GetNextParamPos(hasArgAt);
             if (nextParamPosition < 0)
             {
-                return = Evaluate(func["__fptr"], args, func["__unpack"]);
+                return Evaluate(func["__fptr"], args, func["__unpack"]);
             }
             else
             {
-                paramPositions = { };
+                paramPositions = [];
                 for (i in 0..func["__pcount"] - 1)
                 {
                     if (hasArgAt[i])
@@ -133,7 +133,7 @@ def __EvaluateFunctionObject(fo: Function, arg: var[]..[])
                     }
                 }
             
-                return = __CreateFunctionObject(
+                return __CreateFunctionObject(
                             func["__fptr"],
                             func["__pcount"],
                             paramPositions,
@@ -146,124 +146,124 @@ def __EvaluateFunctionObject(fo: Function, arg: var[]..[])
 
 def __Apply(functionObject: Function, param: var[]..[])
 {
-    return = __EvaluateFunctionObject(functionObject, param);
+    return __EvaluateFunctionObject(functionObject, param);
 }
 
 def __ApplyList(functionObject: Function, params: var[]..[])
 {
-    return = [Imperative]
+    return [Imperative]
     {
         _result = functionObject;
         for(p in params)
         {
             _result = __Apply(_result, p);
         }
-        return = _result;
+        return _result;
     }
 }
 
 def __GetOutput(outputs: var[]..[], key: var)
 {
-    return = outputs[key];
+    return outputs[key];
 }
 
 def __Compose(funcs : Function[])
 {
-    return = __CreateComposedFunctionObject(funcs);
+    return __CreateComposedFunctionObject(funcs);
 }
 
 def __ComposeBuffered(funcs: Function[], amt: int, arg: var[]..[])
 {
-    return = [Imperative]
+    return [Imperative]
     {
         if (amt <= 1)
         {
-            return = __Apply(__Compose(funcs), arg);
+            return __Apply(__Compose(funcs), arg);
         }
         else
         {
             i = Count(funcs)-1;
             first = funcs[i];
             funcs[i] = __Apply(first, arg);
-            return = __CreateFunctionObject(__ComposeBuffered, 3, { 0, 1 }, { funcs, amt-1, null }, true);
+            return __CreateFunctionObject(__ComposeBuffered, 3, [ 0, 1 ], [ funcs, amt-1, null ], true);
         }
     };
 }
 
 def __MinimumItemByKey(list: var[]..[], keyProjector: Function)
 {
-    return = [Imperative]
+    return [Imperative]
     {
         _count = Count(list);
-        _keys = { };
+        _keys = [];
         
         if (_count == 0)
         {
-            return = _keys;
+            return _keys;
         }
 
         for (_index in 0..(_count - 1))
         {
             _keys[_index] = __Apply(keyProjector, list[_index]);
         }
-        return = Sorting.minByKey(list, _keys);
+        return Sorting.minByKey(list, _keys);
     }
 }
 
 def __MaximumItemByKey(list: var[]..[], keyProjector: Function)
 {
-    return = [Imperative]
+    return [Imperative]
     {
         _count = Count(list);
-        _keys = { };
+        _keys = [];
         
         if (_count == 0)
         {
-            return = _keys;
+            return _keys;
         }
 
         for (_index in 0..(_count - 1))
         {
             _keys[_index] = __Apply(keyProjector, list[_index]);
         }
-        return = Sorting.maxByKey(list, _keys);
+        return Sorting.maxByKey(list, _keys);
     }
 }
 
 def __Replace(list: var, with: var, predicate: Function)
 {
-    return = [Imperative]
+    return [Imperative]
     {
         if (__Apply(predicate, list))
         {
-            return = with;
+            return with;
         }
         else
         {
-            return = list;
+            return list;
         }
     };
 }
 
 def __Filter(list: var[]..[], predicate: Function)
 {
-    return = [Imperative]
+    return [Imperative]
     {
         if (list == null) 
         {
-            return = null;
+            return null;
         }
 
         _count = Count(list);
         if (_count == 0)
         {
-            return = {{}, {}};
+            return [[], []];
         }
 
-        _filteredList = {};
+        _filteredList = [];
         _currentIn = 0;
 
-        _filteredOutList = {};
+        _filteredOutList = [];
         _currentOut = 0;
 
         for (_index in 0..(_count - 1))
@@ -281,32 +281,32 @@ def __Filter(list: var[]..[], predicate: Function)
             }
         }
 
-        return = { _filteredList, _filteredOutList };
+        return [ _filteredList, _filteredOutList ];
     };
 }
 
 def __Combine(func: Function, lists: var[]..[])
 {
     argList = Transpose(lists);
-    return = [Imperative]
+    return [Imperative]
     {
-        result = { };
+        result = [];
         for(args in argList)
         {
             result[Count(result)] = __ApplyList(func, args);
         }
-        return = result;
+        return result;
     };
 }
 
 def __Map(func: Function, arg: var[]..[])
 {
-    return = __Combine(func, { arg });
+    return __Combine(func, [ arg ]);
 }
 
 def __LaceShortest(func: Function, lists : var[]..[])
 {
-    return = [Imperative]
+    return [Imperative]
     {
         shortestLen = -1;
         for(item in lists)
@@ -317,25 +317,25 @@ def __LaceShortest(func: Function, lists : var[]..[])
                 shortestLen = count;
             }
         }
-        shortenedLists = { };
+        shortenedLists = [];
         for(item in lists)
         {
             if (shortestLen == 1)
             {
-                shortenedLists[Count(shortenedLists)] = { item[0] };
+                shortenedLists[Count(shortenedLists)] = [ item[0] ];
             }
             else
             {
                 shortenedLists[Count(shortenedLists)] = item[0..shortestLen - 1];
             }
         }
-        return = __Combine(func, shortenedLists);
+        return __Combine(func, shortenedLists);
     };
 }
 
 def __LaceLongest(func: Function, lists : var[]..[])
 {
-    return = [Imperative]
+    return [Imperative]
     {
         longestLen = 0;
         for(item in lists)
@@ -346,7 +346,7 @@ def __LaceLongest(func: Function, lists : var[]..[])
                 longestLen = count;
             }
         }
-        stretchedLists = { };
+        stretchedLists = [];
         for(item in lists)
         {
             count = Count(item);
@@ -358,20 +358,20 @@ def __LaceLongest(func: Function, lists : var[]..[])
             }
             else
             {
-                repeated = { };
+                repeated = [];
                 repeated[0..amtToAdd-1] = last;
                 stretchedLists[Count(stretchedLists)] = Concat(item, repeated);
             }
         }
-        return = __Combine(func, stretchedLists);
+        return __Combine(func, stretchedLists);
     };
 }
 
 def __ApplyNested(fs: Function, xs: var[]..[], amt: int)
 {
-    return = [Imperative]
+    return [Imperative]
     {
-        result = { };
+        result = [];
         if (amt == 0)
         {
             for(x in xs)
@@ -386,18 +386,18 @@ def __ApplyNested(fs: Function, xs: var[]..[], amt: int)
                 result[Count(result)] = __ApplyNested(f, xs, amt-1);
             }
         }
-        return = result;
+        return result;
     };
 }
 
 def __CartesianProduct(func: Function, lists : var[]..[])
 {
-    return = [Imperative]
+    return [Imperative]
     {
         count = Count(lists);
         if (count == 0)
         {
-            return = lists;
+            return lists;
         }
 
         results = func;
@@ -409,22 +409,22 @@ def __CartesianProduct(func: Function, lists : var[]..[])
             nesting = nesting + 1;
         }
 
-        return = results;
+        return results;
     };
 }
 
 def __Scan(accumulator: Function, seed: var[]..[], lists: var[]..[])
 {
-    return = [Imperative]
+    return [Imperative]
     {
         if (lists == null)
         {
-            return = seed;
+            return seed;
         }
 
         //HACK: Transpose({{}}) returns { { null } }
 
-        noEmpties = { };
+        noEmpties = [];
         for (list in lists)
         {
             if (Count(list) > 0)
@@ -435,7 +435,7 @@ def __Scan(accumulator: Function, seed: var[]..[], lists: var[]..[])
         argLists = Transpose(lists);
         _acc = seed;
         
-        result = { _acc };
+        result = [ _acc ];
 
         for(argList in argLists)
         {
@@ -444,22 +444,22 @@ def __Scan(accumulator: Function, seed: var[]..[], lists: var[]..[])
             result[Count(result)] = _acc;
         }
         
-        return = result;
+        return result;
     };
 }
 
 def __Reduce(accumulator: Function, seed: var[]..[], lists : var[]..[])
 {
-    return = [Imperative]
+    return [Imperative]
     {
         if (lists == null)
         {
-            return = seed;
+            return seed;
         }
 
         //HACK: Transpose({{}}) returns { { null } }
 
-        noEmpties = { };
+        noEmpties = [];
         for (list in lists)
         {
             if (Count(list) > 0)
@@ -476,73 +476,73 @@ def __Reduce(accumulator: Function, seed: var[]..[], lists : var[]..[])
             _acc = __ApplyList(accumulator, argList);
         }
         
-        return = _acc;
+        return _acc;
     };
 }
 
 def __SortByFunction(list: var[]..[], func: Function)
 {
-    return = [Imperative]
+    return [Imperative]
     {
         if (list == null)
         {
-            return = null;
+            return null;
         }
 
         _count = Count(list);
-        _keys = { };
+        _keys = [];
 
         if (_count == 0)
         {
-            return = _keys;
+            return _keys;
         }
 
         for (_index in 0..(_count - 1))
         {
             _keys[_index] = __Apply(func, list[_index]);
         }
-        return = Sorting.sortByKey(list, _keys);
+        return Sorting.sortByKey(list, _keys);
     };
 }
 
 def __GroupByFunction(list: var[]..[], func: Function)
 {
-    return = [Imperative]
+    return [Imperative]
     {
         if (list == null)
         {
-            return = null;
+            return null;
         }
 
         _count = Count(list);
-        _keys = { };
+        _keys = [];
 
         if (_count == 0)
         {
-            return = _keys;
+            return _keys;
         }
 
         for (_index in 0..(_count - 1))
         {
             _keys[_index] = __Apply(func, list[_index]);
         }
-        return = Sorting.groupByKey(list, _keys);
+        return Sorting.groupByKey(list, _keys);
     };
 }
 
 def __TrueForAll(list: var[]..[], predicate: Function)
 {
-    return = [Imperative]
+    return [Imperative]
     {
         if (list == null) 
         {
-            return = null;
+            return null;
         }
 
         _count = Count(list);
         if (_count == 0)
         {
-            return = true;
+            return true;
         }
 
         _index = 0;
@@ -552,27 +552,27 @@ def __TrueForAll(list: var[]..[], predicate: Function)
             _value = list[_index];
             if (!__Apply(predicate, _value))
             {
-                return = false;
+                return false;
             }
         }
 
-        return = true;
+        return true;
     };
 }
 
 def __TrueForAny(list: var[]..[], predicate: Function)
 {
-    return = [Imperative]
+    return [Imperative]
     {
         if (list == null) 
         {
-            return = null;
+            return null;
         }
 
         _count = Count(list);
         if (_count == 0)
         {
-            return = true;
+            return true;
         }
 
         _index = 0;
@@ -582,11 +582,11 @@ def __TrueForAny(list: var[]..[], predicate: Function)
             _value = list[_i];
             if (__Apply(predicate, _value))
             {
-                return = true;
+                return true;
             }
         }
 
-        return = false;
+        return false;
     };
 }
 
@@ -596,7 +596,7 @@ def __ForEach(functionObject: Function, lists: var[]..[])
     {
         if (lists == null) 
         {
-            return = null;
+            return null;
         }
 
         argLists = Transpose(lists);
@@ -604,7 +604,7 @@ def __ForEach(functionObject: Function, lists: var[]..[])
         _count = Count(argLists);
         if (_count == 0)
         {
-            return = null;
+            return null;
         }
 
         _index = 0;
@@ -619,12 +619,12 @@ def __ForEach(functionObject: Function, lists: var[]..[])
 
 def LoopWhile(init: var[]..[], continueWhile: Function, loopBody: Function)
 {
-	return = [Imperative]
+	return [Imperative]
 	{
 		while (__Apply(continueWhile, init))
 		{
 			init = __Apply(loopBody, init);
 		}
-		return = init;
+		return init;
 	};
 }

--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshler.cs
@@ -602,7 +602,7 @@ namespace ProtoFFI
     }
 
     /// <summary>
-    /// This class marshales CLR Objects to DS Object and vice-versa.
+    /// This class marshals CLR Objects to DS Object and vice-versa.
     /// </summary>
     class CLRObjectMarshler : FFIObjectMarshler
     {

--- a/src/Engine/ProtoCore/Parser/AssociativeAST.cs
+++ b/src/Engine/ProtoCore/Parser/AssociativeAST.cs
@@ -2251,7 +2251,7 @@ namespace ProtoCore.AST.AssociativeAST
         {
             var buf = new StringBuilder();
 
-            buf.Append("{");
+            buf.Append("[");
             if (Exprs != null)
             {
                 for (int i = 0; i < Exprs.Count; ++i)
@@ -2261,7 +2261,7 @@ namespace ProtoCore.AST.AssociativeAST
                         buf.Append(", ");
                 }
             }
-            buf.Append("}");
+            buf.Append("]");
             buf.Append(base.ToString());
 
             return buf.ToString();

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -146,7 +146,7 @@ public Node root { get; set; }
                         break;
                 }
             }
-			else if (s[i] == '\\' && i == s.Length - 1) {
+            else if (s[i] == '\\' && i == s.Length - 1) {
                  SynErr(Resources.EOF_expected);
                 }
             else
@@ -176,36 +176,6 @@ public Node root { get; set; }
         return false;
     }
 
-    private bool IsListExpression()
-    {
-        short state = 0;
-        Token pt = la;
-        while (pt.kind != _EOF)
-        {
-            switch (state)
-            {
-                case 0:
-                    if (pt.val == "[")
-                    {
-                        state = 1;
-                        pt = scanner.Peek();
-                        continue;
-                    }
-                    goto fail;
-                case 1:
-                    if (pt.val == "Associative" || pt.val == "Imperative")
-                    {
-                        goto fail;
-                    }
-					return true;
-            }
-        }
-
-        fail:
-        scanner.ResetPeek();
-        return false;
-    }
-
     private bool IsLanguageBlock()
     {
         short state = 0;
@@ -227,7 +197,7 @@ public Node root { get; set; }
                     {
                         return true;
                     }
-					goto fail;
+                    goto fail;
             }
         }
 
@@ -236,7 +206,7 @@ public Node root { get; set; }
         return false;
     }
 
-	// Recognize: 
+    // Recognize: 
     //     { "foo" :   
     // OR   
     //     { foo :
@@ -294,41 +264,41 @@ public Node root { get; set; }
         return false;
     }
 
-	private bool IsFunctionCallStatement()
-	{
+    private bool IsFunctionCallStatement()
+    {
         Token pt = la;
         while (pt.kind != _EOF)
         {
-			if( _ident == pt.kind ) 
-			{
-				pt = scanner.Peek();
-				if( _openparen == pt.kind )
-				{
-					scanner.ResetPeek();
-					return true;
-				}
-				else if( _period == pt.kind )
-				{
-					pt = scanner.Peek();
-					continue;
-				}
-			}
-			else
-			{
-				break;
-			}			
-		}
+            if( _ident == pt.kind ) 
+            {
+                pt = scanner.Peek();
+                if( _openparen == pt.kind )
+                {
+                    scanner.ResetPeek();
+                    return true;
+                }
+                else if( _period == pt.kind )
+                {
+                    pt = scanner.Peek();
+                    continue;
+                }
+            }
+            else
+            {
+                break;
+            }			
+        }
 
         scanner.ResetPeek();
         return false;
-	}
+    }
 
-	private bool IsNonAssignmentStatement()
+    private bool IsNonAssignmentStatement()
     {
-		if (core.ParsingMode != ParseMode.AllowNonAssignment)
+        if (core.ParsingMode != ParseMode.AllowNonAssignment)
             return false;
 
-		if (IsTypedVariable())
+        if (IsTypedVariable())
             return false;
 
         Token pt = la;
@@ -344,7 +314,7 @@ public Node root { get; set; }
                 scanner.ResetPeek();
                 return false;
             }
-			else if (pt.val == ";")
+            else if (pt.val == ";")
                 break;
 
             pt = scanner.Peek();
@@ -519,8 +489,8 @@ public Node root { get; set; }
         scanner.ResetPeek();
         return isLocallyTyped;
     }
-	
-	private bool IsFullClosure()
+    
+    private bool IsFullClosure()
     {
         Token pt = la;
         int closureCount = 0;
@@ -530,8 +500,8 @@ public Node root { get; set; }
             pt = scanner.Peek();
             if (pt.val == "(") { closureCount++; continue; }
             if (pt.val == ")") { closureCount--; continue; }
-			if ((pt.kind == 0)||(pt.kind == _endline)) break;
-		}
+            if ((pt.kind == 0)||(pt.kind == _endline)) break;
+        }
         scanner.ResetPeek();
         return (closureCount > 0) ? false : true;
     }
@@ -587,11 +557,11 @@ public Node root { get; set; }
                          return false;
                 }
             }
-			if (pt.val == "=")
-			{
-				scanner.ResetPeek();
-				return false;
-			}
+            if (pt.val == "=")
+            {
+                scanner.ResetPeek();
+                return false;
+            }
         }
         scanner.ResetPeek();        
         return true;    
@@ -609,7 +579,7 @@ public Node root { get; set; }
         return funCallNode;
     }
 
- 	private AssociativeNode GenerateUnaryOperatorMethodCallNode(UnaryOperator op, ProtoCore.AST.AssociativeAST.AssociativeNode operand)
+    private AssociativeNode GenerateUnaryOperatorMethodCallNode(UnaryOperator op, ProtoCore.AST.AssociativeAST.AssociativeNode operand)
     {
         FunctionCallNode funCallNode = new FunctionCallNode();
         IdentifierNode funcName = new IdentifierNode { Value = ProtoCore.DSASM.Op.GetUnaryOpFunction(op), Name = ProtoCore.DSASM.Op.GetUnaryOpFunction(op) };
@@ -649,12 +619,12 @@ public Node root { get; set; }
         return false;
     }
 
-	 // use by associative
-	 private bool IsNotAttributeFunctionClass()
-	 {
-		if (la.val == "[")
-		{
-		    Token t = scanner.Peek();
+     // use by associative
+     private bool IsNotAttributeFunctionClass()
+     {
+        if (la.val == "[")
+        {
+            Token t = scanner.Peek();
             while (t.val != "]" && t.kind != _EOF)
             {
                 t = scanner.Peek();
@@ -671,19 +641,19 @@ public Node root { get; set; }
                 scanner.ResetPeek();
                 return false;
             }
-		}
+        }
 
-		if (la.kind != _kw_class && la.kind != _kw_def)
-			return true;
-		return false;
-	 }
+        if (la.kind != _kw_class && la.kind != _kw_def)
+            return true;
+        return false;
+     }
 
-	 // used by imperative
-	 private bool IsNotAttributeFunction()
-	 {
-	    if (la.val == "[")
-		{
-		    Token t = scanner.Peek();
+     // used by imperative
+     private bool IsNotAttributeFunction()
+     {
+        if (la.val == "[")
+        {
+            Token t = scanner.Peek();
             while (t.val != "]" && t.kind != _EOF)
             {
                 t = scanner.Peek();
@@ -701,19 +671,19 @@ public Node root { get; set; }
                 scanner.ResetPeek();
                 return false;
             }
-		}
+        }
 
         return la.kind != _kw_def;
-	 }
+     }
 
-	 
-	 //Experiment for user-defined synErr message
-	 private void SynErr (string s) {
-		if (errDist >= minErrDist) 
-		core.BuildStatus.LogSyntaxError(s, core.CurrentDSFileName, la.line, la.col);
-		errors.count++;
-		errDist = 0;
-	 }
+     
+     //Experiment for user-defined synErr message
+     private void SynErr (string s) {
+        if (errDist >= minErrDist) 
+        core.BuildStatus.LogSyntaxError(s, core.CurrentDSFileName, la.line, la.col);
+        errors.count++;
+        errDist = 0;
+     }
 
 
 
@@ -1160,7 +1130,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		while (!(StartOf(9))) {SynErr(76); Get();}
 		node = null; 
 		ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
-		 
+		
 		Associative_Expression(out rightNode);
 		ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
 		ProtoCore.AST.AssociativeAST.IdentifierNode leftNode = new ProtoCore.AST.AssociativeAST.IdentifierNode();
@@ -1190,7 +1160,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		while (!(StartOf(9))) {SynErr(77); Get();}
 		node = null; 
 		ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
-		 
+		
 		Associative_Expression(out rightNode);
 		bool allowIdentList = core.Options.GenerateSSA && rightNode is ProtoCore.AST.AssociativeAST.IdentifierListNode;
 		
@@ -1199,22 +1169,22 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		   || rightNode is ProtoCore.AST.AssociativeAST.FunctionCallNode
 		   || allowIdentList)
 		{
-		ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
-		ProtoCore.AST.AssociativeAST.IdentifierNode leftNode = new ProtoCore.AST.AssociativeAST.IdentifierNode();
-		leftNode.Value = leftNode.Name = Constants.kTempProcLeftVar;
+		   ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
+		   ProtoCore.AST.AssociativeAST.IdentifierNode leftNode = new ProtoCore.AST.AssociativeAST.IdentifierNode();
+		   leftNode.Value = leftNode.Name = Constants.kTempProcLeftVar;
 		
-		var unknownType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0);
-		leftNode.datatype = unknownType;
-		leftNode.line = rightNode.line;
-		leftNode.col = rightNode.col;
-		leftNode.endLine = rightNode.endLine;
-		leftNode.endCol = rightNode.endCol;
+		   var unknownType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0);
+		   leftNode.datatype = unknownType;
+		   leftNode.line = rightNode.line;
+		   leftNode.col = rightNode.col;
+		   leftNode.endLine = rightNode.endLine;
+		   leftNode.endCol = rightNode.endCol;
 		
-		expressionNode.LeftNode = leftNode;
-		expressionNode.RightNode = rightNode;
-		expressionNode.Optr = Operator.assign;
-		NodeUtils.UpdateBinaryExpressionLocation(expressionNode);
-		node = expressionNode;
+		   expressionNode.LeftNode = leftNode;
+		   expressionNode.RightNode = rightNode;
+		   expressionNode.Optr = Operator.assign;
+		   NodeUtils.UpdateBinaryExpressionLocation(expressionNode);
+		   node = expressionNode;
 		}
 		
 		if (la.val != ";")
@@ -1703,7 +1673,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.AssociativeAST.AssociativeNode rnode = null; 
 			Expect(1);
 			rnode = new IdentifierNode(t.val);
-			      
+			
 			ProtoCore.AST.AssociativeAST.IdentifierListNode bnode = new ProtoCore.AST.AssociativeAST.IdentifierListNode();
 			bnode.LeftNode = node;
 			bnode.Optr = Operator.dot;
@@ -1806,14 +1776,14 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			typedVar.TypeAlias = strIdent;
 			if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
 			{
-			var unknownType = new ProtoCore.Type();
-			unknownType.UID = ProtoCore.DSASM.Constants.kInvalidIndex;
-			unknownType.Name = strIdent; 
-			typedVar.datatype = unknownType;
+			   var unknownType = new ProtoCore.Type();
+			   unknownType.UID = ProtoCore.DSASM.Constants.kInvalidIndex;
+			   unknownType.Name = strIdent; 
+			   typedVar.datatype = unknownType;
 			}
 			else
 			{
-			typedVar.datatype = core.TypeSystem.BuildTypeObject(type, 0);
+			   typedVar.datatype = core.TypeSystem.BuildTypeObject(type, 0);
 			}
 			
 			if (la.kind == 10) {
@@ -1872,15 +1842,15 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.AssociativeAST.IdentifierListNode idnode = rnode as ProtoCore.AST.AssociativeAST.IdentifierListNode;
 			if (idnode != null && idnode.LeftNode.Name == Node.BuiltinGetValueAtIndexTypeName)
 			{
-			bnode = idnode;
+			   bnode = idnode;
 			}
 			else
 			{
-			bnode = new ProtoCore.AST.AssociativeAST.IdentifierListNode();
-			bnode.LeftNode = node;
-			bnode.Optr = Operator.dot;
-			bnode.RightNode = rnode;
-			NodeUtils.SetNodeLocation(bnode, bnode.LeftNode, bnode.RightNode);
+			   bnode = new ProtoCore.AST.AssociativeAST.IdentifierListNode();
+			   bnode.LeftNode = node;
+			   bnode.Optr = Operator.dot;
+			   bnode.RightNode = rnode;
+			   NodeUtils.SetNodeLocation(bnode, bnode.LeftNode, bnode.RightNode);
 			}
 			node = bnode;
 			
@@ -2299,7 +2269,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			else
 			{
 			   node.line = line; node.col = col;
-			node.endLine = t.line; node.endCol = t.col;
+			   node.endLine = t.line; node.endCol = t.col;
 			}
 			
 		} else if (la.kind == 3) {
@@ -2488,31 +2458,31 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				
 				Associative_Expression(out node);
 				if (tmpIsLeft) {
-				// if "foo[bar]" is on the lhs, it is interpreted as an array initialization expression
-				array = new ProtoCore.AST.AssociativeAST.ArrayNode
-				{
-					Expr = node,
-					Type = nameNode.ArrayDimensions
-				};
+				   // if "foo[bar]" is on the lhs, it is interpreted as an array initialization expression
+				   array = new ProtoCore.AST.AssociativeAST.ArrayNode
+				   {
+				       Expr = node,
+				       Type = nameNode.ArrayDimensions
+				   };
 				
-				NodeUtils.SetNodeLocation(array, t);
-				nameNode.ArrayDimensions = array;
+				   NodeUtils.SetNodeLocation(array, t);
+				   nameNode.ArrayDimensions = array;
 				} else {
-				if (qualifierNode != null)
-				{
-					ProtoCore.AST.AssociativeAST.IdentifierListNode inode = new ProtoCore.AST.AssociativeAST.IdentifierListNode();
-					inode.LeftNode = qualifierNode;
-					inode.Optr = Operator.dot;
-					inode.RightNode = nameNode;
-					NodeUtils.SetNodeLocation(inode, inode.LeftNode, inode.RightNode);
-					nameNode = inode;
-				}
-				// if "foo[bar]" is on the rhs, it is interpreted as an lookup in an array or dictionary
-				nameNode = AstFactory.BuildIndexExpression(nameNode, node) as ArrayNameNode;
+				   if (qualifierNode != null)
+				   {
+				       ProtoCore.AST.AssociativeAST.IdentifierListNode inode = new ProtoCore.AST.AssociativeAST.IdentifierListNode();
+				       inode.LeftNode = qualifierNode;
+				       inode.Optr = Operator.dot;
+				       inode.RightNode = nameNode;
+				       NodeUtils.SetNodeLocation(inode, inode.LeftNode, inode.RightNode);
+				       nameNode = inode;
+				   }
+				   // if "foo[bar]" is on the rhs, it is interpreted as an lookup in an array or dictionary
+				   nameNode = AstFactory.BuildIndexExpression(nameNode, node) as ArrayNameNode;
 				}
 				
 				isLeft = tmpIsLeft; 
-				                            
+				
 			}
 			Expect(11);
 			while (la.kind == 10) {
@@ -2523,21 +2493,21 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 					
 					Associative_Expression(out node);
 					if (tmpIsLeft) {
-					var array2 = new ProtoCore.AST.AssociativeAST.ArrayNode
-					{
-						Expr = node,
-						Type = null
-					};
+					   var array2 = new ProtoCore.AST.AssociativeAST.ArrayNode
+					   {
+					       Expr = node,
+					       Type = null
+					   };
 					
-					NodeUtils.SetNodeLocation(array2, t);
-					array.Type = array2;
-					array = array2;
+					   NodeUtils.SetNodeLocation(array2, t);
+					   array.Type = array2;
+					   array = array2;
 					} else {
-					nameNode = AstFactory.BuildIndexExpression(nameNode, node) as ArrayNameNode;
+					   nameNode = AstFactory.BuildIndexExpression(nameNode, node) as ArrayNameNode;
 					}
 					
 					isLeft = tmpIsLeft; 
-					                            
+					
 				}
 				Expect(11);
 			}
@@ -2966,8 +2936,8 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 
 	void Imperative_returnstmt(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
 		node = null;
-		     var bNode = new ProtoCore.AST.ImperativeAST.BinaryExpressionNode();
-		     NodeUtils.SetNodeLocation(bNode, la);
+		var bNode = new ProtoCore.AST.ImperativeAST.BinaryExpressionNode();
+		NodeUtils.SetNodeLocation(bNode, la);
 		
 		Expect(44);
 		if (la.kind == 45) {
@@ -3189,15 +3159,15 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.ImperativeAST.IdentifierListNode bnode;
 			if (inode != null && inode.LeftNode.Name == Node.BuiltinGetValueAtIndexTypeName)
 			{
-			bnode = inode;
+			   bnode = inode;
 			}
 			else
 			{
-			bnode = new ProtoCore.AST.ImperativeAST.IdentifierListNode();
-			bnode.LeftNode = node;
-			bnode.Optr = Operator.dot;
-			bnode.RightNode = rnode;
-			NodeUtils.SetNodeLocation(bnode, bnode.LeftNode, bnode.RightNode);
+			       bnode = new ProtoCore.AST.ImperativeAST.IdentifierListNode();
+			       bnode.LeftNode = node;
+			       bnode.Optr = Operator.dot;
+			       bnode.RightNode = rnode;
+			       NodeUtils.SetNodeLocation(bnode, bnode.LeftNode, bnode.RightNode);
 			}
 			
 			if (bnode.RightNode is ProtoCore.AST.ImperativeAST.FunctionCallNode)
@@ -3305,32 +3275,32 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				
 				Imperative_expr(out node);
 				if (tmpIsLeft) {
-				// if "foo[bar]" is on the lhs, it is interpreted as an array initialization expression
-				array = new ProtoCore.AST.ImperativeAST.ArrayNode
-				{
-					Expr = node,
-					Type = nameNode.ArrayDimensions
-				};
+				   // if "foo[bar]" is on the lhs, it is interpreted as an array initialization expression
+				   array = new ProtoCore.AST.ImperativeAST.ArrayNode
+				   {
+				       Expr = node,
+				       Type = nameNode.ArrayDimensions
+				   };
 				
-				NodeUtils.SetNodeLocation(array, t);
-				nameNode.ArrayDimensions = array;
+				   NodeUtils.SetNodeLocation(array, t);
+				   nameNode.ArrayDimensions = array;
 				} else {
-				if (qualifierNode != null)
-				{
-					ProtoCore.AST.ImperativeAST.IdentifierListNode inode = new ProtoCore.AST.ImperativeAST.IdentifierListNode();
-					inode.LeftNode = qualifierNode;
-					inode.Optr = Operator.dot;
-					inode.RightNode = nameNode;
-					NodeUtils.SetNodeLocation(inode, inode.LeftNode, inode.RightNode);
-					nameNode = inode;
-				}
+				   if (qualifierNode != null)
+				   {
+				       ProtoCore.AST.ImperativeAST.IdentifierListNode inode = new ProtoCore.AST.ImperativeAST.IdentifierListNode();
+				       inode.LeftNode = qualifierNode;
+				       inode.Optr = Operator.dot;
+				       inode.RightNode = nameNode;
+				       NodeUtils.SetNodeLocation(inode, inode.LeftNode, inode.RightNode);
+				       nameNode = inode;
+				   }
 				
-				// if "foo[bar]" is on the rhs, it is interpreted as an lookup in an array or dictionary
-				nameNode = ProtoCore.AST.ImperativeAST.AstFactory.BuildIndexExpression(nameNode, node) as ProtoCore.AST.ImperativeAST.ArrayNameNode;
+				   // if "foo[bar]" is on the rhs, it is interpreted as an lookup in an array or dictionary
+				   nameNode = ProtoCore.AST.ImperativeAST.AstFactory.BuildIndexExpression(nameNode, node) as ProtoCore.AST.ImperativeAST.ArrayNameNode;
 				}
 				
 				isLeft = tmpIsLeft; 
-				                         
+				
 			}
 			Expect(11);
 			while (la.kind == 10) {
@@ -3341,22 +3311,22 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				if (StartOf(5)) {
 					Imperative_expr(out node);
 					if (tmpIsLeft) {
-					var array2 = new ProtoCore.AST.ImperativeAST.ArrayNode
-					{
-						Expr = node,
-						Type = null
-					};
+					   var array2 = new ProtoCore.AST.ImperativeAST.ArrayNode
+					   {
+					       Expr = node,
+					       Type = null
+					   };
 					
-					NodeUtils.SetNodeLocation(array2, t);
-					array.Type = array2;
-					array = array2;
+					   NodeUtils.SetNodeLocation(array2, t);
+					   array.Type = array2;
+					   array = array2;
 					} else {
-					nameNode = ProtoCore.AST.ImperativeAST.AstFactory.BuildIndexExpression(nameNode, node) as ProtoCore.AST.ImperativeAST.ArrayNameNode;
+					   nameNode = ProtoCore.AST.ImperativeAST.AstFactory.BuildIndexExpression(nameNode, node) as ProtoCore.AST.ImperativeAST.ArrayNameNode;
 					}
 					
 					// TODO(pboyer) this looks incorrect, probably wrong in associative code, too
 					isLeft = tmpIsLeft; 
-					                      
+					
 				}
 				Expect(11);
 			}

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -161,7 +161,8 @@ Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
                             (. node = null; .)
 (
 		Associative_ReturnStatement<out node>
-    |      
+    | 
+	IF(IsLanguageBlock())
         Associative_LanguageBlock<out node>
 	|
 	IF(IsNonAssignmentStatement())
@@ -211,6 +212,7 @@ Associative_ReturnStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode nod
 		ProtoCore.AST.AssociativeAST.AssociativeNode rhs = null;
 	.)
 	(
+		IF(IsLanguageBlock())
 		    Associative_LanguageBlock<out rhs>
 		|
 			Associative_Expression<out rhs>
@@ -1047,10 +1049,11 @@ Associative_FunctionalStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode
                 )
                 |
                 (  
+					IF(IsLanguageBlock())
                                 (. 
                                     withinModifierCheckScope = false; 
                                 .)
-                    Associative_LanguageBlock<out rightNode>
+						Associative_LanguageBlock<out rightNode>
                                 (. 
                                     NodeUtils.SetNodeEndLocation(expressionNode, t);
                                     expressionNode.LeftNode = leftNode;
@@ -1533,9 +1536,26 @@ Associative_Ident<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
             .)
 .
 
-Associative_ArrayExprList<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
+Associative_ExprList<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 =
-'{'                                     (. ProtoCore.AST.AssociativeAST.ExprListNode exprlist = new ProtoCore.AST.AssociativeAST.ExprListNode(); .)
+'['                                     (. var exprlist = new ProtoCore.AST.AssociativeAST.ExprListNode(); .)
+                                        (. NodeUtils.SetNodeStartLocation(exprlist, t); .)
+    [
+                                        
+        Associative_Expression<out node>            (. exprlist.Exprs.Add(node); .)
+        {
+            ','
+            Associative_Expression<out node>        (. exprlist.Exprs.Add(node); .)
+        }
+                                        
+    ]
+']'                                     (. NodeUtils.SetNodeEndLocation(exprlist, t); .)
+                                        (. node = exprlist; .)
+.
+
+Associative_DeprecatedExprList<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
+=
+'{'                                     (. var exprlist = new ProtoCore.AST.AssociativeAST.ExprListNode(); .)
                                         (. NodeUtils.SetNodeStartLocation(exprlist, t); .)
     [
                                         
@@ -1642,9 +1662,16 @@ Associative_NameReference<ref ProtoCore.AST.AssociativeAST.AssociativeNode node>
                                             nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode;
                                         .)
         )
+		|
+        (
+            Associative_ExprList<out node>
+                                        (.
+                                            nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode;
+                                        .)
+        )
         |
         (
-            Associative_ArrayExprList<out node>
+            Associative_DeprecatedExprList<out node>
                                         (.
                                             nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode;
                                         .)

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -160,18 +160,18 @@ Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 =  SYNC                     (. if (!IsFullClosure()) SynErr(Resources.CloseBracketExpected); .)
                             (. node = null; .)
 (
-		Associative_ReturnStatement<out node>
+        Associative_ReturnStatement<out node>
     | 
-	IF(IsLanguageBlock())
+    IF(IsLanguageBlock())
         Associative_LanguageBlock<out node>
-	|
-	IF(IsNonAssignmentStatement())
-		Associative_NonAssignmentStatement<out node>
-	|
+    |
+    IF(IsNonAssignmentStatement())
+        Associative_NonAssignmentStatement<out node>
+    |
     IF(IsFunctionCallStatement())
-		Associative_FunctionCallStatement<out node>
+        Associative_FunctionCallStatement<out node>
 
-	|
+    |
         Associative_FunctionalStatement<out node>
     |
         (
@@ -196,34 +196,34 @@ Associative_Statement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 
 Associative_ReturnStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 =
-	(.
+    (.
         var bNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
-		NodeUtils.SetNodeLocation(bNode, la);
-	.)
-	"return"
-	[
-		'='
-	]
-	(.
-		var lhs = AstFactory.BuildIdentifier("return");
-		lhs.datatype = TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.Return);
-		bNode.LeftNode = lhs;
+        NodeUtils.SetNodeLocation(bNode, la);
+    .)
+    "return"
+    [
+        '='
+    ]
+    (.
+        var lhs = AstFactory.BuildIdentifier("return");
+        lhs.datatype = TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.Return);
+        bNode.LeftNode = lhs;
 
-		ProtoCore.AST.AssociativeAST.AssociativeNode rhs = null;
-	.)
-	(
-		IF(IsLanguageBlock())
-		    Associative_LanguageBlock<out rhs>
-		|
-			Associative_Expression<out rhs>
-			endline
-	)
-	(.
+        ProtoCore.AST.AssociativeAST.AssociativeNode rhs = null;
+    .)
+    (
+        IF(IsLanguageBlock())
+            Associative_LanguageBlock<out rhs>
+        |
+            Associative_Expression<out rhs>
+            endline
+    )
+    (.
         bNode.RightNode = rhs;
         bNode.Optr = Operator.assign;
 
-		node = bNode;
-	.)
+        node = bNode;
+    .)
 .
 
 Associative_StatementList<.out List<ProtoCore.AST.AssociativeAST.AssociativeNode> nodelist.> 
@@ -256,18 +256,18 @@ Associative_classdecl<.out ProtoCore.AST.AssociativeAST.AssociativeNode node.>
     [
         kw_extend
         ident								(. String baseClass = t.val; .)
-		{	
-			'.'
-			(. baseClass += t.val; .)
-			ident
-			(. baseClass += t.val; .)
-		}
-						                      (.
+        {	
+            '.'
+            (. baseClass += t.val; .)
+            ident
+            (. baseClass += t.val; .)
+        }
+                                              (.
                                                     classnode.BaseClass = baseClass;
                                                 .)
     ]
     '{'
-        {										
+        {
                                                (. ProtoCore.CompilerDefinitions.AccessModifier access = ProtoCore.CompilerDefinitions.AccessModifier.Public; .)
             [
                 Associative_AccessSpecifier<out access>
@@ -290,7 +290,7 @@ Associative_classdecl<.out ProtoCore.AST.AssociativeAST.AssociativeNode node.>
                         kw_static               (. isStatic = true; .) 
                     ]
                     (
-						(
+                        (
                                                 (. ProtoCore.AST.AssociativeAST.AssociativeNode funcnode; .)
                             Associative_functiondecl<out funcnode, access, isStatic>      
                                                 (. classnode.Procedures.Add(funcnode); .)
@@ -715,25 +715,25 @@ Associative_FunctionDefinitionBody<out ProtoCore.AST.AssociativeAST.AssociativeN
 TypedIdentifierList<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 =
 (
-		ident
-		(. node = new IdentifierNode(t.val); .)
-		
-			{
-				'.'
-				(. ProtoCore.AST.AssociativeAST.AssociativeNode rnode = null; .)
-				ident
-				(. 
-					rnode = new IdentifierNode(t.val);
+        ident
+        (. node = new IdentifierNode(t.val); .)
+        
+            {
+                '.'
+                (. ProtoCore.AST.AssociativeAST.AssociativeNode rnode = null; .)
+                ident
+                (. 
+                    rnode = new IdentifierNode(t.val);
             
-					ProtoCore.AST.AssociativeAST.IdentifierListNode bnode = new ProtoCore.AST.AssociativeAST.IdentifierListNode();
-					bnode.LeftNode = node;
-					bnode.Optr = Operator.dot;
-					bnode.RightNode = rnode;
-					node = bnode;
-					NodeUtils.SetNodeLocation(bnode, bnode.LeftNode, bnode.RightNode); 
-				.)
-			}
-		
+                    ProtoCore.AST.AssociativeAST.IdentifierListNode bnode = new ProtoCore.AST.AssociativeAST.IdentifierListNode();
+                    bnode.LeftNode = node;
+                    bnode.Optr = Operator.dot;
+                    bnode.RightNode = rnode;
+                    node = bnode;
+                    NodeUtils.SetNodeLocation(bnode, bnode.LeftNode, bnode.RightNode); 
+                .)
+            }
+        
  ) 
  .   
 
@@ -835,38 +835,38 @@ Associative_DecoratedIdentifier<out ProtoCore.AST.AssociativeAST.AssociativeNode
 
             (. 
                 string strIdent = string.Empty;
-				int type = ProtoCore.DSASM.Constants.kInvalidIndex;
-			.)
-				
-				(IF (IsIdentList())
-				(
-					TypedIdentifierList<out node>
-										(.	strIdent = node.ToString(); .)
-				)
-				|
-				(
-					ident
-							(. strIdent = t.val; .)
-							
-				)
-				)
-				(.
-						type = core.TypeSystem.GetType(strIdent);
-						typedVar.TypeAlias = strIdent;
-						if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
-						{
-							var unknownType = new ProtoCore.Type();
-							unknownType.UID = ProtoCore.DSASM.Constants.kInvalidIndex;
-							unknownType.Name = strIdent; 
-							typedVar.datatype = unknownType;
-						}
-						else
-						{
-							typedVar.datatype = core.TypeSystem.BuildTypeObject(type, 0);
-						}
-				.)		
-				
-	
+                int type = ProtoCore.DSASM.Constants.kInvalidIndex;
+            .)
+                
+                (IF (IsIdentList())
+                (
+                    TypedIdentifierList<out node>
+                                        (.	strIdent = node.ToString(); .)
+                )
+                |
+                (
+                    ident
+                            (. strIdent = t.val; .)
+                            
+                )
+                )
+                (.
+                        type = core.TypeSystem.GetType(strIdent);
+                        typedVar.TypeAlias = strIdent;
+                        if (type == ProtoCore.DSASM.Constants.kInvalidIndex)
+                        {
+                            var unknownType = new ProtoCore.Type();
+                            unknownType.UID = ProtoCore.DSASM.Constants.kInvalidIndex;
+                            unknownType.Name = strIdent; 
+                            typedVar.datatype = unknownType;
+                        }
+                        else
+                        {
+                            typedVar.datatype = core.TypeSystem.BuildTypeObject(type, 0);
+                        }
+                .)		
+                
+    
 
         [                               
                         (. var datatype = typedVar.datatype; .)
@@ -900,87 +900,87 @@ Associative_DecoratedIdentifier<out ProtoCore.AST.AssociativeAST.AssociativeNode
 Associative_NonAssignmentStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 =
   SYNC                       (.
-								 node = null; 
-								 ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
-						     .)
+                                 node = null; 
+                                 ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
+                             .)
 (
-	(
-		Associative_Expression<out rightNode>
-					(.
-						//Try to make a false binary expression node.					    
-						ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
-						ProtoCore.AST.AssociativeAST.IdentifierNode leftNode = new ProtoCore.AST.AssociativeAST.IdentifierNode();
-						leftNode.Value = leftNode.Name = Constants.kTempProcLeftVar;
+    (
+        Associative_Expression<out rightNode>
+                    (.
+                        //Try to make a false binary expression node.					    
+                        ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
+                        ProtoCore.AST.AssociativeAST.IdentifierNode leftNode = new ProtoCore.AST.AssociativeAST.IdentifierNode();
+                        leftNode.Value = leftNode.Name = Constants.kTempProcLeftVar;
 
-						var unknownType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0);
-						leftNode.datatype = unknownType;
-						leftNode.line = rightNode.line;
-						leftNode.col = rightNode.col;
-						leftNode.endLine = rightNode.endLine;
-						leftNode.endCol = rightNode.endCol;
+                        var unknownType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0);
+                        leftNode.datatype = unknownType;
+                        leftNode.line = rightNode.line;
+                        leftNode.col = rightNode.col;
+                        leftNode.endLine = rightNode.endLine;
+                        leftNode.endCol = rightNode.endCol;
 
-						expressionNode.LeftNode = leftNode;
-						expressionNode.RightNode = rightNode;
-						expressionNode.Optr = Operator.assign;
-						NodeUtils.UpdateBinaryExpressionLocation(expressionNode);
-						node = expressionNode;
-					.)			
+                        expressionNode.LeftNode = leftNode;
+                        expressionNode.RightNode = rightNode;
+                        expressionNode.Optr = Operator.assign;
+                        NodeUtils.UpdateBinaryExpressionLocation(expressionNode);
+                        node = expressionNode;
+                    .)			
                     
                     (. 
                         if (la.val != ";")
                             SynErr(Resources.SemiColonExpected);  
                     .)
-		endline				
-					(. NodeUtils.SetNodeEndLocation(node, t); .)
+        endline				
+                    (. NodeUtils.SetNodeEndLocation(node, t); .)
 
-	)
+    )
 )
 .
 
 Associative_FunctionCallStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
 =
   SYNC                       (.
-								 node = null; 
-								 ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
-						     .)
+                                 node = null; 
+                                 ProtoCore.AST.AssociativeAST.AssociativeNode rightNode = null;
+                             .)
 (
-	(
-		Associative_Expression<out rightNode>
-					(.
+    (
+        Associative_Expression<out rightNode>
+                    (.
                         bool allowIdentList = core.Options.GenerateSSA && rightNode is ProtoCore.AST.AssociativeAST.IdentifierListNode;
 
-						//Try to make a false binary expression node.
-					    if (rightNode is ProtoCore.AST.AssociativeAST.FunctionDotCallNode 
+                        //Try to make a false binary expression node.
+                        if (rightNode is ProtoCore.AST.AssociativeAST.FunctionDotCallNode 
                             || rightNode is ProtoCore.AST.AssociativeAST.FunctionCallNode
                             || allowIdentList)
-						{
-							ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
-							ProtoCore.AST.AssociativeAST.IdentifierNode leftNode = new ProtoCore.AST.AssociativeAST.IdentifierNode();
-							leftNode.Value = leftNode.Name = Constants.kTempProcLeftVar;
+                        {
+                            ProtoCore.AST.AssociativeAST.BinaryExpressionNode expressionNode = new ProtoCore.AST.AssociativeAST.BinaryExpressionNode();
+                            ProtoCore.AST.AssociativeAST.IdentifierNode leftNode = new ProtoCore.AST.AssociativeAST.IdentifierNode();
+                            leftNode.Value = leftNode.Name = Constants.kTempProcLeftVar;
 
-							var unknownType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0);
-							leftNode.datatype = unknownType;
-							leftNode.line = rightNode.line;
-							leftNode.col = rightNode.col;
-							leftNode.endLine = rightNode.endLine;
-							leftNode.endCol = rightNode.endCol;
+                            var unknownType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0);
+                            leftNode.datatype = unknownType;
+                            leftNode.line = rightNode.line;
+                            leftNode.col = rightNode.col;
+                            leftNode.endLine = rightNode.endLine;
+                            leftNode.endCol = rightNode.endCol;
 
-							expressionNode.LeftNode = leftNode;
-							expressionNode.RightNode = rightNode;
-							expressionNode.Optr = Operator.assign;
-							NodeUtils.UpdateBinaryExpressionLocation(expressionNode);
-							node = expressionNode;
-						}
-					.)			
+                            expressionNode.LeftNode = leftNode;
+                            expressionNode.RightNode = rightNode;
+                            expressionNode.Optr = Operator.assign;
+                            NodeUtils.UpdateBinaryExpressionLocation(expressionNode);
+                            node = expressionNode;
+                        }
+                    .)			
                     
                     (. 
                         if (la.val != ";")
                             SynErr(Resources.SemiColonExpected);  
                     .)
-		endline				
-					(. NodeUtils.SetNodeEndLocation(node, t); .)
+        endline				
+                    (. NodeUtils.SetNodeEndLocation(node, t); .)
 
-	)
+    )
 )
 .
 
@@ -1049,11 +1049,11 @@ Associative_FunctionalStatement<out ProtoCore.AST.AssociativeAST.AssociativeNode
                 )
                 |
                 (  
-					IF(IsLanguageBlock())
+                    IF(IsLanguageBlock())
                                 (. 
                                     withinModifierCheckScope = false; 
                                 .)
-						Associative_LanguageBlock<out rightNode>
+                        Associative_LanguageBlock<out rightNode>
                                 (. 
                                     NodeUtils.SetNodeEndLocation(expressionNode, t);
                                     expressionNode.LeftNode = leftNode;
@@ -1412,7 +1412,7 @@ Associative_Number<out ProtoCore.AST.AssociativeAST.AssociativeNode node>
             else
             {
                 node.line = line; node.col = col;
-				node.endLine = t.line; node.endCol = t.col;
+                node.endLine = t.line; node.endCol = t.col;
             }
         .)
         | 
@@ -1575,36 +1575,36 @@ Associative_DictionaryExpression<out ProtoCore.AST.AssociativeAST.AssociativeNod
 '{'                                     (. var dictBuilder = new ProtoCore.AST.AssociativeAST.DictionaryExpressionBuilder(); .)
                                         (. dictBuilder.SetNodeStartLocation(t); .)
     [
-		(
-			textstring	(. var str = new StringNode {Value = t.val.Trim('"')}; .)  
-						(. dictBuilder.AddKey(str); .)
-		)
-		|
-		(
-			ident		(. var ident = new IdentifierNode(t.val); .)
-						(. NodeUtils.SetNodeLocation(ident, t); .)
-						(. dictBuilder.AddKey(ident); .)
-		)
-	]
-	':'                     
-	Associative_Expression<out node>            (. dictBuilder.AddValue(node); .)
-	{
-		','
-		[
-			(
-				textstring	(. var str = new StringNode { Value = t.val.Trim('"') }; .)
-							(. dictBuilder.AddKey(str); .)  
-			)
-			|
-			(
-				ident		(. var ident = new IdentifierNode(t.val); .)
-							(. NodeUtils.SetNodeLocation(ident, t); .)
-							(. dictBuilder.AddKey(ident); .)
-			)
-		]
-		':'                     
-		Associative_Expression<out node>            (. dictBuilder.AddValue(node); .)
-	}
+        (
+            textstring	(. var str = new StringNode {Value = t.val.Trim('"')}; .)  
+                        (. dictBuilder.AddKey(str); .)
+        )
+        |
+        (
+            ident		(. var ident = new IdentifierNode(t.val); .)
+                        (. NodeUtils.SetNodeLocation(ident, t); .)
+                        (. dictBuilder.AddKey(ident); .)
+        )
+    ]
+    ':'                     
+    Associative_Expression<out node>            (. dictBuilder.AddValue(node); .)
+    {
+        ','
+        [
+            (
+                textstring	(. var str = new StringNode { Value = t.val.Trim('"') }; .)
+                            (. dictBuilder.AddKey(str); .)  
+            )
+            |
+            (
+                ident		(. var ident = new IdentifierNode(t.val); .)
+                            (. NodeUtils.SetNodeLocation(ident, t); .)
+                            (. dictBuilder.AddKey(ident); .)
+            )
+        ]
+        ':'                     
+        Associative_Expression<out node>            (. dictBuilder.AddValue(node); .)
+    }
 '}'                                     (. dictBuilder.SetNodeEndLocation(t); .)
                                         (. node = dictBuilder.ToFunctionCall(); .)
 .
@@ -1614,7 +1614,7 @@ Associative_NameReference<ref ProtoCore.AST.AssociativeAST.AssociativeNode node>
                                         (.
                                             ProtoCore.AST.AssociativeAST.ArrayNameNode nameNode = null; 
                                             ProtoCore.AST.AssociativeAST.GroupExpressionNode groupExprNode = null;
-											ProtoCore.AST.AssociativeAST.ArrayNameNode qualifierNode = node as AST.AssociativeAST.ArrayNameNode;
+                                            ProtoCore.AST.AssociativeAST.ArrayNameNode qualifierNode = node as AST.AssociativeAST.ArrayNameNode;
                                         .)
     (
         (
@@ -1654,15 +1654,15 @@ Associative_NameReference<ref ProtoCore.AST.AssociativeAST.AssociativeNode node>
                                             nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode; 
                                         .)
         )
-		|
-		IF(IsDictionaryExpression())
+        |
+        IF(IsDictionaryExpression())
         (
             Associative_DictionaryExpression<out node>
                                         (.
                                             nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode;
                                         .)
         )
-		|
+        |
         (
             Associative_ExprList<out node>
                                         (.
@@ -1679,9 +1679,9 @@ Associative_NameReference<ref ProtoCore.AST.AssociativeAST.AssociativeNode node>
     )
 
     [
-										(. 
-											ProtoCore.AST.AssociativeAST.ArrayNode array = null;
-										.)
+                                        (. 
+                                            ProtoCore.AST.AssociativeAST.ArrayNode array = null;
+                                        .)
         openbracket             
         [
                                         (. 
@@ -1690,31 +1690,31 @@ Associative_NameReference<ref ProtoCore.AST.AssociativeAST.AssociativeNode node>
                                         .)
             Associative_Expression<out node>
                                         (. 
-											if (tmpIsLeft) {
-												// if "foo[bar]" is on the lhs, it is interpreted as an array initialization expression
-												array = new ProtoCore.AST.AssociativeAST.ArrayNode
-												{
-													Expr = node,
-													Type = nameNode.ArrayDimensions
-												};
+                                            if (tmpIsLeft) {
+                                                // if "foo[bar]" is on the lhs, it is interpreted as an array initialization expression
+                                                array = new ProtoCore.AST.AssociativeAST.ArrayNode
+                                                {
+                                                    Expr = node,
+                                                    Type = nameNode.ArrayDimensions
+                                                };
 
-												NodeUtils.SetNodeLocation(array, t);
-												nameNode.ArrayDimensions = array;
-											} else {
-												if (qualifierNode != null)
-												{
-													ProtoCore.AST.AssociativeAST.IdentifierListNode inode = new ProtoCore.AST.AssociativeAST.IdentifierListNode();
-													inode.LeftNode = qualifierNode;
-													inode.Optr = Operator.dot;
-													inode.RightNode = nameNode;
-													NodeUtils.SetNodeLocation(inode, inode.LeftNode, inode.RightNode);
-													nameNode = inode;
-												}
-												// if "foo[bar]" is on the rhs, it is interpreted as an lookup in an array or dictionary
-												nameNode = AstFactory.BuildIndexExpression(nameNode, node) as ArrayNameNode;
-											}
+                                                NodeUtils.SetNodeLocation(array, t);
+                                                nameNode.ArrayDimensions = array;
+                                            } else {
+                                                if (qualifierNode != null)
+                                                {
+                                                    ProtoCore.AST.AssociativeAST.IdentifierListNode inode = new ProtoCore.AST.AssociativeAST.IdentifierListNode();
+                                                    inode.LeftNode = qualifierNode;
+                                                    inode.Optr = Operator.dot;
+                                                    inode.RightNode = nameNode;
+                                                    NodeUtils.SetNodeLocation(inode, inode.LeftNode, inode.RightNode);
+                                                    nameNode = inode;
+                                                }
+                                                // if "foo[bar]" is on the rhs, it is interpreted as an lookup in an array or dictionary
+                                                nameNode = AstFactory.BuildIndexExpression(nameNode, node) as ArrayNameNode;
+                                            }
 
-											isLeft = tmpIsLeft; 
+                                            isLeft = tmpIsLeft; 
                                         .)
         ]
         closebracket 
@@ -1727,21 +1727,21 @@ Associative_NameReference<ref ProtoCore.AST.AssociativeAST.AssociativeNode node>
                                         .) 
                 Associative_Expression<out node>
                                         (.
-											if (tmpIsLeft) {
-												var array2 = new ProtoCore.AST.AssociativeAST.ArrayNode
-												{
-													Expr = node,
-													Type = null
-												};
+                                            if (tmpIsLeft) {
+                                                var array2 = new ProtoCore.AST.AssociativeAST.ArrayNode
+                                                {
+                                                    Expr = node,
+                                                    Type = null
+                                                };
 
-												NodeUtils.SetNodeLocation(array2, t);
-												array.Type = array2;
-												array = array2;
-											} else {
-												nameNode = AstFactory.BuildIndexExpression(nameNode, node) as ArrayNameNode;
-											}
+                                                NodeUtils.SetNodeLocation(array2, t);
+                                                array.Type = array2;
+                                                array = array2;
+                                            } else {
+                                                nameNode = AstFactory.BuildIndexExpression(nameNode, node) as ArrayNameNode;
+                                            }
 
-											isLeft = tmpIsLeft; 
+                                            isLeft = tmpIsLeft; 
                                         .)
             ]
             closebracket
@@ -1981,20 +1981,20 @@ Associative_IdentifierList<out ProtoCore.AST.AssociativeAST.AssociativeNode node
                                         
                                         ProtoCore.AST.AssociativeAST.IdentifierListNode bnode;
 
-										ProtoCore.AST.AssociativeAST.IdentifierListNode idnode = rnode as ProtoCore.AST.AssociativeAST.IdentifierListNode;
-										if (idnode != null && idnode.LeftNode.Name == Node.BuiltinGetValueAtIndexTypeName)
-										{
-											bnode = idnode;
-										}
-										else
-										{
-											bnode = new ProtoCore.AST.AssociativeAST.IdentifierListNode();
-											bnode.LeftNode = node;
-											bnode.Optr = Operator.dot;
-											bnode.RightNode = rnode;
-											NodeUtils.SetNodeLocation(bnode, bnode.LeftNode, bnode.RightNode);
-										}
-										node = bnode;
+                                        ProtoCore.AST.AssociativeAST.IdentifierListNode idnode = rnode as ProtoCore.AST.AssociativeAST.IdentifierListNode;
+                                        if (idnode != null && idnode.LeftNode.Name == Node.BuiltinGetValueAtIndexTypeName)
+                                        {
+                                            bnode = idnode;
+                                        }
+                                        else
+                                        {
+                                            bnode = new ProtoCore.AST.AssociativeAST.IdentifierListNode();
+                                            bnode.LeftNode = node;
+                                            bnode.Optr = Operator.dot;
+                                            bnode.RightNode = rnode;
+                                            NodeUtils.SetNodeLocation(bnode, bnode.LeftNode, bnode.RightNode);
+                                        }
+                                        node = bnode;
                                         
                                         if (!core.Options.GenerateSSA)
                                         {

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -91,8 +91,8 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
         |
         Imperative_forloop<out node>
         |
-		IF(IsLanguageBlock())
-			Imperative_languageblock<out node>      
+        IF(IsLanguageBlock())
+            Imperative_languageblock<out node>      
         |
         (
             kw_break 
@@ -112,8 +112,8 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
             endline
         )  (. node = new ProtoCore.AST.ImperativeAST.ContinueNode(); NodeUtils.SetNodeLocation(node, t); .)
         |
-		Imperative_returnstmt<out node>
-		|
+        Imperative_returnstmt<out node>
+        |
         (IF(IsAssignmentStatement() || IsVariableDeclaration())
             Imperative_assignstmt<out node>
         )
@@ -140,38 +140,38 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
 Imperative_returnstmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
 =
     (.
-		node = null;
+        node = null;
         var bNode = new ProtoCore.AST.ImperativeAST.BinaryExpressionNode();
         NodeUtils.SetNodeLocation(bNode, la);
-	.)
-	"return"
-	[
-		'='
-	]
-	(.
-		var lhs = BuildImperativeIdentifier("return", ProtoCore.PrimitiveType.Return);
-		bNode.LeftNode = lhs;
+    .)
+    "return"
+    [
+        '='
+    ]
+    (.
+        var lhs = BuildImperativeIdentifier("return", ProtoCore.PrimitiveType.Return);
+        bNode.LeftNode = lhs;
 
-		ProtoCore.AST.ImperativeAST.ImperativeNode rhs = null;
-	.)
+        ProtoCore.AST.ImperativeAST.ImperativeNode rhs = null;
+    .)
 
-	(
-	IF(IsLanguageBlock())
-		Imperative_languageblock<out rhs>
-	|
-	Imperative_expr<out rhs>
+    (
+    IF(IsLanguageBlock())
+        Imperative_languageblock<out rhs>
+    |
+    Imperative_expr<out rhs>
     (.
         if (la.kind != _endline)
             SynErr(Resources.SemiColonExpected);
     .)
     endline
-	)
-	(.
+    )
+    (.
         bNode.RightNode = rhs;
         bNode.Optr = Operator.assign;
 
-		node = bNode;
-	.)
+        node = bNode;
+    .)
 .
 
 Imperative_stmtlist<.out List<ProtoCore.AST.ImperativeAST.ImperativeNode> nodelist.> 
@@ -322,15 +322,15 @@ Imperative_assignstmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                             ProtoCore.AST.ImperativeAST.BinaryExpressionNode bNode = new ProtoCore.AST.ImperativeAST.BinaryExpressionNode();
                             ProtoCore.AST.ImperativeAST.ImperativeNode lhsNode = null; 
                             NodeUtils.SetNodeLocation(bNode, la);
-							isLeft = true;
+                            isLeft = true;
                         .)
     (   
         Imperative_decoratedIdentifier<out lhsNode>
     )
                         (. 
-							isLeft = false;
-							node = lhsNode; 
-						.)
+                            isLeft = false;
+                            node = lhsNode; 
+                        .)
 
     (
         endline
@@ -350,8 +350,8 @@ Imperative_assignstmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                     IF(HasMoreAssignmentStatements())
                         Imperative_assignstmt<out rhsNode>
                 )
-				|
-				IF(IsLanguageBlock())
+                |
+                IF(IsLanguageBlock())
                     Imperative_languageblock<out rhsNode>
                 |
                 (
@@ -531,19 +531,19 @@ Imperative_IdentifierList<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
         Imperative_NameReference<ref rnode>
                                         (.
                                             ProtoCore.AST.ImperativeAST.IdentifierListNode inode = rnode as ProtoCore.AST.ImperativeAST.IdentifierListNode;
-											ProtoCore.AST.ImperativeAST.IdentifierListNode bnode;
-											if (inode != null && inode.LeftNode.Name == Node.BuiltinGetValueAtIndexTypeName)
-											{
-												bnode = inode;
-											}
-											else
-											{
-													bnode = new ProtoCore.AST.ImperativeAST.IdentifierListNode();
-													bnode.LeftNode = node;
-													bnode.Optr = Operator.dot;
-													bnode.RightNode = rnode;
-													NodeUtils.SetNodeLocation(bnode, bnode.LeftNode, bnode.RightNode);
-											}
+                                            ProtoCore.AST.ImperativeAST.IdentifierListNode bnode;
+                                            if (inode != null && inode.LeftNode.Name == Node.BuiltinGetValueAtIndexTypeName)
+                                            {
+                                                bnode = inode;
+                                            }
+                                            else
+                                            {
+                                                    bnode = new ProtoCore.AST.ImperativeAST.IdentifierListNode();
+                                                    bnode.LeftNode = node;
+                                                    bnode.Optr = Operator.dot;
+                                                    bnode.RightNode = rnode;
+                                                    NodeUtils.SetNodeLocation(bnode, bnode.LeftNode, bnode.RightNode);
+                                            }
 
                                             if (bnode.RightNode is ProtoCore.AST.ImperativeAST.FunctionCallNode)
                                             {
@@ -862,7 +862,7 @@ Imperative_NameReference<ref ProtoCore.AST.ImperativeAST.ImperativeNode node>
                                     (.
                                         ProtoCore.AST.ImperativeAST.ArrayNameNode nameNode = null;
                                         ProtoCore.AST.ImperativeAST.GroupExpressionNode groupExprNode = null;
-										ProtoCore.AST.ImperativeAST.ArrayNameNode qualifierNode = node as AST.ImperativeAST.ArrayNameNode;
+                                        ProtoCore.AST.ImperativeAST.ArrayNameNode qualifierNode = node as AST.ImperativeAST.ArrayNameNode;
                                     .)
     (
         (
@@ -897,15 +897,15 @@ Imperative_NameReference<ref ProtoCore.AST.ImperativeAST.ImperativeNode node>
                                         nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
                                     .)
         )
-		|
-		IF(IsDictionaryExpression())
+        |
+        IF(IsDictionaryExpression())
         (
             Imperative_DictionaryExpression<out node>
                                     (.
                                         nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
                                     .)
         )
-		|
+        |
         (
             Imperative_ExprList<out node>
                                     (.
@@ -922,46 +922,46 @@ Imperative_NameReference<ref ProtoCore.AST.ImperativeAST.ImperativeNode node>
     )
 
     [
-		(. ProtoCore.AST.ImperativeAST.ArrayNode array = null; .)
+        (. ProtoCore.AST.ImperativeAST.ArrayNode array = null; .)
         openbracket                  
         [                        
-		                            (. 
+                                    (. 
                                         bool tmpIsLeft = isLeft; 
                                         isLeft = false;
                                     .)
             Imperative_expr<out node>   
                                     (. 
-										if (tmpIsLeft) {
-											// if "foo[bar]" is on the lhs, it is interpreted as an array initialization expression
-											array = new ProtoCore.AST.ImperativeAST.ArrayNode
-											{
-												Expr = node,
-												Type = nameNode.ArrayDimensions
-											};
+                                        if (tmpIsLeft) {
+                                            // if "foo[bar]" is on the lhs, it is interpreted as an array initialization expression
+                                            array = new ProtoCore.AST.ImperativeAST.ArrayNode
+                                            {
+                                                Expr = node,
+                                                Type = nameNode.ArrayDimensions
+                                            };
 
-											NodeUtils.SetNodeLocation(array, t);
-											nameNode.ArrayDimensions = array;
-										} else {
-											if (qualifierNode != null)
-											{
-												ProtoCore.AST.ImperativeAST.IdentifierListNode inode = new ProtoCore.AST.ImperativeAST.IdentifierListNode();
-												inode.LeftNode = qualifierNode;
-												inode.Optr = Operator.dot;
-												inode.RightNode = nameNode;
-												NodeUtils.SetNodeLocation(inode, inode.LeftNode, inode.RightNode);
-												nameNode = inode;
-											}
+                                            NodeUtils.SetNodeLocation(array, t);
+                                            nameNode.ArrayDimensions = array;
+                                        } else {
+                                            if (qualifierNode != null)
+                                            {
+                                                ProtoCore.AST.ImperativeAST.IdentifierListNode inode = new ProtoCore.AST.ImperativeAST.IdentifierListNode();
+                                                inode.LeftNode = qualifierNode;
+                                                inode.Optr = Operator.dot;
+                                                inode.RightNode = nameNode;
+                                                NodeUtils.SetNodeLocation(inode, inode.LeftNode, inode.RightNode);
+                                                nameNode = inode;
+                                            }
 
-											// if "foo[bar]" is on the rhs, it is interpreted as an lookup in an array or dictionary
-											nameNode = ProtoCore.AST.ImperativeAST.AstFactory.BuildIndexExpression(nameNode, node) as ProtoCore.AST.ImperativeAST.ArrayNameNode;
-										}
+                                            // if "foo[bar]" is on the rhs, it is interpreted as an lookup in an array or dictionary
+                                            nameNode = ProtoCore.AST.ImperativeAST.AstFactory.BuildIndexExpression(nameNode, node) as ProtoCore.AST.ImperativeAST.ArrayNameNode;
+                                        }
 
-										isLeft = tmpIsLeft; 
+                                        isLeft = tmpIsLeft; 
                                     .)
         ]
         closebracket 
         { 
-		                        (. 
+                                (. 
                                     bool tmpIsLeft = isLeft; 
                                     isLeft = false;
                                 .) 
@@ -969,23 +969,23 @@ Imperative_NameReference<ref ProtoCore.AST.ImperativeAST.ImperativeNode node>
             [
                 Imperative_expr<out node>
 
-				                (. 
-									if (tmpIsLeft) {
-										var array2 = new ProtoCore.AST.ImperativeAST.ArrayNode
-										{
-											Expr = node,
-											Type = null
-										};
+                                (. 
+                                    if (tmpIsLeft) {
+                                        var array2 = new ProtoCore.AST.ImperativeAST.ArrayNode
+                                        {
+                                            Expr = node,
+                                            Type = null
+                                        };
 
-										NodeUtils.SetNodeLocation(array2, t);
-										array.Type = array2;
-										array = array2;
-									} else {
-										nameNode = ProtoCore.AST.ImperativeAST.AstFactory.BuildIndexExpression(nameNode, node) as ProtoCore.AST.ImperativeAST.ArrayNameNode;
-									}
+                                        NodeUtils.SetNodeLocation(array2, t);
+                                        array.Type = array2;
+                                        array = array2;
+                                    } else {
+                                        nameNode = ProtoCore.AST.ImperativeAST.AstFactory.BuildIndexExpression(nameNode, node) as ProtoCore.AST.ImperativeAST.ArrayNameNode;
+                                    }
 
-									// TODO(pboyer) this looks incorrect, probably wrong in associative code, too
-									isLeft = tmpIsLeft; 
+                                    // TODO(pboyer) this looks incorrect, probably wrong in associative code, too
+                                    isLeft = tmpIsLeft; 
                                 .)
             ]
             closebracket
@@ -1041,36 +1041,36 @@ Imperative_DictionaryExpression<out ProtoCore.AST.ImperativeAST.ImperativeNode n
 '{'                                     (. var dictBuilder = new ProtoCore.AST.ImperativeAST.DictionaryExpressionBuilder(); .)
                                         (. dictBuilder.SetNodeStartLocation(t); .)
     [
-		(
-			textstring	(. var str = new ProtoCore.AST.ImperativeAST.StringNode {Value = t.val.Trim('"')}; .)  
-						(. dictBuilder.AddKey(str); .) 
-		) 
-		|
-		(
-			ident		(. var ident = new ProtoCore.AST.ImperativeAST.IdentifierNode(t.val); .)
-						(. NodeUtils.SetNodeLocation(ident, t); .)
-						(. dictBuilder.AddKey(ident); .)
-		)
-	]
-	':'                     
+        (
+            textstring	(. var str = new ProtoCore.AST.ImperativeAST.StringNode {Value = t.val.Trim('"')}; .)  
+                        (. dictBuilder.AddKey(str); .) 
+        ) 
+        |
+        (
+            ident		(. var ident = new ProtoCore.AST.ImperativeAST.IdentifierNode(t.val); .)
+                        (. NodeUtils.SetNodeLocation(ident, t); .)
+                        (. dictBuilder.AddKey(ident); .)
+        )
+    ]
+    ':'                     
     Imperative_expr<out node>            (. dictBuilder.AddValue(node); .)
     {
         ','
-		[
-			(
-				textstring	(. var str = new ProtoCore.AST.ImperativeAST.StringNode { Value = t.val.Trim('"') }; .)
-							(. dictBuilder.AddKey(str); .)  
-			)
-			|
-			(
-				ident		(. var ident = new ProtoCore.AST.ImperativeAST.IdentifierNode(t.val); .)
-							(. NodeUtils.SetNodeLocation(ident, t); .)
-							(. dictBuilder.AddKey(ident); .)
-			) 
-		]
-		':'                     
-		Imperative_expr<out node>       (. dictBuilder.SetNodeEndLocation(t); .)
-										(. dictBuilder.AddValue(node); .)
+        [
+            (
+                textstring	(. var str = new ProtoCore.AST.ImperativeAST.StringNode { Value = t.val.Trim('"') }; .)
+                            (. dictBuilder.AddKey(str); .)  
+            )
+            |
+            (
+                ident		(. var ident = new ProtoCore.AST.ImperativeAST.IdentifierNode(t.val); .)
+                            (. NodeUtils.SetNodeLocation(ident, t); .)
+                            (. dictBuilder.AddKey(ident); .)
+            ) 
+        ]
+        ':'                     
+        Imperative_expr<out node>       (. dictBuilder.SetNodeEndLocation(t); .)
+                                        (. dictBuilder.AddValue(node); .)
     }
                                         
     

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -91,7 +91,8 @@ Imperative_stmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
         |
         Imperative_forloop<out node>
         |
-        Imperative_languageblock<out node>      
+		IF(IsLanguageBlock())
+			Imperative_languageblock<out node>      
         |
         (
             kw_break 
@@ -155,7 +156,8 @@ Imperative_returnstmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
 	.)
 
 	(
-	Imperative_languageblock<out rhs>
+	IF(IsLanguageBlock())
+		Imperative_languageblock<out rhs>
 	|
 	Imperative_expr<out rhs>
     (.
@@ -348,7 +350,10 @@ Imperative_assignstmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                     IF(HasMoreAssignmentStatements())
                         Imperative_assignstmt<out rhsNode>
                 )
-                |        
+				|
+				IF(IsLanguageBlock())
+                    Imperative_languageblock<out rhsNode>
+                |
                 (
                     Imperative_expr<out rhsNode>        
                     (.
@@ -356,10 +361,6 @@ Imperative_assignstmt<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                            SynErr(Resources.SemiColonExpected);
                     .)
                     endline
-                )
-                |
-                (
-                    Imperative_languageblock<out rhsNode>       
                 )
             )
             (.
@@ -896,7 +897,7 @@ Imperative_NameReference<ref ProtoCore.AST.ImperativeAST.ImperativeNode node>
                                         nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
                                     .)
         )
-        |
+		|
 		IF(IsDictionaryExpression())
         (
             Imperative_DictionaryExpression<out node>
@@ -904,9 +905,16 @@ Imperative_NameReference<ref ProtoCore.AST.ImperativeAST.ImperativeNode node>
                                         nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
                                     .)
         )
-        |
+		|
         (
             Imperative_ExprList<out node>
+                                    (.
+                                        nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
+                                    .)
+        )
+        |
+        (
+            Imperative_DeprecatedExprList<out node>
                                     (.
                                         nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
                                     .)
@@ -1072,8 +1080,29 @@ Imperative_DictionaryExpression<out ProtoCore.AST.ImperativeAST.ImperativeNode n
 
 Imperative_ExprList<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
 =
+        '['                         (.
+                                        var exprlist = new ProtoCore.AST.ImperativeAST.ExprListNode();
+                                        NodeUtils.SetNodeStartLocation(exprlist, t);
+                                    .)
+            [
+                                    
+                Imperative_expr<out node>          (. exprlist.Exprs.Add(node); .)
+                {
+                    ','
+                    Imperative_expr<out node>      (. exprlist.Exprs.Add(node); .)
+                }
+         
+            ]
+        ']'                         (.
+                                        NodeUtils.SetNodeEndLocation(exprlist, t);
+                                        node = exprlist;
+                                    .)
+.
+
+Imperative_DeprecatedExprList<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
+=
         '{'                         (.
-                                        ProtoCore.AST.ImperativeAST.ExprListNode exprlist = new ProtoCore.AST.ImperativeAST.ExprListNode();
+                                        var exprlist = new ProtoCore.AST.ImperativeAST.ExprListNode();
                                         NodeUtils.SetNodeStartLocation(exprlist, t);
                                     .)
             [
@@ -1090,7 +1119,6 @@ Imperative_ExprList<out ProtoCore.AST.ImperativeAST.ImperativeNode node>
                                         node = exprlist;
                                     .)
 .
-
 Imperative_num<out ProtoCore.AST.ImperativeAST.ImperativeNode node>         
     (.  
         node = null; 

--- a/src/Engine/ProtoCore/Parser/atg/Start.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Start.atg
@@ -102,6 +102,36 @@ COMPILER DesignScriptParser
         return false;
     }
 
+    private bool IsLanguageBlock()
+    {
+        short state = 0;
+        Token pt = la;
+        while (pt.kind != _EOF)
+        {
+            switch (state)
+            {
+                case 0:
+                    if (pt.val == "[")
+                    {
+                        state = 1;
+                        pt = scanner.Peek();
+                        continue;
+                    }
+                    goto fail;
+                case 1:
+                    if (pt.val == "Associative" || pt.val == "Imperative")
+                    {
+                        return true;
+                    }
+					goto fail;
+            }
+        }
+
+        fail:
+        scanner.ResetPeek();
+        return false;
+    }
+
 	// Recognize: 
     //     { "foo" :   
     // OR   

--- a/src/Engine/ProtoCore/Parser/atg/Start.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Start.atg
@@ -72,7 +72,7 @@ COMPILER DesignScriptParser
                         break;
                 }
             }
-			else if (s[i] == '\\' && i == s.Length - 1) {
+            else if (s[i] == '\\' && i == s.Length - 1) {
                  SynErr(Resources.EOF_expected);
                 }
             else
@@ -123,7 +123,7 @@ COMPILER DesignScriptParser
                     {
                         return true;
                     }
-					goto fail;
+                    goto fail;
             }
         }
 
@@ -132,7 +132,7 @@ COMPILER DesignScriptParser
         return false;
     }
 
-	// Recognize: 
+    // Recognize: 
     //     { "foo" :   
     // OR   
     //     { foo :
@@ -190,41 +190,41 @@ COMPILER DesignScriptParser
         return false;
     }
 
-	private bool IsFunctionCallStatement()
-	{
+    private bool IsFunctionCallStatement()
+    {
         Token pt = la;
         while (pt.kind != _EOF)
         {
-			if( _ident == pt.kind ) 
-			{
-				pt = scanner.Peek();
-				if( _openparen == pt.kind )
-				{
-					scanner.ResetPeek();
-					return true;
-				}
-				else if( _period == pt.kind )
-				{
-					pt = scanner.Peek();
-					continue;
-				}
-			}
-			else
-			{
-				break;
-			}			
-		}
+            if( _ident == pt.kind ) 
+            {
+                pt = scanner.Peek();
+                if( _openparen == pt.kind )
+                {
+                    scanner.ResetPeek();
+                    return true;
+                }
+                else if( _period == pt.kind )
+                {
+                    pt = scanner.Peek();
+                    continue;
+                }
+            }
+            else
+            {
+                break;
+            }			
+        }
 
         scanner.ResetPeek();
         return false;
-	}
+    }
 
-	private bool IsNonAssignmentStatement()
+    private bool IsNonAssignmentStatement()
     {
-		if (core.ParsingMode != ParseMode.AllowNonAssignment)
+        if (core.ParsingMode != ParseMode.AllowNonAssignment)
             return false;
 
-		if (IsTypedVariable())
+        if (IsTypedVariable())
             return false;
 
         Token pt = la;
@@ -240,7 +240,7 @@ COMPILER DesignScriptParser
                 scanner.ResetPeek();
                 return false;
             }
-			else if (pt.val == ";")
+            else if (pt.val == ";")
                 break;
 
             pt = scanner.Peek();
@@ -415,8 +415,8 @@ COMPILER DesignScriptParser
         scanner.ResetPeek();
         return isLocallyTyped;
     }
-	
-	private bool IsFullClosure()
+    
+    private bool IsFullClosure()
     {
         Token pt = la;
         int closureCount = 0;
@@ -426,8 +426,8 @@ COMPILER DesignScriptParser
             pt = scanner.Peek();
             if (pt.val == "(") { closureCount++; continue; }
             if (pt.val == ")") { closureCount--; continue; }
-			if ((pt.kind == 0)||(pt.kind == _endline)) break;
-		}
+            if ((pt.kind == 0)||(pt.kind == _endline)) break;
+        }
         scanner.ResetPeek();
         return (closureCount > 0) ? false : true;
     }
@@ -483,11 +483,11 @@ COMPILER DesignScriptParser
                          return false;
                 }
             }
-			if (pt.val == "=")
-			{
-				scanner.ResetPeek();
-				return false;
-			}
+            if (pt.val == "=")
+            {
+                scanner.ResetPeek();
+                return false;
+            }
         }
         scanner.ResetPeek();        
         return true;    
@@ -505,7 +505,7 @@ COMPILER DesignScriptParser
         return funCallNode;
     }
 
- 	private AssociativeNode GenerateUnaryOperatorMethodCallNode(UnaryOperator op, ProtoCore.AST.AssociativeAST.AssociativeNode operand)
+    private AssociativeNode GenerateUnaryOperatorMethodCallNode(UnaryOperator op, ProtoCore.AST.AssociativeAST.AssociativeNode operand)
     {
         FunctionCallNode funCallNode = new FunctionCallNode();
         IdentifierNode funcName = new IdentifierNode { Value = ProtoCore.DSASM.Op.GetUnaryOpFunction(op), Name = ProtoCore.DSASM.Op.GetUnaryOpFunction(op) };
@@ -545,12 +545,12 @@ COMPILER DesignScriptParser
         return false;
     }
 
-	 // use by associative
-	 private bool IsNotAttributeFunctionClass()
-	 {
-		if (la.val == "[")
-		{
-		    Token t = scanner.Peek();
+     // use by associative
+     private bool IsNotAttributeFunctionClass()
+     {
+        if (la.val == "[")
+        {
+            Token t = scanner.Peek();
             while (t.val != "]" && t.kind != _EOF)
             {
                 t = scanner.Peek();
@@ -567,19 +567,19 @@ COMPILER DesignScriptParser
                 scanner.ResetPeek();
                 return false;
             }
-		}
+        }
 
-		if (la.kind != _kw_class && la.kind != _kw_def)
-			return true;
-		return false;
-	 }
+        if (la.kind != _kw_class && la.kind != _kw_def)
+            return true;
+        return false;
+     }
 
-	 // used by imperative
-	 private bool IsNotAttributeFunction()
-	 {
-	    if (la.val == "[")
-		{
-		    Token t = scanner.Peek();
+     // used by imperative
+     private bool IsNotAttributeFunction()
+     {
+        if (la.val == "[")
+        {
+            Token t = scanner.Peek();
             while (t.val != "]" && t.kind != _EOF)
             {
                 t = scanner.Peek();
@@ -597,25 +597,25 @@ COMPILER DesignScriptParser
                 scanner.ResetPeek();
                 return false;
             }
-		}
+        }
 
         return la.kind != _kw_def;
-	 }
+     }
 
-	 
-	 //Experiment for user-defined synErr message
-	 private void SynErr (string s) {
-		if (errDist >= minErrDist) 
-		core.BuildStatus.LogSyntaxError(s, core.CurrentDSFileName, la.line, la.col);
-		errors.count++;
-		errDist = 0;
-	 }
+     
+     //Experiment for user-defined synErr message
+     private void SynErr (string s) {
+        if (errDist >= minErrDist) 
+        core.BuildStatus.LogSyntaxError(s, core.CurrentDSFileName, la.line, la.col);
+        errors.count++;
+        errDist = 0;
+     }
 
 
 CHARACTERS
 
     unicodeIdentifierStart = '_' + 'a'..'z' + 'A'..'Z' + '\u00aa'+'\u00b5'+'\u00ba'+'\u00c0'..'\u00d6'+'\u00d8'..'\u00f6'+'\u00f8'..'\u02c1'+'\u02c6'..'\u02d1'+'\u02e0'..'\u02e4'+'\u02ec'+'\u02ee'+'\u0370'..'\u0374'+'\u0376'+'\u0377'+'\u037a'..'\u037d'+'\u0386'+'\u0388'..'\u038a'+'\u038c'+'\u038e'..'\u03a1'+'\u03a3'..'\u03f5'+'\u03f7'..'\u0481'+'\u048a'..'\u0527'+'\u0531'..'\u0556'+'\u0559'+'\u0561'..'\u0587'+'\u05d0'..'\u05ea'+'\u05f0'..'\u05f2'+'\u0620'..'\u064a'+'\u066e'+'\u066f'+'\u0671'..'\u06d3'+'\u06d5'+'\u06e5'+'\u06e6'+'\u06ee'+'\u06ef'+'\u06fa'..'\u06fc'+'\u06ff'+'\u0710'+'\u0712'..'\u072f'+'\u074d'..'\u07a5'+'\u07b1'+'\u07ca'..'\u07ea'+'\u07f4'+'\u07f5'+'\u07fa'+'\u0800'..'\u0815'+'\u081a'+'\u0824'+'\u0828'+'\u0840'..'\u0858'+'\u08a0'+'\u08a2'..'\u08ac'+'\u0904'..'\u0939'+'\u093d'+'\u0950'+'\u0958'..'\u0961'+'\u0971'..'\u0977'+'\u0979'..'\u097f'+'\u0985'..'\u098c'+'\u098f'+'\u0990'+'\u0993'..'\u09a8'+'\u09aa'..'\u09b0'+'\u09b2'+'\u09b6'..'\u09b9'+'\u09bd'+'\u09ce'+'\u09dc'+'\u09dd'+'\u09df'..'\u09e1'+'\u09f0'+'\u09f1'+'\u0a05'..'\u0a0a'+'\u0a0f'+'\u0a10'+'\u0a13'..'\u0a28'+'\u0a2a'..'\u0a30'+'\u0a32'+'\u0a33'+'\u0a35'+'\u0a36'+'\u0a38'+'\u0a39'+'\u0a59'..'\u0a5c'+'\u0a5e'+'\u0a72'..'\u0a74'+'\u0a85'..'\u0a8d'+'\u0a8f'..'\u0a91'+'\u0a93'..'\u0aa8'+'\u0aaa'..'\u0ab0'+'\u0ab2'+'\u0ab3'+'\u0ab5'..'\u0ab9'+'\u0abd'+'\u0ad0'+'\u0ae0'+'\u0ae1'+'\u0b05'..'\u0b0c'+'\u0b0f'+'\u0b10'+'\u0b13'..'\u0b28'+'\u0b2a'..'\u0b30'+'\u0b32'+'\u0b33'+'\u0b35'..'\u0b39'+'\u0b3d'+'\u0b5c'+'\u0b5d'+'\u0b5f'..'\u0b61'+'\u0b71'+'\u0b83'+'\u0b85'..'\u0b8a'+'\u0b8e'..'\u0b90'+'\u0b92'..'\u0b95'+'\u0b99'+'\u0b9a'+'\u0b9c'+'\u0b9e'+'\u0b9f'+'\u0ba3'+'\u0ba4'+'\u0ba8'..'\u0baa'+'\u0bae'..'\u0bb9'+'\u0bd0'+'\u0c05'..'\u0c0c'+'\u0c0e'..'\u0c10'+'\u0c12'..'\u0c28'+'\u0c2a'..'\u0c33'+'\u0c35'..'\u0c39'+'\u0c3d'+'\u0c58'+'\u0c59'+'\u0c60'+'\u0c61'+'\u0c85'..'\u0c8c'+'\u0c8e'..'\u0c90'+'\u0c92'..'\u0ca8'+'\u0caa'..'\u0cb3'+'\u0cb5'..'\u0cb9'+'\u0cbd'+'\u0cde'+'\u0ce0'+'\u0ce1'+'\u0cf1'+'\u0cf2'+'\u0d05'..'\u0d0c'+'\u0d0e'..'\u0d10'+'\u0d12'..'\u0d3a'+'\u0d3d'+'\u0d4e'+'\u0d60'+'\u0d61'+'\u0d7a'..'\u0d7f'+'\u0d85'..'\u0d96'+'\u0d9a'..'\u0db1'+'\u0db3'..'\u0dbb'+'\u0dbd'+'\u0dc0'..'\u0dc6'+'\u0e01'..'\u0e30'+'\u0e32'+'\u0e33'+'\u0e40'..'\u0e46'+'\u0e81'+'\u0e82'+'\u0e84'+'\u0e87'+'\u0e88'+'\u0e8a'+'\u0e8d'+'\u0e94'..'\u0e97'+'\u0e99'..'\u0e9f'+'\u0ea1'..'\u0ea3'+'\u0ea5'+'\u0ea7'+'\u0eaa'+'\u0eab'+'\u0ead'..'\u0eb0'+'\u0eb2'+'\u0eb3'+'\u0ebd'+'\u0ec0'..'\u0ec4'+'\u0ec6'+'\u0edc'..'\u0edf'+'\u0f00'+'\u0f40'..'\u0f47'+'\u0f49'..'\u0f6c'+'\u0f88'..'\u0f8c'+'\u1000'..'\u102a'+'\u103f'+'\u1050'..'\u1055'+'\u105a'..'\u105d'+'\u1061'+'\u1065'+'\u1066'+'\u106e'..'\u1070'+'\u1075'..'\u1081'+'\u108e'+'\u10a0'..'\u10c5'+'\u10c7'+'\u10cd'+'\u10d0'..'\u10fa'+'\u10fc'..'\u1248'+'\u124a'..'\u124d'+'\u1250'..'\u1256'+'\u1258'+'\u125a'..'\u125d'+'\u1260'..'\u1288'+'\u128a'..'\u128d'+'\u1290'..'\u12b0'+'\u12b2'..'\u12b5'+'\u12b8'..'\u12be'+'\u12c0'+'\u12c2'..'\u12c5'+'\u12c8'..'\u12d6'+'\u12d8'..'\u1310'+'\u1312'..'\u1315'+'\u1318'..'\u135a'+'\u1380'..'\u138f'+'\u13a0'..'\u13f4'+'\u1401'..'\u166c'+'\u166f'..'\u167f'+'\u1681'..'\u169a'+'\u16a0'..'\u16ea'+'\u16ee'..'\u16f0'+'\u1700'..'\u170c'+'\u170e'..'\u1711'+'\u1720'..'\u1731'+'\u1740'..'\u1751'+'\u1760'..'\u176c'+'\u176e'..'\u1770'+'\u1780'..'\u17b3'+'\u17d7'+'\u17dc'+'\u1820'..'\u1877'+'\u1880'..'\u18a8'+'\u18aa'+'\u18b0'..'\u18f5'+'\u1900'..'\u191c'+'\u1950'..'\u196d'+'\u1970'..'\u1974'+'\u1980'..'\u19ab'+'\u19c1'..'\u19c7'+'\u1a00'..'\u1a16'+'\u1a20'..'\u1a54'+'\u1aa7'+'\u1b05'..'\u1b33'+'\u1b45'..'\u1b4b'+'\u1b83'..'\u1ba0'+'\u1bae'+'\u1baf'+'\u1bba'..'\u1be5'+'\u1c00'..'\u1c23'+'\u1c4d'..'\u1c4f'+'\u1c5a'..'\u1c7d'+'\u1ce9'..'\u1cec'+'\u1cee'..'\u1cf1'+'\u1cf5'+'\u1cf6'+'\u1d00'..'\u1dbf'+'\u1e00'..'\u1f15'+'\u1f18'..'\u1f1d'+'\u1f20'..'\u1f45'+'\u1f48'..'\u1f4d'+'\u1f50'..'\u1f57'+'\u1f59'+'\u1f5b'+'\u1f5d'+'\u1f5f'..'\u1f7d'+'\u1f80'..'\u1fb4'+'\u1fb6'..'\u1fbc'+'\u1fbe'+'\u1fc2'..'\u1fc4'+'\u1fc6'..'\u1fcc'+'\u1fd0'..'\u1fd3'+'\u1fd6'..'\u1fdb'+'\u1fe0'..'\u1fec'+'\u1ff2'..'\u1ff4'+'\u1ff6'..'\u1ffc'+'\u2071'+'\u207f'+'\u2090'..'\u209c'+'\u2102'+'\u2107'+'\u210a'..'\u2113'+'\u2115'+'\u2119'..'\u211d'+'\u2124'+'\u2126'+'\u2128'+'\u212a'..'\u212d'+'\u212f'..'\u2139'+'\u213c'..'\u213f'+'\u2145'..'\u2149'+'\u214e'+'\u2160'..'\u2188'+'\u2c00'..'\u2c2e'+'\u2c30'..'\u2c5e'+'\u2c60'..'\u2ce4'+'\u2ceb'..'\u2cee'+'\u2cf2'+'\u2cf3'+'\u2d00'..'\u2d25'+'\u2d27'+'\u2d2d'+'\u2d30'..'\u2d67'+'\u2d6f'+'\u2d80'..'\u2d96'+'\u2da0'..'\u2da6'+'\u2da8'..'\u2dae'+'\u2db0'..'\u2db6'+'\u2db8'..'\u2dbe'+'\u2dc0'..'\u2dc6'+'\u2dc8'..'\u2dce'+'\u2dd0'..'\u2dd6'+'\u2dd8'..'\u2dde'+'\u2e2f'+'\u3005'..'\u3007'+'\u3021'..'\u3029'+'\u3031'..'\u3035'+'\u3038'..'\u303c'+'\u3041'..'\u3096'+'\u309d'..'\u309f'+'\u30a1'..'\u30fa'+'\u30fc'..'\u30ff'+'\u3105'..'\u312d'+'\u3131'..'\u318e'+'\u31a0'..'\u31ba'+'\u31f0'..'\u31ff'+'\u3400'..'\u4db5'+'\u4e00'..'\u9fcc'+'\ua000'..'\ua48c'+'\ua4d0'..'\ua4fd'+'\ua500'..'\ua60c'+'\ua610'..'\ua61f'+'\ua62a'+'\ua62b'+'\ua640'..'\ua66e'+'\ua67f'..'\ua697'+'\ua6a0'..'\ua6ef'+'\ua717'..'\ua71f'+'\ua722'..'\ua788'+'\ua78b'..'\ua78e'+'\ua790'..'\ua793'+'\ua7a0'..'\ua7aa'+'\ua7f8'..'\ua801'+'\ua803'..'\ua805'+'\ua807'..'\ua80a'+'\ua80c'..'\ua822'+'\ua840'..'\ua873'+'\ua882'..'\ua8b3'+'\ua8f2'..'\ua8f7'+'\ua8fb'+'\ua90a'..'\ua925'+'\ua930'..'\ua946'+'\ua960'..'\ua97c'+'\ua984'..'\ua9b2'+'\ua9cf'+'\uaa00'..'\uaa28'+'\uaa40'..'\uaa42'+'\uaa44'..'\uaa4b'+'\uaa60'..'\uaa76'+'\uaa7a'+'\uaa80'..'\uaaaf'+'\uaab1'+'\uaab5'+'\uaab6'+'\uaab9'..'\uaabd'+'\uaac0'+'\uaac2'+'\uaadb'..'\uaadd'+'\uaae0'..'\uaaea'+'\uaaf2'..'\uaaf4'+'\uab01'..'\uab06'+'\uab09'..'\uab0e'+'\uab11'..'\uab16'+'\uab20'..'\uab26'+'\uab28'..'\uab2e'+'\uabc0'..'\uabe2'+'\uac00'..'\ud7a3'+'\ud7b0'..'\ud7c6'+'\ud7cb'..'\ud7fb'+'\uf900'..'\ufa6d'+'\ufa70'..'\ufad9'+'\ufb00'..'\ufb06'+'\ufb13'..'\ufb17'+'\ufb1d'+'\ufb1f'..'\ufb28'+'\ufb2a'..'\ufb36'+'\ufb38'..'\ufb3c'+'\ufb3e'+'\ufb40'+'\ufb41'+'\ufb43'+'\ufb44'+'\ufb46'..'\ufbb1'+'\ufbd3'..'\ufd3d'+'\ufd50'..'\ufd8f'+'\ufd92'..'\ufdc7'+'\ufdf0'..'\ufdfb'+'\ufe70'..'\ufe74'+'\ufe76'..'\ufefc'+'\uff21'..'\uff3a'+'\uff41'..'\uff5a'+'\uff66'..'\uffbe'+'\uffc2'..'\uffc7'+'\uffca'..'\uffcf'+'\uffd2'..'\uffd7'+'\uffda'..'\uffdc'.
-	unicodeIdentifierPart = '_' + 'a'..'z' + 'A'..'Z' + '0'..'9' + '\u00aa'+'\u00b5'+'\u00ba'+'\u00c0'..'\u00d6'+'\u00d8'..'\u00f6'+'\u00f8'..'\u02c1'+'\u02c6'..'\u02d1'+'\u02e0'..'\u02e4'+'\u02ec'+'\u02ee'+'\u0370'..'\u0374'+'\u0376'+'\u0377'+'\u037a'..'\u037d'+'\u0386'+'\u0388'..'\u038a'+'\u038c'+'\u038e'..'\u03a1'+'\u03a3'..'\u03f5'+'\u03f7'..'\u0481'+'\u048a'..'\u0527'+'\u0531'..'\u0556'+'\u0559'+'\u0561'..'\u0587'+'\u05d0'..'\u05ea'+'\u05f0'..'\u05f2'+'\u0620'..'\u064a'+'\u066e'+'\u066f'+'\u0671'..'\u06d3'+'\u06d5'+'\u06e5'+'\u06e6'+'\u06ee'+'\u06ef'+'\u06fa'..'\u06fc'+'\u06ff'+'\u0710'+'\u0712'..'\u072f'+'\u074d'..'\u07a5'+'\u07b1'+'\u07ca'..'\u07ea'+'\u07f4'+'\u07f5'+'\u07fa'+'\u0800'..'\u0815'+'\u081a'+'\u0824'+'\u0828'+'\u0840'..'\u0858'+'\u08a0'+'\u08a2'..'\u08ac'+'\u0904'..'\u0939'+'\u093d'+'\u0950'+'\u0958'..'\u0961'+'\u0971'..'\u0977'+'\u0979'..'\u097f'+'\u0985'..'\u098c'+'\u098f'+'\u0990'+'\u0993'..'\u09a8'+'\u09aa'..'\u09b0'+'\u09b2'+'\u09b6'..'\u09b9'+'\u09bd'+'\u09ce'+'\u09dc'+'\u09dd'+'\u09df'..'\u09e1'+'\u09f0'+'\u09f1'+'\u0a05'..'\u0a0a'+'\u0a0f'+'\u0a10'+'\u0a13'..'\u0a28'+'\u0a2a'..'\u0a30'+'\u0a32'+'\u0a33'+'\u0a35'+'\u0a36'+'\u0a38'+'\u0a39'+'\u0a59'..'\u0a5c'+'\u0a5e'+'\u0a72'..'\u0a74'+'\u0a85'..'\u0a8d'+'\u0a8f'..'\u0a91'+'\u0a93'..'\u0aa8'+'\u0aaa'..'\u0ab0'+'\u0ab2'+'\u0ab3'+'\u0ab5'..'\u0ab9'+'\u0abd'+'\u0ad0'+'\u0ae0'+'\u0ae1'+'\u0b05'..'\u0b0c'+'\u0b0f'+'\u0b10'+'\u0b13'..'\u0b28'+'\u0b2a'..'\u0b30'+'\u0b32'+'\u0b33'+'\u0b35'..'\u0b39'+'\u0b3d'+'\u0b5c'+'\u0b5d'+'\u0b5f'..'\u0b61'+'\u0b71'+'\u0b83'+'\u0b85'..'\u0b8a'+'\u0b8e'..'\u0b90'+'\u0b92'..'\u0b95'+'\u0b99'+'\u0b9a'+'\u0b9c'+'\u0b9e'+'\u0b9f'+'\u0ba3'+'\u0ba4'+'\u0ba8'..'\u0baa'+'\u0bae'..'\u0bb9'+'\u0bd0'+'\u0c05'..'\u0c0c'+'\u0c0e'..'\u0c10'+'\u0c12'..'\u0c28'+'\u0c2a'..'\u0c33'+'\u0c35'..'\u0c39'+'\u0c3d'+'\u0c58'+'\u0c59'+'\u0c60'+'\u0c61'+'\u0c85'..'\u0c8c'+'\u0c8e'..'\u0c90'+'\u0c92'..'\u0ca8'+'\u0caa'..'\u0cb3'+'\u0cb5'..'\u0cb9'+'\u0cbd'+'\u0cde'+'\u0ce0'+'\u0ce1'+'\u0cf1'+'\u0cf2'+'\u0d05'..'\u0d0c'+'\u0d0e'..'\u0d10'+'\u0d12'..'\u0d3a'+'\u0d3d'+'\u0d4e'+'\u0d60'+'\u0d61'+'\u0d7a'..'\u0d7f'+'\u0d85'..'\u0d96'+'\u0d9a'..'\u0db1'+'\u0db3'..'\u0dbb'+'\u0dbd'+'\u0dc0'..'\u0dc6'+'\u0e01'..'\u0e30'+'\u0e32'+'\u0e33'+'\u0e40'..'\u0e46'+'\u0e81'+'\u0e82'+'\u0e84'+'\u0e87'+'\u0e88'+'\u0e8a'+'\u0e8d'+'\u0e94'..'\u0e97'+'\u0e99'..'\u0e9f'+'\u0ea1'..'\u0ea3'+'\u0ea5'+'\u0ea7'+'\u0eaa'+'\u0eab'+'\u0ead'..'\u0eb0'+'\u0eb2'+'\u0eb3'+'\u0ebd'+'\u0ec0'..'\u0ec4'+'\u0ec6'+'\u0edc'..'\u0edf'+'\u0f00'+'\u0f40'..'\u0f47'+'\u0f49'..'\u0f6c'+'\u0f88'..'\u0f8c'+'\u1000'..'\u102a'+'\u103f'+'\u1050'..'\u1055'+'\u105a'..'\u105d'+'\u1061'+'\u1065'+'\u1066'+'\u106e'..'\u1070'+'\u1075'..'\u1081'+'\u108e'+'\u10a0'..'\u10c5'+'\u10c7'+'\u10cd'+'\u10d0'..'\u10fa'+'\u10fc'..'\u1248'+'\u124a'..'\u124d'+'\u1250'..'\u1256'+'\u1258'+'\u125a'..'\u125d'+'\u1260'..'\u1288'+'\u128a'..'\u128d'+'\u1290'..'\u12b0'+'\u12b2'..'\u12b5'+'\u12b8'..'\u12be'+'\u12c0'+'\u12c2'..'\u12c5'+'\u12c8'..'\u12d6'+'\u12d8'..'\u1310'+'\u1312'..'\u1315'+'\u1318'..'\u135a'+'\u1380'..'\u138f'+'\u13a0'..'\u13f4'+'\u1401'..'\u166c'+'\u166f'..'\u167f'+'\u1681'..'\u169a'+'\u16a0'..'\u16ea'+'\u16ee'..'\u16f0'+'\u1700'..'\u170c'+'\u170e'..'\u1711'+'\u1720'..'\u1731'+'\u1740'..'\u1751'+'\u1760'..'\u176c'+'\u176e'..'\u1770'+'\u1780'..'\u17b3'+'\u17d7'+'\u17dc'+'\u1820'..'\u1877'+'\u1880'..'\u18a8'+'\u18aa'+'\u18b0'..'\u18f5'+'\u1900'..'\u191c'+'\u1950'..'\u196d'+'\u1970'..'\u1974'+'\u1980'..'\u19ab'+'\u19c1'..'\u19c7'+'\u1a00'..'\u1a16'+'\u1a20'..'\u1a54'+'\u1aa7'+'\u1b05'..'\u1b33'+'\u1b45'..'\u1b4b'+'\u1b83'..'\u1ba0'+'\u1bae'+'\u1baf'+'\u1bba'..'\u1be5'+'\u1c00'..'\u1c23'+'\u1c4d'..'\u1c4f'+'\u1c5a'..'\u1c7d'+'\u1ce9'..'\u1cec'+'\u1cee'..'\u1cf1'+'\u1cf5'+'\u1cf6'+'\u1d00'..'\u1dbf'+'\u1e00'..'\u1f15'+'\u1f18'..'\u1f1d'+'\u1f20'..'\u1f45'+'\u1f48'..'\u1f4d'+'\u1f50'..'\u1f57'+'\u1f59'+'\u1f5b'+'\u1f5d'+'\u1f5f'..'\u1f7d'+'\u1f80'..'\u1fb4'+'\u1fb6'..'\u1fbc'+'\u1fbe'+'\u1fc2'..'\u1fc4'+'\u1fc6'..'\u1fcc'+'\u1fd0'..'\u1fd3'+'\u1fd6'..'\u1fdb'+'\u1fe0'..'\u1fec'+'\u1ff2'..'\u1ff4'+'\u1ff6'..'\u1ffc'+'\u2071'+'\u207f'+'\u2090'..'\u209c'+'\u2102'+'\u2107'+'\u210a'..'\u2113'+'\u2115'+'\u2119'..'\u211d'+'\u2124'+'\u2126'+'\u2128'+'\u212a'..'\u212d'+'\u212f'..'\u2139'+'\u213c'..'\u213f'+'\u2145'..'\u2149'+'\u214e'+'\u2160'..'\u2188'+'\u2c00'..'\u2c2e'+'\u2c30'..'\u2c5e'+'\u2c60'..'\u2ce4'+'\u2ceb'..'\u2cee'+'\u2cf2'+'\u2cf3'+'\u2d00'..'\u2d25'+'\u2d27'+'\u2d2d'+'\u2d30'..'\u2d67'+'\u2d6f'+'\u2d80'..'\u2d96'+'\u2da0'..'\u2da6'+'\u2da8'..'\u2dae'+'\u2db0'..'\u2db6'+'\u2db8'..'\u2dbe'+'\u2dc0'..'\u2dc6'+'\u2dc8'..'\u2dce'+'\u2dd0'..'\u2dd6'+'\u2dd8'..'\u2dde'+'\u2e2f'+'\u3005'..'\u3007'+'\u3021'..'\u3029'+'\u3031'..'\u3035'+'\u3038'..'\u303c'+'\u3041'..'\u3096'+'\u309d'..'\u309f'+'\u30a1'..'\u30fa'+'\u30fc'..'\u30ff'+'\u3105'..'\u312d'+'\u3131'..'\u318e'+'\u31a0'..'\u31ba'+'\u31f0'..'\u31ff'+'\u3400'..'\u4db5'+'\u4e00'..'\u9fcc'+'\ua000'..'\ua48c'+'\ua4d0'..'\ua4fd'+'\ua500'..'\ua60c'+'\ua610'..'\ua61f'+'\ua62a'+'\ua62b'+'\ua640'..'\ua66e'+'\ua67f'..'\ua697'+'\ua6a0'..'\ua6ef'+'\ua717'..'\ua71f'+'\ua722'..'\ua788'+'\ua78b'..'\ua78e'+'\ua790'..'\ua793'+'\ua7a0'..'\ua7aa'+'\ua7f8'..'\ua801'+'\ua803'..'\ua805'+'\ua807'..'\ua80a'+'\ua80c'..'\ua822'+'\ua840'..'\ua873'+'\ua882'..'\ua8b3'+'\ua8f2'..'\ua8f7'+'\ua8fb'+'\ua90a'..'\ua925'+'\ua930'..'\ua946'+'\ua960'..'\ua97c'+'\ua984'..'\ua9b2'+'\ua9cf'+'\uaa00'..'\uaa28'+'\uaa40'..'\uaa42'+'\uaa44'..'\uaa4b'+'\uaa60'..'\uaa76'+'\uaa7a'+'\uaa80'..'\uaaaf'+'\uaab1'+'\uaab5'+'\uaab6'+'\uaab9'..'\uaabd'+'\uaac0'+'\uaac2'+'\uaadb'..'\uaadd'+'\uaae0'..'\uaaea'+'\uaaf2'..'\uaaf4'+'\uab01'..'\uab06'+'\uab09'..'\uab0e'+'\uab11'..'\uab16'+'\uab20'..'\uab26'+'\uab28'..'\uab2e'+'\uabc0'..'\uabe2'+'\uac00'..'\ud7a3'+'\ud7b0'..'\ud7c6'+'\ud7cb'..'\ud7fb'+'\uf900'..'\ufa6d'+'\ufa70'..'\ufad9'+'\ufb00'..'\ufb06'+'\ufb13'..'\ufb17'+'\ufb1d'+'\ufb1f'..'\ufb28'+'\ufb2a'..'\ufb36'+'\ufb38'..'\ufb3c'+'\ufb3e'+'\ufb40'+'\ufb41'+'\ufb43'+'\ufb44'+'\ufb46'..'\ufbb1'+'\ufbd3'..'\ufd3d'+'\ufd50'..'\ufd8f'+'\ufd92'..'\ufdc7'+'\ufdf0'..'\ufdfb'+'\ufe70'..'\ufe74'+'\ufe76'..'\ufefc'+'\uff21'..'\uff3a'+'\uff41'..'\uff5a'+'\uff66'..'\uffbe'+'\uffc2'..'\uffc7'+'\uffca'..'\uffcf'+'\uffd2'..'\uffd7'+'\uffda'..'\uffdc'+'\u0300'..'\u036f'+'\u0483'..'\u0487'+'\u0591'..'\u05bd'+'\u05bf'+'\u05c1'+'\u05c2'+'\u05c4'+'\u05c5'+'\u05c7'+'\u0610'..'\u061a'+'\u064b'..'\u0669'+'\u0670'+'\u06d6'..'\u06dc'+'\u06df'..'\u06e4'+'\u06e7'+'\u06e8'+'\u06ea'..'\u06ed'+'\u06f0'..'\u06f9'+'\u0711'+'\u0730'..'\u074a'+'\u07a6'..'\u07b0'+'\u07c0'..'\u07c9'+'\u07eb'..'\u07f3'+'\u0816'..'\u0819'+'\u081b'..'\u0823'+'\u0825'..'\u0827'+'\u0829'..'\u082d'+'\u0859'..'\u085b'+'\u08e4'..'\u08fe'+'\u0900'..'\u0903'+'\u093a'..'\u093c'+'\u093e'..'\u094f'+'\u0951'..'\u0957'+'\u0962'+'\u0963'+'\u0966'..'\u096f'+'\u0981'..'\u0983'+'\u09bc'+'\u09be'..'\u09c4'+'\u09c7'+'\u09c8'+'\u09cb'..'\u09cd'+'\u09d7'+'\u09e2'+'\u09e3'+'\u09e6'..'\u09ef'+'\u0a01'..'\u0a03'+'\u0a3c'+'\u0a3e'..'\u0a42'+'\u0a47'+'\u0a48'+'\u0a4b'..'\u0a4d'+'\u0a51'+'\u0a66'..'\u0a71'+'\u0a75'+'\u0a81'..'\u0a83'+'\u0abc'+'\u0abe'..'\u0ac5'+'\u0ac7'..'\u0ac9'+'\u0acb'..'\u0acd'+'\u0ae2'+'\u0ae3'+'\u0ae6'..'\u0aef'+'\u0b01'..'\u0b03'+'\u0b3c'+'\u0b3e'..'\u0b44'+'\u0b47'+'\u0b48'+'\u0b4b'..'\u0b4d'+'\u0b56'+'\u0b57'+'\u0b62'+'\u0b63'+'\u0b66'..'\u0b6f'+'\u0b82'+'\u0bbe'..'\u0bc2'+'\u0bc6'..'\u0bc8'+'\u0bca'..'\u0bcd'+'\u0bd7'+'\u0be6'..'\u0bef'+'\u0c01'..'\u0c03'+'\u0c3e'..'\u0c44'+'\u0c46'..'\u0c48'+'\u0c4a'..'\u0c4d'+'\u0c55'+'\u0c56'+'\u0c62'+'\u0c63'+'\u0c66'..'\u0c6f'+'\u0c82'+'\u0c83'+'\u0cbc'+'\u0cbe'..'\u0cc4'+'\u0cc6'..'\u0cc8'+'\u0cca'..'\u0ccd'+'\u0cd5'+'\u0cd6'+'\u0ce2'+'\u0ce3'+'\u0ce6'..'\u0cef'+'\u0d02'+'\u0d03'+'\u0d3e'..'\u0d44'+'\u0d46'..'\u0d48'+'\u0d4a'..'\u0d4d'+'\u0d57'+'\u0d62'+'\u0d63'+'\u0d66'..'\u0d6f'+'\u0d82'+'\u0d83'+'\u0dca'+'\u0dcf'..'\u0dd4'+'\u0dd6'+'\u0dd8'..'\u0ddf'+'\u0df2'+'\u0df3'+'\u0e31'+'\u0e34'..'\u0e3a'+'\u0e47'..'\u0e4e'+'\u0e50'..'\u0e59'+'\u0eb1'+'\u0eb4'..'\u0eb9'+'\u0ebb'+'\u0ebc'+'\u0ec8'..'\u0ecd'+'\u0ed0'..'\u0ed9'+'\u0f18'+'\u0f19'+'\u0f20'..'\u0f29'+'\u0f35'+'\u0f37'+'\u0f39'+'\u0f3e'+'\u0f3f'+'\u0f71'..'\u0f84'+'\u0f86'+'\u0f87'+'\u0f8d'..'\u0f97'+'\u0f99'..'\u0fbc'+'\u0fc6'+'\u102b'..'\u103e'+'\u1040'..'\u1049'+'\u1056'..'\u1059'+'\u105e'..'\u1060'+'\u1062'..'\u1064'+'\u1067'..'\u106d'+'\u1071'..'\u1074'+'\u1082'..'\u108d'+'\u108f'..'\u109d'+'\u135d'..'\u135f'+'\u1712'..'\u1714'+'\u1732'..'\u1734'+'\u1752'+'\u1753'+'\u1772'+'\u1773'+'\u17b4'..'\u17d3'+'\u17dd'+'\u17e0'..'\u17e9'+'\u180b'..'\u180d'+'\u1810'..'\u1819'+'\u18a9'+'\u1920'..'\u192b'+'\u1930'..'\u193b'+'\u1946'..'\u194f'+'\u19b0'..'\u19c0'+'\u19c8'+'\u19c9'+'\u19d0'..'\u19d9'+'\u1a17'..'\u1a1b'+'\u1a55'..'\u1a5e'+'\u1a60'..'\u1a7c'+'\u1a7f'..'\u1a89'+'\u1a90'..'\u1a99'+'\u1b00'..'\u1b04'+'\u1b34'..'\u1b44'+'\u1b50'..'\u1b59'+'\u1b6b'..'\u1b73'+'\u1b80'..'\u1b82'+'\u1ba1'..'\u1bad'+'\u1bb0'..'\u1bb9'+'\u1be6'..'\u1bf3'+'\u1c24'..'\u1c37'+'\u1c40'..'\u1c49'+'\u1c50'..'\u1c59'+'\u1cd0'..'\u1cd2'+'\u1cd4'..'\u1ce8'+'\u1ced'+'\u1cf2'..'\u1cf4'+'\u1dc0'..'\u1de6'+'\u1dfc'..'\u1dff'+'\u200c'+'\u200d'+'\u203f'+'\u2040'+'\u2054'+'\u20d0'..'\u20dc'+'\u20e1'+'\u20e5'..'\u20f0'+'\u2cef'..'\u2cf1'+'\u2d7f'+'\u2de0'..'\u2dff'+'\u302a'..'\u302f'+'\u3099'+'\u309a'+'\ua620'..'\ua629'+'\ua66f'+'\ua674'..'\ua67d'+'\ua69f'+'\ua6f0'+'\ua6f1'+'\ua802'+'\ua806'+'\ua80b'+'\ua823'..'\ua827'+'\ua880'+'\ua881'+'\ua8b4'..'\ua8c4'+'\ua8d0'..'\ua8d9'+'\ua8e0'..'\ua8f1'+'\ua900'..'\ua909'+'\ua926'..'\ua92d'+'\ua947'..'\ua953'+'\ua980'..'\ua983'+'\ua9b3'..'\ua9c0'+'\ua9d0'..'\ua9d9'+'\uaa29'..'\uaa36'+'\uaa43'+'\uaa4c'+'\uaa4d'+'\uaa50'..'\uaa59'+'\uaa7b'+'\uaab0'+'\uaab2'..'\uaab4'+'\uaab7'+'\uaab8'+'\uaabe'+'\uaabf'+'\uaac1'+'\uaaeb'..'\uaaef'+'\uaaf5'+'\uaaf6'+'\uabe3'..'\uabea'+'\uabec'+'\uabed'+'\uabf0'..'\uabf9'+'\ufb1e'+'\ufe00'..'\ufe0f'+'\ufe20'..'\ufe26'+'\ufe33'+'\ufe34'+'\ufe4d'..'\ufe4f'+'\uff10'..'\uff19'+'\uff3f'. 
+    unicodeIdentifierPart = '_' + 'a'..'z' + 'A'..'Z' + '0'..'9' + '\u00aa'+'\u00b5'+'\u00ba'+'\u00c0'..'\u00d6'+'\u00d8'..'\u00f6'+'\u00f8'..'\u02c1'+'\u02c6'..'\u02d1'+'\u02e0'..'\u02e4'+'\u02ec'+'\u02ee'+'\u0370'..'\u0374'+'\u0376'+'\u0377'+'\u037a'..'\u037d'+'\u0386'+'\u0388'..'\u038a'+'\u038c'+'\u038e'..'\u03a1'+'\u03a3'..'\u03f5'+'\u03f7'..'\u0481'+'\u048a'..'\u0527'+'\u0531'..'\u0556'+'\u0559'+'\u0561'..'\u0587'+'\u05d0'..'\u05ea'+'\u05f0'..'\u05f2'+'\u0620'..'\u064a'+'\u066e'+'\u066f'+'\u0671'..'\u06d3'+'\u06d5'+'\u06e5'+'\u06e6'+'\u06ee'+'\u06ef'+'\u06fa'..'\u06fc'+'\u06ff'+'\u0710'+'\u0712'..'\u072f'+'\u074d'..'\u07a5'+'\u07b1'+'\u07ca'..'\u07ea'+'\u07f4'+'\u07f5'+'\u07fa'+'\u0800'..'\u0815'+'\u081a'+'\u0824'+'\u0828'+'\u0840'..'\u0858'+'\u08a0'+'\u08a2'..'\u08ac'+'\u0904'..'\u0939'+'\u093d'+'\u0950'+'\u0958'..'\u0961'+'\u0971'..'\u0977'+'\u0979'..'\u097f'+'\u0985'..'\u098c'+'\u098f'+'\u0990'+'\u0993'..'\u09a8'+'\u09aa'..'\u09b0'+'\u09b2'+'\u09b6'..'\u09b9'+'\u09bd'+'\u09ce'+'\u09dc'+'\u09dd'+'\u09df'..'\u09e1'+'\u09f0'+'\u09f1'+'\u0a05'..'\u0a0a'+'\u0a0f'+'\u0a10'+'\u0a13'..'\u0a28'+'\u0a2a'..'\u0a30'+'\u0a32'+'\u0a33'+'\u0a35'+'\u0a36'+'\u0a38'+'\u0a39'+'\u0a59'..'\u0a5c'+'\u0a5e'+'\u0a72'..'\u0a74'+'\u0a85'..'\u0a8d'+'\u0a8f'..'\u0a91'+'\u0a93'..'\u0aa8'+'\u0aaa'..'\u0ab0'+'\u0ab2'+'\u0ab3'+'\u0ab5'..'\u0ab9'+'\u0abd'+'\u0ad0'+'\u0ae0'+'\u0ae1'+'\u0b05'..'\u0b0c'+'\u0b0f'+'\u0b10'+'\u0b13'..'\u0b28'+'\u0b2a'..'\u0b30'+'\u0b32'+'\u0b33'+'\u0b35'..'\u0b39'+'\u0b3d'+'\u0b5c'+'\u0b5d'+'\u0b5f'..'\u0b61'+'\u0b71'+'\u0b83'+'\u0b85'..'\u0b8a'+'\u0b8e'..'\u0b90'+'\u0b92'..'\u0b95'+'\u0b99'+'\u0b9a'+'\u0b9c'+'\u0b9e'+'\u0b9f'+'\u0ba3'+'\u0ba4'+'\u0ba8'..'\u0baa'+'\u0bae'..'\u0bb9'+'\u0bd0'+'\u0c05'..'\u0c0c'+'\u0c0e'..'\u0c10'+'\u0c12'..'\u0c28'+'\u0c2a'..'\u0c33'+'\u0c35'..'\u0c39'+'\u0c3d'+'\u0c58'+'\u0c59'+'\u0c60'+'\u0c61'+'\u0c85'..'\u0c8c'+'\u0c8e'..'\u0c90'+'\u0c92'..'\u0ca8'+'\u0caa'..'\u0cb3'+'\u0cb5'..'\u0cb9'+'\u0cbd'+'\u0cde'+'\u0ce0'+'\u0ce1'+'\u0cf1'+'\u0cf2'+'\u0d05'..'\u0d0c'+'\u0d0e'..'\u0d10'+'\u0d12'..'\u0d3a'+'\u0d3d'+'\u0d4e'+'\u0d60'+'\u0d61'+'\u0d7a'..'\u0d7f'+'\u0d85'..'\u0d96'+'\u0d9a'..'\u0db1'+'\u0db3'..'\u0dbb'+'\u0dbd'+'\u0dc0'..'\u0dc6'+'\u0e01'..'\u0e30'+'\u0e32'+'\u0e33'+'\u0e40'..'\u0e46'+'\u0e81'+'\u0e82'+'\u0e84'+'\u0e87'+'\u0e88'+'\u0e8a'+'\u0e8d'+'\u0e94'..'\u0e97'+'\u0e99'..'\u0e9f'+'\u0ea1'..'\u0ea3'+'\u0ea5'+'\u0ea7'+'\u0eaa'+'\u0eab'+'\u0ead'..'\u0eb0'+'\u0eb2'+'\u0eb3'+'\u0ebd'+'\u0ec0'..'\u0ec4'+'\u0ec6'+'\u0edc'..'\u0edf'+'\u0f00'+'\u0f40'..'\u0f47'+'\u0f49'..'\u0f6c'+'\u0f88'..'\u0f8c'+'\u1000'..'\u102a'+'\u103f'+'\u1050'..'\u1055'+'\u105a'..'\u105d'+'\u1061'+'\u1065'+'\u1066'+'\u106e'..'\u1070'+'\u1075'..'\u1081'+'\u108e'+'\u10a0'..'\u10c5'+'\u10c7'+'\u10cd'+'\u10d0'..'\u10fa'+'\u10fc'..'\u1248'+'\u124a'..'\u124d'+'\u1250'..'\u1256'+'\u1258'+'\u125a'..'\u125d'+'\u1260'..'\u1288'+'\u128a'..'\u128d'+'\u1290'..'\u12b0'+'\u12b2'..'\u12b5'+'\u12b8'..'\u12be'+'\u12c0'+'\u12c2'..'\u12c5'+'\u12c8'..'\u12d6'+'\u12d8'..'\u1310'+'\u1312'..'\u1315'+'\u1318'..'\u135a'+'\u1380'..'\u138f'+'\u13a0'..'\u13f4'+'\u1401'..'\u166c'+'\u166f'..'\u167f'+'\u1681'..'\u169a'+'\u16a0'..'\u16ea'+'\u16ee'..'\u16f0'+'\u1700'..'\u170c'+'\u170e'..'\u1711'+'\u1720'..'\u1731'+'\u1740'..'\u1751'+'\u1760'..'\u176c'+'\u176e'..'\u1770'+'\u1780'..'\u17b3'+'\u17d7'+'\u17dc'+'\u1820'..'\u1877'+'\u1880'..'\u18a8'+'\u18aa'+'\u18b0'..'\u18f5'+'\u1900'..'\u191c'+'\u1950'..'\u196d'+'\u1970'..'\u1974'+'\u1980'..'\u19ab'+'\u19c1'..'\u19c7'+'\u1a00'..'\u1a16'+'\u1a20'..'\u1a54'+'\u1aa7'+'\u1b05'..'\u1b33'+'\u1b45'..'\u1b4b'+'\u1b83'..'\u1ba0'+'\u1bae'+'\u1baf'+'\u1bba'..'\u1be5'+'\u1c00'..'\u1c23'+'\u1c4d'..'\u1c4f'+'\u1c5a'..'\u1c7d'+'\u1ce9'..'\u1cec'+'\u1cee'..'\u1cf1'+'\u1cf5'+'\u1cf6'+'\u1d00'..'\u1dbf'+'\u1e00'..'\u1f15'+'\u1f18'..'\u1f1d'+'\u1f20'..'\u1f45'+'\u1f48'..'\u1f4d'+'\u1f50'..'\u1f57'+'\u1f59'+'\u1f5b'+'\u1f5d'+'\u1f5f'..'\u1f7d'+'\u1f80'..'\u1fb4'+'\u1fb6'..'\u1fbc'+'\u1fbe'+'\u1fc2'..'\u1fc4'+'\u1fc6'..'\u1fcc'+'\u1fd0'..'\u1fd3'+'\u1fd6'..'\u1fdb'+'\u1fe0'..'\u1fec'+'\u1ff2'..'\u1ff4'+'\u1ff6'..'\u1ffc'+'\u2071'+'\u207f'+'\u2090'..'\u209c'+'\u2102'+'\u2107'+'\u210a'..'\u2113'+'\u2115'+'\u2119'..'\u211d'+'\u2124'+'\u2126'+'\u2128'+'\u212a'..'\u212d'+'\u212f'..'\u2139'+'\u213c'..'\u213f'+'\u2145'..'\u2149'+'\u214e'+'\u2160'..'\u2188'+'\u2c00'..'\u2c2e'+'\u2c30'..'\u2c5e'+'\u2c60'..'\u2ce4'+'\u2ceb'..'\u2cee'+'\u2cf2'+'\u2cf3'+'\u2d00'..'\u2d25'+'\u2d27'+'\u2d2d'+'\u2d30'..'\u2d67'+'\u2d6f'+'\u2d80'..'\u2d96'+'\u2da0'..'\u2da6'+'\u2da8'..'\u2dae'+'\u2db0'..'\u2db6'+'\u2db8'..'\u2dbe'+'\u2dc0'..'\u2dc6'+'\u2dc8'..'\u2dce'+'\u2dd0'..'\u2dd6'+'\u2dd8'..'\u2dde'+'\u2e2f'+'\u3005'..'\u3007'+'\u3021'..'\u3029'+'\u3031'..'\u3035'+'\u3038'..'\u303c'+'\u3041'..'\u3096'+'\u309d'..'\u309f'+'\u30a1'..'\u30fa'+'\u30fc'..'\u30ff'+'\u3105'..'\u312d'+'\u3131'..'\u318e'+'\u31a0'..'\u31ba'+'\u31f0'..'\u31ff'+'\u3400'..'\u4db5'+'\u4e00'..'\u9fcc'+'\ua000'..'\ua48c'+'\ua4d0'..'\ua4fd'+'\ua500'..'\ua60c'+'\ua610'..'\ua61f'+'\ua62a'+'\ua62b'+'\ua640'..'\ua66e'+'\ua67f'..'\ua697'+'\ua6a0'..'\ua6ef'+'\ua717'..'\ua71f'+'\ua722'..'\ua788'+'\ua78b'..'\ua78e'+'\ua790'..'\ua793'+'\ua7a0'..'\ua7aa'+'\ua7f8'..'\ua801'+'\ua803'..'\ua805'+'\ua807'..'\ua80a'+'\ua80c'..'\ua822'+'\ua840'..'\ua873'+'\ua882'..'\ua8b3'+'\ua8f2'..'\ua8f7'+'\ua8fb'+'\ua90a'..'\ua925'+'\ua930'..'\ua946'+'\ua960'..'\ua97c'+'\ua984'..'\ua9b2'+'\ua9cf'+'\uaa00'..'\uaa28'+'\uaa40'..'\uaa42'+'\uaa44'..'\uaa4b'+'\uaa60'..'\uaa76'+'\uaa7a'+'\uaa80'..'\uaaaf'+'\uaab1'+'\uaab5'+'\uaab6'+'\uaab9'..'\uaabd'+'\uaac0'+'\uaac2'+'\uaadb'..'\uaadd'+'\uaae0'..'\uaaea'+'\uaaf2'..'\uaaf4'+'\uab01'..'\uab06'+'\uab09'..'\uab0e'+'\uab11'..'\uab16'+'\uab20'..'\uab26'+'\uab28'..'\uab2e'+'\uabc0'..'\uabe2'+'\uac00'..'\ud7a3'+'\ud7b0'..'\ud7c6'+'\ud7cb'..'\ud7fb'+'\uf900'..'\ufa6d'+'\ufa70'..'\ufad9'+'\ufb00'..'\ufb06'+'\ufb13'..'\ufb17'+'\ufb1d'+'\ufb1f'..'\ufb28'+'\ufb2a'..'\ufb36'+'\ufb38'..'\ufb3c'+'\ufb3e'+'\ufb40'+'\ufb41'+'\ufb43'+'\ufb44'+'\ufb46'..'\ufbb1'+'\ufbd3'..'\ufd3d'+'\ufd50'..'\ufd8f'+'\ufd92'..'\ufdc7'+'\ufdf0'..'\ufdfb'+'\ufe70'..'\ufe74'+'\ufe76'..'\ufefc'+'\uff21'..'\uff3a'+'\uff41'..'\uff5a'+'\uff66'..'\uffbe'+'\uffc2'..'\uffc7'+'\uffca'..'\uffcf'+'\uffd2'..'\uffd7'+'\uffda'..'\uffdc'+'\u0300'..'\u036f'+'\u0483'..'\u0487'+'\u0591'..'\u05bd'+'\u05bf'+'\u05c1'+'\u05c2'+'\u05c4'+'\u05c5'+'\u05c7'+'\u0610'..'\u061a'+'\u064b'..'\u0669'+'\u0670'+'\u06d6'..'\u06dc'+'\u06df'..'\u06e4'+'\u06e7'+'\u06e8'+'\u06ea'..'\u06ed'+'\u06f0'..'\u06f9'+'\u0711'+'\u0730'..'\u074a'+'\u07a6'..'\u07b0'+'\u07c0'..'\u07c9'+'\u07eb'..'\u07f3'+'\u0816'..'\u0819'+'\u081b'..'\u0823'+'\u0825'..'\u0827'+'\u0829'..'\u082d'+'\u0859'..'\u085b'+'\u08e4'..'\u08fe'+'\u0900'..'\u0903'+'\u093a'..'\u093c'+'\u093e'..'\u094f'+'\u0951'..'\u0957'+'\u0962'+'\u0963'+'\u0966'..'\u096f'+'\u0981'..'\u0983'+'\u09bc'+'\u09be'..'\u09c4'+'\u09c7'+'\u09c8'+'\u09cb'..'\u09cd'+'\u09d7'+'\u09e2'+'\u09e3'+'\u09e6'..'\u09ef'+'\u0a01'..'\u0a03'+'\u0a3c'+'\u0a3e'..'\u0a42'+'\u0a47'+'\u0a48'+'\u0a4b'..'\u0a4d'+'\u0a51'+'\u0a66'..'\u0a71'+'\u0a75'+'\u0a81'..'\u0a83'+'\u0abc'+'\u0abe'..'\u0ac5'+'\u0ac7'..'\u0ac9'+'\u0acb'..'\u0acd'+'\u0ae2'+'\u0ae3'+'\u0ae6'..'\u0aef'+'\u0b01'..'\u0b03'+'\u0b3c'+'\u0b3e'..'\u0b44'+'\u0b47'+'\u0b48'+'\u0b4b'..'\u0b4d'+'\u0b56'+'\u0b57'+'\u0b62'+'\u0b63'+'\u0b66'..'\u0b6f'+'\u0b82'+'\u0bbe'..'\u0bc2'+'\u0bc6'..'\u0bc8'+'\u0bca'..'\u0bcd'+'\u0bd7'+'\u0be6'..'\u0bef'+'\u0c01'..'\u0c03'+'\u0c3e'..'\u0c44'+'\u0c46'..'\u0c48'+'\u0c4a'..'\u0c4d'+'\u0c55'+'\u0c56'+'\u0c62'+'\u0c63'+'\u0c66'..'\u0c6f'+'\u0c82'+'\u0c83'+'\u0cbc'+'\u0cbe'..'\u0cc4'+'\u0cc6'..'\u0cc8'+'\u0cca'..'\u0ccd'+'\u0cd5'+'\u0cd6'+'\u0ce2'+'\u0ce3'+'\u0ce6'..'\u0cef'+'\u0d02'+'\u0d03'+'\u0d3e'..'\u0d44'+'\u0d46'..'\u0d48'+'\u0d4a'..'\u0d4d'+'\u0d57'+'\u0d62'+'\u0d63'+'\u0d66'..'\u0d6f'+'\u0d82'+'\u0d83'+'\u0dca'+'\u0dcf'..'\u0dd4'+'\u0dd6'+'\u0dd8'..'\u0ddf'+'\u0df2'+'\u0df3'+'\u0e31'+'\u0e34'..'\u0e3a'+'\u0e47'..'\u0e4e'+'\u0e50'..'\u0e59'+'\u0eb1'+'\u0eb4'..'\u0eb9'+'\u0ebb'+'\u0ebc'+'\u0ec8'..'\u0ecd'+'\u0ed0'..'\u0ed9'+'\u0f18'+'\u0f19'+'\u0f20'..'\u0f29'+'\u0f35'+'\u0f37'+'\u0f39'+'\u0f3e'+'\u0f3f'+'\u0f71'..'\u0f84'+'\u0f86'+'\u0f87'+'\u0f8d'..'\u0f97'+'\u0f99'..'\u0fbc'+'\u0fc6'+'\u102b'..'\u103e'+'\u1040'..'\u1049'+'\u1056'..'\u1059'+'\u105e'..'\u1060'+'\u1062'..'\u1064'+'\u1067'..'\u106d'+'\u1071'..'\u1074'+'\u1082'..'\u108d'+'\u108f'..'\u109d'+'\u135d'..'\u135f'+'\u1712'..'\u1714'+'\u1732'..'\u1734'+'\u1752'+'\u1753'+'\u1772'+'\u1773'+'\u17b4'..'\u17d3'+'\u17dd'+'\u17e0'..'\u17e9'+'\u180b'..'\u180d'+'\u1810'..'\u1819'+'\u18a9'+'\u1920'..'\u192b'+'\u1930'..'\u193b'+'\u1946'..'\u194f'+'\u19b0'..'\u19c0'+'\u19c8'+'\u19c9'+'\u19d0'..'\u19d9'+'\u1a17'..'\u1a1b'+'\u1a55'..'\u1a5e'+'\u1a60'..'\u1a7c'+'\u1a7f'..'\u1a89'+'\u1a90'..'\u1a99'+'\u1b00'..'\u1b04'+'\u1b34'..'\u1b44'+'\u1b50'..'\u1b59'+'\u1b6b'..'\u1b73'+'\u1b80'..'\u1b82'+'\u1ba1'..'\u1bad'+'\u1bb0'..'\u1bb9'+'\u1be6'..'\u1bf3'+'\u1c24'..'\u1c37'+'\u1c40'..'\u1c49'+'\u1c50'..'\u1c59'+'\u1cd0'..'\u1cd2'+'\u1cd4'..'\u1ce8'+'\u1ced'+'\u1cf2'..'\u1cf4'+'\u1dc0'..'\u1de6'+'\u1dfc'..'\u1dff'+'\u200c'+'\u200d'+'\u203f'+'\u2040'+'\u2054'+'\u20d0'..'\u20dc'+'\u20e1'+'\u20e5'..'\u20f0'+'\u2cef'..'\u2cf1'+'\u2d7f'+'\u2de0'..'\u2dff'+'\u302a'..'\u302f'+'\u3099'+'\u309a'+'\ua620'..'\ua629'+'\ua66f'+'\ua674'..'\ua67d'+'\ua69f'+'\ua6f0'+'\ua6f1'+'\ua802'+'\ua806'+'\ua80b'+'\ua823'..'\ua827'+'\ua880'+'\ua881'+'\ua8b4'..'\ua8c4'+'\ua8d0'..'\ua8d9'+'\ua8e0'..'\ua8f1'+'\ua900'..'\ua909'+'\ua926'..'\ua92d'+'\ua947'..'\ua953'+'\ua980'..'\ua983'+'\ua9b3'..'\ua9c0'+'\ua9d0'..'\ua9d9'+'\uaa29'..'\uaa36'+'\uaa43'+'\uaa4c'+'\uaa4d'+'\uaa50'..'\uaa59'+'\uaa7b'+'\uaab0'+'\uaab2'..'\uaab4'+'\uaab7'+'\uaab8'+'\uaabe'+'\uaabf'+'\uaac1'+'\uaaeb'..'\uaaef'+'\uaaf5'+'\uaaf6'+'\uabe3'..'\uabea'+'\uabec'+'\uabed'+'\uabf0'..'\uabf9'+'\ufb1e'+'\ufe00'..'\ufe0f'+'\ufe20'..'\ufe26'+'\ufe33'+'\ufe34'+'\ufe4d'..'\ufe4f'+'\uff10'..'\uff19'+'\uff3f'. 
     digit = '0'..'9'.
     cr  = '\r'. 
     lf  = '\n'.

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -105,6 +105,7 @@
     <Compile Include="DSASM\DSArray.cs" />
     <Compile Include="DSASM\DSObject.cs" />
     <Compile Include="DSASM\DSString.cs" />
+    <Compile Include="FFI\CLRObjectMarshler.cs" />
     <Compile Include="Lang\InternalAttributes.cs" />
     <Compile Include="Lang\Replication\ArgumentAtLevel.cs" />
     <Compile Include="AttributeEntry.cs" />
@@ -171,7 +172,6 @@
     <Compile Include="DynamicFunctionTable.cs" />
     <Compile Include="Exceptions\DebugHalting.cs" />
     <Compile Include="FFI\CLRFFIFunctionPointer.cs" />
-    <Compile Include="FFI\CLRObjectMarshler.cs" />
     <Compile Include="FFI\ImportModuleHandler.cs" />
     <Compile Include="Parser\AssociativeAST.cs" />
     <Compile Include="Parser\AST.cs" />

--- a/src/Engine/ProtoCore/Utils/ParserUtils.cs
+++ b/src/Engine/ProtoCore/Utils/ParserUtils.cs
@@ -122,10 +122,6 @@ namespace ProtoCore.Utils
         /// <summary>
         /// Returns a parser for the DS code.
         /// </summary>
-        /// <param name="code"></param>
-        /// <param name="core"></param>
-        /// <param name="hasBuiltInLoaded"></param>
-        /// <returns></returns>
         public static DesignScriptParser.Parser CreateParser(string code, ProtoCore.Core core)
         {
             byte[] buffer = System.Text.Encoding.UTF8.GetBytes(code);

--- a/src/Libraries/GeometryColor/GeometryColor.cs
+++ b/src/Libraries/GeometryColor/GeometryColor.cs
@@ -103,7 +103,7 @@ namespace Modifiers
         /// will result in an exception. </param>
         /// <returns>A Display object.</returns>
         public static GeometryColor BySurfaceColors([KeepReferenceAttribute]Surface surface,
-            [DefaultArgument("{{Color.ByARGB(255,255,0,0),Color.ByARGB(255,255,255,0)},{Color.ByARGB(255,0,255,255),Color.ByARGB(255,0,0,255)}};")] Color[][] colors)
+            [DefaultArgument("[[Color.ByARGB(255,255,0,0),Color.ByARGB(255,255,255,0)],[Color.ByARGB(255,0,255,255),Color.ByARGB(255,0,0,255)]];")] Color[][] colors)
         {
             if (surface == null)
             {


### PR DESCRIPTION
### Purpose

This PR adds new syntax to initialize lists with square brackets - a la JS or Python. 

```
a = []; // empty list
b = [1,2,3]; // list of 3 numbers
```

This PR doesn't deprecate the old syntax for initializing lists. So, you can still do this:

```
a = {}; // empty list
b = {1,2,3}; // list of 3 numbers
```

A future PR will deprecate this syntax while migrating old code blocks by code rewriting to the new syntax.

<img width="739" alt="screen shot 2018-01-04 at 11 36 59 am" src="https://user-images.githubusercontent.com/916345/34575634-78e18da8-f149-11e7-979e-be6869acf68e.png">

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 

### FYIs

@kronz @Racel 

