### PR TITLE
Spelling corrections in FFI

### DIFF
--- a/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
+++ b/src/Engine/ProtoCore/DSASM/Mirror/ExecutionMirror.cs
@@ -141,7 +141,7 @@ namespace ProtoCore.DSASM.Mirror
             if (classnode.IsImportedClass)
             {
                 var helper = DLLFFIHandler.GetModuleHelper(FFILanguage.CSharp);
-                var marshaller = helper.GetMarshaller(runtimeCore);
+                var marshaller = helper.GetMarshaler(runtimeCore);
                 var strRep = marshaller.GetStringValue(val);
                 formatParams.RestoreOutputTraceDepth();
                 return strRep;

--- a/src/Engine/ProtoCore/DSASM/Stack.cs
+++ b/src/Engine/ProtoCore/DSASM/Stack.cs
@@ -288,8 +288,8 @@ namespace ProtoCore.DSASM
                     if (classnode.IsImportedClass)
                     {
                         var helper = ProtoFFI.DLLFFIHandler.GetModuleHelper(ProtoFFI.FFILanguage.CSharp);
-                        var marshaller1 = helper.GetMarshaller(rtCore1);
-                        var marshaller2 = helper.GetMarshaller(rtCore2);
+                        var marshaller1 = helper.GetMarshaler(rtCore1);
+                        var marshaller2 = helper.GetMarshaler(rtCore2);
                         try
                         {
                             //the interpreter is passed as null as it is not expected to be sued while unmarshalling in this scenario

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -1126,7 +1126,7 @@ namespace ProtoFFI
             return types;
         }
 
-        public override FFIObjectMarshaler GetMarshaller(ProtoCore.RuntimeCore runtimeCore)
+        public override FFIObjectMarshaler GetMarshaler(ProtoCore.RuntimeCore runtimeCore)
         {
             return CLRObjectMarshaler.GetInstance(runtimeCore);
         }
@@ -1187,7 +1187,7 @@ namespace ProtoFFI
             return module;
         }
 
-        public override FFIObjectMarshaler GetMarshaller(ProtoCore.RuntimeCore runtimeCore)
+        public override FFIObjectMarshaler GetMarshaler(ProtoCore.RuntimeCore runtimeCore)
         {
             return CLRObjectMarshaler.GetInstance(runtimeCore);
         }

--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -29,7 +29,7 @@ namespace ProtoFFI
         private CLRModuleType(Type type)
         {
             CLRType = type;
-            string classname = CLRObjectMarshler.GetTypeName(type);
+            string classname = CLRObjectMarshaler.GetTypeName(type);
             ClassNode = CreateEmptyClassNode(classname);
             ClassNode.IsStatic = type.IsAbstract && type.IsSealed;
         }
@@ -196,7 +196,7 @@ namespace ProtoFFI
             get
             {
                 if (null == mProtoCoreType)
-                    mProtoCoreType = CLRObjectMarshler.GetUserDefinedType(CLRType);
+                    mProtoCoreType = CLRObjectMarshaler.GetUserDefinedType(CLRType);
 
                 return mProtoCoreType.Value;
             }
@@ -226,7 +226,7 @@ namespace ProtoFFI
             if (mTypeMaps.TryGetValue(type, out protoCoreType))
                 return protoCoreType;
 
-            if (type == typeof(object) || !CLRObjectMarshler.IsMarshaledAsNativeType(type))
+            if (type == typeof(object) || !CLRObjectMarshaler.IsMarshaledAsNativeType(type))
             {
                 if (type.IsEnum)
                     protoCoreType = CLRModuleType.GetInstance(type, module, string.Empty).ProtoCoreType;
@@ -234,7 +234,7 @@ namespace ProtoFFI
                     protoCoreType = CLRModuleType.GetInstance(type, null, string.Empty).ProtoCoreType;
             }
             else
-                protoCoreType = CLRObjectMarshler.GetProtoCoreType(type);
+                protoCoreType = CLRObjectMarshaler.GetProtoCoreType(type);
 
             lock (mTypeMaps)
             {
@@ -285,7 +285,7 @@ namespace ProtoFFI
 
             string classname = alias;
             if (string.IsNullOrEmpty(classname))
-                classname = CLRObjectMarshler.GetTypeName(type);
+                classname = CLRObjectMarshaler.GetTypeName(type);
 
             ProtoCore.AST.AssociativeAST.ClassDeclNode classnode = CreateEmptyClassNode(classname);
             classnode.ExternLibName = Module.Name;
@@ -326,16 +326,16 @@ namespace ProtoFFI
 
             string classname = alias;
             if (classname == null | classname == string.Empty)
-                classname = CLRObjectMarshler.GetTypeName(type);
+                classname = CLRObjectMarshaler.GetTypeName(type);
 
             ProtoCore.AST.AssociativeAST.ClassDeclNode classnode = CreateEmptyClassNode(classname);
             classnode.ExternLibName = Module.Name;
             classnode.Name = type.Name;
 
             Type baseType = GetBaseType(type);
-            if (baseType != null && !CLRObjectMarshler.IsMarshaledAsNativeType(baseType))
+            if (baseType != null && !CLRObjectMarshaler.IsMarshaledAsNativeType(baseType))
             {
-                string baseTypeName = CLRObjectMarshler.GetTypeName(baseType);
+                string baseTypeName = CLRObjectMarshaler.GetTypeName(baseType);
 
                 classnode.BaseClass = baseTypeName;
                 //Make sure that base class is imported properly.
@@ -1094,7 +1094,7 @@ namespace ProtoFFI
             Type[] types = GetTypes(string.Empty);
             foreach (var item in types)
             {
-                if ("Configuration" == CLRObjectMarshler.GetCategory(item))
+                if ("Configuration" == CLRObjectMarshaler.GetCategory(item))
                     return item;
             }
             return null;
@@ -1126,9 +1126,9 @@ namespace ProtoFFI
             return types;
         }
 
-        public override FFIObjectMarshler GetMarshaller(ProtoCore.RuntimeCore runtimeCore)
+        public override FFIObjectMarshaler GetMarshaller(ProtoCore.RuntimeCore runtimeCore)
         {
-            return CLRObjectMarshler.GetInstance(runtimeCore);
+            return CLRObjectMarshaler.GetInstance(runtimeCore);
         }
     }
 
@@ -1187,9 +1187,9 @@ namespace ProtoFFI
             return module;
         }
 
-        public override FFIObjectMarshler GetMarshaller(ProtoCore.RuntimeCore runtimeCore)
+        public override FFIObjectMarshaler GetMarshaller(ProtoCore.RuntimeCore runtimeCore)
         {
-            return CLRObjectMarshler.GetInstance(runtimeCore);
+            return CLRObjectMarshaler.GetInstance(runtimeCore);
         }
     }
 

--- a/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
+++ b/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
@@ -324,7 +324,7 @@ namespace ProtoFFI
             StackValue dsRetValue = StackValue.Null;
             try
             {
-                FFIObjectMarshler marshaller = Module.GetMarshaller(dsi.runtime.RuntimeCore);
+                FFIObjectMarshaler marshaller = Module.GetMarshaller(dsi.runtime.RuntimeCore);
                 ret = InvokeFunctionPointer(thisObject, parameters);
                 //Reduce to singleton if the attribute is specified.
                 ret = ReflectionInfo.ReduceReturnedCollectionToSingleton(ret);
@@ -452,7 +452,7 @@ namespace ProtoFFI
             List<Object> parameters = new List<object>();
             List<StackValue> s = dsi.runtime.rmem.Stack;
             Object thisObject = null;
-            FFIObjectMarshler marshaller = Module.GetMarshaller(dsi.runtime.RuntimeCore);
+            FFIObjectMarshaler marshaller = Module.GetMarshaller(dsi.runtime.RuntimeCore);
             if (!ReflectionInfo.IsStatic)
             {
                 try
@@ -620,7 +620,7 @@ namespace ProtoFFI
         public override object Execute(ProtoCore.Runtime.Context c, Interpreter dsi)
         {
             List<StackValue> s = dsi.runtime.rmem.Stack;
-            FFIObjectMarshler marshaller = Module.GetMarshaller(dsi.runtime.RuntimeCore);
+            FFIObjectMarshaler marshaller = Module.GetMarshaller(dsi.runtime.RuntimeCore);
 
             var thisObject = marshaller.UnMarshal(s.Last(), c, dsi, ReflectionInfo.DeclaringType);
             //Notify marshler for dispose.

--- a/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
+++ b/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
@@ -324,7 +324,7 @@ namespace ProtoFFI
             StackValue dsRetValue = StackValue.Null;
             try
             {
-                FFIObjectMarshaler marshaller = Module.GetMarshaller(dsi.runtime.RuntimeCore);
+                FFIObjectMarshaler marshaller = Module.GetMarshaler(dsi.runtime.RuntimeCore);
                 ret = InvokeFunctionPointer(thisObject, parameters);
                 //Reduce to singleton if the attribute is specified.
                 ret = ReflectionInfo.ReduceReturnedCollectionToSingleton(ret);
@@ -452,7 +452,7 @@ namespace ProtoFFI
             List<Object> parameters = new List<object>();
             List<StackValue> s = dsi.runtime.rmem.Stack;
             Object thisObject = null;
-            FFIObjectMarshaler marshaller = Module.GetMarshaller(dsi.runtime.RuntimeCore);
+            FFIObjectMarshaler marshaller = Module.GetMarshaler(dsi.runtime.RuntimeCore);
             if (!ReflectionInfo.IsStatic)
             {
                 try
@@ -620,7 +620,7 @@ namespace ProtoFFI
         public override object Execute(ProtoCore.Runtime.Context c, Interpreter dsi)
         {
             List<StackValue> s = dsi.runtime.rmem.Stack;
-            FFIObjectMarshaler marshaller = Module.GetMarshaller(dsi.runtime.RuntimeCore);
+            FFIObjectMarshaler marshaller = Module.GetMarshaler(dsi.runtime.RuntimeCore);
 
             var thisObject = marshaller.UnMarshal(s.Last(), c, dsi, ReflectionInfo.DeclaringType);
             //Notify marshler for dispose.

--- a/src/Engine/ProtoCore/FFI/CLRObjectMarshaler.cs
+++ b/src/Engine/ProtoCore/FFI/CLRObjectMarshaler.cs
@@ -18,10 +18,10 @@ using ProtoCore.Runtime;
 
 namespace ProtoFFI
 {
-    abstract class PrimitiveMarshler : FFIObjectMarshler
+    abstract class PrimitiveMarshaler : FFIObjectMarshaler
     {
         private readonly ProtoCore.Type mType;
-        public PrimitiveMarshler(ProtoCore.Type type)
+        public PrimitiveMarshaler(ProtoCore.Type type)
         {
             mType = type;
         }
@@ -102,7 +102,7 @@ namespace ProtoFFI
     /// <summary>
     /// Marshales integer based primitive types.
     /// </summary>
-    class IntMarshaler : PrimitiveMarshler
+    class IntMarshaler : PrimitiveMarshaler
     {
         public long MaxValue { get; private set; }
         public long MinValue { get; private set; }
@@ -139,7 +139,7 @@ namespace ProtoFFI
     /// <summary>
     /// Marshales floating point primitive types.
     /// </summary>
-    class FloatMarshaler : PrimitiveMarshler
+    class FloatMarshaler : PrimitiveMarshaler
     {
         public double MaxValue { get; private set; }
         public double MinValue { get; private set; }
@@ -174,7 +174,7 @@ namespace ProtoFFI
     /// <summary>
     /// Marshales boolean
     /// </summary>
-    class BoolMarshaler : PrimitiveMarshler
+    class BoolMarshaler : PrimitiveMarshaler
     {
         private static readonly ProtoCore.Type kType = CreateType(ProtoCore.PrimitiveType.Bool);
         public BoolMarshaler() : base(kType) { }
@@ -193,7 +193,7 @@ namespace ProtoFFI
     /// <summary>
     /// Marshales char
     /// </summary>
-    class CharMarshaler : PrimitiveMarshler
+    class CharMarshaler : PrimitiveMarshaler
     {
         private static readonly ProtoCore.Type kType = CreateType(ProtoCore.PrimitiveType.Char);
         public CharMarshaler() : base(kType) { }
@@ -209,16 +209,16 @@ namespace ProtoFFI
         }
     }
 
-    class ArrayMarshaler : PrimitiveMarshler
+    class ArrayMarshaler : PrimitiveMarshaler
     {
-        private readonly CLRObjectMarshler primitiveMarshaler;
+        private readonly CLRObjectMarshaler primitiveMarshaler;
 
         /// <summary>
         /// Constructor for the ArrayMarshaler
         /// </summary>
         /// <param name="primitiveMarshaler">Marshaler to marshal primitive type</param>
         /// <param name="type">Expected DS type for marshaling</param>
-        public ArrayMarshaler(CLRObjectMarshler primitiveMarshaler, ProtoCore.Type type)
+        public ArrayMarshaler(CLRObjectMarshaler primitiveMarshaler, ProtoCore.Type type)
             : base(type)
         {
             this.primitiveMarshaler = primitiveMarshaler;
@@ -436,11 +436,11 @@ namespace ProtoFFI
         }
     }
 
-    class DictionaryMarshaler : PrimitiveMarshler
+    class DictionaryMarshaler : PrimitiveMarshaler
     {
-        private readonly CLRObjectMarshler primitiveMarshaler;
+        private readonly CLRObjectMarshaler primitiveMarshaler;
 
-        public DictionaryMarshaler(CLRObjectMarshler primitiveMarshaler, ProtoCore.Type type)
+        public DictionaryMarshaler(CLRObjectMarshaler primitiveMarshaler, ProtoCore.Type type)
             : base(type)
         {
             this.primitiveMarshaler = primitiveMarshaler;
@@ -580,7 +580,7 @@ namespace ProtoFFI
     /// <summary>
     /// Marshales string as array of chars
     /// </summary>
-    class StringMarshaler : PrimitiveMarshler 
+    class StringMarshaler : PrimitiveMarshaler 
     {
         public static readonly ProtoCore.Type kType = CreateType(ProtoCore.PrimitiveType.String);
 
@@ -604,12 +604,12 @@ namespace ProtoFFI
     /// <summary>
     /// This class marshales CLR Objects to DS Object and vice-versa.
     /// </summary>
-    class CLRObjectMarshler : FFIObjectMarshler
+    class CLRObjectMarshaler : FFIObjectMarshaler
     {
-        private static readonly Dictionary<Type, FFIObjectMarshler> mPrimitiveMarshalers;
-        static CLRObjectMarshler()
+        private static readonly Dictionary<Type, FFIObjectMarshaler> mPrimitiveMarshalers;
+        static CLRObjectMarshaler()
         {
-            mPrimitiveMarshalers = new Dictionary<Type, FFIObjectMarshler>();
+            mPrimitiveMarshalers = new Dictionary<Type, FFIObjectMarshaler>();
             mPrimitiveMarshalers.Add(typeof(Int16), new IntMarshaler(Int16.MaxValue, Int16.MinValue, (long value) => (Int16)value));
             mPrimitiveMarshalers.Add(typeof(Int32), new IntMarshaler(Int32.MaxValue, Int32.MinValue, (long value) => (Int32)value));
             mPrimitiveMarshalers.Add(typeof(Int64), new IntMarshaler(Int64.MaxValue, Int64.MinValue, (long value) => value));
@@ -631,9 +631,9 @@ namespace ProtoFFI
         /// </summary>
         /// <param name="core">Core object.</param>
         /// <returns>CLRObjectMarshler</returns>
-        public static CLRObjectMarshler GetInstance(ProtoCore.RuntimeCore core)
+        public static CLRObjectMarshaler GetInstance(ProtoCore.RuntimeCore core)
         {
-            CLRObjectMarshler marshaller = null;
+            CLRObjectMarshaler marshaller = null;
             if (!mObjectMarshlers.TryGetValue(core, out marshaller))
             {
                 IDisposable[] disposables = null;
@@ -642,7 +642,7 @@ namespace ProtoFFI
                     if (mObjectMarshlers.TryGetValue(core, out marshaller))
                         return marshaller;
 
-                    marshaller = new CLRObjectMarshler(core);
+                    marshaller = new CLRObjectMarshaler(core);
 
                     object value;
                     if (core.DSExecutable.Configurations.TryGetValue(ConfigurationKeys.GeometryXmlProperties, out value))
@@ -755,11 +755,11 @@ namespace ProtoFFI
         /// <param name="dsType">DS Object type, that needs to be marshaled.
         /// </param>
         /// <returns>FFIObjectMarshler or null</returns>
-        private FFIObjectMarshler GetMarshalerForCLRType(Type clrType, StackValue value)
+        private FFIObjectMarshaler GetMarshalerForCLRType(Type clrType, StackValue value)
         {
             var dsType = value.optype;
 
-            FFIObjectMarshler marshaler = null;
+            FFIObjectMarshaler marshaler = null;
             //Expected CLR type is object, get marshaled clrType from dsType
             Type expectedType = clrType;
             if (expectedType == typeof(object))
@@ -776,14 +776,14 @@ namespace ProtoFFI
             // If the source is a Dictionary and the target allows assignment of a Dictionary
             if (IsDictionary(value) && DictionaryMarshaler.IsAssignableFromDictionary(expectedType))
             {
-                var type = PrimitiveMarshler.CreateType(ProtoCore.PrimitiveType.Var);
+                var type = PrimitiveMarshaler.CreateType(ProtoCore.PrimitiveType.Var);
                 type.rank = ProtoCore.DSASM.Constants.kArbitraryRank;
                 return new DictionaryMarshaler(this, type);
             }
 
             if (isArray)
             {
-                var type = PrimitiveMarshler.CreateType(ProtoCore.PrimitiveType.Var);
+                var type = PrimitiveMarshaler.CreateType(ProtoCore.PrimitiveType.Var);
                 type.rank = ProtoCore.DSASM.Constants.kArbitraryRank;
                 return new ArrayMarshaler(this, type);
             }
@@ -806,13 +806,13 @@ namespace ProtoFFI
         /// <param name="dsType">DS Type to which given objType needs to be marshaled.</param>
         /// <param name="objType">CLR object type that needs to marshal.</param>
         /// <returns>FFIObjectMarshler or null</returns>
-        private FFIObjectMarshler GetMarshalerForDsType(ProtoCore.Type dsType, Type objType)
+        private FFIObjectMarshaler GetMarshalerForDsType(ProtoCore.Type dsType, Type objType)
         {
             //Expected DS Type is pointer, so there is no primitive marshaler available.
             if (!dsType.IsIndexable && dsType.UID == (int)ProtoCore.PrimitiveType.Pointer)
                 return null;
 
-            FFIObjectMarshler marshaler = null;
+            FFIObjectMarshaler marshaler = null;
 
             if (DictionaryMarshaler.IsAssignableFromDictionary(objType))
             {
@@ -890,7 +890,7 @@ namespace ProtoFFI
         /// <returns>ProtoCore.Type as equivalent DS type for input System.Type</returns>
         public override ProtoCore.Type GetMarshaledType(Type type)
         {
-            return CLRObjectMarshler.GetProtoCoreType(type);
+            return CLRObjectMarshaler.GetProtoCoreType(type);
         }
 
         /// <summary>
@@ -900,7 +900,7 @@ namespace ProtoFFI
         /// <returns>ProtoCore.Type</returns>
         public static ProtoCore.Type GetProtoCoreType(Type type)
         {
-            ProtoCore.Type retype = PrimitiveMarshler.CreateType(ProtoCore.PrimitiveType.Var);
+            ProtoCore.Type retype = PrimitiveMarshaler.CreateType(ProtoCore.PrimitiveType.Var);
             ComputeDSType(type, ref retype);
             return retype;
         }
@@ -912,7 +912,7 @@ namespace ProtoFFI
         /// <returns>ProtoCore.Type</returns>
         public static ProtoCore.Type GetUserDefinedType(Type type)
         {
-            ProtoCore.Type retype = PrimitiveMarshler.CreateType(ProtoCore.PrimitiveType.Pointer);
+            ProtoCore.Type retype = PrimitiveMarshaler.CreateType(ProtoCore.PrimitiveType.Pointer);
             ComputeDSType(type, ref retype);
             return retype;
         }
@@ -925,7 +925,7 @@ namespace ProtoFFI
         /// <param name="protoCoreType">ref ProtoCore.Type</param>
         private static void ComputeDSType(Type type, ref ProtoCore.Type protoCoreType)
         {
-            FFIObjectMarshler marshaler;
+            FFIObjectMarshaler marshaler;
             Type arrayType = ComputeArrayType(type);
             if (arrayType != null)
             {
@@ -971,11 +971,11 @@ namespace ProtoFFI
             }
             else if (type == typeof(object))
             {
-                protoCoreType = PrimitiveMarshler.CreateType(ProtoCore.PrimitiveType.Var);
+                protoCoreType = PrimitiveMarshaler.CreateType(ProtoCore.PrimitiveType.Var);
                 protoCoreType.rank = 0; //Initially setup zero rank
             }
             else if (type == typeof(void))
-                protoCoreType = PrimitiveMarshler.CreateType(ProtoCore.PrimitiveType.Void);
+                protoCoreType = PrimitiveMarshaler.CreateType(ProtoCore.PrimitiveType.Void);
             else if (protoCoreType.UID == (int)ProtoCore.PrimitiveType.Pointer)
                 protoCoreType.Name = GetTypeName(type);
             else if (mPrimitiveMarshalers.TryGetValue(type, out marshaler))
@@ -1313,7 +1313,7 @@ namespace ProtoFFI
         /// Constructor.
         /// </summary>
         /// <param name="core">Core object for marshler.</param>
-        private CLRObjectMarshler(ProtoCore.RuntimeCore runtimeCore)
+        private CLRObjectMarshaler(ProtoCore.RuntimeCore runtimeCore)
         {
             runtimeCore.Dispose += core_Dispose;
         }
@@ -1324,7 +1324,7 @@ namespace ProtoFFI
         /// <param name="sender">Core object being disposed.</param>
         void core_Dispose(ProtoCore.RuntimeCore sender)
         {
-            CLRObjectMarshler marshaller = null;
+            CLRObjectMarshaler marshaller = null;
             if (!mObjectMarshlers.TryGetValue(sender, out marshaller))
                 throw new KeyNotFoundException();
 
@@ -1349,7 +1349,7 @@ namespace ProtoFFI
 
         private readonly Dictionary<StackValue, Object> DSObjectMap = new Dictionary<StackValue, object>(new PointerValueComparer());
         private readonly Dictionary<Object, StackValue> CLRObjectMap = new Dictionary<object, StackValue>(new ReferenceEqualityComparer());
-        private static readonly Dictionary<ProtoCore.RuntimeCore, CLRObjectMarshler> mObjectMarshlers = new Dictionary<ProtoCore.RuntimeCore, CLRObjectMarshler>();
+        private static readonly Dictionary<ProtoCore.RuntimeCore, CLRObjectMarshaler> mObjectMarshlers = new Dictionary<ProtoCore.RuntimeCore, CLRObjectMarshaler>();
         private static List<IDisposable> mPendingDisposables = new List<IDisposable>();
         private static readonly Object syncroot = new Object();
         #endregion

--- a/src/Engine/ProtoCore/FFI/ContextDataManager.cs
+++ b/src/Engine/ProtoCore/FFI/ContextDataManager.cs
@@ -122,7 +122,7 @@ namespace ProtoFFI
                 SortedSet<Type> types = GetTypesForImport(item.Value.Data);
                 foreach (var type in types)
                 {
-                    if (CLRObjectMarshler.IsMarshaledAsNativeType(type))
+                    if (CLRObjectMarshaler.IsMarshaledAsNativeType(type))
                         continue;
                     ImportNode node = importer.Import(type.Assembly.Location, type.FullName, "");
                     if (impNode != null && node != null)
@@ -158,7 +158,7 @@ namespace ProtoFFI
                 set.Add(valueType);
             }
             else 
-                set.Add(CLRObjectMarshler.GetPublicType(valueType));
+                set.Add(CLRObjectMarshaler.GetPublicType(valueType));
 
             return set;
         }

--- a/src/Engine/ProtoCore/FFI/FFIHandler.cs
+++ b/src/Engine/ProtoCore/FFI/FFIHandler.cs
@@ -26,14 +26,14 @@ namespace ProtoFFI
         public abstract List<FFIFunctionPointer> GetFunctionPointers(string className, string name);
         public abstract FFIFunctionPointer GetFunctionPointer(string className, string name, List<ProtoCore.Type> argTypes, ProtoCore.Type returnType);
         public virtual CodeBlockNode ImportCodeBlock(string typeName, string alias, CodeBlockNode refnode) { return null; } //All modules don't support import
-        public virtual FFIObjectMarshaler GetMarshaller(ProtoCore.RuntimeCore runtimeCore) { return null; }
+        public virtual FFIObjectMarshaler GetMarshaler(ProtoCore.RuntimeCore runtimeCore) { return null; }
         public virtual Type GetExtensionAppType() { return null; }
     }
 
     public abstract class ModuleHelper
     {
         public abstract DLLModule getModule(String name);
-        public abstract FFIObjectMarshaler GetMarshaller(ProtoCore.RuntimeCore runtimeCore);
+        public abstract FFIObjectMarshaler GetMarshaler(ProtoCore.RuntimeCore runtimeCore);
     }
 
     /// <summary>

--- a/src/Engine/ProtoCore/FFI/FFIHandler.cs
+++ b/src/Engine/ProtoCore/FFI/FFIHandler.cs
@@ -26,21 +26,21 @@ namespace ProtoFFI
         public abstract List<FFIFunctionPointer> GetFunctionPointers(string className, string name);
         public abstract FFIFunctionPointer GetFunctionPointer(string className, string name, List<ProtoCore.Type> argTypes, ProtoCore.Type returnType);
         public virtual CodeBlockNode ImportCodeBlock(string typeName, string alias, CodeBlockNode refnode) { return null; } //All modules don't support import
-        public virtual FFIObjectMarshler GetMarshaller(ProtoCore.RuntimeCore runtimeCore) { return null; }
+        public virtual FFIObjectMarshaler GetMarshaller(ProtoCore.RuntimeCore runtimeCore) { return null; }
         public virtual Type GetExtensionAppType() { return null; }
     }
 
     public abstract class ModuleHelper
     {
         public abstract DLLModule getModule(String name);
-        public abstract FFIObjectMarshler GetMarshaller(ProtoCore.RuntimeCore runtimeCore);
+        public abstract FFIObjectMarshaler GetMarshaller(ProtoCore.RuntimeCore runtimeCore);
     }
 
     /// <summary>
     /// This class is responsible for marshaling of FFI objects to DS world and 
     /// vice-versa.
     /// </summary>
-    public abstract class FFIObjectMarshler
+    public abstract class FFIObjectMarshaler
     {
         /// <summary>
         /// Marshales a given FFI object to DS Object of given ProtoCore.Type

--- a/src/Engine/ProtoCore/FFI/PInvokeFFI.cs
+++ b/src/Engine/ProtoCore/FFI/PInvokeFFI.cs
@@ -354,7 +354,7 @@ namespace ProtoFFI
 
     public class PInvokeModuleHelper : ModuleHelper
     {
-        public override FFIObjectMarshler GetMarshaller(ProtoCore.RuntimeCore runtimeCore)
+        public override FFIObjectMarshaler GetMarshaller(ProtoCore.RuntimeCore runtimeCore)
         {
             return null;
         }

--- a/src/Engine/ProtoCore/FFI/PInvokeFFI.cs
+++ b/src/Engine/ProtoCore/FFI/PInvokeFFI.cs
@@ -354,7 +354,7 @@ namespace ProtoFFI
 
     public class PInvokeModuleHelper : ModuleHelper
     {
-        public override FFIObjectMarshaler GetMarshaller(ProtoCore.RuntimeCore runtimeCore)
+        public override FFIObjectMarshaler GetMarshaler(ProtoCore.RuntimeCore runtimeCore)
         {
             return null;
         }

--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -734,7 +734,7 @@ namespace ProtoCore.Lang
             IContextDataProvider provider = runtimeCore.DSExecutable.ContextDataMngr.GetDataProvider(appname);
             ProtoCore.Utils.Validity.Assert(null != provider, string.Format("Couldn't locate data provider for {0}", appname));
 
-            CLRObjectMarshler marshaler = CLRObjectMarshler.GetInstance(runtimeCore);
+            CLRObjectMarshaler marshaler = CLRObjectMarshaler.GetInstance(runtimeCore);
 
             Dictionary<string, Object> parameters = new Dictionary<string, object>();
             if (!svConnectionParameters.IsArray)
@@ -765,7 +765,7 @@ namespace ProtoCore.Lang
             {
                 objects.Add(item.Data);
             }
-            ProtoCore.Type type = PrimitiveMarshler.CreateType(ProtoCore.PrimitiveType.Var);
+            ProtoCore.Type type = PrimitiveMarshaler.CreateType(ProtoCore.PrimitiveType.Var);
             Object obj = objects;
             if (objects.Count == 1)
                 obj = objects[0];

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -106,7 +106,6 @@
     <Compile Include="DSASM\DSObject.cs" />
     <Compile Include="DSASM\DSString.cs" />
     <Compile Include="FFI\CLRObjectMarshaler.cs" />
-    <Compile Include="FFI\CLRObjectMarshler.cs" />
     <Compile Include="Lang\InternalAttributes.cs" />
     <Compile Include="Lang\Replication\ArgumentAtLevel.cs" />
     <Compile Include="AttributeEntry.cs" />

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -105,6 +105,7 @@
     <Compile Include="DSASM\DSArray.cs" />
     <Compile Include="DSASM\DSObject.cs" />
     <Compile Include="DSASM\DSString.cs" />
+    <Compile Include="FFI\CLRObjectMarshaler.cs" />
     <Compile Include="Lang\InternalAttributes.cs" />
     <Compile Include="Lang\Replication\ArgumentAtLevel.cs" />
     <Compile Include="AttributeEntry.cs" />
@@ -171,7 +172,6 @@
     <Compile Include="DynamicFunctionTable.cs" />
     <Compile Include="Exceptions\DebugHalting.cs" />
     <Compile Include="FFI\CLRFFIFunctionPointer.cs" />
-    <Compile Include="FFI\CLRObjectMarshler.cs" />
     <Compile Include="FFI\ImportModuleHandler.cs" />
     <Compile Include="Parser\AssociativeAST.cs" />
     <Compile Include="Parser\AST.cs" />

--- a/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
+++ b/src/Engine/ProtoCore/Reflection/GraphicDataProvider.cs
@@ -158,7 +158,7 @@ namespace ProtoCore.Mirror
             {
                 ProtoCore.DSASM.Interpreter interpreter = new ProtoCore.DSASM.Interpreter(runtimeCore, false);
                 var helper = ProtoFFI.DLLFFIHandler.GetModuleHelper(ProtoFFI.FFILanguage.CSharp);
-                var marshaler = helper.GetMarshaller(runtimeCore);
+                var marshaler = helper.GetMarshaler(runtimeCore);
                 return marshaler.UnMarshal(svData, null, interpreter, typeof(object));
             }
             catch (System.Exception)

--- a/test/Engine/ProtoTestFx/TestFrameWork.cs
+++ b/test/Engine/ProtoTestFx/TestFrameWork.cs
@@ -794,7 +794,7 @@ namespace ProtoTestFx.TD
         string GetFFIObjectStringValue(string dsVariable, int startBlock = 1, int arrayIndex = -1)
         {
             var helper = DLLFFIHandler.GetModuleHelper(FFILanguage.CSharp);
-            var marshaller = helper.GetMarshaller(TestFrameWork.testRuntimeCore);
+            var marshaller = helper.GetMarshaler(TestFrameWork.testRuntimeCore);
             Obj val = testMirror.GetFirstValue(dsVariable, startBlock);
             StackValue sv;
 


### PR DESCRIPTION
### Purpose

There were spelling errors. I fixed them.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 
