### PR TITLE
fix ast topological sort tests

### DIFF
--- a/test/DynamoCoreTests/AstBuilderTest.cs
+++ b/test/DynamoCoreTests/AstBuilderTest.cs
@@ -99,7 +99,7 @@ namespace Dynamo.Tests
                     nodePosMap[ids[idx]] = idx;
                 }
 
-                // no matter input nodes in whatever order, there invariants 
+                // no matter the order of the input nodes, these invariants 
                 // should hold
                 Assert.IsTrue(nodePosMap[id2] > nodePosMap[id1]);
                 Assert.IsTrue(nodePosMap[id3] > nodePosMap[id1]);
@@ -144,7 +144,7 @@ namespace Dynamo.Tests
                     nodePosMap[ids[idx]] = idx;
                 }
 
-                // no matter input nodes in whatever order, there invariants 
+                // no matter the order of the input nodes, these invariants 
                 // should hold
                 Assert.IsTrue(nodePosMap[id1] < nodePosMap[id4]);
                 Assert.IsTrue(nodePosMap[id2] < nodePosMap[id4]);
@@ -186,7 +186,7 @@ namespace Dynamo.Tests
                     nodePosMap[ids[idx]] = idx;
                 }
 
-                // no matter input nodes in whatever order, there invariants 
+                // no matter the order of the input nodes, these invariants 
                 // should hold
                 Assert.IsTrue(nodePosMap[id2] < nodePosMap[id3]);
                 Assert.IsTrue(nodePosMap[id3] < nodePosMap[id1]);
@@ -226,7 +226,7 @@ namespace Dynamo.Tests
                     nodePosMap[ids[idx]] = idx;
                 }
 
-                // no matter input nodes in whatever order, there invariants 
+                // no matter the order of the input nodes, these invariants 
                 // should hold
                 Assert.IsTrue(nodePosMap[id4] < nodePosMap[id3]);
                 Assert.IsTrue(nodePosMap[id4] < nodePosMap[id2]);
@@ -280,7 +280,7 @@ namespace Dynamo.Tests
                     nodePosMap[ids[idx]] = idx;
                 }
 
-                // no matter input nodes in whatever order, there invariants 
+                // no matter the order of the input nodes, these invariants 
                 // should hold
                 Assert.IsTrue(nodePosMap[id1] > nodePosMap[id2]);
                 Assert.IsTrue(nodePosMap[id6] > nodePosMap[id4]);
@@ -338,7 +338,7 @@ namespace Dynamo.Tests
                     nodePosMap[ids[idx]] = idx;
                 }
 
-                // no matter input nodes in whatever order, there invariants 
+                // no matter the order of the input nodes, these invariants 
                 // should hold
                 Assert.IsTrue(nodePosMap[id2] > nodePosMap[id1]);
                 Assert.IsTrue(nodePosMap[id3] > nodePosMap[id1]);
@@ -382,7 +382,7 @@ namespace Dynamo.Tests
                     nodePosMap[ids[idx]] = idx;
                 }
 
-                // no matter input nodes in whatever order, there invariants 
+                // no matter the order of the input nodes, these invariants 
                 // should hold
                 Assert.IsTrue(nodePosMap[id1] < nodePosMap[id4]);
                 Assert.IsTrue(nodePosMap[id2] < nodePosMap[id4]);
@@ -427,7 +427,7 @@ namespace Dynamo.Tests
                     nodePosMap[ids[idx]] = idx;
                 }
 
-                // no matter input nodes in whatever order, there invariants 
+                // no matter the order of the input nodes, these invariants 
                 // should hold
                 Assert.IsTrue(nodePosMap[id2] < nodePosMap[id3]);
                 Assert.IsTrue(nodePosMap[id3] < nodePosMap[id1]);
@@ -468,7 +468,7 @@ namespace Dynamo.Tests
                     nodePosMap[ids[idx]] = idx;
                 }
 
-                // no matter input nodes in whatever order, there invariants 
+                // no matter the order of the input nodes, these invariants 
                 // should hold
                 Assert.IsTrue(nodePosMap[id4] < nodePosMap[id3]);
                 Assert.IsTrue(nodePosMap[id4] < nodePosMap[id2]);
@@ -521,7 +521,7 @@ namespace Dynamo.Tests
                     nodePosMap[ids[idx]] = idx;
                 }
 
-                // no matter input nodes in whatever order, there invariants 
+                // no matter the order of the input nodes, these invariants 
                 // should hold
                 Assert.IsTrue(nodePosMap[id1] > nodePosMap[id2]);
                 Assert.IsTrue(nodePosMap[id6] > nodePosMap[id4]);

--- a/test/DynamoCoreTests/AstBuilderTest.cs
+++ b/test/DynamoCoreTests/AstBuilderTest.cs
@@ -81,25 +81,29 @@ namespace Dynamo.Tests
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList();
 
             var shuffle = new ShuffleUtil<NodeModel>(nodes);
+            var id1 = "654c9a4b-3f58-4f90-9bde-c3e615100b12";
+            var id2 = "8a55ca22-4424-4ccb-bd2f-3fe79bbeaccf";
+            var id3 = "189689be-815b-4a6e-89cb-45b495962cca";
+            var id4 = "918ac1ed-98fa-457d-bdb7-fe7456ea3fb5";
 
             for (int i = 0; i < shuffleCount; ++i)
             {
                 var sortedNodes = AstBuilder.TopologicalSort(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
+                List<string> ids = sortedNodes.Select(node => node.GUID.ToString()).ToList();
 
-                var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < names.Count; ++idx)
+                var nodePosMap = new Dictionary<string, int>();
+                for (int idx = 0; idx < ids.Count; ++idx)
                 {
-                    nodePosMap[names[idx]] = idx;
+                    nodePosMap[ids[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
                 // should hold
-                Assert.IsTrue(nodePosMap[2] > nodePosMap[1]);
-                Assert.IsTrue(nodePosMap[3] > nodePosMap[1]);
-                Assert.IsTrue(nodePosMap[4] > nodePosMap[1]);
+                Assert.IsTrue(nodePosMap[id2] > nodePosMap[id1]);
+                Assert.IsTrue(nodePosMap[id3] > nodePosMap[id1]);
+                Assert.IsTrue(nodePosMap[id4] > nodePosMap[id1]);
             }
         }
 
@@ -117,6 +121,12 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(TestDirectory, @"core\astbuilder\multiinputs.dyn");
             OpenModel(openPath);
 
+            var id1 = "1a00d6cb-f67d-4b79-a810-94145ad31486";
+            var id2 = "8188eb2e-1746-4513-a51e-1dc8dfdb08e6";
+            var id3 = "e5ef9374-389b-45d4-8ca3-44d52276a5cc";
+            var id4 = "c342aed0-eea6-463d-b55f-ae260b0e5320";
+
+
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList();
 
             var shuffle = new ShuffleUtil<NodeModel>(nodes);
@@ -126,19 +136,19 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSort(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
+                List<string> ids = sortedNodes.Select(node => node.GUID.ToString()).ToList();
 
-                var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < names.Count; ++idx)
+                var nodePosMap = new Dictionary<string, int>();
+                for (int idx = 0; idx < ids.Count; ++idx)
                 {
-                    nodePosMap[names[idx]] = idx;
+                    nodePosMap[ids[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
                 // should hold
-                Assert.IsTrue(nodePosMap[1] < nodePosMap[4]);
-                Assert.IsTrue(nodePosMap[2] < nodePosMap[4]);
-                Assert.IsTrue(nodePosMap[3] < nodePosMap[4]);
+                Assert.IsTrue(nodePosMap[id1] < nodePosMap[id4]);
+                Assert.IsTrue(nodePosMap[id2] < nodePosMap[id4]);
+                Assert.IsTrue(nodePosMap[id3] < nodePosMap[id4]);
             }
         }
 
@@ -155,6 +165,10 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(TestDirectory, @"core\astbuilder\tri.dyn");
             OpenModel(openPath);
 
+            var id1 = "2e7200b5-7962-450b-91a8-9b0b35eeed6d";
+            var id2 = "a5b713c3-1969-4cb4-a6f4-b7a299c46d7f";
+            var id3 = "91dbf72b-c2ac-4e87-b52a-cf9a0ebb3ec5";
+
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList();
 
             var shuffle = new ShuffleUtil<NodeModel>(nodes);
@@ -164,18 +178,18 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSort(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 3);
 
-                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
+                List<string> ids = sortedNodes.Select(node => node.GUID.ToString()).ToList();
 
-                var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < names.Count; ++idx)
+                var nodePosMap = new Dictionary<string, int>();
+                for (int idx = 0; idx < ids.Count; ++idx)
                 {
-                    nodePosMap[names[idx]] = idx;
+                    nodePosMap[ids[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
                 // should hold
-                Assert.IsTrue(nodePosMap[2] < nodePosMap[3]);
-                Assert.IsTrue(nodePosMap[3] < nodePosMap[1]);
+                Assert.IsTrue(nodePosMap[id2] < nodePosMap[id3]);
+                Assert.IsTrue(nodePosMap[id3] < nodePosMap[id1]);
             }
         }
 
@@ -189,6 +203,11 @@ namespace Dynamo.Tests
             //
             string openPath = Path.Combine(TestDirectory, @"core\astbuilder\linear.dyn");
             OpenModel(openPath);
+            var id1 = "cc78b400-329a-4bd8-be9b-5dd6593b31c0";
+            var id2 = "306e67f3-d97c-4be7-aab5-298c8c24ae7b";
+            var id3 = "682f2b08-0f11-4248-8b98-a5aff29e5fdf";
+            var id4 = "34786660-d4a5-4643-8d08-317eb16ed377";
+
 
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList();
 
@@ -199,20 +218,20 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSort(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
+                List<string> ids = sortedNodes.Select(node => node.GUID.ToString()).ToList();
 
-                var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < names.Count; ++idx)
+                var nodePosMap = new Dictionary<string, int>();
+                for (int idx = 0; idx < ids.Count; ++idx)
                 {
-                    nodePosMap[names[idx]] = idx;
+                    nodePosMap[ids[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
                 // should hold
-                Assert.IsTrue(nodePosMap[4] < nodePosMap[3]);
-                Assert.IsTrue(nodePosMap[4] < nodePosMap[2]);
-                Assert.IsTrue(nodePosMap[3] < nodePosMap[1]);
-                Assert.IsTrue(nodePosMap[2] < nodePosMap[1]);
+                Assert.IsTrue(nodePosMap[id4] < nodePosMap[id3]);
+                Assert.IsTrue(nodePosMap[id4] < nodePosMap[id2]);
+                Assert.IsTrue(nodePosMap[id3] < nodePosMap[id1]);
+                Assert.IsTrue(nodePosMap[id2] < nodePosMap[id1]);
             }
         }
 
@@ -232,6 +251,17 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(TestDirectory, @"core\astbuilder\complex.dyn");
             OpenModel(openPath);
 
+
+            var id1 = "c7d2e0f5-78db-486a-b20b-1ee451bf48d5";
+            var id2 = "014c3d64-078e-4f92-b582-79387862e306";
+            var id3 = "7744fddd-450d-422f-abd7-32c568e7ee19";
+            var id5 = "bc513069-7825-4f15-bb3e-fa76fa7c84a9";
+            var id7 = "9afc84ab-e0d2-46c6-839f-cef34175d96b";
+            var id4 = "98c54e4f-9118-4c67-a248-2926ed3516ea";
+            var id6 = "6c50a8a1-4e7d-4146-9cfc-1b33de51abea";
+            var id8 = "dd095dd4-1d06-4c29-b6ff-afbc853266cf";
+            var id9 = "d0185e93-7d0f-47a4-a56c-4486bb2b6877";
+
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList();
 
             var shuffle = new ShuffleUtil<NodeModel>(nodes);
@@ -243,18 +273,18 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSort(nodes).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 9);
 
-                var names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
-                var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < names.Count; ++idx)
+                List<string> ids = sortedNodes.Select(node => node.GUID.ToString()).ToList();
+                var nodePosMap = new Dictionary<string, int>();
+                for (int idx = 0; idx < ids.Count; ++idx)
                 {
-                    nodePosMap[names[idx]] = idx;
+                    nodePosMap[ids[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
                 // should hold
-                Assert.IsTrue(nodePosMap[1] > nodePosMap[2]);
-                Assert.IsTrue(nodePosMap[6] > nodePosMap[4]);
-                Assert.IsTrue(nodePosMap[7] > nodePosMap[5]);
+                Assert.IsTrue(nodePosMap[id1] > nodePosMap[id2]);
+                Assert.IsTrue(nodePosMap[id6] > nodePosMap[id4]);
+                Assert.IsTrue(nodePosMap[id7] > nodePosMap[id5]);
             }
         }
 
@@ -286,6 +316,11 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(TestDirectory, @"core\astbuilder\multioutputs.dyn");
             OpenModel(openPath);
 
+            var id1 = "654c9a4b-3f58-4f90-9bde-c3e615100b12";
+            var id2 = "8a55ca22-4424-4ccb-bd2f-3fe79bbeaccf";
+            var id3 = "189689be-815b-4a6e-89cb-45b495962cca";
+            var id4 = "918ac1ed-98fa-457d-bdb7-fe7456ea3fb5";
+
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList();
 
             var shuffle = new ShuffleUtil<NodeModel>(nodes);
@@ -295,19 +330,19 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
+                List<string> ids = sortedNodes.Select(node => node.GUID.ToString()).ToList();
 
-                var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < names.Count; ++idx)
+                var nodePosMap = new Dictionary<string, int>();
+                for (int idx = 0; idx < ids.Count; ++idx)
                 {
-                    nodePosMap[names[idx]] = idx;
+                    nodePosMap[ids[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
                 // should hold
-                Assert.IsTrue(nodePosMap[2] > nodePosMap[1]);
-                Assert.IsTrue(nodePosMap[3] > nodePosMap[1]);
-                Assert.IsTrue(nodePosMap[4] > nodePosMap[1]);
+                Assert.IsTrue(nodePosMap[id2] > nodePosMap[id1]);
+                Assert.IsTrue(nodePosMap[id3] > nodePosMap[id1]);
+                Assert.IsTrue(nodePosMap[id4] > nodePosMap[id1]);
             }
         }
 
@@ -325,6 +360,11 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(TestDirectory, @"core\astbuilder\multiinputs.dyn");
             OpenModel(openPath);
 
+            var id1 = "1a00d6cb-f67d-4b79-a810-94145ad31486";
+            var id2 = "8188eb2e-1746-4513-a51e-1dc8dfdb08e6";
+            var id3 = "e5ef9374-389b-45d4-8ca3-44d52276a5cc";
+            var id4 = "c342aed0-eea6-463d-b55f-ae260b0e5320";
+
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList();
 
             var shuffle = new ShuffleUtil<NodeModel>(nodes);
@@ -334,22 +374,22 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
+                List<string> ids = sortedNodes.Select(node => node.GUID.ToString()).ToList();
 
-                var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < names.Count; ++idx)
+                var nodePosMap = new Dictionary<string, int>();
+                for (int idx = 0; idx < ids.Count; ++idx)
                 {
-                    nodePosMap[names[idx]] = idx;
+                    nodePosMap[ids[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
                 // should hold
-                Assert.IsTrue(nodePosMap[1] < nodePosMap[4]);
-                Assert.IsTrue(nodePosMap[2] < nodePosMap[4]);
-                Assert.IsTrue(nodePosMap[3] < nodePosMap[4]);
-                Assert.IsTrue(nodePosMap[1] < nodePosMap[2]);
-                Assert.IsTrue(nodePosMap[2] < nodePosMap[3]);
-                Assert.IsTrue(nodePosMap[3] < nodePosMap[4]);
+                Assert.IsTrue(nodePosMap[id1] < nodePosMap[id4]);
+                Assert.IsTrue(nodePosMap[id2] < nodePosMap[id4]);
+                Assert.IsTrue(nodePosMap[id3] < nodePosMap[id4]);
+                Assert.IsTrue(nodePosMap[id1] < nodePosMap[id2]);
+                Assert.IsTrue(nodePosMap[id2] < nodePosMap[id3]);
+                Assert.IsTrue(nodePosMap[id3] < nodePosMap[id4]);
             }
         }
 
@@ -366,6 +406,10 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(TestDirectory, @"core\astbuilder\tri.dyn");
             OpenModel(openPath);
 
+            var id1 = "2e7200b5-7962-450b-91a8-9b0b35eeed6d";
+            var id2 = "a5b713c3-1969-4cb4-a6f4-b7a299c46d7f";
+            var id3 = "91dbf72b-c2ac-4e87-b52a-cf9a0ebb3ec5";
+
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList();
 
             var shuffle = new ShuffleUtil<NodeModel>(nodes);
@@ -375,18 +419,18 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 3);
 
-                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
+                List<string> ids = sortedNodes.Select(node => node.GUID.ToString()).ToList();
 
-                var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < names.Count; ++idx)
+                var nodePosMap = new Dictionary<string, int>();
+                for (int idx = 0; idx < ids.Count; ++idx)
                 {
-                    nodePosMap[names[idx]] = idx;
+                    nodePosMap[ids[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
                 // should hold
-                Assert.IsTrue(nodePosMap[2] < nodePosMap[3]);
-                Assert.IsTrue(nodePosMap[3] < nodePosMap[1]);
+                Assert.IsTrue(nodePosMap[id2] < nodePosMap[id3]);
+                Assert.IsTrue(nodePosMap[id3] < nodePosMap[id1]);
             }
         }
 
@@ -401,6 +445,12 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(TestDirectory, @"core\astbuilder\linear.dyn");
             OpenModel(openPath);
 
+            var id1 = "cc78b400-329a-4bd8-be9b-5dd6593b31c0";
+            var id2 = "306e67f3-d97c-4be7-aab5-298c8c24ae7b";
+            var id3 = "682f2b08-0f11-4248-8b98-a5aff29e5fdf";
+            var id4 = "34786660-d4a5-4643-8d08-317eb16ed377";
+
+
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList();
 
             var shuffle = new ShuffleUtil<NodeModel>(nodes);
@@ -410,20 +460,20 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(shuffle.ShuffledList).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 4);
 
-                List<int> names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
+                List<string> ids = sortedNodes.Select(node => node.GUID.ToString()).ToList();
 
-                var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < names.Count; ++idx)
+                var nodePosMap = new Dictionary<string, int>();
+                for (int idx = 0; idx < ids.Count; ++idx)
                 {
-                    nodePosMap[names[idx]] = idx;
+                    nodePosMap[ids[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
                 // should hold
-                Assert.IsTrue(nodePosMap[4] < nodePosMap[3]);
-                Assert.IsTrue(nodePosMap[4] < nodePosMap[2]);
-                Assert.IsTrue(nodePosMap[3] < nodePosMap[1]);
-                Assert.IsTrue(nodePosMap[2] < nodePosMap[1]);
+                Assert.IsTrue(nodePosMap[id4] < nodePosMap[id3]);
+                Assert.IsTrue(nodePosMap[id4] < nodePosMap[id2]);
+                Assert.IsTrue(nodePosMap[id3] < nodePosMap[id1]);
+                Assert.IsTrue(nodePosMap[id2] < nodePosMap[id1]);
             }
         }
 
@@ -443,6 +493,16 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(TestDirectory, @"core\astbuilder\complex.dyn");
             OpenModel(openPath);
 
+            var id1 = "c7d2e0f5-78db-486a-b20b-1ee451bf48d5";
+            var id2 = "014c3d64-078e-4f92-b582-79387862e306";
+            var id3 = "7744fddd-450d-422f-abd7-32c568e7ee19";
+            var id5 = "bc513069-7825-4f15-bb3e-fa76fa7c84a9";
+            var id7 = "9afc84ab-e0d2-46c6-839f-cef34175d96b";
+            var id4 = "98c54e4f-9118-4c67-a248-2926ed3516ea";
+            var id6 = "6c50a8a1-4e7d-4146-9cfc-1b33de51abea";
+            var id8 = "dd095dd4-1d06-4c29-b6ff-afbc853266cf";
+            var id9 = "d0185e93-7d0f-47a4-a56c-4486bb2b6877";
+
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList();
 
             var shuffle = new ShuffleUtil<NodeModel>(nodes);
@@ -454,22 +514,22 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(nodes).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 9);
 
-                var names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
-                var nodePosMap = new Dictionary<int, int>();
-                for (int idx = 0; idx < names.Count; ++idx)
+                List<string> ids = sortedNodes.Select(node => node.GUID.ToString()).ToList();
+                var nodePosMap = new Dictionary<string, int>();
+                for (int idx = 0; idx < ids.Count; ++idx)
                 {
-                    nodePosMap[names[idx]] = idx;
+                    nodePosMap[ids[idx]] = idx;
                 }
 
                 // no matter input nodes in whatever order, there invariants 
                 // should hold
-                Assert.IsTrue(nodePosMap[1] > nodePosMap[2]);
-                Assert.IsTrue(nodePosMap[6] > nodePosMap[4]);
-                Assert.IsTrue(nodePosMap[7] > nodePosMap[5]);
-                Assert.IsTrue(nodePosMap[5] > nodePosMap[3]
-                    || nodePosMap[2] > nodePosMap[3]
-                    || nodePosMap[4] > nodePosMap[3]);
-                Assert.IsTrue(nodePosMap[9] > nodePosMap[8]);
+                Assert.IsTrue(nodePosMap[id1] > nodePosMap[id2]);
+                Assert.IsTrue(nodePosMap[id6] > nodePosMap[id4]);
+                Assert.IsTrue(nodePosMap[id7] > nodePosMap[id5]);
+                Assert.IsTrue(nodePosMap[id5] > nodePosMap[id3]
+                    || nodePosMap[id2] > nodePosMap[id3]
+                    || nodePosMap[id4] > nodePosMap[id3]);
+                Assert.IsTrue(nodePosMap[id9] > nodePosMap[id8]);
             }
         }
 
@@ -490,6 +550,20 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(TestDirectory, @"core\astbuilder\multiinputs2.dyn");
             OpenModel(openPath);
 
+            var id1 = "746381f5-8821-4d0d-8858-a77b128c19db";
+            var id4 = "80b9d424-420f-4666-aecd-19cfdaf43410";
+            var id7 = "5cf48cb3-6c08-403d-aba2-b1054a9dd703";
+            var id2 = "a4c2a32b-6a4f-483b-8e42-43ae263936e1";
+            var id5= "4e51d487-f2fb-4ac7-aa5b-75249a5d138f";
+            var id8 ="8a8809ef-529b-4e13-ab0f-e8762163856a";
+            var id3 ="c0a4a701-2b61-491c-bd59-2f59196728f0";
+            var id9 ="0a340c37-1e30-442e-b935-cc4d4816ed95";
+            var id6 = "be3b4b36-4f42-485c-b346-c8e60e70b81a";
+            var id13 ="3ba2305e-d151-4974-b42e-b5ae5a9a8ffb";
+            var id10 ="afb714d8-74a5-4946-95d5-1b3a4d4e750b";
+            var id12 = "a0b819a9-0077-4fcf-a2fa-29615d86a52c";
+            var id11 = "9dcf916c-827c-446b-bb01-457561fe591b";
+
             var nodes = CurrentDynamoModel.CurrentWorkspace.Nodes.ToList();
 
             var shuffle = new ShuffleUtil<NodeModel>(nodes);
@@ -501,8 +575,14 @@ namespace Dynamo.Tests
                 var sortedNodes = AstBuilder.TopologicalSortForGraph(nodes).ToList();
                 Assert.AreEqual(sortedNodes.Count(), 13);
 
-                var names = sortedNodes.Select(node => Int32.Parse(node.Name)).ToList();
-                Assert.IsTrue(names.SequenceEqual(Enumerable.Range(1, 13)));
+                List<string> ids = sortedNodes.Select(node => node.GUID.ToString()).ToList();
+                var nodePosMap = new Dictionary<string, int>();
+                for (int idx = 0; idx < ids.Count; ++idx)
+                {
+                    nodePosMap[ids[idx]] = idx;
+                }
+                var orderedResult = new List<string> { id1, id2, id3, id4, id5, id6, id7, id8, id9, id10, id11, id12, id13 };
+                Assert.IsTrue(ids.SequenceEqual(orderedResult));
             }
         }
     }


### PR DESCRIPTION
### Purpose

fixes ASTbuilder topo sort tests - these tests relied on node nicknames - but as these are model tests the nicknames won't exist as they are now only loaded when the view is present. Instead I used the ids of the nodes as these will always be present.

note this is just a test update, no changes to behavior.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@alfarok 

### FYIs

@smangarole 