### PR TITLE
Move CoreTest to CoreWPFTest

### DIFF
--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -826,37 +826,6 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void NodesHaveCorrectLocationsIndpendentOfCulture()
-        {
-            string openPath = Path.Combine(TestDirectory, @"core\nodeLocationTest.dyn");
-            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("es-AR");
-            OpenModel(openPath);
-
-            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
-            var node = CurrentDynamoModel.CurrentWorkspace.Nodes.First();
-            Assert.AreEqual(217.952067513811, node.X);
-            Assert.AreEqual(177.041832898393, node.Y);
-
-            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("zu-ZA");
-            OpenModel(openPath);
-
-            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
-            node = CurrentDynamoModel.CurrentWorkspace.Nodes.First();
-            Assert.AreEqual(217.952067513811, node.X);
-            Assert.AreEqual(177.041832898393, node.Y);
-
-            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("ja-JP");
-            OpenModel(openPath);
-
-            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
-            node = CurrentDynamoModel.CurrentWorkspace.Nodes.First();
-            Assert.AreEqual(217.952067513811, node.X);
-            Assert.AreEqual(177.041832898393, node.Y);
-
-            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
-        }
-
-        [Test]
         [Category("RegressionTests")]
         public void Defect_MAGN_3166()
         {

--- a/test/DynamoCoreWpfTests/NodeViewTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewTests.cs
@@ -4,6 +4,8 @@ using Dynamo.Selection;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
 using System.Windows.Input;
+using System.Globalization;
+using System.Threading;
 
 namespace DynamoCoreWpfTests
 {
@@ -136,6 +138,37 @@ namespace DynamoCoreWpfTests
                 Assert.AreEqual(4, nodeView.ViewModel.ZIndex);
                 Assert.AreEqual(2, annotation.ZIndex);
             };
+        }
+
+        [Test]
+        public void NodesHaveCorrectLocationsIndpendentOfCulture()
+        {
+            string openPath = @"core\nodeLocationTest.dyn";
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("es-AR");
+            Open(openPath);
+
+            Assert.AreEqual(1, this.Model.CurrentWorkspace.Nodes.Count());
+            var node = this.Model.CurrentWorkspace.Nodes.First();
+            Assert.AreEqual(217.952067513811, node.X);
+            Assert.AreEqual(177.041832898393, node.Y);
+
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("zu-ZA");
+            Open(openPath);
+
+            Assert.AreEqual(1, this.Model.CurrentWorkspace.Nodes.Count());
+            node = this.Model.CurrentWorkspace.Nodes.First();
+            Assert.AreEqual(217.952067513811, node.X);
+            Assert.AreEqual(177.041832898393, node.Y);
+
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("ja-JP");
+            Open(openPath);
+
+            Assert.AreEqual(1, this.Model.CurrentWorkspace.Nodes.Count());
+            node = this.Model.CurrentWorkspace.Nodes.First();
+            Assert.AreEqual(217.952067513811, node.X);
+            Assert.AreEqual(177.041832898393, node.Y);
+
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
         }
     }
 }


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[QNTM-2838](https://jira.autodesk.com/browse/QNTM-2838)Dynamo Unit Tests [JSON]: NodesHaveCorrectLocationsIndpendentOfCulture()

Purpose：
The original test was a DynamoCoreTest testing if opening and resaving a file with maintain node position, however during Dynamo 2.0 developing, we made this behavior same but only when DynamoViewModel exist (Since in JSON schema, there is no node position in Graph block).

 So I moved this test to be a DynamoWPF test and fixed small signature differences  and made sure new test still passes for both XML and JSON DYNs. Please review this PR and merge if you feel changes are OK.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@alfarok 

### FYIs

@mjkkirschner @ramramps @ColinDayOrg @smangarole 

I feel there could be more similar failures, let's keep this case in mind
