### PR TITLE
Fix dict layout

### DIFF
--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -305,7 +305,7 @@
         {
           "text": "Dictionary",
           "iconUrl": "",
-          "elementType": "group",
+          "elementType": "category",
           "include": [
             {
               "path": "Builtin.DesignScript.Builtin.Dictionary.ByKeysValues"

--- a/tools/NuGet/template-nuget/DynamoVisualProgramming.Core.nuspec
+++ b/tools/NuGet/template-nuget/DynamoVisualProgramming.Core.nuspec
@@ -17,7 +17,8 @@
 5) DynamoShapeManager.dll 
 6) DynamoUtilities.dll
 7) ProtoCore.dll
-8) VMDataBridge.dll</description>
+8) Builtin.dll
+9) VMDataBridge.dll</description>
     <summary>This package contains the core assemblies for Dynamo.</summary>
     <copyright>Copyright Autodesk 2017</copyright>
     <dependencies>
@@ -35,6 +36,7 @@
     <file src="DynamoShapeManager.dll" target="lib\net45" />
     <file src="DynamoUtilities.dll" target="lib\net45" />
     <file src="ProtoCore.dll" target="lib\net45" />
+    <file src="Builtin.dll" target="lib\net45" />
     <file src="VMDataBridge.dll" target="lib\net45" />
   </files>
 </package>


### PR DESCRIPTION
### Purpose
Make `Dictionary` show up as a category element type in the Library layout spec.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
![image](https://user-images.githubusercontent.com/5710686/34688734-1a63be50-f481-11e7-8efa-712bd8e149e7.png)

- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### FYIs
@Racel: making this simple change for the time being.
