### PR TITLE
QNTM-3036: Removing .dll referenced in 'Managed Node and Package Paths' prevents Dynamo from launching

### DIFF
--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -172,6 +172,9 @@ namespace Dynamo.Engine
             LibraryLoadFailedException ex = new LibraryLoadFailedException(args.LibraryPath, args.Reason);
             Log(ex.Message, WarningLevel.Moderate);
 
+            // NOTE: We do not want to throw an exception here if the failure was due
+            // to a missing library that was explicitly (attempoted to be) loaded
+            // but was moved or deleted
             if (args.ThrowOnFailure)
                 throw ex;
         }
@@ -521,8 +524,8 @@ namespace Dynamo.Engine
         ///     Import a library (if it hasn't been imported yet).
         /// </summary>
         /// <param name="library">The library to be loaded</param>
-        /// <param name="isLocalLib">Indicates if the library has been locally imported</param>
-        internal bool ImportLibrary(string library, bool isLocalLib = false)
+        /// <param name="isExplicitlyImportedLib">Indicates if the library has been imported using the "File | ImportLibrary" command</param>
+        internal bool ImportLibrary(string library, bool isExplicitlyImportedLib = false)
         {
             if (null == library)
                 throw new ArgumentNullException();
@@ -549,10 +552,10 @@ namespace Dynamo.Engine
             {
                 string errorMessage = string.Format(Properties.Resources.LibraryPathCannotBeFound, path);
 
-                // In the case that a library was locally imported set the load failed args
-                // to not throw an exception if the load fails. This can happen after using
+                // In the case that a library was explicitly imported using the "File|Import Library" command
+                // set the load failed args to not throw an exception if the load fails. This can happen after using
                 // File|Import Library and then moving or deleting the library.
-                OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(path, errorMessage, !isLocalLib));
+                OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(path, errorMessage, !isExplicitlyImportedLib));
 
                 return false;
             }

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -542,11 +542,18 @@ namespace Dynamo.Engine
                 return false;
             }
 
+            // Copy the library path so that the path can be reported in the case of a failure
+            // to resolve the library path. If there is a failure "library" is set to null.
             string path = library;
             if (!pathManager.ResolveLibraryPath(ref library))
             {
                 string errorMessage = string.Format(Properties.Resources.LibraryPathCannotBeFound, path);
+
+                // In the case that a library was locally imported set the load failed args
+                // to not throw an exception if the load fails. This can happen after using
+                // File|Import Library and then moving or deleting the library.
                 OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(path, errorMessage, !isLocalLib));
+
                 return false;
             }
 

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -171,7 +171,9 @@ namespace Dynamo.Engine
         {
             LibraryLoadFailedException ex = new LibraryLoadFailedException(args.LibraryPath, args.Reason);
             Log(ex.Message, WarningLevel.Moderate);
-            throw ex;
+
+            if (args.ThrowOnFailure)
+                throw ex;
         }
 
         private void PreloadLibraries(IEnumerable<string> preloadLibraries)
@@ -518,8 +520,9 @@ namespace Dynamo.Engine
         /// <summary>
         ///     Import a library (if it hasn't been imported yet).
         /// </summary>
-        /// <param name="library"></param>
-        internal bool ImportLibrary(string library)
+        /// <param name="library">The library to be loaded</param>
+        /// <param name="isLocalLib">Indicates if the library has been locally imported</param>
+        internal bool ImportLibrary(string library, bool isLocalLib = false)
         {
             if (null == library)
                 throw new ArgumentNullException();
@@ -539,10 +542,11 @@ namespace Dynamo.Engine
                 return false;
             }
 
+            string path = library;
             if (!pathManager.ResolveLibraryPath(ref library))
             {
-                string errorMessage = string.Format(Properties.Resources.LibraryPathCannotBeFound, library);
-                OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(library, errorMessage));
+                string errorMessage = string.Format(Properties.Resources.LibraryPathCannotBeFound, path);
+                OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(path, errorMessage, !isLocalLib));
                 return false;
             }
 
@@ -1090,14 +1094,16 @@ namespace Dynamo.Engine
 
         public class LibraryLoadFailedEventArgs : EventArgs
         {
-            public LibraryLoadFailedEventArgs(string libraryPath, string reason)
+            public LibraryLoadFailedEventArgs(string libraryPath, string reason, bool throwOnFailure = true)
             {
                 LibraryPath = libraryPath;
                 Reason = reason;
+                ThrowOnFailure = throwOnFailure;
             }
 
             public string LibraryPath { get; private set; }
             public string Reason { get; private set; }
+            public bool ThrowOnFailure { get; private set; }
         }
 
         public class LibraryLoadedEventArgs : EventArgs

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -1099,6 +1099,9 @@ namespace Dynamo.Engine
             public const string Properties = "Query";
         }
 
+        /// <summary>
+        /// Contains arguments to pass to a handler when a library load fails
+        /// </summary>
         public class LibraryLoadFailedEventArgs : EventArgs
         {
             public LibraryLoadFailedEventArgs(string libraryPath, string reason, bool throwOnFailure = true)
@@ -1108,8 +1111,19 @@ namespace Dynamo.Engine
                 ThrowOnFailure = throwOnFailure;
             }
 
+            /// <summary>
+            /// The path to the library that failed to load
+            /// </summary>
             public string LibraryPath { get; private set; }
+
+            /// <summary>
+            /// The reason that the library failed to load
+            /// </summary>
             public string Reason { get; private set; }
+
+            /// <summary>
+            /// Indicates if the failure should result in an exception being thrown
+            /// </summary>
             public bool ThrowOnFailure { get; private set; }
         }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1157,7 +1157,7 @@ namespace Dynamo.Models
                 // If the path has a .dll or .ds extension it is a locally imported library
                 if (extension == ".dll" || extension == ".ds")
                 {
-                    LibraryServices.ImportLibrary(path);
+                    LibraryServices.ImportLibrary(path, true);
                     continue;
                 }
 

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1154,9 +1154,11 @@ namespace Dynamo.Models
                 if (extension == null)
                     continue;
 
-                // If the path has a .dll or .ds extension it is a locally imported library
+                // If the path has a .dll or .ds extension it is an explicitly imported library
                 if (extension == ".dll" || extension == ".ds")
                 {
+                    // If a library was explicitly loaded by using the "File | ImportLibrary..." command
+                    // and for some reason the import fails we do not want to throw an exception
                     LibraryServices.ImportLibrary(path, true);
                     continue;
                 }

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -211,6 +211,19 @@ namespace Dynamo.PackageManager
             {
                 if (!Directory.Exists(root))
                 {
+                    string extension = null;
+                    if (root != null)
+                    {
+                        extension = Path.GetExtension(root);
+                    }
+
+                    // If the path has a .dll or .ds extension it is a locally imported library
+                    // so do not output an error about the directory
+                    if (extension == ".dll" || extension == ".ds")
+                    {
+                        return;
+                    }
+
                     this.Log(string.Format(Resources.InvalidPackageFolderWarning, root));
                     return;
                 }


### PR DESCRIPTION
### Purpose

This PR addresses a regression that was introduced by some changes to enable importing of local libraries. 

If a locally imported library was deleted or removed Dynamo would throw an exception on startup. The fix is to detect if the exception would have been caused by a missing local import and not throw if so. 

There was also some erroneous error information being logged to the console in the case of a locally imported library, due to a filename being treated as if it were a path. This erroneous information is now being suppressed.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs
