### PR TITLE
Fix the AnnotationModel Test

### DIFF
--- a/test/DynamoCoreTests/AnnotationModelTest.cs
+++ b/test/DynamoCoreTests/AnnotationModelTest.cs
@@ -769,17 +769,5 @@ namespace Dynamo.Tests
             Assert.AreEqual(2, pastedGroup.Nodes.Count());
         }
 
-        [Test]
-        [Category("UnitTests")]
-        public void TestOpeningMalformedAnnotation()
-        {
-            OpenModel("core\\MalformedGroup.dyn");
-            var ws = CurrentDynamoModel.CurrentWorkspace;
-            // the file contains annotation which has a removed node
-            // check if all models are loaded correctly
-            Assert.AreEqual(4, ws.Nodes.Count());
-            Assert.AreEqual(1, ws.Annotations.Count());
-            Assert.AreEqual(4, ws.Annotations.First().Nodes.Count());
-        }
     }
 }

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -738,6 +738,18 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(noteY, noteVm.Top, "Note" + msgPart);
         }
 
+        [Test]
+       public void TestOpeningMalformedAnnotation()
+        {
+            OpenModel("core\\MalformedGroup.dyn");
+            var ws = ViewModel.Model.CurrentWorkspace;
+            // the file contains annotation which has a removed node
+            // check if all models are loaded correctly
+            Assert.AreEqual(4, ws.Nodes.Count());
+            Assert.AreEqual(1, ws.Annotations.Count());
+            Assert.AreEqual(4, ws.Annotations.First().Nodes.Count());
+        }
+
         #endregion
     }
 }

--- a/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/AnnotationViewModelTests.cs
@@ -739,7 +739,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-       public void TestOpeningMalformedAnnotation()
+        public void TestOpeningMalformedAnnotation()
         {
             OpenModel("core\\MalformedGroup.dyn");
             var ws = ViewModel.Model.CurrentWorkspace;


### PR DESCRIPTION
### Purpose

This PR moves the AnnotationModelTest ```TestOpeningMalformedAnnotation``` from the Core to DynamoCoreWPF. This is because Annotation is a property of ViewModel and not View.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@tanga  @mjkkirschner 


