### PR TITLE
Qntm2836 2

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -47,6 +47,8 @@ namespace Dynamo.Graph.Workspaces
             this.libraryServices = libraryServices;
             this.isTestMode = isTestMode;
 
+            //we only do this in test mode because it should not be required-
+            //see comment below in NodeReadConverter.ReadJson - and it could be slow.
             if (this.isTestMode)
             {
                 this.loadedAssemblies = this.buildMapOfLoadedAssemblies();

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -81,14 +81,17 @@ namespace Dynamo.Graph.Workspaces
 
             var obj = JObject.Load(reader);
             var type = Type.GetType(obj["$type"].Value<string>());
-            //if we can't find this type - try to look in our load from assemblies
-            //but only during testing.
+            //if we can't find this type - try to look in our load from assemblies,
+            //but only during testing - this is required during testing because some dlls are loaded
+            //using Assembly.LoadFrom using the assemblyHelper - which loads dlls into loadFrom context - 
+            //dlls loaded with LoadFrom context cannot be found using Type.GetType() - this should
+            //not be an issue during normal dynamo use but if it is we can enable this code.
             if(type == null && this.isTestMode == true)
             {
                 List<Assembly> resultList;
 
                 var typeName = obj["$type"].Value<string>().Split(',').FirstOrDefault();
-                //this assemblyName does not usually usually contain version information...
+                //this assemblyName does not usually contain version information...
                 var assemblyName = obj["$type"].Value<string>().Split(',').Skip(1).FirstOrDefault().Trim();
                 if (assemblyName != null)
                 {

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -59,8 +59,7 @@ namespace Dynamo.Graph.Workspaces
             var dict = new Dictionary<string, List<Assembly>>();
             foreach(var assembly in allAssemblies)
             {
-                var resultList = new List<Assembly>();
-                if (!dict.TryGetValue(assembly.GetName().Name, out resultList))
+                if (!dict.ContainsKey(assembly.GetName().Name))
                 {
                     dict[assembly.GetName().Name] = new List<Assembly>() { assembly };
                 }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1588,7 +1588,7 @@ namespace Dynamo.Graph.Workspaces
                 Converters = new List<JsonConverter>{
                         new ConnectorConverter(logger),
                         new WorkspaceReadConverter(engineController, scheduler, factory, isTestMode, verboseLogging),
-                        new NodeReadConverter(manager, libraryServices),
+                        new NodeReadConverter(manager, libraryServices,isTestMode),
                         new TypedParameterConverter()
                     },
                 ReferenceResolverProvider = () => { return new IdReferenceResolver(); }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -533,7 +533,7 @@ namespace Dynamo.Graph.Workspaces
         public bool IsReadOnly
         {   
             //if the workspace contains xmlDummyNodes it's effectively a readonly graph.
-            get { return isReadOnly || this.containsXmlDummyNodes() || DynamoUtilities.PathHelper.IsReadOnlyPath(this.FileName); }
+            get { return isReadOnly || this.containsXmlDummyNodes(); }
             set
             {
                 isReadOnly = value;

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -533,7 +533,7 @@ namespace Dynamo.Graph.Workspaces
         public bool IsReadOnly
         {   
             //if the workspace contains xmlDummyNodes it's effectively a readonly graph.
-            get { return isReadOnly || this.containsXmlDummyNodes(); }
+            get { return isReadOnly || this.containsXmlDummyNodes() || DynamoUtilities.PathHelper.IsReadOnlyPath(this.FileName); }
             set
             {
                 isReadOnly = value;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1463,8 +1463,9 @@ namespace Dynamo.Models
                 }
                 return true;
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                Console.WriteLine(e.Message);
                 return false;
             }
         }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1134,7 +1134,6 @@
                                                                     </DataTrigger>
                                                                     <DataTrigger Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
                                                                                  Value="Saved">
-                                                                        <!--TODO find out what is up with this binding did it ever do anything?-->
                                                                         <Setter Property="Header"
                                                                                 Value="{Binding Converter={StaticResource WorkspaceToFileNameConverter}}" />
                                                                     </DataTrigger>

--- a/src/DynamoUtilities/AssemblyHelper.cs
+++ b/src/DynamoUtilities/AssemblyHelper.cs
@@ -34,11 +34,15 @@ namespace Dynamo.Utilities
             try
             {
                 var targetAssemblyName = new AssemblyName(args.Name).Name + ".dll";
-
+                Console.WriteLine("trying to resolve");
+                Console.WriteLine(targetAssemblyName);
                 // First check the core path
                 string assemblyPath = Path.Combine(moduleRootFolder, targetAssemblyName);
+                Console.WriteLine("at");
+                Console.WriteLine(assemblyPath);
                 if (File.Exists(assemblyPath))
                 {
+                    Console.WriteLine("loading from "+assemblyPath);
                     return Assembly.LoadFrom(assemblyPath);
                 }
 
@@ -46,8 +50,13 @@ namespace Dynamo.Utilities
                 foreach (var resolutionPath in additionalResolutionPaths)
                 {
                     assemblyPath = Path.Combine(resolutionPath, targetAssemblyName);
+                    Console.WriteLine("trying to resolve");
+                    Console.WriteLine(targetAssemblyName);
+                    Console.WriteLine("at");
+                    Console.WriteLine(assemblyPath);
                     if (File.Exists(assemblyPath))
                     {
+                        Console.WriteLine("loading from " + assemblyPath);
                         return Assembly.LoadFrom(assemblyPath);
                     }
                 }

--- a/src/DynamoUtilities/AssemblyHelper.cs
+++ b/src/DynamoUtilities/AssemblyHelper.cs
@@ -9,14 +9,16 @@ namespace Dynamo.Utilities
     {
         private readonly string moduleRootFolder;
         private readonly IEnumerable<string> additionalResolutionPaths;
+        private bool testMode;
 
-        public AssemblyHelper(string moduleRootFolder, IEnumerable<string> additionalResolutionPaths)
+        public AssemblyHelper(string moduleRootFolder, IEnumerable<string> additionalResolutionPaths, bool testMode = false)
         {
             if (additionalResolutionPaths == null)
                 additionalResolutionPaths = new List<string>();
 
             this.moduleRootFolder = moduleRootFolder;
             this.additionalResolutionPaths = additionalResolutionPaths;
+            this.testMode = testMode;
         }
 
         /// <summary>
@@ -34,15 +36,20 @@ namespace Dynamo.Utilities
             try
             {
                 var targetAssemblyName = new AssemblyName(args.Name).Name + ".dll";
-                Console.WriteLine("trying to resolve");
-                Console.WriteLine(targetAssemblyName);
+
                 // First check the core path
                 string assemblyPath = Path.Combine(moduleRootFolder, targetAssemblyName);
-                Console.WriteLine("at");
-                Console.WriteLine(assemblyPath);
+                if (testMode)
+                {
+                    Console.WriteLine("trying to resolve " + targetAssemblyName + " at " + assemblyPath);
+                }
                 if (File.Exists(assemblyPath))
                 {
-                    Console.WriteLine("loading from "+assemblyPath);
+                    if (testMode)
+                    {
+                        Console.WriteLine("loading from " + assemblyPath);
+
+                    }
                     return Assembly.LoadFrom(assemblyPath);
                 }
 
@@ -50,13 +57,17 @@ namespace Dynamo.Utilities
                 foreach (var resolutionPath in additionalResolutionPaths)
                 {
                     assemblyPath = Path.Combine(resolutionPath, targetAssemblyName);
-                    Console.WriteLine("trying to resolve");
-                    Console.WriteLine(targetAssemblyName);
-                    Console.WriteLine("at");
-                    Console.WriteLine(assemblyPath);
+                    if (testMode)
+                    {
+                        Console.WriteLine("trying to resolve " + targetAssemblyName + " at " + assemblyPath);
+                    }
+
                     if (File.Exists(assemblyPath))
                     {
-                        Console.WriteLine("loading from " + assemblyPath);
+                        if (testMode)
+                        {
+                            Console.WriteLine("loading from " + assemblyPath);
+                        }
                         return Assembly.LoadFrom(assemblyPath);
                     }
                 }
@@ -70,7 +81,7 @@ namespace Dynamo.Utilities
             }
         }
 
-        public static Version GetDynamoVersion(bool includeRevisionNumber=true)
+        public static Version GetDynamoVersion(bool includeRevisionNumber = true)
         {
             var assembly = Assembly.GetCallingAssembly();
             var version = assembly.GetName().Version;

--- a/test/Libraries/CoreNodesTests/Setup.cs
+++ b/test/Libraries/CoreNodesTests/Setup.cs
@@ -24,7 +24,7 @@ namespace DSCoreNodesTests
                 Path.Combine(moduleRootFolder, "nodes")
             };
 
-            assemblyHelper = new AssemblyHelper(moduleRootFolder, resolutionPaths);
+            assemblyHelper = new AssemblyHelper(moduleRootFolder, resolutionPaths,true);
             AppDomain.CurrentDomain.AssemblyResolve += assemblyHelper.ResolveAssembly;
         }
 


### PR DESCRIPTION

### Purpose

https://jira.autodesk.com/browse/QNTM-2836

some tests were failing because when nunit runs tests from command line it seems we fallback to handling assemblyResolve and then we load the assembly using LoadFrom - this loads the assembly into the `LoadFrom` context where it cannot be found using `Type.GetType()` - during json deserialization the first thing we do is look for the node type using `Type.GetType()` - this only seems to be a problem during tests as during local gui testing or running from dynamo these dlls already seem loaded without needing to be handled via assembly resolve and LoadFrom - 

This PR adds a workaround during testing where all assemblies are inspected for the required types.

This PR might fix other JSON tests as well that are failing because of dummy nodes.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@smangarole 