### PR TITLE
Readonly tab updates when graph modified

### DIFF
--- a/src/DynamoCore/Graph/Nodes/DummyNode.cs
+++ b/src/DynamoCore/Graph/Nodes/DummyNode.cs
@@ -151,42 +151,51 @@ namespace Dynamo.Graph.Nodes
             if (nodeElement.ChildNodes != null)
             {
                 foreach (XmlNode childNode in nodeElement.ChildNodes)
-                    if (childNode.Name.Equals("OriginalNodeContent"))
-                        OriginalNodeContent = (XmlElement)nodeElement.FirstChild.FirstChild;
-            }
-
-            if (originalElement != null)
-            {
-                var legacyFullName = originalElement.Attributes["type"];
-                if (legacyFullName != null)
-                    LegacyFullName = legacyFullName.Value;
-            }
-            else if (nodeElement.Attributes["OriginalNodeContent"] != null)
-            {
-                //we have some json, so lets parse it.
-                var jsonObject = JObject.Parse(nodeElement.Attributes["OriginalNodeContent"].Value);
-                if (jsonObject != null)
                 {
-                    this.OriginalNodeContent = jsonObject;
+                    if (childNode.Name.Equals("OriginalNodeContent"))
+                    {
+                        OriginalNodeContent = (XmlElement)nodeElement.FirstChild.FirstChild;
+                        //if it still is null then use the element directly
+                        if (OriginalNodeContent == null)
+                        {
+                            OriginalNodeContent = childNode.FirstChild;
+                        }
+                    }
                 }
             }
 
+                if (originalElement != null)
+                {
+                    var legacyFullName = originalElement.Attributes["type"];
+                    if (legacyFullName != null)
+                        LegacyFullName = legacyFullName.Value;
+                }
+                else if (nodeElement.Attributes["OriginalNodeContent"] != null)
+                {
+                    //we have some json, so lets parse it.
+                    var jsonObject = JObject.Parse(nodeElement.Attributes["OriginalNodeContent"].Value);
+                    if (jsonObject != null)
+                    {
+                        this.OriginalNodeContent = jsonObject;
+                    }
+                }
 
 
-            var legacyAsm = nodeElement.Attributes["legacyAssembly"];
-            if (legacyAsm != null)
-                LegacyAssembly = legacyAsm.Value;
 
-            var nodeNature = nodeElement.Attributes["nodeNature"];
-            if (nodeNature != null)
-            {
-                var nature = Enum.Parse(typeof(Nature), nodeNature.Value);
-                NodeNature = ((Nature)nature);
+                var legacyAsm = nodeElement.Attributes["legacyAssembly"];
+                if (legacyAsm != null)
+                    LegacyAssembly = legacyAsm.Value;
+
+                var nodeNature = nodeElement.Attributes["nodeNature"];
+                if (nodeNature != null)
+                {
+                    var nature = Enum.Parse(typeof(Nature), nodeNature.Value);
+                    NodeNature = ((Nature)nature);
+                }
+
+
+                UpdatePorts();
             }
-
-
-            UpdatePorts();
-        }
 
         private void UpdatePorts()
         {

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -844,7 +844,6 @@ namespace Dynamo.Graph.Workspaces
             SetModelEventOnAnnotation();
             WorkspaceEvents.WorkspaceAdded += computeUpstreamNodesWhenWorkspaceAdded;
         }
-
         /// <summary>
         /// Computes the upstream nodes when workspace is added. when a workspace is added (assuming that
         /// all the nodes and its connectors were added successfully) compute the upstream cache for all

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -396,28 +396,33 @@ namespace Dynamo.Controls
         }
     }
 
-    public class WorkspaceToFileNameConverter : IValueConverter
+    /// <summary>
+    /// A converter that combines readonly state and filename into string to display on workspace tabs.
+    /// </summary>
+    public class ReadOnlyToFileNameConverter : IMultiValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
+            bool readOnly = (bool)values[0];
+            string filename = (string)values[1];
 
-            var wsvm = value as WorkspaceViewModel;
-            if (wsvm != null && !string.IsNullOrEmpty(wsvm.FileName))
+            if (values[0] != null && !string.IsNullOrEmpty(filename))
             {
                 // Convert to path, get file name. If read-only file, append [Read-Only].
-                if (wsvm.Model.IsReadOnly)
-                    return Resources.TabFileNameReadOnlyPrefix + Path.GetFileName(wsvm.FileName);
+                if (readOnly)
+                    return Resources.TabFileNameReadOnlyPrefix + Path.GetFileName(filename);
                 else
-                    return Path.GetFileName(wsvm.FileName);
+                    return Path.GetFileName(filename);
             }
 
             return "Unsaved";
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
             return null;
         }
+
     }
 
     public class PathToSaveStateConverter : IValueConverter

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -84,7 +84,7 @@
     <controls:PortNameConverter x:Key="PortNameConverter" />
     <controls:NodeSearchElementVMToBoolConverter x:Key="NodeSearchElementVMToBoolConverter" />
     <controls:FilePathDisplayConverter x:Key="FilePathDisplayConverter" />
-    <controls:WorkspaceToFileNameConverter x:Key="WorkspaceToFileNameConverter" />
+    <controls:ReadOnlyToFileNameConverter x:Key="ReadOnlyToFileNameConverter" />
     <controls:PathToSaveStateConverter x:Key="PathToSaveStateConverter" />
     <controls:InverseBooleanConverter x:Key="InverseBooleanConverter" />
     <controls:ShowHideConsoleMenuItemConverter x:Key="ShowHideConsoleMenuConverter" />

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -318,6 +318,15 @@ namespace Dynamo.ViewModels
             get { return Model.FileName; }
         }
 
+        /// <summary>
+        /// Is the workspaceModel set as readonly or is the filePath readonly?
+        /// </summary>
+        [JsonIgnore]
+        public bool IsReadOnly
+        {
+            get { return Model.IsReadOnly; }
+        }
+
         [JsonIgnore]
         public bool CanEditName
         {
@@ -677,6 +686,10 @@ namespace Dynamo.ViewModels
             //unsub the events we attached below in NodeAdded.
             this.unsubscribeNodeEvents(nodeViewModel);
             nodeViewModel.Dispose();
+            if (node is DummyNode)
+            {
+                RaisePropertyChanged("IsReadOnly");
+            }
 
             PostNodeChangeActions();
         }
@@ -689,6 +702,10 @@ namespace Dynamo.ViewModels
             _nodes.Add(nodeViewModel);
             Errors.Add(nodeViewModel.ErrorBubble);
             nodeViewModel.UpdateBubbleContent();
+            if (node is DummyNode)
+            {
+                RaisePropertyChanged("IsReadOnly");
+            }
 
             PostNodeChangeActions();
         }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1134,9 +1134,14 @@
                                                                     </DataTrigger>
                                                                     <DataTrigger Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
                                                                                  Value="Saved">
-                                                                        <!--TODO find out what is up with this binding did it ever do anything?-->
-                                                                        <Setter Property="Header"
-                                                                                Value="{Binding Converter={StaticResource WorkspaceToFileNameConverter}}" />
+                                                                        <Setter Property="Header">
+                                                                            <Setter.Value>
+                                                                                <MultiBinding Converter="{StaticResource ReadOnlyToFileNameConverter}">
+                                                                                    <Binding Path="IsReadOnly"></Binding>
+                                                                                    <Binding Path="FileName"></Binding>
+                                                                                </MultiBinding>
+                                                                            </Setter.Value>
+                                                                        </Setter>
                                                                     </DataTrigger>
 
                                                                     <DataTrigger Binding="{Binding HasUnsavedChanges}"
@@ -1390,8 +1395,14 @@
                                                             <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
                                                                        Value="Saved" />
                                                         </MultiDataTrigger.Conditions>
-                                                        <Setter Property="Text"
-                                                                Value="{Binding Converter={StaticResource WorkspaceToFileNameConverter}}" />
+                                                        <Setter Property="Text">
+                                                            <Setter.Value>
+                                                                <MultiBinding Converter="{StaticResource ReadOnlyToFileNameConverter}">
+                                                                    <Binding Path="IsReadOnly"></Binding>
+                                                                    <Binding Path="FileName"></Binding>
+                                                                </MultiBinding>
+                                                            </Setter.Value>
+                                                        </Setter>
                                                     </MultiDataTrigger>
 
                                                     <MultiDataTrigger>
@@ -1412,8 +1423,14 @@
                                                             <Condition Binding="{Binding Path=FileName, Converter={StaticResource PathToSaveStateConverter}}"
                                                                        Value="Saved" />
                                                         </MultiDataTrigger.Conditions>
-                                                        <Setter Property="Text"
-                                                                Value="{Binding Converter={StaticResource WorkspaceToFileNameConverter}}" />
+                                                        <Setter Property="Text">
+                                                            <Setter.Value>
+                                                                <MultiBinding Converter="{StaticResource ReadOnlyToFileNameConverter}">
+                                                                    <Binding Path="IsReadOnly"></Binding>
+                                                                    <Binding Path="FileName"></Binding>
+                                                                </MultiBinding>
+                                                            </Setter.Value>
+                                                        </Setter>
                                                     </MultiDataTrigger>
 
                                                 </Style.Triggers>

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -29,8 +29,8 @@ namespace Dynamo.Tests
             // file exists  
 
             var dynamoModel = ViewModel.Model;
-            Assert.IsNotNull( dynamoModel.CurrentWorkspace );
-            Assert.IsAssignableFrom( typeof(HomeWorkspaceModel), dynamoModel.CurrentWorkspace );
+            Assert.IsNotNull(dynamoModel.CurrentWorkspace);
+            Assert.IsAssignableFrom(typeof(HomeWorkspaceModel), dynamoModel.CurrentWorkspace);
 
             var newPath = GetNewFileNameOnTempPath("dyn");
             dynamoModel.CurrentWorkspace.Save(newPath);
@@ -80,7 +80,7 @@ namespace Dynamo.Tests
             var catName = "Custom Nodes";
 
             var ws = dynamoModel.CustomNodeManager.CreateCustomNode(nodeName, catName, "");
-                
+
             var newPath = GetNewFileNameOnTempPath("dyf");
             dynamoModel.CurrentWorkspace.Save(newPath);
 
@@ -135,7 +135,7 @@ namespace Dynamo.Tests
             var examplePath = Path.Combine(TestDirectory, @"core\math", "Add.dyn");
             ViewModel.OpenCommand.Execute(examplePath);
 
-            Assert.Throws<ArgumentNullException>(()=> model.CurrentWorkspace.Save(""));
+            Assert.Throws<ArgumentNullException>(() => model.CurrentWorkspace.Save(""));
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace Dynamo.Tests
 
             var def = dynamoModel.CustomNodeManager.CreateCustomNode(nodeName, catName, "");
 
-            Assert.Throws<ArgumentNullException>(()=>def.Save(null));
+            Assert.Throws<ArgumentNullException>(() => def.Save(null));
         }
 
         [Test]
@@ -166,7 +166,7 @@ namespace Dynamo.Tests
             Assert.IsNotNull(dynamoModel.CurrentWorkspace);
             Assert.IsAssignableFrom(typeof(HomeWorkspaceModel), dynamoModel.CurrentWorkspace);
 
-            Assert.Throws<ArgumentNullException>(()=>ViewModel.Model.CurrentWorkspace.Save(ViewModel.Model.CurrentWorkspace.FileName));
+            Assert.Throws<ArgumentNullException>(() => ViewModel.Model.CurrentWorkspace.Save(ViewModel.Model.CurrentWorkspace.FileName));
         }
 
         [Test]
@@ -182,7 +182,7 @@ namespace Dynamo.Tests
 
             var def = dynamoModel.CustomNodeManager.CreateCustomNode(nodeName, catName, "");
 
-            Assert.Throws<ArgumentNullException>(()=>def.Save(def.FileName));
+            Assert.Throws<ArgumentNullException>(() => def.Save(def.FileName));
         }
 
         [Test]
@@ -223,7 +223,7 @@ namespace Dynamo.Tests
 
             Assert.IsTrue(File.Exists(newPath));
 
-            Assert.AreEqual(newPath, def.FileName );
+            Assert.AreEqual(newPath, def.FileName);
         }
 
         [Test]
@@ -424,7 +424,7 @@ namespace Dynamo.Tests
             string openPath = Path.Combine(TestDirectory, (@"UI\GroupTest.dyn"));
             var eventCount = 0;
 
-            var handler = new WorkspaceSaveEventHandler((o,e) => { eventCount = eventCount + 1; });
+            var handler = new WorkspaceSaveEventHandler((o, e) => { eventCount = eventCount + 1; });
             //attach handler to the save request
             ViewModel.RequestUserSaveWorkflow += handler;
             //send the command
@@ -434,7 +434,7 @@ namespace Dynamo.Tests
             ViewModel.RequestUserSaveWorkflow -= handler;
 
             //assert the request was made
-            Assert.AreEqual(1,eventCount);
+            Assert.AreEqual(1, eventCount);
         }
 
         [Test]
@@ -468,7 +468,7 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void EnsureOnOpenIfSaveCommandOpensDynFile()
         {
-            
+
             //openPath
             string openPath = Path.Combine(TestDirectory, (@"UI\GroupTest.dyn"));
             //send the command
@@ -548,8 +548,8 @@ namespace Dynamo.Tests
             var node = new DSFunction(dynamoModel.LibraryServices.GetFunctionDescriptor("+"));
             def.AddAndRegisterNode(node, false);
             Assert.IsTrue(def.HasUnsavedChanges);
-            Assert.AreEqual(1, def.Nodes.Count() );
-            
+            Assert.AreEqual(1, def.Nodes.Count());
+
             var newPath = GetNewFileNameOnTempPath("dyf");
             def.Save(newPath);
 
@@ -568,7 +568,7 @@ namespace Dynamo.Tests
 
             //try saving this graph
             var newPath = GetNewFileNameOnTempPath("dyn");
-            Assert.DoesNotThrow(()=> { this.ViewModel.SaveAs(newPath); }) ;
+            Assert.DoesNotThrow(() => { this.ViewModel.SaveAs(newPath); });
 
             //try to open the file we just saved.
             Assert.DoesNotThrow(() => { ViewModel.OpenCommand.Execute(newPath); });
@@ -582,15 +582,17 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
-        public void WorkspaceToFileNameConverterTest()
+        public void ReadonlyToFileNameConverterTest()
         {
             //openPath
             var testFileWithMultipleXmlDummyNode = @"core\dummy_node\dummyNodeXMLMultiple.dyn";
             string openPath = Path.Combine(TestDirectory, testFileWithMultipleXmlDummyNode);
             ViewModel.OpenCommand.Execute(openPath);
 
-            var converter = new WorkspaceToFileNameConverter();
-            var result = converter.Convert(ViewModel.CurrentSpaceViewModel, null, null, null);
+            var converter = new ReadOnlyToFileNameConverter();
+            var result = converter.Convert(new object[] { ViewModel.CurrentSpaceViewModel.Model.IsReadOnly,
+                ViewModel.CurrentSpaceViewModel.FileName }
+                , null, null, null);
             //assert the filename is correct for readonly workspace
             Assert.IsTrue(ViewModel.CurrentSpaceViewModel.Model.IsReadOnly);
             Assert.AreEqual(Resources.TabFileNameReadOnlyPrefix + Path.GetFileName(ViewModel.CurrentSpaceViewModel.FileName), result);
@@ -603,7 +605,9 @@ namespace Dynamo.Tests
             Assert.DoesNotThrow(() => { ViewModel.OpenCommand.Execute(newPath); });
 
             //assert that we no longer have a readonly filename
-            result = converter.Convert(ViewModel.CurrentSpaceViewModel, null, null, null);
+            result = converter.Convert(new object[] { ViewModel.CurrentSpaceViewModel.Model.IsReadOnly,
+                ViewModel.CurrentSpaceViewModel.FileName }
+                , null, null, null);
             //assert the filename is correct for readonly workspace
             Assert.False(ViewModel.CurrentSpaceViewModel.Model.IsReadOnly);
             Assert.AreEqual(Path.GetFileName(ViewModel.CurrentSpaceViewModel.FileName), result);
@@ -692,7 +696,7 @@ namespace Dynamo.Tests
 
             var nodeWorkspace =
                 model.Workspaces.OfType<CustomNodeWorkspaceModel>().FirstOrDefault();
-            
+
             Assert.IsNotNull(nodeWorkspace);
             var oldId = nodeWorkspace.CustomNodeDefinition.FunctionId;
 
@@ -860,7 +864,7 @@ namespace Dynamo.Tests
                     .ToList();
             Assert.AreEqual(10, funcs.Count);
             funcs.ForEach(x => Assert.AreEqual(newName, x.Name));
-            
+
         }
 
         [Test]
@@ -878,7 +882,7 @@ namespace Dynamo.Tests
 
             CustomNodeWorkspaceModel nodeWorkspace;
             Assert.IsTrue(model.CustomNodeManager.TryGetFunctionWorkspace(oldId, true, out nodeWorkspace));
-            
+
             var newPath = GetNewFileNameOnTempPath("dyf");
             var originalNumElements = ViewModel.Model.SearchModel.NumElements;
 
@@ -996,8 +1000,8 @@ namespace Dynamo.Tests
                 listGuids.Add(newId);
                 listNames.Add(newName);
 
-                listGuids.ForEach( x => Assert.IsTrue( ViewModel.Model.CustomNodeManager.NodeInfos.ContainsKey(x) ));
-                listNames.ForEach( x => Assert.IsTrue( ViewModel.Model.CustomNodeManager.Contains(x) ));
+                listGuids.ForEach(x => Assert.IsTrue(ViewModel.Model.CustomNodeManager.NodeInfos.ContainsKey(x)));
+                listNames.ForEach(x => Assert.IsTrue(ViewModel.Model.CustomNodeManager.Contains(x)));
             }
         }
 
@@ -1019,7 +1023,7 @@ namespace Dynamo.Tests
 
                 Assert.AreEqual(connectorCount, workspace.Connectors.Count());
                 Assert.AreEqual(nodeCount, workspace.Nodes.Count());
-            } 
+            }
         }
 
         [Test]
@@ -1076,7 +1080,7 @@ namespace Dynamo.Tests
             var def = dynamoModel.CustomNodeManager.CreateCustomNode(nodeName, catName, "");
 
             var tempPath1 = Path.Combine(TempFolder, nodeName + ".dyf");
-            
+
             // Create the folder first incase it does not exist
             Directory.CreateDirectory(Path.Combine(TempFolder, nodeName, nodeName));
             var tempPath2 = Path.Combine(TempFolder, nodeName, nodeName + ".dyf");


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/QNTM-2503

* fixed a bug in undo/redo deletion of dummy nodes, not retain their original content (might need to be validated) but it atleast detects the content as XML which is good enough to trigger readonly.
* change binding to readonly
* use mutltibinding to readonly and filename changes
* rename converter
* when nodes removed or added raise readonly property change so binding checks readonly state again.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 


### FYIs

