### PR TITLE
Undo redo connection failure

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -264,12 +264,6 @@ namespace Dynamo.Graph.Nodes
                 this.OnRequestSilenceModifiedEvents(true);
 
                 //Save the connectors so that we can recreate them at the correct positions.
-                //before the refactor here: https://github.com/DynamoDS/Dynamo/pull/7301
-                //we didn't actually make new portModels we just updated them, 
-                //but after this PR we remove the data property of ports,
-                //so now new models are created instead,
-                //so we have to delete and create new connectors to go along with those ports.
-
                 SaveAndDeleteConnectors(inportConnections, outportConnections);
 
                 code = newCode;
@@ -385,6 +379,12 @@ namespace Dynamo.Graph.Nodes
 
             var inportConnections = new OrderedDictionary();
             var outportConnections = new OrderedDictionary();
+
+            //before the refactor here: https://github.com/DynamoDS/Dynamo/pull/7301
+            //we didn't actually make new portModels we just updated them, 
+            //but after this PR we remove the data property of ports,
+            //so now new models are created instead,
+            //so we have to delete and create new connectors to go along with those ports.
             SaveAndDeleteConnectors(inportConnections, outportConnections);
 
             var childNodes = nodeElement.ChildNodes.Cast<XmlElement>().ToList();

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -377,6 +377,10 @@ namespace Dynamo.Graph.Nodes
             shouldFocus = helper.ReadBoolean("ShouldFocus");
             code = helper.ReadString("CodeText");
 
+            var inportConnections = new OrderedDictionary();
+            var outportConnections = new OrderedDictionary();
+            SaveAndDeleteConnectors(inportConnections, outportConnections);
+
             var childNodes = nodeElement.ChildNodes.Cast<XmlElement>().ToList();
             var inputPortHelpers =
                 childNodes.Where(node => node.Name.Equals("PortInfo")).Select(x => new XmlElementHelper(x));
@@ -403,6 +407,8 @@ namespace Dynamo.Graph.Nodes
             }
 
             ProcessCodeDirect();
+            //Recreate connectors that can be reused
+            LoadAndCreateConnectors(inportConnections, outportConnections);
         }
 
         internal override IEnumerable<AssociativeNode> BuildAst(List<AssociativeNode> inputAstNodes, CompilationContext context)

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -379,22 +379,22 @@ namespace Dynamo.Graph.Nodes
 
             var inportConnections = new OrderedDictionary();
             var outportConnections = new OrderedDictionary();
-            SaveAndDeleteConnectors(inportConnections, outportConnections);
+           // SaveAndDeleteConnectors(inportConnections, outportConnections);
 
             var childNodes = nodeElement.ChildNodes.Cast<XmlElement>().ToList();
             var inputPortHelpers =
                 childNodes.Where(node => node.Name.Equals("PortInfo")).Select(x => new XmlElementHelper(x));
 
+
+            //set the input ports and outputPorts incase this node is in an error state after processing code.
             // read and set input port info
             inputPortNames =
                 inputPortHelpers.Select(x => x.ReadString("name", String.Empty))
                     .Where(y => !string.IsNullOrEmpty(y))
                     .ToList();
-            //TODO these ports are immediately replaced by process code, any reason to keep?
             SetInputPorts();
 
-            //TODO these ports are immediately replaced by process code, any reason to keep?
-            // read and set ouput port info
+           
             var outputPortHelpers =
                 childNodes.Where(node => node.Name.Equals("OutPortInfo")).Select(x => new XmlElementHelper(x));
             var lineNumbers = outputPortHelpers.Select(x => x.ReadInteger("LineIndex")).ToList();
@@ -410,7 +410,7 @@ namespace Dynamo.Graph.Nodes
 
             ProcessCodeDirect();
             //Recreate connectors that can be reused
-            LoadAndCreateConnectors(inportConnections, outportConnections);
+          //  LoadAndCreateConnectors(inportConnections, outportConnections);
         }
 
         internal override IEnumerable<AssociativeNode> BuildAst(List<AssociativeNode> inputAstNodes, CompilationContext context)
@@ -792,8 +792,8 @@ namespace Dynamo.Graph.Nodes
 
         private void SetInputPorts()
         {
-            //Clear out all the input port models
-            InPorts.Clear();
+
+            InPorts.RemoveAll((p) => { return true; });
 
             // Generate input port data list from the unbound identifiers.
             var inportData = CodeBlockUtils.GenerateInputPortData(inputPortNames);
@@ -809,7 +809,7 @@ namespace Dynamo.Graph.Nodes
                 return;
             
             //Clear out all the output port models
-            OutPorts.Clear();
+            OutPorts.RemoveAll((p) => { return true; });
 
             foreach (var def in allDefs)
             {

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -263,7 +263,13 @@ namespace Dynamo.Graph.Nodes
                 // disable node modification evnets while mutating the code
                 this.OnRequestSilenceModifiedEvents(true);
 
-                //Save the connectors so that we can recreate them at the correct positions
+                //Save the connectors so that we can recreate them at the correct positions.
+                //before the refactor here: https://github.com/DynamoDS/Dynamo/pull/7301
+                //we didn't actually make new portModels we just updated them, 
+                //but after this PR we remove the data property of ports,
+                //so now new models are created instead,
+                //so we have to delete and create new connectors to go along with those ports.
+
                 SaveAndDeleteConnectors(inportConnections, outportConnections);
 
                 code = newCode;
@@ -792,8 +798,12 @@ namespace Dynamo.Graph.Nodes
 
         private void SetInputPorts()
         {
+            //this extension method is used instead because 
+            //observableCollection has very odd behavior when cleared - 
+            //there is no way to reference the cleared items and so they 
+            //cannot be cleaned up properly
 
-            InPorts.RemoveAll((p) => { return true; });
+           InPorts.RemoveAll((p) => { return true; });
 
             // Generate input port data list from the unbound identifiers.
             var inportData = CodeBlockUtils.GenerateInputPortData(inputPortNames);
@@ -807,7 +817,11 @@ namespace Dynamo.Graph.Nodes
 
             if (allDefs.Any() == false)
                 return;
-            
+
+            //this extension method is used instead because 
+            //observableCollection has very odd behavior when cleared - 
+            //there is no way to reference the cleared items and so they 
+            //cannot be cleaned up properly
             //Clear out all the output port models
             OutPorts.RemoveAll((p) => { return true; });
 

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -379,7 +379,7 @@ namespace Dynamo.Graph.Nodes
 
             var inportConnections = new OrderedDictionary();
             var outportConnections = new OrderedDictionary();
-           // SaveAndDeleteConnectors(inportConnections, outportConnections);
+            SaveAndDeleteConnectors(inportConnections, outportConnections);
 
             var childNodes = nodeElement.ChildNodes.Cast<XmlElement>().ToList();
             var inputPortHelpers =
@@ -409,8 +409,8 @@ namespace Dynamo.Graph.Nodes
             }
 
             ProcessCodeDirect();
-            //Recreate connectors that can be reused
-          //  LoadAndCreateConnectors(inportConnections, outportConnections);
+             //Recreate connectors that can be reused
+             LoadAndCreateConnectors(inportConnections, outportConnections);
         }
 
         internal override IEnumerable<AssociativeNode> BuildAst(List<AssociativeNode> inputAstNodes, CompilationContext context)

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -390,8 +390,10 @@ namespace Dynamo.Graph.Nodes
                 inputPortHelpers.Select(x => x.ReadString("name", String.Empty))
                     .Where(y => !string.IsNullOrEmpty(y))
                     .ToList();
+            //TODO these ports are immediately replaced by process code, any reason to keep?
             SetInputPorts();
 
+            //TODO these ports are immediately replaced by process code, any reason to keep?
             // read and set ouput port info
             var outputPortHelpers =
                 childNodes.Where(node => node.Name.Equals("OutPortInfo")).Select(x => new XmlElementHelper(x));

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1039,6 +1039,21 @@ namespace Dynamo.Graph.Nodes
                         SetNodeStateBasedOnConnectionAndDefaults();
                     }
                     break;
+                    //also handle reset - this occurs when the collection is cleared.
+                case System.Collections.Specialized.NotifyCollectionChangedAction.Reset:
+                    if(e.OldItems != null)
+                    {
+                        foreach (PortModel p in e.OldItems)
+                        {
+                            p.PropertyChanged -= OnPortPropertyChanged;
+
+                            p.DestroyConnectors();
+
+                            SetNodeStateBasedOnConnectionAndDefaults();
+                        }
+                    }
+                   
+                    break;
             }
         }
 
@@ -1772,9 +1787,7 @@ namespace Dynamo.Graph.Nodes
 
         private void OnPortConnected(PortModel port, ConnectorModel connector)
         {
-            var handler = PortConnected;
-            if (null != handler) handler(port, connector);
-
+          
             if (port.PortType != PortType.Input) return;
 
             var data = InPorts.IndexOf(port);
@@ -1782,6 +1795,10 @@ namespace Dynamo.Graph.Nodes
             var outData = startPort.Owner.OutPorts.IndexOf(startPort);
             ConnectInput(data, outData, startPort.Owner);
             startPort.Owner.ConnectOutput(outData, data, this);
+
+            var handler = PortConnected;
+            if (null != handler) handler(port, connector);
+
             OnConnectorAdded(connector);
 
             OnNodeModified();

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1039,21 +1039,6 @@ namespace Dynamo.Graph.Nodes
                         SetNodeStateBasedOnConnectionAndDefaults();
                     }
                     break;
-                    //also handle reset - this occurs when the collection is cleared.
-                case System.Collections.Specialized.NotifyCollectionChangedAction.Reset:
-                    if(e.OldItems != null)
-                    {
-                        foreach (PortModel p in e.OldItems)
-                        {
-                            p.PropertyChanged -= OnPortPropertyChanged;
-
-                            p.DestroyConnectors();
-
-                            SetNodeStateBasedOnConnectionAndDefaults();
-                        }
-                    }
-                   
-                    break;
             }
         }
 

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -420,7 +420,7 @@ namespace DynamoCoreWpfTests
             Assert.Pass(); // We should reach here safely without exception.
         }
 
-        [Test, Category("DisplayHardwareDependent"), Category("Failure")]
+        [Test, Category("DisplayHardwareDependent")]
         public void WatchConnectDisconnectTest()
         {
             WatchIsEmptyWhenLoaded();
@@ -460,9 +460,9 @@ namespace DynamoCoreWpfTests
                 DynamoModel.MakeConnectionCommand.Mode.Begin));
             Model.ExecuteCommand(new DynamoModel.MakeConnectionCommand(watchGuid, 0, PortType.Input,
                 DynamoModel.MakeConnectionCommand.Mode.End));
-            
-            DispatcherUtil.DoEvents();
+
             Run();
+            DispatcherUtil.DoEvents();
             tree = nodeView.ChildrenOfType<WatchTree>();
             items = tree.First().treeView1.ChildrenOfType<TextBlock>();
             Assert.AreEqual(8, items.Count());


### PR DESCRIPTION
### Purpose

I found that this PR https://github.com/DynamoDS/Dynamo/pull/7301/ caused a few bugs.  (this PR is over a year old)
1. undoing anything on a codeblock causes ports to be destroyed and new ones created - this left any input connectors to the CBN in a bad state where they were pointing to orphan portModels.
2. The order of events being raised changed from the `nodeModel` base class when a port was connected - this left watch nodes in a bad state after ports were attached in manual run mode.

Both these bugs are fixed in this PR.

#### please note the question below about ids.

A test is added for 1. - now some info about the connections is saved before undo and they are recreated after - both the connectors and ports are actually new objects and so have new IDs. ❓ I am not sure what is the correct behavior here - it seems odd that the objects have new ids, but they are in fact new objects.... I have added a check to the test but left it commented it out for now - @QilongTang looking for feedback on this.

**I will send another PR about the potential refactor of save, load, deserializeCore, and serializeCore** since it turns out that this bug does not really have to do with JSON but `inportData` refactor instead.


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
@ramramps 
### FYIs

@smangarole 