### PR TITLE
File open improvement

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -670,11 +670,17 @@ namespace Dynamo.Core
                 nodeGraph.ElementResolver,
                 workspaceInfo);
             }
-            else if(DynamoUtilities.PathHelper.isValidJson(workspaceInfo.FileName, out jsonDoc))
-            {
-                //we pass null for engine and scheduler as apparently the custom node constructor doesnt need them.
-                newWorkspace = (CustomNodeWorkspaceModel)WorkspaceModel.FromJson(jsonDoc, this.libraryServices, null, null, nodeFactory, false, true, this);
-                newWorkspace.FileName = workspaceInfo.FileName;
+            else {
+                try
+                {
+                    if (DynamoUtilities.PathHelper.isValidJson(workspaceInfo.FileName, out jsonDoc))
+                    {
+                        //we pass null for engine and scheduler as apparently the custom node constructor doesnt need them.
+                        newWorkspace = (CustomNodeWorkspaceModel)WorkspaceModel.FromJson(jsonDoc, this.libraryServices, null, null, nodeFactory, false, true, this);
+                        newWorkspace.FileName = workspaceInfo.FileName;
+                    }
+                }
+                catch (Exception) { }
             }
 
             RegisterCustomNodeWorkspace(newWorkspace);

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1393,20 +1393,32 @@ namespace Dynamo.Models
         public void OpenFileFromPath(string filePath, bool forceManualExecutionMode = false)
         {
             XmlDocument xmlDoc;
-            if (DynamoUtilities.PathHelper.isValidXML(filePath, out xmlDoc))
+            try
             {
-                OpenXmlFileFromPath(xmlDoc, filePath, forceManualExecutionMode);
-                return;
+                if (DynamoUtilities.PathHelper.isValidXML(filePath, out xmlDoc))
+                {
+                    OpenXmlFileFromPath(xmlDoc, filePath, forceManualExecutionMode);
+                    return;
+                }
+            }
+            catch(Exception ex) {
+                Logger.LogError("Could not open workspace at: " + filePath);
+                throw ex;
             }
 
             string fileContents;
-            if (DynamoUtilities.PathHelper.isValidJson(filePath, out fileContents))
+            try
             {
-                OpenJsonFileFromPath(fileContents, filePath, forceManualExecutionMode);
-                return;
+                if (DynamoUtilities.PathHelper.isValidJson(filePath, out fileContents))
+                {
+                    OpenJsonFileFromPath(fileContents, filePath, forceManualExecutionMode);
+                    return;
+                }
             }
-
-            Logger.LogError("Could not open workspace at: " + filePath);
+            catch(Exception ex) {
+                Logger.LogError("Could not open workspace at: " + filePath);
+                throw ex;
+            }
         }
 
         static private DynamoPreferencesData DynamoPreferencesDataFromJson(string json)

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1421,7 +1421,8 @@ namespace Dynamo.Models
                     }
                     catch (Exception e)
                     {
-                        // When Json opening also failed, this file is corrupted for sure
+                        // When Json opening also failed, either this file is corrupted or there
+                        // are other kind of failures related to Json de-serialization
                         throw e;
                     }
                 }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1253,7 +1253,7 @@ namespace Dynamo.ViewModels
                     {
                         errorMsgString = String.Format(e.Message, filePath);
                     }
-                    else if (e is System.Xml.XmlException)
+                    else if (e is System.Xml.XmlException || e is Newtonsoft.Json.JsonReaderException)
                     {
                         errorMsgString = String.Format(Resources.MessageFailedToOpenCorruptedFile, filePath);
                     }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1114,11 +1114,15 @@ namespace Dynamo.ViewModels
 
                 // For Json Workspaces, workspace view info need to be read agin from file
                 string fileContents;
-                if (DynamoUtilities.PathHelper.isValidJson(newVm.Model.FileName, out fileContents))
-                {
-                    ExtraWorkspaceViewInfo viewInfo = WorkspaceViewModel.ExtraWorkspaceViewInfoFromJson(fileContents);
-                    newVm.Model.UpdateWithExtraWorkspaceViewInfo(viewInfo);
+
+                try {
+                    if (DynamoUtilities.PathHelper.isValidJson(newVm.Model.FileName, out fileContents))
+                    {
+                        ExtraWorkspaceViewInfo viewInfo = WorkspaceViewModel.ExtraWorkspaceViewInfoFromJson(fileContents);
+                        newVm.Model.UpdateWithExtraWorkspaceViewInfo(viewInfo);
+                    }
                 }
+                catch (Exception) { }
                 workspaces.Add(newVm);
             }
         }

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -96,7 +96,7 @@ namespace DynamoUtilities
         /// </summary>
         /// <param name="path">path to the target xml file</param>
         /// <param name="xmlDoc">System.Xml.XmlDocument repensentation of target xml file</param>
-        /// <returns></returns>
+        /// <returns>Return true if file is XML, exception if not</returns>
         public static bool isValidXML(string path, out XmlDocument xmlDoc)
         {
             // Based on https://msdn.microsoft.com/en-us/library/875kz807(v=vs.110).aspx
@@ -119,7 +119,7 @@ namespace DynamoUtilities
         /// </summary>
         /// <param name="path">path to the target json file</param>
         /// <param name="fileContents"> string contents of target json file</param>
-        /// <returns></returns>
+        /// <returns>Return true if file is Json, exception if not</returns>
         public static bool isValidJson(string path, out string fileContents)
         {
             fileContents = "";
@@ -133,18 +133,18 @@ namespace DynamoUtilities
                     var obj = Newtonsoft.Json.Linq.JToken.Parse(fileContents);
                     return true;
                 }
-                return false;
+                throw new JsonReaderException();
             }
             catch (JsonReaderException jex)
             {
                 //Exception in parsing Json
                 Console.WriteLine(jex.Message);
-                return false;
+                throw jex;
             }
             catch (Exception ex) //some other exception
             {
                 Console.WriteLine(ex.ToString());
-                return false;
+                throw ex;
             }
         }
     }

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -107,10 +107,10 @@ namespace DynamoUtilities
                 xmlDoc.Load(path);
                 return true;
             }
-            catch
+            catch(Exception ex)
             {
                 xmlDoc = null;
-                return false;
+                throw ex;
             }
         }
 

--- a/test/DynamoCoreTests/CoreDynTests.cs
+++ b/test/DynamoCoreTests/CoreDynTests.cs
@@ -400,7 +400,7 @@ namespace Dynamo.Tests
             }
             catch (System.Exception e)
             {
-                Assert.IsTrue(e is System.Xml.XmlException);
+                Assert.IsTrue(e is System.Xml.XmlException || e is Newtonsoft.Json.JsonReaderException);
             }
         }
 


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[QNTM-2673](https://jira.autodesk.com/browse/QNTM-2673) Non-existent entry in Recent Files list does not pop up a message.

This is a regression that during the Dynamo 2.0 Json serialization and de-serialization work, we no longer throw exceptions from `DynamoModel.OpenFileFromPath()`. I am re-enabling this behavior from this PR so that DynamoViewModel can catch and display the corresponding message.  
Notice that now 
1. Corrupted XML and corrupted Json should all be recognized.
example image for corrupted Json:
![image](https://user-images.githubusercontent.com/3942418/35297134-1d45f3dc-004c-11e8-8f84-239004e7f157.png)

2. Un-exist file should be recognized
![image](https://user-images.githubusercontent.com/3942418/35297681-c3c77e78-004d-11e8-81b0-e12a13b8b26a.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ColinDayOrg  

### FYIs

@jnealb @ramramps @mjkkirschner @alfarok 