### PR TITLE
Keep Dictionary keys sorted, code modernization

### DIFF
--- a/src/Libraries/Builtin/Dictionary.cs
+++ b/src/Libraries/Builtin/Dictionary.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using Autodesk.DesignScript.Runtime;
+﻿using Autodesk.DesignScript.Runtime;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -10,11 +9,11 @@ namespace DesignScript
     {
         public class Dictionary
         {
-            private readonly ImmutableDictionary<string, object> D;
+            private readonly ImmutableSortedDictionary<string, object> D;
 
-            private Dictionary(ImmutableDictionary<string, object> dict)
+            private Dictionary(ImmutableSortedDictionary<string, object> dict)
             {
-                this.D = dict;
+                D = dict;
             }
 
             /// <summary>
@@ -28,12 +27,9 @@ namespace DesignScript
             public static Dictionary ByKeysValues(IList<string> keys,
                 [KeepReference] [ArbitraryDimensionArrayImport] IList<object> values)
             {
-                var pairs = keys.Cast<string>().Zip(values.Cast<object>(), (a, b) =>
-                {
-                    return new KeyValuePair<string, object>(a, b);
-                });
+                var pairs = keys.Zip(values, (a, b) => new KeyValuePair<string, object>(a, b));
 
-                return new Dictionary(ImmutableDictionary.Create<string, object>().AddRange(pairs));
+                return new Dictionary(ImmutableSortedDictionary.Create<string, object>().AddRange(pairs));
             }
 
             /// <summary>
@@ -41,7 +37,7 @@ namespace DesignScript
             /// </summary>
             /// <returns name="keys">The keys of the Dictionary</returns>
             /// <returns name="values">The values of the Dictionary</returns>
-            [MultiReturn(new[] {"keys", "values"})]
+            [MultiReturn("keys", "values")]
             public IDictionary<string, object> Components()
             {
                 return new Dictionary<string, object>
@@ -55,44 +51,32 @@ namespace DesignScript
             ///     Produces the keys in a Dictionary.
             /// </summary>
             /// <returns name="keys">The keys of the Dictionary</returns>
-            public IEnumerable<string> Keys
-            {
-                get { return D.Keys; }
-            }
+            public IEnumerable<string> Keys => D.Keys;
 
             /// <summary>
             ///     Produces the values in a Dictionary.
             /// </summary>
             /// <returns name="values">The values of the Dictionary</returns>
             [AllowRankReduction]
-            public IEnumerable<object> Values
-            {
-                get { return D.Values; }
-            }
+            public IEnumerable<object> Values => D.Values;
 
             /// <summary>
             ///     The number of key value pairs in a Dictionary.
             /// </summary>
-            public int Count
-            {
-                get { return D.Count; }
-            }
-            
+            public int Count => D.Count;
+
             /// <summary>
             ///     Produce a new Dictionary with a list of keys set to the new values, possibly overwriting existing key-value pairs. 
             ///     These two lists are expected to be of the same length. If not, the shorter of the two bounds the number of insertions.
             /// </summary>
-            /// <param name="key">The keys in the Dictionary to set. If the same key already exists, the value at that key will be modified.</param>
-            /// <param name="value">The corresponding values to insert.</param>
+            /// <param name="keys">The keys in the Dictionary to set. If the same key already exists, the value at that key will be modified.</param>
+            /// <param name="values">The corresponding values to insert.</param>
             /// <returns name="dictionary">A new Dictionary with the entries inserted.</returns>
             /// <search>insert,add</search>
             public Dictionary SetValueAtKeys(IList<string> keys,
                 [KeepReference] [ArbitraryDimensionArrayImport] IList<object> values)
             {
-                var pairs = keys.Cast<string>().Zip(values.Cast<object>(), (a, b) =>
-                {
-                    return new KeyValuePair<string, object>(a, b);
-                });
+                var pairs = keys.Zip(values, (a, b) => new KeyValuePair<string, object>(a, b));
 
                 return new Dictionary(D.SetItems(pairs));
             }
@@ -100,7 +84,7 @@ namespace DesignScript
             /// <summary>
             ///     Produce a new Dictionary with the given keys removed.
             /// </summary>
-            /// <param name="key">The key in the Dictionary to remove</param>
+            /// <param name="keys">The key in the Dictionary to remove</param>
             /// <returns name="dictionary">A new Dictionary with the key removed</returns>
             /// <search>drop,delete</search>
             public Dictionary RemoveKeys(IList<string> keys)


### PR DESCRIPTION
### Purpose

Previously, dictionary keys were returned in an undefined order. Now, they should be sorted lexically by key. This comes at near zero performance cost as internally `System.Collections.Immutable.Dictionary` already represent a dictionary as a balanced binary tree. The code changes are obviously minimal. 

### Effects

This _will not_ affect https://github.com/DynamoDS/Dynamo/pull/8487, which only applies to preview bubble _display_ of multi-return nodes. This PR only applies to display of `Dictionary`'s in all other contexts.

This _will_ affect the order in which `Dictionary.Keys` and `Dictionary.Values` are returned.

<img width="845" alt="screen shot 2018-01-24 at 3 16 03 pm" src="https://user-images.githubusercontent.com/916345/35354888-88750c6a-0119-11e8-9e23-a62b2d4f95ce.png">

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 

### FYIs

@Racel @kronz 