### PR TITLE
Keep connector ids on codeblock after undo...

### DIFF
--- a/src/DynamoCore/Core/UndoRedoRecorder.cs
+++ b/src/DynamoCore/Core/UndoRedoRecorder.cs
@@ -398,8 +398,12 @@ namespace Dynamo.Core
                         try
                         {
                             ModelBase toBeDeleted = undoClient.GetModelForElement(element);
-                            RecordActionInternal(newGroup, toBeDeleted, modelActionType);
-                            undoClient.DeleteModel(element);
+                            if (toBeDeleted != null)
+                            {
+
+                                RecordActionInternal(newGroup, toBeDeleted, modelActionType);
+                                undoClient.DeleteModel(element);
+                            }
                         }
                         catch (ArgumentException e)
                         {
@@ -420,8 +424,12 @@ namespace Dynamo.Core
 
                     case UserAction.Modification:
                         ModelBase toBeUpdated = undoClient.GetModelForElement(element);
-                        RecordActionInternal(newGroup, toBeUpdated, modelActionType);
-                        undoClient.ReloadModel(element);
+                        if (toBeUpdated != null)
+                        {
+
+                            RecordActionInternal(newGroup, toBeUpdated, modelActionType);
+                            undoClient.ReloadModel(element);
+                        }
                         break;
 
                     case UserAction.Deletion:
@@ -457,14 +465,21 @@ namespace Dynamo.Core
 
                     case UserAction.Modification:
                         ModelBase toBeUpdated = undoClient.GetModelForElement(element);
-                        RecordActionInternal(newGroup, toBeUpdated, modelActionType);
-                        undoClient.ReloadModel(element);
+                        if (toBeUpdated != null)
+                        {
+
+                            RecordActionInternal(newGroup, toBeUpdated, modelActionType);
+                            undoClient.ReloadModel(element);
+                        }
                         break;
 
                     case UserAction.Deletion:
                         ModelBase toBeDeleted = undoClient.GetModelForElement(element);
-                        RecordActionInternal(newGroup, toBeDeleted, modelActionType);
-                        undoClient.DeleteModel(element);
+                        if (toBeDeleted != null)
+                        {
+                            RecordActionInternal(newGroup, toBeDeleted, modelActionType);
+                            undoClient.DeleteModel(element);
+                        }
                         break;
                 }
             }

--- a/src/DynamoCore/Graph/ModelBase.cs
+++ b/src/DynamoCore/Graph/ModelBase.cs
@@ -13,7 +13,7 @@ namespace Dynamo.Graph
     /// <summary>
     /// SaveContext represents several contexts, in which node can be serialized/deserialized.
     /// </summary>
-    public enum SaveContext { File, Copy, Undo, Preset };
+    public enum SaveContext { File, Copy, Undo, Preset, None };
 
     /// <summary>
     /// This class encapsulates the input parameters that need to be passed into nodes

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -920,7 +920,7 @@ namespace Dynamo.Graph.Nodes
                                 this,
                                 startPortModel.Index,
                                 i);
-                            //during an undo operation we should set the old input connector
+                            //during an undo operation we should set the new input connector
                             //to have the same id as the old connector.
                             if(context == SaveContext.Undo)
                             {
@@ -954,7 +954,7 @@ namespace Dynamo.Graph.Nodes
                             var endPortModel = oldConnector.End;
                             NodeModel endNode = endPortModel.Owner;
                             var connector = ConnectorModel.Make(this, endNode, i, endPortModel.Index);
-                            //during an undo operation we should set the old input connector
+                            //during an undo operation we should set the new input connector
                             //to have the same id as the old connector.
                             if (context == SaveContext.Undo)
                             {

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -954,7 +954,7 @@ namespace Dynamo.Graph.Nodes
                             var endPortModel = oldConnector.End;
                             NodeModel endNode = endPortModel.Owner;
                             var connector = ConnectorModel.Make(this, endNode, i, endPortModel.Index);
-                            //during an undo operation we should set the new input connector
+                            //during an undo operation we should set the new output connector
                             //to have the same id as the old connector.
                             if (context == SaveContext.Undo)
                             {

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -401,7 +401,6 @@ namespace Dynamo.Graph.Workspaces
                     {
                         throw new InvalidOperationException("'guid' field missing from recorded model");
                     }
-                    undoRecorder.RecordModelAsOffTrack(Guid.Parse(guidAttribute.Value));
                 }
                 else
                 {

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -325,6 +325,11 @@ namespace Dynamo.Graph.Workspaces
             {
                 RemoveAndDisposeNode(model as NodeModel);
             }
+            else if(model == null)
+            {
+                return;
+            }
+            //some unknown type
             else
             {
                 // If it gets here we obviously need to handle it.
@@ -351,7 +356,10 @@ namespace Dynamo.Graph.Workspaces
         public void ReloadModel(XmlElement modelData)
         {
             ModelBase model = GetModelForElement(modelData);
-            model.Deserialize(modelData, SaveContext.Undo);
+            if(model != null)
+            {
+                model.Deserialize(modelData, SaveContext.Undo);
+            }
         }
 
         /// <summary>
@@ -479,9 +487,10 @@ namespace Dynamo.Graph.Workspaces
             ModelBase foundModel = GetModelInternal(modelGuid);
             if (null != foundModel)
                 return foundModel;
-
-            throw new ArgumentException(
-                string.Format("Unhandled model type: {0}", helper.ReadString("type", modelData.Name)));
+            
+            //if we could not find a matching model
+            this.Log(string.Format("Please Report: Unhandled model type: {0}, could not find a matching model with given id", helper.ReadString("type", modelData.Name)), Logging.WarningLevel.Error);
+            return null;
         }
 
         /// <summary>

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -367,11 +367,7 @@ namespace Dynamo.Graph.Workspaces
         public event Action<ConnectorModel> ConnectorDeleted;
         protected virtual void OnConnectorDeleted(ConnectorModel obj)
         {
-            if (hasNodeInSyncWithDefinition)
-            {
-                undoRecorder.RecordModelAsOffTrack(obj.GUID);
-            }
-
+           
             var handler = ConnectorDeleted;
             if (handler != null) handler(obj);
             //Check if the workspace is loaded, i.e all the nodes are

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -364,7 +364,14 @@ b = c[w][x][y][z];";
                 this.CurrentDynamoModel.CurrentWorkspace.Redo();
                 this.CurrentDynamoModel.CurrentWorkspace.Redo();
             });
-
+            
+            //undo deletion again
+            this.CurrentDynamoModel.CurrentWorkspace.Undo();
+            //get the new codeblock instance
+            codeBlockNode2 = CurrentDynamoModel.CurrentWorkspace.Nodes.Where(x => x.GUID == codeBlockNode2.GUID).FirstOrDefault() as CodeBlockNodeModel;
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
+            Assert.AreEqual(oldConnectorGuid, codeBlockNode2.InPorts[0].Connectors[0].GUID);
         }
 
         [Test]

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -17,6 +17,7 @@ using ProtoCore.Utils;
 
 using DynCmd = Dynamo.Models.DynamoModel;
 using Dynamo.Models;
+using Dynamo.Graph.Workspaces;
 
 namespace Dynamo.Tests
 {
@@ -296,10 +297,9 @@ b = c[w][x][y][z];";
             this.CurrentDynamoModel.CurrentWorkspace.Undo();
             Assert.AreEqual(oldPos, codeBlockNode2.X);
 
-            //TODO not sure this is required behavior...
             //assert that after undo the port and connector have the same GUIDs
             //Assert.AreEqual(oldinputPortGuid, codeBlockNode2.InPorts[0].GUID);
-            //Assert.AreEqual(oldConnectorGuid, codeBlockNode2.InPorts[0].Connectors[0].GUID);
+            Assert.AreEqual(oldConnectorGuid, codeBlockNode2.InPorts[0].Connectors[0].GUID);
 
 
             RunCurrentModel();
@@ -307,6 +307,63 @@ b = c[w][x][y][z];";
             Assert.IsTrue(codeBlockNode2.InPorts[0].Connectors.Count > 0);
             Assert.IsTrue(codeBlockNode1.OutPorts[0].Connectors.Count > 0);
             Assert.AreEqual(3, codeBlockNode2.CachedValue.Data);
+
+        }
+
+        [Test]
+        public void UndoRedoCodeBlockDeletionDoesNotCrash()
+        {
+            RunCurrentModel();
+            // Create the initial code block node.
+            var codeBlockNode1 = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(codeBlockNode1, "3;");
+
+            // Create the second code block node.
+            var codeBlockNode2 = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(codeBlockNode2, "x;");
+
+            //connect them
+            this.CurrentDynamoModel.ExecuteCommand(
+                new DynamoModel.MakeConnectionCommand(codeBlockNode1.GUID, 0, PortType.Output,
+             DynamoModel.MakeConnectionCommand.Mode.Begin));
+            this.CurrentDynamoModel.ExecuteCommand(
+                new DynamoModel.MakeConnectionCommand(codeBlockNode2.GUID, 0, PortType.Input,
+                DynamoModel.MakeConnectionCommand.Mode.End));
+            RunCurrentModel();
+
+            var oldConnectorGuid = codeBlockNode2.InPorts[0].Connectors[0].GUID;
+
+            //record the codeblock for undo - this is the issue as undoing this will deserialize the codeblock
+            WorkspaceModel.RecordModelsForModification(new List<ModelBase> { codeBlockNode2 }, CurrentDynamoModel.CurrentWorkspace.UndoRecorder);
+
+            //delete it
+            this.CurrentDynamoModel.ExecuteCommand(
+                new DynamoModel.DeleteModelCommand(codeBlockNode2.GUID));
+
+            //undo the deletion.
+            this.CurrentDynamoModel.CurrentWorkspace.Undo();
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
+
+            //get the new codeblock instance
+            codeBlockNode2 = CurrentDynamoModel.CurrentWorkspace.Nodes.Where(x => x.GUID == codeBlockNode2.GUID).FirstOrDefault() as CodeBlockNodeModel;
+
+            Assert.AreEqual(oldConnectorGuid, codeBlockNode2.InPorts[0].Connectors[0].GUID);
+
+            //undo the initial recording...
+            this.CurrentDynamoModel.CurrentWorkspace.Undo();
+            //assert nothing changed
+            Assert.AreEqual(1, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
+            Assert.AreEqual(oldConnectorGuid, codeBlockNode2.InPorts[0].Connectors[0].GUID);
+
+            //redo the deletion
+            Assert.DoesNotThrow(() =>
+            {
+                this.CurrentDynamoModel.CurrentWorkspace.Redo();
+                this.CurrentDynamoModel.CurrentWorkspace.Redo();
+                this.CurrentDynamoModel.CurrentWorkspace.Redo();
+                this.CurrentDynamoModel.CurrentWorkspace.Redo();
+            });
 
         }
 


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/QNTM-3237

PR fixes a crash when undo/redo fails to find a connector after a codeblock is deserialized and all connectors change their ids.

When a codeblock is deserialized now we save the connector guids and when rebuilding the connectors as part of deserialization we attempt in certain cases to reset the new connectors guids to the guid of the old connectors that existed before the deserialization. 

In addition because the number of cases seem quite high here I modified the undo/redo `getModelForElement` method which searches the workspace for a model by id - if it fails to find a model it used to throw, now it logs an error and returns null. I don't think a failed undo/redo should crash the application - but it is likely that putting the undo/redo stack into such a state may lead to more failures, we may also need to dump the undo and redo stacks when this occurs as a safeguard and start fresh. **I have not done that yet**

A test is added for the bug report that Neal filed and it checks for connectors having the same ids... port ids still change, but this should not be a problem as far as connectors are concerned.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@jnealb