### PR TITLE
QNTM-2121

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1430,7 +1430,7 @@ namespace Dynamo.ViewModels
         /// <param name="path">The path to the file.</param>
         /// <exception cref="IOException"></exception>
         /// <exception cref="UnauthorizedAccessException"></exception>
-        internal void SaveAs(string path, bool isBackup = false)
+        public void SaveAs(string path, bool isBackup = false)
         {
             try
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -537,6 +537,20 @@ namespace Dynamo.ViewModels
             try
             {
                 // Stage 1: Serialize the workspace.
+                string fileName = string.Empty;
+                try
+                {
+                    fileName = Path.GetFileName(filePath);
+                }
+                catch (ArgumentException)
+                {
+                }
+
+                if (fileName != string.Empty)
+                {
+                    Model.Name = fileName;
+                }
+              
                 var json = Model.ToJson(engine);
 
                 // Stage 2: Add the View.

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -529,6 +529,27 @@ namespace Dynamo.Tests
 
         [Test]
         [Category("UnitTests")]
+        public void CanSaveAndReadWorkspaceName()
+        {
+            // get empty workspace
+            var dynamoModel = ViewModel.Model;
+            Assert.IsNotNull(dynamoModel.CurrentWorkspace);
+            Assert.AreEqual("Home", ViewModel.Model.CurrentWorkspace.Name);
+
+            // get file path and name of file
+            var filePath = GetNewFileNameOnTempPath("dyn");
+            var fileName = Path.GetFileName(filePath);
+
+            // save
+            ViewModel.SaveAs(filePath);
+
+            // load
+            ViewModel.Model.OpenFileFromPath(filePath);
+            Assert.AreEqual(fileName, ViewModel.Model.CurrentWorkspace.Name);
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void CustomNodeWorkspaceHasUnsavedChangesPropertyIsSetOnSaveAs()
         {
             // open file


### PR DESCRIPTION
### Purpose

When saving in JSON format the Name property is expected to be set to the file name.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs
