### PR TITLE
Don't show internal GUID on code block port labels

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -1029,7 +1029,7 @@ namespace Dynamo.Graph.Nodes
 
         private string LocalizeIdentifier(string identifierName)
         {
-            return string.Format("blablabla{0}_{1}", identifierName, AstIdentifierGuid);
+            return string.Format("{0}_{1}", identifierName, AstIdentifierGuid);
         }
 
         private class ImperativeIdentifierInPlaceMapper : ImperativeAstReplacer

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -736,9 +736,7 @@ namespace Dynamo.Graph.Nodes
                 identifierNode = statement.LeftNode as IdentifierNode;
                 if (identifierNode != null) // Found the identifier...
                 {
-                    // ... that is not a temporary variable, take it!
-                    if (!IsTempIdentifier(identifierNode.Value))
-                        break;
+                    break;
                 }
             }
 

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -11,6 +11,7 @@ using Dynamo.Engine;
 using Dynamo.Engine.CodeGeneration;
 using Dynamo.Graph.Connectors;
 using Dynamo.Migration;
+using Dynamo.Properties;
 using Dynamo.Utilities;
 using ProtoCore;
 using ProtoCore.AST.AssociativeAST;
@@ -23,6 +24,7 @@ using ArrayNode = ProtoCore.AST.AssociativeAST.ArrayNode;
 using Node = ProtoCore.AST.Node;
 using Operator = ProtoCore.DSASM.Operator;
 using Newtonsoft.Json;
+using ProtoCore.DSASM;
 
 namespace Dynamo.Graph.Nodes
 {
@@ -41,7 +43,6 @@ namespace Dynamo.Graph.Nodes
         private string code = string.Empty;
         private List<string> inputIdentifiers = new List<string>();
         private List<string> inputPortNames = new List<string>();
-        private readonly List<string> tempVariables = new List<string>();
         private string previewVariable;
         private readonly LibraryServices libraryServices;
 
@@ -298,23 +299,12 @@ namespace Dynamo.Graph.Nodes
             }
         }
 
-        /// <summary>
-        /// Temporary variables that generated in code.
-        /// </summary>
-        [JsonIgnore]
-        public IEnumerable<string> TempVariables
-        {
-            get { return tempVariables; }
-        }
 
         /// <summary>
         /// Code statement of CBN
         /// </summary>
         [JsonIgnore]
-        public IEnumerable<Statement> CodeStatements
-        {
-            get { return codeStatements; }
-        }
+        public IEnumerable<Statement> CodeStatements => codeStatements;
 
         #endregion
 
@@ -735,6 +725,11 @@ namespace Dynamo.Graph.Nodes
             CreateInputOutputPorts();
         }
 
+        private static bool IsTempIdentifier(string name)
+        {
+            return name.StartsWith(Constants.kTempVarForNonAssignment);
+        }
+
         private void SetPreviewVariable(IEnumerable<Node> parsedNodes)
         {
             previewVariable = null;
@@ -748,7 +743,7 @@ namespace Dynamo.Graph.Nodes
                 if (identifierNode != null) // Found the identifier...
                 {
                     // ... that is not a temporary variable, take it!
-                    if (!tempVariables.Contains(identifierNode.Value))
+                    if (!IsTempIdentifier(identifierNode.Value))
                         break;
                 }
             }
@@ -831,9 +826,7 @@ namespace Dynamo.Graph.Nodes
 
             foreach (var def in allDefs)
             {
-                string tooltip = def.Key;
-                if (tempVariables.Contains(def.Key))
-                    tooltip = Formatting.TOOL_TIP_FOR_TEMP_VARIABLE;
+                var tooltip = IsTempIdentifier(def.Key) ? string.Format(Resources.CodeBlockTempIdentifierOutputLabel, def.Value) : def.Key;
 
                 OutPorts.Add(new PortModel(PortType.Output, this, new PortData(string.Empty, tooltip)
                 {
@@ -1036,7 +1029,7 @@ namespace Dynamo.Graph.Nodes
 
         private string LocalizeIdentifier(string identifierName)
         {
-            return string.Format("{0}_{1}", identifierName, AstIdentifierGuid);
+            return string.Format("blablabla{0}_{1}", identifierName, AstIdentifierGuid);
         }
 
         private class ImperativeIdentifierInPlaceMapper : ImperativeAstReplacer

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -76,12 +76,6 @@ namespace Dynamo.Graph.Nodes
         [JsonIgnore]
         public ElementResolver ElementResolver { get; set; }
 
-        private struct Formatting
-        {
-            public const double INITIAL_MARGIN = 0;
-            public const string TOOL_TIP_FOR_TEMP_VARIABLE = "Statement Output";
-        }
-
         /// <summary>
         ///     Indicates whether node is input node
         /// </summary>
@@ -400,7 +394,7 @@ namespace Dynamo.Graph.Nodes
             var lineNumbers = outputPortHelpers.Select(x => x.ReadInteger("LineIndex")).ToList();
             foreach (var line in lineNumbers)
             {
-                var tooltip = Formatting.TOOL_TIP_FOR_TEMP_VARIABLE;
+                var tooltip = string.Format(Resources.CodeBlockTempIdentifierOutputLabel, line);
                 OutPorts.Add(new PortModel(PortType.Output, this, new PortData(string.Empty, tooltip)
                 {
                     LineIndex = line, // Logical line index.
@@ -870,8 +864,6 @@ namespace Dynamo.Graph.Nodes
             {
                 PortModel portModel = OutPorts[i];
                 string portName = portModel.ToolTip;
-                if (portModel.ToolTip.Equals(Formatting.TOOL_TIP_FOR_TEMP_VARIABLE))
-                    portName += i.ToString(CultureInfo.InvariantCulture);
                 if (portModel.Connectors.Count != 0)
                 {
                     outportConnections.Add(portName, new List<ConnectorModel>());

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -196,6 +196,15 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Value of expression at line {0}.
+        /// </summary>
+        public static string CodeBlockTempIdentifierOutputLabel {
+            get {
+                return ResourceManager.GetString("CodeBlockTempIdentifierOutputLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Composes two single parameter functions into one function..
         /// </summary>
         public static string ComposeFunctionNodeDescription {
@@ -367,7 +376,7 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The virtual machine that powers Dynamo is experiencing some unexpected errors internally and is likely &quot;having great difficulties pulling itself together. It is &quot;recommended that you save your work now and reload the file. Giving the Dynamo VM a new lease of life can potentially make it feel happier and behave better. 
+        ///   Looks up a localized string similar to The virtual machine that powers Dynamo is experiencing some unexpected errors internally and is likely having great difficulties pulling itself together. It is recommended that you save your work now and reload the file. Giving the Dynamo VM a new lease of life can potentially make it feel happier and behave better. 
         ///
         ///If you don&apos;t mind, it would be helpful for you to send us your file. That will make it quicker for us to get these issues fixed..
         /// </summary>

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -238,7 +238,7 @@ Default value: 1</value>
     <value>Your file cannot be opened</value>
   </data>
   <data name="DisplayEngineFailureMessageDescription" xml:space="preserve">
-    <value>The virtual machine that powers Dynamo is experiencing some unexpected errors internally and is likely "having great difficulties pulling itself together. It is "recommended that you save your work now and reload the file. Giving the Dynamo VM a new lease of life can potentially make it feel happier and behave better. 
+    <value>The virtual machine that powers Dynamo is experiencing some unexpected errors internally and is likely having great difficulties pulling itself together. It is recommended that you save your work now and reload the file. Giving the Dynamo VM a new lease of life can potentially make it feel happier and behave better. 
 
 If you don't mind, it would be helpful for you to send us your file. That will make it quicker for us to get these issues fixed.</value>
   </data>
@@ -661,5 +661,8 @@ value : bool = false</value>
   </data>
   <data name="UnresolvedNodesWarningMessage" xml:space="preserve">
     <value>This graph currently contains some unresolved nodes, and cannot be saved until the nodes are resolved. If the graph is saved using SaveAs - the unresolved nodes will be removed from the file.</value>
+  </data>
+  <data name="CodeBlockTempIdentifierOutputLabel" xml:space="preserve">
+    <value>Value of expression at line {0}</value>
   </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -238,7 +238,7 @@ Default value: 1</value>
     <value>Your file cannot be opened</value>
   </data>
   <data name="DisplayEngineFailureMessageDescription" xml:space="preserve">
-    <value>The virtual machine that powers Dynamo is experiencing some unexpected errors internally and is likely "having great difficulties pulling itself together. It is "recommended that you save your work now and reload the file. Giving the Dynamo VM a new lease of life can potentially make it feel happier and behave better. 
+    <value>The virtual machine that powers Dynamo is experiencing some unexpected errors internally and is likely having great difficulties pulling itself together. It is recommended that you save your work now and reload the file. Giving the Dynamo VM a new lease of life can potentially make it feel happier and behave better. 
 
 If you don't mind, it would be helpful for you to send us your file. That will make it quicker for us to get these issues fixed.</value>
   </data>
@@ -670,5 +670,8 @@ value : bool = false</value>
   </data>
   <data name="UnresolvedNodesWarningTitle" xml:space="preserve">
     <value>Graph Contains Unresolved Nodes and Cannot Be Saved.</value>
+  </data>
+  <data name="CodeBlockTempIdentifierOutputLabel" xml:space="preserve">
+    <value>Value of expression at line {0}</value>
   </data>
 </root>

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -18,6 +18,7 @@ using ProtoCore.Utils;
 using DynCmd = Dynamo.Models.DynamoModel;
 using Dynamo.Models;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Properties;
 
 namespace Dynamo.Tests
 {
@@ -1381,6 +1382,7 @@ var06 = g;
             AssertPreviewValue("6fe8b8b3-3c81-4210-b58b-df60cc778fb0", null);
             AssertPreviewValue("24f7cbca-a101-44df-a751-8ed264096c20", null);
             AssertPreviewValue("2afe34da-e7ae-43c1-a43a-fa233a7e1906", DesignScript.Builtin.Dictionary.ByKeysValues(new List<string>() { "foo" }, new List<object>() { "bar" }));
+            
         }
 
         [Test]
@@ -1389,6 +1391,18 @@ var06 = g;
             string openPath = Path.Combine(TestDirectory, @"core\migration\CodeBlockWithArray.dyn");
             RunModel(openPath);
             AssertPreviewValue("b80e0c94-4a98-4f98-a197-f426a0a96db3", new object[] { 1, 2, 3 });
+        }
+
+        [Test]
+        public void CodeBlockNodeModelOutputPortLabels()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\cbn\OutputPortLabels.dyn");
+            RunModel(openPath);
+
+            var cbn = GetModel().Workspaces.First().Nodes.First() as CodeBlockNodeModel;
+            Assert.AreEqual(string.Format(Resources.CodeBlockTempIdentifierOutputLabel, 1), cbn.OutPorts.First().ToolTip); 
+            Assert.AreEqual(string.Format(Resources.CodeBlockTempIdentifierOutputLabel, 2), cbn.OutPorts.ElementAt(1).ToolTip); 
+            Assert.AreEqual(string.Format(Resources.CodeBlockTempIdentifierOutputLabel, 4), cbn.OutPorts.ElementAt(2).ToolTip); 
         }
     }
 

--- a/test/core/cbn/OutputPortLabels.dyn
+++ b/test/core/cbn/OutputPortLabels.dyn
@@ -1,0 +1,78 @@
+{
+  "Uuid": "b55de8cb-3363-4f3d-9680-201082814348",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "OutputPortLabels.dyn",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "1;\n[Imperative]{ return 5;\n };\n\"foo\";",
+      "Id": "d96ab731fec24471bcd9444aeab3faf4",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "5727748b51f44dd2a452b4de4c2fa77a",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "6a70ea8d2b884b359f8ec26a287395bc",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "fec5551f0eab4381bd90b961cbf2b920",
+          "Name": "",
+          "Description": "Value of expression at line 4",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.0.2821",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": null,
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "d96ab731fec24471bcd9444aeab3faf4",
+        "Excluded": false,
+        "X": 247.0,
+        "Y": 156.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Code block ports for non-assignment statements produced a very ugly tooltip incorporating an internal GUID. This PR fixes that.

**Before**

<img width="526" alt="screen shot 2018-01-31 at 2 47 49 pm" src="https://user-images.githubusercontent.com/916345/35645968-b970bb48-069b-11e8-8893-39ce2d7a50d7.png">

**After**

<img width="617" alt="screen shot 2018-01-31 at 3 08 41 pm" src="https://user-images.githubusercontent.com/916345/35646000-d0099c3a-069b-11e8-8174-5ef7ea4c990c.png">

Normal assignments are not affected:

<img width="500" alt="screen shot 2018-01-31 at 3 10 29 pm" src="https://user-images.githubusercontent.com/916345/35646020-dc1645d2-069b-11e8-9867-00398985543e.png">

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap
