### PR TITLE
Remove CBN from Basic-Input

### DIFF
--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -450,9 +450,6 @@
                   "path": "Core.Input.Number"
                 },
                 {
-                  "path": "Core.Input.Code Block"
-                },
-                {
                   "path": "Core.Input.Input"
                 },
                 {


### PR DESCRIPTION
### Purpose

This PR is to remove CBN from Input section.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### FYIs

@Racel @QilongTang @mjkkirschner @alfarok @ColinDayOrg 
