### PR TITLE
QNTM-2121 (fix): Do not save the extension in the Name property in JSON files

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -541,6 +541,11 @@ namespace Dynamo.ViewModels
                 try
                 {
                     fileName = Path.GetFileName(filePath);
+                    string extension = Path.GetExtension(filePath);
+                    if (extension == ".dyn" || extension == ".dyf")
+                    {
+                      fileName = Path.GetFileNameWithoutExtension(filePath);
+                    }
                 }
                 catch (ArgumentException)
                 {

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -539,6 +539,11 @@ namespace Dynamo.Tests
             // get file path and name of file
             var filePath = GetNewFileNameOnTempPath("dyn");
             var fileName = Path.GetFileName(filePath);
+            string extension = Path.GetExtension(filePath);
+            if (extension == ".dyn" || extension == ".dyf")
+            {
+              fileName = Path.GetFileNameWithoutExtension(filePath);
+            }
 
             // save
             ViewModel.SaveAs(filePath);


### PR DESCRIPTION
### Purpose

This PR addresses an issue found in the implementation of QNTM-2121. When the filename is being saved into the JSON Name property the extension was being saved as well. It was decided the the name should not include the extension. Note that the extension is only omitted if it is ".dyn" or ".dyf" to enable saving of files with no extension and a period in the filename.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
