### PR TITLE
Remove library collapse button

### DIFF
--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -1525,6 +1525,7 @@
                             </TextBlock>
                             <Image Grid.Column="0"
                                Name="LibrarySidebarIcon"
+                               Source="/DynamoCoreWpf;component/UI/Images/expand_normal.png"
                                Visibility="Visible"
                                Width="10"
                                Height="10"

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1622,6 +1622,7 @@ namespace Dynamo.Controls
         {
             get
             {
+                // Threshold that determines if button should be displayed
                 if (LibraryViewColumn.Width.Value < 20)
                 { libraryCollapsed = true; }
 

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -1602,30 +1602,27 @@ namespace Dynamo.Controls
             tb.Foreground = (Brush)bc.ConvertFrom("#cccccc");
             Image collapseIcon = (Image)sp.Children[1];
 
-            Uri imageUri;
-
             // When hovered swap appropriate expand/collapse icons
             if (LibraryCollapsed)
-            { imageUri = new Uri(@"pack://application:,,,/DynamoCoreWpf;component/UI/Images/expand_hover.png"); }
-
-            else
-            { imageUri = new Uri(@"pack://application:,,,/DynamoCoreWpf;component/UI/Images/collapse_hover.png"); }
-
-            BitmapImage hover = new BitmapImage(imageUri);
-            collapseIcon.Source = hover;
+            {
+                Uri imageUri;
+                imageUri = new Uri(@"pack://application:,,,/DynamoCoreWpf;component/UI/Images/expand_hover.png");
+                BitmapImage hover = new BitmapImage(imageUri);
+                collapseIcon.Source = hover;
+            }
         }
 
         private bool libraryCollapsed;
 
         // Retain last known library width prior to collapsing
-        public double LibraryWidthCache { get; set; } = 200;
+        private const double defaultLibraryWidth = 200;
 
         // Check if library is collapsed or expanded
         public bool LibraryCollapsed
         {
             get
             {
-                if (LibraryViewColumn.Width.Value < 2)
+                if (LibraryViewColumn.Width.Value < 20)
                 { libraryCollapsed = true; }
 
                 else
@@ -1640,18 +1637,12 @@ namespace Dynamo.Controls
         {
             if (LibraryCollapsed)
             {
-                var imageUri = new Uri(@"pack://application:,,,/DynamoCoreWpf;component/UI/Images/expand_normal.png");
-                BitmapImage icon = new BitmapImage(imageUri);
-                LibrarySidebarIcon.Source = icon;
-                LibrarySidebarText.Visibility = Visibility.Visible;
+                collapsedSidebar.Visibility = Visibility.Visible;
             }
 
             else
             {
-                var imageUri = new Uri(@"pack://application:,,,/DynamoCoreWpf;component/UI/Images/collapse_normal.png");
-                BitmapImage icon = new BitmapImage(imageUri);
-                LibrarySidebarIcon.Source = icon;
-                LibrarySidebarText.Visibility = Visibility.Collapsed;
+                collapsedSidebar.Visibility = Visibility.Collapsed;
             }
         }
 
@@ -1659,14 +1650,12 @@ namespace Dynamo.Controls
         {
             if(LibraryCollapsed)
             {
-                // Restore library to previous width (or default if none)
-                LibraryViewColumn.Width = new GridLength(LibraryWidthCache, GridUnitType.Star);
+                // Restore library to default width (200)
+                LibraryViewColumn.Width = new GridLength(defaultLibraryWidth, GridUnitType.Star);
             }
 
             else
             {
-                // Cache library width and collapse
-                LibraryWidthCache = LibraryViewColumn.Width.Value;
                 LibraryViewColumn.Width = new GridLength(0, GridUnitType.Star);
             }
 
@@ -1681,6 +1670,11 @@ namespace Dynamo.Controls
             var bc = new BrushConverter();
             tb.Foreground = (Brush)bc.ConvertFromString("#aaaaaa");
             Image collapseIcon = (Image)sp.Children[1];
+
+            Uri imageUri;
+            imageUri = new Uri(@"pack://application:,,,/DynamoCoreWpf;component/UI/Images/expand_normal.png");
+            BitmapImage hover = new BitmapImage(imageUri);
+            collapseIcon.Source = hover;
 
             updateCollapseIcon();
         }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml.cs
@@ -111,7 +111,7 @@ namespace Dynamo.Controls
             SizeChanged += DynamoView_SizeChanged;
             LocationChanged += DynamoView_LocationChanged;
 
-            // Apply initial appropriate expand/collapse library icon depending on state
+            // Apply appropriate expand/collapse library button state depending on initial width
             updateCollapseIcon();
 
             // Check that preference bounds are actually within one
@@ -1602,7 +1602,7 @@ namespace Dynamo.Controls
             tb.Foreground = (Brush)bc.ConvertFrom("#cccccc");
             Image collapseIcon = (Image)sp.Children[1];
 
-            // When hovered swap appropriate expand/collapse icons
+            // When hovered swap appropriate expand/collapse button state
             if (LibraryCollapsed)
             {
                 Uri imageUri;
@@ -1614,8 +1614,8 @@ namespace Dynamo.Controls
 
         private bool libraryCollapsed;
 
-        // Retain last known library width prior to collapsing
-        private const double defaultLibraryWidth = 200;
+        // Default library width
+        private const int defaultLibraryWidth = 200;
 
         // Check if library is collapsed or expanded
         public bool LibraryCollapsed
@@ -1632,7 +1632,7 @@ namespace Dynamo.Controls
             }
         }
 
-        // Check if library is collapsed or expanded and apply appropriate icon
+        // Check if library is collapsed or expanded and apply appropriate button state
         private void updateCollapseIcon()
         {
             if (LibraryCollapsed)


### PR DESCRIPTION
### Purpose

This PR removes the collapse button on the library.  When the library width is less than the specified threshold (20) we display the button in the expand state.

This is a modification to [PR-8511](https://github.com/DynamoDS/Dynamo/pull/8511)

![libraryexpandonly](https://user-images.githubusercontent.com/13341935/35689641-fe3b6f06-0741-11e8-9911-45547c7d0ec7.gif)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@pboyer 

### FYIs

@Racel @jnealb 
