### PR TITLE
Remove presets from the nodes selection context menu and the Dynamo CLI

### DIFF
--- a/src/DynamoApplications/StartupUtils.cs
+++ b/src/DynamoApplications/StartupUtils.cs
@@ -78,16 +78,6 @@ namespace Dynamo.Applications
                 //
                 var openfilepath = string.Empty;
 
-                // import a set of presets from another dyn or presetfile 
-                // DynamoSandbox.exe /o "C:\file path\graph.dyn" /p "C:\states.dyn"
-                //
-                var presetFile = string.Empty;
-
-                // set current opened graph to state by name 
-                // DynamoSandbox.exe /o "C:\file path\graph.dyn" /s "state1"
-                //
-                var presetStateid = string.Empty;
-
                 // print the resulting values of all nodes to the console 
                 // DynamoSandbox.exe /o "C:\file path\graph.dyn" /v "C:\someoutputfilepath.xml"
                 //
@@ -100,9 +90,6 @@ namespace Dynamo.Applications
                 .Add("c=|C=", "CommandFilePath, Instruct Dynamo to open a commandfile and run the commands it contains at this path," +
                 "this option is only supported when run from DynamoSandbox", c => commandFilePath = c)
                 .Add("l=|L=", "Running Dynamo under a different locale setting", l => locale = l)
-                .Add("p=|P=", "PresetFile, Instruct Dynamo to import the presets at this path into the opened .dyn", p => presetFile = p)
-                .Add("s=|S=", "PresetStateID, Instruct Dynamo to set the graph to the specified preset by name," +
-                "this can be set to a statename or 'all', which will evaluate all states in the dyn", s => presetStateid = s)
                 .Add("v=|V=", "Verbose, Instruct Dynamo to output all evalautions it performs to an xml file at this path", v => verbose = v)
                 .Add("x|X", "When used in combination with the 'O' flag, opens a .dyn file from the specified path and converts it to .json." + 
                 "File will have the .json extension and be located in the same directory as the original file.", x => convertFile = x != null)
@@ -116,23 +103,20 @@ namespace Dynamo.Applications
                 }
 
                 //check for incompatabile parameters
-                if ((!string.IsNullOrEmpty(presetStateid) || (!string.IsNullOrEmpty(presetFile) || (!string.IsNullOrEmpty(verbose)))) && string.IsNullOrEmpty(openfilepath))
+                if (!string.IsNullOrEmpty(verbose) && string.IsNullOrEmpty(openfilepath))
                 {
-                    Console.WriteLine("you must supply a file to open if you want to load a preset or presetFile, or want to save an evaluation output ");
+                    Console.WriteLine("you must supply a file to open if you want to save an evaluation output ");
                 }
                 return new CommandLineArguments
                 {
                     Locale = locale,
                     CommandFilePath = commandFilePath,
                     OpenFilePath = openfilepath,
-                    PresetStateID = presetStateid,
-                    PresetFilePath = presetFile,
                     Verbose = verbose,
                     ConvertFile = convertFile
                 };
             }
 
-          
             private static void ShowHelp(OptionSet opSet)
             {
                 Console.WriteLine("options:");
@@ -142,8 +126,6 @@ namespace Dynamo.Applications
             public string Locale { get; set; }
             public string CommandFilePath { get; set; }
             public string OpenFilePath { get; set; }
-            public string PresetStateID { get; set; }
-            public string PresetFilePath { get; set; }
             public string Verbose { get; set; }
             
             public bool ConvertFile { get; set; }
@@ -183,7 +165,6 @@ namespace Dynamo.Applications
 
         public static DynamoModel MakeModel(bool CLImode)
         {
-
             var geometryFactoryPath = string.Empty;
             var preloaderLocation = string.Empty;
             PreloadShapeManager(ref geometryFactoryPath, ref preloaderLocation);

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -439,8 +439,6 @@
                     <MenuItem  Header="{x:Static p:Resources.ContextMenuNodesFromSelection}"
                            Command="{Binding NodeFromSelectionCommand}" CommandTarget="{Binding ElementName=_this}" />
 
-                    <MenuItem  Header="{x:Static p:Resources.DynamoViewEditMenuCreatePreset}"
-                           Command="{Binding DynamoViewModel.ShowNewPresetsDialogCommand}" />
 
                     <MenuItem  Header="{x:Static p:Resources.ContextMenuNodeToCode}"
                            Command="{Binding NodeToCodeCommand}"


### PR DESCRIPTION
### Purpose

[QNTM-3138](https://jira.autodesk.com/browse/QNTM-3138)

This PR removes Presets from the nodes selection context menu and the Dynamo CLI.  Presets were made obsolete in [PR-8207](https://github.com/DynamoDS/Dynamo/pull/8207) but remained in the context menu and CLI.

### Documentation

Updated [CLI Wiki](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Command-Line-Interface)
[API changes Wiki](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) was update in previous PR mentioned above.

### Testing
Task A/C calls for manual testing.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@varvaratou 
