### PR TITLE
QNTM-2116: Check for persistent warning as well as plain warning

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/HomeWorkspaceViewModel.cs
@@ -140,7 +140,7 @@ namespace Dynamo.Wpf.ViewModels.Core
 
         void hwm_EvaluationCompleted(object sender, EvaluationCompletedEventArgs e)
         {
-            bool hasWarnings = Model.Nodes.Any(n => n.State == ElementState.Warning);
+            bool hasWarnings = Model.Nodes.Any(n => n.State == ElementState.Warning || n.State == ElementState.PersistentWarning);
 
             if (!hasWarnings)
             {


### PR DESCRIPTION
### Purpose

This PR is to fix the warning display that is not being properly displayed in the case of a code block error. There was a new warning type introduced for code blocks that was not being properly checked.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@alfarok 
