### PR TITLE
Don't support identifiers as keys in dictionary syntax

### DIFF
--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -2397,16 +2397,16 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		dictBuilder.SetNodeStartLocation(t); 
 		if (la.kind == 4) {
 			Get();
-			var str = new StringNode {Value = t.val.Trim('"')}; 
-			dictBuilder.AddKey(str); 
+			var key = new StringNode {Value = t.val.Trim('"')}; 
+			dictBuilder.AddKey(key); 
 			Expect(48);
 			Associative_Expression(out node);
 			dictBuilder.AddValue(node); 
 			while (la.kind == 52) {
 				Get();
 				Expect(4);
-				var str = new StringNode { Value = t.val.Trim('"') }; 
-				dictBuilder.AddKey(str); 
+				var nextkey = new StringNode { Value = t.val.Trim('"') }; 
+				dictBuilder.AddKey(nextkey); 
 				Expect(48);
 				Associative_Expression(out node);
 				dictBuilder.AddValue(node); 
@@ -3852,16 +3852,16 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		dictBuilder.SetNodeStartLocation(t); 
 		if (la.kind == 4) {
 			Get();
-			var str = new ProtoCore.AST.ImperativeAST.StringNode {Value = t.val.Trim('"')}; 
-			dictBuilder.AddKey(str); 
+			var key = new ProtoCore.AST.ImperativeAST.StringNode {Value = t.val.Trim('"')}; 
+			dictBuilder.AddKey(key); 
 			Expect(48);
 			Imperative_expr(out node);
 			dictBuilder.AddValue(node); 
 			while (la.kind == 52) {
 				Get();
 				Expect(4);
-				var str = new ProtoCore.AST.ImperativeAST.StringNode { Value = t.val.Trim('"') }; 
-				dictBuilder.AddKey(str); 
+				var nextkey = new ProtoCore.AST.ImperativeAST.StringNode { Value = t.val.Trim('"') }; 
+				dictBuilder.AddKey(nextkey); 
 				Expect(48);
 				Imperative_expr(out node);
 				dictBuilder.SetNodeEndLocation(t); 

--- a/src/Engine/ProtoCore/Parser/Parser.cs
+++ b/src/Engine/ProtoCore/Parser/Parser.cs
@@ -231,8 +231,6 @@ public Node root { get; set; }
 
     // Recognize: 
     //     { "foo" :   
-    // OR   
-    //     { foo :
     private bool IsDictionaryExpression()
     {
         short state = 0;
@@ -250,7 +248,7 @@ public Node root { get; set; }
                     }
                     goto fail;
                 case 1:
-                    if (pt.kind == _textstring || pt.kind ==_ident)
+                    if (pt.kind == _textstring)
                     {
                         state = 2;
                         pt = scanner.Peek();
@@ -2397,32 +2395,18 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		Expect(46);
 		var dictBuilder = new ProtoCore.AST.AssociativeAST.DictionaryExpressionBuilder(); 
 		dictBuilder.SetNodeStartLocation(t); 
-		if (la.kind == 1 || la.kind == 4) {
-			if (la.kind == 4) {
-				Get();
-				var str = new StringNode {Value = t.val.Trim('"')}; 
-				dictBuilder.AddKey(str); 
-			} else {
-				Get();
-				var ident = new IdentifierNode(t.val); 
-				NodeUtils.SetNodeLocation(ident, t); 
-				dictBuilder.AddKey(ident); 
-			}
+		if (la.kind == 4) {
+			Get();
+			var str = new StringNode {Value = t.val.Trim('"')}; 
+			dictBuilder.AddKey(str); 
 			Expect(48);
 			Associative_Expression(out node);
 			dictBuilder.AddValue(node); 
 			while (la.kind == 52) {
 				Get();
-				if (la.kind == 4) {
-					Get();
-					var str = new StringNode { Value = t.val.Trim('"') }; 
-					dictBuilder.AddKey(str); 
-				} else if (la.kind == 1) {
-					Get();
-					var ident = new IdentifierNode(t.val); 
-					NodeUtils.SetNodeLocation(ident, t); 
-					dictBuilder.AddKey(ident); 
-				} else SynErr(94);
+				Expect(4);
+				var str = new StringNode { Value = t.val.Trim('"') }; 
+				dictBuilder.AddKey(str); 
 				Expect(48);
 				Associative_Expression(out node);
 				dictBuilder.AddValue(node); 
@@ -2482,7 +2466,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Associative_DictionaryExpression(out node);
 			nameNode = node as ProtoCore.AST.AssociativeAST.ArrayNameNode;
 			
-		} else SynErr(95);
+		} else SynErr(94);
 		if (la.kind == 10) {
 			ProtoCore.AST.AssociativeAST.ArrayNode array = null;
 			
@@ -2651,7 +2635,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			} else if (la.kind == 2) {
 				Get();
 				isLongest = false; 
-			} else SynErr(96);
+			} else SynErr(95);
 			repguide = t.val;
 			if (isLongest)
 			{
@@ -2673,7 +2657,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				} else if (la.kind == 2) {
 					Get();
 					isLongest = false; 
-				} else SynErr(97);
+				} else SynErr(96);
 				repguide = t.val;
 				if (isLongest)
 				{
@@ -2789,7 +2773,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			  SynErr(Resources.SemiColonExpected);
 			
 			Get();
-		} else SynErr(98);
+		} else SynErr(97);
 	}
 
 	void Imperative_languageblock(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -2818,7 +2802,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Hydrogen(out codeBlockNode);
 		} else if (langblock.codeblock.Language == ProtoCore.Language.Imperative ) {
 			Imperative(out codeBlockNode);
-		} else SynErr(99);
+		} else SynErr(98);
 		if (langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			int openCurlyBraceCount = 0, closeCurlyBraceCount = 0; 
 			ProtoCore.AST.ImperativeAST.CodeBlockNode codeBlockInvalid = new ProtoCore.AST.ImperativeAST.CodeBlockNode(); 
@@ -2839,12 +2823,12 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 					break; 
 				} else if (StartOf(8)) {
 					Get(); 
-				} else SynErr(100);
+				} else SynErr(99);
 			}
 			codeBlockNode = codeBlockInvalid; 
 		} else if (la.kind == 47) {
 			Get();
-		} else SynErr(101);
+		} else SynErr(100);
 		langblock.CodeBlockNode = codeBlockNode; 
 		node = langblock; 
 	}
@@ -2871,7 +2855,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt; 
 			Imperative_stmt(out singleStmt);
 			ifStmtNode.IfBody.Add(singleStmt); 
-		} else SynErr(102);
+		} else SynErr(101);
 		NodeUtils.SetNodeEndLocation(ifStmtNode.IfBodyPosition, t); 
 		while (la.kind == 30) {
 			ProtoCore.AST.ImperativeAST.ElseIfBlock elseifBlock = new ProtoCore.AST.ImperativeAST.ElseIfBlock(); 
@@ -2895,7 +2879,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				elseifBlock.Body.Add(singleStmt); 
-			} else SynErr(103);
+			} else SynErr(102);
 			NodeUtils.SetNodeEndLocation(elseifBlock.ElseIfBodyPosition, t); 
 			ifStmtNode.ElseIfList.Add(elseifBlock); 
 		}
@@ -2911,7 +2895,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 				Imperative_stmt(out singleStmt);
 				ifStmtNode.ElseBody.Add(singleStmt); 
-			} else SynErr(104);
+			} else SynErr(103);
 			NodeUtils.SetNodeEndLocation(ifStmtNode.ElseBodyPosition, t); 
 		}
 		node = ifStmtNode; 
@@ -2964,7 +2948,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			ProtoCore.AST.ImperativeAST.ImperativeNode singleStmt = null; 
 			Imperative_stmt(out singleStmt);
 			loopNode.Body.Add(singleStmt); 
-		} else SynErr(105);
+		} else SynErr(104);
 		forloop = loopNode;
 		
 	}
@@ -2991,7 +2975,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			   SynErr(Resources.SemiColonExpected);
 			
 			Expect(23);
-		} else SynErr(106);
+		} else SynErr(105);
 		bNode.RightNode = rhs;
 		bNode.Optr = Operator.assign;
 		
@@ -3031,7 +3015,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 				  SynErr(Resources.SemiColonExpected);
 				
 				Expect(23);
-			} else SynErr(107);
+			} else SynErr(106);
 			bNode.LeftNode = lhsNode;
 			bNode.RightNode = rhsNode;
 			bNode.Optr = Operator.assign;
@@ -3040,7 +3024,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			
 		} else if (StartOf(8)) {
 			SynErr("';' is expected"); 
-		} else SynErr(108);
+		} else SynErr(107);
 	}
 
 	void Imperative_expr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3176,7 +3160,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			node = typedVar; 
 		} else if (StartOf(3)) {
 			Imperative_IdentifierList(out node);
-		} else SynErr(109);
+		} else SynErr(108);
 	}
 
 	void Imperative_IdentifierList(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3304,7 +3288,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Imperative_DictionaryExpression(out node);
 			nameNode = node as ProtoCore.AST.ImperativeAST.ArrayNameNode;
 			
-		} else SynErr(110);
+		} else SynErr(109);
 		if (la.kind == 10) {
 			ProtoCore.AST.ImperativeAST.ArrayNode array = null; 
 			Get();
@@ -3418,7 +3402,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Imperative_negexpr(out node);
 		} else if (la.kind == 14 || la.kind == 60) {
 			Imperative_bitunaryexpr(out node);
-		} else SynErr(111);
+		} else SynErr(110);
 	}
 
 	void Imperative_negexpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3460,7 +3444,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Get();
 			op = UnaryOperator.Negate; 
 			#endif                     
-		} else SynErr(112);
+		} else SynErr(111);
 	}
 
 	void Imperative_factor(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3490,7 +3474,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			Imperative_IdentifierList(out node);
 		} else if (la.kind == 14 || la.kind == 15 || la.kind == 60) {
 			Imperative_unaryexpr(out node);
-		} else SynErr(113);
+		} else SynErr(112);
 	}
 
 	void Imperative_negop(out UnaryOperator op) {
@@ -3524,7 +3508,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else if (la.kind == 59) {
 			Get();
 			op = Operator.or; 
-		} else SynErr(114);
+		} else SynErr(113);
 	}
 
 	void Imperative_RangeExpr(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3591,7 +3575,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			op = Operator.nq; 
 			break;
 		}
-		default: SynErr(115); break;
+		default: SynErr(114); break;
 		}
 	}
 
@@ -3666,7 +3650,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else if (la.kind == 15) {
 			Get();
 			op = Operator.sub; 
-		} else SynErr(116);
+		} else SynErr(115);
 	}
 
 	void Imperative_interimfactor(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3698,7 +3682,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else if (la.kind == 57) {
 			Get();
 			op = Operator.mod; 
-		} else SynErr(117);
+		} else SynErr(116);
 	}
 
 	void Imperative_bitop(out Operator op) {
@@ -3712,7 +3696,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		} else if (la.kind == 64) {
 			Get();
 			op = Operator.bitwisexor; 
-		} else SynErr(118);
+		} else SynErr(117);
 	}
 
 	void Imperative_Char(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3793,7 +3777,7 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 			else{
 			   NodeUtils.SetNodeLocation(node, t); }
 			
-		} else SynErr(119);
+		} else SynErr(118);
 	}
 
 	void Imperative_functioncall(out ProtoCore.AST.ImperativeAST.ImperativeNode node) {
@@ -3866,32 +3850,18 @@ langblock.codeblock.Language == ProtoCore.Language.NotSpecified) {
 		Expect(46);
 		var dictBuilder = new ProtoCore.AST.ImperativeAST.DictionaryExpressionBuilder(); 
 		dictBuilder.SetNodeStartLocation(t); 
-		if (la.kind == 1 || la.kind == 4) {
-			if (la.kind == 4) {
-				Get();
-				var str = new ProtoCore.AST.ImperativeAST.StringNode {Value = t.val.Trim('"')}; 
-				dictBuilder.AddKey(str); 
-			} else {
-				Get();
-				var ident = new ProtoCore.AST.ImperativeAST.IdentifierNode(t.val); 
-				NodeUtils.SetNodeLocation(ident, t); 
-				dictBuilder.AddKey(ident); 
-			}
+		if (la.kind == 4) {
+			Get();
+			var str = new ProtoCore.AST.ImperativeAST.StringNode {Value = t.val.Trim('"')}; 
+			dictBuilder.AddKey(str); 
 			Expect(48);
 			Imperative_expr(out node);
 			dictBuilder.AddValue(node); 
 			while (la.kind == 52) {
 				Get();
-				if (la.kind == 4) {
-					Get();
-					var str = new ProtoCore.AST.ImperativeAST.StringNode { Value = t.val.Trim('"') }; 
-					dictBuilder.AddKey(str); 
-				} else if (la.kind == 1) {
-					Get();
-					var ident = new ProtoCore.AST.ImperativeAST.IdentifierNode(t.val); 
-					NodeUtils.SetNodeLocation(ident, t); 
-					dictBuilder.AddKey(ident); 
-				} else SynErr(120);
+				Expect(4);
+				var str = new ProtoCore.AST.ImperativeAST.StringNode { Value = t.val.Trim('"') }; 
+				dictBuilder.AddKey(str); 
 				Expect(48);
 				Imperative_expr(out node);
 				dictBuilder.SetNodeEndLocation(t); 
@@ -4042,33 +4012,31 @@ public class Errors {
 			case 91: s = "invalid Associative_MulOp"; break;
 			case 92: s = "invalid Associative_Level"; break;
 			case 93: s = "invalid Associative_Number"; break;
-			case 94: s = "invalid Associative_DictionaryExpression"; break;
+			case 94: s = "invalid Associative_NameReference"; break;
 			case 95: s = "invalid Associative_NameReference"; break;
 			case 96: s = "invalid Associative_NameReference"; break;
-			case 97: s = "invalid Associative_NameReference"; break;
-			case 98: s = "invalid Imperative_stmt"; break;
+			case 97: s = "invalid Imperative_stmt"; break;
+			case 98: s = "invalid Imperative_languageblock"; break;
 			case 99: s = "invalid Imperative_languageblock"; break;
 			case 100: s = "invalid Imperative_languageblock"; break;
-			case 101: s = "invalid Imperative_languageblock"; break;
+			case 101: s = "invalid Imperative_ifstmt"; break;
 			case 102: s = "invalid Imperative_ifstmt"; break;
 			case 103: s = "invalid Imperative_ifstmt"; break;
-			case 104: s = "invalid Imperative_ifstmt"; break;
-			case 105: s = "invalid Imperative_forloop"; break;
-			case 106: s = "invalid Imperative_returnstmt"; break;
+			case 104: s = "invalid Imperative_forloop"; break;
+			case 105: s = "invalid Imperative_returnstmt"; break;
+			case 106: s = "invalid Imperative_assignstmt"; break;
 			case 107: s = "invalid Imperative_assignstmt"; break;
-			case 108: s = "invalid Imperative_assignstmt"; break;
-			case 109: s = "invalid Imperative_decoratedIdentifier"; break;
-			case 110: s = "invalid Imperative_NameReference"; break;
-			case 111: s = "invalid Imperative_unaryexpr"; break;
-			case 112: s = "invalid Imperative_unaryop"; break;
-			case 113: s = "invalid Imperative_factor"; break;
-			case 114: s = "invalid Imperative_logicalop"; break;
-			case 115: s = "invalid Imperative_relop"; break;
-			case 116: s = "invalid Imperative_addop"; break;
-			case 117: s = "invalid Imperative_mulop"; break;
-			case 118: s = "invalid Imperative_bitop"; break;
-			case 119: s = "invalid Imperative_num"; break;
-			case 120: s = "invalid Imperative_DictionaryExpression"; break;
+			case 108: s = "invalid Imperative_decoratedIdentifier"; break;
+			case 109: s = "invalid Imperative_NameReference"; break;
+			case 110: s = "invalid Imperative_unaryexpr"; break;
+			case 111: s = "invalid Imperative_unaryop"; break;
+			case 112: s = "invalid Imperative_factor"; break;
+			case 113: s = "invalid Imperative_logicalop"; break;
+			case 114: s = "invalid Imperative_relop"; break;
+			case 115: s = "invalid Imperative_addop"; break;
+			case 116: s = "invalid Imperative_mulop"; break;
+			case 117: s = "invalid Imperative_bitop"; break;
+			case 118: s = "invalid Imperative_num"; break;
 
 			default: s = "error " + n; break;
 		}

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1580,12 +1580,6 @@ Associative_DictionaryExpression<out ProtoCore.AST.AssociativeAST.AssociativeNod
 				textstring	(. var str = new StringNode {Value = t.val.Trim('"')}; .)  
 							(. dictBuilder.AddKey(str); .)
 			)
-			|
-			(
-				ident		(. var ident = new IdentifierNode(t.val); .)
-							(. NodeUtils.SetNodeLocation(ident, t); .)
-							(. dictBuilder.AddKey(ident); .)
-			)
 		)
 		':'                     
 		Associative_Expression<out node>            (. dictBuilder.AddValue(node); .)
@@ -1595,12 +1589,6 @@ Associative_DictionaryExpression<out ProtoCore.AST.AssociativeAST.AssociativeNod
 				(
 					textstring	(. var str = new StringNode { Value = t.val.Trim('"') }; .)
 								(. dictBuilder.AddKey(str); .)  
-				)
-				|
-				(
-					ident		(. var ident = new IdentifierNode(t.val); .)
-								(. NodeUtils.SetNodeLocation(ident, t); .)
-								(. dictBuilder.AddKey(ident); .)
 				)
 			)
 			':'                     

--- a/src/Engine/ProtoCore/Parser/atg/Associative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Associative.atg
@@ -1577,8 +1577,8 @@ Associative_DictionaryExpression<out ProtoCore.AST.AssociativeAST.AssociativeNod
 	[
 		(
 			(
-				textstring	(. var str = new StringNode {Value = t.val.Trim('"')}; .)  
-							(. dictBuilder.AddKey(str); .)
+				textstring	(. var key = new StringNode {Value = t.val.Trim('"')}; .)  
+							(. dictBuilder.AddKey(key); .)
 			)
 		)
 		':'                     
@@ -1587,8 +1587,8 @@ Associative_DictionaryExpression<out ProtoCore.AST.AssociativeAST.AssociativeNod
 			','
 			(
 				(
-					textstring	(. var str = new StringNode { Value = t.val.Trim('"') }; .)
-								(. dictBuilder.AddKey(str); .)  
+					textstring	(. var nextkey = new StringNode { Value = t.val.Trim('"') }; .)
+								(. dictBuilder.AddKey(nextkey); .)  
 				)
 			)
 			':'                     

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -1054,12 +1054,6 @@ Imperative_DictionaryExpression<out ProtoCore.AST.ImperativeAST.ImperativeNode n
 				textstring	(. var str = new ProtoCore.AST.ImperativeAST.StringNode {Value = t.val.Trim('"')}; .)  
 							(. dictBuilder.AddKey(str); .) 
 			) 
-			|
-			(
-				ident		(. var ident = new ProtoCore.AST.ImperativeAST.IdentifierNode(t.val); .)
-							(. NodeUtils.SetNodeLocation(ident, t); .)
-							(. dictBuilder.AddKey(ident); .)
-			)
 		)
 		':'                     
 		Imperative_expr<out node>            (. dictBuilder.AddValue(node); .)
@@ -1070,12 +1064,6 @@ Imperative_DictionaryExpression<out ProtoCore.AST.ImperativeAST.ImperativeNode n
 					textstring	(. var str = new ProtoCore.AST.ImperativeAST.StringNode { Value = t.val.Trim('"') }; .)
 								(. dictBuilder.AddKey(str); .)  
 				)
-				|
-				(
-					ident		(. var ident = new ProtoCore.AST.ImperativeAST.IdentifierNode(t.val); .)
-								(. NodeUtils.SetNodeLocation(ident, t); .)
-								(. dictBuilder.AddKey(ident); .)
-				) 
 			)
 			':'                     
 			Imperative_expr<out node>       (. dictBuilder.SetNodeEndLocation(t); .)

--- a/src/Engine/ProtoCore/Parser/atg/Imperative.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Imperative.atg
@@ -1051,8 +1051,8 @@ Imperative_DictionaryExpression<out ProtoCore.AST.ImperativeAST.ImperativeNode n
 	[
 		(
 			(
-				textstring	(. var str = new ProtoCore.AST.ImperativeAST.StringNode {Value = t.val.Trim('"')}; .)  
-							(. dictBuilder.AddKey(str); .) 
+				textstring	(. var key = new ProtoCore.AST.ImperativeAST.StringNode {Value = t.val.Trim('"')}; .)  
+							(. dictBuilder.AddKey(key); .) 
 			) 
 		)
 		':'                     
@@ -1061,8 +1061,8 @@ Imperative_DictionaryExpression<out ProtoCore.AST.ImperativeAST.ImperativeNode n
 			','
 			(
 				(
-					textstring	(. var str = new ProtoCore.AST.ImperativeAST.StringNode { Value = t.val.Trim('"') }; .)
-								(. dictBuilder.AddKey(str); .)  
+					textstring	(. var nextkey = new ProtoCore.AST.ImperativeAST.StringNode { Value = t.val.Trim('"') }; .)
+								(. dictBuilder.AddKey(nextkey); .)  
 				)
 			)
 			':'                     

--- a/src/Engine/ProtoCore/Parser/atg/Start.atg
+++ b/src/Engine/ProtoCore/Parser/atg/Start.atg
@@ -157,8 +157,6 @@ COMPILER DesignScriptParser
 
     // Recognize: 
     //     { "foo" :   
-    // OR   
-    //     { foo :
     private bool IsDictionaryExpression()
     {
         short state = 0;
@@ -176,7 +174,7 @@ COMPILER DesignScriptParser
                     }
                     goto fail;
                 case 1:
-                    if (pt.kind == _textstring || pt.kind ==_ident)
+                    if (pt.kind == _textstring)
                     {
                         state = 2;
                         pt = scanner.Peek();

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -1382,7 +1382,9 @@ var06 = g;
             AssertPreviewValue("6fe8b8b3-3c81-4210-b58b-df60cc778fb0", null);
             AssertPreviewValue("24f7cbca-a101-44df-a751-8ed264096c20", null);
             AssertPreviewValue("2afe34da-e7ae-43c1-a43a-fa233a7e1906", DesignScript.Builtin.Dictionary.ByKeysValues(new List<string>() { "foo" }, new List<object>() { "bar" }));
-            
+
+            AssertError("0cb2f07a-95ab-49ed-bd7e-3e21281b87a3"); // uses identifier as dictionary key
+            AssertError("a2b3ac31-98f0-46b0-906e-8617821d0a51"); // uses old syntax {1,2}
         }
 
         [Test]

--- a/test/DynamoCoreTests/DSEvaluationUnitTestBase.cs
+++ b/test/DynamoCoreTests/DSEvaluationUnitTestBase.cs
@@ -121,6 +121,12 @@ namespace Dynamo.Tests
             }
         }
 
+        protected void AssertError(string guid)
+        {
+            var node = GetModel().CurrentWorkspace.Nodes.First(n => n.GUID.ToString() == guid);
+            Assert.True(node.IsInErrorState);
+        }
+
         protected void AssertPreviewValue(string guid, object value)
         {
             string previewVariable = GetVarName(guid);

--- a/test/Engine/ProtoTest/TD/MultiLangTests/CollectionAssignment.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/CollectionAssignment.cs
@@ -3182,7 +3182,7 @@ test = foo().IntVal;
             String code =
             @"
                 b=""x"";
-                a = {b : (b!=null)?4:-4};
+                a = {""x"" : (b!=null)?4:-4};
                 r = a [b];
             ";
 
@@ -3203,19 +3203,20 @@ test = foo().IntVal;
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("r", new object[] { 4, -4 });
         }
-        [Test]
+
+        [Test, Category("Failure")]
         public void T52_DictionaryKeynull()
         {
             // as per spec this is null as key is supported
             String code =
-            @"
+                @"
                 b=null;
                 a = {b : 4};
                 r = a [b];
             ";
-
             thisTest.RunAndVerifyRuntimeWarning(code, ProtoCore.Runtime.WarningID.InvalidArguments);
         }
+
         [Test]
         public void T53_DictionaryKeyUpdate()
         {
@@ -3224,16 +3225,16 @@ test = foo().IntVal;
             @"
                 r = a[b];
                 b = ""y"";
-                a ={ b: 10};
+                a ={ ""y"": 10};
             ";
 
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("r", 10);
         }
+
         [Test]
         public void T54_DictionaryKeyUpdate_2()
         {
-
             String code =
             @"
                a = [1, 2, 3];
@@ -3257,8 +3258,7 @@ test = foo().IntVal;
             @"
             def test(c:int)
             {
-                b = ""x"";
-                a = {b : c};
+                a = {""x"" : c};
                 return = a;
             }
                 
@@ -3268,6 +3268,7 @@ test = foo().IntVal;
             ExecutionMirror mirror = thisTest.RunScriptSource(code);
             thisTest.Verify("r", 5);
         }
+
         [Test, Category("Failure")]
         [Category("DSDefinedClass_Ported")]
         public void T60_DictionaryDotOperator()
@@ -3306,7 +3307,7 @@ x = y[b];
 
         }
         [Test]
-        public void T70_DictionaryImeperativeWhile()
+        public void T70_DictionaryImperativeWhile()
         {
 
             String code =
@@ -3410,7 +3411,7 @@ r2 = a[""1""];
         [Test]
         public void T72_Dictionarytypeconversion()
         {
-
+            // Dictionary expression keys not (yet) supported
             String code =
             @"
                
@@ -3418,9 +3419,7 @@ r2 = a[""1""];
 
             def foo(b1)
             {
-
-                d = { b1: true};
-                return = d;
+                return Dictionary.ByKeysValues(b1, true);
             }
             z1 = foo(b);
             x = z1[b];
@@ -3433,7 +3432,7 @@ r2 = a[""1""];
         [Test]
         public void T73_Dictionaryrepguideszip()
         {
-
+            // Dictionary expression keys not (yet) supported
             String code =
             @"
                
@@ -3441,9 +3440,7 @@ r2 = a[""1""];
 
             def foo(b1 : var)
             {
-
-                a1 = { b1: true};
-                return = a1;
+                return Dictionary.ByKeysValues(b1, true);
             }
             z1 = foo(b < 1 >);
             x = z1[0][b];

--- a/test/core/cbn/TestDictionaryListSyntax.dyn
+++ b/test/core/cbn/TestDictionaryListSyntax.dyn
@@ -2,7 +2,7 @@
   "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
   "IsCustomNode": false,
   "Description": "",
-  "Name": "Home",
+  "Name": "TestDictionaryListSyntax",
   "ElementResolver": {
     "ResolutionMap": {
       "DesignScript.Builtin.Dictionary": {
@@ -23,7 +23,7 @@
         {
           "Id": "d4ce5edd31534092b990fbafed359a1f",
           "Name": "",
-          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "Description": "Value of expression at line 1",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -43,7 +43,7 @@
         {
           "Id": "edf52521f33947a3840ec55e3260b968",
           "Name": "",
-          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "Description": "Value of expression at line 1",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -83,7 +83,7 @@
         {
           "Id": "dc2aadd016e44b22bb076acc391f32fe",
           "Name": "",
-          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "Description": "Value of expression at line 1",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -248,7 +248,7 @@
         {
           "Id": "601a6087432f45a892db35875d0b664c",
           "Name": "",
-          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "Description": "Value of expression at line 1",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -297,7 +297,7 @@
         {
           "Id": "2c3dc25c806845b9a3e00313b2cccdaa",
           "Name": "",
-          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "Description": "Value of expression at line 1",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -346,7 +346,7 @@
         {
           "Id": "36854257d0e64cf1bc29e7e1d4b3a43e",
           "Name": "",
-          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "Description": "Value of expression at line 1",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -395,7 +395,7 @@
         {
           "Id": "3210d309f62e4f39904536a765179b20",
           "Name": "",
-          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "Description": "Value of expression at line 1",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -444,7 +444,7 @@
         {
           "Id": "64b2a51934cd4069b51f2936066e3832",
           "Name": "",
-          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "Description": "Value of expression at line 1",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -459,6 +459,16 @@
       "NodeType": "CodeBlockNode",
       "Code": "{1,2};",
       "Id": "0cb2f07a95ab49edbd7e3e21281b87a3",
+      "Inputs": [],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "{ foo: \"bar\" };",
+      "Id": "a2b3ac3198f046b0906e8617821d0a51",
       "Inputs": [],
       "Outputs": [],
       "Replication": "Disabled",
@@ -523,7 +533,18 @@
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
-    "Camera": null,
+    "Camera": {
+      "Name": "Default Camera",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
     "NodeViews": [
       {
         "ShowGeometry": true,
@@ -556,14 +577,6 @@
         "Excluded": false,
         "X": 101.0,
         "Y": 69.0
-      },
-      {
-        "ShowGeometry": true,
-        "Name": "Code Block",
-        "Id": "01d27d0f50ce4a63b16255df4af82238",
-        "Excluded": false,
-        "X": 14.0,
-        "Y": 814.0
       },
       {
         "ShowGeometry": true,
@@ -682,8 +695,16 @@
         "Name": "Code Block",
         "Id": "0cb2f07a95ab49edbd7e3e21281b87a3",
         "Excluded": false,
-        "X": 1104.0,
-        "Y": 261.0
+        "X": 313.0,
+        "Y": 788.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "a2b3ac3198f046b0906e8617821d0a51",
+        "Excluded": false,
+        "X": 149.0,
+        "Y": 796.0
       }
     ],
     "Annotations": [],


### PR DESCRIPTION
### Purpose

We decided that only supporting string literals as keys in the first release of Dictionary's is the most reasonable approach. Beyond simplifying the parser and eliminating the complexities of interaction with other language features (notably replication), this approach makes our initialization syntax essentially identical to JSON.

Previously, we also supported identifiers as keys. Now we only support string literals.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 
