### PR TITLE
Delete null key assignment test

### DIFF
--- a/test/Engine/ProtoTest/TD/MultiLangTests/CollectionAssignment.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/CollectionAssignment.cs
@@ -3204,19 +3204,6 @@ test = foo().IntVal;
             thisTest.Verify("r", new object[] { 4, -4 });
         }
 
-        [Test, Category("Failure")]
-        public void T52_DictionaryKeynull()
-        {
-            // as per spec this is null as key is supported
-            String code =
-                @"
-                b=null;
-                a = {b : 4};
-                r = a [b];
-            ";
-            thisTest.RunAndVerifyRuntimeWarning(code, ProtoCore.Runtime.WarningID.InvalidArguments);
-        }
-
         [Test]
         public void T53_DictionaryKeyUpdate()
         {


### PR DESCRIPTION
### Purpose

This ain't supported, so we're removing the test. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@gregmarr 
