### PR TITLE
Fix list count, level display in preview bubble with dictionary present

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -153,7 +153,6 @@ namespace Dynamo.ViewModels
             }
         }
 
-
         /// <summary>
         /// Number of items in the overall list if node output is a list
         /// </summary>
@@ -256,13 +255,17 @@ namespace Dynamo.ViewModels
             {
                 return GetMaximumDepthAndItemNumber(wvm.Children[0]);
             }
-            else
+
+            // if it's a list, recurse
+            if (wvm.NodeLabel == LIST)
             {
                 var depthAndNumbers = wvm.Children.Select(GetMaximumDepthAndItemNumber);
                 var maxDepth = depthAndNumbers.Select(t => t.Item1).DefaultIfEmpty(1).Max() + 1;
                 var itemNumber = depthAndNumbers.Select(t => t.Item2).Sum();
                 return new Tuple<int, int>(maxDepth, itemNumber);
             }
+
+            return new Tuple<int, int>(1,1);
         }
 
         /// <summary>

--- a/test/DynamoCoreWpfTests/WatchNodeTests.cs
+++ b/test/DynamoCoreWpfTests/WatchNodeTests.cs
@@ -230,5 +230,25 @@ namespace DynamoCoreWpfTests
 
             Assert.AreEqual("Function", watchVM.NodeLabel);
         }
+
+        [Test]
+        public void WatchNestedDictionary()
+        {
+            string openPath = Path.Combine(TestDirectory, @"core\watch\watchNestedDictionaryList.dyn");
+            ViewModel.OpenCommand.Execute(openPath);
+            ViewModel.HomeSpace.Run();
+
+            var watchNode = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<CodeBlockNodeModel>();
+            var watchVM = ViewModel.WatchHandler.GenerateWatchViewModelForData(
+                watchNode.CachedValue,
+                ViewModel.Model.EngineController.LiveRunnerRuntimeCore,
+                watchNode.AstIdentifierForPreview.Name);
+
+            watchVM.CountNumberOfItems();
+            watchVM.CountLevels();
+
+            Assert.AreEqual(3, watchVM.Levels.ElementAt(0));
+            Assert.AreEqual(2, watchVM.NumberOfItems);
+        }
     }
 }

--- a/test/core/watch/watchNestedDictionaryList.dyn
+++ b/test/core/watch/watchNestedDictionaryList.dyn
@@ -1,0 +1,76 @@
+{
+  "Uuid": "b3971a38-9e42-4229-9ebd-7fa012a6ac9b",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "watchNestedDictionaryList",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "Builtin.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[[{\"foo\": [1,2]}, {\"bar\": [1,2,3,4], \"baz\": 1}]];",
+      "Id": "937132ee84a64220b496e9f7d86f477a",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "65eb03b27fd64885a55e921c23592d61",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.0.2821",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Default Camera",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "937132ee84a64220b496e9f7d86f477a",
+        "Excluded": false,
+        "X": 119.0,
+        "Y": 213.0
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

@kronz has identified that we count leaf elements that are underneath dictionaries in overall item count on preview bubbles. We also showed Dictionary's as "levels" in lists, which is not true. This PR fixes the two issues.

<img width="546" alt="screen shot 2018-02-09 at 3 45 28 pm" src="https://user-images.githubusercontent.com/916345/36050247-c9a60ada-0db3-11e8-932c-64c71deadc1a.png">

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps 