### PR TITLE
Fix overlap of expansion button in preview bubble with Dictionary

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Preview/WatchViewModel.cs
@@ -10,7 +10,6 @@ namespace Dynamo.ViewModels
 {
     public class WatchViewModel : NotificationObject
     {
-
         #region Events
 
         public event Action Clicked;
@@ -211,7 +210,7 @@ namespace Dynamo.ViewModels
             this.tagGeometry = tagGeometry;
             numberOfItems = 0;
             maxListLevel = 0;
-            isCollection = label == WatchViewModel.LIST;
+            isCollection = label == WatchViewModel.LIST || label == WatchViewModel.DICTIONARY;
         }
 
         private bool CanFindNodeForPath(object obj)


### PR DESCRIPTION
### Purpose

Dictionary keys sometimes overlapped the expand button in preview bubbles. Now they shouldn't.

**BEFORE**

<img width="546" alt="screen shot 2018-02-09 at 3 45 28 pm" src="https://user-images.githubusercontent.com/916345/36052566-361ed6d0-0dbc-11e8-87a8-885f2504d0d3.png">

**AFTER**

<img width="526" alt="screen shot 2018-02-09 at 4 55 20 pm" src="https://user-images.githubusercontent.com/916345/36052568-399f8f16-0dbc-11e8-9601-b1efd920c99b.png">


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps 

CC @kronz @Racel 
