### PR TITLE
Test workspace names should be a file path and maintain their original structure

### DIFF
--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -444,6 +444,9 @@ namespace Dynamo.Tests
         public static string jsonNonGuidFolderName = "json_nonGuidIds";
         public static string jsonFolderName = "json";
 
+        public const string coreTestsGuidPath = "DynamoTestsJSON/DynamoCoreTests/Guid";
+        public const string coreTestsNonGuidPath = "DynamoTestsJSON/DynamoCoreTests/NonGuid";
+
         private TimeSpan lastExecutionDuration = new TimeSpan();
         private Dictionary<Guid, string> modelsGuidToIdMap = new Dictionary<Guid, string>();
 
@@ -800,7 +803,7 @@ namespace Dynamo.Tests
             Assert.IsNotNullOrEmpty(jo.ToString());
 
             // Call structured copy function
-            SaveJsonTempWithFolderStructure("DynamoTestsJSON/DynamoCoreTests/Guid", filePathBase, jo);
+            SaveJsonTempWithFolderStructure(coreTestsGuidPath, filePathBase, jo);
 
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonFolderName);
@@ -829,7 +832,7 @@ namespace Dynamo.Tests
             Assert.IsNotNullOrEmpty(jo.ToString());
 
             // Call structured copy function
-            SaveJsonTempWithFolderStructure("DynamoTestsJSON/DynamoCoreTests/NonGuid", filePathBase, jo);
+            SaveJsonTempWithFolderStructure(coreTestsNonGuidPath, filePathBase, jo);
 
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonNonGuidFolderName);

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -444,8 +444,8 @@ namespace Dynamo.Tests
         public static string jsonNonGuidFolderName = "json_nonGuidIds";
         public static string jsonFolderName = "json";
 
-        public const string coreTestsGuidPath = "DynamoTestsJSON/DynamoCoreTests/Guid";
-        public const string coreTestsNonGuidPath = "DynamoTestsJSON/DynamoCoreTests/NonGuid";
+        private const string coreTestsGuidPath = "DynamoTestsJSON/DynamoCoreTests/Guid";
+        private const string coreTestsNonGuidPath = "DynamoTestsJSON/DynamoCoreTests/NonGuid";
 
         private TimeSpan lastExecutionDuration = new TimeSpan();
         private Dictionary<Guid, string> modelsGuidToIdMap = new Dictionary<Guid, string>();
@@ -762,7 +762,14 @@ namespace Dynamo.Tests
             Assert.IsTrue(inputs.SequenceEqual(inputs2));
         }
 
-        private static string SaveJsonTempWithFolderStructure(string folder, string filePath, JObject jo)
+        /// <summary>
+        /// Copy test file to specified folder while 
+        /// maintaining original directory structure
+        /// </summary>
+        /// <param name="folder">destination folder</param>
+        /// <param name="filePath">test file path</param>
+        /// <param name="jo">test json object</param>
+        private static void SaveJsonTempWithFolderStructure(string folder, string filePath, JObject jo)
         {
             // Get all folder structure following "\\test"
             var expectedStructure = filePath.Split(new string[] { "\\test" }, StringSplitOptions.None).Last();
@@ -791,8 +798,6 @@ namespace Dynamo.Tests
             }
 
             File.WriteAllText(jsonPath, jo.ToString());
-
-            return jo.ToString();
         }
 
         private static string ConvertCurrentWorkspaceToJsonAndSave(DynamoModel model, string filePathBase)

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -580,17 +580,19 @@ namespace DynamoCoreWpfTests
 
         }
 
-        private static string SaveJsonTempWithFolderStructure(DynamoViewModel viewModel, string filePath, JObject jo)
+        private static string SaveJsonTempWithFolderStructure(string folder, string filePath, JObject jo)
         {   
             // Get all folder structure following "\\test"
             var expectedStructure = filePath.Split(new string[] { "\\test" }, StringSplitOptions.None).Last();
-
+            // Update workspace name to be a file path, see QNTM-2973
+            jo["Name"]=expectedStructure.Replace("\\", "/");
+            
             // Current test fileName
             var fileName = Path.GetFileName(filePath);
 
             // Get temp folder path
             var tempPath = Path.GetTempPath();
-            var jsonFolder = Path.Combine(tempPath, "DynamoTestJSON");
+            var jsonFolder = Path.Combine(tempPath, folder);
             jsonFolder += Path.GetDirectoryName(expectedStructure);
 
             if (!System.IO.Directory.Exists(jsonFolder))
@@ -599,7 +601,7 @@ namespace DynamoCoreWpfTests
             }
 
             // Combine directory with test file name
-            var jsonPath = jsonFolder + "\\" + fileName;
+            var jsonPath = jsonFolder + "/" + fileName;
 
             if (File.Exists(jsonPath))
             {
@@ -624,8 +626,8 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNullOrEmpty(jsonModel);
             Assert.IsNotNullOrEmpty(jo.ToString());
 
-            // Call new structured copy function
-            SaveJsonTempWithFolderStructure(viewModel, filePath, jo);
+            // Call structured copy function
+            SaveJsonTempWithFolderStructure("DynamoTestsJSON/DynamoCoreWPFTests/Guid", filePath, jo);
 
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonFolderName);
@@ -662,8 +664,8 @@ namespace DynamoCoreWpfTests
 
             Assert.IsNotNullOrEmpty(json);
 
-            // Call new structured copy function
-            SaveJsonTempWithFolderStructure(viewModel, filePath, jo);
+            // Call structured copy function
+            SaveJsonTempWithFolderStructure("DynamoTestsJSON/DynamoCoreWPFTests/NonGuid", filePath, jo);
 
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonNonGuidFolderName);

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -470,8 +470,8 @@ namespace DynamoCoreWpfTests
         public static string jsonNonGuidFolderName = "jsonWithView_nonGuidIds";
         public static string jsonFolderName = "jsonWithView";
 
-        public const string coreWPFTestsGuidPath = "DynamoTestsJSON/DynamoCoreWPFTests/Guid";
-        public const string coreWPFTestsNonGuidPath = "DynamoTestsJSON/DynamoCoreWPFTests/NonGuid";
+        private const string coreWPFTestsGuidPath = "DynamoTestsJSON/DynamoCoreWPFTests/Guid";
+        private const string coreWPFTestsNonGuidPath = "DynamoTestsJSON/DynamoCoreWPFTests/NonGuid";
 
         private TimeSpan lastExecutionDuration = new TimeSpan();
         private Dictionary<Guid, string> modelsGuidToIdMap = new Dictionary<Guid, string>();
@@ -583,7 +583,14 @@ namespace DynamoCoreWpfTests
 
         }
 
-        private static string SaveJsonTempWithFolderStructure(string folder, string filePath, JObject jo)
+        /// <summary>
+        /// Copy test file to specified folder while 
+        /// maintaining original directory structure
+        /// </summary>
+        /// <param name="folder">destination folder</param>
+        /// <param name="filePath">test file path</param>
+        /// <param name="jo">test json object</param>
+        private static void SaveJsonTempWithFolderStructure(string folder, string filePath, JObject jo)
         {   
             // Get all folder structure following "\\test"
             var expectedStructure = filePath.Split(new string[] { "\\test" }, StringSplitOptions.None).Last();
@@ -612,8 +619,6 @@ namespace DynamoCoreWpfTests
             }
 
             File.WriteAllText(jsonPath, jo.ToString());
-
-            return jo.ToString();
         }
 
         private static string ConvertCurrentWorkspaceViewToJsonAndSave(DynamoViewModel viewModel, string filePath)

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -470,6 +470,9 @@ namespace DynamoCoreWpfTests
         public static string jsonNonGuidFolderName = "jsonWithView_nonGuidIds";
         public static string jsonFolderName = "jsonWithView";
 
+        public const string coreTestsGuidPath = "DynamoTestsJSON/DynamoCoreWPFTests/Guid";
+        public const string coreTestsNonGuidPath = "DynamoTestsJSON/DynamoCoreWPFTests/NonGuid";
+
         private TimeSpan lastExecutionDuration = new TimeSpan();
         private Dictionary<Guid, string> modelsGuidToIdMap = new Dictionary<Guid, string>();
 
@@ -627,7 +630,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNullOrEmpty(jo.ToString());
 
             // Call structured copy function
-            SaveJsonTempWithFolderStructure("DynamoTestsJSON/DynamoCoreWPFTests/Guid", filePath, jo);
+            SaveJsonTempWithFolderStructure(coreTestsGuidPath, filePath, jo);
 
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonFolderName);
@@ -665,7 +668,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNullOrEmpty(json);
 
             // Call structured copy function
-            SaveJsonTempWithFolderStructure("DynamoTestsJSON/DynamoCoreWPFTests/NonGuid", filePath, jo);
+            SaveJsonTempWithFolderStructure(coreTestsNonGuidPath, filePath, jo);
 
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonNonGuidFolderName);

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -470,8 +470,8 @@ namespace DynamoCoreWpfTests
         public static string jsonNonGuidFolderName = "jsonWithView_nonGuidIds";
         public static string jsonFolderName = "jsonWithView";
 
-        public const string coreTestsGuidPath = "DynamoTestsJSON/DynamoCoreWPFTests/Guid";
-        public const string coreTestsNonGuidPath = "DynamoTestsJSON/DynamoCoreWPFTests/NonGuid";
+        public const string coreWPFTestsGuidPath = "DynamoTestsJSON/DynamoCoreWPFTests/Guid";
+        public const string coreWPFTestsNonGuidPath = "DynamoTestsJSON/DynamoCoreWPFTests/NonGuid";
 
         private TimeSpan lastExecutionDuration = new TimeSpan();
         private Dictionary<Guid, string> modelsGuidToIdMap = new Dictionary<Guid, string>();
@@ -630,7 +630,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNullOrEmpty(jo.ToString());
 
             // Call structured copy function
-            SaveJsonTempWithFolderStructure(coreTestsGuidPath, filePath, jo);
+            SaveJsonTempWithFolderStructure(coreWPFTestsGuidPath, filePath, jo);
 
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonFolderName);
@@ -668,7 +668,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNullOrEmpty(json);
 
             // Call structured copy function
-            SaveJsonTempWithFolderStructure(coreTestsNonGuidPath, filePath, jo);
+            SaveJsonTempWithFolderStructure(coreWPFTestsNonGuidPath, filePath, jo);
 
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonNonGuidFolderName);


### PR DESCRIPTION
### Purpose

[QNTM-2973](https://jira.autodesk.com/browse/QNTM-2973)

This PR ensures all core and coreWPF tests are copied in a their original structure to a temporary location to be copied to S3 for CoGS testing.  The workspace names are also updated just for the copied files to correspond to their location.  The files are structured as outlined below...

```
├───DynamoTestsJSON
│   ├───DynamoCoreTests
│   │   ├───Guid
│   │   └───NonGuid
│   └───DynamoCoreWPFTests
│       ├───Guid
│       └───NonGuid
```

The Guid and NonGuid folders follow the same folder structure as `Dynamo/Test`.  For example, inside of one of the `Guid` or `NonGuid` folder you may see folders such as `core`, `UI`, etc.  Flattened versions of all these subfolders are still copied to the root `Temp` location under the naming `json`, `json_NonGuidIds`, `jsonWithView`, and `jsonWithView_NonGuidIds`.

Workspace Naming Example:
```json
{
  "Uuid": "1b4db7eb-4057-5ddf-91e0-36dec72071f5",
  "IsCustomNode": false,
  "Description": "TestDescription",
  "Name": "/core/Angle.dyn",
  "ElementResolver": {
    "ResolutionMap": {}
  }
```

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps 

### FYIs

@gregmarr 
