### PR TITLE
Test workspace names should be a file path and maintain their original structure

### DIFF
--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -580,17 +580,25 @@ namespace DynamoCoreWpfTests
 
         }
 
-        private static string SaveJsonTempWithFolderStructure(DynamoViewModel viewModel, string filePath, JObject jo)
+        /// <summary>
+        /// Copy test file to specified folder while 
+        /// maintaining original directory structure
+        /// and assigning file path as workspace name.
+        /// </summary>
+        /// <param name="filePath">original test file path</param>
+        /// <param name="jo">test json object</param>
+        private static void SaveJsonTempWithFolderStructure(string filePath, JObject jo)
         {   
             // Get all folder structure following "\\test"
             var expectedStructure = filePath.Split(new string[] { "\\test" }, StringSplitOptions.None).Last();
+            jo["Name"] = expectedStructure.Replace("\\", "/");
 
             // Current test fileName
             var fileName = Path.GetFileName(filePath);
 
             // Get temp folder path
             var tempPath = Path.GetTempPath();
-            var jsonFolder = Path.Combine(tempPath, "DynamoTestJSON");
+            var jsonFolder = Path.Combine(tempPath, "DynamoCoreWPFTests");
             jsonFolder += Path.GetDirectoryName(expectedStructure);
 
             if (!System.IO.Directory.Exists(jsonFolder))
@@ -607,8 +615,6 @@ namespace DynamoCoreWpfTests
             }
 
             File.WriteAllText(jsonPath, jo.ToString());
-
-            return jo.ToString();
         }
 
         private static string ConvertCurrentWorkspaceViewToJsonAndSave(DynamoViewModel viewModel, string filePath)
@@ -624,8 +630,9 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNullOrEmpty(jsonModel);
             Assert.IsNotNullOrEmpty(jo.ToString());
 
-            // Call new structured copy function
-            SaveJsonTempWithFolderStructure(viewModel, filePath, jo);
+            // Call structured copy function for CoGS testing, see QNTM-2973
+            // Only called for CoreWPFTests w/ Guids
+            SaveJsonTempWithFolderStructure(filePath, jo);
 
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonFolderName);
@@ -661,9 +668,6 @@ namespace DynamoCoreWpfTests
             json = serializationTestUtils.replaceModelIdsWithNonGuids(json, model.CurrentWorkspace ,modelsGuidToIdMap);
 
             Assert.IsNotNullOrEmpty(json);
-
-            // Call new structured copy function
-            SaveJsonTempWithFolderStructure(viewModel, filePath, jo);
 
             var tempPath = Path.GetTempPath();
             var jsonFolder = Path.Combine(tempPath, jsonNonGuidFolderName);


### PR DESCRIPTION
### Purpose

[QNTM-2973](https://jira.autodesk.com/browse/QNTM-2973)

This PR ensures all DynamoCoreWPF test files with GUIDS are copied to a temporary location while maintaining their original structure to later be copied to S3 for CoGS testing.  The workspace names are also updated just for the copied test files in order to correspond to the files location.  The files are structured as outlined below...

```
├───Temp
│   ├───DynamoCoreWPFTests
│      ├───All GUID Structured Test Files
```
All of the files with `DynamoCoreWPFTests` follow the same folder structure as `Dynamo/Test`.  For example, inside this folder you may see folders such as `core`, `UI`, etc.  Flattened versions of all these sub-folders are still copied to the root `Temp` location under the naming `json`, `json_NonGuidIds`, `jsonWithView`, and `jsonWithView_NonGuidIds` and required for other testing.

Workspace Naming Example:
```json
{
  "Uuid": "1b4db7eb-4057-5ddf-91e0-36dec72071f5",
  "IsCustomNode": false,
  "Description": "TestDescription",
  "Name": "/core/Angle.dyn",
  "ElementResolver": {
    "ResolutionMap": {}
  }
```

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps 

### FYIs

@gregmarr 
