### PR TITLE
QNTM-3341: Skip throwing an exception while explicitly importing corrupt DS file

### DIFF
--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -604,7 +604,7 @@ namespace Dynamo.Engine
             }
             catch (Exception e)
             {
-                OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(library, e.Message));
+                OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(library, e.Message, !isExplicitlyImportedLib));
                 return false;
             }
 

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -173,8 +173,8 @@ namespace Dynamo.Engine
             Log(ex.Message, WarningLevel.Moderate);
 
             // NOTE: We do not want to throw an exception here if the failure was due
-            // to a missing library that was explicitly (attempoted to be) loaded
-            // but was moved or deleted
+            // to a missing library that was explicitly (attempted to be) loaded
+            // but was moved or deleted OR if a .DS file with syntax error(s) is loaded
             if (args.ThrowOnFailure)
                 throw ex;
         }
@@ -555,7 +555,8 @@ namespace Dynamo.Engine
                 // In the case that a library was explicitly imported using the "File|Import Library" command
                 // set the load failed args to not throw an exception if the load fails. This can happen after using
                 // File|Import Library and then moving or deleting the library.
-                OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(path, errorMessage, !isExplicitlyImportedLib));
+                OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(path, errorMessage,
+                    throwOnFailure: !isExplicitlyImportedLib));
 
                 return false;
             }
@@ -604,7 +605,8 @@ namespace Dynamo.Engine
             }
             catch (Exception e)
             {
-                OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(library, e.Message, !isExplicitlyImportedLib));
+                OnLibraryLoadFailed(new LibraryLoadFailedEventArgs(library, e.Message,
+                    throwOnFailure: !isExplicitlyImportedLib));
                 return false;
             }
 


### PR DESCRIPTION
### Purpose

This fixes a crash while starting Dynamo and a ".DS" file with bad syntax is imported by default. 

The path to a ".DS" file can be set as one of the default package paths if it has been imported successfully in a previous session of Dynamo. However, if for some reason the file is edited and its syntax is broken, it can cause Dynamo to crash at startup when Dynamo tries to import it again (by default).

The fix is to skip throwing an exception in `LibraryLoadFailureHandler` by setting the `LibraryLoadFailedEventArgs`'s `ThrowOnFailure` argument to `false` in such cases so that Dynamo can continue loading other libraries and launch successfully.

JIRA: https://jira.autodesk.com/browse/QNTM-3341

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@pboyer 

### FYIs

@jnealb 
