### PR TITLE
Fix failing serialization test re: json inputs/outputs

### DIFF
--- a/test/core/dummy_node/2080_JSONTESTCRASH undo_redo.dyn
+++ b/test/core/dummy_node/2080_JSONTESTCRASH undo_redo.dyn
@@ -7,6 +7,7 @@
     "ResolutionMap": {}
   },
   "Inputs": [],
+  "Outputs": [],
   "Nodes": [
     {
       "ConcreteType": "Dynamo.Graph.Nodes.UNKNOWNTYPE, DynamoCore",
@@ -80,7 +81,9 @@
         "Id": "158f8f25ddb746c88323ae262e87611e",
         "Excluded": false,
         "X": 76.8,
-        "Y": 65.3999999999999
+        "Y": 65.3999999999999,
+        "IsInput": false,
+        "IsOutput": false
       },
       {
         "ShowGeometry": true,
@@ -88,7 +91,9 @@
         "Id": "6cbd0760736f4235a03b38fb359e9957",
         "Excluded": false,
         "X": 76.8,
-        "Y": 162.4
+        "Y": 162.4,
+        "IsInput": false,
+        "IsOutput": false
       }
     ],
     "Annotations": [],


### PR DESCRIPTION
### Purpose

This PR fixes a failing test related to the [8517 PR](https://github.com/DynamoDS/Dynamo/pull/8517)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 