### PR TITLE
Custom Node Workspace Category Preservation

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -678,6 +678,7 @@ namespace Dynamo.Core
                     //we pass null for engine and scheduler as apparently the custom node constructor doesn't need them.
                     newWorkspace = (CustomNodeWorkspaceModel)WorkspaceModel.FromJson(jsonDoc, this.libraryServices, null, null, nodeFactory, false, true, this);
                     newWorkspace.FileName = workspaceInfo.FileName;
+                    newWorkspace.Category = workspaceInfo.Category;
                 }
 
             }

--- a/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
+++ b/test/DynamoCoreTests/CustomNodeWorkspaceOpening.cs
@@ -91,12 +91,24 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void JsonCustomNodeWorkspaceIsAddedToSearchOnOpening()
+        public void JsonCustomNodeWorkspaceIsAddedToSearchOnOpeningDyf()
         {
             OpenTestFile(@"core\combine", "Sequence_Json.dyf");
 
             var res = CurrentDynamoModel.SearchModel.Search("Sequence2");
             Assert.AreEqual("Sequence2", res.First().Name);
+        }
+
+        [Test]
+        public void JsonCustomNodeWorkspaceIsAddedToSearchOnOpeningDyn()
+        {
+            // Opening a dyn should automatically add any dyf in the same
+            // folder as CustomNodeWorkspace and maintain the saved category
+            OpenTestFile(@"core\combine", "combine-with-three.dyn");
+
+            var res = CurrentDynamoModel.SearchModel.Search("Sequence2");
+            Assert.AreEqual("Sequence2", res.First().Name);
+            Assert.AreEqual("Misc", res.First().FullCategoryName);
         }
     }
 


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[QNTM-3302](https://jira.autodesk.com/browse/QNTM-3302)
Custom Node Category gets reset to "Custom nodes" erroneously which is reported in https://github.com/DynamoDS/Dynamo/issues/8477

This PR:
1 This PR preserve Custom Node Workspace Category during initialization
2 Add Unit test to make sure the behavior is always checked

[ Running Self-CI: https://ecwest.autodesk.com/commander/link/jobDetails/jobs/354af057-18b9-11e8-8cd1-a0d3c1eff5a4? ]  Passed

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps 

### FYIs

@jnealb @andydandy74 
