### PR TITLE
Serialize builtin Dictionary data for serialization tests

### DIFF
--- a/src/DynamoCLI/CommandLineRunner.cs
+++ b/src/DynamoCLI/CommandLineRunner.cs
@@ -69,20 +69,9 @@ namespace DynamoCLI
                     var resultsdict = new Dictionary<Guid, List<object>>();
                     foreach (var node in model.CurrentWorkspace.Nodes)
                     {
-                        var portvalues = new List<object>();
-                        foreach (var port in node.OutPorts)
-                        {
-                            var value = node.GetValue(port.Index, model.EngineController);
-                            if (value.IsCollection)
-                            {
-                                portvalues.Add(GetStringRepOfCollection(value));
-                            }
-                            else
-                            {
-                                portvalues.Add(value.StringData);
-                            }
-                            
-                        }
+                        var portvalues = node.OutPorts.Select(p =>
+                        ProtoCore.Utils.CoreUtils.GetDataOfValue(node.GetValue(p.Index, model.EngineController))).ToList();
+
                         resultsdict.Add(node.GUID, portvalues);
                     }
                     outputresults.Add(resultsdict);

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -725,6 +725,34 @@ namespace ProtoCore.Utils
             }
             return codeblock;
         }
+        
+        /// <summary>
+        /// Returns the CLR object for a given mirror data
+        /// </summary>
+        public static object GetDataOfValue(Mirror.MirrorData value)
+        {
+            if (value.IsCollection)
+            {
+                return value.GetElements().Select(GetDataOfValue).ToList();
+            }
+
+            if (!value.IsPointer)
+            {
+                var data = value.Data;
+
+                if (data != null)
+                {
+                    return data;
+                }
+            }
+            else if (value.Data is DesignScript.Builtin.Dictionary)
+            {
+                var dict = (DesignScript.Builtin.Dictionary)value.Data;
+                return dict.Keys.Zip(dict.Values, (key, val) => new { key, val }).ToDictionary(ns => ns.key, ns => ns.val);
+            }
+
+            return value.StringData;
+        }
 
         public static ProcedureNode GetFunctionByName(string name, CodeBlock codeBlock)
         {

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -128,7 +128,7 @@ namespace Dynamo.Tests
                     }
 
                     var portvalues = n.OutPorts.Select(p =>
-                        GetDataOfValue(n.GetValue(p.Index, controller))).ToList<object>();
+                        ProtoCore.Utils.CoreUtils.GetDataOfValue(n.GetValue(p.Index, controller))).ToList();
 
                     n.InPorts.ToList().ForEach(p =>
                     {
@@ -160,32 +160,7 @@ namespace Dynamo.Tests
                 }
             }
         }
-
-        private static object GetDataOfValue(ProtoCore.Mirror.MirrorData value)
-        {
-            if (value.IsCollection)
-            {
-                return value.GetElements().Select(GetDataOfValue).ToList();
-            }
-
-            if (!value.IsPointer)
-            {
-                var data = value.Data;
-
-                if (data != null)
-                {
-                    return data;
-                }
-            }
-            else if (value.Data is DesignScript.Builtin.Dictionary)
-            {
-                var dict = (DesignScript.Builtin.Dictionary) value.Data;
-                return dict.Keys.Zip(dict.Values, (num, str) => new {num, str }).ToDictionary(ns => ns.num, ns => ns.str);
-            }
-
-            return value.StringData;
-        }
-
+        
         /// <summary>
         /// compare two workspace comparison objects that represent workspace models
         /// </summary>

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -165,7 +165,7 @@ namespace Dynamo.Tests
         {
             if (value.IsCollection)
             {
-                return value.GetElements().Select(x => GetDataOfValue(x)).ToList<object>();
+                return value.GetElements().Select(GetDataOfValue).ToList();
             }
 
             if (!value.IsPointer)
@@ -176,6 +176,11 @@ namespace Dynamo.Tests
                 {
                     return data;
                 }
+            }
+            else if (value.Data is DesignScript.Builtin.Dictionary)
+            {
+                var dict = (DesignScript.Builtin.Dictionary) value.Data;
+                return dict.Keys.Zip(dict.Values, (num, str) => new {num, str }).ToDictionary(ns => ns.num, ns => ns.str);
             }
 
             return value.StringData;


### PR DESCRIPTION
### Purpose
Serialize builtin Dictionary data for serialization tests

Example output for `githubissue_6729.data`:
![image](https://user-images.githubusercontent.com/5710686/36622054-369717e0-18c9-11e8-9c3b-16ab71f028c6.png)

```
{
  "nodeData": {
    "66560c4e-f711-435a-a406-82cfd71d97fb": {
      "nodeType": "Dynamo.Graph.Nodes.CodeBlockNodeModel",
      "portValues": [
        {
          "out": [
            [
              3
            ],
            [
              3
            ]
          ],
          "in": [
            [
              1,
              2
            ],
            [
              4,
              5
            ]
          ]
        }
      ]
    },
    "1f2eeba0-9e76-4fb9-850d-1a9db5992a85": {
      "nodeType": "Dynamo.Graph.Nodes.CodeBlockNodeModel",
      "portValues": [
        [
          4,
          5
        ]
      ]
    },
    "a1a9e8a5-a791-4924-82e1-0dc6dd2215ed": {
      "nodeType": "CoreNodeModels.Watch",
      "portValues": [
        [
          4,
          5
        ]
      ]
    }
  },
  "executionDuration": 1.8746318
}
```

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @gregmarr 


