### PR TITLE
Add JSON.Parse, JSON.Stringify, and JSON.StringifyList to core library

### DIFF
--- a/src/Libraries/CoreNodes/CoreNodes.csproj
+++ b/src/Libraries/CoreNodes/CoreNodes.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Compare.cs" />
     <Compile Include="DateTime.cs" />
     <Compile Include="FileSystem.cs" />
+    <Compile Include="JSON.cs" />
     <Compile Include="List.cs" />
     <Compile Include="Math.cs" />
     <Compile Include="Object.cs" />

--- a/src/Libraries/CoreNodes/JSON.cs
+++ b/src/Libraries/CoreNodes/JSON.cs
@@ -15,7 +15,7 @@ namespace DSCore
         ///     Parse converts an arbitrary JSON string to a value. It is the opposite of JSON.Stringify.
         /// </summary>
         /// <param name="json">A JSON string</param>
-        /// <returns name="result"></returns>
+        /// <returns name="result">The result type depends on the content of the input string. The result type can be a primitive value (e.g. string, boolean, double), a List, or a Dictionary.</returns>
         public static object Parse(string json)
         {
             return ToNative(JToken.Parse(json));
@@ -57,22 +57,25 @@ namespace DSCore
         ///     Stringify converts an arbitrary value to JSON. It is the opposite of JSON.Parse.
         /// </summary>
         /// <param name="value">Any value</param>
-        /// <returns name="json">The resultant JSON.</returns>
+        /// <returns name="json">A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.</returns>
         public static string Stringify(object value)
         {
             return JsonConvert.SerializeObject(value, new DictConverter());
         }
 
         /// <summary>
-        ///     Stringify converts a list of arbitrary values to JSON. It is similar to JSON.Stringify, except it doesn't replicate.
+        ///     StringifyList converts a list of arbitrary values to JSON. JSON.StringifyList is similar to JSON.Stringify, except it doesn't replicate.
         /// </summary>
         /// <param name="values">A List of values</param>
-        /// <returns name="json">The resultant JSON</returns>
+        /// <returns name="json">A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.</returns>
         public static string StringifyList([ArbitraryDimensionArrayImport] object values)
         {
             return JsonConvert.SerializeObject(values, new DictConverter());
         }
 
+        /// <summary>
+        /// Ensures DesignScript.Builtin.Dictionary's, which deliberately don't implement IDictionary, are transformed into JSON objects.
+        /// </summary>
         private class DictConverter : JsonConverter
         {
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -1049,6 +1049,9 @@
                 },
                 {
                   "path": "DSCoreNodes.DSCore.JSON.Stringify"
+                },
+                {
+                  "path": "DSCoreNodes.DSCore.JSON.StringifyList"
                 }
               ],
               "childElements": [ ]

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -1043,6 +1043,12 @@
                 },
                 {
                   "path": "DSOffice.DSOffice.Data.ExportCSV"
+                },
+                {
+                  "path": "DSCoreNodes.DSCore.JSON.Parse"
+                },
+                {
+                  "path": "DSCoreNodes.DSCore.JSON.Stringify"
                 }
               ],
               "childElements": [ ]


### PR DESCRIPTION
### Purpose

These code changes provide a small, but powerful set of APIs for working with JSON in Dynamo.

The API mirrors that available in JavaScript - `JSON.Parse`, `JSON.Stringify`, and `JSON.StringifyList`. The latter has a signature of `JSON.StringifyList(value: var[]..[])` so it prevents replication.

**JSON.Parse**

<img width="1467" alt="screen shot 2018-02-23 at 11 32 18 am" src="https://user-images.githubusercontent.com/916345/36677329-d780455a-1adb-11e8-8ab3-40e7a99bf6fe.png">

**JSON.Stringify**

<img width="1634" alt="screen shot 2018-02-23 at 11 44 18 am" src="https://user-images.githubusercontent.com/916345/36677316-d362d97e-1adb-11e8-8e9e-55531fb4b7fb.png">

**JSON.StringifyList**

<img width="559" alt="screen shot 2018-02-23 at 2 48 15 pm" src="https://user-images.githubusercontent.com/916345/36677300-cd59251a-1adb-11e8-899f-2710ef049bfb.png">


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@Racel @kronz 
