### PR TITLE
Serialize Dictionaries to XML in CLI

### DIFF
--- a/src/DynamoCLI/CommandLineRunner.cs
+++ b/src/DynamoCLI/CommandLineRunner.cs
@@ -69,8 +69,20 @@ namespace DynamoCLI
                     var resultsdict = new Dictionary<Guid, List<object>>();
                     foreach (var node in model.CurrentWorkspace.Nodes)
                     {
-                        var portvalues = node.OutPorts.Select(p =>
-                        ProtoCore.Utils.CoreUtils.GetDataOfValue(node.GetValue(p.Index, model.EngineController))).ToList();
+                        var portvalues = new List<object>();
+                        foreach (var port in node.OutPorts)
+                        {
+                            var value = node.GetValue(port.Index, model.EngineController);
+                            if (value.IsCollection)
+                            {
+                                portvalues.Add(GetStringRepOfCollection(value));
+                            }
+                            else
+                            {
+                                portvalues.Add(value.StringData);
+                            }
+
+                        }
 
                         resultsdict.Add(node.GUID, portvalues);
                     }

--- a/src/DynamoCLI/DynamoCLI.csproj
+++ b/src/DynamoCLI/DynamoCLI.csproj
@@ -78,6 +78,10 @@
       <Name>ProtoCore</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\Libraries\Builtin\Builtin.csproj">
+      <Project>{c0d6dee5-5532-4345-9c66-4c00d7fdb8be}</Project>
+      <Name>Builtin</Name>
+    </ProjectReference>
     <ProjectReference Include="..\NodeServices\DynamoServices.csproj">
       <Project>{ef879a10-041d-4c68-83e7-3192685f1bae}</Project>
       <Name>DynamoServices</Name>

--- a/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
+++ b/src/DynamoCoreWpf/Interfaces/IWatchHandler.cs
@@ -167,7 +167,7 @@ namespace Dynamo.Interfaces
                 return node;
             }
 
-            if (data.IsPointer && data.Data is DesignScript.Builtin.Dictionary)
+            if (data.IsPointer && data.IsDictionary)
             {
                 var dict = data.Data as DesignScript.Builtin.Dictionary;
 

--- a/src/DynamoCoreWpf/Utilities/CompactBubbleHandler.cs
+++ b/src/DynamoCoreWpf/Utilities/CompactBubbleHandler.cs
@@ -60,7 +60,7 @@ namespace Dynamo.Wpf.Utilities
                     : null;
             }
 
-            if (mirrorData.IsPointer && mirrorData.Data is DesignScript.Builtin.Dictionary)
+            if (mirrorData.IsPointer && mirrorData.IsDictionary)
             {
                 var dict = mirrorData.Data as DesignScript.Builtin.Dictionary;
 

--- a/src/Engine/ProtoCore/Reflection/MirrorData.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorData.cs
@@ -267,6 +267,8 @@ namespace ProtoCore
                 }
             }
 
+            public bool IsDictionary => Data is DesignScript.Builtin.Dictionary;
+
             /// <summary>
             /// Determines if this data is a pointer
             /// </summary>

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -745,7 +745,7 @@ namespace ProtoCore.Utils
                     return data;
                 }
             }
-            else if (value.Data is DesignScript.Builtin.Dictionary)
+            else if (value.IsDictionary)
             {
                 var dict = (DesignScript.Builtin.Dictionary)value.Data;
                 return dict.Keys.Zip(dict.Values, (key, val) => new { key, val }).ToDictionary(ns => ns.key, ns => ns.val);

--- a/test/Libraries/CommandLineTests/CommandLineTests.cs
+++ b/test/Libraries/CommandLineTests/CommandLineTests.cs
@@ -89,5 +89,20 @@ namespace Dynamo.Tests
             AssertOutputValuesForGuid("8229dec7-b4ae-463b-a7ac-e36671fefef0", new List<Tuple<int, string>> { Tuple.Create(0, "{Surface,Surface,Surface,Surface,Surface,Surface}") }, output);
 
         }
+
+        [Test]
+        public void CanOpenAndRunFileWithDictionaryCorrectlyToOutputFileFromDynamoCLIexe()
+        {
+            string openpath = Path.Combine(TestDirectory, @"core\commandline\simpleDict.dyn");
+            var newpath = GetNewFileNameOnTempPath("xml");
+            string commandstring = "/o" + " " + openpath + " " + "/v" + " " + newpath;
+
+            DynamoCLI.Program.Main(CommandStringToStringArray(commandstring));
+            var output = new XmlDocument();
+            output.Load(newpath);
+            AssertOutputValuesForGuid("36c30251-c867-4d73-9a3b-24f3e9ab00e5", new List<Tuple<int, string>> { Tuple.Create(0, "{e : 6, d : {4, 5}, a : 1, c : {bar : 999, foo : 99}, b : 2}") }, output);
+            AssertOutputValuesForGuid("6a5bcff0-ce40-4773-aee6-88d99104b4a7", new List<Tuple<int, string>> { Tuple.Create(0, "{a,b,c,d,e}"), Tuple.Create(1, "{1,2,{bar : 999, foo : 99},{4,5},6}") }, output);
+
+        }
     }
 }


### PR DESCRIPTION

### Purpose

This PR reverts the change to the CLI in #8593 due to CLI test failures.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@smangarole 
