### PR TITLE
QNTM-3547: Marshall int64 to int32 in Python marshaller

### DIFF
--- a/src/DynamoUtilities/DataMarshaler.cs
+++ b/src/DynamoUtilities/DataMarshaler.cs
@@ -75,6 +75,9 @@ namespace Dynamo.Utilities
                 return null;
 
             var targetType = obj.GetType();
+
+            // TODO: Remove this conversion after updating IronPython version in 2.1
+            // in which IronPython will support Int64
             if (typeof (long) == targetType)
             {
                 obj = Convert.ToInt32(obj);

--- a/src/DynamoUtilities/DataMarshaler.cs
+++ b/src/DynamoUtilities/DataMarshaler.cs
@@ -75,7 +75,11 @@ namespace Dynamo.Utilities
                 return null;
 
             var targetType = obj.GetType();
-            if (typeof(long) == targetType) obj = Convert.ToInt32(obj);
+            if (typeof (long) == targetType)
+            {
+                obj = Convert.ToInt32(obj);
+                targetType = obj.GetType();
+            }
 
             Converter<object, object> marshaler;
             if (marshalers.TryGetValue(targetType, out marshaler) || cache.TryGetValue(targetType, out marshaler))

--- a/src/DynamoUtilities/DataMarshaler.cs
+++ b/src/DynamoUtilities/DataMarshaler.cs
@@ -75,6 +75,7 @@ namespace Dynamo.Utilities
                 return null;
 
             var targetType = obj.GetType();
+            if (typeof(long) == targetType) obj = Convert.ToInt32(obj);
 
             Converter<object, object> marshaler;
             if (marshalers.TryGetValue(targetType, out marshaler) || cache.TryGetValue(targetType, out marshaler))

--- a/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEvalTests.cs
@@ -87,5 +87,21 @@ namespace DSIronPythonTests
 
             Assert.AreEqual(3, output);
         }
-    }
+
+        [Test]
+        public void SliceOperator_Output()
+        {
+            var names = new ArrayList { "indx" };
+            var vals = new ArrayList { 3 };
+
+            var output = DSIronPython.IronPythonEvaluator.EvaluateIronPythonScript(
+                "OUT = [1,2,3,4,5,6,7][indx:indx+2]",
+                names,
+                vals);
+
+            var expected = new ArrayList { 4, 5 };
+
+            Assert.AreEqual(expected, output);
+        }
+}
 }


### PR DESCRIPTION
### Purpose

Marshall `Int64` to `Int32` in Python marshaller: This is a fix for 2.0 release. We are holding off on #8587 until 2.1 and making an exception for Python nodes to marshal 64 bit to 32 bit integers.

### Declarations 

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@jnealb @Racel @smangarole 
