### PR TITLE
Update UUID logic for dyn and dyf files in serialization tests

### DIFF
--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -422,6 +422,7 @@ namespace Dynamo.Tests
             if (!filePathBase.Contains("jsonWithView_nonGuidIds"))
             {
                 string structuredTestPath;
+                string flattenedTestPath = Path.GetTempPath() + "jsonWithView_nonGuidIds";
                 string extension = Path.GetExtension(filePathBase);
                 string pathWithoutExt = filePathBase.Substring(0, filePathBase.Length - extension.Length);
 
@@ -447,12 +448,12 @@ namespace Dynamo.Tests
                 File.WriteAllText(structuredTestPath, dataMapStr);
 
                 // Write to flattened path
-                if (File.Exists(filePathBase + ".data"))
+                if (File.Exists(flattenedTestPath + ".data"))
                 {
-                    File.Delete(filePathBase + ".data");
+                    File.Delete(flattenedTestPath + ".data");
                 }
 
-                File.WriteAllText(filePathBase + ".data", dataMapStr);
+                File.WriteAllText(flattenedTestPath + ".data", dataMapStr);
             }
 
             else

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -422,7 +422,8 @@ namespace Dynamo.Tests
             if (!filePathBase.Contains("jsonWithView_nonGuidIds"))
             {
                 string structuredTestPath;
-                string flattenedTestPath = Path.GetTempPath() + "jsonWithView_nonGuidIds";
+                string fileName = Path.GetFileNameWithoutExtension(filePathBase);
+                string flattenedTestPath = Path.GetTempPath() + "jsonWithView_nonGuidIds\\" + fileName;
                 string extension = Path.GetExtension(filePathBase);
                 string pathWithoutExt = filePathBase.Substring(0, filePathBase.Length - extension.Length);
 

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -418,8 +418,8 @@ namespace Dynamo.Tests
                 dataMapStr = dataMapStr.Replace(guidKey.ToString(), modelsGuidToIdMap[guidKey]);
             }
 
-            // If "jsonWithView_nonGuidIds" test copy .data file to additional structured folder location
-            if (!filePathBase.Contains("jsonWithView_nonGuidIds"))
+            // If "DynamoCoreWPFTests" test copy .data file to additional structured folder location
+            if (filePathBase.Contains("DynamoCoreWPFTests"))
             {
                 string structuredTestPath;
                 string fileName = Path.GetFileNameWithoutExtension(filePathBase);

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -608,11 +608,24 @@ namespace DynamoCoreWpfTests
             // Get all folder structure following "\\test"
             var expectedStructure = filePath.Remove(0, SerializationTests.TestDirectory.Length);
             var newWSName = expectedStructure.Replace("\\", "/");
+            var extension = Path.GetExtension(filePath);
+
             // Update WS name to original test file path
             jo["Name"] = newWSName;
-            var nameBasedGuid = GuidUtility.Create(currentDynamoModel.CurrentWorkspace.Guid, newWSName);
-            // Update Uuid to be unique based on new WS name
-            jo["Uuid"] = nameBasedGuid;
+
+            if (extension == ".dyf")
+            {
+                // If .dyf file use the existing Uuid
+                var customNodeWS = (CustomNodeWorkspaceModel) currentDynamoModel.CurrentWorkspace;
+                jo["Uuid"] = customNodeWS.CustomNodeId;
+            }
+
+            else
+            {
+                // If .dyn file update Uuid to be unique based on new WS name
+                var nameBasedGuid = GuidUtility.Create(currentDynamoModel.CurrentWorkspace.Guid, newWSName);
+                jo["Uuid"] = nameBasedGuid;
+            }
 
             // Current test fileName
             var fileName = Path.GetFileName(filePath);
@@ -640,7 +653,6 @@ namespace DynamoCoreWpfTests
 
             // Write DesignScript file
             string dsFileName = Path.GetFileNameWithoutExtension(fileName);
-            string extension = Path.GetExtension(filePath);
 
             // Determine if .dyn or .dyf
             // If .dyn and .dyf share common file name .ds and .data files is collide

--- a/test/DynamoCoreWpfTests/SerializationTests.cs
+++ b/test/DynamoCoreWpfTests/SerializationTests.cs
@@ -616,8 +616,11 @@ namespace DynamoCoreWpfTests
             if (extension == ".dyf")
             {
                 // If .dyf file use the existing Uuid
-                var customNodeWS = (CustomNodeWorkspaceModel) currentDynamoModel.CurrentWorkspace;
-                jo["Uuid"] = customNodeWS.CustomNodeId;
+                var customNodeWS = currentDynamoModel.CurrentWorkspace as CustomNodeWorkspaceModel;
+                if(customNodeWS != null)
+                {
+                    jo["Uuid"] = customNodeWS.CustomNodeId;
+                }
             }
 
             else


### PR DESCRIPTION
### Purpose

This PR does the following:
- removes duplicate .data files from being created in the structured test files
- for .dyn files, assign UUIDs based on the current WS GUID and new WS Name (reflects the files location)
- for .dyf files, assign UUIDs based on the CustomNodeID

This ensures UUIDs remain consistent and are not modified when the WS is closed and reopened/executed.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps 

### FYIs

@gregmarr 
