### PR TITLE
QNTM-2901: Fix crash while calling static methods from Imperative block

### DIFF
--- a/src/Engine/ProtoCore/ClassTable.cs
+++ b/src/Engine/ProtoCore/ClassTable.cs
@@ -296,9 +296,9 @@ namespace ProtoCore.DSASM
                 return null;
             }
 
-            return  ProcTable.GetFunctionsByNameAndArgumentNumber(procName, argCount)
-                          .Where(p => p.IsConstructor)
-                          .FirstOrDefault();
+            return  ProcTable
+                          .GetFunctionsByNameAndArgumentNumber(procName, argCount)
+                          .FirstOrDefault(p => p.IsConstructor);
         }
 
         public ProcedureNode GetFirstStaticFunctionBy(string procName)

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -329,7 +329,7 @@ namespace ProtoImperative
                     int realType;
                     procNode = classNode.GetMemberFunction(procName, arglist, globalClassIndex, out isAccessible, out realType, isStaticOrConstructor);
 
-                    if (isStaticOrConstructor && procNode == null)
+                    if (isStaticOrConstructor)
                     {
                         procNode = classNode.GetFirstConstructorBy(procName, arglist.Count);
                         if (procNode == null)
@@ -340,7 +340,7 @@ namespace ProtoImperative
                         if (procNode != null)
                         {
                             isAccessible = procNode.AccessModifier == ProtoCore.CompilerDefinitions.AccessModifier.Public;
-                            realType = refClassIndex;
+                            realType = refClassIndex = procNode.ClassID;
                         }
                     }
 
@@ -350,7 +350,6 @@ namespace ProtoImperative
 
                         if (!isAccessible)
                         {
-                            type = lefttype = realType;
                             string message = String.Format(ProtoCore.Properties.Resources.kMethodIsInaccessible, procName);
                             buildStatus.LogWarning(WarningID.AccessViolation, message, core.CurrentDSFileName, funcCall.line, funcCall.col, graphNode);
                             hasLogError = true;

--- a/test/Engine/ProtoTest/Imperative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Imperative/MicroFeatureTests.cs
@@ -1093,6 +1093,71 @@ a = [Imperative]
         }
 
         [Test]
+        public void CallBaseClassMethodWithDerivedClass()
+        {
+            var code =
+@"
+import(""FFITarget.dll"");
+
+d = [Imperative]
+{
+	d = DummyPoint.ByCoordinates(0,0,0);
+	return UnknownPoint.Translate(d, 1, 0, 0);
+};
+a = d.X;
+  ";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("a", 1);
+
+        }
+
+        [Test]
+        public void CallBaseClassCtorWithDerivedClass_Fails()
+        {
+            var code =
+@"
+import(""DSCoreNodes.dll"");
+import(""BuiltIn.ds"");
+import(""FFITarget.dll"");
+
+a = [Imperative]
+{
+	l = [];
+	d = DummyPoint.ByCoordinates(0,0,0);
+	l = List.AddItemToEnd(d, l);
+	return UnknownPoint.Centroid(l);
+};
+  ";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("a", null);
+
+        }
+
+        [Test]
+        public void CallBaseClassCtorWithBaseClass()
+        {
+            var code =
+@"
+import(""DSCoreNodes.dll"");
+import(""BuiltIn.ds"");
+import(""FFITarget.dll"");
+
+a = [Imperative]
+{
+	l = [];
+	d1 = DummyPoint.ByCoordinates(0,9,0);
+	l = List.AddItemToEnd(d1, l);
+	d2 = DummyPoint.ByCoordinates(0,10,0);
+	l = List.AddItemToEnd(d2, l);
+	return DummyPoint.Centroid(l).Y;
+};
+  ";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("a", 9.5);
+
+        }
+
+        [Test]
         public void NegativeIndexOnCollection003()
         {
             String code =


### PR DESCRIPTION
### Purpose

This is a fix to prevent a crash while calling base class member functions using the derived class names from imperative blocks using their static method counterparts. For example, the following code would crash:
```
def foo(line : var)
{
	return [Imperative]
	{
		return = Line.SegmentLengthAtParameter(line, 1);
	}
};
l = Line.ByStartPointEndPoint(p1, p2);
foo(l);
```
since `SegmentLengthAtParameter` is a member function defined on the base `Curve` class. 

This is now fixed. 
Note: This isn't supported in TS but it has always been supported in Dynamo in `Associative` code as the original intent was to continue to be able to call base class members using derived class objects, just the difference being, we wanted to do this with the static method counterpart. This same behaviour is now fixed for `Imperative` code.

Note that the same will not work for constructors or static methods on the base class invoked with the derived class names, which is as expected. 

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@pboyer 

### FYIs

@jnealb @smangarole 
