### PR TITLE
Fix the notes guids

### DIFF
--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -72,7 +72,7 @@ namespace Dynamo.Tests
             foreach (var annotationModels in model.Annotations.Select(x=>x.Nodes))
             {
                 var annotationList = annotationModels.ToList();
-                for (var i = 0; i < Enumerable.Count(annotationList.ToList()); i++)
+                for (var i = 0; i < annotationList.Count(); i++)
                 {
                     if (annotationList[i] is NoteModel)
                     {

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using Dynamo.Engine;
 using Dynamo.Events;
 using System.Text.RegularExpressions;
+using Dynamo.Graph.Notes;
 using Dynamo.Utilities;
 using Newtonsoft.Json.Linq;
 
@@ -65,6 +66,21 @@ namespace Dynamo.Tests
                 modelsGuidToIdMap.Add(connector.GUID, idcount.ToString());
                 json = json.Replace(connector.GUID.ToString("N"), idcount.ToString());
                 idcount = idcount + 1;
+            }
+
+            //alter the output json so that all Notemodel ids are not guids
+            foreach (var annotationModels in model.Annotations.Select(x=>x.Nodes))
+            {
+                var annotationList = annotationModels.ToList();
+                for (var i = 0; i < Enumerable.Count(annotationList.ToList()); i++)
+                {
+                    if (annotationList[i] is NoteModel)
+                    {
+                        modelsGuidToIdMap.Add(annotationList[i].GUID, idcount.ToString());
+                        json = json.Replace(annotationList[i].GUID.ToString("N"), idcount.ToString());
+                        idcount = idcount + 1;
+                    }
+                }
             }
             //alter the output json so that all annotationModel ids are not guids
             foreach (var annotation in model.Annotations)


### PR DESCRIPTION

### Purpose

Task : https://jira.autodesk.com/browse/QNTM-2974

This PR fixes the ID's for notes inside annotation. This is only for the tests.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@ColinDayOrg 
@alfarok 
