### PR TITLE
QNTM-2546: Fix list@level crash

### DIFF
--- a/src/Engine/ProtoCore/Lang/Replication/ArgumentAtLevel.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/ArgumentAtLevel.cs
@@ -77,11 +77,9 @@ namespace ProtoCore.Lang.Replication
     {
         private static List<ElementAtLevel> GetElementsAtLevel(StackValue argument, int level, List<int> indices, bool recordIndices, RuntimeCore runtimeCore)
         {
+            if(!argument.IsArray) return new List<ElementAtLevel>();
+
             var array = runtimeCore.Heap.ToHeapObject<DSArray>(argument);
-            if (array == null)
-            {
-                return new List<ElementAtLevel>();
-            }
 
             int count = array.Values.Count();
             if (level == 0)

--- a/test/Engine/ProtoTest/AtLevel/AtLevelTest.cs
+++ b/test/Engine/ProtoTest/AtLevel/AtLevelTest.cs
@@ -451,5 +451,30 @@ r = foo(xs@@L1, ys@@L1);
             thisTest.RunAndVerifyRuntimeWarning(code, ProtoCore.Runtime.WarningID.MoreThanOneDominantList);
             thisTest.Verify("r", new object[] { 5, 7, 9 });
         }
+
+        [Test]
+        public void TestNestedListStructureAtLevel1()
+        {
+            string code = @"
+import(""DSCoreNodes.dll"");
+import(""BuiltIn.ds"");
+l = List.Transpose([""test"", 1..3]@@L1<1>);
+";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("l",
+                new object[] {null, new object[] {new[] {1}, new[] {2}, new[] {3}}});
+        }
+
+        [Test]
+        public void TestNestedListAtLevel1()
+        {
+            string code = @"
+import(""DSCoreNodes.dll"");
+import(""BuiltIn.ds"");
+l = DSCore.Object.IsNull([""test"", 1..3]@L1);
+";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("l", new object[] { false, false, false });
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Fixes a crash with List@Level.

`GetElementsAtLevel` assumes the input argument is an array, if not `ToHeapObject<DSArray>` throws an invalid cast exception. This was the reason the exception was thrown that resulted in the crash. The fix is to add the check that if the input argument is not an array, then simply return an empty list. Previously this check existed but was unreachable code as the exception could be thrown before the check.
 
### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### FYIs

@jnealb @smangarole 
