### PR TITLE
Fix the AnnotationID's for notes

### DIFF
--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -68,19 +68,13 @@ namespace Dynamo.Tests
                 idcount = idcount + 1;
             }
 
+
             //alter the output json so that all Notemodel ids are not guids
-            foreach (var annotationModels in model.Annotations.Select(x=>x.Nodes))
+            foreach (var note in model.Notes)
             {
-                var annotationList = annotationModels.ToList();
-                for (var i = 0; i < annotationList.Count(); i++)
-                {
-                    if (annotationList[i] is NoteModel)
-                    {
-                        modelsGuidToIdMap.Add(annotationList[i].GUID, idcount.ToString());
-                        json = json.Replace(annotationList[i].GUID.ToString("N"), idcount.ToString());
-                        idcount = idcount + 1;
-                    }
-                }
+                modelsGuidToIdMap.Add(note.GUID, idcount.ToString());
+                json = json.Replace(note.GUID.ToString("N"), idcount.ToString());
+                idcount = idcount + 1;
             }
             //alter the output json so that all annotationModel ids are not guids
             foreach (var annotation in model.Annotations)


### PR DESCRIPTION
### Purpose

This PR fixes the bug with changing Notes UUID to ID. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@gregmarr 

