### PR TITLE
Deprecate GetKeys, GetValues, ContainsKey, RemoveKey nodes

### DIFF
--- a/src/DynamoCore/BuiltInAndOperators/BuiltIn.Migrations.xml
+++ b/src/DynamoCore/BuiltInAndOperators/BuiltIn.Migrations.xml
@@ -140,20 +140,4 @@
     <oldName>TrueForAny</oldName>
     <newName>List.TrueForAny</newName>
   </priorNameHint>
-  <priorNameHint>
-    <oldName>RemoveKey</oldName>
-    <newName>List.RemoveKey</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>GetValues</oldName>
-    <newName>List.GetValues</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>GetKeys</oldName>
-    <newName>List.GetKeys</newName>
-  </priorNameHint>
-  <priorNameHint>
-    <oldName>ContainsKey</oldName>
-    <newName>List.ContainsKey</newName>
-  </priorNameHint>
 </migrations>

--- a/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
+++ b/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
@@ -200,24 +200,6 @@
 			<param name="connectionParameters"></param>
             <search>import,data</search>
         </member>
-		<member name="GetKeys">
-			<param name="list">list of values</param>
-            <search>keys</search>
-        </member>
-		<member name="GetValues">
-			<param name="list">list of values</param>
-            <search>values</search>
-        </member>
-		<member name="RemoveKey">
-			<param name="list">list of values</param>
-			<param name="key"></param>
-            <search>remove,key</search>
-        </member>
-		<member name="ContainsKey">
-			<param name="list">list of values</param>
-			<param name="key"></param>
-            <search>contain,key</search>
-        </member>
 		<member name="Evaluate">
 			<param name="functionPointer"></param>
 			<param name="params"></param>

--- a/src/DynamoCore/BuiltInAndOperators/BuiltInImages.resx
+++ b/src/DynamoCore/BuiltInAndOperators/BuiltInImages.resx
@@ -390,40 +390,6 @@
         JI9gLoWz7cXQ93/JCoU/papupp2IriB/ZMIAAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="List.ContainsKey.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAPNSURBVHhe7ZnhTRtBFIQpgRIogRLIz0j5QQmUQAl0
-        gJQGKIESUCrgd37RAZRAZtC76PluOY/tNd6XzCeN8N3Nenmz9u7e+cwYY4wxxhhjjDHGGGOMMcYYY4wx
-        5ii8vr5eQ/fQE/QGvYf4+hG6CavpCYOFXqAp8DU9Q5fR1PQAgfLT3Qr7M3GwzqO5ORSEeTUL9w7idMTz
-        FKelPCVRd9G8Dr9+fD+HrpKG+SozUOgqDhfg2mUEP+kpLo0Pgr6BnqH3ht6gB+gi7MPC0PMgxOlxYajQ
-        Z8HPxYEYepcxG4C3OD0mCPMyQm2FvaaHeIuhQODnDD0NwGNcGg+EyLn+JYW6q4b7JiDwhxQ+Ne63FQHe
-        zwLdVfzm8D3uOmnvxR5B85M/36YO/ennvN8K9ZTigO48CAj6AuKNVw6fx+PeA6DQ21T4SNppEBAyt53z
-        vf+Q69MGKPJxVvTH3hp/d9kRHUvyICDs+Se/xnMgFPiUCt74p3HMm68cyCm09QaKYZcMn7DAVOzizjJd
-        O5W2honA+ehhCr/OHS9BgXkANnYLOD71+iB9khl6GoBaz3xQ5HwLyjWBU8+hW9NJ3FbmtYTzOs9lD6/n
-        tYiSpxGEPv0mQNWZfggKvZ4V3lMfuxD8nW70/i6q+MvnTfTwPK9T00DVCvFQUDCDycH10MYWEMd81HEd
-        hx/gmIPwd5eD1xyEDc9/AYo+dK7nAHLKOslja0w7vAHj42lq+Ke0TRBaXox3kbxXPwYIfP7Qja/rDQJC
-        zHOwqpOGTxB2/nVsUt01BIFyh6KsCRysk4ZPEPa/NQAEwfLbwHWhNS1xuzhMgQi7NQX5B/ivBIFzEb6F
-        6i7CxphDma0VWxXNTC9aIa8pmpletEJeUzQzvVDCVTxmT5RwFY/ZEyVcxWP2RAlX8Zg9UcJVPGZPlHAV
-        j2nw7efv921Sws2e1nscS9F9XVpFzZXDjWYLsqf1HsdSdF+XVlFz5XCj2YLsab3HsRTd10UpJocbpxYo
-        HqWvXp4yKMUo4Soepa9enjIoxSjhKh6lr16eMijFKOEqHqWvXp4yKMUo4Soepa9enjIoxSjhKh6lr16e
-        MijFKOEqHqWvXp4yKMUo4Soepa9enjIoxSjhKh6lr16eMijF5HAVRbMFSl+9PGVQimmFvKZotkDpq5en
-        DEoxrZDXFM0WKH318pRBKaaipwxKMRU9ZVCKqegpg1JMRU8ZlGIqesqgFFPRU4ZcjKJotqDl/QpF93Vp
-        FbWmaLag5f0KRfd1aRW1pmi2oOX9CkX3xhhjjDHGGGOMMcYYY0wtzs7+AHQMG/iX3PCGAAAAAElFTkSu
-        QmCC
-</value>
-  </data>
-  <data name="List.ContainsKey.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAEISURBVFhH7ZPBCYNAEEUtwRIswRLMMZBDSkgJlmAH
-        QhqwFEkFOedkB1qC+SN/ZbJhZV1BgtkHDzez6/xBTRKJRA5H3/cZrGFLr9xaz+NyLmBFM5YXUQMUsISj
-        1LjtDwJrOFreuO0FglMOkLPkB4IyK9jHmrdPSCjs4EfdCzSTRy9NZZCOax8LtpABJLzkz3VIIzZseLWV
-        oQZ1FRvePoHwissw2NwOfsLpgxR5bl4bEC7vXv4B6z8+A5rmsIUmXNYptxeRYDjA+ZUcB/VEJlneDx36
-        PwOc7q/RaA+g91zyeDi6iesJ6DOudTBxAHsALcv7DbBlHcyWUL0ORppoWf6qu+TxSOQXSZI3xbCmfssH
-        M0cAAAAASUVORK5CYII=
-</value>
-  </data>
   <data name="List.Equals.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
@@ -456,61 +422,6 @@
         5Noj/S4oKTzZ7s4GD7zc/RwlhbPtbjUMQy01kcKVTcRRuHN44EU7CSWx//eHT4atdIgUxifiKBSHB160
         k4gLmMuSAuIt6KQ+UjjnE3FUM4YHXrSTcGLWhzDvMQQl5nsRAZVLXEGeVzHIIN/HaAQjG/7+czwiw3w/
         JI9gLoWz7cXQ93/JCoU/papupp2IriB/ZMIAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="List.GetKeys.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAALYSURBVHhe7ZvRTRwxFEUpgRIogRLIZ6R8UAIlUAId
-        IKUBSqAElArynS9KoARyb/RGmlj27oztWRnrHOlKWTPMeM5bPLZ3cwUAAAAAAAAAAAAA8IX49eP75+yJ
-        Wx2TXIdnS9zqmOQ6PFviVsek1NFZ24ej1NFZ24ej1NFZ24ej1NFZ24ej1NFZ24ej1NFZ24ej1NFZ24ej
-        1NFZ24ej1NFZ24dj3dFZE7c6JrkOz5a41THJdXi2xK0CAAAAfEG+/fzzoHwon4W8KzdxOPREYi0/Jz3N
-        U/wK9EJSt8p3KEBPJHSPfIcC9EIy98p3KEAPJLJGvkMBWpHEWvkOBWhBAlvkOxSgFslrle9QgBokrka+
-        F16vylvkt0IB9iJp1e/8OAXUIolNw06cBmqQwOYxP04Fe5G8Hg9cClCDxNXKv0vyEKeErViakpO7JWw1
-        tyCBrcPOXZwK9iJ5PcZ8ClBCcq4tSLHoJ+UxXt/Gv3NCT8WLrGWBtXwKRgHWSIilW65XoKnA1rCiPYUF
-        Kac+n20NBcghMX7XH/GOT0MBUiTlUvIdCrBGQi4p36EAayTkORF0dCjAgmR4KpmTdFQ8Bb2Oy4NkvKzk
-        HB0Pc8hfsIyVnEvkNi4NRkJ6bCFszUtcFhYk5ZIP3/u4LCxIivdicrKOCGN/iqRcrABxSVgjMecK4P2g
-        9Y5lS3gAp0jKqQI8xmH/8Ovk53vDdnOKpJQewtkZi9q9S5o7/mziFLBGYkrT0Oy7Ve03yXFb8xGngDUS
-        U1qIFYeLzLFb8hq/DimSk9uKyG6Wqf0+OW5r+IpJCcnJDSue9fw3a9FrH+eNtPTYc3mPU0AJSSo9XP3X
-        4Z/5YV07FWUFvAWJOuIDGfZ/tiJZvT8VQ/5eJM1F6LE98RynhBok0KvemjHfD2lWvD2QSP81bP1+kIcu
-        pppHIbn+GuIyG/IQ5f+75ddeSfOtZgAAAAAAAAAAAACAGq6u/gIAGTMu/POJlAAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="List.GetKeys.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADvSURBVFhH7ZXrCcIwFIUzQkfoCI5QfwoO0REcoRsU
-        XMARHKE4gb+dwhHqueUUQkhrAvcGwXxwSB835+TRh6tUfpbH+TRriZZ5rB212mxSjVPbbFKNU9tspKOW
-        aPknHK+vHhqohpfLgMAbNHvqeMueSHi5ASAoFl5mAAiJhU+8bQuCYuEj1LNEFxg3UEeVW3aYSvBW4KqB
-        5frAfArCYrIZAIzlwxIL9PWGDuyiC4y/Lb1oZLk+MPeXf2srTPdfXisJWWbpnfu6LMUWwLxlyBOS10/a
-        cAAty21AwN6DaPPRCUGQzP7uBctxub9dpWKDcx+nSN1Zs+//gQAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="List.GetValues.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAKJSURBVHhe7ZrRTSMxFEVTAiVQAiXA50r7QQmUQAl0
-        gLQNUAIloK2A7/3aEigB7kWPyEzsKEMceLbOka4S3iST6+uM7XHYAAAAAAAAAAAAAAAAAAAA9OTv71/n
-        0mWpOASnIoJ+kF6k14aepFvpLN4Gx6IwHfyzVAu8JXfSXZwCvopCvC9C/YrccedxOliDgvNwUwt1rXw1
-        XMRp4RAUWK/wP+ROYF44BAV1XQTXU0/xEdBCIZ1J+1Y5x8qrpLtv0nhL4zBeC25U3UTTxkCG/y8aMIPG
-        6AQZ9Xq/1gDLy8mROyd/J8hkbfj5tI7Xc3fSKeeIUyp3J8jgculZXTqqtu9Kya68E7PMeYVSmr2PQzvo
-        2NqtiSzKuz0ic8sOaJqtvHYE5b4ZlLllqNUbJ9V9r1C+bgQ5/NzbITJYm4R3Ji7Vem9TLOWwWhN9q75P
-        Hi7z70XJZGsLwoH7mPf5v2Ps92fVvLyvyOJxecwebxY1y68dYw/KRgvjP6XtFefnRX0bpB+l8p7k4f0N
-        ws+L+jjhfyDDPzm5toY7h/0pSP19IXk4eozSFtX8nvHCNzJdu4xPLQfZvEnSseoPOq5LOyG7VqsPg8zX
-        xthe8rfZncwPNC0cToTVW/xGfCgKq/dQdBunhkNRaL06YbtKgZUoPA9Hx8wJfPN7oCB9NazpCC9nmWh7
-        41Alb1k44PJmyEtJ1/x/RAQPAAAAAAAAAACwj6s//15nVzQ1JzXDsymampOa4dkUTc1Jy+is9XS0jM5a
-        T0fL6Kz1dLSMzlpPR8vorPV0tIzOWk9Hy+is9XS0jM5aT0fL6Kz1dJRGZ1U0NSc1w7MpmpqTmuHZFE0F
-        AAAAAAAAAAAAAAAAAACA/Gw2b0aZyZp1VyuuAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="List.GetValues.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADgSURBVFhH7ZTRCYMwGIQdoSM4giO0j4U+dJRuInQB
-        R+gIxQl87lNHcAR7JyeEUOFPiFLo/8Hxq+S/S0y0chzHQn85H6Ajqx7tAwJr6AlNgXjfaMh2IISrHhUa
-        i8+3nQQCuiAwVwOUt21o5Cqpm4y+BVg0yDINNXe65iRiY6vG2TAVNL5l0NJE12taDirf1PLm2M+ad1bQ
-        yOA4KBaDW42/Qjy4TajZLAeZre09V1dr6HYghJPg1xBuwQPa94fk/Cen+2sqJVmmsTSWqslYja01Gaux
-        tSbDxlKSpeM4v0hVfQBun8aMsyDMmAAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="List.GroupByFunction.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -639,38 +550,6 @@
         IvQj4zgaXzrOO4DszP/nAGtaDrDWs5Ta9yG0gWxkH+B+Pg1Qo/IrAxioVWlDfek4HQh/QbXK/CB8kKVv
         WE8D4bODrvZhKhgoS19DD6mHeD2dHqcBAW4AgppD8FoY3us4HQhxbwBBzbUznENwE2n/Hwi4QQf5FrJr
         h6brmG1odxDgBiDw7pWE5xCzDRUKhTiq6g3eZlB9QHywdwAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="List.RemoveKey.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAOCSURBVHhe7Zw/btRAHIVzhByBI+QIUCJRhIKOIkfI
-        EdJSReICOUK4QURFmZoqR8gR4D00g5xh7Myf3wZ5833SE9q1PZa+tzuetRVOAAAAAAAAAAAAAAAAAAAA
-        9sC7rz/f1pI2w6GQ5DPlQfm1kkflNO0OkUis5VtwTfwyfBOikdRW+Q4FRCKhPfIdCohCMnvlOxQQgUSO
-        yHcoYBZJHJXvUMAMEjgj36GAUSRvRP6VcqPcpZyl4aAHi1O6P/npcJhBImemHX75ziCBzPn/C8nrle99
-        81zPnD+DxSm9n/y7dDjMIJGj0w4FzCKJM3M+BbQgUW8UPyS5ULxOzw9NzpUe+b7373n+Pr1+TKeAEsk5
-        VS4XsiJylYaHLSTK4kenla1cp1PAGpLk2wA1eRFhzt9Cgg4p36GANSTHF9eatMjcptPBEonxUrImLDoX
-        6ZSwRGJuC1GHyGU6HSyRGK/xa8Iic5NOByWS4yVnTVpUvJzlFvMaknPolQ8X3i0kyLcGauKiwq/fLSTo
-        xQr4/uH9qXKeXoaSxt7fswQJ2irA01N+SF7b3pI/BSRB98ovJXQ5uhj7UdlXCRK0VsATSXo9etv5aiHI
-        8nNCStA45dj7KsGCCmHOfdr8BL1/Xez3bD5++eECSvk5UyXo+Fqxzn5KkKTar+DqhVPv+xlAue9mvn36
-        bBmloGWGStBxa/JzdlVC+UcSa9+A3vtFlnCxkLKWrhK0/3PyHW/fx+8PifKTrlJexDUgX4DDStB+xyU/
-        I1m1J1++QPtT77m/V76/VX8lSMh0Cdp+nPKNZPmeUORTsH/mX4kZLkHvH6/8jKUpsyX4+NVPsgR1l6DX
-        xy8/I3kuYfRBvKedZ1ceEtVcgv59PfKXSKTn/tZvg/fz/s0SJKylhEvl9cnPWKjiFVLtgY2l+31vHxIg
-        cS0lbOV45b8UEjhaAvKjkMjeEpAfjYS2loD8Q2CpykOSvBUe7kcjqS1LzWU2fzFDB5LZKz+HEmaRxFH5
-        OZQwiuS1yG+5JlBCL5LWIt/bvV/L6ogSWpGsZvnpEB9DCRFIUrf8jN6jhBkkZ1h+RtsoYQRJmZaf0T6U
-        0INkhMnPaF9KaEUi7goxZbrkZ3RMSwn8vxOSsCVqSH5Gx26Nzd8kZCSjJmpKfkZj1MZGfomkLEWFyM8U
-        YyN/jSQqVH4mjY18AAAAAAAAAAAAADgeTk5+A7S1ccjwkOOsAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="List.RemoveKey.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAExSURBVFhH7ZXBDYJAEEUpgRIsgRL0aOLBAjxw9kQJ
-        dEBiAxwsxFiBZ0+WQAn4f/KXLDgkBneJh/3JD7vsOm8cZiFLSkoKod3luaU1XU+A5vAD7uVaS/FlwNdL
-        ACALvk4CgMzBN9oST4BYcM7ZhLm2hZWC17IFb7Q1vBC89WCW4x09BOc/tqC+C20PLwTvJrCp43a8AZx6
-        ez/sZx8B1nJ4eYUAcBVg5x81Hnw9nR8A9HCpnwwSnOsdvCwJQFwDVt7YmYFLmAmMksDYwXmf12XHE5C5
-        Fw4rc+QeBB8lQRj8O9wXYKzATW7g0RsPED+Jl65h4N8KsEpgl8SqcL/szh+NGUUATZ+5X4m4SQBgNhyu
-        5ukILgS/CTLAnQjWGh3ne4HABcwkzIbDfSbRapqU9K/KsjeQAqDGMr5NSAAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="List.SortByFunction.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/src/DynamoCore/Library/LibraryServices.cs
+++ b/src/DynamoCore/Library/LibraryServices.cs
@@ -801,6 +801,8 @@ namespace Dynamo.Engine
                                                                     argType))
                                                         let visibleInLibrary =
                                                             (method.MethodAttribute == null || !method.MethodAttribute.HiddenInLibrary)
+                                                        let obsoleteMsg =
+                                                            (method.MethodAttribute != null ? method.MethodAttribute.ObsoleteMessage: String.Empty)
                                                         let description = 
                                                             (method.MethodAttribute != null ? method.MethodAttribute.Description :String.Empty)
                                                         select
@@ -815,6 +817,7 @@ namespace Dynamo.Engine
                                                                 IsVisibleInLibrary = visibleInLibrary,
                                                                 IsBuiltIn = true,
                                                                 IsPackageMember = false,
+                                                                ObsoleteMsg = obsoleteMsg,
                                                                 Assembly = Categories.BuiltIn
                                                             });
 

--- a/src/Engine/ProtoCore/DSASM/DSArray.cs
+++ b/src/Engine/ProtoCore/DSASM/DSArray.cs
@@ -53,6 +53,52 @@ namespace ProtoCore.DSASM
             }
         }
 
+        /// <summary>
+        /// Returns true if array contain key or not.
+        /// </summary>
+        public bool ContainsKey(StackValue key)
+        {
+            if (key.IsNumeric)
+            {
+                var index = (int)key.ToInteger().IntegerValue;
+                if (index < 0)
+                {
+                    index = index + Count;
+                }
+                return (index >= 0 && index < Count);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Remove a key from array. Return true if key exsits.
+        /// </summary>
+        public bool RemoveKey(StackValue key)
+        {
+            if (key.IsNumeric)
+            {
+                int index = (int)key.ToInteger().IntegerValue;
+                if (index < 0)
+                {
+                    index = index + Count;
+                }
+
+                if (index >= 0 && index < Count)
+                {
+                    SetValueAt(index, StackValue.Null);
+
+                    if (index == Count - 1)
+                    {
+                        Count -= 1;
+                    }
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public IDictionary<StackValue,StackValue> ToDictionary()
         {
             return Enumerable.Range(0, Count)

--- a/src/Engine/ProtoCore/DSASM/DSArray.cs
+++ b/src/Engine/ProtoCore/DSASM/DSArray.cs
@@ -53,52 +53,6 @@ namespace ProtoCore.DSASM
             }
         }
 
-        /// <summary>
-        /// Returns true if array contain key or not.
-        /// </summary>
-        public bool ContainsKey(StackValue key)
-        {
-            if (key.IsNumeric)
-            {
-                var index = (int)key.ToInteger().IntegerValue;
-                if (index < 0)
-                {
-                    index = index + Count;
-                }
-                return (index >= 0 && index < Count);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Remove a key from array. Return true if key exsits.
-        /// </summary>
-        public bool RemoveKey(StackValue key)
-        {
-            if (key.IsNumeric)
-            {
-                int index = (int)key.ToInteger().IntegerValue;
-                if (index < 0)
-                {
-                    index = index + Count;
-                }
-
-                if (index >= 0 && index < Count)
-                {
-                    SetValueAt(index, StackValue.Null);
-
-                    if (index == Count - 1)
-                    {
-                        Count -= 1;
-                    }
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         public IDictionary<StackValue,StackValue> ToDictionary()
         {
             return Enumerable.Range(0, Count)

--- a/src/Engine/ProtoCore/ExtendedLibraries/BuiltIn.ds
+++ b/src/Engine/ProtoCore/ExtendedLibraries/BuiltIn.ds
@@ -41,25 +41,5 @@ class List extends DSCore.List
 	{
 		return __TrueForAny(list, predicate);
 	}
-
-	public static def RemoveKey(list: var[]..[], key: var)
-	{
-		return __RemoveKey(list, key);
-	}
-
-	public static def GetValues(list: var[]..[])
-	{
-		return __GetValues(list);
-	}
-
-	public static def GetKeys(list: var[]..[])
-	{
-		return __GetKeys(list);
-	}
-
-	public static def ContainsKey: bool(list: var[]..[], key: var)
-	{
-		return __ContainsKey(list, key);
-	}
 }
 

--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -446,22 +446,74 @@ namespace ProtoCore.Lang
 
                 case BuiltInMethods.MethodID.GetKeys:
                     {
-                        ret = StackValue.Null;
+                        StackValue array = formalParameters[0];
+                        if (!array.IsArray)
+                        {
+                            runtimeCore.RuntimeStatus.LogWarning(WarningID.OverIndexing, Resources.kArrayOverIndexed);
+                            ret = StackValue.Null;
+                        }
+                        else
+                        {
+                            var result = runtimeCore.Heap.ToHeapObject<DSArray>(array).Keys.ToArray();
+                            try
+                            {
+                                ret = rmem.Heap.AllocateArray(result);
+                            }
+                            catch (RunOutOfMemoryException)
+                            {
+                                runtimeCore.RuntimeStatus.LogWarning(WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                                ret = StackValue.Null;
+                            }
+                        }
                         break;
                     }
                 case BuiltInMethods.MethodID.GetValues:
                     {
-                        ret = StackValue.Null;
+                        StackValue array = formalParameters[0];
+                        if (!array.IsArray)
+                        {
+                            runtimeCore.RuntimeStatus.LogWarning(WarningID.OverIndexing, Resources.kArrayOverIndexed);
+                            ret = StackValue.Null;
+                        }
+                        else
+                        {
+                            var result = runtimeCore.Heap.ToHeapObject<DSArray>(array).Values;
+                            try
+                            {
+                                ret = rmem.Heap.AllocateArray(result.ToArray());
+                            }
+                            catch (RunOutOfMemoryException)
+                            {
+                                runtimeCore.RuntimeStatus.LogWarning(WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
+                                ret = StackValue.Null;
+                            }
+                        }
                         break;
                     }
                 case BuiltInMethods.MethodID.ContainsKey:
                     {
-                        ret = StackValue.Null;
+                        StackValue array = formalParameters[0];
+                        StackValue key = formalParameters[1];
+                        if (array.IsArray)
+                        {
+                            bool result = runtimeCore.Heap.ToHeapObject<DSArray>(array).ContainsKey(key);
+                            ret = StackValue.BuildBoolean(result);
+                        }
+                        else
+                        {
+                            ret = StackValue.BuildBoolean(false);
+                        }
                         break;
                     }
                 case BuiltInMethods.MethodID.RemoveKey:
                     {
-                        ret = StackValue.Null;
+                        StackValue array = formalParameters[0];
+                        StackValue key = formalParameters[1];
+                        if (array.IsArray)
+                        {
+                            runtimeCore.Heap.ToHeapObject<DSArray>(array).RemoveKey(key);
+                        }
+                        return array;
                         break;
                     }
                 case BuiltInMethods.MethodID.Evaluate:

--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -446,74 +446,22 @@ namespace ProtoCore.Lang
 
                 case BuiltInMethods.MethodID.GetKeys:
                     {
-                        StackValue array = formalParameters[0];
-                        if (!array.IsArray)
-                        {
-                            runtimeCore.RuntimeStatus.LogWarning(WarningID.OverIndexing, Resources.kArrayOverIndexed);
-                            ret = StackValue.Null;
-                        }
-                        else
-                        {
-                            var result = runtimeCore.Heap.ToHeapObject<DSArray>(array).Keys.ToArray();
-                            try
-                            {
-                                ret = rmem.Heap.AllocateArray(result);
-                            }
-                            catch (RunOutOfMemoryException)
-                            {
-                                runtimeCore.RuntimeStatus.LogWarning(WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
-                                ret = StackValue.Null;
-                            }
-                        }
+                        ret = StackValue.Null;
                         break;
                     }
                 case BuiltInMethods.MethodID.GetValues:
                     {
-                        StackValue array = formalParameters[0];
-                        if (!array.IsArray)
-                        {
-                            runtimeCore.RuntimeStatus.LogWarning(WarningID.OverIndexing, Resources.kArrayOverIndexed);
-                            ret = StackValue.Null;
-                        }
-                        else
-                        {
-                            var result = runtimeCore.Heap.ToHeapObject<DSArray>(array).Values;
-                            try
-                            {
-                                ret = rmem.Heap.AllocateArray(result.ToArray());
-                            }
-                            catch (RunOutOfMemoryException)
-                            {
-                                runtimeCore.RuntimeStatus.LogWarning(WarningID.RunOutOfMemory, Resources.RunOutOfMemory);
-                                ret = StackValue.Null;
-                            }
-                        }
+                        ret = StackValue.Null;
                         break;
                     }
                 case BuiltInMethods.MethodID.ContainsKey:
                     {
-                        StackValue array = formalParameters[0];
-                        StackValue key = formalParameters[1];
-                        if (array.IsArray)
-                        {
-                            bool result = runtimeCore.Heap.ToHeapObject<DSArray>(array).ContainsKey(key);
-                            ret = StackValue.BuildBoolean(result);
-                        }
-                        else
-                        {
-                            ret = StackValue.BuildBoolean(false);
-                        }
+                        ret = StackValue.Null;
                         break;
                     }
                 case BuiltInMethods.MethodID.RemoveKey:
                     {
-                        StackValue array = formalParameters[0];
-                        StackValue key = formalParameters[1];
-                        if (array.IsArray)
-                        {
-                            runtimeCore.Heap.ToHeapObject<DSArray>(array).RemoveKey(key);
-                        }
-                        return array;
+                        ret = StackValue.Null;
                         break;
                     }
                 case BuiltInMethods.MethodID.Evaluate:

--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -457,7 +457,7 @@ namespace ProtoCore.Lang
                             var result = runtimeCore.Heap.ToHeapObject<DSArray>(array).Keys.ToArray();
                             try
                             {
-                                runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, "\"GetKeys\" is deprecated, please use Dictionary data type with Dictionary.Keys");
+                                runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, string.Format(Resources.ListMethodDeprecated, "GetKeys", "Dictionary.Keys"));
                                 ret = rmem.Heap.AllocateArray(result);
                             }
                             catch (RunOutOfMemoryException)
@@ -481,7 +481,7 @@ namespace ProtoCore.Lang
                             var result = runtimeCore.Heap.ToHeapObject<DSArray>(array).Values;
                             try
                             {
-                                runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, "\"GetValues\" is deprecated, please use Dictionary data type with Dictionary.Values");
+                                runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, string.Format(Resources.ListMethodDeprecated, "GetValues", "Dictionary.Values"));
                                 ret = rmem.Heap.AllocateArray(result.ToArray());
                             }
                             catch (RunOutOfMemoryException)
@@ -499,7 +499,7 @@ namespace ProtoCore.Lang
                         if (array.IsArray)
                         {
                             bool result = runtimeCore.Heap.ToHeapObject<DSArray>(array).ContainsKey(key);
-                            runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, "\"ContainsKey\" is deprecated, please use Dictionary data type with Dictionary.Keys & List.Contains");
+                            runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, string.Format(Resources.ListMethodDeprecated, "ContainsKey", "Dictionary.Keys & List.Contains"));
                             ret = StackValue.BuildBoolean(result);
                         }
                         else
@@ -514,7 +514,7 @@ namespace ProtoCore.Lang
                         StackValue key = formalParameters[1];
                         if (array.IsArray)
                         {
-                            runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, "\"RemoveKey\" is deprecated, please use Dictionary data type with Dictionary.RemoveKeys");
+                            runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, string.Format(Resources.ListMethodDeprecated, "RemoveKey", "Dictionary.RemoveKeys"));
                             runtimeCore.Heap.ToHeapObject<DSArray>(array).RemoveKey(key);
                         }
                         return array;

--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -457,6 +457,7 @@ namespace ProtoCore.Lang
                             var result = runtimeCore.Heap.ToHeapObject<DSArray>(array).Keys.ToArray();
                             try
                             {
+                                runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, "\"GetKeys\" is deprecated, please use Dictionary data type with Dictionary.Keys");
                                 ret = rmem.Heap.AllocateArray(result);
                             }
                             catch (RunOutOfMemoryException)
@@ -480,6 +481,7 @@ namespace ProtoCore.Lang
                             var result = runtimeCore.Heap.ToHeapObject<DSArray>(array).Values;
                             try
                             {
+                                runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, "\"GetValues\" is deprecated, please use Dictionary data type with Dictionary.Values");
                                 ret = rmem.Heap.AllocateArray(result.ToArray());
                             }
                             catch (RunOutOfMemoryException)
@@ -497,6 +499,7 @@ namespace ProtoCore.Lang
                         if (array.IsArray)
                         {
                             bool result = runtimeCore.Heap.ToHeapObject<DSArray>(array).ContainsKey(key);
+                            runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, "\"ContainsKey\" is deprecated, please use Dictionary data type with Dictionary.Keys & List.Contains");
                             ret = StackValue.BuildBoolean(result);
                         }
                         else
@@ -511,6 +514,7 @@ namespace ProtoCore.Lang
                         StackValue key = formalParameters[1];
                         if (array.IsArray)
                         {
+                            runtimeCore.RuntimeStatus.LogWarning(WarningID.Default, "\"RemoveKey\" is deprecated, please use Dictionary data type with Dictionary.RemoveKeys");
                             runtimeCore.Heap.ToHeapObject<DSArray>(array).RemoveKey(key);
                         }
                         return array;

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -121,10 +121,10 @@ namespace ProtoCore.Lang
             "SetUnion",                 // kUnion
             Constants.kInlineConditionalMethodName,
             "Break",                    // kBreak
-            "__GetKeys",                  // kGetKeys    
-            "__GetValues",                // kGetValues    
-            "__RemoveKey",                // kRemoveKey
-            "__ContainsKey",              // kContainsKey
+            "GetKeys",                  // kGetKeys    
+            "GetValues",                // kGetValues    
+            "RemoveKey",                // kRemoveKey
+            "ContainsKey",              // kContainsKey
             "Evaluate",                 // kEvaluateFunctionPointer
             Constants.kNodeAstFailed,   // kNodeAstFailed
             "__GC",                     // kGC

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -824,7 +824,8 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank))
                     },
                     ID = MethodID.GetKeys,
-                     MethodAttributes = new MethodAttributes(){Description = Resources.GetKeys}
+                     MethodAttributes = new MethodAttributes(true, false, "This node is obsolete, please use Dictionary data type with Dictionary.Keys"){Description = Resources.GetKeys}
+                        
                     //MAGN_3382 MethodAttributes = new MethodAttributes(true),
                 },
 
@@ -836,7 +837,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank))
                     },
                     ID = MethodID.GetValues,
-                     MethodAttributes = new MethodAttributes(){Description = Resources.GetValues}
+                     MethodAttributes = new MethodAttributes(true, false, "This node is obsolete, please use Dictionary data type with Dictionary.Values"){Description = Resources.GetValues}
                     //MAGN_3382 MethodAttributes = new MethodAttributes(true),
                 },
 
@@ -849,7 +850,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("key", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0))
                     },
                     ID = MethodID.RemoveKey,
-                    MethodAttributes = new MethodAttributes(){Description = Resources.RemoveKeys}
+                    MethodAttributes = new MethodAttributes(true, false, "This node is obsolete, please use Dictionary data type with Dictionary.RemoveKeys"){Description = Resources.RemoveKeys}
                     //MethodAttributes = new MethodAttributes(true), MAGN-3382
                 },
 
@@ -862,7 +863,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("key", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0))
                     },
                     ID = MethodID.ContainsKey,
-                    MethodAttributes = new MethodAttributes(){Description = Resources.ContainsKeys}
+                    MethodAttributes = new MethodAttributes(true, false, "This node is obsolete, please use Dictionary data type with Dictionary.Keys & List.Contains"){Description = Resources.ContainsKeys}
                     //MAGN-3382 MethodAttributes = new MethodAttributes(true),
                 },
 

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -824,7 +824,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank))
                     },
                     ID = MethodID.GetKeys,
-                     MethodAttributes = new MethodAttributes(true, false){Description = Resources.GetKeys}
+                     MethodAttributes = new MethodAttributes(hiddenInLibrary: true){Description = Resources.GetKeys}
                         
                     //MAGN_3382 MethodAttributes = new MethodAttributes(true),
                 },
@@ -837,7 +837,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank))
                     },
                     ID = MethodID.GetValues,
-                     MethodAttributes = new MethodAttributes(true, false){Description = Resources.GetValues}
+                     MethodAttributes = new MethodAttributes(hiddenInLibrary: true){Description = Resources.GetValues}
                     //MAGN_3382 MethodAttributes = new MethodAttributes(true),
                 },
 
@@ -850,7 +850,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("key", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0))
                     },
                     ID = MethodID.RemoveKey,
-                    MethodAttributes = new MethodAttributes(true, false){Description = Resources.RemoveKeys}
+                    MethodAttributes = new MethodAttributes(hiddenInLibrary: true){Description = Resources.RemoveKeys}
                     //MethodAttributes = new MethodAttributes(true), MAGN-3382
                 },
 
@@ -863,7 +863,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("key", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0))
                     },
                     ID = MethodID.ContainsKey,
-                    MethodAttributes = new MethodAttributes(true, false){Description = Resources.ContainsKeys}
+                    MethodAttributes = new MethodAttributes(hiddenInLibrary: true){Description = Resources.ContainsKeys}
                     //MAGN-3382 MethodAttributes = new MethodAttributes(true),
                 },
 

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -824,7 +824,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank))
                     },
                     ID = MethodID.GetKeys,
-                     MethodAttributes = new MethodAttributes(true, false, "This node is obsolete, please use Dictionary data type with Dictionary.Keys"){Description = Resources.GetKeys}
+                     MethodAttributes = new MethodAttributes(true, false){Description = Resources.GetKeys}
                         
                     //MAGN_3382 MethodAttributes = new MethodAttributes(true),
                 },
@@ -837,7 +837,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("list", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, Constants.kArbitraryRank))
                     },
                     ID = MethodID.GetValues,
-                     MethodAttributes = new MethodAttributes(true, false, "This node is obsolete, please use Dictionary data type with Dictionary.Values"){Description = Resources.GetValues}
+                     MethodAttributes = new MethodAttributes(true, false){Description = Resources.GetValues}
                     //MAGN_3382 MethodAttributes = new MethodAttributes(true),
                 },
 
@@ -850,7 +850,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("key", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0))
                     },
                     ID = MethodID.RemoveKey,
-                    MethodAttributes = new MethodAttributes(true, false, "This node is obsolete, please use Dictionary data type with Dictionary.RemoveKeys"){Description = Resources.RemoveKeys}
+                    MethodAttributes = new MethodAttributes(true, false){Description = Resources.RemoveKeys}
                     //MethodAttributes = new MethodAttributes(true), MAGN-3382
                 },
 
@@ -863,7 +863,7 @@ namespace ProtoCore.Lang
                         new KeyValuePair<string, Type>("key", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0))
                     },
                     ID = MethodID.ContainsKey,
-                    MethodAttributes = new MethodAttributes(true, false, "This node is obsolete, please use Dictionary data type with Dictionary.Keys & List.Contains"){Description = Resources.ContainsKeys}
+                    MethodAttributes = new MethodAttributes(true, false){Description = Resources.ContainsKeys}
                     //MAGN-3382 MethodAttributes = new MethodAttributes(true),
                 },
 

--- a/src/Engine/ProtoCore/Properties/Resources.Designer.cs
+++ b/src/Engine/ProtoCore/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace ProtoCore.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -1849,6 +1849,15 @@ namespace ProtoCore.Properties {
         public static string lessthan_expected {
             get {
                 return ResourceManager.GetString("lessthan_expected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Method &apos;{0}&apos; has been deprecated, please use method &apos;{1}&apos; instead with Dictionary type.
+        /// </summary>
+        public static string ListMethodDeprecated {
+            get {
+                return ResourceManager.GetString("ListMethodDeprecated", resourceCulture);
             }
         }
         

--- a/src/Engine/ProtoCore/Properties/Resources.en-US.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.en-US.resx
@@ -938,4 +938,7 @@ Parameter name: {0}</value>
   <data name="DeprecatedListInitializationSyntax" xml:space="preserve">
     <value>Curly braces are no longer used for list creation. Use square brackets instead, like [] or [1,2,3].</value>
   </data>
+  <data name="ListMethodDeprecated" xml:space="preserve">
+    <value>Method '{0}' has been deprecated, please use method '{1}' instead with Dictionary type</value>
+  </data>
 </root>

--- a/src/Engine/ProtoCore/Properties/Resources.resx
+++ b/src/Engine/ProtoCore/Properties/Resources.resx
@@ -941,4 +941,7 @@ Parameter name: {0}</value>
   <data name="DeprecatedListInitializationSyntax" xml:space="preserve">
     <value>Curly braces are no longer used for list creation. Use square brackets instead, like [] or [1,2,3].</value>
   </data>
+  <data name="ListMethodDeprecated" xml:space="preserve">
+    <value>Method '{0}' has been deprecated, please use method '{1}' instead with Dictionary type</value>
+  </data>
 </root>

--- a/src/Libraries/CoreNodes/DSCoreNodesImages.resx
+++ b/src/Libraries/CoreNodes/DSCoreNodesImages.resx
@@ -1740,38 +1740,6 @@
         bNshf0xzCSE3MT2HCTCraS4h5ufouW0DDGuW83NUXDrO2QjhC66DNqE0XQ6tAAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="DSCore.List.RemoveKey.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAOCSURBVHhe7Zw/btRAHIVzhByBI+QIUCJRhIKOIkfI
-        EdJSReICOUK4QURFmZoqR8gR4D00g5xh7Myf3wZ5833SE9q1PZa+tzuetRVOAAAAAAAAAAAAAAAAAAAA
-        9sC7rz/f1pI2w6GQ5DPlQfm1kkflNO0OkUis5VtwTfwyfBOikdRW+Q4FRCKhPfIdCohCMnvlOxQQgUSO
-        yHcoYBZJHJXvUMAMEjgj36GAUSRvRP6VcqPcpZyl4aAHi1O6P/npcJhBImemHX75ziCBzPn/C8nrle99
-        81zPnD+DxSm9n/y7dDjMIJGj0w4FzCKJM3M+BbQgUW8UPyS5ULxOzw9NzpUe+b7373n+Pr1+TKeAEsk5
-        VS4XsiJylYaHLSTK4kenla1cp1PAGpLk2wA1eRFhzt9Cgg4p36GANSTHF9eatMjcptPBEonxUrImLDoX
-        6ZSwRGJuC1GHyGU6HSyRGK/xa8Iic5NOByWS4yVnTVpUvJzlFvMaknPolQ8X3i0kyLcGauKiwq/fLSTo
-        xQr4/uH9qXKeXoaSxt7fswQJ2irA01N+SF7b3pI/BSRB98ovJXQ5uhj7UdlXCRK0VsATSXo9etv5aiHI
-        8nNCStA45dj7KsGCCmHOfdr8BL1/Xez3bD5++eECSvk5UyXo+Fqxzn5KkKTar+DqhVPv+xlAue9mvn36
-        bBmloGWGStBxa/JzdlVC+UcSa9+A3vtFlnCxkLKWrhK0/3PyHW/fx+8PifKTrlJexDUgX4DDStB+xyU/
-        I1m1J1++QPtT77m/V76/VX8lSMh0Cdp+nPKNZPmeUORTsH/mX4kZLkHvH6/8jKUpsyX4+NVPsgR1l6DX
-        xy8/I3kuYfRBvKedZ1ceEtVcgv59PfKXSKTn/tZvg/fz/s0SJKylhEvl9cnPWKjiFVLtgY2l+31vHxIg
-        cS0lbOV45b8UEjhaAvKjkMjeEpAfjYS2loD8Q2CpykOSvBUe7kcjqS1LzWU2fzFDB5LZKz+HEmaRxFH5
-        OZQwiuS1yG+5JlBCL5LWIt/bvV/L6ogSWpGsZvnpEB9DCRFIUrf8jN6jhBkkZ1h+RtsoYQRJmZaf0T6U
-        0INkhMnPaF9KaEUi7goxZbrkZ3RMSwn8vxOSsCVqSH5Gx26Nzd8kZCSjJmpKfkZj1MZGfomkLEWFyM8U
-        YyN/jSQqVH4mjY18AAAAAAAAAAAAADgeTk5+A7S1ccjwkOOsAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="DSCore.List.RemoveKey.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAExSURBVFhH7ZXBDYJAEEUpgRIsgRL0aOLBAjxw9kQJ
-        dEBiAxwsxFiBZ0+WQAn4f/KXLDgkBneJh/3JD7vsOm8cZiFLSkoKod3luaU1XU+A5vAD7uVaS/FlwNdL
-        ACALvk4CgMzBN9oST4BYcM7ZhLm2hZWC17IFb7Q1vBC89WCW4x09BOc/tqC+C20PLwTvJrCp43a8AZx6
-        ez/sZx8B1nJ4eYUAcBVg5x81Hnw9nR8A9HCpnwwSnOsdvCwJQFwDVt7YmYFLmAmMksDYwXmf12XHE5C5
-        Fw4rc+QeBB8lQRj8O9wXYKzATW7g0RsPED+Jl65h4N8KsEpgl8SqcL/szh+NGUUATZ+5X4m4SQBgNhyu
-        5ukILgS/CTLAnQjWGh3ne4HABcwkzIbDfSbRapqU9K/KsjeQAqDGMr5NSAAAAABJRU5ErkJggg==
-</value>
-  </data>
   <data name="DSCore.List.Reorder.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -185,15 +185,6 @@
               "elementType": "group",
               "include": [
                 {
-                  "path": "BuiltIn.List.ContainsKey"
-                },
-                {
-                  "path": "BuiltIn.List.GetKeys"
-                },
-                {
-                  "path": "BuiltIn.List.GetValues"
-                },
-                {
                   "path": "DSCoreNodes.DSCore.List.GroupByKey"
                 },
                 {
@@ -207,10 +198,6 @@
                 },
                 {
                   "path": "DSCoreNodes.DSCore.List.NormalizeDepth"
-                },
-
-                {
-                  "path": "BuiltIn.List.RemoveKey"
                 },
                 {
                   "path": "DSCoreNodes.DSCore.List.Reverse"

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -1661,7 +1661,7 @@ var06 = g;
             var codeCompletionServices = new CodeCompletionServices(libraryServicesCore);
 
             string functionPrefix = "List";
-            string functionName = "ContainsKey";
+            string functionName = "RemoveIfNot";
 
             string code = "";
             var overloads = codeCompletionServices.GetFunctionSignatures(code, functionName, functionPrefix);
@@ -1673,7 +1673,7 @@ var06 = g;
             {
                 Assert.AreEqual(functionName, overload.Text);
             }
-            Assert.AreEqual("ContainsKey : bool (list : [], key : var)", overloads.ElementAt(0).Stub);
+            Assert.AreEqual("RemoveIfNot : [] (list : [], type : string)", overloads.ElementAt(0).Stub);
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
@@ -3361,30 +3361,6 @@ def foo ()
         }
 
         [Test]
-        public void TestRemoveKeyNoThrow()
-        {
-            string code = @"
-import(""BuiltIn.ds"");
-x = 0;
-y = List.RemoveKey(x, x);
-";
-            thisTest.RunScriptSource(code);
-            thisTest.Verify("y", 0);
-        }
-
-        [Test]
-        public void TestContainsKeyNoThrow()
-        {
-            string code = @"
-import(""BuiltIn.ds"");
-x = 0;
-y = List.ContainsKey(x, x);
-";
-            Assert.DoesNotThrow(() => thisTest.RunScriptSource(code));
-            thisTest.Verify("y", false);
-        }
-
-        [Test]
         public void TestMapToWithReverserRange()
         {
             string code = @"

--- a/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
@@ -3369,7 +3369,7 @@ x = 0;
 y = List.RemoveKey(x, x);
 ";
             thisTest.RunScriptSource(code);
-            thisTest.Verify("y", 0);
+            thisTest.Verify("y", null);
         }
 
         [Test]
@@ -3381,7 +3381,7 @@ x = 0;
 y = List.ContainsKey(x, x);
 ";
             Assert.DoesNotThrow(() => thisTest.RunScriptSource(code));
-            thisTest.Verify("y", false);
+            thisTest.Verify("y", null);
         }
 
         [Test]

--- a/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
+++ b/test/Engine/ProtoTest/TD/MultiLangTests/Builtin_Functions.cs
@@ -3369,7 +3369,7 @@ x = 0;
 y = List.RemoveKey(x, x);
 ";
             thisTest.RunScriptSource(code);
-            thisTest.Verify("y", null);
+            thisTest.Verify("y", 0);
         }
 
         [Test]
@@ -3381,7 +3381,7 @@ x = 0;
 y = List.ContainsKey(x, x);
 ";
             Assert.DoesNotThrow(() => thisTest.RunScriptSource(code));
-            thisTest.Verify("y", null);
+            thisTest.Verify("y", false);
         }
 
         [Test]

--- a/test/ViewExtensionLibraryTests/resources/libraryItems.json
+++ b/test/ViewExtensionLibraryTests/resources/libraryItems.json
@@ -5665,38 +5665,6 @@
       "keywords": ""
     },
     {
-      "fullyQualifiedName": "List.RemoveKey",
-      "iconUrl": "http://localhost/icons/List.RemoveKey.Small?path=BuiltIn.ds",
-      "contextData": "List.RemoveKey@var[]..[],var",
-      "parameters": null,
-      "itemType": "action",
-      "keywords": ""
-    },
-    {
-      "fullyQualifiedName": "List.GetValues",
-      "iconUrl": "http://localhost/icons/List.GetValues.Small?path=BuiltIn.ds",
-      "contextData": "List.GetValues@var[]..[]",
-      "parameters": null,
-      "itemType": "action",
-      "keywords": ""
-    },
-    {
-      "fullyQualifiedName": "List.GetKeys",
-      "iconUrl": "http://localhost/icons/List.GetKeys.Small?path=BuiltIn.ds",
-      "contextData": "List.GetKeys@var[]..[]",
-      "parameters": null,
-      "itemType": "action",
-      "keywords": ""
-    },
-    {
-      "fullyQualifiedName": "List.ContainsKey",
-      "iconUrl": "http://localhost/icons/List.ContainsKey.Small?path=BuiltIn.ds",
-      "contextData": "List.ContainsKey@var[]..[],var",
-      "parameters": null,
-      "itemType": "action",
-      "keywords": ""
-    },
-    {
       "fullyQualifiedName": "DynamoUnits.Location.Name",
       "iconUrl": "http://localhost/icons/DynamoUnits.Location.Name.Small?path=DynamoUnits.dll",
       "contextData": "DynamoUnits.Location.Name",


### PR DESCRIPTION
### Purpose

The purpose of this PR is to signal to the user that the 1.3 GetKeys, GetValues, ContainsKey, and RemoveKey nodes and design script functions (for use with Lists) have been deprecated.  Specifically this task removes the migration logic to the List namespace, hides these nodes in the library, and adds a persistent warning that informs the user of the depreciation and the appropriate Dictionary Node or DS to use instead.

<img width="698" alt="screen shot 2018-03-05 at 5 50 29 pm" src="https://user-images.githubusercontent.com/2145751/37004235-c090d2de-209d-11e8-8f28-16a2c5dd1651.png">

TODO 
* sync with Library repo 

### Declarations

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @aparajit-pratap 

### FYIs

@Racel @QilongTang 