### PR TITLE
QNTM-3393: Performance issue in this VW graph

### DIFF
--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -171,63 +171,85 @@ namespace ProtoCore
 
         #region Trace Data Serialization Methods/Members
 
+        private IEnumerable<GraphNode> GetGraphNodeData(Executable executable)
+        {
+            // No executable, nothing to return
+            if (executable == null)
+              return null;
+
+            // No stream data to query
+            var stream = executable.instrStreamList;
+            if (stream == null || stream.Length == 0)
+              return null;
+
+            // Get the list of graph node if one exists
+            var graph = stream[0].dependencyGraph;
+            if (graph == null)
+              return null;
+
+            return graph.GraphList;
+        }
+
         /// <summary>
         /// Call this method to obtain serialized trace data for a list of nodes.
         /// </summary>
         /// <param name="nodeGuids">A list of System.Guid of nodes whose 
         /// serialized trace data is to be retrieved. This parameter cannot be 
         /// null.</param>
+        /// <param name="executable">A container of callsite data for the nodes in the graph.</param>
         /// <returns>Returns a dictionary that maps each node Guid to its 
         /// corresponding list of serialized callsite trace data.</returns>
-        /// 
         public IDictionary<Guid, List<CallSite.RawTraceData>>
-            GetTraceDataForNodes(IEnumerable<Guid> nodeGuids, Executable executable)
+                GetTraceDataForNodes(IEnumerable<Guid> nodeGuids, Executable executable)
         {
             if (nodeGuids == null)
                 throw new ArgumentNullException("nodeGuids");
 
             var nodeDataPairs = new Dictionary<Guid, List<CallSite.RawTraceData>>();
 
-            if (!nodeGuids.Any()) // Nothing to persist now.
+            // Nothing to persist now
+            if (!nodeGuids.Any())
                 return nodeDataPairs;
 
-            // Attempt to get the list of graph node if one exists.
-            IEnumerable<GraphNode> graphNodes = null;
+            IEnumerable<GraphNode> graphNodeData = GetGraphNodeData(executable);
+            if (graphNodeData == null)
+              return nodeDataPairs;
+
+            Dictionary<Guid, List<string>> callsiteMap = new Dictionary<Guid, List<string>>();
+            foreach (GraphNode graphNode in graphNodeData)
             {
-                if (executable != null)
+                Guid guid = graphNode.guid;
+
+                List<string> callsSiteData;
+                if (!callsiteMap.TryGetValue(guid, out callsSiteData))
                 {
-                    var stream = executable.instrStreamList;
-                    if (stream != null && (stream.Length > 0))
-                    {
-                        var graph = stream[0].dependencyGraph;
-                        if (graph != null)
-                            graphNodes = graph.GraphList;
-                    }
+                    callsSiteData = new List<string>();
+                    callsiteMap[guid] = callsSiteData;
                 }
 
-                if (graphNodes == null) // No execution has taken place.
-                    return nodeDataPairs;
+                callsSiteData.Add(graphNode.CallsiteIdentifier);
             }
 
             foreach (Guid nodeGuid in nodeGuids)
             {
-                // Get a list of GraphNode objects that correspond to this node.
-                var graphNodeIds = graphNodes.
-                    Where(gn => gn.guid == nodeGuid).
-                    Select(gn => gn.CallsiteIdentifier);
-
-                if (!graphNodeIds.Any())
-                    continue;
+                List<string> graphNodeIds;
+                if (!callsiteMap.TryGetValue(nodeGuid, out graphNodeIds))
+                  continue;
 
                 // Get all callsites that match the graph node ids.
                 // 
                 // Note we assume the graph node is the top-level graph node here.
                 // The callsite id is the concatenation of all graphnodes' callsite
                 // identifier along the nested function call. 
-                var matchingCallSites = (from cs in CallsiteCache
+                var matchingCallSitesQuery = (from cs in CallsiteCache
                                          from gn in graphNodeIds
                                          where !string.IsNullOrEmpty(gn) && cs.Key.StartsWith(gn)
                                          select new { cs.Key, cs.Value });
+                List<KeyValuePair<string, CallSite>> matchingCallSites = new List<KeyValuePair<string, CallSite>>();
+                foreach (var queryItem in matchingCallSitesQuery)
+                {
+                    matchingCallSites.Add(new KeyValuePair<string, CallSite>(queryItem.Key, queryItem.Value));
+                }
 
                 // Append each callsite element under node element.
                 var serializedCallsites = new List<CallSite.RawTraceData>();

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -241,15 +241,10 @@ namespace ProtoCore
                 // Note we assume the graph node is the top-level graph node here.
                 // The callsite id is the concatenation of all graphnodes' callsite
                 // identifier along the nested function call. 
-                var matchingCallSitesQuery = (from cs in CallsiteCache
+                var matchingCallSites = (from cs in CallsiteCache
                                          from gn in graphNodeIds
                                          where !string.IsNullOrEmpty(gn) && cs.Key.StartsWith(gn)
                                          select new { cs.Key, cs.Value });
-                List<KeyValuePair<string, CallSite>> matchingCallSites = new List<KeyValuePair<string, CallSite>>();
-                foreach (var queryItem in matchingCallSitesQuery)
-                {
-                    matchingCallSites.Add(new KeyValuePair<string, CallSite>(queryItem.Key, queryItem.Value));
-                }
 
                 // Append each callsite element under node element.
                 var serializedCallsites = new List<CallSite.RawTraceData>();


### PR DESCRIPTION
### Purpose
One of the hypothesized reasons for the performance issues in the VW graph is due to the saving of backup files while running Dynamo. The save time for this graph is extremely long (~33-36 seconds under the debugger). The reason for this was found to be due to testing for trace data to be saved. This PR makes the testing more efficient and reduces the save time (to ~2-3 seconds). Hopefully testing with D4R will show that the functionality is actually faster and not just broken for some reason by these changes.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@mjkkirschner 

### FYIs
@alfarok 
