### PR TITLE
Do not update FileName on save for backups or customNodes

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -991,6 +991,20 @@ namespace Dynamo.Graph.Workspaces
             try
             {
                 // Stage 1: Serialize the workspace.
+                string fileName = string.Empty;
+                try
+                {
+                    fileName = Path.GetFileName(filePath);
+                    string extension = Path.GetExtension(filePath);
+                    if (extension == ".dyn" || extension == ".dyf")
+                    {
+                        fileName = Path.GetFileNameWithoutExtension(filePath);
+                    }
+                }
+                catch (ArgumentException)
+                {
+                }
+
                 var json = this.ToJson(engine);
 
                 // Stage 2: Save
@@ -1001,6 +1015,13 @@ namespace Dynamo.Graph.Workspaces
                 if (!isBackup)
                 {
                     FileName = filePath;
+                    // only update the name if this is not a backup save
+                    // and this is a homeworkspace. (don't update customNode based on filePath
+                    // as customNode names are set via properties.
+                    if (fileName != string.Empty && this is HomeWorkspaceModel)
+                    {
+                        this.Name = fileName;
+                    }
                     OnSaved();
                 }
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1425,6 +1425,7 @@ namespace Dynamo.ViewModels
         /// exception is written to the console.
         /// </summary>
         /// <param name="path">The path to the file.</param>
+        /// <param name="isBackup">Indicates if an automated backup save has called this function.</param>
         /// <exception cref="IOException"></exception>
         /// <exception cref="UnauthorizedAccessException"></exception>
         public void SaveAs(string path, bool isBackup = false)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -547,25 +547,6 @@ namespace Dynamo.ViewModels
             try
             {
                 // Stage 1: Serialize the workspace.
-                string fileName = string.Empty;
-                try
-                {
-                    fileName = Path.GetFileName(filePath);
-                    string extension = Path.GetExtension(filePath);
-                    if (extension == ".dyn" || extension == ".dyf")
-                    {
-                      fileName = Path.GetFileNameWithoutExtension(filePath);
-                    }
-                }
-                catch (ArgumentException)
-                {
-                }
-
-                if (fileName != string.Empty)
-                {
-                    Model.Name = fileName;
-                }
-              
                 var json = Model.ToJson(engine);
                 var json_parsed = JObject.Parse(json);
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -546,6 +546,8 @@ namespace Dynamo.ViewModels
 
             try
             {
+                //set the name before serializing model.
+                this.Model.setNameBasedOnFileName(filePath, isBackup);
                 // Stage 1: Serialize the workspace.
                 var json = Model.ToJson(engine);
                 var json_parsed = JObject.Parse(json);

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -15,14 +15,17 @@ using Dynamo.ViewModels;
 using Dynamo.Utilities;
 using CoreNodeModels.Input;
 using Dynamo.Graph.Connectors;
+using Dynamo.Graph.Nodes;
 
 namespace Dynamo.Tests
 {
+    [TestFixture]
     public class WorkspaceSaving : DynamoViewModelUnitTest
     {
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
+            libraries.Add("VMDataBridge.dll");
             libraries.Add("Builtin.dll");
             libraries.Add("DSCoreNodes.dll");
             base.GetLibrariesToPreload(libraries);
@@ -602,16 +605,17 @@ namespace Dynamo.Tests
             var outnode2 = new Output();
             outnode1.Symbol = "out2";
 
-            var numberNode = new DoubleInput();
-            numberNode.Value = "5";
+            var cbn = new CodeBlockNodeModel(this.ViewModel.EngineController.LibraryServices);
+            cbn.SetCodeContent("5;",this.ViewModel.CurrentSpace.ElementResolver);
+
             ViewModel.FocusCustomNodeWorkspace(funcguid);
 
-            this.ViewModel.CurrentSpace.AddAndRegisterNode(numberNode);
+            this.ViewModel.CurrentSpace.AddAndRegisterNode(cbn);
             this.ViewModel.CurrentSpace.AddAndRegisterNode(outnode1);
             this.ViewModel.CurrentSpace.AddAndRegisterNode(outnode2);
 
-            new ConnectorModel(numberNode.OutPorts.FirstOrDefault(), outnode1.InPorts.FirstOrDefault(), Guid.NewGuid());
-            new ConnectorModel(numberNode.OutPorts.FirstOrDefault(), outnode2.InPorts.FirstOrDefault(), Guid.NewGuid());
+            new ConnectorModel(cbn.OutPorts.FirstOrDefault(), outnode1.InPorts.FirstOrDefault(), Guid.NewGuid());
+            new ConnectorModel(cbn.OutPorts.FirstOrDefault(), outnode2.InPorts.FirstOrDefault(), Guid.NewGuid());
 
             var savePath = GetNewFileNameOnTempPath("dyf");
            this.ViewModel.SaveAs(savePath);


### PR DESCRIPTION
https://jira.autodesk.com/browse/QNTM-2121
https://jira.autodesk.com/browse/QNTM-3627


### Purpose

so I changed the location and behavior of the functionality in QNTM-2121 - please consider these three issues:

* if no view is present and save is initiated from a model shouldn't the name be updated? Was this done for some specific reason? To avoid test failures or something?
* This update to the name property should not happen during backup save, only during actual save intended by the user so the filePath is actually meaningful.
* The name for customNodes should never be set to the filePath and never automatically, as the customNode name is a name representing the function which is to be called, not the location of the graph on disk... It does not need to be unique (we used the filepaths as names for workspaces so that we could generate unique GUIDS based on those names) this makes no sense for customnodes as they already have guids.

Am I missing something?

TODO:
- [x] automated tests
- [ ] run self serve


![screen shot 2018-03-06 at 11 22 28 pm](https://user-images.githubusercontent.com/508936/37073718-a50cd1a8-2196-11e8-93bf-ea68af58b6ff.png)
![screen shot 2018-03-06 at 11 22 13 pm](https://user-images.githubusercontent.com/508936/37073719-a54091be-2196-11e8-8de8-de2e7a29a594.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
@ColinDayOrg 
### FYIs

@kronz @jnealb @smangarole 