### PR TITLE
Update elementTypes for watch, color, and color range

### DIFF
--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -808,7 +808,7 @@
             {
               "text": "Color",
               "iconUrl": "",
-              "elementType": "classType",
+              "elementType": "group",
               "include": [
                 {
                   "path": "DSCoreNodes.DSCore.Color.Red"
@@ -855,7 +855,7 @@
             {
               "text": "Color Range",
               "iconUrl": "",
-              "elementType": "classType",
+              "elementType": "group",
               "include": [
                 {
                   "path": "Core.Color.Color Range"
@@ -872,7 +872,7 @@
             {
               "text": "Watch",
               "iconUrl": "",
-              "elementType": "classType",
+              "elementType": "group",
               "include": [
                 {
                   "path": "Core.View.Watch"


### PR DESCRIPTION
### Purpose

[QNTM-3645](https://jira.autodesk.com/browse/QNTM-3645)

This PR fixes a bug that was causing Color, Color Range, and Watch nodes to appear at the top of erratic searches.  This was due to the fact that these `groups` nested under the Display `category` specified an elementType that did not exist instead of the `group` type.  See [librarie docs](https://github.com/DynamoDS/librarie.js/blob/6bda5ec64257908df4da59278833babaed5a4452/docs/layout-specs.md#element-types) for more info on these types.

![image](https://user-images.githubusercontent.com/13341935/37179534-e8932400-22f3-11e8-9bc5-48ecb4c4eb14.png)

![image](https://user-images.githubusercontent.com/13341935/37179702-803dcbd4-22f4-11e8-998d-4dd0efb3e296.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps 

### FYIs

@QilongTang @mjkkirschner @jnealb 
