### PR TITLE
Dynamo migration change

### DIFF
--- a/src/DynamoCore/Core/DynamoMigrator.cs
+++ b/src/DynamoCore/Core/DynamoMigrator.cs
@@ -61,13 +61,9 @@ namespace Dynamo.Core
 
     /// <summary>
     /// Base class for all versions of Dynamo classes relating to
-    /// migrating preferences, packages and definitions from older versions
-    /// For version specific migration, derived classes will override base class methods
-    /// The naming convention for derived classes is "DynamoMigrator{MajorVersion}{MinorVersion}"
-    /// For e.g. derived migrator class for verion 0.7 is "DynamoMigrator07"
-    /// Derived migrator class for version 0.8 is "DynamoMigrator08" and so on.
-    /// Constructors of classes derived from DynamoMigratorBase need to be public
-    /// as their instances are created through reflection.
+    /// migrating preferences from older versions
+    /// For version specific migration, derived classes 
+    /// should override base class methods
     /// </summary>
     internal class DynamoMigratorBase
     {
@@ -109,6 +105,8 @@ namespace Dynamo.Core
             }
         }
 
+        #endregion
+
         private PreferenceSettings preferenceSettings;
         public PreferenceSettings PreferenceSettings
         {
@@ -118,8 +116,6 @@ namespace Dynamo.Core
             }
             set { preferenceSettings = value; }
         }
-
-        #endregion
 
         protected DynamoMigratorBase(FileVersion version)
         {
@@ -158,20 +154,18 @@ namespace Dynamo.Core
         }
 
         /// <summary>
-        /// Migrates preference settings, packages, custom node definitions, etc. 
+        /// Migrates preference settings, customized migration step in derived class. 
         /// from source migrator version to current version.
         /// This function can be overridden by version specific migrator classes
         /// </summary>
         /// <param name="sourceMigrator"> source migrator version from which to migrate from </param>
-        /// /// <returns>new migrator instance after migration</returns>
+        /// <returns>new migrator instance after migration</returns>
         protected virtual DynamoMigratorBase MigrateFrom(DynamoMigratorBase sourceMigrator)
         {
             PreferenceSettings = sourceMigrator.PreferenceSettings;
             if (PreferenceSettings == null) return this;
 
-            // All preference settings are copied over including custom package folders
-            // However if one of the custom folder locations points to the user data directory
-            // of the previous version, it needs to be replaced with that of the current version
+            // All preference settings are copied over except for custom package folders
             PreferenceSettings.CustomPackageFolders.Clear();
             PreferenceSettings.CustomPackageFolders.Insert(0, UserDataDirectory);
             


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[QNTM-3485](https://jira.autodesk.com/browse/QNTM-3485)
Crash when loading a Dynamo 1.3 package that references 2.0 VariableInputNodeModel

This PR removes the ability for DynamoMigrator to copy `definations` and `packages` from old Dynamo version to new one, as long as the ability to inherit `CustomPackageFolders` in old `PreferenceSettings`. Thus, the first time user launches Dynamo 2.0, it will keep all the setting from old Dynamo major version ( like Library width, console height, window size) but will not attempt to load any of the old packages or definations, since the paths Dynamo manages will be clean. (see picture below)

![image](https://user-images.githubusercontent.com/3942418/37169853-1f6f2bf8-22d7-11e8-9446-babf303faf4d.png)

To Do:
- [x] Update UserDataMigrationTests
- [x] Run Self-CI
https://ecwest.autodesk.com/commander/link/jobDetails/jobs/973c2416-2310-11e8-bf57-a0d3c1eff5a4?

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap @ramramps @mjkkirschner

### FYIs

@kronz @jnealb @smangarole 
