### PR TITLE
fix localization error

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
@@ -15,6 +15,7 @@ namespace Dynamo.Graph.Workspaces
     /// </summary>
     public class WorkspaceInfo
     {
+        private const string dynamo1HomeWorkspaceNameString = "Home";
         public WorkspaceInfo(string id, string name, string description, RunType runType)
         {
             ID = id;
@@ -111,7 +112,7 @@ namespace Dynamo.Graph.Workspaces
                 // we have a dyf and it lacks an ID field, we need to assign it
                 // a deterministic guid based on its name.  By doing it deterministically,
                 // files remain compatible
-                if (string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(funName) && funName != Properties.Resources.DefaultHomeWorkspaceName)
+                if (string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(funName) && funName != dynamo1HomeWorkspaceNameString)
                 {
                     id = GuidUtility.Create(GuidUtility.UrlNamespace, funName).ToString();
                 }

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
@@ -186,7 +186,8 @@ namespace Dynamo.Graph.Workspaces
                 // we have a dyf and it lacks an ID field, we need to assign it
                 // a deterministic guid based on its name.  By doing it deterministically,
                 // files remain compatible
-                //TODO(mjk) we should get rid of this and throw instead since non hame names are now valid in json format.
+                //TODO(mjk) we should get rid of this and throw instead or use the isCustomNode flag to determine this
+                //since non home names are now valid in json format.
                 if (string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(funName) && funName != dynamo1HomeWorkspaceNameString)
                 {
                     id = GuidUtility.Create(GuidUtility.UrlNamespace, funName).ToString();

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceInfo.cs
@@ -15,6 +15,7 @@ namespace Dynamo.Graph.Workspaces
     /// </summary>
     public class WorkspaceInfo
     {
+        //in dynamo 1.x the workspace name for home workspaces was always "Home" no matter what the language was.
         private const string dynamo1HomeWorkspaceNameString = "Home";
         public WorkspaceInfo(string id, string name, string description, RunType runType)
         {
@@ -185,7 +186,8 @@ namespace Dynamo.Graph.Workspaces
                 // we have a dyf and it lacks an ID field, we need to assign it
                 // a deterministic guid based on its name.  By doing it deterministically,
                 // files remain compatible
-                if (string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(funName) && funName != Properties.Resources.DefaultHomeWorkspaceName)
+                //TODO(mjk) we should get rid of this and throw instead since non hame names are now valid in json format.
+                if (string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(funName) && funName != dynamo1HomeWorkspaceNameString)
                 {
                     id = GuidUtility.Create(GuidUtility.UrlNamespace, funName).ToString();
                 }


### PR DESCRIPTION

### Purpose

Don't use localized string to check if workspace is a home workspace.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps 
@QilongTang 

### FYIs

@andydandy74 @kronz @jnealb 