### PR TITLE
Fix warnings for type mismatched calls on properties

### DIFF
--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -361,13 +361,12 @@ namespace ProtoCore
 
             var qualifiedMethodName = methodName;
 
-            ClassNode classNode = null;
             var className = string.Empty;
             var classNameSimple = string.Empty;
 
             if (classScope != Constants.kGlobalScope)
             {
-                classNode = runtimeCore.DSExecutable.classTable.ClassNodes[classScope];
+                var classNode = runtimeCore.DSExecutable.classTable.ClassNodes[classScope];
                 className = classNode.Name;
                 classNameSimple = className.Split('.').Last();
                 qualifiedMethodName = classNameSimple + "." + methodName;
@@ -377,9 +376,7 @@ namespace ProtoCore
             {
                 if (classScope != Constants.kGlobalScope)
                 {
-                    var procNodes = classNode.ProcTable.GetFunctionsByName(methodName);
-
-                    if (procNodes.Any() && arguments != null && arguments.Any())
+                    if (arguments != null && arguments.Any())
                     {
                         qualifiedMethodName = classNameSimple + "." + propertyName;
 

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -361,11 +361,11 @@ namespace ProtoCore
 
             var qualifiedMethodName = methodName;
 
+            var className = runtimeCore.DSExecutable.classTable.ClassNodes[classScope].Name;
+            var classNameSimple = className.Split('.').Last();
+
             if (classScope != Constants.kGlobalScope)
             {
-                var className = runtimeCore.DSExecutable.classTable.ClassNodes[classScope].Name;
-                var classNameSimple = className.Split('.').Last();
-
                 qualifiedMethodName = classNameSimple + "." + methodName;
             }
 
@@ -373,8 +373,22 @@ namespace ProtoCore
             {
                 if (classScope != Constants.kGlobalScope)
                 {
-                    string classname = runtimeCore.DSExecutable.classTable.ClassNodes[classScope].Name;
-                    message = string.Format(Resources.kPropertyOfClassNotFound, propertyName, classname);
+                    var classNode = runtimeCore.DSExecutable.classTable.ClassNodes[classScope];
+                    var procNodes = classNode.ProcTable.GetFunctionsByName(methodName);
+
+                    if (procNodes.Any() && arguments != null && arguments.Any())
+                    {
+                        qualifiedMethodName = classNameSimple + "." + propertyName;
+
+                        // if the property is found on the class, it must be a static getter being called on 
+                        // an instance argument type not matching the property
+                        message = string.Format(Resources.NonOverloadMethodResolutionError, qualifiedMethodName,
+                            className, GetTypeName(arguments[0]));
+                    }
+                    else
+                    {
+                        message = string.Format(Resources.kPropertyOfClassNotFound, propertyName, className);
+                    }
                 }
                 else
                 {

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -361,11 +361,15 @@ namespace ProtoCore
 
             var qualifiedMethodName = methodName;
 
-            var className = runtimeCore.DSExecutable.classTable.ClassNodes[classScope].Name;
-            var classNameSimple = className.Split('.').Last();
+            ClassNode classNode = null;
+            var className = string.Empty;
+            var classNameSimple = string.Empty;
 
             if (classScope != Constants.kGlobalScope)
             {
+                classNode = runtimeCore.DSExecutable.classTable.ClassNodes[classScope];
+                className = classNode.Name;
+                classNameSimple = className.Split('.').Last();
                 qualifiedMethodName = classNameSimple + "." + methodName;
             }
 
@@ -373,7 +377,6 @@ namespace ProtoCore
             {
                 if (classScope != Constants.kGlobalScope)
                 {
-                    var classNode = runtimeCore.DSExecutable.classTable.ClassNodes[classScope];
                     var procNodes = classNode.ProcTable.GetFunctionsByName(methodName);
 
                     if (procNodes.Any() && arguments != null && arguments.Any())


### PR DESCRIPTION
### Purpose

After the switch to static method compilation of methods and properties, the warning messages weren't updated properly and were confusing:
![image](https://user-images.githubusercontent.com/5710686/37231738-4c627e9c-23ba-11e8-83e8-adc06bef7e98.png)

This PR fixes the warning messages in these cases:
![image](https://user-images.githubusercontent.com/5710686/37231812-94b2427c-23ba-11e8-84d1-31b46d2c2435.png)
![image](https://user-images.githubusercontent.com/5710686/37231989-265d0d42-23bb-11e8-8c8a-c5a612a71950.png)
![image](https://user-images.githubusercontent.com/5710686/37232075-74459c9a-23bb-11e8-959e-a36ddd3850e6.png)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@pboyer 

### FYIs

@jnealb @kronz 
