### PR TITLE
Missed Rank node changes

### DIFF
--- a/src/Engine/ProtoCore/ExtendedLibraries/BuiltIn.ds
+++ b/src/Engine/ProtoCore/ExtendedLibraries/BuiltIn.ds
@@ -41,5 +41,9 @@ class List extends DSCore.List
 	{
 		return __TrueForAny(list, predicate);
 	}
+	public static def Rank : int(list: var[]..[])
+  	{		
+ 		return __Rank(list);
+ 	}
 }
 

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -98,7 +98,7 @@ namespace ProtoCore.Lang
             "MapTo",                    // kMapTo
             "NormalizeDepth",           // kNormalizeDepth
             "Print",                    // kPrint
-            "Rank",                     // kRank
+            "__Rank",                     // kRank
             "Remove",                   // kRemove
             "RemoveDuplicates",         // kRemoveDuplicates
             "RemoveNulls",              // kRemoveNulls


### PR DESCRIPTION
### Purpose

This PR is to include two changes for the Rank node I overlooked when combining the https://github.com/DynamoDS/Dynamo/pull/8624 and https://github.com/DynamoDS/Dynamo/pull/8617 PR's.  This PR restores the Rank node with the other changes to the library.  Migration, Documentation, Icon, and Lib Testing was previously handled in https://github.com/DynamoDS/Dynamo/pull/8636

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 

### FYIs

@QilongTang @mjkkirschner @alfarok 