### PR TITLE
set unsavedChanges to false for json customNodes

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -679,8 +679,10 @@ namespace Dynamo.Core
                     newWorkspace = (CustomNodeWorkspaceModel)WorkspaceModel.FromJson(jsonDoc, this.libraryServices, null, null, nodeFactory, false, true, this);
                     newWorkspace.FileName = workspaceInfo.FileName;
                     newWorkspace.Category = workspaceInfo.Category;
+                    // Mark the custom node workspace as having no changes - when we set the category on the above line
+                    // this marks the workspace as changed.
+                    newWorkspace.HasUnsavedChanges = false;
                 }
-
             }
 
             RegisterCustomNodeWorkspace(newWorkspace);

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PublishPackageViewModel.cs
@@ -749,7 +749,7 @@ namespace Dynamo.PackageManager
 
         }
 
-        private IEnumerable<string> GetAllFiles()
+        internal IEnumerable<string> GetAllFiles()
         {
             // get all function defs
             var allFuncs = AllFuncDefs().ToList();

--- a/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/PublishPackageViewModelTests.cs
@@ -75,6 +75,26 @@ namespace DynamoCoreWpfTests
 
         }
 
+        [Test]
+        public void CanPublishLateInitializedJsonCustomNode()
+        {
+
+            string nodePath = Path.Combine(TestDirectory,"core","CustomNodes", "jsonCustomNode.dyf");
+
+            //add this customNode to the package without opening it.
+            var vm = new PublishPackageViewModel(this.ViewModel);
+            ViewModel.OnRequestPackagePublishDialog(vm);
+            vm.AddFile(nodePath);
+
+            //assert we don't raise any exceptions during getAllFiles
+            //- this will check the customNode has no unsaved changes.
+
+            Assert.AreEqual(1, vm.CustomNodeDefinitions.Count);
+            Assert.DoesNotThrow(() => {vm.GetAllFiles();});
+            Assert.AreEqual(nodePath, vm.GetAllFiles().First());
+
+        }
+
 
         [Test]
         public void NewPackageVersionUpload_DoesNotThrowExceptionWhenDLLIsLoadedSeveralTimes()

--- a/test/core/CustomNodes/jsonCustomNode.dyf
+++ b/test/core/CustomNodes/jsonCustomNode.dyf
@@ -1,0 +1,117 @@
+{
+  "Uuid": "4c15f5e0-efb9-4faa-b140-966a1f0a954d",
+  "IsCustomNode": true,
+  "Category": "Customnodes",
+  "Description": "a jsoncustomNode",
+  "Name": "test2",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Symbol, DynamoCore",
+      "NodeType": "InputNode",
+      "Parameter": {
+        "Name": "s",
+        "TypeName": "var",
+        "TypeRank": -1,
+        "DefaultValue": null
+      },
+      "Id": "5a6bdadb4de24f13bd1d80ec436860db",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "f1b7628c02ab4d209444f86989f57bac",
+          "Name": "",
+          "Description": "Symbol",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A function parameter, use with custom nodes.\r\n\r\nYou can specify the type and default value for parameter. E.g.,\r\n\r\ninput : var[]..[]\r\nvalue : bool = false"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
+      "NodeType": "OutputNode",
+      "ElementResolver": null,
+      "Symbol": "d",
+      "Id": "00e4510fc3cf485a896202a95d434cea",
+      "Inputs": [
+        {
+          "Id": "104f30743ad943f19b55580191c179b1",
+          "Name": "",
+          "Description": "",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "A function output, use with custom nodes"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "f1b7628c02ab4d209444f86989f57bac",
+      "End": "104f30743ad943f19b55580191c179b1",
+      "Id": "3491acf554214a0b81b4aa38fde9cd9f"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": false,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.1.4456",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Input",
+        "Id": "5a6bdadb4de24f13bd1d80ec436860db",
+        "IsInput": false,
+        "IsOutput": false,
+        "Excluded": false,
+        "X": 222.65968586387436,
+        "Y": 444.31413612565444
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Output",
+        "Id": "00e4510fc3cf485a896202a95d434cea",
+        "IsInput": false,
+        "IsOutput": false,
+        "Excluded": false,
+        "X": 363.39267015706804,
+        "Y": 335.74869109947645
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/CustomNodes/jsonCustomNode.dyf
+++ b/test/core/CustomNodes/jsonCustomNode.dyf
@@ -71,7 +71,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": false,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.0.1.4456",
+      "Version": "2.0.0.4456",
       "RunType": "Manual",
       "RunPeriod": "1000"
     },


### PR DESCRIPTION
### Purpose
https://jira.autodesk.com/browse/QNTM-3715

unable to publish a json customnode - it actually appears this does not effect xml dyfs - so the dyf file included with the task is not useful for testing - just FYI.

when we initialize a customNode without opening it we need to set `unsavedChanges` to false, since we directly set the category, and setting the category marks the workspace as modified. This does not happen for XML based workspaces as this is all done inside the workspace and workspaceInfo constructors - for JSON `customNodeWorkspaces` we set the category in the `customNode manager`.

I have added a test.

I still need to run the self serve CI.

When this is good we should cherry pick it.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang (if you have time)

### FYIs

@smangarole @Racel 