### PR TITLE
NodeModel derived nodes should deserialize into correct node state

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1036,7 +1036,7 @@ namespace Dynamo.Graph.Nodes
             SetNameFromNodeNameAttribute();
 
             IsSelected = false;
-            State = ElementState.Dead;
+            SetNodeStateBasedOnConnectionAndDefaults();
             ArgumentLacing = LacingStrategy.Disabled;
 
             RaisesModificationEvents = true;


### PR DESCRIPTION
### Purpose

[QNTM-1902](https://jira.autodesk.com/browse/QNTM-1902)

This PR enables the checking of a nodes state when the constructor for that node is called.  We stopped serializing the node state property in the move to JSON so they node state was always defaulting to `dead` (unsatisfied) upon deserialization.  In the scenario where this node model derived node does not take any inputs the node would never update its state and remain stuck in `dead`.  Instead of defaulting to the `dead` state we now check the state based on the the input connections and default values using an existing nodeModel method.

More info on the [node state types](https://github.com/alfarok/Dynamo/blob/82da04efc60646419460aa7b7d241d543ab983f0/src/DynamoCore/Graph/Nodes/NodeModel.cs#L2515).

Previous Behavior (node deserializing into `dead` state):
![nodestate](https://user-images.githubusercontent.com/13341935/37851317-d38154f2-2eb4-11e8-99be-df820999ed4b.gif)

### Testing
Currently running self-serve CI

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 


