### PR TITLE
QNTM - 3770 Fix for custom node crash

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -186,8 +186,22 @@ namespace Dynamo.ViewModels
         public AnnotationViewModel(WorkspaceViewModel workspaceViewModel, AnnotationModel model)
         {             
             annotationModel = model;           
-            this.WorkspaceViewModel = workspaceViewModel;                                     
+            this.WorkspaceViewModel = workspaceViewModel;
             model.PropertyChanged += model_PropertyChanged;
+            //https://jira.autodesk.com/browse/QNTM-3770
+            //Notes and Groups are serialized as annotations. Do not unselect the node selection during
+            //Notes serialization
+            if (model.Nodes.Count() > 0)
+            {
+                // Group is created already.So just populate it.
+                var selectNothing = new DynamoModel.SelectModelCommand(Guid.Empty, System.Windows.Input.ModifierKeys.None.AsDynamoType());
+                WorkspaceViewModel.DynamoViewModel.ExecuteCommand(selectNothing);
+            }
+            
+        }
+
+        internal void ClearSelection()
+        {
             // Group is created already.So just populate it.
             var selectNothing = new DynamoModel.SelectModelCommand(Guid.Empty, System.Windows.Input.ModifierKeys.None.AsDynamoType());
             WorkspaceViewModel.DynamoViewModel.ExecuteCommand(selectNothing);


### PR DESCRIPTION
### Purpose

Task : https://jira.autodesk.com/browse/QNTM-3770

Notes and Groups are serialized as Annotations. During serialization, if there are notes in the graph, annotationViewModel will deselect all the nodes (the code was written 2 years ago). This is causing the crash when creating the custom nodes. There will be a crash if a custom node is created during the backup save (serialization). The fix is to check if the annotation serialization is for "notes". 

This is not an issue for Groups because Groups are actually serialized into AnnotationModels. For notes, the serialization is little different, where the noteModel is serialized as AnnotationModel.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ColinDayOrg 

### FYIs

@mjkkirschner @smangarole 