### PR TITLE
[Cherry-picked] NodeModel derived nodes should deserialize into correct node state

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1036,7 +1036,7 @@ namespace Dynamo.Graph.Nodes
             SetNameFromNodeNameAttribute();
 
             IsSelected = false;
-            State = ElementState.Dead;
+            SetNodeStateBasedOnConnectionAndDefaults();
             ArgumentLacing = LacingStrategy.Disabled;
 
             RaisesModificationEvents = true;

--- a/test/DynamoCoreTests/CoreDynTests.cs
+++ b/test/DynamoCoreTests/CoreDynTests.cs
@@ -63,6 +63,29 @@ namespace Dynamo.Tests
             AssertPreviewValue("41279a88-2f0b-4bd3-bef1-1be693df5c7e", new[] { 6, 7, 8, 9, 10 });
         }
 
+        /// <summary>
+        /// Confirm that node model derived nodes deserialize into correct node state.
+        /// </summary>
+        [Test]
+        public void verifyNodeStates()
+        {
+            // open/run xml test graph
+            string openPath = Path.Combine(TestDirectory, @"core\NodeStates.dyn");
+            RunModel(openPath);
+
+            // check dead node
+            var deadNode = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("1237a148-7a90-489d-b677-11038072c288");
+            Assert.AreEqual(ElementState.Dead, deadNode.State);
+
+            // check warning node
+            var warningNode = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("50219c24-e583-4b85-887c-409fb062da6e");
+            Assert.AreEqual(ElementState.Warning, warningNode.State);
+
+            // check active node
+            var activeNode = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("72136fa9-7aec-4ed5-a23b-1ee1c13294a6");
+            Assert.AreEqual(ElementState.Active, activeNode.State);
+        }
+
 
         /// <summary>
         /// Confirm that a node with multiple outputs evaluates successfully.

--- a/test/DynamoCoreTests/CoreDynTests.cs
+++ b/test/DynamoCoreTests/CoreDynTests.cs
@@ -69,21 +69,38 @@ namespace Dynamo.Tests
         [Test]
         public void verifyNodeStates()
         {
-            // open/run xml test graph
+            // Open/Run XML test graph
             string openPath = Path.Combine(TestDirectory, @"core\NodeStates.dyn");
             RunModel(openPath);
 
-            // check dead node
+            // Check dead node XML
             var deadNode = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("1237a148-7a90-489d-b677-11038072c288");
             Assert.AreEqual(ElementState.Dead, deadNode.State);
-
-            // check warning node
+            // Check warning node XML
             var warningNode = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("50219c24-e583-4b85-887c-409fb062da6e");
             Assert.AreEqual(ElementState.Warning, warningNode.State);
-
-            // check active node
+            // Check active node XML
             var activeNode = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("72136fa9-7aec-4ed5-a23b-1ee1c13294a6");
             Assert.AreEqual(ElementState.Active, activeNode.State);
+
+            // Save/Open/Run JSON graph
+            string tempPath = Path.Combine(Path.GetTempPath(), "NodeStates.dyn");
+            CurrentDynamoModel.CurrentWorkspace.Save(tempPath);
+            CurrentDynamoModel.OpenFileFromPath(tempPath);
+            CurrentDynamoModel.CurrentWorkspace.RequestRun();
+
+            // Check dead node JSON
+            deadNode = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("1237a148-7a90-489d-b677-11038072c288");
+            Assert.AreEqual(ElementState.Dead, deadNode.State);
+            // Check warning node JSON
+            warningNode = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("50219c24-e583-4b85-887c-409fb062da6e");
+            Assert.AreEqual(ElementState.Warning, warningNode.State);
+            // Check active node JSON
+            activeNode = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("72136fa9-7aec-4ed5-a23b-1ee1c13294a6");
+            Assert.AreEqual(ElementState.Active, activeNode.State);
+
+            // Delete temp graph file
+            File.Delete(tempPath);
         }
 
 

--- a/test/core/NodeStates.dyn
+++ b/test/core/NodeStates.dyn
@@ -1,0 +1,37 @@
+<Workspace Version="1.3.1.1736" X="28.6102606536401" Y="202.636307772807" zoom="1.1988764122517" ScaleFactor="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <CoreNodeModels.ColorRange guid="1237a148-7a90-489d-b677-11038072c288" type="CoreNodeModels.ColorRange" nickname="Color Range" x="321.099019802796" y="-95.459543677794" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </CoreNodeModels.ColorRange>
+    <CoreNodeModels.ColorRange guid="50219c24-e583-4b85-887c-409fb062da6e" type="CoreNodeModels.ColorRange" nickname="Color Range" x="361.862804616395" y="112.341989875386" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+      <PortInfo index="2" default="False" />
+    </CoreNodeModels.ColorRange>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="0db97f86-fbd8-4195-b2a0-aa0e78ca1d72" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="267.062804616395" y="143.341989875386" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="1;" ShouldFocus="false" />
+    <UnitsUI.UnitTypes guid="72136fa9-7aec-4ed5-a23b-1ee1c13294a6" type="UnitsUI.UnitTypes" nickname="Unit Types" x="413.895645272127" y="318.1178586754" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false" index="0:Area" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="0db97f86-fbd8-4195-b2a0-aa0e78ca1d72" start_index="0" end="50219c24-e583-4b85-887c-409fb062da6e" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations>
+    <Dynamo.Graph.Annotations.AnnotationModel guid="8c1f73b2-1f3a-4a59-9082-2a686739aea3" annotationText="dead" left="311.099019802796" top="-141.459543677794" width="316.8" height="191.4" fontSize="30" InitialTop="-95.459543677794" InitialHeight="175.4" TextblockHeight="36" backgrouund="#FFC1D676">
+      <Models ModelGuid="1237a148-7a90-489d-b677-11038072c288" />
+    </Dynamo.Graph.Annotations.AnnotationModel>
+    <Dynamo.Graph.Annotations.AnnotationModel guid="96ee3348-6330-450f-83c8-4dd3311ad2f4" annotationText="warning" left="257.062804616395" top="66.341989875386" width="411.6" height="191.4" fontSize="30" InitialTop="112.341989875386" InitialHeight="175.4" TextblockHeight="36" backgrouund="#FFC1D676">
+      <Models ModelGuid="50219c24-e583-4b85-887c-409fb062da6e" />
+      <Models ModelGuid="0db97f86-fbd8-4195-b2a0-aa0e78ca1d72" />
+    </Dynamo.Graph.Annotations.AnnotationModel>
+    <Dynamo.Graph.Annotations.AnnotationModel guid="5d5382f5-f46e-49e8-b5a6-92b99cb9c863" annotationText="active" left="403.895645272127" top="272.1178586754" width="167.2" height="138.6" fontSize="30" InitialTop="318.1178586754" InitialHeight="122.6" TextblockHeight="36" backgrouund="#FFC1D676">
+      <Models ModelGuid="72136fa9-7aec-4ed5-a23b-1ee1c13294a6" />
+    </Dynamo.Graph.Annotations.AnnotationModel>
+  </Annotations>
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

[QNTM-1902](https://jira.autodesk.com/browse/QNTM-1902)

This PR enables the checking of a nodes state when the constructor for that node is called.  We stopped serializing the node state property in the move to JSON so the node state was always defaulting to `dead` (unsatisfied) upon deserialization.  In the scenario where this node model derived node does not take any inputs the node would never update its state and remain stuck in the `dead` state.  Instead of defaulting to the `dead` state we now check the state based on the the input connections and default values using an existing nodeModel method `SetNodeStateBasedOnConnectionAndDefaults()`.

More info on the [node state types](https://github.com/alfarok/Dynamo/blob/82da04efc60646419460aa7b7d241d543ab983f0/src/DynamoCore/Graph/Nodes/NodeModel.cs#L2515).

Previous Behavior (node deserializing into `dead` state):
![nodestate](https://user-images.githubusercontent.com/13341935/37851317-d38154f2-2eb4-11e8-99be-df820999ed4b.gif)

### Testing
Added unit test `verifyNodeStates()` that does the following:
- opens a 1.3 XML graph with dead, active, and warning state nodes
- verifies the correct states for each case
- saves a temporary JSON version of the graph
- opens and executes the JSON graph
- re-runs assertions
- deletes the temporary JSON file

![image](https://user-images.githubusercontent.com/13341935/37855238-b9105888-2ec4-11e8-9501-ff7e918ca1fd.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYI

@mjkkirschner 