### PR TITLE
Addons section closes each time user creates an instance of any custom node

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -704,7 +704,7 @@ namespace Dynamo.Core
         private void RegisterCustomNodeWorkspace(
             CustomNodeWorkspaceModel newWorkspace, CustomNodeInfo info, CustomNodeDefinition definition)
         {
-
+            loadedWorkspaceModels[newWorkspace.CustomNodeId] = newWorkspace;
             SetFunctionDefinition(definition);
             OnDefinitionUpdated(definition);
             newWorkspace.DefinitionUpdated += () =>
@@ -715,7 +715,6 @@ namespace Dynamo.Core
             };
 
             SetNodeInfo(info);
-            loadedWorkspaceModels[newWorkspace.CustomNodeId] = newWorkspace;
 
             newWorkspace.InfoChanged += () =>
             {

--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -95,6 +95,8 @@ namespace Dynamo.Core
 
         #endregion
 
+        #region Events
+
         /// <summary>
         ///     An event that is fired when a definition is updated
         /// </summary>
@@ -125,6 +127,7 @@ namespace Dynamo.Core
             var handler = CustomNodeRemoved;
             if (handler != null) handler(functionId);
         }
+        #endregion
 
         /// <summary>
         ///     Creates a new Custom Node Instance.
@@ -701,7 +704,6 @@ namespace Dynamo.Core
         private void RegisterCustomNodeWorkspace(
             CustomNodeWorkspaceModel newWorkspace, CustomNodeInfo info, CustomNodeDefinition definition)
         {
-            loadedWorkspaceModels[newWorkspace.CustomNodeId] = newWorkspace;
 
             SetFunctionDefinition(definition);
             OnDefinitionUpdated(definition);
@@ -713,6 +715,8 @@ namespace Dynamo.Core
             };
 
             SetNodeInfo(info);
+            loadedWorkspaceModels[newWorkspace.CustomNodeId] = newWorkspace;
+
             newWorkspace.InfoChanged += () =>
             {
                 var newInfo = newWorkspace.CustomNodeInfo;

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -118,6 +118,7 @@ namespace Dynamo.Models
         #endregion
 
         #region events
+
         internal delegate void FunctionNamePromptRequestHandler(object sender, FunctionNamePromptEventArgs e);
         internal event FunctionNamePromptRequestHandler RequestsFunctionNamePrompt;
         internal void OnRequestsFunctionNamePrompt(Object sender, FunctionNamePromptEventArgs e)
@@ -1051,7 +1052,9 @@ namespace Dynamo.Models
                 {
                     if (info.FunctionId == newInfo.FunctionId)
                     {
-                        bool isCategoryChanged = searchElement.FullCategoryName != newInfo.Category;
+                        var group = SearchElementGroup.None;
+                        var processedName = SearchModel.ProcessNodeCategory(newInfo.Category,ref group);
+                        bool isCategoryChanged = searchElement.FullCategoryName != newInfo.Category && searchElement.FullCategoryName != processedName;
                         searchElement.SyncWithCustomNodeInfo(newInfo);
                         SearchModel.Update(searchElement, isCategoryChanged);
                     }

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1052,9 +1052,7 @@ namespace Dynamo.Models
                 {
                     if (info.FunctionId == newInfo.FunctionId)
                     {
-                        var group = SearchElementGroup.None;
-                        var processedName = SearchModel.ProcessNodeCategory(newInfo.Category,ref group);
-                        bool isCategoryChanged = searchElement.FullCategoryName != newInfo.Category && searchElement.FullCategoryName != processedName;
+                        bool isCategoryChanged = searchElement.FullCategoryName != newInfo.Category;
                         searchElement.SyncWithCustomNodeInfo(newInfo);
                         SearchModel.Update(searchElement, isCategoryChanged);
                     }

--- a/src/DynamoCore/Search/SearchLibrary.cs
+++ b/src/DynamoCore/Search/SearchLibrary.cs
@@ -45,7 +45,9 @@ namespace Dynamo.Search
                 keys.Add(entry.Description.ToLower(), 0.1);
 
                 foreach (var tag in entry.SearchTags.Select(x => x.ToLower()))
+                {
                     keys.Add(tag, 0.5);
+                }
 
                 OnEntryUpdated(entry);
                 return; // Entry updated.

--- a/src/DynamoCoreWpf/Properties/AssemblyInfo.cs
+++ b/src/DynamoCoreWpf/Properties/AssemblyInfo.cs
@@ -32,3 +32,4 @@ using System.Windows;
 [assembly: InternalsVisibleTo("DynamoSandbox")]
 [assembly: InternalsVisibleTo("WpfVisualizationTests")]
 [assembly: InternalsVisibleTo("DynamoPackagesUITests")]
+[assembly: InternalsVisibleTo("ViewExtensionLibraryTests")]

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -432,6 +432,7 @@ namespace Dynamo.ViewModels
 
         internal void UpdateEntry(NodeSearchElement entry)
         {
+            //look for the viewModel which should own this nodeSearchElement entry.
             var rootNode = libraryRoot;
             foreach (var categoryName in entry.Categories)
             {

--- a/src/LibraryViewExtension/LibraryViewController.cs
+++ b/src/LibraryViewExtension/LibraryViewController.cs
@@ -131,7 +131,6 @@ namespace Dynamo.LibraryUI
             toggleBrowserVisibility(this.browser);
         }
 
-
         /// <summary>
         /// Call this method to create a new node in Dynamo canvas.
         /// </summary>
@@ -143,7 +142,7 @@ namespace Dynamo.LibraryUI
                 //if the node we're trying to create is a customNode, lets disable the eventObserver.
                 // this will stop the libraryController from refreshing the libraryView on custom node creation.
                 var resultGuid = Guid.Empty;
-                if (Guid.TryParse(nodeName,out resultGuid))
+                if (Guid.TryParse(nodeName, out resultGuid))
                 {
                     this.disableObserver = true;
                 }
@@ -316,12 +315,13 @@ namespace Dynamo.LibraryUI
             customization.SpecificationUpdated += (o, e) => controller.RaiseEvent("libraryDataUpdated");
 
             var observer = new EventObserver<NodeSearchElement, IEnumerable<NodeSearchElement>>(
-                    elements => NotifySearchModelUpdate(customization,elements), CollectToList
+                    elements => NotifySearchModelUpdate(customization, elements), CollectToList
                 ).Throttle(TimeSpan.FromMilliseconds(throttleTime));
 
             Action<NodeSearchElement> handler = (searchElement) =>
              {
-                if ((controller as LibraryViewController).disableObserver)
+                 var libraryViewController = (controller as LibraryViewController);
+                 if ((libraryViewController != null) && (libraryViewController.disableObserver))
                  {
                      return;
                  }
@@ -367,7 +367,7 @@ namespace Dynamo.LibraryUI
         /// specification and raise specification changed event.</param>
         /// <param name="elements">List of updated elements</param>
         private static void NotifySearchModelUpdate(ILibraryViewCustomization customization, IEnumerable<NodeSearchElement> elements)
-        {  
+        {
             //elements might be null if we have removed an element.
             if (elements != null)
             {
@@ -378,7 +378,7 @@ namespace Dynamo.LibraryUI
                .SkipWhile(s => s.Contains("://"))
                .Select(p => new LayoutIncludeInfo() { path = p });
 
-               customization.AddIncludeInfo(includes, "Add-ons");
+                customization.AddIncludeInfo(includes, "Add-ons");
 
             }
         }

--- a/test/DynamoCoreWpfTests/Utility/DispatcherUtil.cs
+++ b/test/DynamoCoreWpfTests/Utility/DispatcherUtil.cs
@@ -7,7 +7,7 @@ using System.Windows.Threading;
 
 namespace DynamoCoreWpfTests.Utility
 {
-    internal static class DispatcherUtil
+    public static class DispatcherUtil
     {
         /// <summary>
         ///     Force the Dispatcher to empty it's queue

--- a/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
+++ b/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
@@ -381,7 +381,7 @@ namespace ViewExtensionLibraryTests
 
             var customization = new LibraryViewCustomization();
 
-            var disposable = LibraryViewController.SetupSearchModelEventsObserver(null,model, controller.Object, customization, timeout);
+            var disposable = LibraryViewController.SetupSearchModelEventsObserver(model, controller.Object, customization, timeout);
             controller.Verify(c => c.RaiseEvent(libraryDataUpdated, It.IsAny<object[]>()), Times.Never);
 
             var d1 = MockNodeSearchElement("A", "B");

--- a/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
+++ b/test/ViewExtensionLibraryTests/LibraryResourceProviderTests.cs
@@ -381,7 +381,7 @@ namespace ViewExtensionLibraryTests
 
             var customization = new LibraryViewCustomization();
 
-            var disposable = LibraryViewController.SetupSearchModelEventsObserver(model, controller.Object, customization, timeout);
+            var disposable = LibraryViewController.SetupSearchModelEventsObserver(null,model, controller.Object, customization, timeout);
             controller.Verify(c => c.RaiseEvent(libraryDataUpdated, It.IsAny<object[]>()), Times.Never);
 
             var d1 = MockNodeSearchElement("A", "B");

--- a/test/ViewExtensionLibraryTests/LibraryViewControllerTests.cs
+++ b/test/ViewExtensionLibraryTests/LibraryViewControllerTests.cs
@@ -1,0 +1,136 @@
+﻿using CefSharp;
+using Dynamo.Configuration;
+using Dynamo.Extensions;
+using Dynamo.Graph.Workspaces;
+using Dynamo.Interfaces;
+using Dynamo.LibraryUI;
+using Dynamo.Models;
+using Dynamo.Scheduler;
+using Dynamo.Search.SearchElements;
+using Dynamo.Wpf.Extensions;
+using DynamoCoreWpfTests;
+using DynamoCoreWpfTests.Utility;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ViewExtensionLibraryTests
+{
+    class LibraryViewControllerTests : DynamoTestUIBase
+    {
+        private string PackagesDirectory { get { return Path.Combine(GetTestDirectory(this.ExecutingDirectory), "pkgs"); } }
+
+        protected override DynamoModel.IStartConfiguration CreateStartConfiguration(IPathResolver pathResolver)
+        {
+            return new DynamoModel.DefaultStartConfiguration()
+            {
+                PathResolver = pathResolver,
+                StartInTestMode = true,
+                GeometryFactoryPath = preloader.GeometryFactoryPath,
+                ProcessMode = TaskProcessMode.Synchronous,
+                Preferences = new PreferenceSettings() { CustomPackageFolders = new List<string>() { this.PackagesDirectory } }
+            };
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void CreatingNodeCustomNodeDefinitionOrUpdatingItShouldRaiseUpdate()
+        {
+            var customNodeManager = this.Model.CustomNodeManager;
+            var nodeSearchModel = this.Model.SearchModel;
+            var customization = new LibraryViewCustomization();
+            var commandExec = new ViewExtensionCommandExecutive(this.ViewModel);
+            var testCallback = new Mock<IJavascriptCallback>();
+
+            const string libraryDataUpdated = "libraryDataUpdated";
+            var resetevent = new AutoResetEvent(false);
+            var refreshCount = 0;
+            var timeout = 50;
+
+            testCallback.Setup(c => c.CanExecute).Returns(true);
+            testCallback.Setup(c => c.ExecuteAsync()).Callback(() => {
+                refreshCount = refreshCount + 1; resetevent.Set(); });
+
+            var controller = new LibraryViewController(this.View, commandExec, customization);
+            controller.On(libraryDataUpdated, testCallback.Object);
+
+            Assert.AreEqual(0, refreshCount);
+
+            var path =System.IO.Path.Combine(TempFolder, "customNodeLibraryTest.dyf");
+
+
+                var cnId = Guid.NewGuid();
+            // lets make a real customnode, this will register the custom node and we should assert a refresh was raised so we can see it.
+            this.Model.ExecuteCommand(new DynamoModel.CreateCustomNodeCommand(cnId, "customNodeLibraryTest", "tests", "", false));
+         
+            Assert.IsTrue(resetevent.WaitOne(timeout * 100));
+            Assert.AreEqual(1, refreshCount);
+            resetevent.Reset();
+
+            //save will raise an event.
+            this.Model.Workspaces.OfType<CustomNodeWorkspaceModel>().FirstOrDefault().Save(path);
+            Assert.IsTrue(resetevent.WaitOne(timeout * 100));
+            Assert.AreEqual(2, refreshCount);
+            resetevent.Reset();
+
+            //  get the searchElement for this custom node and update it.
+            var realNodeData = nodeSearchModel.SearchEntries.OfType<CustomNodeSearchElement>().Where(x => x.ID == cnId).FirstOrDefault();
+            //  updating should raise an event.
+            nodeSearchModel.Update(realNodeData);
+
+            Assert.IsTrue(resetevent.WaitOne(timeout * 100));
+            Assert.AreEqual(3, refreshCount);
+
+            //cleanup the saved custom node
+            System.IO.File.Delete(path);
+
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void InstantiatingLazyLoadedCustomNodeShouldNotRaiseUpdate()
+        {
+
+
+            var customNodeManager = this.Model.CustomNodeManager;
+            var nodeSearchModel = this.Model.SearchModel;
+            var customization = new LibraryViewCustomization();
+            var commandExec = new ViewExtensionCommandExecutive(this.ViewModel);
+            var testCallback = new Mock<IJavascriptCallback>();
+
+            const string libraryDataUpdated = "libraryDataUpdated";
+            var refreshCount = 0;
+            var infoUpdated = false;
+
+            testCallback.Setup(c => c.CanExecute).Returns(true);
+            testCallback.Setup(c => c.ExecuteAsync()).Callback(() => {
+                refreshCount = refreshCount + 1;
+            });
+
+            var controller = new LibraryViewController(this.View, commandExec, customization);
+            controller.On(libraryDataUpdated, testCallback.Object);
+
+            //lets grab a real customNode which was loaded from the package directory specified above
+            var customNodeSearchEntry = nodeSearchModel.SearchEntries.OfType<CustomNodeSearchElement>().FirstOrDefault();
+            var cnId = customNodeSearchEntry.ID;
+            //lets attempt to create this, we should not raise an update, but we should see info get updated in the search.
+            customNodeManager.InfoUpdated += (data) =>
+            {
+                Assert.AreEqual(data.FunctionId, cnId);
+                infoUpdated = true;
+
+            };
+            controller.CreateNode(cnId.ToString());
+            DispatcherUtil.DoEvents();
+            Assert.AreEqual(0, refreshCount);
+            Assert.IsTrue(infoUpdated);
+
+        }
+    }
+}

--- a/test/ViewExtensionLibraryTests/ViewExtensionLibraryTests.csproj
+++ b/test/ViewExtensionLibraryTests/ViewExtensionLibraryTests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="..\..\src\AssemblySharedInfoGenerator\AssemblySharedInfo.cs">
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
+    <Compile Include="LibraryViewControllerTests.cs" />
     <Compile Include="LibraryViewCustomizationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -110,10 +111,18 @@
       <Name>LibraryViewExtension</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Tools\DynamoShapeManager\DynamoShapeManager.csproj">
+      <Project>{263FA9C1-F81E-4A8E-95E0-8CDAE20F177B}</Project>
+      <Name>DynamoShapeManager</Name>
+    </ProjectReference>
     <ProjectReference Include="..\DynamoCoreTests\DynamoCoreTests.csproj">
       <Project>{472084ed-1067-4b2c-8737-3839a6143eb2}</Project>
       <Name>DynamoCoreTests</Name>
       <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\DynamoCoreWpfTests\DynamoCoreWpfTests.csproj">
+      <Project>{7DD8077A-201E-4C56-96C5-3C901A51BDF3}</Project>
+      <Name>DynamoCoreWpfTests</Name>
     </ProjectReference>
     <ProjectReference Include="..\Libraries\SystemTestServices\SystemTestServices.csproj">
       <Project>{89563cd0-509b-40a5-8728-9d3ec6fe8410}</Project>


### PR DESCRIPTION
### Purpose

This PR addresses an issue where the `libraryViewExtension` is refreshed anytime a customNode's info is modified. This kicks off a searchEntry update, which eventually calls refreshLibraryView() which rebuilds the elements for the library, and loses the currently expanded information.

#### whats happening?

The event is raised because when a `customNode` is first instantiated the` customNodeManager `registers a bunch of handlers to the workspace. This is not done until the first customNode instance of that customNode type is placed. When that happens `SetNodeInfo` is called and bunch of refreshes occur on the library, actually more than 1 because the node is removed and added due to weirdness with category names.

Take away is that refreshLibrary is called when the node is first placed because it's a custom node that has not been placed before - and because we update searchEntry for this customNode in the dynamo NodeSearchModel is being updated when this happens.

#### potential fixes

* One approach was to restore or retain the expanded state and pass it back to the libraryView somehow, this is what I would do given more time. ✅ the method `DirectToLibrary()` would be useful for this - it lives on the LibraryContainer and does what we need, the work is in constructing the path to the node to expand in the correct format.

* ~~I ended up using the `custom node manager` to check if a custom node was already registered before raising any events to the library.  Right before we raise an update to the library - we check if the customNodeManager has a workspace with the ID of our customNode function id. If it does, we raise the event, otherwise we bail. This suppresses refreshes of the library when a customNode is being placed. Removals are not effected as a null searchElement is passed. To get this to work I had to slightly alter the order of the `RegisterCustomNodeWorkspace` function so that it only pushes the workspace to its dictionary of loaded workspaces after SetNodeInfo is called (which ends up kicking off the library refresh).~~

* I added a `disableEventObserver` flag to the LibraryExtension which is checked in a handler before actually invoking the callback in the observer - we set the flag true when a customNode is being created via the library - occurs when a user clicks on a library item, it is then set false. 

I am at a loss for testing this as this logic lives in the libraryController which never gets instantiated during tests, I might be able to factor it out into a static method and test that, maybe this should be tested using one of our other tools which can test views without Nunit - @jnealb - FYI?

- [x] Add tests
- [ ] Self Serve CI
- [x] Team feedback - is it worth investigating modifying `refreshLibraryView()` to accept an item to expand after refresh?


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
@ramramps 
### FYIs

@Racel 