### PR TITLE
fix name property for NodeModels that are inputs

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -362,6 +362,7 @@ namespace Dynamo.Graph.Workspaces
                     if(matchingNode != null)
                     {
                         matchingNode.IsSetAsInput = true;
+                        matchingNode.Name = inputData.Name;
                     }
                 }
             }
@@ -377,6 +378,7 @@ namespace Dynamo.Graph.Workspaces
                     if (matchingNode != null)
                     {
                         matchingNode.IsSetAsOutput = true;
+                        matchingNode.Name = outputData.Name;
                     }
                 }
             }


### PR DESCRIPTION
### Purpose
When we deserialize json file format and create the workspace we don't transfer the name property to nodeModels. This is property is easily available to be transfered since it's part of 'Inputs' definition in json. We already transfer isSetAsInput for all the nodes except selection (which seems to be a bug that I will write about separately).

### Reviewers
@QilongTang @mjkkirschner 
### FYIs
@kronz 
