### PR TITLE
WIP: Deserialize Node View IsFrozen and IsSetAsOutput property on DynamoMode File Open

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -397,8 +397,21 @@ namespace Dynamo.Graph.Workspaces
                     var inputsView = nodesView.ToArray().Select(x => x.ToObject<Dictionary<string, string>>()).ToList();
                     foreach (var inputViewData in inputsView)
                     {
+                        bool updateIsSetAsInput = true;
                         string isSetAsInput = "";
                         if (!inputViewData.TryGetValue("IsSetAsInput", out isSetAsInput) || isSetAsInput == bool.FalseString)
+                        {
+                            updateIsSetAsInput = false;
+                        }
+
+                        bool updateIsFrozen = true;
+                        string isFrozen = "";
+                        if (!inputViewData.TryGetValue("IsFrozen", out isFrozen) || isFrozen == bool.FalseString)
+                        {
+                            updateIsFrozen = false;
+                        }
+
+                        if (updateIsSetAsInput == false && updateIsFrozen == false)
                         {
                             continue;
                         }
@@ -419,7 +432,8 @@ namespace Dynamo.Graph.Workspaces
                             var matchingNode = nodes.Where(x => x.GUID == inputGuid).FirstOrDefault();
                             if (matchingNode != null)
                             {
-                                matchingNode.IsSetAsInput = true;
+                                matchingNode.IsSetAsInput = updateIsSetAsInput;
+                                matchingNode.IsFrozen = updateIsFrozen;
                                 string inputName = "";
                                 if (inputViewData.TryGetValue("Name", out inputName))
                                 {
@@ -427,7 +441,9 @@ namespace Dynamo.Graph.Workspaces
                                 }
                             }
                         }
+
                     }
+
                 }
             }
 

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -404,6 +404,13 @@ namespace Dynamo.Graph.Workspaces
                             updateIsSetAsInput = false;
                         }
 
+                        bool updateIsSetAsOutput = true;
+                        string isSetAsOutput = "";
+                        if (!inputViewData.TryGetValue("IsSetAsOutput", out isSetAsOutput) || isSetAsOutput == bool.FalseString)
+                        {
+                            updateIsSetAsOutput = false;
+                        }
+
                         bool updateIsFrozen = true;
                         string isFrozen = "";
                         if (!inputViewData.TryGetValue("IsFrozen", out isFrozen) || isFrozen == bool.FalseString)
@@ -411,7 +418,7 @@ namespace Dynamo.Graph.Workspaces
                             updateIsFrozen = false;
                         }
 
-                        if (updateIsSetAsInput == false && updateIsFrozen == false)
+                        if (updateIsSetAsInput == false && updateIsSetAsOutput == false && updateIsFrozen == false)
                         {
                             continue;
                         }
@@ -433,6 +440,7 @@ namespace Dynamo.Graph.Workspaces
                             if (matchingNode != null)
                             {
                                 matchingNode.IsSetAsInput = updateIsSetAsInput;
+                                matchingNode.IsSetAsOutput = updateIsSetAsOutput;
                                 matchingNode.IsFrozen = updateIsFrozen;
                                 string inputName = "";
                                 if (inputViewData.TryGetValue("Name", out inputName))


### PR DESCRIPTION
### Purpose

If we want to....
As a Dynamo Dev, I want to deserialize Node View IsFrozen and/or IsSetAsOutput property on DynamoMode File Open

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @ramramps @mjkkirschner 

### FYIs

@Racel 