### PR TITLE
Custom nodes Fix

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -444,6 +444,10 @@ namespace Dynamo.Graph.Nodes.CustomNodes
                             Parameter = new TypedParameter(name, type, defaultValue, null, comment);
                         }
                     }
+                    else
+                    {
+                        Parameter = new TypedParameter(name, type, defaultValue, null, comment);
+                    }
                 }
                 else
                 {

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -1104,5 +1104,20 @@ namespace Dynamo.Tests
             Assert.IsNotNull(node2);
             Assert.AreEqual("var2: xxx.yyy", node2.Parameter.ToNameString());
         }
+
+        [Test]
+        public void Regress3872_XMLInputNodesDeserilization()
+        {
+            var filePath = Path.Combine(TestDirectory, @"core\custom_node_serialization\GraphFunction.dyf");
+            OpenModel(filePath);
+            var customNodeWs = CurrentDynamoModel.CurrentWorkspace as CustomNodeWorkspaceModel;
+            Assert.IsNotNull(customNodeWs);
+            var node1 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("e058111a-0c58-4dbf-9293-6ab711f530bf") as Symbol;
+            Assert.IsNotNull(node1);
+            Assert.AreEqual("x-start: var[]..[]", node1.Parameter.ToNameString());
+            var node2 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace("2601b801-c8af-413b-9c58-f8b100d62ed8") as Symbol;
+            Assert.IsNotNull(node2);
+            Assert.AreEqual("x-step: var[]..[]", node2.Parameter.ToNameString());
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This PR fixes a bug  where the 1.3 xml custom nodes failed to serialize the input symbol...

Task : https://github.com/DynamoDS/Dynamo/pull/8726

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 


