### PR TITLE
swtich registration of js object to async version

### DIFF
--- a/src/LibraryViewExtension/LibraryViewController.cs
+++ b/src/LibraryViewExtension/LibraryViewController.cs
@@ -190,7 +190,7 @@ namespace Dynamo.LibraryUI
             var browser = view.Browser;
             this.browser = browser;
             sidebarGrid.Children.Add(view);
-            browser.RegisterJsObject("controller", this);
+            browser.RegisterAsyncJsObject("controller", this);
             //RegisterResources(browser);
 
             view.Loaded += OnLibraryViewLoaded;

--- a/src/LibraryViewExtension/web/library/library.html
+++ b/src/LibraryViewExtension/web/library/library.html
@@ -24,6 +24,10 @@
     <script>
         //Get hold of object registered from C#
         let csharpController = window["controller"];
+        //check if one of our methods does not exist
+        if (csharpController.closeNodeTooltip == null) {
+            throw new Error("The c# LibraryViewController was not registered into the browser correctly.")
+        }
 
         function refreshLibraryView(libraryController) {
             //Create library container

--- a/src/LibraryViewExtension/web/library/library.html
+++ b/src/LibraryViewExtension/web/library/library.html
@@ -24,8 +24,8 @@
     <script>
         //Get hold of object registered from C#
         let csharpController = window["controller"];
-        //check if one of our methods does not exist
-        if (csharpController.closeNodeTooltip == null) {
+        //Check if the controller is null or one of our methods does not exist.
+        if (csharpController == null || csharpController.closeNodeTooltip == null) {
             throw new Error("The c# LibraryViewController was not registered into the browser correctly.")
         }
 


### PR DESCRIPTION
### Purpose
to address an issue we assume is similar to:
https://github.com/cefsharp/CefSharp/issues/1611
https://github.com/DynamoDS/Dynamo/issues/8757

we switch the `registerJsObject` method to `registerAsyncJSobject` - apparently this is recommended for our CEFSharp version, and is faster than the other registration method. The work involved is minimal (appears so) because we only use methods on our cross language object anyway and we do not use the results of those method calls.

When an object is registered this way its methods return promises, but since we do not use the results of calls to the registered object on the js side, we should be able to just call them like before. In initial testing behavior seems the same if not a small bit faster. (not profiled).

I can not verify that this PR actually fixes the user's issue - I have tried installing Heimdal v2.2.2 and cannot reproduce the failure.

I do not yet have a copy of mcafee anti virus to test with.

I do not know how to get heimdall client to run - it may be a corporate only/ enterprise wide component. 


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@QilongTang @ramramps 


### FYIs
@Racel @jnealb @smangarole 
