### PR TITLE
Save View info during Custom Node Info edition

### DIFF
--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -93,7 +93,7 @@ namespace Dynamo.Wpf
 
             if (args.Success)
             {
-                updateSavedCustomNodeWorkspace(args, dynamoViewModel, functionNodeModel);
+                SerializeCustomNodeWorkspaceWithNewInfo(args, dynamoViewModel, functionNodeModel);
             }
         }
 
@@ -103,7 +103,7 @@ namespace Dynamo.Wpf
         /// <param name="args">FunctionNamePromptEventArgs which contains updated dyf info</param>
         /// <param name="dynamoViewModel">Dynamo View Model</param>
         /// <param name="functionNodeModel">Custom Node</param>
-        internal void updateSavedCustomNodeWorkspace(FunctionNamePromptEventArgs args, DynamoViewModel dynamoViewModel, Function functionNodeModel)
+        internal void SerializeCustomNodeWorkspaceWithNewInfo(FunctionNamePromptEventArgs args, DynamoViewModel dynamoViewModel, Function functionNodeModel)
         {
             CustomNodeWorkspaceModel ws;
             dynamoViewModel.Model.CustomNodeManager.TryGetFunctionWorkspace(

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -65,7 +65,7 @@ namespace Dynamo.Wpf
             nodeView.UpdateLayout();
         }
 
-        internal void EditCustomNodeProperties()
+        private void EditCustomNodeProperties()
         {
             CustomNodeInfo info;
             var model = dynamoViewModel.Model;
@@ -93,20 +93,31 @@ namespace Dynamo.Wpf
 
             if (args.Success)
             {
-                CustomNodeWorkspaceModel ws;
-                model.CustomNodeManager.TryGetFunctionWorkspace(
-                    functionNodeModel.Definition.FunctionId,
-                    DynamoModel.IsTestMode,
-                    out ws);
-                ws.SetInfo(args.Name, args.Category, args.Description);
+                updateSavedCustomNodeWorkspace(args, dynamoViewModel, functionNodeModel);
+            }
+        }
 
-                if (!string.IsNullOrEmpty(ws.FileName))
-                {
-                    // Construct a temp WorkspaceViewModel based on for serializing
-                    WorkspaceViewModel temp = new WorkspaceViewModel(ws, dynamoViewModel);
-                    temp.Save(ws.FileName);
-                    temp.Dispose();
-                }
+        /// <summary>
+        /// Serialize and update dyf based on FunctionNamePromptEventArgs
+        /// </summary>
+        /// <param name="args">FunctionNamePromptEventArgs which contains updated dyf info</param>
+        /// <param name="dynamoViewModel">Dynamo View Model</param>
+        /// <param name="functionNodeModel">Custom Node</param>
+        internal void updateSavedCustomNodeWorkspace(FunctionNamePromptEventArgs args, DynamoViewModel dynamoViewModel, Function functionNodeModel)
+        {
+            CustomNodeWorkspaceModel ws;
+            dynamoViewModel.Model.CustomNodeManager.TryGetFunctionWorkspace(
+                functionNodeModel.Definition.FunctionId,
+                DynamoModel.IsTestMode,
+                out ws);
+            ws.SetInfo(args.Name, args.Category, args.Description);
+
+            if (!string.IsNullOrEmpty(ws.FileName))
+            {
+                // Construct a temp WorkspaceViewModel based on for serializing
+                WorkspaceViewModel temp = new WorkspaceViewModel(ws, dynamoViewModel);
+                temp.Save(ws.FileName);
+                temp.Dispose();
             }
         }
 

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -113,6 +113,7 @@ namespace Dynamo.Wpf
                     var newJObject = Newtonsoft.Json.Linq.JObject.Parse(newJson);
                     newJObject.Add("View", originalJson.SelectToken("View"));
 
+                    // Save the updated dyf
                     File.WriteAllText(ws.FileName, newJObject.ToString());
                 }
             }

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -114,7 +114,9 @@ namespace Dynamo.Wpf
 
             if (!string.IsNullOrEmpty(ws.FileName))
             {
-                // Construct a temp WorkspaceViewModel based on for serializing
+                // Construct a temp WorkspaceViewModel based on the CustomNodeWorkspaceModel
+                // for serialization. We need to do so because only CustomNodeWorkspaceModel
+                // is accessible at this point, the dyf is not guaranteed to be opened
                 WorkspaceViewModel temp = new WorkspaceViewModel(ws, dynamoViewModel);
                 temp.Save(ws.FileName);
                 temp.Dispose();

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -103,18 +103,10 @@ namespace Dynamo.Wpf
 
                 if (!string.IsNullOrEmpty(ws.FileName))
                 {
-                    string fileContents = File.ReadAllText(ws.FileName);
-                    var originalJson = Newtonsoft.Json.Linq.JObject.Parse(fileContents);
-
-                    // Serialize the custom node workspace.
-                    var newJson = ws.ToJson(dynamoViewModel.EngineController);
-
-                    // Append the View block since it is unchanged
-                    var newJObject = Newtonsoft.Json.Linq.JObject.Parse(newJson);
-                    newJObject.Add("View", originalJson.SelectToken("View"));
-
-                    // Save the updated dyf
-                    File.WriteAllText(ws.FileName, newJObject.ToString());
+                    // Construct a temp WorkspaceViewModel based on for serializing
+                    WorkspaceViewModel temp = new WorkspaceViewModel(ws, dynamoViewModel);
+                    temp.Save(ws.FileName);
+                    temp.Dispose();
                 }
             }
         }

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Windows.Controls;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes.CustomNodes;
@@ -102,7 +103,17 @@ namespace Dynamo.Wpf
 
                 if (!string.IsNullOrEmpty(ws.FileName))
                 {
-                    ws.Save(ws.FileName, false, dynamoViewModel.EngineController);
+                    string fileContents = File.ReadAllText(ws.FileName);
+                    var originalJson = Newtonsoft.Json.Linq.JObject.Parse(fileContents);
+
+                    // Serialize the custom node workspace.
+                    var newJson = ws.ToJson(dynamoViewModel.EngineController);
+
+                    // Append the View block since it is unchanged
+                    var newJObject = Newtonsoft.Json.Linq.JObject.Parse(newJson);
+                    newJObject.Add("View", originalJson.SelectToken("View"));
+
+                    File.WriteAllText(ws.FileName, newJObject.ToString());
                 }
             }
         }

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -65,7 +65,7 @@ namespace Dynamo.Wpf
             nodeView.UpdateLayout();
         }
 
-        private void EditCustomNodeProperties()
+        internal void EditCustomNodeProperties()
         {
             CustomNodeInfo info;
             var model = dynamoViewModel.Model;

--- a/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
+++ b/src/DynamoCoreWpf/NodeViewCustomization/NodeViewCustomizations/FunctionNodeViewCustomization.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Windows.Controls;
 using Dynamo.Controls;
 using Dynamo.Graph.Nodes.CustomNodes;

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -470,7 +470,7 @@ namespace Dynamo.ViewModels
             InCanvasSearchViewModel.Visible = true;
         }
         /// <summary>
-        /// This event is triggred from Workspace Model. Used in instrumentation
+        /// This event is triggered from Workspace Model. Used in instrumentation
         /// </summary>
         /// <param name="modelData"> Workspace model data as JSON </param>
         /// <returns>workspace model with view block in string format</returns>

--- a/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewCustomizationTests.cs
@@ -137,7 +137,7 @@ namespace DynamoCoreWpfTests
 
         }
 
-        //these tests live here as they have a dependencey on CoreNodesWpf which
+        //these tests live here as they have a dependency on CoreNodesWpf which
         //is only accessible at test time after it is loaded via Dynamo 
         [Test]
         [Category("UnitTests")]
@@ -414,8 +414,8 @@ namespace DynamoCoreWpfTests
             OpenAndRun(@"UI\InvalidValueShouldNotCrashColorRangeNode.dyn");
             var node0 = Model.CurrentWorkspace.Nodes.First(n => n.GUID == guid0);
             var node1 = Model.CurrentWorkspace.Nodes.First(n => n.GUID == guid1);
-            node0.OnNodeModified(); // Mark node as dirty to tigger an immediate run.
-            node1.OnNodeModified(); // Mark node as dirty to tigger an immediate run.
+            node0.OnNodeModified(); // Mark node as dirty to trigger an immediate run.
+            node1.OnNodeModified(); // Mark node as dirty to trigger an immediate run.
 
             Assert.Pass(); // We should reach here safely without exception.
         }

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -792,6 +792,37 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void CustomNodeEditNodeDescriptionKeepingViewBlockInDyf()
+        {
+            // new custom node
+            // Set file path
+            // custom node update description and node name
+            // Check if serialized workspace still have view block
+
+            var dynamoModel = ViewModel.Model;
+            var nodeName = "Cool node";
+            var catName = "Custom Nodes";
+            var initialId = Guid.NewGuid();
+
+            var def = dynamoModel.CustomNodeManager.CreateCustomNode(nodeName, catName, "", initialId);
+            var workspace = (CustomNodeWorkspaceModel)def;
+            workspace.FileName = GetNewFileNameOnTempPath("dyf");
+
+            Dynamo.Wpf.FunctionNodeViewCustomization temp = new Dynamo.Wpf.FunctionNodeViewCustomization();
+            FunctionNamePromptEventArgs args = new FunctionNamePromptEventArgs();
+            args.Success = true;
+            args.Name = "Cool node_v2";
+            args.Category = "Custom Nodes";
+            args.Description = "test";
+
+            temp.EditCustomNodeProperties(null, args);
+
+            string fileContents = File.ReadAllText(workspace.FileName);
+            var Jobject = Newtonsoft.Json.Linq.JObject.Parse(fileContents);
+            Assert.IsTrue(Jobject["View"] != null);
+        }
+
+        [Test]
         public void CustomNodeSaveAsAddsNewIdToEnvironmentAndMaintainsOldOne()
         {
             // open custom node
@@ -952,7 +983,7 @@ namespace Dynamo.Tests
         {
             // open custom node
             // SaveAs
-            // two nodes are returned in search on custom node name, difer 
+            // two nodes are returned in search on custom node name, differ 
 
             var model = ViewModel.Model;
             var examplePath = Path.Combine(TestDirectory, @"core\custom_node_saving", "Constant2.dyf");
@@ -1004,7 +1035,7 @@ namespace Dynamo.Tests
         {
             // open custom node
             // SaveAs
-            // two nodes are returned in search on custom node name, difer 
+            // two nodes are returned in search on custom node name, differ 
 
             var model = ViewModel.Model;
             var examplePath = Path.Combine(TestDirectory, @"core\custom_node_saving", "Constant2.dyf");

--- a/test/DynamoCoreWpfTests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceSaving.cs
@@ -827,7 +827,7 @@ namespace Dynamo.Tests
                 Category = "Custom Nodes",
                 CanEditName = false
             };
-            temp.updateSavedCustomNodeWorkspace(args, ViewModel, newCustNodeInstance);
+            temp.SerializeCustomNodeWorkspaceWithNewInfo(args, ViewModel, newCustNodeInstance);
 
             // Check if serialized workspace still have view block
             string fileContents = File.ReadAllText(workspace.FileName);


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[QNTM-4180](https://jira.autodesk.com/browse/QNTM-4180)
Github Issue: Node coordinates in custom nodes are set to 0,0 when editing node properties

Per: https://github.com/DynamoDS/Dynamo/issues/8803

This PR will preserve the same dyf **View** block when editing custom node workspace.

This is a proposed fix. View info will be lost if we use `CustomNodeWorkspace.Save()` so ideally we want to call `WorkspaceViewModel.Save()` while WorkspaceModel is the only thing available here, I have looked at the possibility of keeping a dictionary of ViewModel under `CustomNodeManager` but seems not worth it and over complicate stuff. In that case, what else can we use rather than our Save() function? I think appending the original **View** block can work strictly because we know in this case user only modifies CustomNodeInfo without touching view info. Other suggestions are welcome.

Need unit testing 😉 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
https://ecwest.autodesk.com/commander/link/jobDetails/jobs/6f1300bb-4edf-11e8-b04f-a0d3c1eff5a4?
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps @mjkkirschner 

### FYIs

@smangarole @jnealb @andydandy74 
