### PR TITLE
Add path for TextTransform.exe with VS17 installation

### DIFF
--- a/src/transform_all.bat
+++ b/src/transform_all.bat
@@ -18,10 +18,16 @@ echo the following T4 templates will be transformed:
 type t4list.txt
 
 set TextTransform=%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\11.0\TextTransform.exe
+
 IF NOT EXIST "%TextTransform%" set TextTransform=%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\12.0\TextTransform.exe
 
-set TextTransform=%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\12.0\TextTransform.exe
 IF NOT EXIST "%TextTransform%" set TextTransform=%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\14.0\TextTransform.exe
+
+IF NOT EXIST "%TextTransform%" set TextTransform=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\Common7\IDE\TextTransform.exe
+
+IF NOT EXIST "%TextTransform%" set TextTransform=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\TextTransform.exe
+
+IF NOT EXIST "%TextTransform%" set TextTransform=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\IDE\TextTransform.exe
 
 :: transform all the templates
 for /f %%d in (t4list.txt) do (


### PR DESCRIPTION
### Purpose

This adds a path for the TextTransform.exe if the developer only has VisualStudio 2017 installed.  The `AssemblyInfoGenerator` project silently fails to update the shared `AssemblySharedInfo.cs` if a valid path to **TextTransfrom.exe** is not found.  This is not critical; https://github.com/DynamoDS/Dynamo/pull/8832 unblocked previous issues for local testing.

TODO: Self-Service CI

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @smangarole 

### FYIs

@sm6srw 