### PR TITLE
Cherry-Pick #8824 - QNTM 4211 - File Path node is missing in Player

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/FileSystem.cs
+++ b/src/Libraries/CoreNodeModels/Input/FileSystem.cs
@@ -111,15 +111,6 @@ namespace CoreNodeModels.Input
         {
             ShouldDisplayPreviewCore = false;
         }
-
-        /// <summary>
-        ///     Indicates whether node is input node.
-        ///     Used to bind visibility of UI for user selection.
-        /// </summary>
-        public override bool IsInputNode
-        {
-        get { return false; }
-        }
     }
 
     [NodeName("Directory Path")]

--- a/test/core/isInput_isOutput/FilePath_DirectoryPath.dyn
+++ b/test/core/isInput_isOutput/FilePath_DirectoryPath.dyn
@@ -1,0 +1,121 @@
+{
+  "Uuid": "a11ee45f-bfac-4431-a32d-be6932b05561",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "FilePath_DirectoryPath",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [
+    {
+      "Id": "3c3955202373444da29a1e1bd4804023",
+      "Name": "File Path",
+      "Type": "string",
+      "Value": "No file selected.",
+      "Description": "Allows you to select a file on the system to get its filename"
+    },
+    {
+      "Id": "1bc0f8dce2974dbfb9e52ded278e3c9d",
+      "Name": "Directory Path",
+      "Type": "string",
+      "Value": "No file selected.",
+      "Description": "Allows you to select a directory on the system to get its path"
+    }
+  ],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Input.Filename, CoreNodeModels",
+      "HintPath": "No file selected.",
+      "InputValue": "No file selected.",
+      "NodeType": "ExtensionNode",
+      "Id": "3c3955202373444da29a1e1bd4804023",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4dcec3cf8f2046b9afbf5f556baade5c",
+          "Name": "",
+          "Description": "Filename",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows you to select a file on the system to get its filename"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.Directory, CoreNodeModels",
+      "HintPath": "No file selected.",
+      "InputValue": "No file selected.",
+      "NodeType": "ExtensionNode",
+      "Id": "1bc0f8dce2974dbfb9e52ded278e3c9d",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "052b45cfead84d818ae9a954a9d1bfbd",
+          "Name": "",
+          "Description": "Directory",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows you to select a directory on the system to get its path"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.1.4395",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "File Path",
+        "Id": "3c3955202373444da29a1e1bd4804023",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 277.5,
+        "Y": 251.75
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Directory Path",
+        "Id": "1bc0f8dce2974dbfb9e52ded278e3c9d",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 278.5,
+        "Y": 373.75
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Cherry-pick [8824](https://github.com/DynamoDS/Dynamo/pull/8824): 2.0.1 Hotfix, File Path node does not support the IsInput setting in its context menu. 
 https://jira.autodesk.com/browse/QNTM-4211

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### FYIs

@QilongTang @ramramps 