### PR TITLE
Update nuspec to include Newtonsoft.Json

### DIFF
--- a/tools/NuGet/template-nuget/DynamoVisualProgramming.Core.nuspec
+++ b/tools/NuGet/template-nuget/DynamoVisualProgramming.Core.nuspec
@@ -25,6 +25,7 @@
       <dependency id="Prism" version="4.1"/>
       <dependency id="NUnit" version="2.6.3"/>
       <dependency id="DynamoVisualProgramming.ZeroTouchLibrary" version="@VERSION@"/>
+      <dependency id="Newtonsoft.Json" version="8.0.3"/>
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[QNTM-4059](https://jira.autodesk.com/browse/QNTM-4059)
As a Dynamo dev, I want to specify a dependency on newtonsoft json.net within Dynamo Nugets

This one line fix addresses the issue reported at https://forum.dynamobim.com/t/dynamo-2-0-duplicates-ports-of-custom-node-when-file-is-saved-and-reopened/20867/3

Here is the steps to reproduce:
1. Clone and build the CustomNode project user created at https://github.com/Eckart-S/CustomNode
2. You should see node dll under folder together with the original reference of Newtonsoft.Json v11
![image](https://user-images.githubusercontent.com/3942418/39934835-1fcad2e4-5515-11e8-86ba-5e9e16996b8f.png)
3. Open DynamoRevit or Dynamo Sandbox
4. Create a CustomNode from library
5. Save the file
6. Reopen the file, you should see the same node with different number of ports

After this one line change, I verified that user will only have to reference our new DynamoCore nuget and NewtonSoft.Json will be imported automatically for them and rebuilt node does not have such issue anymore. Note: user will need to set CopyLocal=false when building the package, but it is fine to also leave it to true since versions aligned with Dynamo


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
No DynamoCode there, will not introduce regression
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ramramps @mjkkirschner 

### FYIs

@jnealb @smangarole @Racel 
