### PR TITLE
Fix "Extansion" typo

### DIFF
--- a/src/DynamoCore/Extensions/ExtensionLoader.cs
+++ b/src/DynamoCore/Extensions/ExtensionLoader.cs
@@ -19,8 +19,8 @@ namespace Dynamo.Extensions
     /// 
     /// Example:
     /// <ExtensionDefinition>
-    ///   <AssemblyPath>..\ExtansionName.dll</AssemblyPath>
-    ///   <TypeName>Dynamo.ExtansionName.ExtansionTypeName</TypeName>
+    ///   <AssemblyPath>..\ExtensionName.dll</AssemblyPath>
+    ///   <TypeName>Dynamo.ExtensionName.ExtensionTypeName</TypeName>
     /// </ExtensionDefinition>
     /// </summary>
     public class ExtensionLoader: IExtensionLoader, ILogSource


### PR DESCRIPTION
### Purpose

Fix a type where `Extension` was spelled as `Extansion`.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
