### PR TITLE
AVP NumberInputNode deserialization

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
+++ b/src/Libraries/CoreNodeModels/Input/BaseTypes.cs
@@ -751,7 +751,8 @@ namespace CoreNodeModels.Input
 
             public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
             {
-                return ((double)reader.Value).ToString(CultureInfo.InvariantCulture);
+                double doubleVal = System.Convert.ToDouble(reader.Value, CultureInfo.InvariantCulture);
+                return doubleVal.ToString(CultureInfo.InvariantCulture);
             }
 
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -801,6 +801,31 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void CanOpenDoubleInputFile()
+        {
+            string openPath = Path.Combine(TestDirectory,
+                @"core\number\TestNumberDeserialization.dyn");
+            OpenModel(openPath);
+
+            Assert.AreEqual(3, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+
+            var node1 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DoubleInput>(
+                Guid.Parse("6fc905f8533f433a90fe4b9181463d53"));
+            Assert.IsNotNull(node1);
+            Assert.AreEqual(node1.Value, "1");
+
+            var node2 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DoubleInput>(
+                Guid.Parse("d40969e40f3449dfb7eb20317ff91752"));
+            Assert.IsNotNull(node2);
+            Assert.AreEqual(node2.Value, "1");
+
+            var node3 = CurrentDynamoModel.CurrentWorkspace.NodeFromWorkspace<DoubleInput>(
+                Guid.Parse("8d298e3f574a420b8c789829951da295"));
+            Assert.IsNotNull(node3);
+            Assert.AreEqual(node3.Value, "1.1");
+        }
+
+        [Test]
         [Category("UnitTests")]
         public void SelectionDoesNotChangeWhenAddingAlreadySelectedNode()
         {

--- a/test/core/number/TestNumberDeserialization.dyn
+++ b/test/core/number/TestNumberDeserialization.dyn
@@ -1,0 +1,137 @@
+{
+  "Uuid": "b7b0bdcf-f122-4917-930a-f4496db1de7e",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "TestNumberDeserialization",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "InputValue": 1.0,
+      "Id": "6fc905f8533f433a90fe4b9181463d53",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "bd41de2dd39e46a0b99cc1426eb4cd0a",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "InputValue": 1,
+      "Id": "d40969e40f3449dfb7eb20317ff91752",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "5dc09c1038a945cb85c2fb10077e7bb2",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "InputValue": 1.1,
+      "Id": "8d298e3f574a420b8c789829951da295",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "050e337d5eee49359a45b7c5330b7c79",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number."
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.5145",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Number",
+        "Id": "6fc905f8533f433a90fe4b9181463d53",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 99.600000000000051,
+        "Y": 95.199999999999932
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Number",
+        "Id": "d40969e40f3449dfb7eb20317ff91752",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 100.40000000000003,
+        "Y": 155.99999999999991
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Number",
+        "Id": "8d298e3f574a420b8c789829951da295",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 98.400000000000063,
+        "Y": 222.79999999999993
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose
This PR addresses the Dynamo deserialization of a `NumberInput` node that was originally serialized in AVP.  The `NumberInput` node in AVP defines the `InputValue` property of type `number`.  If the value is an integer (1, 1.0, 1.00, etc) the value is always serialized as 1 (without any decimals).  Upon deserialization in Dynamo an error was being thrown while attempting to parse the expected `double` value.  This change resolves the issue and enables proper deserialization/execution.

### Testing
3 unit tests added verifying proper deserialization of number nodes containing values of 1, 1.0, 1.1

![image](https://user-images.githubusercontent.com/13341935/40743658-2cd695b2-6420-11e8-9501-b01e0f5a0e95.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@ramramps 
