### PR TITLE
QNTM-4488: Fix AST creation for partial multi-outport custom nodes

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CustomNodes/CustomNodeController.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/CustomNodeController.cs
@@ -111,18 +111,17 @@ namespace Dynamo.Graph.Nodes.CustomNodes
         {
             base.BuildAstForPartialMultiOutput(model, rhs, resultAst);
 
-            var emptyList = AstFactory.BuildExprList(new List<AssociativeNode>());
-            var previewIdInit = AstFactory.BuildAssignment(model.AstIdentifierForPreview, emptyList);
-
-            resultAst.Add(previewIdInit);
-            resultAst.AddRange(
-                Definition.ReturnKeys.Select(
-                    (rtnKey, idx) =>
-                        AstFactory.BuildAssignment(
-                            AstFactory.BuildIdentifier(
-                                model.AstIdentifierForPreview.Name,
-                                AstFactory.BuildStringNode(rtnKey)),
-                            model.GetAstIdentifierForOutputIndex(idx))));
+            var kvps = Definition.ReturnKeys.Select(
+                (rtnKey, idx) =>
+                    new KeyValuePair<AssociativeNode, AssociativeNode>(AstFactory.BuildStringNode(rtnKey),
+                        model.GetAstIdentifierForOutputIndex(idx)));
+            var dict = new DictionaryExpressionBuilder();
+            foreach (var kvp in kvps)
+            {
+                dict.AddKey(kvp.Key);
+                dict.AddValue(kvp.Value);
+            }
+            resultAst.Add(AstFactory.BuildAssignment(model.AstIdentifierForPreview, dict.ToFunctionCall()));
         }
 
         protected override void AssignIdentifiersForFunctionCall(

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -579,6 +579,18 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void TestPartialCustomMultiOutputNode()
+        {
+            RunModel(@"core\multiout\partial-multiout-customnode.dyn");
+            AssertPreviewValue("0ce0d95c-a644-4268-8820-065d7edb2778", new[] { 2, 0.5, 0 });
+
+            var guid = Guid.Parse("0ce0d95c-a644-4268-8820-065d7edb2778");
+            var node = CurrentDynamoModel.CurrentWorkspace.Nodes.FirstOrDefault(n => n.GUID == guid);
+            Assert.IsTrue(node.State != ElementState.Warning);
+
+        }
+
+        [Test]
         public void PartialApplicationWithMultipleOutputs()
         {
             string openPath = Path.Combine(TestDirectory, @"core\multiout\partial-multi-custom.dyn");

--- a/test/core/multiout/partial-multiout-customnode.dyf
+++ b/test/core/multiout/partial-multiout-customnode.dyf
@@ -1,0 +1,430 @@
+{
+  "Uuid": "238e45c0-da11-46fa-96b8-1a53b398143c",
+  "IsCustomNode": true,
+  "Category": "BIM4StrucProjects.Testing",
+  "Description": "",
+  "Name": "Test Lacing",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Symbol, DynamoCore",
+      "NodeType": "InputNode",
+      "Parameter": {
+        "Name": "population",
+        "TypeName": "var",
+        "TypeRank": -1,
+        "DefaultValue": null,
+        "Description": ""
+      },
+      "Id": "dfcb351709084dffb44b3655fe9ffcb3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "9e44aa5ce5894c0bad65ca6a061ac4ac",
+          "Name": "",
+          "Description": "Symbol",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "A function parameter, use with custom nodes.\r\n\r\nYou can specify the type and default value for parameter. E.g.,\r\n\r\ninput : var[]..[]\r\nvalue : bool = false"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "pop[0];\npop[1];\npop[2];",
+      "Id": "f8eb10a0162946e5bef516cfef4db570",
+      "Inputs": [
+        {
+          "Id": "cf2d6d536df040dfbaf933c11201081b",
+          "Name": "pop",
+          "Description": "pop",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "1846035914f1432795f2509776f11623",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "1814c109f7a54975bd7024996cb1af1f",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0b96194d7b964ae9a195e03860ad2825",
+          "Name": "",
+          "Description": "Value of expression at line 3",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "+@var[]..[],var[]..[]",
+      "Id": "d1907af6fa894c1091697caeb5640000",
+      "Inputs": [
+        {
+          "Id": "e1963c1ca4e84b87a673ebd9f5b594d0",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "8e407162050a48f68de23f8158d374a2",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "43bdd3652fbc4aa6bea7f70546a6d20f",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Adds x to y.\n\n+ (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "/@var[]..[],var[]..[]",
+      "Id": "8476c4c1f1c24d7dad30faac5e228969",
+      "Inputs": [
+        {
+          "Id": "1790fb7d33894d22acd8f9cfa9dfa355",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "bb641fdca0eb46c8951818bb38ceb19c",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "48328d731389475d9a8af4f1eff4a6ec",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Divides x by y.\n\n/ (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
+      "NodeType": "OutputNode",
+      "ElementResolver": null,
+      "Symbol": "intermediate1",
+      "Id": "2ddf4f0db95a4d70a2019106929e4467",
+      "Inputs": [
+        {
+          "Id": "48b77b31775f428e9731acd57106a58e",
+          "Name": "",
+          "Description": "",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "A function output, use with custom nodes"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "/@var[]..[],var[]..[]",
+      "Id": "98b38a563aa44a72865884ae69956e69",
+      "Inputs": [
+        {
+          "Id": "5b7dcb871d9e438fa81114fd94309ad9",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9aa926e0a299458a983c574f4d0fdc9e",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "408db3dbc9b44713a26e4b1dcd56c7d8",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Divides x by y.\n\n/ (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
+      "NodeType": "OutputNode",
+      "ElementResolver": null,
+      "Symbol": "finalresult",
+      "Id": "22ae10b2d42747a88eaa6239fa39b9a5",
+      "Inputs": [
+        {
+          "Id": "e878beeacff24b399f51aeb4d6a6bdb4",
+          "Name": "",
+          "Description": "",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "A function output, use with custom nodes"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Output, DynamoCore",
+      "NodeType": "OutputNode",
+      "ElementResolver": null,
+      "Symbol": "intermediate2",
+      "Id": "365e8abb1597409d86ffea49eba0535d",
+      "Inputs": [
+        {
+          "Id": "93564ba093944791a320e8ca34f94966",
+          "Name": "",
+          "Description": "",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "A function output, use with custom nodes"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "9e44aa5ce5894c0bad65ca6a061ac4ac",
+      "End": "cf2d6d536df040dfbaf933c11201081b",
+      "Id": "3c72d9392366407b8dc67e25803ae177"
+    },
+    {
+      "Start": "1846035914f1432795f2509776f11623",
+      "End": "e1963c1ca4e84b87a673ebd9f5b594d0",
+      "Id": "799a417f92474c9f88397495b5b76b40"
+    },
+    {
+      "Start": "1846035914f1432795f2509776f11623",
+      "End": "5b7dcb871d9e438fa81114fd94309ad9",
+      "Id": "48f32705050a4f5a99502de7baf9e120"
+    },
+    {
+      "Start": "1814c109f7a54975bd7024996cb1af1f",
+      "End": "8e407162050a48f68de23f8158d374a2",
+      "Id": "08aa3b7291a9431fab7309aee85eb85a"
+    },
+    {
+      "Start": "0b96194d7b964ae9a195e03860ad2825",
+      "End": "bb641fdca0eb46c8951818bb38ceb19c",
+      "Id": "945543f2cf684545881d30ac2157c9df"
+    },
+    {
+      "Start": "0b96194d7b964ae9a195e03860ad2825",
+      "End": "9aa926e0a299458a983c574f4d0fdc9e",
+      "Id": "5dc3f12d2e864cd7b437f187f8e0fd20"
+    },
+    {
+      "Start": "43bdd3652fbc4aa6bea7f70546a6d20f",
+      "End": "1790fb7d33894d22acd8f9cfa9dfa355",
+      "Id": "775f30eee1c3477781073d97811af73e"
+    },
+    {
+      "Start": "43bdd3652fbc4aa6bea7f70546a6d20f",
+      "End": "48b77b31775f428e9731acd57106a58e",
+      "Id": "73d20107eddf4b30ac3a6233ac3543dd"
+    },
+    {
+      "Start": "48328d731389475d9a8af4f1eff4a6ec",
+      "End": "e878beeacff24b399f51aeb4d6a6bdb4",
+      "Id": "28e6c3e548b94d04b105d34a3a6084df"
+    },
+    {
+      "Start": "408db3dbc9b44713a26e4b1dcd56c7d8",
+      "End": "93564ba093944791a320e8ca34f94966",
+      "Id": "228bb91b22b04899a8902ee80a6d8d4a"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": false,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.1.5055",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Input",
+        "Id": "dfcb351709084dffb44b3655fe9ffcb3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 353.0,
+        "Y": 326.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "f8eb10a0162946e5bef516cfef4db570",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 512.0,
+        "Y": 337.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "+",
+        "Id": "d1907af6fa894c1091697caeb5640000",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 672.55034620157107,
+        "Y": 262.06848251211261
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "/",
+        "Id": "8476c4c1f1c24d7dad30faac5e228969",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 889.634817539842,
+        "Y": 344.52084137310339
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Output",
+        "Id": "2ddf4f0db95a4d70a2019106929e4467",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1113.88219247984,
+        "Y": 266.252733196302
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "/",
+        "Id": "98b38a563aa44a72865884ae69956e69",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 892.75089990433446,
+        "Y": 482.81060714115358
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Output",
+        "Id": "22ae10b2d42747a88eaa6239fa39b9a5",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1110.90009754451,
+        "Y": 346.769296450185
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Output",
+        "Id": "365e8abb1597409d86ffea49eba0535d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1123.82250893094,
+        "Y": 437.226176155164
+      }
+    ],
+    "Annotations": [],
+    "X": -226.57015283145495,
+    "Y": -5.851365201685951,
+    "Zoom": 1.0060041900272456
+  }
+}

--- a/test/core/multiout/partial-multiout-customnode.dyn
+++ b/test/core/multiout/partial-multiout-customnode.dyn
@@ -1,0 +1,312 @@
+{
+  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "partial-multiout-customnode",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.HigherOrder.ApplyFunction, CoreNodeModels",
+      "VariableInputPorts": true,
+      "NodeType": "ExtensionNode",
+      "Id": "3c9b450c4f094fef82cfdda2670d214d",
+      "Inputs": [
+        {
+          "Id": "29c1c3efba2a4a2898aad86a2eab5694",
+          "Name": "func",
+          "Description": "Function to apply.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "8e1692b04a13450486ed56a89c8c5996",
+          "Name": "arg1",
+          "Description": "Argument #1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "23f08654099f4c0a994ec379d542e1d1",
+          "Name": "func(args)",
+          "Description": "Result of application.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Applies a function to arguments."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[0,\n2,\n4];",
+      "Id": "5e04de3ceaf7487296fffc0ac8d3fb0b",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "a56fde4954e24782bfd4e68474bbae06",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CustomNodes.Function, DynamoCore",
+      "FunctionSignature": "238e45c0-da11-46fa-96b8-1a53b398143c",
+      "FunctionType": "Graph",
+      "NodeType": "FunctionNode",
+      "Id": "f77d85e8becc41e4b34f78cbcc905034",
+      "Inputs": [
+        {
+          "Id": "a693cbefd88348d0a214cb20322aac0e",
+          "Name": "population",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "99b830b2a27040e688cd04e1f1cce3d1",
+          "Name": "intermediate1",
+          "Description": "return value",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "58876a2d6e5e487480d8556f2facb97e",
+          "Name": "finalresult",
+          "Description": "return value",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "7d03db5fbefe43998b37b38597a5f927",
+          "Name": "intermediate2",
+          "Description": "return value",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": ""
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[a,b,c];",
+      "Id": "16f8bef9f79247d6b974f998825cbd0a",
+      "Inputs": [
+        {
+          "Id": "938db040dc6e4e42bb0e200bdced9095",
+          "Name": "a",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "52ba20f9e4204f40bdaaa0b0158ee6c1",
+          "Name": "b",
+          "Description": "b",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "add230d530564ed9ad212e690587cc41",
+          "Name": "c",
+          "Description": "c",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "da78768441c94aceb0fb9e562dbb83da",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "0ce0d95ca64442688820065d7edb2778",
+      "Inputs": [
+        {
+          "Id": "08e78f9ca78c4fc2987c9780fb343263",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "7f07ce55c404455e8652cdac9a837e75",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "23f08654099f4c0a994ec379d542e1d1",
+      "End": "08e78f9ca78c4fc2987c9780fb343263",
+      "Id": "4c7b4b4a42064f35b5c9999e97bbe67d"
+    },
+    {
+      "Start": "a56fde4954e24782bfd4e68474bbae06",
+      "End": "8e1692b04a13450486ed56a89c8c5996",
+      "Id": "a9a36a83c75e4622884b1689087734b1"
+    },
+    {
+      "Start": "99b830b2a27040e688cd04e1f1cce3d1",
+      "End": "938db040dc6e4e42bb0e200bdced9095",
+      "Id": "ba9d65eb1ef24fd5bc4fcb0e6732517e"
+    },
+    {
+      "Start": "58876a2d6e5e487480d8556f2facb97e",
+      "End": "52ba20f9e4204f40bdaaa0b0158ee6c1",
+      "Id": "814411d21c3846d8b98b3861fc25fbb0"
+    },
+    {
+      "Start": "7d03db5fbefe43998b37b38597a5f927",
+      "End": "add230d530564ed9ad212e690587cc41",
+      "Id": "771ed7aa2a3940b9a862710831b897f3"
+    },
+    {
+      "Start": "da78768441c94aceb0fb9e562dbb83da",
+      "End": "29c1c3efba2a4a2898aad86a2eab5694",
+      "Id": "4f8be2bb91334089acee9b6fba2867fe"
+    }
+  ],
+  "Dependencies": [
+    "238e45c0-da11-46fa-96b8-1a53b398143c"
+  ],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.5286",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Function Apply",
+        "Id": "3c9b450c4f094fef82cfdda2670d214d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1374.1834529244932,
+        "Y": 269.71518583055035
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "5e04de3ceaf7487296fffc0ac8d3fb0b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1001.8132893420693,
+        "Y": 379.83969965536465
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Test Lacing",
+        "Id": "f77d85e8becc41e4b34f78cbcc905034",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 837.2753690181753,
+        "Y": 178.13249755639586
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "16f8bef9f79247d6b974f998825cbd0a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1193.1438789320134,
+        "Y": 207.87593689816123
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Watch",
+        "Id": "0ce0d95ca64442688820065d7edb2778",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1600.813787578501,
+        "Y": 280.14887681134695
+      }
+    ],
+    "Annotations": [],
+    "X": -1226.9474843626972,
+    "Y": -173.04890965289673,
+    "Zoom": 1.2530798397214138
+  }
+}


### PR DESCRIPTION
### Purpose

Fix for incorrect warning displayed with partial multi-output custom node when compiled to Dictionary.
![image](https://user-images.githubusercontent.com/5710686/41376981-b3ee57fc-6f28-11e8-80f9-bad87a4b786d.png)

Previously the compiled AST generated for such a node was:
```
varx["out1"] = varx_out1;
varx["out2"] = varx_out2;
varx["out3"] = varx_out3;
```
This should be compiled to:
```
varx = Dictionary.ByKeysValues(["out1", "out2", "out3"], [varx_out1, varx_out2, varx_out3]);
```
![image](https://user-images.githubusercontent.com/5710686/41377106-15da932c-6f29-11e8-8202-602f05e30853.png)

JIRA: https://jira.autodesk.com/browse/QNTM-4488


### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@kronz @jnealb 
