### PR TITLE
Tune Dynamo rendering precision

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/RenderPackageFactoryViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/RenderPackageFactoryViewModel.cs
@@ -31,7 +31,13 @@ namespace Dynamo.Wpf.ViewModels
             set
             {
                 if (factory.TessellationParameters.MaxTessellationDivisions == value) return;
+
                 factory.TessellationParameters.MaxTessellationDivisions = value;
+                if (value >= 8 && value <= 12)
+                    factory.TessellationParameters.Tolerance = 0;
+                else
+                    factory.TessellationParameters.Tolerance = -1;
+
                 RaisePropertyChanged("MaxTessellationDivisions");
             }
         }

--- a/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/DynamoView.xaml
@@ -688,7 +688,7 @@
                                 <TextBlock Text="{x:Static p:Resources.DynamoViewSettingMenuLowRenderPrecision}"
                                            Margin="0,0,10,0"></TextBlock>
                                 <Slider Width="100"
-                                        Minimum="12"
+                                        Minimum="8"
                                         Maximum="512"
                                         Value="{Binding Path=RenderPackageFactoryViewModel.MaxTessellationDivisions, Mode=TwoWay}"></Slider>
                                 <TextBlock Text="{x:Static p:Resources.DynamoViewSettingMenuHighRenderPrecision}"


### PR DESCRIPTION
### Purpose

This pull request containt changes related to perfomence issue recieved from Alias users. 
Changes list:
- Min value of "Render precision" changed to 8
- Tolerance will change to 0 when "Render presion" is in range 8-12

Result of render 5000 spheres with parameter 8/0 about 5 seconds and with default parameters more than 10 minute.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning]

### Reviewers

@aparajit-pratap 