### PR TITLE
Fix Dictionary Preview in Code block node

### DIFF
--- a/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Preview/PreviewControl.xaml.cs
@@ -371,7 +371,8 @@ namespace Dynamo.UI.Controls
             RunOnSchedulerSync(
                 () =>
                 {
-                    var preferredDictionaryOrdering = nodeViewModel.NodeModel.OutPorts.Select(p => p.Name);
+                    var preferredDictionaryOrdering = 
+                    nodeViewModel.NodeModel.OutPorts.Select(p => p.Name).Where(n => !String.IsNullOrEmpty(n));
                     newViewModel = nodeViewModel.DynamoViewModel.WatchHandler.GenerateWatchViewModelForData(
                         nodeViewModel.NodeModel.CachedValue, preferredDictionaryOrdering,
                         null, nodeViewModel.NodeModel.AstIdentifierForPreview.Name, false);


### PR DESCRIPTION
### Purpose

The following node preview for a Dictionary in a CBN containing multple output ports does not expand currently. This is the screenshot after the fix: 
![image](https://user-images.githubusercontent.com/5710686/43348493-3f961486-91c8-11e8-87a8-86701bf1a1d1.png)

This is because `preferredDictionaryOrdering` was a list of empty strings (3 in this case, one for each output port) and even though it should have been ignored it passed the check in `DefaultWatchHandler::ProcessThing`. This fix it to prevent the list from containing empty strings. Note that `preferredDictionaryOrdering` must only be populated for multi output nodes that have a `MultiReturnAttribute`.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@jnealb 
