### PR TITLE
Re-enable strack trace reporting for opted in users

### DIFF
--- a/src/NodeServices/Analytics.cs
+++ b/src/NodeServices/Analytics.cs
@@ -120,6 +120,15 @@ namespace Dynamo.Logging
         public static void TrackException(Exception ex, bool isFatal)
         {
             if (client != null) client.TrackException(ex, isFatal);
+
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+
+            sb.AppendLine("Type: " + ex.GetType());
+            sb.AppendLine("Fatal: " + isFatal);
+            sb.AppendLine("Message: " + ex.Message);
+            sb.AppendLine("StackTrace: " + ex.StackTrace);
+
+            LogPiiInfo("Analytics.TrackException", sb.ToString());
         }
 
         /// <summary>


### PR DESCRIPTION

### Purpose

A previous set of changes removed reporting stack traces to instrumentation. This re-enables the feature in the simplest manner in order to begin capturing the data again.

A fuller solution will need to follow later.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@Racel 

### FYIs
