### PR TITLE
Issue-9049 - BasicInteractive should allow an OutPort name and tooltip override 

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
+++ b/src/Libraries/CoreNodeModels/Input/BasicInteractive.cs
@@ -73,6 +73,12 @@ namespace CoreNodeModels.Input
             RegisterAllPorts();
         }
 
+        protected BasicInteractive(string outPortName, string outPortToolTip)
+        {
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData(outPortName, outPortToolTip)));
+            RegisterAllPorts();
+        }
+
         public override string PrintExpression()
         {
             return Value.ToString();


### PR DESCRIPTION
### Purpose
This PR resolves #9049.

There is currently no way of defining the information of an out port of a custom node that extends BasicInteractive.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs
