### PR TITLE
QNTM-4394 Match Revit CEF intitializtion settings

### DIFF
--- a/src/DynamoPackagesUI/Views/PackageManagerView.xaml.cs
+++ b/src/DynamoPackagesUI/Views/PackageManagerView.xaml.cs
@@ -30,8 +30,6 @@ namespace DynamoPackagesUI.Views
             if (!Cef.IsInitialized)
             {
                 var settings = new CefSettings { RemoteDebuggingPort = 8088 };
-                //to fix Fickering set disable-gpu to true
-                settings.CefCommandLineArgs.Add("disable-gpu", "1");
                 Cef.Initialize(settings);
             }
 

--- a/src/LibraryViewExtension/Views/DetailsView.xaml.cs
+++ b/src/LibraryViewExtension/Views/DetailsView.xaml.cs
@@ -33,8 +33,6 @@ namespace Dynamo.LibraryUI.Views
             if (!Cef.IsInitialized)
             {
                 var settings = new CefSettings { RemoteDebuggingPort = 8088 };
-                //to fix Fickering set disable-gpu to true
-                settings.SetOffScreenRenderingBestPerformanceArgs();
                 Cef.Initialize(settings);
             }
 

--- a/src/LibraryViewExtension/Views/LibraryView.xaml.cs
+++ b/src/LibraryViewExtension/Views/LibraryView.xaml.cs
@@ -24,8 +24,6 @@ namespace Dynamo.LibraryUI.Views
             if (!Cef.IsInitialized)
             {
                 var settings = new CefSettings { RemoteDebuggingPort = 8088 };
-                //to fix Fickering set disable-gpu to true
-                settings.SetOffScreenRenderingBestPerformanceArgs();
                 //Matching the API with  version 55
                 Cef.Initialize(settings);
             }


### PR DESCRIPTION
### Purpose

The purpose of this PR is to match Dynamo’s CEF initialization settings with those set by Revit.  Currently the delta is that Dynamo disables GPU acceleration.  For Revit 2018 and 2019, Revit does not disable GPU acceleration in the CEF context as there are supported Revit addins who require LMV (and threejs).  When Dynamo is run in these contexts, Revit’s CEF settings are the first to be set and Dynamo’s preferences (and other subsequent CEF addins) are ignored.  Although not every Dynamo session (Sandbox for example) has this situation, disabling GPU rendering in core has the potential to mask bugs that are present for a majority of users.  Dynamo core should match Revit’s CEF settings and version and should continue to match settings and versions as they change in future releases.

[QNTM-4934](https://jira.autodesk.com/browse/QNTM-4934)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @alfarok 

### FYIs

@sm6srw @Dewb 