### PR TITLE
testSession constructor RC 2.02

### DIFF
--- a/test/Libraries/TestServices/TestSessionConfiguration.cs
+++ b/test/Libraries/TestServices/TestSessionConfiguration.cs
@@ -24,10 +24,14 @@ namespace TestServices
         /// <summary>
         /// The requested libG library version as a full system.version string.
         /// If the key is not present in the config file a default value will be selected.
-        /// If the key is set to 'HostDefault' - the version will be set to null, and
-        /// Hosts will be responsible for loading libG and providing a version to load.
         /// </summary>
         public Version RequestedLibraryVersion2 { get; private set; }
+        /// <summary>
+        /// Did the TestSessionConfiguration load a valid config file or could one not be found.
+        /// This can be used to indicate if the TestSessionConfiguration is valid or a set of defaults.
+        /// </summary>
+        public bool LoadedValidConfigFile { get; private set; } = true;
+        
 
         public TestSessionConfiguration()
             : this(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)){}
@@ -69,6 +73,7 @@ namespace TestServices
                 };
                 var shapeManagerPath = string.Empty;
                 RequestedLibraryVersion2 = Utilities.GetInstalledAsmVersion2(versions, ref shapeManagerPath, dynamoCoreDirectory);
+                LoadedValidConfigFile = false;
                 return;
             }
 
@@ -97,11 +102,6 @@ namespace TestServices
                 var realVersion = Preloader.MapLibGVersionEnumToFullVersion(libVersion);
                 RequestedLibraryVersion2 = realVersion;
 
-            }
-            //if the config is set to HostDefault
-            else if(versionStr.ToLower().Contains("hostdefault"))
-            {
-                RequestedLibraryVersion2 = null;
             }
             // fallback to a mid range version
             else

--- a/test/Libraries/TestServices/TestSessionConfiguration.cs
+++ b/test/Libraries/TestServices/TestSessionConfiguration.cs
@@ -29,6 +29,7 @@ namespace TestServices
         public string DynamoCorePath { get; private set; }
         [Obsolete("Please use the Version2 Property instead.")]
         public LibraryVersion RequestedLibraryVersion { get { return (LibraryVersion)this.RequestedLibraryVersion2.Major; }}
+
         /// <summary>
         /// The requested libG library version as a full system.version string.
         /// If the key is not present in the config file a default value will be selected.
@@ -36,8 +37,9 @@ namespace TestServices
         public Version RequestedLibraryVersion2 { get; private set; }
   
         /// <summary>
-        /// This constructor does not read configuration from a config file, is set by the parameters passed to this 
-        /// constructor. It can be used by test fixtures that know which libG version should load.
+        /// This constructor does not read configuration from a config file, the configuration properties are
+        /// set directly by the parameters passed to this constructor. 
+        /// It can be used by test fixtures that know which libG version should be loaded.
         /// </summary>
         /// <param name="dynamoCoreDirectory"></param>
         /// <param name="requestedVersion"></param>
@@ -90,25 +92,25 @@ namespace TestServices
             var dir = GetAppSetting(config, "DynamoBasePath");
             DynamoCorePath = string.IsNullOrEmpty(dir) ? dynamoCoreDirectory : dir;
 
-            //if an old client supplies an older format test config we should still load it.
+            // if an old client supplies an older format test config we should still load it.
             var versionStrOld = GetAppSetting(config, "RequestedLibraryVersion");
             var versionStr = GetAppSetting(config, "RequestedLibraryVersion2");
 
             Version version;
             LibraryVersion libVersion;
-            // first try to load the requested library in the more precise format
+            // first try to load the requested library in the more precise format.
             if (Version.TryParse(versionStr, out version))
             {
                 RequestedLibraryVersion2 = version;
             }
-            // else try to load the older one and convert it to a known precise version
+            // else try to load the older one and convert it to a known precise version.
             else if (Enum.TryParse<LibraryVersion>(versionStrOld, out libVersion))
             {
                 var realVersion = Preloader.MapLibGVersionEnumToFullVersion(libVersion);
                 RequestedLibraryVersion2 = realVersion;
 
             }
-            // find an installed ASM version if could not find a specified version in the config file
+            // find an installed ASM version if we could not find a specified version in the config file.
             else
             {
                 var shapeManagerPath = string.Empty;

--- a/test/Libraries/TestServices/TestSessionConfiguration.cs
+++ b/test/Libraries/TestServices/TestSessionConfiguration.cs
@@ -21,6 +21,12 @@ namespace TestServices
         public string DynamoCorePath { get; private set; }
         [Obsolete("Please use the Version2 Property instead.")]
         public LibraryVersion RequestedLibraryVersion { get { return (LibraryVersion)this.RequestedLibraryVersion2.Major; }}
+        /// <summary>
+        /// The requested libG library version as a full system.version string.
+        /// If the key is not present in the config file a default value will be selected.
+        /// If the key is set to 'HostDefault' - the version will be set to null, and
+        /// Hosts will be responsible for loading libG and providing a version to load.
+        /// </summary>
         public Version RequestedLibraryVersion2 { get; private set; }
 
         public TestSessionConfiguration()
@@ -91,6 +97,11 @@ namespace TestServices
                 var realVersion = Preloader.MapLibGVersionEnumToFullVersion(libVersion);
                 RequestedLibraryVersion2 = realVersion;
 
+            }
+            //if the config is set to HostDefault
+            else if(versionStr.ToLower().Contains("hostdefault"))
+            {
+                RequestedLibraryVersion2 = null;
             }
             // fallback to a mid range version
             else


### PR DESCRIPTION
### Purpose

This PR solves the issue of loading the correct libG during RevitNodeTests in two different ways.

* It adds a new TestSessionConfiguration constructor that totally ignores the config file and sets the values directly. (unclear if this should be used as it limits flexibility of the revit tests) - but it makes them more robust I think.
* when the `RequestedLibraryVersion2` key cannot be parsed to a version or does not exist, then we fallback to doing a scan of installed asm versions instead of falling back to a random version. This means if the value is set to anything thats not a valid version we'll scan and likely find the installed revit asm on a test machine. So that will also work if we do not use the new `testSession` constructor.


Please see the related revit PR I will link.



### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 
@QilongTang 
### FYIs

@ZiyunShang