### PR TITLE
5909 pre-fill Github issue reports with crash details

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.0.2.6067")]
+[assembly: AssemblyVersion("2.0.2.6426")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.0.2.6067")]
+[assembly: AssemblyFileVersion("2.0.2.6426")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.0.2.6426")]
+[assembly: AssemblyVersion("2.0.2.6067")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.0.2.6426")]
+[assembly: AssemblyFileVersion("2.0.2.6067")]

--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -97,7 +97,7 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Link to Dynamo's issues on github
         /// </summary>
-        public static string GitHubBugReportingLink = "https://github.com/DynamoDS/Dynamo/issues";
+        public static string GitHubBugReportingLink = "https://github.com/DynamoDS/Dynamo/issues/new";
         #endregion
 
         #region Canvas Configurations

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Wpf.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -762,6 +762,15 @@ namespace Dynamo.Wpf.Properties {
         public static string CrashPromptDialogTitle {
             get {
                 return ResourceManager.GetString("CrashPromptDialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Crash report from Dynamo {0}.
+        /// </summary>
+        public static string CrashPromptGithubNewIssueTitle {
+            get {
+                return ResourceManager.GetString("CrashPromptGithubNewIssueTitle", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Wpf.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1961,10 +1961,10 @@ Do you want to install the latest Dynamo update?</value>
     <value>Package Path Added</value>
   </data>
   <data name="PackagePathAutoAddNotificationShortDescription" xml:space="preserve">
-    <value>A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to "Settings &gt; Manage Node and Package Paths..."</value>
+    <value>A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to "Settings > Manage Node and Package Paths..."</value>
   </data>
   <data name="PackagePathAutoAddNotificationDetailedDescription" xml:space="preserve">
-    <value>The import path "{0}" was added to "Manage Node and Package Paths". If you want to update or remove this path, please open "Settings &gt; Manage Node and Package Paths..."</value>
+    <value>The import path "{0}" was added to "Manage Node and Package Paths". If you want to update or remove this path, please open "Settings > Manage Node and Package Paths..."</value>
   </data>
   <data name="NodeContextMenuIsInput" xml:space="preserve">
     <value>Is Input</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1961,10 +1961,10 @@ Do you want to install the latest Dynamo update?</value>
     <value>Package Path Added</value>
   </data>
   <data name="PackagePathAutoAddNotificationShortDescription" xml:space="preserve">
-    <value>A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to "Settings > Manage Node and Package Paths..."</value>
+    <value>A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to "Settings &gt; Manage Node and Package Paths..."</value>
   </data>
   <data name="PackagePathAutoAddNotificationDetailedDescription" xml:space="preserve">
-    <value>The import path "{0}" was added to "Manage Node and Package Paths". If you want to update or remove this path, please open "Settings > Manage Node and Package Paths..."</value>
+    <value>The import path "{0}" was added to "Manage Node and Package Paths". If you want to update or remove this path, please open "Settings &gt; Manage Node and Package Paths..."</value>
   </data>
   <data name="NodeContextMenuIsInput" xml:space="preserve">
     <value>Is Input</value>
@@ -2195,5 +2195,8 @@ Want to publish a different package?</value>
   <data name="CustomNodePropertyWindowLocationNote" xml:space="preserve">
     <value>Custom Nodes will be placed in the Add-Ons section of the library.</value>
     <comment>Note regarding Custom Node library location</comment>
+  </data>
+  <data name="CrashPromptGithubNewIssueTitle" xml:space="preserve">
+    <value>Crash report from Dynamo {0}</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml.cs
@@ -95,7 +95,7 @@ namespace Dynamo.Nodes.Prompts
 
         private void PostOnGithub_Click(object sender, RoutedEventArgs e)
         {
-            DynamoViewModel.ReportABug(null);
+            DynamoViewModel.ReportABug(this.CrashDetailsContent.Text);
         }
 
         private void Details_Click(object sender, RoutedEventArgs e)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -800,7 +800,31 @@ namespace Dynamo.ViewModels
 
         public static void ReportABug(object parameter)
         {
-            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.GitHubBugReportingLink));
+            if (parameter != null)
+            {
+                UriBuilder baseUri = new UriBuilder(Configurations.GitHubBugReportingLink);
+
+                string title = "title=" + string.Format(
+                    Resources.CrashPromptGithubNewIssueTitle,
+                    AssemblyHelper.GetDynamoVersion().ToString()
+                    );
+                string body = "body=" + parameter.ToString();
+
+                // if the base Uri has pre-existing parameters, we need to append to them
+                // otherwise it's safe to directly assign
+                if (baseUri.Query != null && baseUri.Query.Length > 1)
+                    baseUri.Query = baseUri.Query.Substring(1) + "&" + title + "&" + body;
+                else
+                    baseUri.Query = title + "&" + body;
+
+                // this will properly format & escape the string for use as a uri
+                var combinedUrl = baseUri.ToString();
+
+                // launching the process using explorer.exe will format the URL incorrectly
+                // and Github will not recognise the query parameters in the URL
+                Process.Start(new ProcessStartInfo(combinedUrl));
+            }
+            else Process.Start(new ProcessStartInfo("explorer.exe", Configurations.GitHubBugReportingLink));
         }
 
         public static void ReportABug()

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -810,18 +810,15 @@ namespace Dynamo.ViewModels
                     );
                 string body = "body=" + parameter.ToString();
 
-                // if the base Uri has pre-existing parameters, we need to append to them
-                // otherwise it's safe to directly assign
-                if (baseUri.Query != null && baseUri.Query.Length > 1)
-                    baseUri.Query = baseUri.Query.Substring(1) + "&" + title + "&" + body;
-                else
-                    baseUri.Query = title + "&" + body;
+                // append the title and body to the URL as query parameters
+                baseUri.Query = title + "&" + body;
 
                 // this will properly format & escape the string for use as a uri
                 var combinedUrl = baseUri.ToString();
 
                 // launching the process using explorer.exe will format the URL incorrectly
                 // and Github will not recognise the query parameters in the URL
+                // so launch with default operating system web browser
                 Process.Start(new ProcessStartInfo(combinedUrl));
             }
             else Process.Start(new ProcessStartInfo("explorer.exe", Configurations.GitHubBugReportingLink));

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -798,9 +798,9 @@ namespace Dynamo.ViewModels
             return Model.CustomNodeManager.Contains((Guid)parameters);
         }
 
-        public static void ReportABug(object parameter)
+        public static void ReportABug(object bodyContent)
         {
-            if (parameter != null)
+            if (bodyContent != null)
             {
                 UriBuilder baseUri = new UriBuilder(Configurations.GitHubBugReportingLink);
 
@@ -808,18 +808,18 @@ namespace Dynamo.ViewModels
                     Resources.CrashPromptGithubNewIssueTitle,
                     AssemblyHelper.GetDynamoVersion().ToString()
                     );
-                string body = "body=" + parameter.ToString();
+                string body = "body=" + bodyContent.ToString();
 
                 // append the title and body to the URL as query parameters
                 baseUri.Query = title + "&" + body;
 
                 // this will properly format & escape the string for use as a uri
-                var combinedUrl = baseUri.ToString();
+                var urlWithParameters = baseUri.ToString();
 
                 // launching the process using explorer.exe will format the URL incorrectly
                 // and Github will not recognise the query parameters in the URL
                 // so launch with default operating system web browser
-                Process.Start(new ProcessStartInfo(combinedUrl));
+                Process.Start(new ProcessStartInfo(urlWithParameters));
             }
             else Process.Start(new ProcessStartInfo("explorer.exe", Configurations.GitHubBugReportingLink));
         }


### PR DESCRIPTION
### Purpose

Fixes #5909 by pre-filling the new Github issue page with 
- an appropriate title that includes Dynamo version number : `Crash report from Dynamo 2.0.1`
- issue body filled with the crash details text, displayed in the `CrashPrompt` window bottom text box

Currently pressing `Submit to Github` takes you here : 

![image](https://user-images.githubusercontent.com/11439624/46560424-9e175880-c8eb-11e8-9319-2d846a333165.png)


With the new behaviour, pressing `Submit to Github` takes you here :
 
![image](https://user-images.githubusercontent.com/11439624/46560449-b9826380-c8eb-11e8-8fcb-830ab1928ad5.png)

In the above image, the `This is the error text` body would be replaced by the actual details of the crash stack trace, as per original screenshot in #5909 . 

I can't seem to be able to make Dynamo crash on purpose right now (funny how that works...), so dunno how to replicate.

#### Other notes
- sends users to `https://github.com/DynamoDS/Dynamo/issues/new` by default when no crash text is supplied (friendlier than sending to the super-busy all issues page)
- as per current implementation, you still need to be logged in to Github to be able to submit the issue

#### Further improvements
We could add the rest of the current `issue template` text to the body and wrap the `crash dump` inside a nice code block, but I'm afraid that'd make the query string way too long. Open to ideas/suggestions ?

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@Racel 

### FYIs

@andydandy74 , @johnpierson 
