### PR TITLE
remap old style libG names to new folder names

### DIFF
--- a/src/Tools/DynamoShapeManager/Properties/AssemblyInfo.cs
+++ b/src/Tools/DynamoShapeManager/Properties/AssemblyInfo.cs
@@ -7,3 +7,4 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("DynamoShapeManager")]
 [assembly: AssemblyCulture("")]
 [assembly: InternalsVisibleTo("TestServices")]
+[assembly: InternalsVisibleTo("DynamoCoreTests")]

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -241,6 +241,10 @@ namespace DynamoShapeManager
         /// <returns> new version LibG path or Empty string if the path could not be remapped.</returns>
         internal static string RemapOldLibGPathToNewVersionPath(string preloaderLocation)
         {
+            if (String.IsNullOrEmpty(preloaderLocation))
+            {
+                return string.Empty;
+            }
             var folderName = Path.GetFileName(preloaderLocation);
             var splitName = folderName.Split('_');
             if (splitName.Count() == 2)

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -235,7 +235,7 @@ namespace DynamoShapeManager
 
         /// <summary>
         /// Attempts to remap a an old LibG path to a new one using a version map.
-        /// We assume that 
+        /// We assume that the leaf directory is of the form LibG_[Version].
         /// </summary>
         /// <param name="preloaderLocation"></param>
         /// <returns> returns "" if the path does not appear to be a valid old libG path.</returns>

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -238,7 +238,7 @@ namespace DynamoShapeManager
         /// We assume that the leaf directory is of the form LibG_[Version].
         /// </summary>
         /// <param name="preloaderLocation"></param>
-        /// <returns> returns "" if the path does not appear to be a valid old libG path.</returns>
+        /// <returns> new version LibG path or Empty string if the path could not be remapped.</returns>
         internal static string RemapOldLibGPathToNewVersionPath(string preloaderLocation)
         {
             var folderName = Path.GetFileName(preloaderLocation);

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -185,7 +185,7 @@ namespace DynamoShapeManager
         /// 
         public static void PreloadAsmFromPath(string preloaderLocation, string asmLocation)
         {
-            // this will with be empty, the originally requested preloaderLocation or a remapped location
+            // this will either be empty, the originally requested preloaderLocation, or a remapped location
             // based on the old libG version number.
             var preloaderLocationToLoad = "";
 

--- a/test/DynamoCoreTests/libGPreloaderTests.cs
+++ b/test/DynamoCoreTests/libGPreloaderTests.cs
@@ -206,5 +206,19 @@ namespace Dynamo.Tests
             var newPath = DynamoShapeManager.Utilities.RemapOldLibGPathToNewVersionPath(oldPath);
             Assert.AreEqual(new DirectoryInfo(Path.Combine("C", "Dynamo", "Extern", "FakePath", "LibG_223_0_1")), new DirectoryInfo(newPath));
         }
+        [Test]
+        public void RemapPathShouldReturnEmptyStringForNewPath()
+        {
+            var oldPath = Path.Combine("C", "Dynamo", "Extern", "FakePath", "LibG_223_0_1");
+            var newPath = DynamoShapeManager.Utilities.RemapOldLibGPathToNewVersionPath(oldPath);
+            Assert.AreEqual(String.Empty, newPath);
+        }
+        [Test]
+        public void RemapPathShouldReturnEmptyStringForNullPath()
+        {
+            string oldPath = null;
+            var newPath = DynamoShapeManager.Utilities.RemapOldLibGPathToNewVersionPath(oldPath);
+            Assert.AreEqual(string.Empty, newPath);
+        }
     }
 }

--- a/test/DynamoCoreTests/libGPreloaderTests.cs
+++ b/test/DynamoCoreTests/libGPreloaderTests.cs
@@ -198,5 +198,13 @@ namespace Dynamo.Tests
             libG22440path.Delete(true);
             libG22401path.Delete(true);
         }
+
+        [Test]
+        public void LoadASMFromPathShouldWorkWithOldPath()
+        {
+            var oldPath = Path.Combine("C","Dynamo","Extern","FakePath","LibG_223");
+            var newPath = DynamoShapeManager.Utilities.RemapOldLibGPathToNewVersionPath(oldPath);
+            Assert.AreEqual(new DirectoryInfo(Path.Combine("C", "Dynamo", "Extern", "FakePath", "LibG_223_0_1")), new DirectoryInfo(newPath));
+        }
     }
 }


### PR DESCRIPTION

### Purpose

![image](https://user-images.githubusercontent.com/508936/46563985-ab741900-c8d2-11e8-8bd1-8cfba9e9e911.png)

To deal with the issue of an old DynamoRevit client calling a new DynamoCore where libG folders have had their names changed to specify precise version - dynamo should attempt to remap the folder name before giving up.


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
@alfarok 
### FYIs

@kronz 
@smangarole 