### PR TITLE
QNTM-5568 Refinery needs to support culture invariance for number fmt, part Deux

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeInputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeInputData.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
@@ -115,7 +116,7 @@ namespace Dynamo.Graph.Nodes
             var valNumberComparison = false;
             try
             {
-                valNumberComparison = Math.Abs(Convert.ToDouble(this.Value) - Convert.ToDouble(converted.Value)) < .000001;
+                valNumberComparison = Math.Abs(Convert.ToDouble(this.Value, CultureInfo.InvariantCulture) - Convert.ToDouble(converted.Value, CultureInfo.InvariantCulture)) < .000001;
             }
             catch (Exception e)
             {

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -887,9 +887,15 @@ namespace Dynamo.Graph.Nodes
                 // When Concrete type is dictionary or other type not expressed in enum, type is set to unknown
                 object returnObj = CachedValue?.Data?? new object();
                 var returnType = NodeOutputData.getNodeOutputTypeFromType(returnObj.GetType());
+                var returnValue = String.Empty;
 
                 // IntialValue is returned when the Type enum does not equal unknown
-                var returnValue = (returnType != NodeOutputTypes.unknownOutput) ? returnObj.ToString() : String.Empty; 
+                if(returnType != NodeOutputTypes.unknownOutput)
+                {
+                    var formattableReturnObj = returnObj as IFormattable;
+                    returnValue = formattableReturnObj != null ? formattableReturnObj.ToString(null, CultureInfo.InvariantCulture) : returnObj.ToString();
+                }
+
                 
                 return new NodeOutputData()
                 {

--- a/src/DynamoCore/Graph/Nodes/NodeOutputData.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeOutputData.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
@@ -84,7 +85,7 @@ namespace Dynamo.Graph.Nodes
             var valNumberComparison = false;
             try
             {
-                valNumberComparison = Math.Abs(Convert.ToDouble(this.IntitialValue) - Convert.ToDouble(converted.IntitialValue)) < .000001;
+                valNumberComparison = Math.Abs(Convert.ToDouble(this.IntitialValue, CultureInfo.InvariantCulture) - Convert.ToDouble(converted.IntitialValue, CultureInfo.InvariantCulture)) < .000001;
             }
             catch (Exception e)
             {

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="DummyNodeTests.cs" />
     <Compile Include="ImperativeClodeBlockTest.cs" />
     <Compile Include="InheritanceTests.cs" />
+    <Compile Include="InputOutputDataTests.cs" />
     <Compile Include="libGPreloaderTests.cs" />
     <Compile Include="ListAtLevelTests.cs" />
     <Compile Include="MultiOutputNodeTest.cs" />

--- a/test/DynamoCoreTests/InputOutputDataTests.cs
+++ b/test/DynamoCoreTests/InputOutputDataTests.cs
@@ -1,0 +1,65 @@
+﻿using System.Globalization;
+using System.Threading;
+using Dynamo.Graph.Nodes;
+using NUnit.Framework;
+
+
+namespace Dynamo.Tests
+{
+
+    [Category("InputOutputData")]
+    class InputOutputDataTest : DynamoModelTestBase
+    {
+        [Test]
+        [Category("RegressionTests")]
+        public void TestNodeOutputDataInDifferentCulture()
+        {
+            var frCulture = CultureInfo.CreateSpecificCulture("fr-FR");
+
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            Thread.CurrentThread.CurrentCulture = frCulture;
+            Thread.CurrentThread.CurrentUICulture = frCulture;
+
+            NodeOutputData outputData1 = new NodeOutputData();
+            outputData1.InitialValue = "1.23";
+            NodeOutputData outputData2 = new NodeOutputData();
+            outputData2.InitialValue = "123";
+            Assert.IsFalse(outputData1.Equals(outputData2));
+
+            outputData2.InitialValue = "1.23";
+            Assert.IsTrue(outputData1.Equals(outputData2));
+
+
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+            Thread.CurrentThread.CurrentUICulture = currentUICulture;
+        }
+
+        [Test]
+        [Category("RegressionTests")]
+        public void TestNodeInputDataInDifferentCulture()
+        {
+            var frCulture = CultureInfo.CreateSpecificCulture("fr-FR");
+
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            Thread.CurrentThread.CurrentCulture = frCulture;
+            Thread.CurrentThread.CurrentUICulture = frCulture;
+
+            NodeInputData inputData1 = new NodeInputData();
+            inputData1.Value = "1.23";
+            NodeInputData inputData2 = new NodeInputData();
+            inputData2.Value = "123";
+            Assert.IsFalse(inputData1.Equals(inputData2));
+
+            inputData2.Value = "1.23";
+            Assert.IsTrue(inputData1.Equals(inputData2));
+
+
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+            Thread.CurrentThread.CurrentUICulture = currentUICulture;
+        }
+    }
+}

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1257,58 +1257,6 @@ namespace Dynamo.Tests
             Assert.IsNotNull(cbn);
             Assert.IsTrue(cbn.GetAstIdentifierForOutputIndex(0).Value.StartsWith("num"));
         }
-
-        [Test]
-        [Category("RegressionTests")]
-        public void TestNodeOutputDataInDifferentCulture()
-        {
-            var frCulture = CultureInfo.CreateSpecificCulture("fr-FR");
-            
-            var currentCulture = Thread.CurrentThread.CurrentCulture;
-            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
-
-            Thread.CurrentThread.CurrentCulture = frCulture;
-            Thread.CurrentThread.CurrentUICulture = frCulture;
-
-            NodeOutputData outputData1 = new NodeOutputData();
-            outputData1.InitialValue = "1.23";
-            NodeOutputData outputData2 = new NodeOutputData();
-            outputData2.InitialValue = "123";
-            Assert.IsFalse(outputData1.Equals(outputData2));
-
-            outputData2.InitialValue = "1.23";
-            Assert.IsTrue(outputData1.Equals(outputData2));
-
-
-            Thread.CurrentThread.CurrentCulture = currentCulture;
-            Thread.CurrentThread.CurrentUICulture = currentUICulture;
-        }
-
-        [Test]
-        [Category("RegressionTests")]
-        public void TestNodeInputDataInDifferentCulture()
-        {
-            var frCulture = CultureInfo.CreateSpecificCulture("fr-FR");
-            
-            var currentCulture = Thread.CurrentThread.CurrentCulture;
-            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
-
-            Thread.CurrentThread.CurrentCulture = frCulture;
-            Thread.CurrentThread.CurrentUICulture = frCulture;
-
-            NodeInputData inputData1 = new NodeInputData();
-            inputData1.Value = "1.23";
-            NodeInputData inputData2 = new NodeInputData();
-            inputData2.Value = "123";
-            Assert.IsFalse(inputData1.Equals(inputData2));
-
-            inputData2.Value = "1.23";
-            Assert.IsTrue(inputData1.Equals(inputData2));
-
-
-            Thread.CurrentThread.CurrentCulture = currentCulture;
-            Thread.CurrentThread.CurrentUICulture = currentUICulture;
-        }
     }
 
     [Category("NodeToCode")]

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1257,6 +1257,58 @@ namespace Dynamo.Tests
             Assert.IsNotNull(cbn);
             Assert.IsTrue(cbn.GetAstIdentifierForOutputIndex(0).Value.StartsWith("num"));
         }
+
+        [Test]
+        [Category("RegressionTests")]
+        public void TestNodeOutputDataInDifferentCulture()
+        {
+            var frCulture = CultureInfo.CreateSpecificCulture("fr-FR");
+            
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            Thread.CurrentThread.CurrentCulture = frCulture;
+            Thread.CurrentThread.CurrentUICulture = frCulture;
+
+            NodeOutputData outputData1 = new NodeOutputData();
+            outputData1.InitialValue = "1.23";
+            NodeOutputData outputData2 = new NodeOutputData();
+            outputData2.InitialValue = "123";
+            Assert.IsFalse(outputData1.Equals(outputData2));
+
+            outputData2.InitialValue = "1.23";
+            Assert.IsTrue(outputData1.Equals(outputData2));
+
+
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+            Thread.CurrentThread.CurrentUICulture = currentUICulture;
+        }
+
+        [Test]
+        [Category("RegressionTests")]
+        public void TestNodeInputDataInDifferentCulture()
+        {
+            var frCulture = CultureInfo.CreateSpecificCulture("fr-FR");
+            
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            Thread.CurrentThread.CurrentCulture = frCulture;
+            Thread.CurrentThread.CurrentUICulture = frCulture;
+
+            NodeInputData inputData1 = new NodeInputData();
+            inputData1.Value = "1.23";
+            NodeInputData inputData2 = new NodeInputData();
+            inputData2.Value = "123";
+            Assert.IsFalse(inputData1.Equals(inputData2));
+
+            inputData2.Value = "1.23";
+            Assert.IsTrue(inputData1.Equals(inputData2));
+
+
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+            Thread.CurrentThread.CurrentUICulture = currentUICulture;
+        }
     }
 
     [Category("NodeToCode")]

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -680,23 +680,22 @@ namespace Dynamo.Tests
         public void SerializationInDifferentCultureTest(string filePath)
         {
             var frCulture = CultureInfo.CreateSpecificCulture("fr-FR");
-            
+
+            // Save current culture - usually "en-US"
             var currentCulture = Thread.CurrentThread.CurrentCulture;
             var currentUICulture = Thread.CurrentThread.CurrentUICulture;
 
+            // Set "fr-FR"
             Thread.CurrentThread.CurrentCulture = frCulture;
-            Assert.AreEqual(Thread.CurrentThread.CurrentCulture.Name, frCulture.Name);
             Thread.CurrentThread.CurrentUICulture = frCulture;
-            Assert.AreEqual(Thread.CurrentThread.CurrentUICulture.Name, frCulture.Name);
 
             DoWorkspaceOpenAndCompare(filePath, jsonFolderNameDifferentCulture, ConvertCurrentWorkspaceToJsonAndSave,
                 serializationTestUtils.CompareWorkspaceModels,
                 serializationTestUtils.SaveWorkspaceComparisonData);
 
+            // Restore "en-US"
             Thread.CurrentThread.CurrentCulture = currentCulture;
-            Assert.AreEqual(Thread.CurrentThread.CurrentCulture.Name, currentCulture.Name);
             Thread.CurrentThread.CurrentUICulture = currentUICulture;
-            Assert.AreEqual(Thread.CurrentThread.CurrentUICulture.Name, currentUICulture.Name);
         }
 
         /// <summary>

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -17,6 +17,7 @@ using Dynamo.Utilities;
 using Newtonsoft.Json.Linq;
 using System.Globalization;
 using Dynamo.Graph.Nodes.ZeroTouch;
+using System.Threading;
 
 namespace Dynamo.Tests
 {
@@ -664,6 +665,33 @@ namespace Dynamo.Tests
             DoWorkspaceOpenAndCompare(filePath, jsonFolderName, ConvertCurrentWorkspaceToJsonAndSave,
                 serializationTestUtils.CompareWorkspaceModels,
                 serializationTestUtils.SaveWorkspaceComparisonData);
+        }
+
+        /// <summary>
+        /// This parameterized test finds all .dyn files in directories within
+        /// the test directory, opens them and executes, then converts them to
+        /// json and executes again, comparing the values from the two runs
+        /// while being in a different culture.
+        /// </summary>
+        /// <param name="filePath">The path to a .dyn file. This parameter is supplied
+        /// by the test framework.</param>
+        [Test, TestCaseSource("FindWorkspaces"), Category("JsonTestExclude")]
+        public void SerializationTestInDifferentCulture(string filePath)
+        {
+            var frCulture = CultureInfo.CreateSpecificCulture("fr-FR");
+            
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var currentUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            Thread.CurrentThread.CurrentCulture = frCulture;
+            Thread.CurrentThread.CurrentUICulture = frCulture;
+
+            DoWorkspaceOpenAndCompare(filePath, jsonFolderName, ConvertCurrentWorkspaceToJsonAndSave,
+                serializationTestUtils.CompareWorkspaceModels,
+                serializationTestUtils.SaveWorkspaceComparisonData);
+
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+            Thread.CurrentThread.CurrentUICulture = currentUICulture;
         }
 
         /// <summary>

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -519,6 +519,7 @@ namespace Dynamo.Tests
     {
         public static string jsonNonGuidFolderName = "json_nonGuidIds";
         public static string jsonFolderName = "json";
+        public static string jsonFolderNameDifferentCulture = "json_differentCulture";
 
         private TimeSpan lastExecutionDuration = new TimeSpan();
         private Dictionary<Guid, string> modelsGuidToIdMap = new Dictionary<Guid, string>();
@@ -676,7 +677,7 @@ namespace Dynamo.Tests
         /// <param name="filePath">The path to a .dyn file. This parameter is supplied
         /// by the test framework.</param>
         [Test, TestCaseSource("FindWorkspaces"), Category("JsonTestExclude")]
-        public void SerializationTestInDifferentCulture(string filePath)
+        public void SerializationInDifferentCultureTest(string filePath)
         {
             var frCulture = CultureInfo.CreateSpecificCulture("fr-FR");
             
@@ -684,14 +685,18 @@ namespace Dynamo.Tests
             var currentUICulture = Thread.CurrentThread.CurrentUICulture;
 
             Thread.CurrentThread.CurrentCulture = frCulture;
+            Assert.AreEqual(Thread.CurrentThread.CurrentCulture.Name, frCulture.Name);
             Thread.CurrentThread.CurrentUICulture = frCulture;
+            Assert.AreEqual(Thread.CurrentThread.CurrentUICulture.Name, frCulture.Name);
 
-            DoWorkspaceOpenAndCompare(filePath, jsonFolderName, ConvertCurrentWorkspaceToJsonAndSave,
+            DoWorkspaceOpenAndCompare(filePath, jsonFolderNameDifferentCulture, ConvertCurrentWorkspaceToJsonAndSave,
                 serializationTestUtils.CompareWorkspaceModels,
                 serializationTestUtils.SaveWorkspaceComparisonData);
 
             Thread.CurrentThread.CurrentCulture = currentCulture;
+            Assert.AreEqual(Thread.CurrentThread.CurrentCulture.Name, currentCulture.Name);
             Thread.CurrentThread.CurrentUICulture = currentUICulture;
+            Assert.AreEqual(Thread.CurrentThread.CurrentUICulture.Name, currentUICulture.Name);
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

This pull request addresses JIRA task [QNTM-5568](https://jira.autodesk.com/browse/QNTM-5568).

#### This pull request does
- format the value string in output nodes using the  `InvariantCulture` format
- use the `InvariantCulture` format when converting the value string in input and output nodes to `double`
- Added tests for `InputData` and `OutputData`
- Added test for loading and comparing dyn files while being in a different culture.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@longc @mjkkirschner 

### FYIs

