### PR TITLE
Prevent crash when starting DynamoSandbox without ASM

### DIFF
--- a/src/Tools/DynamoShapeManager/Preloader.cs
+++ b/src/Tools/DynamoShapeManager/Preloader.cs
@@ -139,7 +139,14 @@ namespace DynamoShapeManager
             shapeManagerPath = string.Empty; // Folder that contains ASM binaries.
             version = Utilities.GetInstalledAsmVersion2(versionList, ref shapeManagerPath, rootFolder);
 
-            var libGFolderName = string.Format("libg_{0}_{1}_{2}", version.Major, version.Minor, version.Build);
+            int major = 0, minor = 0, build = 0;
+            if (version != null)
+            {
+                major = version.Major;
+                minor = version.Minor;
+                build = version.Build;
+            }
+            var libGFolderName = string.Format("libg_{0}_{1}_{2}", major, minor, build);
             preloaderLocation = Path.Combine(rootFolder, libGFolderName);
             geometryFactoryPath = Path.Combine(preloaderLocation,
                 Utilities.GeometryFactoryAssembly);

--- a/test/DynamoCoreTests/libGPreloaderTests.cs
+++ b/test/DynamoCoreTests/libGPreloaderTests.cs
@@ -220,5 +220,13 @@ namespace Dynamo.Tests
             var newPath = DynamoShapeManager.Utilities.RemapOldLibGPathToNewVersionPath(oldPath);
             Assert.AreEqual(string.Empty, newPath);
         }
+        [Test]
+        public void PreloaderThatDoesNotFindASMDoesNotThrow()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var preloader = new Preloader(Path.GetTempPath(), new[] { new Version(999, 999, 999) });
+            });
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Prevent a crash when starting DynamoSandbox on a system where ASM is not (or cannot be) found.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- (n/a) User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- (n/a) Snapshot of UI changes, if any.
- (n/a) Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

