### PR TITLE
Address race condition where library resources attempt to load before the Browser completes loading

### DIFF
--- a/src/LibraryViewExtension/Handlers/ResourceHandlerFactory.cs
+++ b/src/LibraryViewExtension/Handlers/ResourceHandlerFactory.cs
@@ -17,13 +17,15 @@ namespace Dynamo.LibraryUI.Handlers
         private HashSet<string> supportedSchemes = new HashSet<string>();
         private DynamoLogger logger;
 
-        // For Library testing purposes
+        //TODO: Remove this after testing.
+        //For testing purpose.
         public ResourceHandlerFactory()
         {
 
         }
 
-        // Log for testing purposes
+        //TODO: Remove this after testing.
+        //For testing purpose.
         public ResourceHandlerFactory(DynamoLogger log)
         {
             this.logger = log;

--- a/src/LibraryViewExtension/Handlers/ResourceHandlerFactory.cs
+++ b/src/LibraryViewExtension/Handlers/ResourceHandlerFactory.cs
@@ -17,6 +17,12 @@ namespace Dynamo.LibraryUI.Handlers
         private HashSet<string> supportedSchemes = new HashSet<string>();
         private DynamoLogger logger;
 
+        // For Library testing purposes
+        public ResourceHandlerFactory()
+        {
+
+        }
+
         // Log for testing purposes
         public ResourceHandlerFactory(DynamoLogger log)
         {

--- a/src/LibraryViewExtension/Handlers/ResourceHandlerFactory.cs
+++ b/src/LibraryViewExtension/Handlers/ResourceHandlerFactory.cs
@@ -17,15 +17,7 @@ namespace Dynamo.LibraryUI.Handlers
         private HashSet<string> supportedSchemes = new HashSet<string>();
         private DynamoLogger logger;
 
-        //TODO: Remove this after testing.
-        //For testing purpose.
-        public ResourceHandlerFactory()
-        {
-            
-        }
-
-        //TODO: Remove this after testing.
-        //For testing purpose.
+        // Log for testing purposes
         public ResourceHandlerFactory(DynamoLogger log)
         {
             this.logger = log;
@@ -48,12 +40,14 @@ namespace Dynamo.LibraryUI.Handlers
                 }
 
 #endif
+                // Create a handlerItem for the new resource,
+                // if the resource has already been loaded don't load it again
                 if(!Handlers.TryGetValue(request.Url, out handlerItem))
                 {
                     IResourceHandler handler = this.GetResourceHandler(request);
-                    // TODO - verify bool param - determines whether or not the handler
-                    // should be used once(true) or until manually unregistered
-                    handlerItem = new DefaultResourceHandlerFactoryItem(handler, false);
+
+                    // Make sure the handler is unregistered after use
+                    handlerItem = new DefaultResourceHandlerFactoryItem(handler, true);
                 }
 
                 return handlerItem.Handler;

--- a/src/LibraryViewExtension/Handlers/ResourceHandlerFactory.cs
+++ b/src/LibraryViewExtension/Handlers/ResourceHandlerFactory.cs
@@ -55,6 +55,7 @@ namespace Dynamo.LibraryUI.Handlers
                     IResourceHandler handler = this.GetResourceHandler(request);
 
                     // Make sure the handler is unregistered after use
+                    // See: https://cefsharp.github.io/api/63.0.0/html/T_CefSharp_DefaultResourceHandlerFactoryItem.htm
                     handlerItem = new DefaultResourceHandlerFactoryItem(handler, true);
                 }
 

--- a/src/LibraryViewExtension/LibraryViewController.cs
+++ b/src/LibraryViewExtension/LibraryViewController.cs
@@ -199,7 +199,7 @@ namespace Dynamo.LibraryUI
             {
                 string error = "The library browser is still loading, another attempt to load the resources will be made when loading is complete." +
                     System.Environment.NewLine +
-                    "Exception: " + ex;
+                    "Exception: " + ex.Message;
                 this.dynamoViewModel.Model.Logger.LogError(error);
             }
 
@@ -225,7 +225,7 @@ namespace Dynamo.LibraryUI
                 {
                     string error = "Failed to The library loaded library resources after a browser loading state change." +
                         System.Environment.NewLine +
-                        "Exception: " + ex;
+                        "Exception: " + ex.Message;
                     this.dynamoViewModel.Model.Logger.LogError(error);
                 }
             }

--- a/src/LibraryViewExtension/LibraryViewController.cs
+++ b/src/LibraryViewExtension/LibraryViewController.cs
@@ -195,9 +195,11 @@ namespace Dynamo.LibraryUI
                 string msg = "Successfully loaded library resources on first attempt.";
                 this.dynamoViewModel.Model.Logger.Log(msg);
             }
-            catch
+            catch(Exception ex)
             {
-                string error = "The library browser is still loading, another attempt to load the resources will be made when loading is complete.";
+                string error = "The library browser is still loading, another attempt to load the resources will be made when loading is complete." +
+                    System.Environment.NewLine +
+                    "Exception: " + ex;
                 this.dynamoViewModel.Model.Logger.LogError(error);
             }
 
@@ -219,9 +221,11 @@ namespace Dynamo.LibraryUI
                     string msg = "Successfully loaded library resources after a browser loading state change.";
                     this.dynamoViewModel.Model.Logger.Log(msg);
                 }
-                catch
+                catch(Exception ex)
                 {
-                    string error = "Failed to The library loaded library resources after a browser loading state change.";
+                    string error = "Failed to The library loaded library resources after a browser loading state change." +
+                        System.Environment.NewLine +
+                        "Exception: " + ex;
                     this.dynamoViewModel.Model.Logger.LogError(error);
                 }
             }

--- a/src/LibraryViewExtension/LibraryViewController.cs
+++ b/src/LibraryViewExtension/LibraryViewController.cs
@@ -187,11 +187,6 @@ namespace Dynamo.LibraryUI
             browser.SizeChanged += Browser_SizeChanged;
             browser.LoadError += Browser_LoadError;
 
-            // TODO - this was added Fall 2017 due to issues with 
-            // library failing to load due to timing issues.  DYN-944 
-            // is a testing task that should make the final determination
-            // as it no longer seems required in CEF v65.0.1
-            /*
             //wait for the browser to load before setting the resources
             browser.LoadingStateChanged += (sender, args) =>
             {
@@ -201,7 +196,6 @@ namespace Dynamo.LibraryUI
                     RegisterResources(browser);
                 }
             };
-            */
 
             return view;
         }

--- a/src/LibraryViewExtension/LibraryViewController.cs
+++ b/src/LibraryViewExtension/LibraryViewController.cs
@@ -209,11 +209,18 @@ namespace Dynamo.LibraryUI
             }
         }
 
+        // Browser LoadError events occur when the resource load for a navigation fails or is canceled
         private void Browser_LoadError(object sender, LoadErrorEventArgs e)
         {
             System.Diagnostics.Trace.WriteLine("*****Chromium Browser Messages******");
             System.Diagnostics.Trace.Write(e.ErrorText);
+
+            // TODO - ERR_ABORTED error in Dynamo Console occurs after browser initialization only on startup,
+            // possibly because the initial resource loading is cancelled and retriggered when the browser is loaded
+            // http://cefsharp.github.io/api/55.0.0/html/E_CefSharp_WinForms_ChromiumWebBrowser_LoadError.htm
+#if DEBUG
             this.dynamoViewModel.Model.Logger.LogError(e.ErrorText);
+#endif
         }
 
         //if the browser window itself is resized, toggle visibility to force redraw.

--- a/src/LibraryViewExtension/LibraryViewController.cs
+++ b/src/LibraryViewExtension/LibraryViewController.cs
@@ -183,57 +183,29 @@ namespace Dynamo.LibraryUI
             browser.RegisterAsyncJsObject("controller", this);
 
             view.Loaded += OnLibraryViewLoaded;
+            browser.Loaded += BrowserLoaded;
             browser.SizeChanged += Browser_SizeChanged;
             browser.LoadError += Browser_LoadError;
-            browser.LoadingStateChanged += LoadingStateChanged;
-
-            // Attempt to register required resources, but if the browser is still loading
-            // another attempt will be made when the loading state of the browser changes (see event above)
-            try
-            {
-                RegisterResources(browser);
-                string msg = "Successfully loaded library resources on first attempt.";
-                this.dynamoViewModel.Model.Logger.Log(msg);
-            }
-            catch(Exception ex)
-            {
-                string error = "The library browser is still loading, another attempt to load the resources will be made when loading is complete." +
-                    System.Environment.NewLine +
-                    "Exception: " + ex.Message;
-                this.dynamoViewModel.Model.Logger.LogError(error);
-            }
 
             return view;
         }
 
-        // This event is trigger twice,
-        // Once when loading is initiated either programmatically or by user action, 
-        // and once when loading is terminated due to completion, cancellation of failure.
-        private void LoadingStateChanged(object send, LoadingStateChangedEventArgs browserArgs)
+        // Load library resources once the browser is ready for interaction
+        private void BrowserLoaded(object sender, RoutedEventArgs e)
         {
-            // If the loading state has changed and the page has finished loading
-            if (!browserArgs.IsLoading)
+            // Attempt to load resources
+            try
             {
-                // Attempt to load resources
-                try
-                {
-                    RegisterResources(browser);
-                    string msg = "Successfully loaded library resources after a browser loading state change.";
-                    this.dynamoViewModel.Model.Logger.Log(msg);
-                }
-                catch(Exception ex)
-                {
-                    string error = "Failed to The library loaded library resources after a browser loading state change." +
-                        System.Environment.NewLine +
-                        "Exception: " + ex.Message;
-                    this.dynamoViewModel.Model.Logger.LogError(error);
-                }
+                RegisterResources(this.browser);
+                string msg = "Successfully loaded the library resources.";
+                this.dynamoViewModel.Model.Logger.Log(msg);
             }
-            // Browser is still loading or a browser failure has occured
-            else
+            catch (Exception ex)
             {
-                string error = "The library browser is still loading or an error has occured, another attempt to load the resources will be made if loading can be completed.";
-                this.dynamoViewModel.Model.Logger.Log(error);
+                string error = "Failed to load the library resources." +
+                    Environment.NewLine +
+                    "Exception: " + ex.Message;
+                this.dynamoViewModel.Model.Logger.LogError(error);
             }
         }
 

--- a/src/LibraryViewExtension/web/library/library.html
+++ b/src/LibraryViewExtension/web/library/library.html
@@ -39,7 +39,6 @@
                 let layoutSpecsJson = downloaded["layoutSpecs"];
 
                 if (!loadedTypesJson || (!layoutSpecsJson)) {
-                    console.log("Error: Couldn't get enough data to load library.");
                     return; // Not fully downloaded yet, bail.
                 }
 


### PR DESCRIPTION
### Purpose

[QNTM-5759](https://jira.autodesk.com/browse/QNTM-5759)

As a result of [DYN-944](https://jira.autodesk.com/browse/DYN-944) a race condition was discovered where an attempt to load library resources is made before the browser window has been fully loaded. This PR ensures library resources get loaded once the browser is ready by subscribing to `browser.Loaded` and waiting for the event to fire before attempting to register our resources.

Additionally, this PR adds a few comments to other sections of the resource handler and makes sure handlers are properly unregistered after being used.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang

### FYIs

@mjkkirschner 
