### PR TITLE
Support namespace qualifiers in classes used in Imperative blocks

### DIFF
--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -645,12 +645,6 @@ namespace ProtoCore
                 if (identListNode != null)
                 {
                     isImperativeFunc = identListNode.RightNode is AST.ImperativeAST.FunctionCallNode;
-                    //if (isImperativeFunc)
-                    //{
-                    //    var className = CoreUtils.GetIdentifierExceptMethodName(identListNode);
-                    //    ci = core.ClassTable.IndexOf(className);
-                    //}
-                    //else
                     if(!isImperativeFunc)
                     {
                         var className = CoreUtils.GetIdentifierStringUntilFirstParenthesis(identListNode);

--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -639,20 +639,19 @@ namespace ProtoCore
 
                 // Check if node.LeftNode is a valid class
                 var identListNode = bnode.LeftNode as AST.ImperativeAST.IdentifierListNode;
-                //int ci = Constants.kInvalidIndex;
+                int ci = Constants.kInvalidIndex;
 
                 if (identListNode != null && finalType.UID != Constants.kInvalidIndex)
                 {
-                    //var className = CoreUtils.GetIdentifierExceptMethodName(identListNode);
-                    //ci = core.ClassTable.IndexOf(className);
-                    //if (ci != Constants.kInvalidIndex)
-                    //{
-                    //    finalType.UID = lefttype.UID = ci;
-                    //}
+                    var className = CoreUtils.GetIdentifierExceptMethodName(identListNode);
+                    ci = core.ClassTable.IndexOf(className);
+                    if (ci != Constants.kInvalidIndex)
+                    {
+                        finalType.UID = lefttype.UID = ci;
+                    }
                     lefttype.UID = finalType.UID;
                 }
-                //if (ci == Constants.kInvalidIndex)
-                if(finalType.UID == Constants.kInvalidIndex)
+                if (ci == Constants.kInvalidIndex)
                 {
                     DfsEmitIdentList(bnode.LeftNode, bnode, contextClassScope, ref lefttype, ref depth, ref finalType, isLeftidentList, graphNode, subPass);
 

--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -640,20 +640,28 @@ namespace ProtoCore
                 // Check if node.LeftNode is a valid class
                 var identListNode = bnode.LeftNode as AST.ImperativeAST.IdentifierListNode;
                 int ci = Constants.kInvalidIndex;
-                bool isImpIdentOrFunc = true;
+                bool isImperativeFunc = true;
 
                 if (identListNode != null)
                 {
-                    isImpIdentOrFunc = identListNode.RightNode is AST.ImperativeAST.IdentifierNode || 
-                                        identListNode.RightNode is AST.ImperativeAST.FunctionCallNode;
-                    var className = CoreUtils.GetIdentifierExceptMethodName(identListNode);
-                    ci = core.ClassTable.IndexOf(className);
-                    if (ci != Constants.kInvalidIndex && !isImpIdentOrFunc)
+                    isImperativeFunc = identListNode.RightNode is AST.ImperativeAST.FunctionCallNode;
+                    //if (isImperativeFunc)
+                    //{
+                    //    var className = CoreUtils.GetIdentifierExceptMethodName(identListNode);
+                    //    ci = core.ClassTable.IndexOf(className);
+                    //}
+                    //else
+                    if(!isImperativeFunc)
+                    {
+                        var className = CoreUtils.GetIdentifierStringUntilFirstParenthesis(identListNode);
+                        ci = core.ClassTable.IndexOf(className);
+                    }
+                    if (ci != Constants.kInvalidIndex && !isImperativeFunc)
                     {
                         finalType.UID = lefttype.UID = ci;
                     }
                 }
-                if (ci == Constants.kInvalidIndex || isImpIdentOrFunc)
+                if (ci == Constants.kInvalidIndex || isImperativeFunc)
                 {
                     DfsEmitIdentList(bnode.LeftNode, bnode, contextClassScope, ref lefttype, ref depth, ref finalType, isLeftidentList, graphNode, subPass);
 

--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -637,13 +637,18 @@ namespace ProtoCore
                     throw new BuildHaltException(message);
                 }
 
-                // Check if node.LeftNode is a valid class
                 var identListNode = bnode.LeftNode as AST.ImperativeAST.IdentifierListNode;
                 int ci = Constants.kInvalidIndex;
                 bool isImperativeFunc = true;
 
                 if (identListNode != null)
                 {
+                    // Check if identListNode is a valid class 
+                    // A valid class exists for the following cases of identListNode:
+                    // A.B.ClassName
+                    // A valid class is not found for the following, in which case, continue recursing into LeftNode:
+                    // A.B.ClassName.foo() where identListNode.RightNode is the function foo()
+                    // A.B.ClassName.Property
                     isImperativeFunc = identListNode.RightNode is AST.ImperativeAST.FunctionCallNode;
                     if(!isImperativeFunc)
                     {

--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -640,17 +640,20 @@ namespace ProtoCore
                 // Check if node.LeftNode is a valid class
                 var identListNode = bnode.LeftNode as AST.ImperativeAST.IdentifierListNode;
                 int ci = Constants.kInvalidIndex;
+                bool isImpIdentOrFunc = true;
 
                 if (identListNode != null)
                 {
+                    isImpIdentOrFunc = identListNode.RightNode is AST.ImperativeAST.IdentifierNode || 
+                                        identListNode.RightNode is AST.ImperativeAST.FunctionCallNode;
                     var className = CoreUtils.GetIdentifierExceptMethodName(identListNode);
                     ci = core.ClassTable.IndexOf(className);
-                    if (ci != Constants.kInvalidIndex)
+                    if (ci != Constants.kInvalidIndex && !isImpIdentOrFunc)
                     {
                         finalType.UID = lefttype.UID = ci;
                     }
                 }
-                if (ci == Constants.kInvalidIndex)
+                if (ci == Constants.kInvalidIndex || isImpIdentOrFunc)
                 {
                     DfsEmitIdentList(bnode.LeftNode, bnode, contextClassScope, ref lefttype, ref depth, ref finalType, isLeftidentList, graphNode, subPass);
 
@@ -2049,7 +2052,9 @@ namespace ProtoCore
             }
         }
 
-        protected void EmitIdentifierListNode(Node node, ref Type inferedType, bool isBooleanOp = false,
+        protected void EmitIdentifierListNode(Node node, 
+            ref Type inferedType, 
+            bool isBooleanOp = false,
             AssociativeGraph.GraphNode graphNode = null,
             CompilerDefinitions.SubCompilePass subPass = CompilerDefinitions.SubCompilePass.None,
             Node bnode = null)

--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -641,7 +641,7 @@ namespace ProtoCore
                 var identListNode = bnode.LeftNode as AST.ImperativeAST.IdentifierListNode;
                 int ci = Constants.kInvalidIndex;
 
-                if (identListNode != null && finalType.UID != Constants.kInvalidIndex)
+                if (identListNode != null)
                 {
                     var className = CoreUtils.GetIdentifierExceptMethodName(identListNode);
                     ci = core.ClassTable.IndexOf(className);
@@ -649,7 +649,6 @@ namespace ProtoCore
                     {
                         finalType.UID = lefttype.UID = ci;
                     }
-                    lefttype.UID = finalType.UID;
                 }
                 if (ci == Constants.kInvalidIndex)
                 {
@@ -667,7 +666,7 @@ namespace ProtoCore
 
             if (node is AST.ImperativeAST.GroupExpressionNode)
             {
-                AST.ImperativeAST.ArrayNode array = node.ArrayDimensions;
+                var array = node.ArrayDimensions;
                 node = node.Expression;
                 node.ArrayDimensions = array;
             }
@@ -680,7 +679,8 @@ namespace ProtoCore
                 node.ArrayDimensions = array;
                 node.ReplicationGuides = replicationGuides;
             }
-            else if (node is AST.ImperativeAST.IdentifierNode || node is AST.AssociativeAST.IdentifierNode)
+
+            if (node is AST.ImperativeAST.IdentifierNode || node is AST.AssociativeAST.IdentifierNode)
             {
                 dynamic identnode = node;
 
@@ -739,7 +739,7 @@ namespace ProtoCore
                         }
                         else
                         {
-                            DSASM.DyanmicVariableNode dynamicVariableNode = new DSASM.DyanmicVariableNode(identnode.Value, globalProcIndex, globalClassIndex);
+                            var dynamicVariableNode = new DSASM.DyanmicVariableNode(identnode.Value, globalProcIndex, globalClassIndex);
                             core.DynamicVariableTable.variableTable.Add(dynamicVariableNode);
                             int dim = 0;
                             if (null != identnode.ArrayDimensions)
@@ -788,8 +788,8 @@ namespace ProtoCore
                     StackValue op = StackValue.Null;
                     if (0 == depth || (symbolnode != null && symbolnode.isStatic))
                     {
-                        if (ProtoCore.DSASM.Constants.kGlobalScope == symbolnode.functionIndex
-                            && ProtoCore.DSASM.Constants.kInvalidIndex != symbolnode.classScope)
+                        if (Constants.kGlobalScope == symbolnode.functionIndex
+                            && Constants.kInvalidIndex != symbolnode.classScope)
                         {
                             // member var
                             if (symbolnode.isStatic)
@@ -822,7 +822,7 @@ namespace ProtoCore
                     else
                     {
                         // change to dynamic call to facilitate update mechanism
-                        DSASM.DyanmicVariableNode dynamicVariableNode = new DSASM.DyanmicVariableNode(identnode.Name, globalProcIndex, globalClassIndex);
+                        var dynamicVariableNode = new DSASM.DyanmicVariableNode(identnode.Name, globalProcIndex, globalClassIndex);
                         core.DynamicVariableTable.variableTable.Add(dynamicVariableNode);
                         StackValue dynamicOp = StackValue.BuildDynamic(core.DynamicVariableTable.variableTable.Count - 1);
                         EmitInstrConsole(ProtoCore.DSASM.kw.pushm, identnode.Value + "[dynamic]");
@@ -858,7 +858,7 @@ namespace ProtoCore
                 {
                     ProtoCore.Utils.NodeUtils.SetNodeLocation(node, binaryExpNode, binaryExpNode);
                 }
-                ProcedureNode procnode = TraverseFunctionCall(node, pNode, lefttype.UID, depth, ref finalType, graphNode, subPass, binaryExpNode);
+                var procnode = TraverseFunctionCall(node, pNode, lefttype.UID, depth, ref finalType, graphNode, subPass, binaryExpNode);
 
                 // Restore the graphNode dependent state
                 if (null != graphNode)

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -724,7 +724,7 @@ namespace ProtoCore.Utils
             return newIdentList;
         }
 
-        public static AST.ImperativeAST.ImperativeNode CreateNodeByCombiningIdentifiers(IList<AST.ImperativeAST.ImperativeNode> nodeList)
+        private static AST.ImperativeAST.ImperativeNode CreateNodeByCombiningIdentifiers(IList<AST.ImperativeAST.ImperativeNode> nodeList)
         {
             int count = nodeList.Count;
             if (count == 0)

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -729,7 +729,7 @@ namespace ProtoCore.Utils
             return newIdentList;
         }
 
-        public static AST.ImperativeAST.ImperativeNode CreateNodeByCombiningIdentifiers(IList<AST.ImperativeAST.ImperativeNode> nodeList)
+        private static AST.ImperativeAST.ImperativeNode CreateNodeByCombiningIdentifiers(IList<AST.ImperativeAST.ImperativeNode> nodeList)
         {
             int count = nodeList.Count;
             if (count == 0)

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -478,8 +478,13 @@ namespace ProtoCore.Utils
         /// </summary>
         /// <param name="identList"></param>
         /// <returns></returns>
-        public static string GetIdentifierStringUntilFirstParenthesis(IdentifierListNode identList)
+        public static string GetIdentifierStringUntilFirstParenthesis(AST.Node node)
         {
+            dynamic identList = node as IdentifierListNode;
+            if(identList == null)
+            {
+                identList = node as AST.ImperativeAST.IdentifierListNode;
+            }
             Validity.Assert(null != identList);
             string identListString = identList.ToString();
             int removeIndex = identListString.IndexOf('(');
@@ -724,7 +729,7 @@ namespace ProtoCore.Utils
             return newIdentList;
         }
 
-        private static AST.ImperativeAST.ImperativeNode CreateNodeByCombiningIdentifiers(IList<AST.ImperativeAST.ImperativeNode> nodeList)
+        public static AST.ImperativeAST.ImperativeNode CreateNodeByCombiningIdentifiers(IList<AST.ImperativeAST.ImperativeNode> nodeList)
         {
             int count = nodeList.Count;
             if (count == 0)

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -545,6 +545,60 @@ namespace ProtoCore.Utils
         }
 
         /// <summary>
+        /// Retrieves the string format of the identifier list from left to right, leaving out any symbols after the last identifier.
+        /// Given: A.B()
+        ///     Return: "A"
+        /// Given: A.B.C()[0]
+        ///     Return: "A.B"
+        /// Given: A.B().C
+        ///     Return: "A"
+        /// Given: A.B[0].C
+        ///     Return: "A.B[0].C"
+        /// Given: A().B (global function)
+        ///     Return: empty string
+        /// Given: A.B[0].C()
+        ///     Return: "A.B[0]"
+        /// </summary>
+        /// <param name="identList"></param>
+        /// <returns></returns>
+        public static string GetIdentifierExceptMethodName(AST.ImperativeAST.IdentifierListNode identList)
+        {
+            Validity.Assert(null != identList);
+
+            var leftNode = identList.LeftNode;
+            var rightNode = identList.RightNode;
+
+            var intermediateNodes = new List<AST.ImperativeAST.ImperativeNode>();
+            if (!(rightNode is AST.ImperativeAST.FunctionCallNode))
+            {
+                intermediateNodes.Insert(0, rightNode);
+            }
+
+            while (leftNode is AST.ImperativeAST.IdentifierListNode)
+            {
+                rightNode = ((AST.ImperativeAST.IdentifierListNode)leftNode).RightNode;
+                if (rightNode is AST.ImperativeAST.FunctionCallNode)
+                {
+                    intermediateNodes.Clear();
+                }
+                else
+                {
+                    intermediateNodes.Insert(0, rightNode);
+                }
+                leftNode = ((AST.ImperativeAST.IdentifierListNode)leftNode).LeftNode;
+
+            }
+            if (leftNode is AST.ImperativeAST.FunctionCallNode)
+            {
+                intermediateNodes.Clear();
+                return "";
+            }
+            intermediateNodes.Insert(0, leftNode);
+
+            return CreateNodeByCombiningIdentifiers(intermediateNodes).ToString();
+        }
+
+        /// <summary>
         /// Inspects the input identifier list to match all class names with the class used in it
         /// </summary>
         /// <param name="classTable"></param>
@@ -659,6 +713,38 @@ namespace ProtoCore.Utils
             for (var n = 2; n < count; ++n)
             {
                 var subIdentList = new IdentifierListNode
+                {
+                    LeftNode = newIdentList,
+                    RightNode = nodeList[n],
+                    Optr = Operator.dot
+                };
+                newIdentList = subIdentList;
+            }
+
+            return newIdentList;
+        }
+
+        public static AST.ImperativeAST.ImperativeNode CreateNodeByCombiningIdentifiers(IList<AST.ImperativeAST.ImperativeNode> nodeList)
+        {
+            int count = nodeList.Count;
+            if (count == 0)
+                return null;
+
+            if (count == 1)
+            {
+                return nodeList[0];
+            }
+
+            var newIdentList = new AST.ImperativeAST.IdentifierListNode
+            {
+                LeftNode = nodeList[0],
+                RightNode = nodeList[1],
+                Optr = Operator.dot
+            };
+
+            for (var n = 2; n < count; ++n)
+            {
+                var subIdentList = new AST.ImperativeAST.IdentifierListNode
                 {
                     LeftNode = newIdentList,
                     RightNode = nodeList[n],

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -315,7 +315,7 @@ namespace ProtoImperative
                 {
                     refClassIndex = core.ClassTable.IndexOf(leftnode.Name);
                 }
-                else if(leftnode is IdentifierListNode)
+                else if (leftnode is IdentifierListNode)
                 {
                     var isFunctionCall = ((IdentifierListNode)leftnode).RightNode is FunctionCallNode;
                     if (!isFunctionCall)
@@ -2326,11 +2326,22 @@ namespace ProtoImperative
             if (identList.LeftNode is IdentifierListNode)
             {
                 var leftNode = (IdentifierListNode)identList.LeftNode;
-                // Check if identList.LeftNode is not a valid class before emitting getters
-                var className = CoreUtils.GetIdentifierExceptMethodName(leftNode);
-                int ci = core.ClassTable.IndexOf(className);
-                var isIdentifierOrFunction = leftNode.RightNode is IdentifierNode || leftNode.RightNode is FunctionCallNode;
-                if (ci == Constants.kInvalidIndex || isIdentifierOrFunction)
+                // Check if leftNode is not a valid class before emitting getters
+                int ci = Constants.kInvalidIndex;
+                //if (leftNode.RightNode is FunctionCallNode)
+                //{
+                //    var className = CoreUtils.GetIdentifierExceptMethodName(leftNode);
+                //    ci = core.ClassTable.IndexOf(className);
+                //}
+                //else
+                var isFuncCall = leftNode.RightNode is FunctionCallNode;
+                if(!isFuncCall)
+                {
+                    var className = CoreUtils.GetIdentifierStringUntilFirstParenthesis(leftNode);
+                    ci = core.ClassTable.IndexOf(className);
+                }
+
+                if (ci == Constants.kInvalidIndex || isFuncCall)
                 {
                     var leftIdentList = identList.LeftNode;
                     var retNode = EmitGettersForRHSIdentList(leftIdentList, ref inferedType, graphNode);

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -2327,6 +2327,11 @@ namespace ProtoImperative
             {
                 var leftNode = (IdentifierListNode)identList.LeftNode;
                 // Check if leftNode is not a valid class before emitting getters
+                // A valid class exists for the following cases of leftNode:
+                // A.B.ClassName
+                // A valid class is not found for the following, in which case, continue recursing into LeftNode:
+                // A.B.ClassName.foo() where leftNode.RightNode is the function foo()
+                // A.B.ClassName.Property
                 int ci = Constants.kInvalidIndex;
                 var isFuncCall = leftNode.RightNode is FunctionCallNode;
                 if(!isFuncCall)

--- a/src/Engine/ProtoImperative/CodeGen.cs
+++ b/src/Engine/ProtoImperative/CodeGen.cs
@@ -2322,9 +2322,9 @@ namespace ProtoImperative
             if (identList.LeftNode is IdentifierListNode)
             {
                 // Check if identList.LeftNode is not a valid class before emitting getters
-                //var className = CoreUtils.GetIdentifierExceptMethodName((IdentifierListNode)identList.LeftNode);
-                //int ci = core.ClassTable.IndexOf(className);
-                if (inferedType.UID == Constants.kInvalidIndex)
+                var className = CoreUtils.GetIdentifierExceptMethodName((IdentifierListNode)identList.LeftNode);
+                int ci = core.ClassTable.IndexOf(className);
+                if (ci == Constants.kInvalidIndex)
                 {
                     var leftIdentList = identList.LeftNode;
                     var retNode = EmitGettersForRHSIdentList(leftIdentList, ref inferedType, graphNode);
@@ -2391,7 +2391,6 @@ namespace ProtoImperative
             {
                 var className = CoreUtils.GetIdentifierExceptMethodName((IdentifierListNode)inode.LeftNode);
                 ci = core.ClassTable.IndexOf(className);
-                inferedType.UID = ci;
             }
 
             if (ci == Constants.kInvalidIndex)

--- a/test/Engine/FFITarget/ClassFunctionality.cs
+++ b/test/Engine/FFITarget/ClassFunctionality.cs
@@ -52,6 +52,11 @@ namespace FFITarget
 
         public static int StaticProp { get; set; }
 
+        public static ClassFunctionality Instance
+        {
+            get { return new ClassFunctionality(2349); }
+        }
+
         public static int get_StaticProperty
         {
             get { return 99; }

--- a/test/Engine/ProtoTest/FFITests/CSFFITest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFITest.cs
@@ -641,7 +641,6 @@ sum;
                             val = a.Value;
                             ";
             Type dummy = typeof (FFITarget.DummyDispose);
-            code = string.Format("import(\"{0}\");\r\n{1}", dummy.AssemblyQualifiedName, code);
             ValidationData[] data = { new ValidationData { ValueName = "val", ExpectedValue = (Int64)(20), BlockIndex = 0 } };
             ExecuteAndVerify(code, data);
         }

--- a/test/Engine/ProtoTest/Imperative/MicroFeatureTests.cs
+++ b/test/Engine/ProtoTest/Imperative/MicroFeatureTests.cs
@@ -1158,6 +1158,30 @@ a = [Imperative]
         }
 
         [Test]
+        public void CallNamespaceQualifiedClassMethod()
+        {
+            var code =
+@"
+import(""DSCoreNodes.dll"");
+import(""BuiltIn.ds"");
+import(""FFITarget.dll"");
+
+a = [Imperative]
+{
+    l = [];
+	d1 = FFITarget.DummyPoint.ByCoordinates(0,9,0);
+	l = DSCore.List.AddItemToEnd(d1, l);
+	d2 = DummyPoint.ByCoordinates(0,10,0);
+	l = List.AddItemToEnd(d2, l);
+	return FFITarget.DummyPoint.Centroid(l).Y;
+};
+  ";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("a", 9.5);
+
+        }
+
+        [Test]
         public void NegativeIndexOnCollection003()
         {
             String code =

--- a/test/Engine/ProtoTest/TD/Imperative/Imperative.cs
+++ b/test/Engine/ProtoTest/TD/Imperative/Imperative.cs
@@ -222,6 +222,40 @@ a1 = test();
         }
 
         [Test]
+        public void TestNamespaceQualifiedStaticProperty()
+        {
+            String code =
+             @"
+			 import(""FFITarget.dll"");
+
+                a=[Imperative]
+                {
+                    ClassFunctionality.StaticProp = 1133;
+                    return FFITarget.ClassFunctionality.StaticProp;
+                };
+            ";
+            ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code);
+            thisTest.Verify("a", 1133);
+        }
+
+        [Test]
+        public void TestNamespaceQualifiedStaticPropertyChaining()
+        {
+            String code =
+             @"
+			 import(""FFITarget.dll"");
+
+                a=[Imperative]
+                {
+                    ClassFunctionality.StaticProp = 1133;
+                    return [FFITarget.ClassFunctionality.Instance.StaticFunction(), FFITarget.ClassFunctionality.Instance.IntVal];
+                };
+            ";
+            ExecutionMirror mirror = thisTest.VerifyRunScriptSource(code);
+            thisTest.Verify("a", new double[] { 1133, 2349 });
+        }
+
+        [Test]
         [Category("DSDefinedClass_Ported")]
         public void T012_ClassConstructorNestedScope_ImplicitTypeConversion()
         {


### PR DESCRIPTION
### Purpose

Support namespace qualifiers in classes used in Imperative blocks: https://jira.autodesk.com/browse/QNTM-5647
![image](https://user-images.githubusercontent.com/5710686/48733377-6580d380-ec3a-11e8-9c2f-df2dc75cad2f.png)
![image](https://user-images.githubusercontent.com/5710686/48733388-792c3a00-ec3a-11e8-96a0-7346a001fa9c.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang @ColinDayOrg 

### FYIs

@smangarole 
