### PR TITLE
pixelRange should be < width or height

### DIFF
--- a/src/Libraries/CoreNodes/FileSystem.cs
+++ b/src/Libraries/CoreNodes/FileSystem.cs
@@ -369,7 +369,10 @@ namespace DSCore.IO
                         y =>
                             Enumerable.Range(0, numX)
                                 .Select(x =>
-                                     Color.ByColor(image.GetPixel(x * (image.Width / (numX-1)), y * (image.Height / (numY-1)))))
+                                     Color.ByColor(image.GetPixel(
+                                     (int)(x * ((float)(image.Width-1) / (numX-1))),
+                                     (int)(y * ((float)(image.Height-1) / (numY-1))))
+                                     ))
                                 .ToArray())
                     .ToArray();
         }


### PR DESCRIPTION
* do floating point math until we actually call GetPixel so that offsets are as close as possible
* max pixel coords should be height -1 and width -1


### Purpose

Last PR had a bug in it - max pixel coords were equal to height,width - image.GexPixels is 0 based.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
@alfarok 
### FYIs

@aparajit-pratap 

I'm going to merge this now and will think about how to test this - I've tried testing symmetry of gradients I can generate online or find in images but they are all slightly non symmetrical themselves so validating the coordinates is difficult, I believe the output is much better than previous though as now we atleast get to the other side of the image. Of course there is still some rounding going on when we pass the pixel coord in float to the getPixel function which accepts an integer. - We do a cast here - which truncates the float - like `Math.Floor`

If there are any failures after this lets revert both of these until we have time to schedule this appropriately.
