### PR TITLE
Fix crash on Node2code operation in case of conflicts with non-unique namespaces

### DIFF
--- a/src/Engine/ProtoCore/Namespace/SymbolTable.cs
+++ b/src/Engine/ProtoCore/Namespace/SymbolTable.cs
@@ -222,6 +222,10 @@ namespace ProtoCore.Namespace
                         break;
                 }
                 Debug.Assert(!shortNamespaces.ContainsKey(symbol));
+                if(string.IsNullOrEmpty(shortName))
+                {
+                    shortName = symbol.FullName;
+                }
                 shortNamespaces.Add(symbol, shortName);
             }
             return shortNamespaces;

--- a/test/Engine/ProtoTest/DebugTests/NamespaceConflictTest.cs
+++ b/test/Engine/ProtoTest/DebugTests/NamespaceConflictTest.cs
@@ -11,7 +11,6 @@ namespace ProtoTest.DebugTests
     {
         [Test]
         [Category("Trace")]
-        [Category("Failure")]
         public void DupImportTest()
         {
             var mirror = thisTest.RunScriptSource(
@@ -23,10 +22,9 @@ b = B.DupTargetTest.DupTargetTest();
 bO = b.Foo();
 "
 );
-            // Tracked by http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1947
-            string defectID = "MAGN-1947 IntegrationTests.NamespaceConflictTest.DupImportTest";
+            thisTest.VerifyBuildWarningCount(ProtoCore.BuildData.WarningID.MultipleSymbolFoundFromName, 1);
             thisTest.Verify("aO", 1);
-            thisTest.Verify("bO", 2);
+            thisTest.Verify("bO", null);
 
         }
 
@@ -53,19 +51,6 @@ p = a;
 );
             thisTest.VerifyBuildWarningCount(ProtoCore.BuildData.WarningID.MultipleSymbolFoundFromName, 1);
             thisTest.Verify("p", null);
-        }
-
-
-        [Test]
-        [Category("Trace")]
-        public void DupImportTestNeg()
-        {
-            var mirror = thisTest.RunScriptSource(
-@"import(""FFITarget.dll"");
-a = DupTargetTest.DupTargetTest(); 
-aO = a.Foo();
-"
-);
         }
     }
 }

--- a/test/Engine/ProtoTest/FFITests/CSFFITest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFITest.cs
@@ -1290,31 +1290,27 @@ a12;
         }
 
         [Test]
-        [Category("Failure")]
         public void TestNamespaceClassResolution()
         {
             // Tracked by http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1947
             string code =
                 @"import(""FFITarget.dll"");
                     import(""BuiltIn.ds"");
-                    x = 1..2;
 
+                    x = 1..2;
                     Xo = x[0];
 
-                    aDup = A.DupTargetTest(x);
+                    aDup = A.DupTargetTest.DupTargetTest(x);
                     aReadback = aDup.Prop[0];
 
-                    bDup = B.DupTargetTest(x);
-                    bReadback = bDup.Prop[1];
-
-                    check = List.Equals(aDup.Prop,bDup.Prop);";
+                    bDup = B.DupTargetTest.DupTargetTest(x);
+                    bReadback = bDup.Prop[1];";
 
             thisTest.RunScriptSource(code);
-            thisTest.Verify("check", true);
             thisTest.Verify("Xo", 1);
 
             thisTest.Verify("aReadback", 1);
-            thisTest.Verify("bReadback", 2);
+            thisTest.Verify("bReadback", null);
 
             TestFrameWork.VerifyBuildWarning(ProtoCore.BuildData.WarningID.MultipleSymbolFound);
             string[] classes = thisTest.GetAllMatchingClasses("DupTargetTest");
@@ -1322,30 +1318,24 @@ a12;
         }
 
         [Test]
-        [Category("Failure")]
         public void TestSubNamespaceClassResolution()
         {
-            // Tracked by http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-1947
             string code =
                 @"import(""FFITarget.dll"");
                     import(""BuiltIn.ds"");
-                    aDup = A.DupTargetTest(0);
+                    aDup = A.DupTargetTest.DupTargetTest(0);
                     aReadback = aDup.Prop;
 
-                    bDup = B.DupTargetTest(1); //This should match exactly BClass.DupTargetTest
+                    bDup = B.DupTargetTest.DupTargetTest(1);
                     bReadback = bDup.Prop;
-                    
-                    cDup = C.B.DupTargetTest(2);
-                    cReadback = cDup.Prop;
 
-                    check = List.Equals(aDup.Prop,bDup.Prop);
-                    check = List.Equals(bDup.Prop,cDup.Prop);
+                    cDup = C.B.DupTargetTest.DupTargetTest(2);
+                    cReadback = cDup.Prop;
 ";
-            string err = "MAGN-1947 IntegrationTests.NamespaceConflictTest.DupImportTest";
-            thisTest.RunScriptSource(code, err);
-            thisTest.Verify("check", true);
+            thisTest.RunScriptSource(code);
             thisTest.Verify("aReadback", 0);
-            thisTest.Verify("bReadback", 1);
+            thisTest.Verify("bDup", null);
+            thisTest.Verify("bReadback", null);
             thisTest.Verify("cReadback", 2);
 
             TestFrameWork.VerifyBuildWarning(ProtoCore.BuildData.WarningID.MultipleSymbolFound);

--- a/test/core/node2code/NonUniqueNamespaceConflict_throwsNodeWarning.dyn
+++ b/test/core/node2code/NonUniqueNamespaceConflict_throwsNodeWarning.dyn
@@ -1,0 +1,74 @@
+{
+  "Uuid": "d975bf5b-a5ef-45af-b39b-ae5704b9b814",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "NonUniqueNamespaceConflict_throwsNodeWarning",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "FFITarget.B.DupTargetTest.DupTargetTest",
+      "Id": "ebb33bb13f4143d5b9ba64c8c421f1c3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "70a9cb93033a431d88de21406cef4241",
+          "Name": "DupTargetTest",
+          "Description": "DupTargetTest",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "DupTargetTest.DupTargetTest ( ): DupTargetTest"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.6876",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "DupTargetTest.DupTargetTest",
+        "Id": "ebb33bb13f4143d5b9ba64c8c421f1c3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 301.333333333333,
+        "Y": 250.666666666667
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose
JIRA link: https://jira.autodesk.com/browse/QNTM-5426

This addresses a crash on performing node to code on class with non-unique namespace with another class: E.g. If there are 2 classes, `B.C.List` and `A.B.C.List`, where `A`, `B`, and `C` are namespaces for 2 classes of the same name `List`, the language cannot distinguish between them even if both classes are pre-qualified with their full namespaces, since in this case `B.C.List` can be considered a partial namespace for `A.B.C.List`. In such a case node to code fails to find a (shortest) unique qualified name for example, a `List.Count` node (as it cannot decide which namespaces to qualify the class `List` with) and returns a `null` for the unique name. The code following this step does not account for a `null` name and thus results in a crash.

The fix is to return the fully qualified name no matter whether it is unique or not so as to prevent the crash and let the code block node throw an error indicating to the user of the namespace conflict as follows:
![image](https://user-images.githubusercontent.com/5710686/48746624-1782c480-ec68-11e8-9f21-7263b1f01acf.png)

The above graph is a result of a node-to-code command on `DSCore.String.ToUpper` node in the presence of another class with the same name belonging to namespace `X.DSCore.String`.

Note: The above error message appears only at compile-time (manual mode). When the graph is executed directly (Auto mode), the runtime error message is not so useful:
![image](https://user-images.githubusercontent.com/5710686/48746865-29189c00-ec69-11e8-8bd3-0f08ba6c4edd.png)

We can consider displaying the above compilation error (which is more useful to the user) as a future improvement. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@ColinDayOrg 

Colin, this is my take on the issue that you've been investigating. I've added some background describing the current behavior, reasons for the crash, and fix. Please take a look.

### FYIs
@mjkkirschner 
