### PR TITLE
Ensure changes to IsInput & IsOutput mark the node/graph as modified

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -35,6 +35,8 @@ namespace Dynamo.Graph.Nodes
         private LacingStrategy argumentLacing = LacingStrategy.Auto;
         private bool displayLabels;
         private bool isVisible;
+        private bool isSetAsInput = false;
+        private bool isSetAsOutput = false;
         private bool canUpdatePeriodically;
         private string name;
         private ElementState state;
@@ -210,7 +212,6 @@ namespace Dynamo.Graph.Nodes
             }
         }
 
-        private bool isSetAsInput = false;
         /// <summary>
         /// This property is user-controllable via a checkbox and is set to true when a user wishes to include
         /// this node in a Customizer as an interactive control.
@@ -231,7 +232,7 @@ namespace Dynamo.Graph.Nodes
                 if (isSetAsInput != value)
                 {
                     isSetAsInput = value;
-                    this.OnNodeModified();
+                    RaisePropertyChanged("IsSetAsInput");
                 }
             }
         }
@@ -249,8 +250,6 @@ namespace Dynamo.Graph.Nodes
                 return !IsCustomFunction;
             }
         }
-
-        private bool isSetAsOutput = false;
 
         /// <summary>
         /// This property is user-controllable via a checkbox and is set to true when a user wishes to include
@@ -272,7 +271,7 @@ namespace Dynamo.Graph.Nodes
                 if (isSetAsOutput != value)
                 {
                     isSetAsOutput = value;
-                    this.OnNodeModified();
+                    RaisePropertyChanged("IsSetAsOutput");
                 }
             }
         }

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -232,7 +232,7 @@ namespace Dynamo.Graph.Nodes
                 if (isSetAsInput != value)
                 {
                     isSetAsInput = value;
-                    RaisePropertyChanged("IsSetAsInput");
+                    RaisePropertyChanged(nameof(IsSetAsInput));
                 }
             }
         }
@@ -271,7 +271,7 @@ namespace Dynamo.Graph.Nodes
                 if (isSetAsOutput != value)
                 {
                     isSetAsOutput = value;
-                    RaisePropertyChanged("IsSetAsOutput");
+                    RaisePropertyChanged(nameof(IsSetAsOutput));
                 }
             }
         }

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -228,7 +228,11 @@ namespace Dynamo.Graph.Nodes
 
             set
             {
-                isSetAsInput = value;
+                if (isSetAsInput != value)
+                {
+                    isSetAsInput = value;
+                    this.OnNodeModified();
+                }
             }
         }
 
@@ -265,7 +269,11 @@ namespace Dynamo.Graph.Nodes
 
             set
             {
-                isSetAsOutput = value;
+                if (isSetAsOutput != value)
+                {
+                    isSetAsOutput = value;
+                    this.OnNodeModified();
+                }
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1072,21 +1072,12 @@ namespace Dynamo.Graph.Workspaces
             node.Modified += NodeModified;
             node.ConnectorAdded += OnConnectorAdded;
             node.UpdateASTCollection +=OnToggleNodeFreeze;
-            node.PropertyChanged += Node_PropertyChanged;
 
             var functionNode = node as Function;
             if (functionNode != null)
             {
                 functionNode.Controller.SyncWithDefinitionStart += OnSyncWithDefinitionStart;
                 functionNode.Controller.SyncWithDefinitionEnd += OnSyncWithDefinitionEnd;
-            }
-        }
-
-        private void Node_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
-        {
-            if(e.PropertyName == "IsSetAsInput" || e.PropertyName == "IsSetAsOutput")
-            {
-                this.HasUnsavedChanges = true;
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -1072,12 +1072,21 @@ namespace Dynamo.Graph.Workspaces
             node.Modified += NodeModified;
             node.ConnectorAdded += OnConnectorAdded;
             node.UpdateASTCollection +=OnToggleNodeFreeze;
+            node.PropertyChanged += Node_PropertyChanged;
 
             var functionNode = node as Function;
             if (functionNode != null)
             {
                 functionNode.Controller.SyncWithDefinitionStart += OnSyncWithDefinitionStart;
                 functionNode.Controller.SyncWithDefinitionEnd += OnSyncWithDefinitionEnd;
+            }
+        }
+
+        private void Node_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if(e.PropertyName == "IsSetAsInput" || e.PropertyName == "IsSetAsOutput")
+            {
+                this.HasUnsavedChanges = true;
             }
         }
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -237,6 +237,14 @@ namespace Dynamo.Controls
                 case "CachedValue":
                     CachedValueChanged();
                     break;
+
+                case "IsSetAsInput":
+                    (this.DataContext as NodeViewModel).DynamoViewModel.CurrentSpace.HasUnsavedChanges = true;
+                    break;
+
+                case "IsSetAsOutput":
+                    (this.DataContext as NodeViewModel).DynamoViewModel.CurrentSpace.HasUnsavedChanges = true;
+                    break;
             }
         }
 

--- a/test/DynamoCoreWpfTests/NodeViewTests.cs
+++ b/test/DynamoCoreWpfTests/NodeViewTests.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
+using Dynamo.Controls;
+using Dynamo.Graph.Workspaces;
+using Dynamo.ViewModels;
 using Dynamo.Selection;
 using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
@@ -169,6 +173,61 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(177.041832898393, node.Y);
 
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+        }
+
+        [Test]
+        public void SettingNodeAsInputOrOutputMarksGraphAsModified()
+        {
+            Open(@"core\isInput_isOutput\IsInput.dyn");
+
+            // Get the node view for a specific node in the graph
+            NodeView nodeView = NodeViewWithGuid("c275ece0-2316-4e27-8d51-915257374c1e");
+
+            // Get a reference to the current workspace
+            NodeViewModel nodeViewModel = (nodeView.DataContext as NodeViewModel);
+            WorkspaceModel ws = nodeViewModel.DynamoViewModel.CurrentSpace;
+
+            // Verify IsSetAsInput is set to true
+            Assert.AreEqual(nodeViewModel.IsSetAsInput, true);
+            // Verify IsSetAsOutput is set to false
+            Assert.AreEqual(nodeViewModel.IsSetAsOutput, false);
+            // Verify the graph is not marked as modified
+            Assert.AreEqual(ws.HasUnsavedChanges, false);
+
+            // Set IsSetAsInput to false
+            nodeViewModel.IsSetAsInput = false;
+            // Verify graph is marked as modified
+            Assert.AreEqual(nodeViewModel.IsSetAsInput, false);
+            Assert.AreEqual(ws.HasUnsavedChanges, true);
+
+            // Save the graph
+            string tempPath = Path.Combine(Path.GetTempPath(), "IsInput.dyn");
+            ws.Save(tempPath);
+
+            // Verify graph is no longer marked as modified
+            Assert.AreEqual(nodeViewModel.IsSetAsInput, false);
+            Assert.AreEqual(ws.HasUnsavedChanges, false);
+
+            // Repeat process for IsSetAsOutput //
+
+            // Verify IsSetAsOutput is set to false
+            Assert.AreEqual(nodeViewModel.IsSetAsOutput, false);
+            // Set IsSetAsOutput to true
+            nodeViewModel.IsSetAsOutput = true;
+
+            // Verify graph is marked as modified
+            Assert.AreEqual(nodeViewModel.IsSetAsOutput, true);
+            Assert.AreEqual(ws.HasUnsavedChanges, true);
+
+            // Save the graph
+            ws.Save(tempPath);
+
+            // Verify graph is no longer marked as modified
+            Assert.AreEqual(nodeViewModel.IsSetAsOutput, true);
+            Assert.AreEqual(ws.HasUnsavedChanges, false);
+
+            // Delete temp file
+            File.Delete(tempPath);
         }
     }
 }


### PR DESCRIPTION
### Purpose

[QNTM-5311](https://jira.autodesk.com/browse/QNTM-5311)

Setting `IsInput` or `IsOutput` should mark the workspace as modified so the user will be notified to `save` when attempting to close a modified graph.  I also noticed undo/redo is also broken for this functionality and working for other context menu items, will file an additional task as it was not included in this scope.

![isinputisoutput](https://user-images.githubusercontent.com/13341935/49040305-32859500-f190-11e8-9cd9-3277557c9b24.gif)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

### FYIs

@saintentropy 
