### PR TITLE
Fix crash with incorrect syntax in CBN in custom node

### DIFF
--- a/src/DynamoCore/Engine/CodeGeneration/AstBuilder.cs
+++ b/src/DynamoCore/Engine/CodeGeneration/AstBuilder.cs
@@ -472,7 +472,7 @@ namespace Dynamo.Engine.CodeGeneration
             else
             {
                 // For single output, directly return that identifier or null.
-                AssociativeNode returnValue = outputs.Count == 1 ? outputs[0] : new NullNode();
+                AssociativeNode returnValue = outputs.Count == 1 && outputs[0] != null ? outputs[0] : new NullNode();
                 functionBody.Body.Add(AstFactory.BuildReturnStatement(returnValue));
             }
 


### PR DESCRIPTION
### Purpose

JIRA: https://jira.autodesk.com/browse/QNTM-4425

The crash occurs at the time of compilation of the custom node definition. It tries to build a `return` AST statement with the output from the code block node but since the code block output is `null` owing to the syntax error, an `ArgumentNullException` is thrown from the `AstFactory.BuildReturnStatement`, which apparently isn't caught anywhere and results in a crash. The fix is to build a `NullNode` if the rhs returned from the code block AST is `null` and then pass this `NullNode` as input to the `BuildReturnStatement` method to generate AST for a `return = null;` statement.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang @ColinDayOrg 

Adding a test case would be tricky here - it would be best to add a recordable test but I'm not sure if we can add these for a custom node workspace. Will check.

