### PR TITLE
More fixes for keepListStructure

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -1835,7 +1835,7 @@ namespace Dynamo.Graph.Nodes
             {
                 case "Level":
                 case "UseLevels":
-                case "ShouldKeepListStructure":
+                case "KeepListStructure":
                     OnNodeModified();
                     break;
                 case "UsingDefaultValue":

--- a/src/DynamoCore/Graph/Nodes/PortModel.cs
+++ b/src/DynamoCore/Graph/Nodes/PortModel.cs
@@ -29,7 +29,7 @@ namespace Dynamo.Graph.Nodes
         private bool usingDefaultValue;
         private bool isEnabled = true;
         private bool useLevels = false;
-        private bool shouldKeepListStructure = false;
+        private bool keepListStructure = false;
         private int level = 1;
         private string toolTip;
         #endregion
@@ -271,14 +271,14 @@ namespace Dynamo.Graph.Nodes
         {
             get
             {
-                return shouldKeepListStructure;
+                return keepListStructure;
             }
             set
             {
-                if (shouldKeepListStructure != value)
+                if (keepListStructure != value)
                 {
-                    shouldKeepListStructure = value;
-                    RaisePropertyChanged("ShouldKeepListStructure");
+                    keepListStructure = value;
+                    RaisePropertyChanged(nameof(KeepListStructure));
                 }
             }
         }

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -191,7 +191,7 @@
                                       TrueBrush="{StaticResource PinnedIconForegroundColor}"
                                       FalseBrush="{StaticResource UnpinnedIconForegroundColor}">
     </controls:BooleanToBrushConverter>
-    <controls:BooleanToBrushConverter x:Key="KeepListStructureHighlighColorConverter"
+    <controls:BooleanToBrushConverter x:Key="KeepListStructureHighlightColorConverter"
                                       TrueBrush="{StaticResource KeepListStructureHighlight}"
                                       FalseBrush="{StaticResource NotKeepListStructureHighlight}">
     </controls:BooleanToBrushConverter>

--- a/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/Ports.xaml
@@ -109,7 +109,7 @@
                     </Rectangle.Margin>
                 </Rectangle>
                 <Rectangle Name="highlightOverlay"
-                       Fill="{Binding Path=ShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlighColorConverter}}"
+                       Fill="{Binding Path=ShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlightColorConverter}}"
                        MinWidth="19"
                        Margin="0,0,0,1"
                        IsHitTestVisible="True">
@@ -174,7 +174,7 @@
                   Visibility="{Binding Path=UseLevelVisibility}">
                 <Rectangle
                     Name="highlightOverlayForArrow" 
-                    Fill="{Binding Path=ShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlighColorConverter}}"
+                    Fill="{Binding Path=ShouldKeepListStructure, Converter={StaticResource KeepListStructureHighlightColorConverter}}"
                     MinWidth="10"
                     Margin="0,0,0,1"
                     IsHitTestVisible="True">


### PR DESCRIPTION

### Purpose

https://jira.autodesk.com/browse/QNTM-4759
I missed some other behaviors which were broken in 2.0 release. I've fixed two of them and added a test.

* The property `KeepListStructure` needs to raise a change notification with the same string or the UI bindings will not fire.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@alfarok 
@ColinDayOrg 

### FYIs

@smangarole 