### PR TITLE
Add ParseJSON and  StringifyJSON to core library 

### DIFF
--- a/src/Libraries/CoreNodes/CoreNodes.csproj
+++ b/src/Libraries/CoreNodes/CoreNodes.csproj
@@ -74,7 +74,7 @@
     <Compile Include="Compare.cs" />
     <Compile Include="DateTime.cs" />
     <Compile Include="FileSystem.cs" />
-    <Compile Include="JSON.cs" />
+    <Compile Include="Data.cs" />
     <Compile Include="List.cs" />
     <Compile Include="Math.cs" />
     <Compile Include="Object.cs" />

--- a/src/Libraries/CoreNodes/CoreNodes.csproj
+++ b/src/Libraries/CoreNodes/CoreNodes.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Compare.cs" />
     <Compile Include="DateTime.cs" />
     <Compile Include="FileSystem.cs" />
+    <Compile Include="JSON.cs" />
     <Compile Include="List.cs" />
     <Compile Include="Math.cs" />
     <Compile Include="Object.cs" />

--- a/src/Libraries/CoreNodes/Data.cs
+++ b/src/Libraries/CoreNodes/Data.cs
@@ -51,18 +51,6 @@ namespace DSCore
             }
         }
 
-        /*
-        /// <summary>
-        ///     Stringify converts an arbitrary value to JSON. It is the opposite of JSON.Parse.
-        /// </summary>
-        /// <param name="value">Any value</param>
-        /// <returns name="json">A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.</returns>
-        public static string Stringify(object value)
-        {
-            return JsonConvert.SerializeObject(value, new DictConverter());
-        }
-        */
-
         /// <summary>
         ///     Stringify converts a list of arbitrary values to JSON. Replication can also be used to apply the operation over a list, producing a list of JSON strings.
         /// </summary>

--- a/src/Libraries/CoreNodes/Data.cs
+++ b/src/Libraries/CoreNodes/Data.cs
@@ -1,22 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Autodesk.DesignScript.Runtime;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace DSCore
 {
-    public static class JSON
+    public static class Data
     {
         /// <summary>
         ///     Parse converts an arbitrary JSON string to a value. It is the opposite of JSON.Stringify.
         /// </summary>
         /// <param name="json">A JSON string</param>
         /// <returns name="result">The result type depends on the content of the input string. The result type can be a primitive value (e.g. string, boolean, double), a List, or a Dictionary.</returns>
-        public static object Parse(string json)
+        public static object ParseJSON(string json)
         {
             return ToNative(JToken.Parse(json));
         }
@@ -53,6 +51,7 @@ namespace DSCore
             }
         }
 
+        /*
         /// <summary>
         ///     Stringify converts an arbitrary value to JSON. It is the opposite of JSON.Parse.
         /// </summary>
@@ -62,13 +61,14 @@ namespace DSCore
         {
             return JsonConvert.SerializeObject(value, new DictConverter());
         }
+        */
 
         /// <summary>
-        ///     StringifyList converts a list of arbitrary values to JSON. JSON.StringifyList is similar to JSON.Stringify, except it doesn't replicate.
+        ///     Stringify converts a list of arbitrary values to JSON. Replication can also be used to apply the operation over a list, producing a list of JSON strings.
         /// </summary>
         /// <param name="values">A List of values</param>
         /// <returns name="json">A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.</returns>
-        public static string StringifyList([ArbitraryDimensionArrayImport] object values)
+        public static string StringifyJSON([ArbitraryDimensionArrayImport] object values)
         {
             return JsonConvert.SerializeObject(values, new DictConverter());
         }

--- a/src/Libraries/CoreNodes/Data.cs
+++ b/src/Libraries/CoreNodes/Data.cs
@@ -52,7 +52,7 @@ namespace DSCore
         }
 
         /// <summary>
-        ///     Stringify converts a list of arbitrary values to JSON. Replication can also be used to apply the operation over a list, producing a list of JSON strings.
+        ///     Stringify converts an arbitrary value or a list of arbitrary values to JSON. Replication can be used to apply the operation over a list, producing a list of JSON strings.
         /// </summary>
         /// <param name="values">A List of values</param>
         /// <returns name="json">A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.</returns>

--- a/src/Libraries/CoreNodes/JSON.cs
+++ b/src/Libraries/CoreNodes/JSON.cs
@@ -15,7 +15,7 @@ namespace DSCore
         ///     Parse converts an arbitrary JSON string to a value. It is the opposite of JSON.Stringify.
         /// </summary>
         /// <param name="json">A JSON string</param>
-        /// <returns name="result"></returns>
+        /// <returns name="result">The result type depends on the content of the input string. The result type can be a primitive value (e.g. string, boolean, double), a List, or a Dictionary.</returns>
         public static object Parse(string json)
         {
             return ToNative(JToken.Parse(json));
@@ -57,22 +57,25 @@ namespace DSCore
         ///     Stringify converts an arbitrary value to JSON. It is the opposite of JSON.Parse.
         /// </summary>
         /// <param name="value">Any value</param>
-        /// <returns name="json">The resultant JSON.</returns>
+        /// <returns name="json">A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.</returns>
         public static string Stringify(object value)
         {
             return JsonConvert.SerializeObject(value, new DictConverter());
         }
 
         /// <summary>
-        ///     Stringify converts a list of arbitrary values to JSON. It is similar to JSON.Stringify, except it doesn't replicate.
+        ///     StringifyList converts a list of arbitrary values to JSON. JSON.StringifyList is similar to JSON.Stringify, except it doesn't replicate.
         /// </summary>
         /// <param name="values">A List of values</param>
-        /// <returns name="json">The resultant JSON</returns>
+        /// <returns name="json">A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.</returns>
         public static string StringifyList([ArbitraryDimensionArrayImport] object values)
         {
             return JsonConvert.SerializeObject(values, new DictConverter());
         }
 
+        /// <summary>
+        /// Ensures DesignScript.Builtin.Dictionary's, which deliberately don't implement IDictionary, are transformed into JSON objects.
+        /// </summary>
         private class DictConverter : JsonConverter
         {
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -1026,7 +1026,15 @@
                 },
                 {
                   "path": "DSOffice.DSOffice.Data.ExportCSV"
-                },
+                }
+              ],
+              "childElements": [ ]
+            },
+            {
+              "text": "JSON",
+              "iconUrl": "",
+              "elementType": "group",
+              "include": [
                 {
                   "path": "DSCoreNodes.DSCore.JSON.Parse"
                 },

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -1032,6 +1032,9 @@
                 },
                 {
                   "path": "DSCoreNodes.DSCore.JSON.Stringify"
+                },
+                {
+                  "path": "DSCoreNodes.DSCore.JSON.StringifyList"
                 }
               ],
               "childElements": [ ]

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -1026,23 +1026,12 @@
                 },
                 {
                   "path": "DSOffice.DSOffice.Data.ExportCSV"
-                }
-              ],
-              "childElements": [ ]
-            },
-            {
-              "text": "JSON",
-              "iconUrl": "",
-              "elementType": "group",
-              "include": [
-                {
-                  "path": "DSCoreNodes.DSCore.JSON.Parse"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.JSON.Stringify"
+                  "path": "DSCoreNodes.DSCore.Data.ParseJSON"
                 },
                 {
-                  "path": "DSCoreNodes.DSCore.JSON.StringifyList"
+                  "path": "DSCoreNodes.DSCore.Data.StringifyJSON"
                 }
               ],
               "childElements": [ ]

--- a/src/LibraryViewExtension/web/library/layoutSpecs.json
+++ b/src/LibraryViewExtension/web/library/layoutSpecs.json
@@ -1026,6 +1026,12 @@
                 },
                 {
                   "path": "DSOffice.DSOffice.Data.ExportCSV"
+                },
+                {
+                  "path": "DSCoreNodes.DSCore.JSON.Parse"
+                },
+                {
+                  "path": "DSCoreNodes.DSCore.JSON.Stringify"
                 }
               ],
               "childElements": [ ]

--- a/test/DynamoCoreTests/DSCoreDataTests.cs
+++ b/test/DynamoCoreTests/DSCoreDataTests.cs
@@ -152,6 +152,18 @@ namespace Dynamo.Tests
             AssertPreviewValue("a0af3136-aaaf-40c2-b2ef-cee522f9ea45", true);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void VerifyDesignScriptMatchesNodes()
+        {
+            // Load test graph
+            string path = Path.Combine(TestDirectory, @"core\json\JSON_Nodes_DesignScript.dyn");
+            OpenModel(path);
+
+            // Verify DesignScript usage of ParseJSON and StringifyJSON results match nodes
+            AssertPreviewValue("5df5ed6d-6270-4018-a479-4f7cefcf7fe8", true);
+        }
+
         // Helper Functions //
 
         // Get node from a provided workspace by searching GUIDs

--- a/test/DynamoCoreTests/DSCoreDataTests.cs
+++ b/test/DynamoCoreTests/DSCoreDataTests.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Workspaces;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Dynamo.Tests
+{
+    internal class DSCoreDataTests : DynamoModelTestBase
+    {
+        // Preload required libraries
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("VMDataBridge.dll");
+            libraries.Add("DesignScriptBuiltin.dll");
+            libraries.Add("DSCoreNodes.dll");
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void LoadJSONFromFile()
+        {
+            // Load JSON file 
+            string jsonFilePath = Path.Combine(TestDirectory, @"core\json\JSONFile.json");
+            JObject jsonObject = JObject.Parse(File.ReadAllText(jsonFilePath));
+
+            // Load JSON file graph
+            string path = Path.Combine(TestDirectory, @"core\json\JSON_Nodes_Test.dyn");
+            OpenModel(path);
+
+            // Get node data
+            WorkspaceModel workspace = CurrentDynamoModel.CurrentWorkspace;
+            var engine = CurrentDynamoModel.EngineController;
+            // Get Dictionary Components node
+            string testNodeGuid = "aa367b7b-22c5-492e-be30-9690c8a45960";
+            NodeModel testNode = getNodeById(workspace, testNodeGuid);
+
+            // Get test node data
+            var rawVal = testNode.GetValue(0, engine).Data;
+
+            // Verify the test node is returning a valid dictionary
+            Assert.AreEqual(typeof(DesignScript.Builtin.Dictionary).FullName, rawVal.GetType().FullName);
+
+            // Compare the keys and values of the node result against the test loaded result
+            var dictionary = (rawVal as DesignScript.Builtin.Dictionary);
+
+            var nodeKeys = dictionary.Keys.ToList();
+            var nodeValues = dictionary.Values.ToList();
+            var localKeys = jsonObject.Properties().Select(p => p.Name).ToList();
+            var localValues = jsonObject.Properties().Select(p => p.Value).ToList();
+
+            // Sort
+            nodeKeys.Sort();
+            localKeys.Sort();
+
+            // Verify list lengths
+            Assert.AreEqual(nodeKeys.Count, localKeys.Count);
+            Assert.AreEqual(nodeValues.Count, nodeValues.Count);
+
+            // Verify keys
+            Assert.AreEqual(nodeKeys, localKeys);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void CompareDictionaryAndJSON()
+        {
+            // Load JSON file 
+            string jsonFilePath = Path.Combine(TestDirectory, @"core\json\JSONFile.json");
+            JObject jsonObject = JObject.Parse(File.ReadAllText(jsonFilePath));
+
+            // Load JSON file graph
+            string path = Path.Combine(TestDirectory, @"core\json\JSON_Nodes_Test.dyn");
+            OpenModel(path);
+
+            // Assert all keys match between Dynamo Dictionary and parsed JSON
+            AssertPreviewValue("5b0b1aba-ee6b-420e-aa12-e54270c00718", true);
+
+            // Assert all values match between Dynamo Dictionary and parsed JSON
+            AssertPreviewValue("5b0b1aba-ee6b-420e-aa12-e54270c00718", true);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void ParseJSON()
+        {
+            // Open the test graph
+            string path = Path.Combine(TestDirectory, @"core\json\JSON_Nodes_Test.dyn");
+            OpenModel(path);
+
+            // Get node data
+            WorkspaceModel workspace = CurrentDynamoModel.CurrentWorkspace;
+            string testNodeGuid = "9dca6adc-dcf2-436a-9317-43a0af5195bc";
+            NodeModel testNode = getNodeById(workspace, testNodeGuid);
+
+            // Expected parsed types
+            string[] expectedOutputs = new string[]
+            {
+                    typeof(System.Boolean).FullName,
+                    typeof(System.Boolean).FullName,
+                    typeof(DesignScript.Builtin.Dictionary).FullName,
+                    typeof(System.String).FullName,
+                    typeof(System.Int64).FullName,
+                    typeof(System.DateTime).FullName,
+                    typeof(System.Double).FullName,
+                    typeof(DesignScript.Builtin.Dictionary).FullName
+            };
+
+            // Verify node output types match expected output
+            AssertPreviewValue(testNode.GUID.ToString(), expectedOutputs);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void StringifyJSON()
+        {
+            // Open the test graph
+            string path = Path.Combine(TestDirectory, @"core\json\JSON_Nodes_Test.dyn");
+            OpenModel(path);
+
+            // Get node data
+            WorkspaceModel workspace = CurrentDynamoModel.CurrentWorkspace;
+            string testNodeGuid = "31f973f9-0764-47e1-b770-7b6b97d8803e";
+            NodeModel testNode = getNodeById(workspace, testNodeGuid);
+
+            // Expected parsed types
+            List<string> expectedOutputs = Enumerable.Repeat(typeof(System.String).FullName, 8).ToList();
+            
+            // Verify node output types match expected output
+            AssertPreviewValue(testNode.GUID.ToString(), expectedOutputs);
+        }
+
+        // Helper Functions //
+
+        // Get node from a provided workspace by searching GUIDs
+        private NodeModel getNodeById(WorkspaceModel workspace, string guid)
+        {
+            foreach (NodeModel node in workspace.Nodes)
+            {
+                if (node.GUID.ToString() == guid)
+                {
+                    return node;
+                }
+            }
+
+            // Node not found, throw
+            throw new Exception("Unable to locate a node in the workspace associated with the provided GUID.");
+        }
+    }
+}

--- a/test/DynamoCoreTests/DSCoreDataTests.cs
+++ b/test/DynamoCoreTests/DSCoreDataTests.cs
@@ -134,6 +134,24 @@ namespace Dynamo.Tests
             AssertPreviewValue(testNode.GUID.ToString(), expectedOutputs);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void VerifyStringifyReplication()
+        {
+            // Load test graph
+            string path = Path.Combine(TestDirectory, @"core\json\JSON_Nodes_Replication.dyn");
+            OpenModel(path);
+
+            // Verify applying replication produces different result
+            AssertPreviewValue("b69f2b6e-a328-43cf-a7a3-db42576ce814", true);
+
+            // Verify DesignScript and node stringify functionality produces the same results - no replication.
+            AssertPreviewValue("e81d053f-dbc5-4b1e-86df-075c9b279aa3", true);
+
+            // Verify DesignScript and node stringify functionality produces the same results - with replication.
+            AssertPreviewValue("a0af3136-aaaf-40c2-b2ef-cee522f9ea45", true);
+        }
+
         // Helper Functions //
 
         // Get node from a provided workspace by searching GUIDs

--- a/test/DynamoCoreTests/DSCoreDataTests.cs
+++ b/test/DynamoCoreTests/DSCoreDataTests.cs
@@ -175,9 +175,6 @@ namespace Dynamo.Tests
             string path = Path.Combine(TestDirectory, @"core\json\JSON_Nodes_PythonJSONParsing.dyn");
             OpenModel(path);
 
-            AssertNoDummyNodes();
-            AssertNullValues();
-
             // Verify keys match when parsing JSON via Python
             AssertPreviewValue("e4e600d9-12a6-400e-adb3-02c1ad26cddf", true);
 

--- a/test/DynamoCoreTests/DSCoreDataTests.cs
+++ b/test/DynamoCoreTests/DSCoreDataTests.cs
@@ -164,6 +164,21 @@ namespace Dynamo.Tests
             AssertPreviewValue("5df5ed6d-6270-4018-a479-4f7cefcf7fe8", true);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void ParsingJSONInPythonReturnsSameResult()
+        {
+            // Load test graph
+            string path = Path.Combine(TestDirectory, @"core\json\JSON_Nodes_PythonJSONParsing.dyn");
+            OpenModel(path);
+
+            // Verify keys match when parsing JSON via Python
+            AssertPreviewValue("e4e600d9-12a6-400e-adb3-02c1ad26cddf", true);
+
+            // Verify values match when parsing JSON via Python
+            AssertPreviewValue("cdad5bf1-f5f7-47f4-a119-ad42e5084cfa", true);
+        }
+
         // Helper Functions //
 
         // Get node from a provided workspace by searching GUIDs

--- a/test/DynamoCoreTests/DSCoreDataTests.cs
+++ b/test/DynamoCoreTests/DSCoreDataTests.cs
@@ -17,6 +17,7 @@ namespace Dynamo.Tests
             libraries.Add("VMDataBridge.dll");
             libraries.Add("DesignScriptBuiltin.dll");
             libraries.Add("DSCoreNodes.dll");
+            libraries.Add("DSIronPython.dll");
             base.GetLibrariesToPreload(libraries);
         }
 
@@ -31,13 +32,14 @@ namespace Dynamo.Tests
             // Load JSON file graph
             string path = Path.Combine(TestDirectory, @"core\json\JSON_Nodes_Test.dyn");
             OpenModel(path);
+            AssertNoDummyNodes();
 
             // Get node data
-            WorkspaceModel workspace = CurrentDynamoModel.CurrentWorkspace;
+            var workspace = CurrentDynamoModel.CurrentWorkspace;
             var engine = CurrentDynamoModel.EngineController;
             // Get Dictionary Components node
-            string testNodeGuid = "aa367b7b-22c5-492e-be30-9690c8a45960";
-            NodeModel testNode = getNodeById(workspace, testNodeGuid);
+            Guid testNodeGuid = Guid.Parse("aa367b7b-22c5-492e-be30-9690c8a45960");
+            NodeModel testNode = workspace.NodeFromWorkspace(testNodeGuid);
 
             // Get test node data
             var rawVal = testNode.GetValue(0, engine).Data;
@@ -93,9 +95,9 @@ namespace Dynamo.Tests
             OpenModel(path);
 
             // Get node data
-            WorkspaceModel workspace = CurrentDynamoModel.CurrentWorkspace;
-            string testNodeGuid = "9dca6adc-dcf2-436a-9317-43a0af5195bc";
-            NodeModel testNode = getNodeById(workspace, testNodeGuid);
+            var workspace = CurrentDynamoModel.CurrentWorkspace;
+            Guid testNodeGuid = Guid.Parse("9dca6adc-dcf2-436a-9317-43a0af5195bc");
+            NodeModel testNode = workspace.NodeFromWorkspace(testNodeGuid);
 
             // Expected parsed types
             string[] expectedOutputs = new string[]
@@ -123,9 +125,9 @@ namespace Dynamo.Tests
             OpenModel(path);
 
             // Get node data
-            WorkspaceModel workspace = CurrentDynamoModel.CurrentWorkspace;
-            string testNodeGuid = "31f973f9-0764-47e1-b770-7b6b97d8803e";
-            NodeModel testNode = getNodeById(workspace, testNodeGuid);
+            var workspace = CurrentDynamoModel.CurrentWorkspace;
+            Guid testNodeGuid = Guid.Parse("31f973f9-0764-47e1-b770-7b6b97d8803e");
+            NodeModel testNode = workspace.NodeFromWorkspace(testNodeGuid);
 
             // Expected parsed types
             List<string> expectedOutputs = Enumerable.Repeat(typeof(System.String).FullName, 8).ToList();
@@ -159,6 +161,7 @@ namespace Dynamo.Tests
             // Load test graph
             string path = Path.Combine(TestDirectory, @"core\json\JSON_Nodes_DesignScript.dyn");
             OpenModel(path);
+            AssertNoDummyNodes();
 
             // Verify DesignScript usage of ParseJSON and StringifyJSON results match nodes
             AssertPreviewValue("5df5ed6d-6270-4018-a479-4f7cefcf7fe8", true);
@@ -172,28 +175,14 @@ namespace Dynamo.Tests
             string path = Path.Combine(TestDirectory, @"core\json\JSON_Nodes_PythonJSONParsing.dyn");
             OpenModel(path);
 
+            AssertNoDummyNodes();
+            AssertNullValues();
+
             // Verify keys match when parsing JSON via Python
             AssertPreviewValue("e4e600d9-12a6-400e-adb3-02c1ad26cddf", true);
 
             // Verify values match when parsing JSON via Python
             AssertPreviewValue("cdad5bf1-f5f7-47f4-a119-ad42e5084cfa", true);
-        }
-
-        // Helper Functions //
-
-        // Get node from a provided workspace by searching GUIDs
-        private NodeModel getNodeById(WorkspaceModel workspace, string guid)
-        {
-            foreach (NodeModel node in workspace.Nodes)
-            {
-                if (node.GUID.ToString() == guid)
-                {
-                    return node;
-                }
-            }
-
-            // Node not found, throw
-            throw new Exception("Unable to locate a node in the workspace associated with the provided GUID.");
         }
     }
 }

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -80,6 +80,7 @@
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
     <Compile Include="AnalyticsTests.cs" />
+    <Compile Include="DSCoreDataTests.cs" />
     <Compile Include="HomgeneousListTests.cs" />
     <Compile Include="AtLevelTest.cs" />
     <Compile Include="AttributeTest.cs" />

--- a/test/core/json/JSONFile.json
+++ b/test/core/json/JSONFile.json
@@ -1,0 +1,51 @@
+{
+	"Lisa Rose": {
+		"Lady in the Water": 2.5,
+		"Snakes on a Plane": 3.5,
+ 		"Just My Luck": 3.0,
+ 		"Superman Returns": 3.5,
+ 		"You, Me and Dupree": 2.5,
+ 		"The Night Listener": 3.0
+ 	},
+	"Gene Seymour": {
+		"Lady in the Water": 3.0,
+		"Snakes on a Plane": 3.5,
+ 		"Just My Luck": 1.5,
+ 		"Superman Returns": 5.0,
+ 		"The Night Listener": 3.0,
+ 		"You, Me and Dupree": 3.5
+ 	},
+	"Michael Phillips": {
+		"Lady in the Water": 2.5,
+		"Snakes on a Plane": 3.0,
+ 		"Superman Returns": 3.5,
+ 		"The Night Listener": 4.0
+ 	},
+	"Claudia Puig": {
+		"Snakes on a Plane": 3.5,
+		"Just My Luck": 3.0,
+ 		"The Night Listener": 4.5,
+ 		"Superman Returns": 4.0,
+ 		"You, Me and Dupree": 2.5
+ 	},
+	"Mick LaSalle": {
+		"Lady in the Water": 3.0,
+		"Snakes on a Plane": 4.0,
+ 		"Just My Luck": 2.0,
+ 		"Superman Returns": 3.0,
+ 		"The Night Listener": 3.0,
+ 		"You, Me and Dupree": 2.0
+ 	},
+	"Jack Matthews": {
+		"Lady in the Water": 3.0,
+		"Snakes on a Plane": 4.0,
+ 		"The Night Listener": 3.0,
+ 		"Superman Returns": 5.0,
+ 		"You, Me and Dupree": 3.5
+ 	},
+	"Toby": {
+		"Snakes on a Plane":4.5,
+		"You, Me and Dupree":1.0,
+		"Superman Returns":4.0
+	}
+}

--- a/test/core/json/JSON_Nodes_DesignScript.dyn
+++ b/test/core/json/JSON_Nodes_DesignScript.dyn
@@ -1,0 +1,857 @@
+{
+  "Uuid": "1930b3c5-827c-401a-8d8d-0e2cf87bd4f2",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "JSON_Nodes_DesignScript",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "DSCore.Data": {
+        "Key": "DSCore.Data",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
+      },
+      "DSCore.Object": {
+        "Key": "DSCore.Object",
+        "Value": "DSCoreNodes.dll"
+      },
+      "Color": {
+        "Key": "DSCore.Color",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSCore.DateTime.Now": {
+        "Key": "DSCore.DateTime",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSCore.DateTime": {
+        "Key": "DSCore.DateTime",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSOffice.Data": {
+        "Key": "DSOffice.Data",
+        "Value": "DSOffice.dll"
+      },
+      "String": {
+        "Key": "DSCore.String",
+        "Value": "DSCoreNodes.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "{\"thing\":1};",
+      "Id": "9896e2e584ab4878995edabf655adb7f",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "09054552ae5b4a50810d7336bfac6fb8",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "DSCore.Data.ParseJSON(\"{'thing':1}\");",
+      "Id": "5d92427abe284dfd923123d0f46a154e",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "05beb3e9dc2c49d3981af756af188a81",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "==@var[]..[],var[]..[]",
+      "Id": "cc757866fc9f4b03ab7ac29bd24c2691",
+      "Inputs": [
+        {
+          "Id": "6abf369204a6475fa981d3ed59d0d7ac",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0f0034411af04da9b5bd1c7d19058fc1",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "24111d1d3d164d8387a982f412c03e7f",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Equal x to y?\n\n== (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Keys",
+      "Id": "fd2adefe0ae24c82b9a21e37bc3270cc",
+      "Inputs": [
+        {
+          "Id": "cd235574e98445c8bd7d693ba5181989",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "f84ff287e2414841ab117faf67398c65",
+          "Name": "keys",
+          "Description": "The keys of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the keys in a Dictionary.\n\nDictionary.Keys: string[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Values",
+      "Id": "a10d121afa164294b34b55028b0bcc75",
+      "Inputs": [
+        {
+          "Id": "587c9178123f4c05ac80d5f0c5e0911a",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "61a8e729991242bf878be4f565689357",
+          "Name": "values",
+          "Description": "The values of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the values in a Dictionary.\n\nDictionary.Values: var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Values",
+      "Id": "6344c9f0cf4e42f1899e113e59648805",
+      "Inputs": [
+        {
+          "Id": "ffebefcaeb6f42688c18f7c3d9657194",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "0287514e607c459789e82f4a5691bc08",
+          "Name": "values",
+          "Description": "The values of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the values in a Dictionary.\n\nDictionary.Values: var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Keys",
+      "Id": "4c67c8c398d441e6b2dcc77d2af578aa",
+      "Inputs": [
+        {
+          "Id": "2c8f9e54eb334039a143c22f3074a472",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "0a68fd4de7d64f5ba20ba6ef77f67e4a",
+          "Name": "keys",
+          "Description": "The keys of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the keys in a Dictionary.\n\nDictionary.Keys: string[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "==@var[]..[],var[]..[]",
+      "Id": "7fbaf41bd837408e853535e4bbe53d96",
+      "Inputs": [
+        {
+          "Id": "fae7bccf26f94e128144e3c4b12a0e15",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5735fa02e5da48ec82400ae2971933a1",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "4bc55a5638fe4f20903eff5b810eadbe",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Equal x to y?\n\n== (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.CreateList, CoreNodeModels",
+      "VariableInputPorts": true,
+      "NodeType": "ExtensionNode",
+      "Id": "65076e6059454a6c9219e7999d7f329e",
+      "Inputs": [
+        {
+          "Id": "16113b2134dd4695b20e2c60c3a316ce",
+          "Name": "item0",
+          "Description": "Item Index #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c15e80c532494bf0a94ca004e76f4a24",
+          "Name": "item1",
+          "Description": "Item Index #1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "51c636f8376e4dbaa1bbe2a220abf31d",
+          "Name": "item2",
+          "Description": "Item Index #2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "30551afc49134e968215d7a685177dd9",
+          "Name": "list",
+          "Description": "A list",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Makes a new list out of the given inputs"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "DSCore.Data.StringifyJSON(x);",
+      "Id": "db5ae39ba8af4af38123c862b196b257",
+      "Inputs": [
+        {
+          "Id": "177f1f89d43a4ad898e57b09d3c4fd11",
+          "Name": "x",
+          "Description": "x",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "71aadd6eccdb4a0a99fa4d595d0b2a1d",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Data.StringifyJSON@var[]..[]",
+      "Id": "2317517171a8444780ab7faedb0b0cbe",
+      "Inputs": [
+        {
+          "Id": "11780133094642d58b214023613d7a58",
+          "Name": "values",
+          "Description": "A List of values\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "839d76c17b5543fb9287c94f0907e795",
+          "Name": "json",
+          "Description": "A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Stringify converts a list of arbitrary values to JSON. Replication can also be used to apply the operation over a list, producing a list of JSON strings.\n\nData.StringifyJSON (values: var[]..[]): string"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "==@var[]..[],var[]..[]",
+      "Id": "03c6ad2f1bf44f6a877b7a90a5d55376",
+      "Inputs": [
+        {
+          "Id": "03677669fec048f2b5671a637d672c53",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e5bb4f98bfc2469bb9a2489082ab6a06",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "a9e26722bbc240019045484ae4796ec5",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Equal x to y?\n\n== (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.Flatten@var[]..[],int",
+      "Id": "2ca52e0784bc49588d1db3de49b2727e",
+      "Inputs": [
+        {
+          "Id": "7705b44f95a746fc81158f8c42c946b3",
+          "Name": "list",
+          "Description": "List to flatten.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "945c2785706f437f880b20a131cbb62e",
+          "Name": "amt",
+          "Description": "Layers of nesting to remove.\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "06f763a48957445c9c8cda3b69e355cb",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Flattens a nested list of lists by a certain amount.\n\nList.Flatten (list: var[]..[], amt: int = -1): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.Flatten@var[]..[],int",
+      "Id": "db35c87a67b5499e989c0e27a5740745",
+      "Inputs": [
+        {
+          "Id": "3dff3d5f7a6546419bbf51f690f50164",
+          "Name": "list",
+          "Description": "List to flatten.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c780afb00cff4939bf917605762ddec7",
+          "Name": "amt",
+          "Description": "Layers of nesting to remove.\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "213550ae03af4694aa2f5c93b84e12b2",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Flattens a nested list of lists by a certain amount.\n\nList.Flatten (list: var[]..[], amt: int = -1): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.AllTrue@var[]..[]",
+      "Id": "5df5ed6d62704018a4794f7cefcf7fe8",
+      "Inputs": [
+        {
+          "Id": "2284def686834c01a51dd245fece034e",
+          "Name": "list",
+          "Description": "List to be checked on whether all items are true.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "6f23188ff678436eb8e62f7b263cfe5f",
+          "Name": "bool",
+          "Description": "Whether all items are true.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Determines if all items in the given list is a boolean and has a true value.\n\nList.AllTrue (list: var[]..[]): bool"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "09054552ae5b4a50810d7336bfac6fb8",
+      "End": "cd235574e98445c8bd7d693ba5181989",
+      "Id": "eb69b2bac98f4f9db78f9edf511840ca"
+    },
+    {
+      "Start": "09054552ae5b4a50810d7336bfac6fb8",
+      "End": "587c9178123f4c05ac80d5f0c5e0911a",
+      "Id": "76482dcd62aa49bc84aead5287bc79aa"
+    },
+    {
+      "Start": "09054552ae5b4a50810d7336bfac6fb8",
+      "End": "177f1f89d43a4ad898e57b09d3c4fd11",
+      "Id": "e7d798e336eb4bdfb46fd642aeba71d2"
+    },
+    {
+      "Start": "09054552ae5b4a50810d7336bfac6fb8",
+      "End": "11780133094642d58b214023613d7a58",
+      "Id": "ad15b91a7d764c399bcf5d09da73587c"
+    },
+    {
+      "Start": "05beb3e9dc2c49d3981af756af188a81",
+      "End": "2c8f9e54eb334039a143c22f3074a472",
+      "Id": "940607312dd945379cfde89239e81f6f"
+    },
+    {
+      "Start": "05beb3e9dc2c49d3981af756af188a81",
+      "End": "ffebefcaeb6f42688c18f7c3d9657194",
+      "Id": "345c57aaab5c43eaac5b1c800a7448bb"
+    },
+    {
+      "Start": "24111d1d3d164d8387a982f412c03e7f",
+      "End": "3dff3d5f7a6546419bbf51f690f50164",
+      "Id": "563a771575754fc8b4713131b114d1af"
+    },
+    {
+      "Start": "f84ff287e2414841ab117faf67398c65",
+      "End": "0f0034411af04da9b5bd1c7d19058fc1",
+      "Id": "94c15ebbfa3a4dc38ae9853c3e2a3580"
+    },
+    {
+      "Start": "61a8e729991242bf878be4f565689357",
+      "End": "5735fa02e5da48ec82400ae2971933a1",
+      "Id": "36ccb197f9c044759cb99a8729669237"
+    },
+    {
+      "Start": "0287514e607c459789e82f4a5691bc08",
+      "End": "fae7bccf26f94e128144e3c4b12a0e15",
+      "Id": "6c01ab84ac7843229732f9f5e10be15d"
+    },
+    {
+      "Start": "0a68fd4de7d64f5ba20ba6ef77f67e4a",
+      "End": "6abf369204a6475fa981d3ed59d0d7ac",
+      "Id": "50c44c35e7ae42b6939135170ce7dd8f"
+    },
+    {
+      "Start": "4bc55a5638fe4f20903eff5b810eadbe",
+      "End": "7705b44f95a746fc81158f8c42c946b3",
+      "Id": "f7a58cd7f895439bb8c70c34e33fe6f1"
+    },
+    {
+      "Start": "30551afc49134e968215d7a685177dd9",
+      "End": "2284def686834c01a51dd245fece034e",
+      "Id": "b2a9c3bd1b0949519f53dd84e90ff84c"
+    },
+    {
+      "Start": "71aadd6eccdb4a0a99fa4d595d0b2a1d",
+      "End": "03677669fec048f2b5671a637d672c53",
+      "Id": "5fdb03b64fbb4b858b148cb4178fd329"
+    },
+    {
+      "Start": "839d76c17b5543fb9287c94f0907e795",
+      "End": "e5bb4f98bfc2469bb9a2489082ab6a06",
+      "Id": "1213be0a83de49a58010f02a06b2543c"
+    },
+    {
+      "Start": "a9e26722bbc240019045484ae4796ec5",
+      "End": "51c636f8376e4dbaa1bbe2a220abf31d",
+      "Id": "e5f70cc94be1406d9e1ab8b431af63f1"
+    },
+    {
+      "Start": "06f763a48957445c9c8cda3b69e355cb",
+      "End": "c15e80c532494bf0a94ca004e76f4a24",
+      "Id": "7603f82a33c94b90ac40d5cdfef27b3c"
+    },
+    {
+      "Start": "213550ae03af4694aa2f5c93b84e12b2",
+      "End": "16113b2134dd4695b20e2c60c3a316ce",
+      "Id": "66f6f6ae41c84f22a6d40481ff15027c"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.7026",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": 21.867825578044727,
+      "EyeY": 19.274547487046178,
+      "EyeZ": 31.756911571437136,
+      "LookX": -28.37709460685215,
+      "LookY": -23.334097814445666,
+      "LookZ": -18.917563478535403,
+      "UpX": -0.31169405899427993,
+      "UpY": 0.92718385456678731,
+      "UpZ": -0.20779055180239758
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "9896e2e584ab4878995edabf655adb7f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1789.7616646786505,
+        "Y": -502.42254681249773
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "5d92427abe284dfd923123d0f46a154e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1693.3259793534196,
+        "Y": -744.68277604760078
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "==",
+        "Id": "cc757866fc9f4b03ab7ac29bd24c2691",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2379.9796567976732,
+        "Y": -771.35231587239775
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.Keys",
+        "Id": "fd2adefe0ae24c82b9a21e37bc3270cc",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2068.152475403444,
+        "Y": -592.38649010401866
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.Values",
+        "Id": "a10d121afa164294b34b55028b0bcc75",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2070.1069579898417,
+        "Y": -508.11662416979721
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.Values",
+        "Id": "6344c9f0cf4e42f1899e113e59648805",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2073.4897844139373,
+        "Y": -701.31202707784837
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.Keys",
+        "Id": "4c67c8c398d441e6b2dcc77d2af578aa",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2071.5353018275373,
+        "Y": -785.58189301206937
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "==",
+        "Id": "7fbaf41bd837408e853535e4bbe53d96",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2369.9964667413728,
+        "Y": -573.248269939633
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List Create",
+        "Id": "65076e6059454a6c9219e7999d7f329e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2892.2344105248621,
+        "Y": -599.79751106793049
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "db5ae39ba8af4af38123c862b196b257",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2053.490362487591,
+        "Y": -392.12315034410852
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Data.StringifyJSON",
+        "Id": "2317517171a8444780ab7faedb0b0cbe",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2151.6786533083118,
+        "Y": -288.0003585633599
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "==",
+        "Id": "03c6ad2f1bf44f6a877b7a90a5d55376",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2370.7384086462985,
+        "Y": -340.20598399714703
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.Flatten",
+        "Id": "2ca52e0784bc49588d1db3de49b2727e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2578.3290990634664,
+        "Y": -572.99247622124949
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.Flatten",
+        "Id": "db35c87a67b5499e989c0e27a5740745",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2582.4131234756892,
+        "Y": -769.31212484498258
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.AllTrue",
+        "Id": "5df5ed6d62704018a4794f7cefcf7fe8",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3112.5072050932667,
+        "Y": -601.77048937872564
+      }
+    ],
+    "Annotations": [
+      {
+        "Id": "47310fb3243444d98b8242c37612c3a2",
+        "Title": "DesignScript vs Nodes",
+        "Nodes": [
+          "9896e2e584ab4878995edabf655adb7f",
+          "5d92427abe284dfd923123d0f46a154e",
+          "cc757866fc9f4b03ab7ac29bd24c2691",
+          "fd2adefe0ae24c82b9a21e37bc3270cc",
+          "a10d121afa164294b34b55028b0bcc75",
+          "6344c9f0cf4e42f1899e113e59648805",
+          "4c67c8c398d441e6b2dcc77d2af578aa",
+          "7fbaf41bd837408e853535e4bbe53d96",
+          "65076e6059454a6c9219e7999d7f329e",
+          "db5ae39ba8af4af38123c862b196b257",
+          "2317517171a8444780ab7faedb0b0cbe",
+          "03c6ad2f1bf44f6a877b7a90a5d55376",
+          "2ca52e0784bc49588d1db3de49b2727e",
+          "db35c87a67b5499e989c0e27a5740745"
+        ],
+        "Left": 1683.3259793534196,
+        "Top": -838.58189301206937,
+        "Width": 1338.9084311714425,
+        "Height": 643.58153444870948,
+        "FontSize": 36.0,
+        "InitialTop": -785.58189301206937,
+        "InitialHeight": 620.58153444870948,
+        "TextblockHeight": 43.0,
+        "Background": "#FF848484"
+      },
+      {
+        "Id": "300496ad79f44f5e933dc789a0fc42b9",
+        "Title": "Verify JSON DesignScript produces same results as nodes.\r\n5df5ed6d-6270-4018-a479-4f7cefcf7fe8",
+        "Nodes": [
+          "5df5ed6d62704018a4794f7cefcf7fe8"
+        ],
+        "Left": 3102.5072050932667,
+        "Top": -698.27048937872564,
+        "Width": 433.24666666666667,
+        "Height": 189.5,
+        "FontSize": 24.0,
+        "InitialTop": -601.77048937872564,
+        "InitialHeight": 123.0,
+        "TextblockHeight": 86.5,
+        "Background": "#FFC1D676"
+      }
+    ],
+    "X": -1062.437691353759,
+    "Y": 801.0493989261372,
+    "Zoom": 0.73189294402694061
+  }
+}

--- a/test/core/json/JSON_Nodes_PythonJSONParsing.dyn
+++ b/test/core/json/JSON_Nodes_PythonJSONParsing.dyn
@@ -1,0 +1,926 @@
+{
+  "Uuid": "1930b3c5-827c-401a-8d8d-0e2cf87bd4f2",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "JSON_Nodes_PythonJSONParsing",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "DSCore.Data": {
+        "Key": "DSCore.Data",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
+      },
+      "DSCore.Object": {
+        "Key": "DSCore.Object",
+        "Value": "DSCoreNodes.dll"
+      },
+      "Color": {
+        "Key": "DSCore.Color",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSCore.DateTime.Now": {
+        "Key": "DSCore.DateTime",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSCore.DateTime": {
+        "Key": "DSCore.DateTime",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSOffice.Data": {
+        "Key": "DSOffice.Data",
+        "Value": "DSOffice.dll"
+      },
+      "String": {
+        "Key": "DSCore.String",
+        "Value": "DSCoreNodes.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Input.StringInput, CoreNodeModels",
+      "NodeType": "StringInputNode",
+      "InputValue": "{\"Lisa Rose\": {\"Lady in the Water\": 2.5, \"Snakes on a Plane\": 3.5,\r\n \"Just My Luck\": 3.0, \"Superman Returns\": 3.5, \"You, Me and Dupree\": 2.5, \r\n \"The Night Listener\": 3.0},\r\n\"Gene Seymour\": {\"Lady in the Water\": 3.0, \"Snakes on a Plane\": 3.5, \r\n \"Just My Luck\": 1.5, \"Superman Returns\": 5.0, \"The Night Listener\": 3.0, \r\n \"You, Me and Dupree\": 3.5}, \r\n\"Michael Phillips\": {\"Lady in the Water\": 2.5, \"Snakes on a Plane\": 3.0,\r\n \"Superman Returns\": 3.5, \"The Night Listener\": 4.0},\r\n\"Claudia Puig\": {\"Snakes on a Plane\": 3.5, \"Just My Luck\": 3.0,\r\n \"The Night Listener\": 4.5, \"Superman Returns\": 4.0, \r\n \"You, Me and Dupree\": 2.5},\r\n\"Mick LaSalle\": {\"Lady in the Water\": 3.0, \"Snakes on a Plane\": 4.0, \r\n \"Just My Luck\": 2.0, \"Superman Returns\": 3.0, \"The Night Listener\": 3.0,\r\n \"You, Me and Dupree\": 2.0}, \r\n\"Jack Matthews\": {\"Lady in the Water\": 3.0, \"Snakes on a Plane\": 4.0,\r\n \"The Night Listener\": 3.0, \"Superman Returns\": 5.0, \"You, Me and Dupree\": 3.5},\r\n\"Toby\": {\"Snakes on a Plane\":4.5,\"You, Me and Dupree\":1.0,\"Superman Returns\":4.0}}",
+      "Id": "ef6fde2c28f04625a6ab85e80c7b31c6",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "fa662a4bc8d9440188676ce61bf1c625",
+          "Name": "",
+          "Description": "String",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a string."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Data.ParseJSON@string",
+      "Id": "6ffabd95f6034f2fa6f7da1c1fcc0cae",
+      "Inputs": [
+        {
+          "Id": "aacca3ba5dfe4b4daed986a203b0b230",
+          "Name": "json",
+          "Description": "A JSON string\n\nstring",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8ba0501216904d3dbc852c716ff0a8c3",
+          "Name": "result",
+          "Description": "The result type depends on the content of the input string. The result type can be a primitive value (e.g. string, boolean, double), a List, or a Dictionary.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Parse converts an arbitrary JSON string to a value. It is the opposite of JSON.Stringify.\n\nData.ParseJSON (json: string): var[]..[]"
+    },
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "import json\r\n\r\ndataEnteringNode = IN\r\njsonString = IN[0]\r\nuser = IN[1]\r\n\r\njsonObject = json.loads(jsonString)\r\nuserData = jsonObject[user]\r\n\r\nkeys = []\r\nvalues = []\r\n\r\nfor key in userData:\r\n\tkeys.append(key)\r\n\t# String conversion required until\r\n\t# dictionary marshalling is handled\r\n\tvalues.append(userData[key])\r\n\r\nOUT = [keys, values]",
+      "VariableInputPorts": true,
+      "Id": "779061094688496285e56d9a328a5d3a",
+      "Inputs": [
+        {
+          "Id": "a299696d83114338a32ab5fc7f9d6ace",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a36fa9e4667645bcb9fd5d323c865871",
+          "Name": "IN[1]",
+          "Description": "Input #1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "0f2a5482f3344f3882e0d1d6fa538eb3",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded IronPython script."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"Lisa Rose\";",
+      "Id": "1fef9be1da6f408393d454b8aec11705",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "e7f642f033534a228b0e4b9832cad7e2",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "keys = out[0];\nvalues = out[1];",
+      "Id": "d87d6380630649cca2f86b9e7b053799",
+      "Inputs": [
+        {
+          "Id": "53003810c5f44358a1cc7909b3243747",
+          "Name": "out",
+          "Description": "out",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "bf7c44f4d39844b68a7d5b088170d216",
+          "Name": "",
+          "Description": "keys",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "34c03b8aa96941c58cfde9e1ab16b29b",
+          "Name": "",
+          "Description": "values",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.ValueAtKey@string",
+      "Id": "5778370a7ee74066b1a73763ac892ebf",
+      "Inputs": [
+        {
+          "Id": "b7f35246239649f1ae6216b5c45eb252",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "82c747a1c5ce4bd0936174746a5de1ca",
+          "Name": "key",
+          "Description": "The key in the Dictionary to obtain.\n\nstring",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9b4540e5237944dea8a676bf1eb29110",
+          "Name": "value",
+          "Description": "The value at the specified key or null if it is not set.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Obtain the value at a specified key\n\nDictionary.ValueAtKey (key: string): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Keys",
+      "Id": "0794a62dd0ee4c70852cab647051d0d8",
+      "Inputs": [
+        {
+          "Id": "0def5511c88f411f9d63dd40c80f6fb5",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "081e65273ca54914b9764995838695f4",
+          "Name": "keys",
+          "Description": "The keys of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the keys in a Dictionary.\n\nDictionary.Keys: string[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Values",
+      "Id": "c712f0c408b64c76967b71f792288d91",
+      "Inputs": [
+        {
+          "Id": "5ddb853331004434bda90455d039ab9b",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "97b81f3206884fd5ae581fe3127ff93b",
+          "Name": "values",
+          "Description": "The values of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the values in a Dictionary.\n\nDictionary.Values: var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "==@var[]..[],var[]..[]",
+      "Id": "c5f4378f241e47bd866a650b009df83f",
+      "Inputs": [
+        {
+          "Id": "60598df75b27408286e9729b32bdba7f",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e12c8d46553e4b9dbffc53c4e9b1f1b0",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "100088eb5f104087a03784361b967736",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Equal x to y?\n\n== (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.Sort@var[]",
+      "Id": "2aa594928a4841e7899eb8aaf1eb0cd6",
+      "Inputs": [
+        {
+          "Id": "e98f923977f142988a6388f0822a5692",
+          "Name": "list",
+          "Description": "The list of items to be sorted.\n\nvar[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "cecaac1f0f634f9f92904e9ed95b69d3",
+          "Name": "newList",
+          "Description": "The indices of the items in the sorted list.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Sorts a list by the items and return their indices.\n\nList.Sort (list: var[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.Sort@var[]",
+      "Id": "692715347cc94fecbb098abebbd7e9d1",
+      "Inputs": [
+        {
+          "Id": "f43d3e3ca4ef4d059c2b8dba76ca3e0f",
+          "Name": "list",
+          "Description": "The list of items to be sorted.\n\nvar[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "264ebbfa893f46c3a52bf9f6a6014734",
+          "Name": "newList",
+          "Description": "The indices of the items in the sorted list.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Sorts a list by the items and return their indices.\n\nList.Sort (list: var[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "==@var[]..[],var[]..[]",
+      "Id": "0acfced04037419da1e459da6e4e2d3b",
+      "Inputs": [
+        {
+          "Id": "e49dba07946146d6b16e328a0ee1d879",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "94339aeb28804bcfafd75b0fa7b90791",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "eac7182e955f40b09a2800c0f3081907",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Equal x to y?\n\n== (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.Sort@var[]",
+      "Id": "b5a54dcf3dfd485ebd771356780b8495",
+      "Inputs": [
+        {
+          "Id": "5c1a41cac413484c8aa4ce3c41bcb7cf",
+          "Name": "list",
+          "Description": "The list of items to be sorted.\n\nvar[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "83035afaf1ff4af0973f5199d84036ea",
+          "Name": "newList",
+          "Description": "The indices of the items in the sorted list.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Sorts a list by the items and return their indices.\n\nList.Sort (list: var[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.Sort@var[]",
+      "Id": "93d189b6cfd24cc8839ef3f432378ec4",
+      "Inputs": [
+        {
+          "Id": "29310781d81241caa05785f586c9e32c",
+          "Name": "list",
+          "Description": "The list of items to be sorted.\n\nvar[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e0500d8a64034f8288cf2a34bdea9f1f",
+          "Name": "newList",
+          "Description": "The indices of the items in the sorted list.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Sorts a list by the items and return their indices.\n\nList.Sort (list: var[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.AllTrue@var[]..[]",
+      "Id": "e4e600d912a6400eadb302c1ad26cddf",
+      "Inputs": [
+        {
+          "Id": "b0fe6959b4874bc9b1732d2300d78553",
+          "Name": "list",
+          "Description": "List to be checked on whether all items are true.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "254195ac25b546da82a5c4803dc22ee0",
+          "Name": "bool",
+          "Description": "Whether all items are true.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Determines if all items in the given list is a boolean and has a true value.\n\nList.AllTrue (list: var[]..[]): bool"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.AllTrue@var[]..[]",
+      "Id": "cdad5bf1f5f747f4a119ad42e5084cfa",
+      "Inputs": [
+        {
+          "Id": "99c38e3a3c6448aaae957cd8717a409b",
+          "Name": "list",
+          "Description": "List to be checked on whether all items are true.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e3529807d86f4869a9df5a68e86877ee",
+          "Name": "bool",
+          "Description": "Whether all items are true.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Determines if all items in the given list is a boolean and has a true value.\n\nList.AllTrue (list: var[]..[]): bool"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "fa662a4bc8d9440188676ce61bf1c625",
+      "End": "aacca3ba5dfe4b4daed986a203b0b230",
+      "Id": "2d716aa78a5f4f8db84925c12aa6e497"
+    },
+    {
+      "Start": "fa662a4bc8d9440188676ce61bf1c625",
+      "End": "a299696d83114338a32ab5fc7f9d6ace",
+      "Id": "377f20c6ab6b48d9bd2b7fe35e0089c7"
+    },
+    {
+      "Start": "8ba0501216904d3dbc852c716ff0a8c3",
+      "End": "b7f35246239649f1ae6216b5c45eb252",
+      "Id": "730ef7dec6064ed6aab3c593042f8e09"
+    },
+    {
+      "Start": "0f2a5482f3344f3882e0d1d6fa538eb3",
+      "End": "53003810c5f44358a1cc7909b3243747",
+      "Id": "e48825e706c64151b9e103d21329cde5"
+    },
+    {
+      "Start": "e7f642f033534a228b0e4b9832cad7e2",
+      "End": "a36fa9e4667645bcb9fd5d323c865871",
+      "Id": "2ba187c8e3cf44d582a73e63cde76c16"
+    },
+    {
+      "Start": "e7f642f033534a228b0e4b9832cad7e2",
+      "End": "82c747a1c5ce4bd0936174746a5de1ca",
+      "Id": "99be5d52197e4fc58d415c5e36901b39"
+    },
+    {
+      "Start": "bf7c44f4d39844b68a7d5b088170d216",
+      "End": "e98f923977f142988a6388f0822a5692",
+      "Id": "e6e12e1a12db445fbb97dab172c1cf76"
+    },
+    {
+      "Start": "34c03b8aa96941c58cfde9e1ab16b29b",
+      "End": "29310781d81241caa05785f586c9e32c",
+      "Id": "6f58091e4b1f4eddb2fcfc64cd467579"
+    },
+    {
+      "Start": "9b4540e5237944dea8a676bf1eb29110",
+      "End": "0def5511c88f411f9d63dd40c80f6fb5",
+      "Id": "c7b3b9aa470a42aaa3e1d6106c62b45c"
+    },
+    {
+      "Start": "9b4540e5237944dea8a676bf1eb29110",
+      "End": "5ddb853331004434bda90455d039ab9b",
+      "Id": "1903b56376604e08a90fd9eb94978742"
+    },
+    {
+      "Start": "081e65273ca54914b9764995838695f4",
+      "End": "f43d3e3ca4ef4d059c2b8dba76ca3e0f",
+      "Id": "744136fdeb93436591dc434e08363b31"
+    },
+    {
+      "Start": "97b81f3206884fd5ae581fe3127ff93b",
+      "End": "5c1a41cac413484c8aa4ce3c41bcb7cf",
+      "Id": "f6c9094f863b40eca18707288012cf66"
+    },
+    {
+      "Start": "100088eb5f104087a03784361b967736",
+      "End": "b0fe6959b4874bc9b1732d2300d78553",
+      "Id": "ddbd3e4623734a91aa5262b2b9b58385"
+    },
+    {
+      "Start": "cecaac1f0f634f9f92904e9ed95b69d3",
+      "End": "60598df75b27408286e9729b32bdba7f",
+      "Id": "24cf18f6795b47dc9284e5b5375a2728"
+    },
+    {
+      "Start": "264ebbfa893f46c3a52bf9f6a6014734",
+      "End": "e12c8d46553e4b9dbffc53c4e9b1f1b0",
+      "Id": "532dfb67ddad4b7d9f2af9120f3247c9"
+    },
+    {
+      "Start": "eac7182e955f40b09a2800c0f3081907",
+      "End": "99c38e3a3c6448aaae957cd8717a409b",
+      "Id": "a644b488252b47ccae5a3580fa33ad00"
+    },
+    {
+      "Start": "83035afaf1ff4af0973f5199d84036ea",
+      "End": "94339aeb28804bcfafd75b0fa7b90791",
+      "Id": "875f9f31f97d47b19d6e5df0d4cc8cf0"
+    },
+    {
+      "Start": "e0500d8a64034f8288cf2a34bdea9f1f",
+      "End": "e49dba07946146d6b16e328a0ee1d879",
+      "Id": "9b47b3fc3f9c46409899f9b9552a401d"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.7035",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": 21.867825578044727,
+      "EyeY": 19.274547487046178,
+      "EyeZ": 31.756911571437136,
+      "LookX": -28.37709460685215,
+      "LookY": -23.334097814445666,
+      "LookZ": -18.917563478535403,
+      "UpX": -0.31169405899427993,
+      "UpY": 0.92718385456678731,
+      "UpZ": -0.20779055180239758
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "String",
+        "Id": "ef6fde2c28f04625a6ab85e80c7b31c6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1292.705451720042,
+        "Y": 483.9745864706814
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Data.ParseJSON",
+        "Id": "6ffabd95f6034f2fa6f7da1c1fcc0cae",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1527.3996075366563,
+        "Y": 482.95858662810139
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "779061094688496285e56d9a328a5d3a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1902.0323660358056,
+        "Y": 295.37182159321435
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "1fef9be1da6f408393d454b8aec11705",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1713.6627560043753,
+        "Y": 327.5521778544055
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "d87d6380630649cca2f86b9e7b053799",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2059.197251781246,
+        "Y": 299.03830403780796
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.ValueAtKey",
+        "Id": "5778370a7ee74066b1a73763ac892ebf",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2290.0971508009493,
+        "Y": 481.22298318666628
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.Keys",
+        "Id": "0794a62dd0ee4c70852cab647051d0d8",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2528.1576267737064,
+        "Y": 434.99759303111534
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.Values",
+        "Id": "c712f0c408b64c76967b71f792288d91",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2522.7580463962954,
+        "Y": 522.87848669691527
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "==",
+        "Id": "c5f4378f241e47bd866a650b009df83f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3017.7034310002541,
+        "Y": 327.46475917231186
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.Sort",
+        "Id": "2aa594928a4841e7899eb8aaf1eb0cd6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2789.5220827279127,
+        "Y": 292.62033666367597
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.Sort",
+        "Id": "692715347cc94fecbb098abebbd7e9d1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2789.1398094584392,
+        "Y": 377.24815758419373
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "==",
+        "Id": "0acfced04037419da1e459da6e4e2d3b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3017.0289573795008,
+        "Y": 483.67471955201279
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.Sort",
+        "Id": "b5a54dcf3dfd485ebd771356780b8495",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2788.5616426223482,
+        "Y": 548.992639976918
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.Sort",
+        "Id": "93d189b6cfd24cc8839ef3f432378ec4",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2787.4340087465625,
+        "Y": 464.3222146679006
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.AllTrue",
+        "Id": "e4e600d912a6400eadb302c1ad26cddf",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3247.9796812989362,
+        "Y": 314.39355688810986
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.AllTrue",
+        "Id": "cdad5bf1f5f747f4a119ad42e5084cfa",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3246.8826608107138,
+        "Y": 513.279024458347
+      }
+    ],
+    "Annotations": [
+      {
+        "Id": "5e5772c86163414abd16558e504ca524",
+        "Title": "String to JSON",
+        "Nodes": [
+          "ef6fde2c28f04625a6ab85e80c7b31c6",
+          "6ffabd95f6034f2fa6f7da1c1fcc0cae"
+        ],
+        "Left": 1282.705451720042,
+        "Top": 429.95858662810139,
+        "Width": 433.69415581661428,
+        "Height": 757.51599984258,
+        "FontSize": 36.0,
+        "InitialTop": 482.95858662810139,
+        "InitialHeight": 146.01599984258002,
+        "TextblockHeight": 43.0,
+        "Background": "#FF848484"
+      },
+      {
+        "Id": "814ee365dcb04dfb85b4c4ec07493168",
+        "Title": "Parse JSON String in Python",
+        "Nodes": [
+          "779061094688496285e56d9a328a5d3a",
+          "1fef9be1da6f408393d454b8aec11705",
+          "d87d6380630649cca2f86b9e7b053799"
+        ],
+        "Left": 1703.6627560043753,
+        "Top": 242.37182159321435,
+        "Width": 560.5344957768707,
+        "Height": 178.18035626119115,
+        "FontSize": 36.0,
+        "InitialTop": 295.37182159321435,
+        "InitialHeight": 177.18035626119115,
+        "TextblockHeight": 43.0,
+        "Background": "#FF848484"
+      },
+      {
+        "Id": "a2c2e2184eef4432a781307e2b710d3d",
+        "Title": "Extract Keys/Value",
+        "Nodes": [
+          "5778370a7ee74066b1a73763ac892ebf",
+          "0794a62dd0ee4c70852cab647051d0d8",
+          "c712f0c408b64c76967b71f792288d91",
+          "c5f4378f241e47bd866a650b009df83f",
+          "2aa594928a4841e7899eb8aaf1eb0cd6",
+          "692715347cc94fecbb098abebbd7e9d1",
+          "0acfced04037419da1e459da6e4e2d3b",
+          "b5a54dcf3dfd485ebd771356780b8495",
+          "93d189b6cfd24cc8839ef3f432378ec4"
+        ],
+        "Left": 2280.0971508009493,
+        "Top": 239.62033666367597,
+        "Width": 916.60628019930482,
+        "Height": 402.372303313242,
+        "FontSize": 36.0,
+        "InitialTop": 292.62033666367597,
+        "InitialHeight": 401.372303313242,
+        "TextblockHeight": 43.0,
+        "Background": "#FF848484"
+      },
+      {
+        "Id": "0b3eac3154204dfca51411083a1fb5c9",
+        "Title": "Keys match when parsing JSON in Python\r\ne4e600d9-12a6-400e-adb3-02c1ad26cddf",
+        "Nodes": [
+          "e4e600d912a6400eadb302c1ad26cddf"
+        ],
+        "Left": 3237.9796812989362,
+        "Top": 246.89355688810986,
+        "Width": 457.05333333333334,
+        "Height": 160.5,
+        "FontSize": 24.0,
+        "InitialTop": 314.39355688810986,
+        "InitialHeight": 145.0,
+        "TextblockHeight": 57.5,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "29205f0693d34f13a41798eb21e96f4b",
+        "Title": "Values match when parsing JSON in Python\r\ncdad5bf1-f5f7-47f4-a119-ad42e5084cfa",
+        "Nodes": [
+          "cdad5bf1f5f747f4a119ad42e5084cfa"
+        ],
+        "Left": 3236.8826608107138,
+        "Top": 416.77902445834695,
+        "Width": 433.01333333333338,
+        "Height": 189.5,
+        "FontSize": 24.0,
+        "InitialTop": 513.279024458347,
+        "InitialHeight": 145.0,
+        "TextblockHeight": 86.5,
+        "Background": "#FFC1D676"
+      }
+    ],
+    "X": -937.64951064912168,
+    "Y": -104.09548099844363,
+    "Zoom": 0.7485460120568
+  }
+}

--- a/test/core/json/JSON_Nodes_Replication.dyn
+++ b/test/core/json/JSON_Nodes_Replication.dyn
@@ -1,0 +1,852 @@
+{
+  "Uuid": "1930b3c5-827c-401a-8d8d-0e2cf87bd4f2",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "JSON_Nodes_Replication",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "DSCore.Data": {
+        "Key": "DSCore.Data",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
+      },
+      "DSCore.Object": {
+        "Key": "DSCore.Object",
+        "Value": "DSCoreNodes.dll"
+      },
+      "Color": {
+        "Key": "DSCore.Color",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSCore.DateTime.Now": {
+        "Key": "DSCore.DateTime",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSCore.DateTime": {
+        "Key": "DSCore.DateTime",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSOffice.Data": {
+        "Key": "DSOffice.Data",
+        "Value": "DSOffice.dll"
+      },
+      "String": {
+        "Key": "DSCore.String",
+        "Value": "DSCoreNodes.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "str1 = DSCore.Data.StringifyJSON(l1);",
+      "Id": "9e703493cc9f4874bbc154c3bc33e356",
+      "Inputs": [
+        {
+          "Id": "142261965b7747b8b3cce5ea71e4dfe9",
+          "Name": "l1",
+          "Description": "l1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "76768ddc3bc140479e2a52e2dccee33a",
+          "Name": "",
+          "Description": "str1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[1, 2, 3];",
+      "Id": "37eeb04cce414ef5815771296dfe2b73",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "286ce4f0fbb6493488740db2ddea8a6f",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "str1 = DSCore.Data.StringifyJSON(l1<1>);",
+      "Id": "a9f9fcf59e9a4f009883868d5dcf4b51",
+      "Inputs": [
+        {
+          "Id": "5dc049586c4741ed8ee0391af338e0cd",
+          "Name": "l1",
+          "Description": "l1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e59a0d9d10b74a278be7ecc6646efa7b",
+          "Name": "",
+          "Description": "str1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Data.StringifyJSON@var[]..[]",
+      "Id": "f6932b9bd1664e63853dcb8b47ce278a",
+      "Inputs": [
+        {
+          "Id": "1bf5c5cf53b943b0af69e8d61a45a7c7",
+          "Name": "values",
+          "Description": "A List of values\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "46c1c5d6402845f1aa65a1a874a66dcb",
+          "Name": "json",
+          "Description": "A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Stringify converts a list of arbitrary values to JSON. Replication can also be used to apply the operation over a list, producing a list of JSON strings.\n\nData.StringifyJSON (values: var[]..[]): string"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Data.StringifyJSON@var[]..[]",
+      "Id": "0d747d2a5e0d4061ab9350a816e07720",
+      "Inputs": [
+        {
+          "Id": "150a45bae741477b9a020a8485ec7c0d",
+          "Name": "values",
+          "Description": "A List of values\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 1,
+          "UseLevels": true,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "334cf574d4354d6a893e4f6afbfa0c39",
+          "Name": "json",
+          "Description": "A JSON string where primitive types (e.g. double, int, boolean), Lists, and Dictionary's will be turned into the associated JSON type.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Stringify converts a list of arbitrary values to JSON. Replication can also be used to apply the operation over a list, producing a list of JSON strings.\n\nData.StringifyJSON (values: var[]..[]): string"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "75b67b26805544dab84b31bceeaba709",
+      "Inputs": [
+        {
+          "Id": "671803769f8e47478c09ec8d2a9e416d",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8bcd10f2091842a5850db8cfe6bcbe7e",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "a0cc1e9d81104d3b857e7252cbf73b82",
+      "Inputs": [
+        {
+          "Id": "6e3ab79a523e4f76ba9ad6f578563f4c",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "4be39a360f2e4d25b4a8ff5b312d2941",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "0a33d64866f24fc6b0dde92540af761d",
+      "Inputs": [
+        {
+          "Id": "5e05e9b5703c4b31a008e9f1a70fc7e7",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "5fe6f3913f05440ca692af2a583bd982",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Watch, CoreNodeModels",
+      "NodeType": "ExtensionNode",
+      "Id": "2c107f0f108e4b15b9b27f3d97267a6f",
+      "Inputs": [
+        {
+          "Id": "309d84563ca54da5a5171b6b81ccef0f",
+          "Name": "",
+          "Description": "Node to evaluate.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "0d8452c84c7843a7927ce9c93605c1ba",
+          "Name": "",
+          "Description": "Watch contents.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Visualize the output of node."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "==@var[]..[],var[]..[]",
+      "Id": "bb7e096d79e541a4b519530aa291d052",
+      "Inputs": [
+        {
+          "Id": "a072268db9e04059bc8d7fa31527346a",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "919b2b9d4dd447fa811c34f1d6a8011c",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "74b41fedbb414ebca6090f357f835aaf",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Equal x to y?\n\n== (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "==@var[]..[],var[]..[]",
+      "Id": "93e1298a4e2f4b068a72f2b4a176894a",
+      "Inputs": [
+        {
+          "Id": "63852461cabb4c2fb4ef756793ddc046",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "2643d8d0b0c44d228e5382474de588f1",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "4e5652f74e894c1ba29dc25b1c0e8613",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Equal x to y?\n\n== (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.AllTrue@var[]..[]",
+      "Id": "e81d053fdbc54b1e86df075c9b279aa3",
+      "Inputs": [
+        {
+          "Id": "19533dc33ab247db81fd27cd5df6fcd2",
+          "Name": "list",
+          "Description": "List to be checked on whether all items are true.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e7b2d6ba24df4223b34e4813b2da29a8",
+          "Name": "bool",
+          "Description": "Whether all items are true.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Determines if all items in the given list is a boolean and has a true value.\n\nList.AllTrue (list: var[]..[]): bool"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.AllTrue@var[]..[]",
+      "Id": "a0af3136aaaf40c2b2efcee522f9ea45",
+      "Inputs": [
+        {
+          "Id": "dfac7e1b9e1b463c8fff5cafae80b653",
+          "Name": "list",
+          "Description": "List to be checked on whether all items are true.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "93604a1ad92f4887bebc47c4e391d2c0",
+          "Name": "bool",
+          "Description": "Whether all items are true.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Determines if all items in the given list is a boolean and has a true value.\n\nList.AllTrue (list: var[]..[]): bool"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "==@var[]..[],var[]..[]",
+      "Id": "1c21d6cd77e54120affc3ecb1713f782",
+      "Inputs": [
+        {
+          "Id": "d0c45115e3744490a935ca9760ae5c5b",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "8abf57a9a8bd470b8f3906d2670fda2c",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "450996146fee461fbaf294862e1c99d9",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Equal x to y?\n\n== (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.AllFalse@var[]..[]",
+      "Id": "b69f2b6ea32843cfa7a3db42576ce814",
+      "Inputs": [
+        {
+          "Id": "4615819e65ef4ecd8d374de984be56f8",
+          "Name": "list",
+          "Description": "List to be checked on whether all items are false.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b5659c75c7a84b9fb254d07f2ce84e94",
+          "Name": "bool",
+          "Description": "Whether all items are false.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Determines if all items in the given list is a boolean and has a false value.\n\nList.AllFalse (list: var[]..[]): bool"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "76768ddc3bc140479e2a52e2dccee33a",
+      "End": "671803769f8e47478c09ec8d2a9e416d",
+      "Id": "a7a27065fa2c41999c25cfe23eab93e7"
+    },
+    {
+      "Start": "76768ddc3bc140479e2a52e2dccee33a",
+      "End": "d0c45115e3744490a935ca9760ae5c5b",
+      "Id": "ac77d19f1431475faace28a999976360"
+    },
+    {
+      "Start": "286ce4f0fbb6493488740db2ddea8a6f",
+      "End": "142261965b7747b8b3cce5ea71e4dfe9",
+      "Id": "0a58fb1b96594cbdb20515288c846cd7"
+    },
+    {
+      "Start": "286ce4f0fbb6493488740db2ddea8a6f",
+      "End": "5dc049586c4741ed8ee0391af338e0cd",
+      "Id": "c71e6cc559ca4adbb05dc5c96c4cc19c"
+    },
+    {
+      "Start": "286ce4f0fbb6493488740db2ddea8a6f",
+      "End": "1bf5c5cf53b943b0af69e8d61a45a7c7",
+      "Id": "4dc42312279e431db6ddb60bcd6acda6"
+    },
+    {
+      "Start": "286ce4f0fbb6493488740db2ddea8a6f",
+      "End": "150a45bae741477b9a020a8485ec7c0d",
+      "Id": "865bc10ea87d4f7d8135f2176430afab"
+    },
+    {
+      "Start": "e59a0d9d10b74a278be7ecc6646efa7b",
+      "End": "6e3ab79a523e4f76ba9ad6f578563f4c",
+      "Id": "34d258ff57214eac9f26660ad6b52367"
+    },
+    {
+      "Start": "e59a0d9d10b74a278be7ecc6646efa7b",
+      "End": "8abf57a9a8bd470b8f3906d2670fda2c",
+      "Id": "063b61ee9ac5418c89648c0726c1b724"
+    },
+    {
+      "Start": "46c1c5d6402845f1aa65a1a874a66dcb",
+      "End": "5e05e9b5703c4b31a008e9f1a70fc7e7",
+      "Id": "0cfcc6bb33ee4d5a864d7e484d6f1872"
+    },
+    {
+      "Start": "334cf574d4354d6a893e4f6afbfa0c39",
+      "End": "309d84563ca54da5a5171b6b81ccef0f",
+      "Id": "f973d3fa6e114fa6b54a58887f950281"
+    },
+    {
+      "Start": "8bcd10f2091842a5850db8cfe6bcbe7e",
+      "End": "a072268db9e04059bc8d7fa31527346a",
+      "Id": "bfde8324de6641059ace3b30b18a2264"
+    },
+    {
+      "Start": "4be39a360f2e4d25b4a8ff5b312d2941",
+      "End": "63852461cabb4c2fb4ef756793ddc046",
+      "Id": "7c589fdd37934494ae9bc823372ca0e9"
+    },
+    {
+      "Start": "5fe6f3913f05440ca692af2a583bd982",
+      "End": "919b2b9d4dd447fa811c34f1d6a8011c",
+      "Id": "f2ddaa9274c4413da0b3c2a9fa4e6ef3"
+    },
+    {
+      "Start": "0d8452c84c7843a7927ce9c93605c1ba",
+      "End": "2643d8d0b0c44d228e5382474de588f1",
+      "Id": "22dfbd51c7d748dca9fa9d8b26cf908f"
+    },
+    {
+      "Start": "74b41fedbb414ebca6090f357f835aaf",
+      "End": "19533dc33ab247db81fd27cd5df6fcd2",
+      "Id": "fbaba40423e247d89b4c509c28b07533"
+    },
+    {
+      "Start": "4e5652f74e894c1ba29dc25b1c0e8613",
+      "End": "dfac7e1b9e1b463c8fff5cafae80b653",
+      "Id": "9fb134875ade49eebabb5d339da52729"
+    },
+    {
+      "Start": "450996146fee461fbaf294862e1c99d9",
+      "End": "4615819e65ef4ecd8d374de984be56f8",
+      "Id": "b7dc14a3ee364626885e4c9675eb360f"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.7026",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -40.454418571994019,
+      "EyeY": 14.070785516657553,
+      "EyeZ": 131.66138982634251,
+      "LookX": -28.37709460685215,
+      "LookY": -23.334097814445666,
+      "LookZ": -18.917563478535403,
+      "UpX": -0.31169405899427993,
+      "UpY": 0.92718385456678731,
+      "UpZ": -0.20779055180239758
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "9e703493cc9f4874bbc154c3bc33e356",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2481.2975967346488,
+        "Y": -454.28658315125813
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "37eeb04cce414ef5815771296dfe2b73",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2305.0708077323716,
+        "Y": -301.90197545332262
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "a9f9fcf59e9a4f009883868d5dcf4b51",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2482.2650988892615,
+        "Y": -359.71046179293012
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Data.StringifyJSON",
+        "Id": "f6932b9bd1664e63853dcb8b47ce278a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2486.830430740833,
+        "Y": -256.88165567105034
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Data.StringifyJSON",
+        "Id": "0d747d2a5e0d4061ab9350a816e07720",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2488.7108068628545,
+        "Y": -150.99869811757094
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Watch",
+        "Id": "75b67b26805544dab84b31bceeaba709",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2911.6551622135371,
+        "Y": -531.46537270075123
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Watch",
+        "Id": "a0cc1e9d81104d3b857e7252cbf73b82",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2912.7048660878654,
+        "Y": -429.87442514096062
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Watch",
+        "Id": "0a33d64866f24fc6b0dde92540af761d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2913.5365073551866,
+        "Y": -258.74413746997152
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Watch",
+        "Id": "2c107f0f108e4b15b9b27f3d97267a6f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2920.2526663879303,
+        "Y": -152.58931512419542
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "==",
+        "Id": "bb7e096d79e541a4b519530aa291d052",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3107.0425357084628,
+        "Y": -367.35953228526552
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "==",
+        "Id": "93e1298a4e2f4b068a72f2b4a176894a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3108.1311733551047,
+        "Y": -112.40888187048836
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.AllTrue",
+        "Id": "e81d053fdbc54b1e86df075c9b279aa3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3337.9350420115666,
+        "Y": -367.130806069315
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.AllTrue",
+        "Id": "a0af3136aaaf40c2b2efcee522f9ea45",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3333.7075174916135,
+        "Y": -111.32684173147726
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "==",
+        "Id": "1c21d6cd77e54120affc3ecb1713f782",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3111.5114457340369,
+        "Y": -603.63508414386172
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.AllFalse",
+        "Id": "b69f2b6ea32843cfa7a3db42576ce814",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3340.5891362082184,
+        "Y": -603.29971075365029
+      }
+    ],
+    "Annotations": [
+      {
+        "Id": "99cd0dc1362a4c479236577749dd3283",
+        "Title": "Compare DesignScript vs List@Level - no replication.\r\ne81d053f-dbc5-4b1e-86df-075c9b279aa3",
+        "Nodes": [
+          "e81d053fdbc54b1e86df075c9b279aa3"
+        ],
+        "Left": 3327.9350420115666,
+        "Top": -463.630806069315,
+        "Width": 452.69666666666672,
+        "Height": 189.5,
+        "FontSize": 24.0,
+        "InitialTop": -367.130806069315,
+        "InitialHeight": 123.0,
+        "TextblockHeight": 86.5,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "5fdddce3004b431f8e1de1cf7cd6f413",
+        "Title": "Compare DesignScript vs List@Level - with replication.\r\na0af3136-aaaf-40c2-b2ef-cee522f9ea45",
+        "Nodes": [
+          "a0af3136aaaf40c2b2efcee522f9ea45"
+        ],
+        "Left": 3323.7075174916135,
+        "Top": -207.82684173147726,
+        "Width": 432.23333333333335,
+        "Height": 189.5,
+        "FontSize": 24.0,
+        "InitialTop": -111.32684173147726,
+        "InitialHeight": 123.0,
+        "TextblockHeight": 86.5,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "777c9ccb8e1941e4b61a40c5c7c9cb83",
+        "Title": "Verify replication produces different result.\r\nb69f2b6e-a328-43cf-a7a3-db42576ce814",
+        "Nodes": [
+          "b69f2b6ea32843cfa7a3db42576ce814"
+        ],
+        "Left": 3330.5891362082184,
+        "Top": -670.79971075365029,
+        "Width": 449.57666666666671,
+        "Height": 160.5,
+        "FontSize": 24.0,
+        "InitialTop": -603.29971075365029,
+        "InitialHeight": 123.0,
+        "TextblockHeight": 57.5,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "5ac0b9eee1264a8c8d44ed6f69031c5c",
+        "Title": "Replication",
+        "Nodes": [
+          "9e703493cc9f4874bbc154c3bc33e356",
+          "37eeb04cce414ef5815771296dfe2b73",
+          "a9f9fcf59e9a4f009883868d5dcf4b51",
+          "f6932b9bd1664e63853dcb8b47ce278a",
+          "0d747d2a5e0d4061ab9350a816e07720",
+          "75b67b26805544dab84b31bceeaba709",
+          "a0cc1e9d81104d3b857e7252cbf73b82",
+          "0a33d64866f24fc6b0dde92540af761d",
+          "2c107f0f108e4b15b9b27f3d97267a6f",
+          "bb7e096d79e541a4b519530aa291d052",
+          "93e1298a4e2f4b068a72f2b4a176894a",
+          "1c21d6cd77e54120affc3ecb1713f782"
+        ],
+        "Left": 2295.0708077323716,
+        "Top": -656.63508414386172,
+        "Width": 995.44063800166532,
+        "Height": 683.5457690196663,
+        "FontSize": 36.0,
+        "InitialTop": -603.63508414386172,
+        "InitialHeight": 660.5457690196663,
+        "TextblockHeight": 43.0,
+        "Background": "#FF848484"
+      }
+    ],
+    "X": -1705.4791854994724,
+    "Y": 684.04356239529932,
+    "Zoom": 0.80657604406541994
+  }
+}

--- a/test/core/json/JSON_Nodes_Test.dyn
+++ b/test/core/json/JSON_Nodes_Test.dyn
@@ -1,0 +1,1034 @@
+{
+  "Uuid": "19433588-cb44-439f-a3b5-bdc676dcb105",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "JSON_Nodes_Test",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "DSCore.Object": {
+        "Key": "DSCore.Object",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSCore.Data": {
+        "Key": "DSCore.Data",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
+      },
+      "Color": {
+        "Key": "DSCore.Color",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSCore.DateTime.Now": {
+        "Key": "DSCore.DateTime",
+        "Value": "DSCoreNodes.dll"
+      },
+      "DSCore.DateTime": {
+        "Key": "DSCore.DateTime",
+        "Value": "DSCoreNodes.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[\n\tDSCore.Object.Type(DSCore.Data.ParseJSON(\"false\")),\n\tDSCore.Object.Type(DSCore.Data.ParseJSON(\"[false]\")[0]),\n\tDSCore.Object.Type(DSCore.Data.ParseJSON(\"{\\\"foo\\\": false}\")),\n\tDSCore.Object.Type(DSCore.Data.ParseJSON(\"\\\"another test\\\"\")),\n\tDSCore.Object.Type(DSCore.Data.ParseJSON(\"12\")),\n\tDSCore.Object.Type(DSCore.Data.ParseJSON(\"\\\"2009-02-15T00:00:00Z\\\"\")),\n\tDSCore.Object.Type(DSCore.Data.ParseJSON(\"1e10\")),\n\tDSCore.Object.Type(DSCore.Data.ParseJSON(\"{\\\"foo\\\": [1,{},3]}\"))\n];",
+      "Id": "9dca6adcdcf2436a931743a0af5195bc",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "a007ba6a79be46a1867ea53b5034a123",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[\n\tDSCore.Object.Type(DSCore.Data.StringifyJSON({ \"foo\" : 5 })),\n\tDSCore.Object.Type(DSCore.Data.StringifyJSON(12)),\n\tDSCore.Object.Type(DSCore.Data.StringifyJSON([1,2,3])[0]),\n\tDSCore.Object.Type(DSCore.Data.StringifyJSON(Color.ByARGB())),\n\tDSCore.Object.Type(DSCore.Data.StringifyJSON(\"foo\")),\n\tDSCore.Object.Type(DSCore.Data.StringifyJSON(null)),\n\tDSCore.Object.Type(DSCore.Data.StringifyJSON(false)),\n\tDSCore.Object.Type(DSCore.Data.StringifyJSON(DSCore.DateTime.Now))\n];",
+      "Id": "31f973f9076447e1b7707b6b97d8803e",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "a8d0f07239f64d76a8d58569da303264",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.IO.FileSystem.ReadText@var",
+      "Id": "25c7e61f2a2a4c3faf50075c0b214d99",
+      "Inputs": [
+        {
+          "Id": "79dcb87afcca4b3291b48c36af2f368e",
+          "Name": "file",
+          "Description": "var",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ee731216251441549065bc3f00c2d7db",
+          "Name": "str",
+          "Description": "Contents of the text file.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Reads a text file and returns the contents as a string.\n\nFileSystem.ReadText (file: var): string"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Data.ParseJSON@string",
+      "Id": "aa367b7b22c5492ebe309690c8a45960",
+      "Inputs": [
+        {
+          "Id": "d50dec447a904b7a8e84beb65aa39eb0",
+          "Name": "json",
+          "Description": "A JSON string\n\nstring",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "1cf7f91f6e784fd4bfe2d552d42d1fbe",
+          "Name": "result",
+          "Description": "The result type depends on the content of the input string. The result type can be a primitive value (e.g. string, boolean, double), a List, or a Dictionary.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Parse converts an arbitrary JSON string to a value. It is the opposite of JSON.Stringify.\n\nData.ParseJSON (json: string): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\".\\\\JSONFile.json\";",
+      "Id": "383b2d48b8794dc68f908c99ac9ebe3d",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "e8bda62e07b84f7d8b6ea2a0dab2a590",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Keys",
+      "Id": "ee83c75e9e244c518cf5ba9949ac9bc8",
+      "Inputs": [
+        {
+          "Id": "3b615796268243939a410ee6dca88b43",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "0bb1d001f4ff4bdd8a8fc2100efd9dbd",
+          "Name": "keys",
+          "Description": "The keys of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the keys in a Dictionary.\n\nDictionary.Keys: string[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "{\n\t\"Lisa Rose\": {\n\t\t\"Lady in the Water\": 2.5,\n\t\t\"Snakes on a Plane\": 3.5,\n \t\t\"Just My Luck\": 3.0,\n \t\t\"Superman Returns\": 3.5,\n \t\t\"You, Me and Dupree\": 2.5,\n \t\t\"The Night Listener\": 3.0\n \t},\n\t\"Gene Seymour\": {\n\t\t\"Lady in the Water\": 3.0,\n\t\t\"Snakes on a Plane\": 3.5,\n \t\t\"Just My Luck\": 1.5,\n \t\t\"Superman Returns\": 5.0,\n \t\t\"The Night Listener\": 3.0,\n \t\t\"You, Me and Dupree\": 3.5\n \t},\n\t\"Michael Phillips\": {\n\t\t\"Lady in the Water\": 2.5,\n\t\t\"Snakes on a Plane\": 3.0,\n \t\t\"Superman Returns\": 3.5,\n \t\t\"The Night Listener\": 4.0\n \t},\n\t\"Claudia Puig\": {\n\t\t\"Snakes on a Plane\": 3.5,\n\t\t\"Just My Luck\": 3.0,\n \t\t\"The Night Listener\": 4.5,\n \t\t\"Superman Returns\": 4.0,\n \t\t\"You, Me and Dupree\": 2.5\n \t},\n\t\"Mick LaSalle\": {\n\t\t\"Lady in the Water\": 3.0,\n\t\t\"Snakes on a Plane\": 4.0,\n \t\t\"Just My Luck\": 2.0,\n \t\t\"Superman Returns\": 3.0,\n \t\t\"The Night Listener\": 3.0,\n \t\t\"You, Me and Dupree\": 2.0\n \t},\n\t\"Jack Matthews\": {\n\t\t\"Lady in the Water\": 3.0,\n\t\t\"Snakes on a Plane\": 4.0,\n \t\t\"The Night Listener\": 3.0,\n \t\t\"Superman Returns\": 5.0,\n \t\t\"You, Me and Dupree\": 3.5\n \t},\n\t\"Toby\": {\n\t\t\"Snakes on a Plane\":4.5,\n\t\t\"You, Me and Dupree\":1.0,\n\t\t\"Superman Returns\":4.0\n\t}\n};",
+      "Id": "5e432217ec7f4dd9b2d3051e90b15c4b",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "bfc9d95d90654ec4a586c80e08ba9c03",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "==@var[]..[],var[]..[]",
+      "Id": "f0996771675a44ff9514b60c781dc454",
+      "Inputs": [
+        {
+          "Id": "580a7d64459c43539d78fece42485a64",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "501390103a734424b563cc4ac53ba8a7",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "3771ff4337d4454797ddca60d99526cc",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Equal x to y?\n\n== (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.ValueAtKey@string",
+      "Id": "ae6d01ce5bff48afa62a329889e7eab6",
+      "Inputs": [
+        {
+          "Id": "a778feab2a564314bc08844bdc03d95e",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "7f08eee003db4e429cf48dc5589a44ad",
+          "Name": "key",
+          "Description": "The key in the Dictionary to obtain.\n\nstring",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c06c4838d590405ab17ab67d9ee4a88d",
+          "Name": "value",
+          "Description": "The value at the specified key or null if it is not set.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Obtain the value at a specified key\n\nDictionary.ValueAtKey (key: string): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.ValueAtKey@string",
+      "Id": "811158cdc6374216b5aa9c57466e6180",
+      "Inputs": [
+        {
+          "Id": "682745e3bb714fae844321721f7ddabc",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "52cd687ec6c44a8c810ad4f6623d878e",
+          "Name": "key",
+          "Description": "The key in the Dictionary to obtain.\n\nstring",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e4d3839ec51c455c8c68a1727ba7a303",
+          "Name": "value",
+          "Description": "The value at the specified key or null if it is not set.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Obtain the value at a specified key\n\nDictionary.ValueAtKey (key: string): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Keys",
+      "Id": "15df70eaad6f4953ba6d4886a09abbd2",
+      "Inputs": [
+        {
+          "Id": "a25f2ec2dc1d40839a73e2d7bcec64c7",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "d924856fa3be434186905b168c39e23d",
+          "Name": "keys",
+          "Description": "The keys of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the keys in a Dictionary.\n\nDictionary.Keys: string[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Values",
+      "Id": "cc352f459dc944ff92d842b06e47a691",
+      "Inputs": [
+        {
+          "Id": "986a61fbc4a94e17a20114a69c6de74e",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "cd9dfb19e9cc436d92b7ea4f610ffb62",
+          "Name": "values",
+          "Description": "The values of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the values in a Dictionary.\n\nDictionary.Values: var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Values",
+      "Id": "510f8d6b044e49b9b5c87fed028c884d",
+      "Inputs": [
+        {
+          "Id": "548429d8a0c147b89245219f4bdab0bf",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e8c7672d47e949509bca0876febb4711",
+          "Name": "values",
+          "Description": "The values of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the values in a Dictionary.\n\nDictionary.Values: var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Keys",
+      "Id": "784b9f3fd5fc4a5db31f491ccddfe16b",
+      "Inputs": [
+        {
+          "Id": "beae94429ef542fb8f4545a5acc6a213",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8d9f20e936094d0c8ce2df76581511da",
+          "Name": "keys",
+          "Description": "The keys of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the keys in a Dictionary.\n\nDictionary.Keys: string[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "==@var[]..[],var[]..[]",
+      "Id": "386b516001104b30b85b38b3d22a678e",
+      "Inputs": [
+        {
+          "Id": "2ff64e0fb4e3410db75f695d15e9de18",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "18e7f779879947859fc938279164e5e7",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c36e0815a9b44211a06a3966fe665598",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Equal x to y?\n\n== (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.Flatten@var[]..[],int",
+      "Id": "71fe687ab0e94de7bfa094de3c7aaeb5",
+      "Inputs": [
+        {
+          "Id": "5480b64a4ba242249888a8a1ea26a1fe",
+          "Name": "list",
+          "Description": "List to flatten.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0a9dd7d0b48a48f3ac2a841083a2fe07",
+          "Name": "amt",
+          "Description": "Layers of nesting to remove.\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e280e8fee81a40b8ac0de417ef75a963",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Flattens a nested list of lists by a certain amount.\n\nList.Flatten (list: var[]..[], amt: int = -1): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.AllTrue@var[]..[]",
+      "Id": "3464510891444af98b3ede7f8458d805",
+      "Inputs": [
+        {
+          "Id": "0770854ba1414466b2188f695dee84ff",
+          "Name": "list",
+          "Description": "List to be checked on whether all items are true.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "a90d8b1fe7d0438ca0c24d6dc28ceeca",
+          "Name": "bool",
+          "Description": "Whether all items are true.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Determines if all items in the given list is a boolean and has a true value.\n\nList.AllTrue (list: var[]..[]): bool"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.AllTrue@var[]..[]",
+      "Id": "5b0b1abaee6b420eaa12e54270c00718",
+      "Inputs": [
+        {
+          "Id": "f1d53a23fce644e4929b611d524dbbc3",
+          "Name": "list",
+          "Description": "List to be checked on whether all items are true.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "058c126dab6b4f5b86f38f6ce5430f99",
+          "Name": "bool",
+          "Description": "Whether all items are true.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Determines if all items in the given list is a boolean and has a true value.\n\nList.AllTrue (list: var[]..[]): bool"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.Flatten@var[]..[],int",
+      "Id": "9e7eeb2338c84b2c9c9cd1a1e149772b",
+      "Inputs": [
+        {
+          "Id": "997dc36edd6242bea339946bf966d8dd",
+          "Name": "list",
+          "Description": "List to flatten.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "266b2493c8a445d9a6e801691d033594",
+          "Name": "amt",
+          "Description": "Layers of nesting to remove.\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "5825a7cd0fa6491e88f4a2cf9a3fe8b4",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Flattens a nested list of lists by a certain amount.\n\nList.Flatten (list: var[]..[], amt: int = -1): var[]..[]"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "ee731216251441549065bc3f00c2d7db",
+      "End": "d50dec447a904b7a8e84beb65aa39eb0",
+      "Id": "b7e27aa7bad14f0a8c6aeb50e08a12a5"
+    },
+    {
+      "Start": "1cf7f91f6e784fd4bfe2d552d42d1fbe",
+      "End": "3b615796268243939a410ee6dca88b43",
+      "Id": "87046c304787435fa4e7d9efef95ae00"
+    },
+    {
+      "Start": "1cf7f91f6e784fd4bfe2d552d42d1fbe",
+      "End": "682745e3bb714fae844321721f7ddabc",
+      "Id": "5fc8c994616444edac58b4a4e3ded9ca"
+    },
+    {
+      "Start": "e8bda62e07b84f7d8b6ea2a0dab2a590",
+      "End": "79dcb87afcca4b3291b48c36af2f368e",
+      "Id": "d6daa17e9be64d5da9b58abd063b2ef4"
+    },
+    {
+      "Start": "0bb1d001f4ff4bdd8a8fc2100efd9dbd",
+      "End": "7f08eee003db4e429cf48dc5589a44ad",
+      "Id": "58339ad3ed684833aff7a5646b01f8d3"
+    },
+    {
+      "Start": "0bb1d001f4ff4bdd8a8fc2100efd9dbd",
+      "End": "52cd687ec6c44a8c810ad4f6623d878e",
+      "Id": "44c80ece6fa54bd5853ab9ef8e08e995"
+    },
+    {
+      "Start": "bfc9d95d90654ec4a586c80e08ba9c03",
+      "End": "a778feab2a564314bc08844bdc03d95e",
+      "Id": "9a41a754c3564bad9b988b7a408ce0fd"
+    },
+    {
+      "Start": "3771ff4337d4454797ddca60d99526cc",
+      "End": "997dc36edd6242bea339946bf966d8dd",
+      "Id": "0bbfc4f6e25147dc96799ef1fc1e1330"
+    },
+    {
+      "Start": "c06c4838d590405ab17ab67d9ee4a88d",
+      "End": "beae94429ef542fb8f4545a5acc6a213",
+      "Id": "f3176848026e4d0a84ed7bf7f1c7bd3a"
+    },
+    {
+      "Start": "c06c4838d590405ab17ab67d9ee4a88d",
+      "End": "548429d8a0c147b89245219f4bdab0bf",
+      "Id": "90925e714d964573a885c4f353960244"
+    },
+    {
+      "Start": "e4d3839ec51c455c8c68a1727ba7a303",
+      "End": "a25f2ec2dc1d40839a73e2d7bcec64c7",
+      "Id": "787ea63950c64a4d9c51433581be891e"
+    },
+    {
+      "Start": "e4d3839ec51c455c8c68a1727ba7a303",
+      "End": "986a61fbc4a94e17a20114a69c6de74e",
+      "Id": "d977ab5eb41f4e1995b89d226d922de0"
+    },
+    {
+      "Start": "d924856fa3be434186905b168c39e23d",
+      "End": "580a7d64459c43539d78fece42485a64",
+      "Id": "8f37c460f555489f9741470850a4f8f5"
+    },
+    {
+      "Start": "cd9dfb19e9cc436d92b7ea4f610ffb62",
+      "End": "2ff64e0fb4e3410db75f695d15e9de18",
+      "Id": "c0d71765b81d4407a1d393595e4001d0"
+    },
+    {
+      "Start": "e8c7672d47e949509bca0876febb4711",
+      "End": "18e7f779879947859fc938279164e5e7",
+      "Id": "8ad424d033fe4ba3abe7647c5bc3402c"
+    },
+    {
+      "Start": "8d9f20e936094d0c8ce2df76581511da",
+      "End": "501390103a734424b563cc4ac53ba8a7",
+      "Id": "fdbc342e5f924662b205e5b4d752142e"
+    },
+    {
+      "Start": "c36e0815a9b44211a06a3966fe665598",
+      "End": "5480b64a4ba242249888a8a1ea26a1fe",
+      "Id": "d78239b88c004d3cb7d71916e406d205"
+    },
+    {
+      "Start": "e280e8fee81a40b8ac0de417ef75a963",
+      "End": "0770854ba1414466b2188f695dee84ff",
+      "Id": "16bd76eac3f4433e973d82eef2ec66bf"
+    },
+    {
+      "Start": "5825a7cd0fa6491e88f4a2cf9a3fe8b4",
+      "End": "f1d53a23fce644e4929b611d524dbbc3",
+      "Id": "831bfe68d4614fa8b73140f81e4a87ed"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.7026",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "PARSE_JSON",
+        "Id": "9dca6adcdcf2436a931743a0af5195bc",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 55.2341807391179,
+        "Y": 130.03048296842132
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "STRINGIFY_JSON",
+        "Id": "31f973f9076447e1b7707b6b97d8803e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 53.489559029699876,
+        "Y": 478.22668691129803
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "FileSystem.ReadText",
+        "Id": "25c7e61f2a2a4c3faf50075c0b214d99",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 937.95630320271778,
+        "Y": 263.03513373087515
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Data.ParseJSON",
+        "Id": "aa367b7b22c5492ebe309690c8a45960",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1109.9465455331144,
+        "Y": 262.70882389437918
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "383b2d48b8794dc68f908c99ac9ebe3d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 735.495343986644,
+        "Y": 267.33537191864218
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.Keys",
+        "Id": "ee83c75e9e244c518cf5ba9949ac9bc8",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1325.3469678698737,
+        "Y": 258.031920208076
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dynamo Dictionary",
+        "Id": "5e432217ec7f4dd9b2d3051e90b15c4b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 731.2622937420341,
+        "Y": 363.24987499769327
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "==",
+        "Id": "f0996771675a44ff9514b60c781dc454",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2135.5100804819076,
+        "Y": 137.79639184509725
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.ValueAtKey",
+        "Id": "ae6d01ce5bff48afa62a329889e7eab6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1597.6646099491802,
+        "Y": 300.08592598745474
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.ValueAtKey",
+        "Id": "811158cdc6374216b5aa9c57466e6180",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1599.7404549530061,
+        "Y": 143.56331847211015
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.Keys",
+        "Id": "15df70eaad6f4953ba6d4886a09abbd2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1855.1415953563599,
+        "Y": 97.373300957078015
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.Values",
+        "Id": "cc352f459dc944ff92d842b06e47a691",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1852.7585865109879,
+        "Y": 182.85606327942892
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.Values",
+        "Id": "510f8d6b044e49b9b5c87fed028c884d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1849.4677560510379,
+        "Y": 351.54424353735931
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Dictionary.Keys",
+        "Id": "784b9f3fd5fc4a5db31f491ccddfe16b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1856.6991963835824,
+        "Y": 264.84937334321478
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "==",
+        "Id": "386b516001104b30b85b38b3d22a678e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2138.7085986397715,
+        "Y": 265.35905188269794
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.Flatten",
+        "Id": "71fe687ab0e94de7bfa094de3c7aaeb5",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2323.4834820077831,
+        "Y": 266.22087133897156
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.AllTrue",
+        "Id": "3464510891444af98b3ede7f8458d805",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2561.5346310478508,
+        "Y": 304.52074076270105
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.AllTrue",
+        "Id": "5b0b1abaee6b420eaa12e54270c00718",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2566.0103286748536,
+        "Y": 75.739845443382762
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.Flatten",
+        "Id": "9e7eeb2338c84b2c9c9cd1a1e149772b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2327.7228888068685,
+        "Y": 137.40030161311194
+      }
+    ],
+    "Annotations": [
+      {
+        "Id": "fb0e56f017914521b0ac990c45999ebb",
+        "Title": "ParseJSON()\r\n9dca6adc-dcf2-436a-9317-43a0af5195bc",
+        "Nodes": [
+          "9dca6adcdcf2436a931743a0af5195bc"
+        ],
+        "Left": 45.2341807391179,
+        "Top": 33.530482968421325,
+        "Width": 662.90000000000009,
+        "Height": 339.0,
+        "FontSize": 36.0,
+        "InitialTop": 130.03048296842132,
+        "InitialHeight": 145.0,
+        "TextblockHeight": 86.5,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "4f422d1045f8437ca3b42ecc87029398",
+        "Title": "StringifyJSON()\r\n31f973f9-0764-47e1-b770-7b6b97d8803e",
+        "Nodes": [
+          "31f973f9076447e1b7707b6b97d8803e"
+        ],
+        "Left": 43.489559029699876,
+        "Top": 381.72668691129803,
+        "Width": 678.22333333333336,
+        "Height": 339.0,
+        "FontSize": 36.0,
+        "InitialTop": 478.22668691129803,
+        "InitialHeight": 145.0,
+        "TextblockHeight": 86.5,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "8ce677344de249e093b938339e16d6cc",
+        "Title": "Compare JSON/Dictionary Key/Values",
+        "Nodes": [
+          "25c7e61f2a2a4c3faf50075c0b214d99",
+          "aa367b7b22c5492ebe309690c8a45960",
+          "383b2d48b8794dc68f908c99ac9ebe3d",
+          "ee83c75e9e244c518cf5ba9949ac9bc8",
+          "5e432217ec7f4dd9b2d3051e90b15c4b",
+          "f0996771675a44ff9514b60c781dc454",
+          "ae6d01ce5bff48afa62a329889e7eab6",
+          "811158cdc6374216b5aa9c57466e6180",
+          "15df70eaad6f4953ba6d4886a09abbd2",
+          "cc352f459dc944ff92d842b06e47a691",
+          "510f8d6b044e49b9b5c87fed028c884d",
+          "784b9f3fd5fc4a5db31f491ccddfe16b",
+          "386b516001104b30b85b38b3d22a678e",
+          "71fe687ab0e94de7bfa094de3c7aaeb5",
+          "9e7eeb2338c84b2c9c9cd1a1e149772b"
+        ],
+        "Left": 721.2622937420341,
+        "Top": 44.373300957078015,
+        "Width": 1802.4605950648343,
+        "Height": 1281.3765740406152,
+        "FontSize": 36.0,
+        "InitialTop": 97.373300957078015,
+        "InitialHeight": 1258.3765740406152,
+        "TextblockHeight": 43.0,
+        "Background": "#FFB5B5B5"
+      },
+      {
+        "Id": "7a5b7aa2b25246fdad452af61771d38f",
+        "Title": "All Values Match\r\n5b0b1aba-ee6b-420e-aa12-e54270c00718",
+        "Nodes": [
+          "3464510891444af98b3ede7f8458d805"
+        ],
+        "Left": 2551.5346310478508,
+        "Top": 208.02074076270105,
+        "Width": 686.17000000000007,
+        "Height": 189.5,
+        "FontSize": 36.0,
+        "InitialTop": 304.52074076270105,
+        "InitialHeight": 123.0,
+        "TextblockHeight": 86.5,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "eed2e986223a43f2b63d483b04e0a40f",
+        "Title": "All Keys Match\r\n5b0b1aba-ee6b-420e-aa12-e54270c00718",
+        "Nodes": [
+          "5b0b1abaee6b420eaa12e54270c00718"
+        ],
+        "Left": 2556.0103286748536,
+        "Top": -20.760154556617238,
+        "Width": 686.17000000000007,
+        "Height": 189.5,
+        "FontSize": 36.0,
+        "InitialTop": 75.739845443382762,
+        "InitialHeight": 123.0,
+        "TextblockHeight": 86.5,
+        "Background": "#FFC1D676"
+      }
+    ],
+    "X": 95.675757742115252,
+    "Y": 179.97415057092428,
+    "Zoom": 0.42560868662467261
+  }
+}


### PR DESCRIPTION
### Purpose

Picking up the work original completed by @pboyer in #8597

This PR:
- cherry-picks the work completed by Peter
- renames the class from `JSON` to `Data` as dicussed with the team
- eliminates the `Stringify` node and renames `StringifyList` to `StringifyJSON` (replication and list@level can accomplish the same behavior)
- renames `Parse` to `ParseJSON`
- design script syntax
    - `DSCore.Data.ParseJSON("{'thing':1}");`
    - `DSCore.Data.StringifyJSON({"thing":1});`
- adds unit testing and test graphs

Icons Task: [DYN-975](https://jira.autodesk.com/browse/DYN-975)

**Library Layout**
![image](https://user-images.githubusercontent.com/13341935/49522887-a6056180-f876-11e8-89e5-afe03fbe97a4.png)

**Stringify vs StringifyList**
![image](https://user-images.githubusercontent.com/13341935/49523593-1bbdfd00-f878-11e8-8c54-fa86cb54a573.png)

**Examples**
![image](https://user-images.githubusercontent.com/13341935/49533481-1323f180-f88d-11e8-923e-da1c5f0e764d.png)
![image](https://user-images.githubusercontent.com/13341935/49533536-3d75af00-f88d-11e8-9847-92fb6105d048.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap @ColinDayOrg 

### FYIs

@mjkkirschner @QilongTang @Racel 