### PR TITLE
Add marshaling between Dynamo and Python dictionaries

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.1.0.7051")]
+[assembly: AssemblyVersion("2.1.0.4395")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.1.0.7051")]
+[assembly: AssemblyFileVersion("2.1.0.4395")]

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -45,7 +45,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.1.0.4395")]
+[assembly: AssemblyVersion("2.1.0.7051")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -64,4 +64,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.1.0.4395")]
+[assembly: AssemblyFileVersion("2.1.0.7051")]

--- a/src/DynamoUtilities/DataMarshaler.cs
+++ b/src/DynamoUtilities/DataMarshaler.cs
@@ -18,11 +18,13 @@ namespace Dynamo.Utilities
 
         public DataMarshaler()
         {
-            //RegisterMarshaler((IEnumerable e) => e.Cast<object>().Select(Marshal));
             RegisterMarshaler((IList e) => e.Cast<object>().Select(Marshal).ToList());
             RegisterMarshaler(
                 (IDictionary dict) =>
-                    dict.Cast<dynamic>().ToDictionary(x => Marshal(x.Key), x => Marshal(x.Value)));
+                {
+                    // Dictionary<TKey, TValue> and IronPython.Runtime.PythonDictionary both implement IDictionary
+                    return dict.Keys.Cast<object>().ToDictionary(key => Marshal(key), key => Marshal(dict[key]));
+                });
         }
 
         /// <summary>

--- a/src/Libraries/DSIronPython/DSIronPython.csproj
+++ b/src/Libraries/DSIronPython/DSIronPython.csproj
@@ -97,6 +97,10 @@
       <Name>DynamoServices</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\DesignScriptBuiltin\DesignScriptBuiltin.csproj">
+      <Project>{c0d6dee5-5532-4345-9c66-4c00d7fdb8be}</Project>
+      <Name>DesignScriptBuiltin</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -107,10 +111,6 @@
     <ItemGroup>
       <PythonStdLib Include="$(ProjectDir)..\..\packages\IronPython.StdLib.2.7.8.1\contentFiles\any\any\Lib\**\*.*" />
     </ItemGroup>
-    <Copy 
-      SourceFiles="@(PythonStdLib)"
-      DestinationFiles="@(PythonStdLib->'$(TargetDir)IronPython.StdLib.2.7.8\%(RecursiveDir)%(Filename)%(Extension)')"
-      SkipUnchangedFiles="true"
-    />
+    <Copy SourceFiles="@(PythonStdLib)" DestinationFiles="@(PythonStdLib->'$(TargetDir)IronPython.StdLib.2.7.8\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/src/Libraries/DSIronPython/IronPythonEvaluator.cs
+++ b/src/Libraries/DSIronPython/IronPythonEvaluator.cs
@@ -9,6 +9,7 @@ using Dynamo.Utilities;
 using IronPython.Hosting;
 
 using Microsoft.Scripting.Hosting;
+using Microsoft.Scripting.Utils;
 
 namespace DSIronPython
 {
@@ -54,7 +55,8 @@ namespace DSIronPython
             // Return the standard library path
             if (!string.IsNullOrEmpty(dynamoCorePath))
             { return dynamoCorePath + @"\IronPython.StdLib.2.7.8"; }
-            else { return null; }
+
+            return null;
         }
 
         /// <summary>
@@ -154,6 +156,16 @@ namespace DSIronPython
                                 pyList.Add(item);
                             }
                             return pyList;
+                        });
+                    inputMarshaler.RegisterMarshaler(
+                        delegate (DesignScript.Builtin.Dictionary dict)
+                        {
+                            var pyDict = new IronPython.Runtime.PythonDictionary();
+                            foreach (var key in dict.Keys)
+                            {
+                                pyDict.Add(inputMarshaler.Marshal(key), inputMarshaler.Marshal(dict.ValueAtKey(key)));
+                            }
+                            return pyDict;
                         });
                 }
                 return inputMarshaler;

--- a/test/DynamoCoreTests/DSEvaluationUnitTestBase.cs
+++ b/test/DynamoCoreTests/DSEvaluationUnitTestBase.cs
@@ -155,7 +155,7 @@ namespace Dynamo.Tests
             {
                 if (!(value is IEnumerable))
                 {
-                    Assert.Fail("Data is collection but expected vlaue is not.");
+                    Assert.Fail("Data is collection but expected value is not.");
                 }
                 AssertCollection(data, value as IEnumerable);
             }
@@ -180,7 +180,7 @@ namespace Dynamo.Tests
                 try
                 {
                     double mirrorData = Convert.ToDouble(data.Data);
-                    Assert.AreEqual((double)value, Convert.ToDouble(data.Data), 0.00001);
+                    Assert.AreEqual((double)value, mirrorData, 0.00001);
                 }
                 catch (Exception e)
                 {
@@ -191,30 +191,59 @@ namespace Dynamo.Tests
             {
                 Assert.AreEqual(data.Class.ClassName, value);
             }
-            else if (data.IsPointer && value is DesignScript.Builtin.Dictionary)
+            else if (data.IsDictionary) 
             {
                 var thisData = data.Data as DesignScript.Builtin.Dictionary;
 
-                if (thisData == null)
+                if (value is DesignScript.Builtin.Dictionary)
                 {
-                    Assert.Fail("Data is expected to be DS Dictionary but is not.");
-                }
-                var otherVal = (DesignScript.Builtin.Dictionary) value;
+                    var otherVal = (DesignScript.Builtin.Dictionary) value;
 
-                if (otherVal.Count != thisData.Count)
-                {
-                    Assert.Fail("Data and expected value are 2 different dictionaries.");
-                }
-                foreach (var key in otherVal.Keys)
-                {
-                    var val = thisData.ValueAtKey(key);
-                    if (val == null)
+                    if (otherVal.Count != thisData.Count)
                     {
                         Assert.Fail("Data and expected value are 2 different dictionaries.");
                     }
-                    if (val.GetType().IsValueType)
+
+                    foreach (var key in otherVal.Keys)
                     {
-                        Assert.AreEqual(val, thisData.ValueAtKey(key));
+                        var val = thisData.ValueAtKey(key);
+                        if (val == null)
+                        {
+                            Assert.Fail("Data and expected value are 2 different dictionaries.");
+                        }
+
+                        if (val.GetType().IsValueType)
+                        {
+                            Assert.AreEqual(val, thisData.ValueAtKey(key));
+                        }
+                    }
+                }
+                else if (value is IDictionary)
+                {
+                    var otherVal = (IDictionary)value;
+
+                    if (otherVal.Count != thisData.Count)
+                    {
+                        Assert.Fail("Data and expected value are 2 different dictionaries.");
+                    }
+
+                    foreach (var key in otherVal.Keys)
+                    {
+                        if (!(key is string))
+                        {
+                            Assert.Fail("Expected value is a dictionary with non-string key(s).");
+                        }
+                        var strKey = (string) key;
+                        var val = thisData.ValueAtKey(strKey);
+                        if (val == null)
+                        {
+                            Assert.Fail("Data and expected value are 2 different dictionaries.");
+                        }
+
+                        if (val.GetType().IsValueType)
+                        {
+                            Assert.AreEqual(val, thisData.ValueAtKey(strKey));
+                        }
                     }
                 }
             }

--- a/test/Libraries/DynamoPythonTests/PythonEditTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEditTests.cs
@@ -16,6 +16,7 @@ namespace Dynamo.Tests
     {
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
+            libraries.Add("DesignScriptBuiltin.dll");
             libraries.Add("DSIronPython.dll");
             base.GetLibrariesToPreload(libraries);
         }
@@ -159,7 +160,7 @@ namespace Dynamo.Tests
             foreach(NodeModel node in allNodes) {
                 var guid = node.GUID.ToString();
 
-                // if node is a test node, verify truthy value
+                // if node is a test node, verify truth value
                 if (testingNodeGUIDS.Contains(guid) ) {
                     AssertPreviewValue(guid, true);
                 }
@@ -167,6 +168,43 @@ namespace Dynamo.Tests
 
             var pynode = model.CurrentWorkspace.Nodes.OfType<PythonNode>().First();
             Assert.NotNull(pynode);
+        }
+
+        [Test]
+        public void ReturnPythonDictionary_AsDynamoDictionary()
+        {
+            // open test graph
+            var examplePath = Path.Combine(TestDirectory, @"core\python", "python_dict.dyn");
+            ViewModel.OpenCommand.Execute(examplePath);
+
+            var guid = "490a8d54d0fa4782ae18c81f6eef8306";
+
+            AssertPreviewValue(guid, new Dictionary<string, int> { { "abc", 123 }, { "def", 345 } });
+        }
+
+        [Test]
+        public void InputDynamoDictionary_AsPythonDictionary()
+        {
+            // open test graph
+            var examplePath = Path.Combine(TestDirectory, @"core\python", "python_dict2.dyn");
+            ViewModel.OpenCommand.Execute(examplePath);
+
+            var guid = "490a8d54d0fa4782ae18c81f6eef8306";
+
+            AssertPreviewValue(guid,
+                new List<object> {new Dictionary<string, int> {{"abcd", 123}}, new List<int> {1, 2, 3, 4, 5, 6, 7, 8, 9}});
+        }
+
+        [Test]
+        public void ReturnIronPythonDictionary_AsDynamoDictionary()
+        {
+            // open test graph
+            var examplePath = Path.Combine(TestDirectory, @"core\python", "netDict_from_python.dyn");
+            ViewModel.OpenCommand.Execute(examplePath);
+
+            var guid = "490a8d54d0fa4782ae18c81f6eef8306";
+
+            AssertPreviewValue(guid, new Dictionary<string, int> {{"abc", 123}, {"def", 10}});
         }
 
         private void UpdatePythonNodeContent(ModelBase pythonNode, string value)

--- a/test/core/json/JSON_Nodes_PythonJSONParsing.dyn
+++ b/test/core/json/JSON_Nodes_PythonJSONParsing.dyn
@@ -95,7 +95,7 @@
     {
       "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
       "NodeType": "PythonScriptNode",
-      "Code": "import json\r\n\r\ndataEnteringNode = IN\r\njsonString = IN[0]\r\nuser = IN[1]\r\n\r\njsonObject = json.loads(jsonString)\r\nuserData = jsonObject[user]\r\n\r\nkeys = []\r\nvalues = []\r\n\r\nfor key in userData:\r\n\tkeys.append(key)\r\n\t# String conversion required until\r\n\t# dictionary marshalling is handled\r\n\tvalues.append(userData[key])\r\n\r\nOUT = [keys, values]",
+      "Code": "import json\r\n\r\ndataEnteringNode = IN\r\njsonString = IN[0]\r\nuser = IN[1]\r\n\r\njsonObject = json.loads(jsonString)\r\nuserData = jsonObject[user]\r\n\r\n\r\nOUT = userData",
       "VariableInputPorts": true,
       "Id": "779061094688496285e56d9a328a5d3a",
       "Inputs": [
@@ -155,11 +155,11 @@
     {
       "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
       "NodeType": "CodeBlockNode",
-      "Code": "keys = out[0];\nvalues = out[1];",
+      "Code": "keys = out.Keys;\nvalues = out.Values;",
       "Id": "d87d6380630649cca2f86b9e7b053799",
       "Inputs": [
         {
-          "Id": "53003810c5f44358a1cc7909b3243747",
+          "Id": "87ff69c2617446f7a1a3987bfce094b4",
           "Name": "out",
           "Description": "out",
           "UsingDefaultValue": false,
@@ -170,7 +170,7 @@
       ],
       "Outputs": [
         {
-          "Id": "bf7c44f4d39844b68a7d5b088170d216",
+          "Id": "67eafcdb583044248d5cd4c1323c4dd6",
           "Name": "",
           "Description": "keys",
           "UsingDefaultValue": false,
@@ -179,7 +179,7 @@
           "KeepListStructure": false
         },
         {
-          "Id": "34c03b8aa96941c58cfde9e1ab16b29b",
+          "Id": "fde4208a2a4f49d8b0a8c2ffa8329285",
           "Name": "",
           "Description": "values",
           "UsingDefaultValue": false,
@@ -567,8 +567,8 @@
     },
     {
       "Start": "0f2a5482f3344f3882e0d1d6fa538eb3",
-      "End": "53003810c5f44358a1cc7909b3243747",
-      "Id": "e48825e706c64151b9e103d21329cde5"
+      "End": "87ff69c2617446f7a1a3987bfce094b4",
+      "Id": "489639b5e8824525bc0a8beeeeca41d0"
     },
     {
       "Start": "e7f642f033534a228b0e4b9832cad7e2",
@@ -581,14 +581,14 @@
       "Id": "99be5d52197e4fc58d415c5e36901b39"
     },
     {
-      "Start": "bf7c44f4d39844b68a7d5b088170d216",
+      "Start": "67eafcdb583044248d5cd4c1323c4dd6",
       "End": "e98f923977f142988a6388f0822a5692",
-      "Id": "e6e12e1a12db445fbb97dab172c1cf76"
+      "Id": "7311dcc1110e47609c9937874f374abb"
     },
     {
-      "Start": "34c03b8aa96941c58cfde9e1ab16b29b",
+      "Start": "fde4208a2a4f49d8b0a8c2ffa8329285",
       "End": "29310781d81241caa05785f586c9e32c",
-      "Id": "6f58091e4b1f4eddb2fcfc64cd467579"
+      "Id": "fa722d5154f54f34a2770a8228436388"
     },
     {
       "Start": "9b4540e5237944dea8a676bf1eb29110",
@@ -648,7 +648,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.1.0.7035",
+      "Version": "2.1.0.7085",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
@@ -835,13 +835,13 @@
           "6ffabd95f6034f2fa6f7da1c1fcc0cae"
         ],
         "Left": 1282.705451720042,
-        "Top": 429.95858662810139,
-        "Width": 433.69415581661428,
-        "Height": 757.51599984258,
+        "Top": 429.62525329476807,
+        "Width": 434.02748914994766,
+        "Height": 774.6826665092467,
         "FontSize": 36.0,
         "InitialTop": 482.95858662810139,
         "InitialHeight": 146.01599984258002,
-        "TextblockHeight": 43.0,
+        "TextblockHeight": 43.333333333333336,
         "Background": "#FF848484"
       },
       {
@@ -853,13 +853,13 @@
           "d87d6380630649cca2f86b9e7b053799"
         ],
         "Left": 1703.6627560043753,
-        "Top": 242.37182159321435,
-        "Width": 560.5344957768707,
-        "Height": 178.18035626119115,
+        "Top": 242.038488259881,
+        "Width": 594.20116244353733,
+        "Height": 178.51368959452449,
         "FontSize": 36.0,
         "InitialTop": 295.37182159321435,
         "InitialHeight": 177.18035626119115,
-        "TextblockHeight": 43.0,
+        "TextblockHeight": 43.333333333333336,
         "Background": "#FF848484"
       },
       {
@@ -877,13 +877,13 @@
           "93d189b6cfd24cc8839ef3f432378ec4"
         ],
         "Left": 2280.0971508009493,
-        "Top": 239.62033666367597,
-        "Width": 916.60628019930482,
-        "Height": 402.372303313242,
+        "Top": 239.28700333034263,
+        "Width": 916.93961353263819,
+        "Height": 402.70563664657539,
         "FontSize": 36.0,
         "InitialTop": 292.62033666367597,
         "InitialHeight": 401.372303313242,
-        "TextblockHeight": 43.0,
+        "TextblockHeight": 43.333333333333336,
         "Background": "#FF848484"
       },
       {
@@ -893,13 +893,13 @@
           "e4e600d912a6400eadb302c1ad26cddf"
         ],
         "Left": 3237.9796812989362,
-        "Top": 246.89355688810986,
+        "Top": 247.06022355477651,
         "Width": 457.05333333333334,
-        "Height": 160.5,
+        "Height": 160.33333333333334,
         "FontSize": 24.0,
         "InitialTop": 314.39355688810986,
         "InitialHeight": 145.0,
-        "TextblockHeight": 57.5,
+        "TextblockHeight": 57.333333333333336,
         "Background": "#FFC1D676"
       },
       {
@@ -909,18 +909,18 @@
           "cdad5bf1f5f747f4a119ad42e5084cfa"
         ],
         "Left": 3236.8826608107138,
-        "Top": 416.77902445834695,
+        "Top": 416.61235779168027,
         "Width": 433.01333333333338,
-        "Height": 189.5,
+        "Height": 189.66666666666669,
         "FontSize": 24.0,
         "InitialTop": 513.279024458347,
         "InitialHeight": 145.0,
-        "TextblockHeight": 86.5,
+        "TextblockHeight": 86.666666666666671,
         "Background": "#FFC1D676"
       }
     ],
-    "X": -937.64951064912168,
-    "Y": -104.09548099844363,
+    "X": -1051.6495106491216,
+    "Y": -110.76214766511026,
     "Zoom": 0.7485460120568
   }
 }

--- a/test/core/python/netDict_from_python.dyn
+++ b/test/core/python/netDict_from_python.dyn
@@ -1,0 +1,126 @@
+{
+  "Uuid": "23d0aaa0-9b42-406d-aad0-5b3962c51e5c",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "netDict_from_python",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nfrom System.Collections.Generic import Dictionary,List\r\nimport clr\r\n\r\n# The inputs to this node will be stored as a list in the IN variables.\r\ndict = IN[0]\r\n\r\n\r\n# Place your code below this line\r\n\r\nnet_dict = Dictionary[str,int]()\r\n# Assign your output to the OUT variable.\r\nfor k, v in dict.items():\r\n\tnet_dict.Add(k, v)\r\n\t\r\nOUT = net_dict",
+      "VariableInputPorts": true,
+      "Id": "490a8d54d0fa4782ae18c81f6eef8306",
+      "Inputs": [
+        {
+          "Id": "c0a6dd1427e2431cbaa66386e7581f78",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c22911e84b564cecb09c6a8f55661791",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded IronPython script."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "{\"abc\":123, \"def\":10};",
+      "Id": "e1f1c82d24b0484d93990fca95926011",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "86efc04625aa46cf80d3e06c7537929b",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "86efc04625aa46cf80d3e06c7537929b",
+      "End": "c0a6dd1427e2431cbaa66386e7581f78",
+      "Id": "88695235622d416a921402e6167e2b9d"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.7071",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "490a8d54d0fa4782ae18c81f6eef8306",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 519.33333333333326,
+        "Y": 132.00000000000006
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "e1f1c82d24b0484d93990fca95926011",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 73.333333333333371,
+        "Y": 144.33333333333337
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/python/python_dict.dyn
+++ b/test/core/python/python_dict.dyn
@@ -1,0 +1,126 @@
+{
+  "Uuid": "23d0aaa0-9b42-406d-aad0-5b3962c51e5c",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "python_dict",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\n\r\n# The inputs to this node will be stored as a list in the IN variables.\r\nkey = IN[0]\r\n\r\npyDict = {\"abc\" : 123, key : 345} \r\n# Place your code below this line\r\n\r\n# Assign your output to the OUT variable.\r\nOUT = pyDict",
+      "VariableInputPorts": true,
+      "Id": "490a8d54d0fa4782ae18c81f6eef8306",
+      "Inputs": [
+        {
+          "Id": "c0a6dd1427e2431cbaa66386e7581f78",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c22911e84b564cecb09c6a8f55661791",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded IronPython script."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"def\";",
+      "Id": "e1f1c82d24b0484d93990fca95926011",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "d35d6f36918e4ca895a5b87792b742b2",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "d35d6f36918e4ca895a5b87792b742b2",
+      "End": "c0a6dd1427e2431cbaa66386e7581f78",
+      "Id": "f51c196c929f4ae6b365498473553cfd"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.7085",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "490a8d54d0fa4782ae18c81f6eef8306",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 213.33333333333326,
+        "Y": 123.33333333333337
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "e1f1c82d24b0484d93990fca95926011",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 73.333333333333371,
+        "Y": 144.33333333333337
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/core/python/python_dict2.dyn
+++ b/test/core/python/python_dict2.dyn
@@ -1,0 +1,126 @@
+{
+  "Uuid": "23d0aaa0-9b42-406d-aad0-5b3962c51e5c",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "python_dict2",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "DesignScript.Builtin.Dictionary": {
+        "Key": "DesignScript.Builtin.Dictionary",
+        "Value": "DesignScriptBuiltin.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
+      "NodeType": "PythonScriptNode",
+      "Code": "# Load the Python Standard and DesignScript Libraries\r\nimport sys\r\nimport clr\r\n\r\n# The inputs to this node will be stored as a list in the IN variables.\r\ndict = IN[0]\r\n\r\n\r\n# Place your code below this line\r\n\r\n# Assign your output to the OUT variable.\r\nOUT = [dict[\"dict\"], dict[\"list\"]]",
+      "VariableInputPorts": true,
+      "Id": "490a8d54d0fa4782ae18c81f6eef8306",
+      "Inputs": [
+        {
+          "Id": "c0a6dd1427e2431cbaa66386e7581f78",
+          "Name": "IN[0]",
+          "Description": "Input #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "c22911e84b564cecb09c6a8f55661791",
+          "Name": "OUT",
+          "Description": "Result of the python script",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Runs an embedded IronPython script."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "{\"dict\":{\"abcd\":123}, \"list\":1..9};",
+      "Id": "e1f1c82d24b0484d93990fca95926011",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "5801426be2fc4ed8a226c0cd37bd0137",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "5801426be2fc4ed8a226c0cd37bd0137",
+      "End": "c0a6dd1427e2431cbaa66386e7581f78",
+      "Id": "5b3ce39fabd2444da055f5e830178c3d"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.7071",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Python Script",
+        "Id": "490a8d54d0fa4782ae18c81f6eef8306",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 519.33333333333326,
+        "Y": 132.00000000000006
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "e1f1c82d24b0484d93990fca95926011",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 73.333333333333371,
+        "Y": 144.33333333333337
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

Add Dynamo Dictionary <-> Python Dictionary marshaling support.
JIRA: https://jira.autodesk.com/browse/QNTM-2990

![image](https://user-images.githubusercontent.com/5710686/49675173-7324be80-fa6c-11e8-8038-f69a6f459b46.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

I've yet to add tests and run self-service - WIP

### Reviewers

@alfarok 
@mjkkirschner 
