### PR TITLE
UI fix for Dictionary label in node preview

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -2869,26 +2869,4 @@ namespace Dynamo.Controls
             throw new NotImplementedException();
         }
     }
-
-    /// <summary>
-    /// Converter is used in WatchTree.xaml 
-    /// It converts the boolean value of WatchViewModel.IsTopLevel to determine the margin of the list node label
-    /// </summary>
-
-    public class TopLevelLabelMarginConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            if ((bool)value)
-            {
-                return new Thickness(-4,0,4,0);
-            }
-            return new Thickness(0,0,4,0);
-        }
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
 }

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -162,7 +162,6 @@
     <controls:LeftThicknessConverter x:Key="LeftThicknessConverter" />
     <controls:ListIndexBackgroundConverter x:Key="ListIndexBackgroundConverter" />
     <controls:ListIndexMarginConverter x:Key="ListIndexMarginConverter" />
-    <controls:TopLevelLabelMarginConverter x:Key="TopLevelLabelMarginConverter"/>
     <controls:NestedContentMarginConverter x:Key="NestedContentMarginConverter"/>
     <controls:ClassViewMarginConverter x:Key="ClassViewMarginConverter" />
     <controls:ElementGroupToColorConverter x:Key="ElementGroupToColorConverter" />

--- a/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
+++ b/src/DynamoCoreWpf/Views/Preview/WatchTree.xaml
@@ -312,7 +312,7 @@
                                    Visibility="{Binding Path=NodeLabel, Converter={StaticResource EmptyStringToCollapsedConverter}}"
                                    Width="Auto"
                                    FontFamily="Consolas"
-                                   Margin="{Binding Path =IsTopLevel, Converter={StaticResource TopLevelLabelMarginConverter}}" />
+                                   Margin="0,0,4,0"/>
                         <Button Content="{Binding Path=Link}"
                                 RenderTransformOrigin="0.5,0.5"
                                 Margin="10,2,2,2"


### PR DESCRIPTION
### Purpose

This fixes the `Dictionary` top-level label in the node preview. The text was partially cut-off - more specifically the `D` in `Dictionary`. The reason was that the top-level label had a different margin setting than nested labels. This fix removes the special setting for top-level labels and keeps just one margin setting for both top and nested labels. 

Before:
![image](https://user-images.githubusercontent.com/5710686/49778183-c6f90700-fcfb-11e8-9a87-0d59fee6065c.png)

After:
![image](https://user-images.githubusercontent.com/5710686/49776249-26064e00-fcf3-11e8-9fbb-42e0358b11e5.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 
@Racel - this requires your UX review as the top-level labels for both `List` and `Dictionary` texts are shifted 4 units to the right and are the same as nested labels. Note that I couldn't find an alternative way of fixing this UI issue.

