### PR TITLE
API for libG Preloader Lookup

### DIFF
--- a/src/Tools/DynamoShapeManager/Preloader.cs
+++ b/src/Tools/DynamoShapeManager/Preloader.cs
@@ -136,16 +136,7 @@ namespace DynamoShapeManager
             var shapeManagerPath = string.Empty; // Folder that contains ASM binaries.
             Version2 = Utilities.GetInstalledAsmVersion2(versionList, ref shapeManagerPath, rootFolder);
             ShapeManagerPath = shapeManagerPath;
-
-            int major = 0, minor = 0, build = 0;
-            if (Version2 != null)
-            {
-                major = Version2.Major;
-                minor = Version2.Minor;
-                build = Version2.Build;
-            }
-            var libGFolderName = string.Format("libg_{0}_{1}_{2}", major, minor, build);
-            PreloaderLocation = Path.Combine(rootFolder, libGFolderName);
+            PreloaderLocation = Utilities.GetLibGPreloaderLocation(Version2, rootFolder);
             GeometryFactoryPath = Path.Combine(PreloaderLocation,
                 Utilities.GeometryFactoryAssembly);
         }

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -203,6 +203,38 @@ namespace DynamoShapeManager
         }
 
         /// <summary>
+        /// Get the corresponding libG preloader location for the target ASM loading version.
+        /// </summary>
+        /// <param name="version">The target loading version of ASM.</param>
+        /// <param name="rootFolder">Full path of the directory that contains 
+        /// LibG_major_minor_build folder. In a 
+        /// typical setup this would be the same directory that contains Dynamo 
+        /// core modules. This must represent a valid directory.</param>
+        /// <returns></returns>
+        public static string GetLibGPreloaderLocation(Version version, string rootFolder)
+        {
+            int major = 0, minor = 0, build = 0;
+            if (version != null)
+            {
+                major = version.Major;
+                minor = version.Minor;
+                build = version.Build;
+            }
+
+            var libGFolderName = string.Format("libg_{0}_{1}_{2}", version.Major, version.Minor, version.Build);
+            var dir = new DirectoryInfo(Path.Combine(rootFolder, libGFolderName));
+            if (dir.Exists)
+                return dir.FullName;
+            else
+            {
+                // This usually means libG version is behind the target version, fallback to use another existing version 
+                var rootDir = new DirectoryInfo(rootFolder);
+                // TODO: Sort the existing libG folders somehow and find a folder below the target ASM version
+                return rootDir.GetDirectories().Where(x => x.Name.Contains("LibG_" + version.Major.ToString())).First().FullName;
+            }
+        }
+
+        /// <summary>
         /// Call this method to preload ASM binaries from a specific location. This 
         /// method does not have a return value, any failures in loading ASM binaries
         /// will result in an exception being thrown.

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -215,12 +215,9 @@ namespace DynamoShapeManager
         /// <returns></returns>
         public static string GetLibGPreloaderLocation(Version version, string rootFolder)
         {
-            int major = 0, minor = 0, build = 0;
-            if (version != null)
+            if (version == null)
             {
-                major = version.Major;
-                minor = version.Minor;
-                build = version.Build;
+                version = new Version(0, 0, 0);
             }
 
             var libGFolderName = string.Format("libg_{0}_{1}_{2}", version.Major, version.Minor, version.Build);
@@ -251,8 +248,8 @@ namespace DynamoShapeManager
                 }
                 preloaderVersions.Sort();
                 preloaderVersions.Reverse();
-                // Pick the closest preloader version below
-                var preloaderVersion = preloaderVersions.First();
+                // Pick the closest preloader version below or use the default value when no libG folder found
+                var preloaderVersion = preloaderVersions.FirstOrDefault() == null ? version : preloaderVersions.First();
                 libGFolderName = string.Format("libg_{0}_{1}_{2}", preloaderVersion.Major, preloaderVersion.Minor, preloaderVersion.Build);
                 return libGFolderName;
             }

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -286,11 +286,11 @@ namespace DynamoShapeManager
 
             if (string.IsNullOrEmpty(preloaderLocationToLoad))
             {
-                throw new ArgumentException("preloadedPath");
+                throw new ArgumentException("Invalid LibG preloader location for ASM at " + asmLocation);
             }
             if (string.IsNullOrEmpty(asmLocation) || !Directory.Exists(asmLocation))
             {
-                throw new ArgumentException("asmLocation");
+                throw new ArgumentException("Invalid ASM location " + asmLocation);
             }
             var preloaderPath = Path.Combine(preloaderLocationToLoad, PreloaderAssembly);
 

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -205,7 +205,7 @@ namespace DynamoShapeManager
         /// <summary>
         /// Get the corresponding libG preloader location for the target ASM loading version.
         /// If there is exact match preloader version to the target ASM version, use it, 
-        /// otherwise use the closet below.
+        /// otherwise use the closest below.
         /// </summary>
         /// <param name="version">The target loading version of ASM.</param>
         /// <param name="rootFolder">Full path of the directory that contains 
@@ -226,7 +226,9 @@ namespace DynamoShapeManager
             var libGFolderName = string.Format("libg_{0}_{1}_{2}", version.Major, version.Minor, version.Build);
             var dir = new DirectoryInfo(Path.Combine(rootFolder, libGFolderName));
             if (dir.Exists)
+            {
                 return dir.FullName;
+            }
             else
             {
                 // This usually means libG preloader version is behind the target version
@@ -239,7 +241,7 @@ namespace DynamoShapeManager
                 foreach (var folder in libgFolders)
                 {
                     var match = regExp.Match(folder.Name);
-                    if (match.Groups.Count == 4)
+                    if (match.Groups.Count == 4 && Convert.ToInt32(match.Groups[1].Value) <= version.Major)
                     {
                         preloaderVersions.Add(new Version(
                                 Convert.ToInt32(match.Groups[1].Value),

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -250,8 +250,7 @@ namespace DynamoShapeManager
                 preloaderVersions.Reverse();
                 // Pick the closest preloader version below or use the default value when no libG folder found
                 var preloaderVersion = preloaderVersions.FirstOrDefault() == null ? version : preloaderVersions.First();
-                libGFolderName = string.Format("libg_{0}_{1}_{2}", preloaderVersion.Major, preloaderVersion.Minor, preloaderVersion.Build);
-                return libGFolderName;
+                return Path.Combine(rootFolder, string.Format("libg_{0}_{1}_{2}", preloaderVersion.Major, preloaderVersion.Minor, preloaderVersion.Build));
             }
         }
 

--- a/test/DynamoCoreTests/libGPreloaderTests.cs
+++ b/test/DynamoCoreTests/libGPreloaderTests.cs
@@ -167,6 +167,41 @@ namespace Dynamo.Tests
             libG22500path.Delete(true);
         }
 
+        [Test]
+        public void GetLibGPreloaderLocation_libGVersionFallback()
+        {
+            var versions = new List<Version>()
+            {
+                    new Version(225,4,0)
+            };
+
+            var mockedInstalledASMs = new Dictionary<string, Tuple<int, int, int, int>>()
+            {
+
+                {"revit_Prerelease_InstallLocation" ,Tuple.Create<int,int,int,int>(225,3,0,0)},
+            };
+
+            var targetVersion = new Version(225, 3, 0);
+
+            // mock a folder with libASMLibVersionToVersionG folders with correct names
+            var foundPath = "";
+            var rootFolder = Path.Combine(Path.GetTempPath(), "LibGTest");
+            // both versions of libG exist
+            var libG22440path = System.IO.Directory.CreateDirectory(Path.Combine(rootFolder, "LibG_224_4_0"));
+            var libG22500path = System.IO.Directory.CreateDirectory(Path.Combine(rootFolder, "LibG_225_0_0"));
+
+            var foundVersion = DynamoShapeManager.Utilities.GetInstalledAsmVersion2(
+                versions, ref foundPath, rootFolder, (path) => { return mockedInstalledASMs; });
+
+            // The found version in this case is a fallback of lowest version within same major which should be 225.0.0
+            Assert.AreEqual(targetVersion, foundVersion);
+            Assert.AreEqual("revit_Prerelease_InstallLocation", foundPath);
+            Assert.AreEqual(libG22500path.Name.ToLower(), DynamoShapeManager.Utilities.GetLibGPreloaderLocation(foundVersion, rootFolder));
+            // cleanup
+            libG22440path.Delete(true);
+            libG22500path.Delete(true);
+        }
+
 
         [Test]
         public void GetInstalledASMVersions2_FindsVersionedLibGFolders_WithRootFolderFallback()

--- a/test/DynamoCoreTests/libGPreloaderTests.cs
+++ b/test/DynamoCoreTests/libGPreloaderTests.cs
@@ -193,10 +193,12 @@ namespace Dynamo.Tests
             var foundVersion = DynamoShapeManager.Utilities.GetInstalledAsmVersion2(
                 versions, ref foundPath, rootFolder, (path) => { return mockedInstalledASMs; });
 
-            // The found version in this case is a fallback of lowest version within same major which should be 225.0.0
+            // The found ASM version in this case is a fallback of lowest version within same major which should be 225.3.0
             Assert.AreEqual(targetVersion, foundVersion);
             Assert.AreEqual("revit_Prerelease_InstallLocation", foundPath);
-            Assert.AreEqual(libG22500path.Name.ToLower(), DynamoShapeManager.Utilities.GetLibGPreloaderLocation(foundVersion, rootFolder));
+
+            // The found libG preloader version in this case is another fallback of closest version below 225.3.0
+            Assert.AreEqual(libG22500path.FullName.ToLower(), DynamoShapeManager.Utilities.GetLibGPreloaderLocation(foundVersion, rootFolder).ToLower());
             // cleanup
             libG22440path.Delete(true);
             libG22500path.Delete(true);


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

This is an improvement when working with a beta release of ASM release that we make our libG preloader lookup mechanism more tolerant than just search for the exact match.

The influence of this API is that for in-process Dynamo integration, client need to add this API call to their ASM preloading logic:

```
        internal static Version PreloadAsmFromRevit()
        {
            var asmLocation = AppDomain.CurrentDomain.BaseDirectory;
            Version libGversion = findRevitASMVersion(asmLocation);
            var dynCorePath = DynamoRevitApp.DynamoCorePath;
            var preloaderLocation = DynamoShapeManager.Utilities.GetLibGPreloaderLocation(libGversion, dynCorePath);
            DynamoShapeManager.Utilities.PreloadAsmFromPath(preloaderLocation, asmLocation);
            return libGversion;
        }
```

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
Running self-CI
- [ ] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@angelowang @mjkkirschner 

### FYIs

@aparajit-pratap @alfarok 
