### PR TITLE
cherry pick -Avoid namespace collisions when collapsing graph to custom node (#9330) 2.1 RC

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Xml;
 using Dynamo.Engine;
+using Dynamo.Engine.NodeToCode;
 using Dynamo.Graph;
 using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Connectors;
@@ -22,6 +17,13 @@ using Dynamo.Models;
 using Dynamo.Properties;
 using Dynamo.Selection;
 using Dynamo.Utilities;
+using ProtoCore.AST.AssociativeAST;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Xml;
 using Symbol = Dynamo.Graph.Nodes.CustomNodes.Symbol;
 
 namespace Dynamo.Core
@@ -674,7 +676,8 @@ namespace Dynamo.Core
                 nodeGraph.ElementResolver,
                 workspaceInfo);
             }
-            else {
+            else
+            {
                 Exception ex;
                 if (DynamoUtilities.PathHelper.isValidJson(workspaceInfo.FileName, out jsonDoc, out ex))
                 {
@@ -1031,6 +1034,7 @@ namespace Dynamo.Core
 
                 var inConnectors = new List<Tuple<NodeModel, int>>();
                 var uniqueInputSenders = new Dictionary<Tuple<NodeModel, int>, Symbol>();
+                var classTable = this.libraryServices.LibraryManagementCore.ClassTable;
 
                 //Step 3: insert variables (reference step 1)
                 foreach (var input in Enumerable.Range(0, inputs.Count).Zip(inputs, Tuple.Create))
@@ -1077,10 +1081,17 @@ namespace Dynamo.Core
                             var funcDesc = dsFunc.Controller.Definition;
                             parameters = funcDesc.Parameters.ToList();
 
+                            // if the node is an instance member the function won't contain a 
+                            // parameter for this type so we need to generate a new typedParameter.
                             if (funcDesc.Type == Engine.FunctionType.InstanceMethod ||
                                 funcDesc.Type == Engine.FunctionType.InstanceProperty)
                             {
-                                var dummyType = new ProtoCore.Type() { Name = funcDesc.ClassName };
+                                var dummyType = new ProtoCore.Type
+                                {
+                                    Name = funcDesc.ClassName,
+                                    UID = classTable.IndexOf(funcDesc.ClassName)
+                                };
+
                                 var instanceParam = new TypedParameter(funcDesc.ClassName, dummyType);
                                 parameters.Insert(0, instanceParam);
                             }
@@ -1090,10 +1101,35 @@ namespace Dynamo.Core
                         //    input_var_name : type
                         if (parameters != null && parameters.Count() > inputReceiverData)
                         {
-                            var typeName = parameters[inputReceiverData].DisplayTypeName;
-                            if (!string.IsNullOrEmpty(typeName))
+                            var port = inputReceiverNode.InPorts[inputReceiverData];
+                            var typedParameter = parameters[inputReceiverData];
+                            // initially set the type name to the full type name
+                            // then try to shorten it.
+                            if (!string.IsNullOrEmpty(typedParameter.Type.Name))
                             {
-                                node.InputSymbol += " : " + typeName;
+                                try
+                                {
+
+                                    var typedNode = new TypedIdentifierNode
+                                    {
+                                        Name = port.Name,
+                                        Value = port.Name,
+                                        datatype = typedParameter.Type,
+                                        TypeAlias = typedParameter.Type.Name
+                                    };
+
+                                    NodeToCodeCompiler.ReplaceWithShortestQualifiedName(
+                                        classTable,
+                                        new List<AssociativeNode> { typedNode },
+                                        currentWorkspace.ElementResolver);
+
+                                    node.InputSymbol = $"{typedNode.Value} :{typedNode.TypeAlias}";
+                                }
+                                catch(Exception e)
+                                {
+                                    node.InputSymbol += ":" + typedParameter.Type.Name;
+                                    this.AsLogger().LogError($"{e.Message}: could not generate a short type name for {typedParameter.Type.Name}");
+                                }
                             }
                         }
 

--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -112,6 +112,7 @@ limitations under the License.
     <Compile Include="Configuration\DebugSettings.cs" />
     <Compile Include="Configuration\Context.cs" />
     <Compile Include="Core\DynamoMigrator.cs" />
+    <Compile Include="Engine\ShortestQualifiedNameReplacer.cs" />
     <Compile Include="Exceptions\LibraryLoadFailedException.cs" />
     <Compile Include="Graph\Nodes\NodeOutputData.cs" />
     <Compile Include="Graph\Nodes\NodeInputData.cs" />

--- a/src/DynamoCore/Engine/NodeToCode/NodeToCode.cs
+++ b/src/DynamoCore/Engine/NodeToCode/NodeToCode.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Dynamo.Core;
+﻿using Dynamo.Core;
 using Dynamo.Engine.CodeGeneration;
 using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
@@ -10,7 +7,9 @@ using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM;
 using ProtoCore.Namespace;
 using ProtoCore.SyntaxAnalysis;
-using ProtoCore.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Dynamo.Engine.NodeToCode
 {
@@ -299,142 +298,6 @@ namespace Dynamo.Engine.NodeToCode
                 node.RightNode = newRightNode;
 
             return node;
-        }
-    }
-
-    /// <summary>
-    /// Replace a fully qualified function call with short name. 
-    /// </summary>
-    internal class ShortestQualifiedNameReplacer : AstReplacer
-    {
-        private readonly ClassTable classTable;
-        private readonly ElementResolver resolver;
-
-        public ShortestQualifiedNameReplacer(ClassTable classTable, ElementResolver resolver)
-        {
-            this.classTable = classTable;
-            this.resolver = resolver;
-        }
-
-        public override AssociativeNode VisitIdentifierListNode(IdentifierListNode node)
-        {
-            if (node == null)
-                return null;
-
-            // First pass attempt to resolve the node class name 
-            // and shorten it before traversing it deeper
-            AssociativeNode shortNameNode;
-            if (TryShortenClassName(node, out shortNameNode))
-                return shortNameNode;
-
-            var rightNode = node.RightNode;
-            var leftNode = node.LeftNode;
-
-            rightNode = rightNode.Accept(this);
-            var newLeftNode = leftNode.Accept(this);
-
-            node = new IdentifierListNode
-            {
-                LeftNode = newLeftNode,
-                RightNode = rightNode,
-                Optr = Operator.dot
-            };
-            return leftNode != newLeftNode ? node : RewriteNodeWithShortName(node);
-        }
-
-        private bool TryShortenClassName(IdentifierListNode node, out AssociativeNode shortNameNode)
-        {
-            shortNameNode = null;
-
-            string qualifiedName = CoreUtils.GetIdentifierExceptMethodName(node);
-
-            // if it is a global method with no class
-            if (string.IsNullOrEmpty(qualifiedName))
-                return false;
-
-            // Make sure qualifiedName is not a property
-            var matchingClasses = classTable.GetAllMatchingClasses(qualifiedName);
-            if (matchingClasses.Length == 0)
-                return false;
-
-            string className = qualifiedName.Split('.').Last();
-
-            var symbol = new ProtoCore.Namespace.Symbol(qualifiedName);
-            if (!symbol.Matches(node.ToString()))
-                return false;
-
-            shortNameNode = CreateNodeFromShortName(className, qualifiedName);
-            return shortNameNode != null;
-        }
-
-        private IdentifierListNode RewriteNodeWithShortName(IdentifierListNode node)
-        {
-            // Get class name from AST
-            string qualifiedName = CoreUtils.GetIdentifierExceptMethodName(node);
-
-            // if it is a global method
-            if (string.IsNullOrEmpty(qualifiedName))
-                return node;
-
-            // Make sure qualifiedName is not a property
-            var lNode = node.LeftNode;
-            var matchingClasses = classTable.GetAllMatchingClasses(qualifiedName);
-            while (matchingClasses.Length == 0 && lNode is IdentifierListNode)
-            {
-                qualifiedName = lNode.ToString();
-                matchingClasses = classTable.GetAllMatchingClasses(qualifiedName);
-                lNode = ((IdentifierListNode)lNode).LeftNode;
-            }
-            qualifiedName = lNode.ToString();
-            string className = qualifiedName.Split('.').Last();
-
-            var newIdentList = CreateNodeFromShortName(className, qualifiedName);
-            if (newIdentList == null)
-                return node;
-
-            // Replace class name in input node with short name (newIdentList)
-            node = new IdentifierListNode
-            {
-                LeftNode = newIdentList,
-                RightNode = node.RightNode,
-                Optr = Operator.dot
-            };
-            return node;
-        }
-
-        private AssociativeNode CreateNodeFromShortName(string className, string qualifiedName)
-        {
-            // Get the list of conflicting namespaces that contain the same class name
-            var matchingClasses = CoreUtils.GetResolvedClassName(classTable, AstFactory.BuildIdentifier(className));
-            if (matchingClasses.Length == 0)
-                return null;
-
-            string shortName;
-            // if there is no class conflict simply use the class name as the shortest name
-            if (matchingClasses.Length == 1)
-            {
-                shortName = className;
-            }
-            else
-            {
-                shortName = resolver != null ? resolver.LookupShortName(qualifiedName) : null;
-
-                if (string.IsNullOrEmpty(shortName))
-                {
-                    // Use the namespace list as input to derive the list of shortest unique names
-                    var symbolList =
-                        matchingClasses.Select(matchingClass => new ProtoCore.Namespace.Symbol(matchingClass))
-                            .ToList();
-                    var shortNames = ProtoCore.Namespace.Symbol.GetShortestUniqueNames(symbolList);
-
-                    // Get the shortest name corresponding to the fully qualified name
-                    shortName = shortNames[new ProtoCore.Namespace.Symbol(qualifiedName)];
-                }
-            }
-            // Rewrite the AST using the shortest name
-            var newIdentList = CoreUtils.CreateNodeFromString(shortName);
-            return newIdentList;
-
         }
     }
 
@@ -1194,6 +1057,7 @@ namespace Dynamo.Engine.NodeToCode
                 ast.Accept(replacer);
             }
         }
+
 
         /// <summary>
         /// Compile a set of nodes to ASTs. 

--- a/src/DynamoCore/Engine/ShortestQualifiedNameReplacer.cs
+++ b/src/DynamoCore/Engine/ShortestQualifiedNameReplacer.cs
@@ -1,0 +1,191 @@
+﻿using ProtoCore;
+using ProtoCore.AST.AssociativeAST;
+using ProtoCore.DSASM;
+using ProtoCore.Namespace;
+using ProtoCore.SyntaxAnalysis;
+using ProtoCore.Utils;
+using System.Linq;
+
+
+namespace Dynamo.Engine
+{
+    /// <summary>
+    /// Replace a fully qualified function call with short name. 
+    /// </summary>
+    internal class ShortestQualifiedNameReplacer : AstReplacer
+    {
+        private readonly ClassTable classTable;
+        private readonly ElementResolver resolver;
+
+        public ShortestQualifiedNameReplacer(ClassTable classTable, ElementResolver resolver)
+        {
+            this.classTable = classTable;
+            this.resolver = resolver;
+        }
+
+        public override AssociativeNode VisitTypedIdentifierNode(TypedIdentifierNode node)
+        {
+            if (node == null)
+                return null;
+
+            // If type is primitive type
+            if (node.datatype.UID != (int)PrimitiveType.InvalidType &&
+                node.datatype.UID < (int)PrimitiveType.MaxPrimitive)
+                return node;
+
+            // build an idlistnode from the full type name
+            var identListNode = CoreUtils.CreateNodeFromString(node.TypeAlias);
+            if (identListNode == null)
+                return node;
+
+            // visit the idlist 
+            var shortNameNode = identListNode.Accept(this);
+            if (shortNameNode == null)
+                return node;
+
+
+            var resultingNode = new TypedIdentifierNode
+            {
+                Name = node.Name,
+                Value = node.Name,
+                datatype = node.datatype
+            };
+
+
+            //return a typedIdNode built from the shortNameId returned above.
+            resultingNode.TypeAlias = shortNameNode.ToString();
+
+            //modify the AST node that was passed to the visitor.
+            node.Name = resultingNode.Name;
+            node.Value = resultingNode.Value;
+            node.datatype = resultingNode.datatype;
+            node.TypeAlias = resultingNode.TypeAlias;
+
+            return node;
+        }
+
+
+        public override AssociativeNode VisitIdentifierListNode(IdentifierListNode node)
+        {
+            if (node == null)
+                return null;
+
+            // First pass attempt to resolve the node class name 
+            // and shorten it before traversing it deeper
+            AssociativeNode shortNameNode;
+            if (TryShortenClassName(node, out shortNameNode))
+            {
+                return shortNameNode;
+            }
+
+            var rightNode = node.RightNode;
+            var leftNode = node.LeftNode;
+
+            rightNode = rightNode.Accept(this);
+            var newLeftNode = leftNode.Accept(this);
+
+            node = new IdentifierListNode
+            {
+                LeftNode = newLeftNode,
+                RightNode = rightNode,
+                Optr = Operator.dot
+            };
+            return leftNode != newLeftNode ? node : RewriteNodeWithShortName(node);
+        }
+
+        private bool TryShortenClassName(IdentifierListNode node, out AssociativeNode shortNameNode)
+        {
+            shortNameNode = null;
+
+            string qualifiedName = CoreUtils.GetIdentifierExceptMethodName(node);
+
+            // if it is a global method with no class
+            if (string.IsNullOrEmpty(qualifiedName))
+                return false;
+
+            // Make sure qualifiedName is not a property
+            var matchingClasses = classTable.GetAllMatchingClasses(qualifiedName);
+            if (matchingClasses.Length == 0)
+                return false;
+
+            string className = qualifiedName.Split('.').Last();
+
+            var symbol = new ProtoCore.Namespace.Symbol(qualifiedName);
+            if (!symbol.Matches(node.ToString()))
+                return false;
+
+            shortNameNode = CreateNodeFromShortName(className, qualifiedName);
+            return shortNameNode != null;
+        }
+
+        private IdentifierListNode RewriteNodeWithShortName(IdentifierListNode node)
+        {
+            // Get class name from AST
+            string qualifiedName = CoreUtils.GetIdentifierExceptMethodName(node);
+
+            // if it is a global method
+            if (string.IsNullOrEmpty(qualifiedName))
+                return node;
+
+            // Make sure qualifiedName is not a property
+            var lNode = node.LeftNode;
+            var matchingClasses = classTable.GetAllMatchingClasses(qualifiedName);
+            while (matchingClasses.Length == 0 && lNode is IdentifierListNode)
+            {
+                qualifiedName = lNode.ToString();
+                matchingClasses = classTable.GetAllMatchingClasses(qualifiedName);
+                lNode = ((IdentifierListNode)lNode).LeftNode;
+            }
+            qualifiedName = lNode.ToString();
+            string className = qualifiedName.Split('.').Last();
+
+            var newIdentList = CreateNodeFromShortName(className, qualifiedName);
+            if (newIdentList == null)
+                return node;
+
+            // Replace class name in input node with short name (newIdentList)
+            node = new IdentifierListNode
+            {
+                LeftNode = newIdentList,
+                RightNode = node.RightNode,
+                Optr = Operator.dot
+            };
+            return node;
+        }
+
+        private AssociativeNode CreateNodeFromShortName(string className, string qualifiedName)
+        {
+            // Get the list of conflicting namespaces that contain the same class name
+            var matchingClasses = CoreUtils.GetResolvedClassName(classTable, AstFactory.BuildIdentifier(className));
+            if (matchingClasses.Length == 0)
+                return null;
+
+            string shortName;
+            // if there is no class conflict simply use the class name as the shortest name
+            if (matchingClasses.Length == 1)
+            {
+                shortName = className;
+            }
+            else
+            {
+                shortName = resolver != null ? resolver.LookupShortName(qualifiedName) : null;
+
+                if (string.IsNullOrEmpty(shortName))
+                {
+                    // Use the namespace list as input to derive the list of shortest unique names
+                    var symbolList =
+                        matchingClasses.Select(matchingClass => new ProtoCore.Namespace.Symbol(matchingClass))
+                            .ToList();
+                    var shortNames = ProtoCore.Namespace.Symbol.GetShortestUniqueNames(symbolList);
+
+                    // Get the shortest name corresponding to the fully qualified name
+                    shortName = shortNames[new ProtoCore.Namespace.Symbol(qualifiedName)];
+                }
+            }
+            // Rewrite the AST using the shortest name
+            var newIdentList = CoreUtils.CreateNodeFromString(shortName);
+            return newIdentList;
+
+        }
+    }
+}

--- a/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
+++ b/src/DynamoCore/Graph/Nodes/CustomNodes/Function.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Xml;
-using Dynamo.Engine;
+﻿using Dynamo.Engine;
 using Dynamo.Engine.CodeGeneration;
 using Dynamo.Library;
 using Newtonsoft.Json;
@@ -12,6 +8,10 @@ using ProtoCore.BuildData;
 using ProtoCore.DSASM;
 using ProtoCore.Namespace;
 using ProtoCore.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
 
 namespace Dynamo.Graph.Nodes.CustomNodes
 {
@@ -387,10 +387,24 @@ namespace Dynamo.Graph.Nodes.CustomNodes
             ElementResolver = new ElementResolver();
         }
 
+        // TODO - Dynamo 3.0 - use JSONConstructor on this method
+        // and remove custom logic in nodeReadConverter for symbol nodes.
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Symbol"/> class.
+        /// </summary>
+        public Symbol(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts, TypedParameter parameter, ElementResolver elementResolver) : base(inPorts, outPorts)
+        {
+            ArgumentLacing = LacingStrategy.Disabled;
+            InputSymbol = parameter.ToCommentNameString();
+            ElementResolver = elementResolver ?? new ElementResolver();
+        }
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="Symbol"/> class.
         /// </summary>
         [JsonConstructor]
+        [Obsolete("This method will be removed in Dynamo 3.0 - please use the constructor with ElementResolver parameter ")]
         public Symbol(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts, TypedParameter parameter) : base(inPorts, outPorts)
         {
             ArgumentLacing = LacingStrategy.Disabled;

--- a/src/DynamoCore/Graph/Workspaces/NodesToCodeExtensions.cs
+++ b/src/DynamoCore/Graph/Workspaces/NodesToCodeExtensions.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using Dynamo.Engine;
+﻿using Dynamo.Engine;
 using Dynamo.Engine.NodeToCode;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
 using Dynamo.Selection;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
 
 namespace Dynamo.Graph.Workspaces
 {

--- a/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
+++ b/src/DynamoCore/Graph/Workspaces/SerializationConverters.cs
@@ -167,6 +167,7 @@ namespace Dynamo.Graph.Workspaces
                 if (isUnresolved)
                   function.UpdatePortsForUnresolved(inPorts, outPorts);
             }
+
             else if (type == typeof(CodeBlockNodeModel))
             {
                 var code = obj["Code"].Value<string>();
@@ -244,7 +245,12 @@ namespace Dynamo.Graph.Workspaces
             else
             {
                 node = (NodeModel)obj.ToObject(type);
-
+                
+                // if node is an customNode input symbol - assign the element resolver.
+                if(node is Nodes.CustomNodes.Symbol)
+                {
+                    (node as Nodes.CustomNodes.Symbol).ElementResolver = ElementResolver;
+                }
                 // We don't need to remap ports for any nodes with json constructors which pass ports
                 remapPorts = false;
             }

--- a/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
+++ b/src/Engine/ProtoCore/SyntaxAnalysis/AstVisitor.cs
@@ -1,9 +1,8 @@
 ﻿using ProtoCore.AST;
 using ProtoCore.AST.AssociativeAST;
-using ImperativeNode = ProtoCore.AST.ImperativeAST.ImperativeNode;
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using ImperativeNode = ProtoCore.AST.ImperativeAST.ImperativeNode;
 
 namespace ProtoCore.SyntaxAnalysis
 {

--- a/src/Engine/ProtoCore/Utils/CoreUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CoreUtils.cs
@@ -1,12 +1,14 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using ProtoCore.AST.AssociativeAST;
 using ProtoCore.DSASM;
-using ProtoCore.AST.AssociativeAST;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ProtoCore.Utils
 {
     public static class CoreUtils
     {
+
+
         public static void InsertPredefinedAndBuiltinMethods(Core core, CodeBlockNode root)
         {
             if (DSASM.InterpreterMode.Normal == core.Options.RunMode)

--- a/test/DynamoCoreTests/CustomNodes.cs
+++ b/test/DynamoCoreTests/CustomNodes.cs
@@ -894,6 +894,82 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void TestCustomNodeFromCollapsedNodeHasSpecificTypes()
+        {
+            var examplePath = Path.Combine(TestDirectory, @"core\CustomNodes\");
+            OpenModel(Path.Combine(examplePath, "simpleGeometry.dyn"));
+
+            // Convert a DSFunction node Line.ByStartPointEndPoint to custom node.
+            var node = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DSFunction>().First();
+
+            var selectionSet = new List<NodeModel> { node };
+            var ws = CurrentDynamoModel.CustomNodeManager.Collapse(
+                selectionSet,
+                Enumerable.Empty<NoteModel>(),
+                CurrentDynamoModel.CurrentWorkspace,
+                true,
+                new FunctionNamePromptEventArgs
+                {
+                    Category = "Testing",
+                    Description = "",
+                    Name = "__CollapseTest__",
+                    Success = true
+                });
+
+            CurrentDynamoModel.AddCustomNodeWorkspace(ws);
+            CurrentDynamoModel.OpenCustomNodeWorkspace(ws.CustomNodeId);
+            var inputs = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<Symbol>().ToList();
+            Assert.IsNotNull(inputs);
+
+            inputs.ForEach(x => Assert.NotNull(x));
+
+            Assert.IsTrue(inputs.All(t => t.InputSymbol.EndsWith(":Point")));
+        }
+
+        [Test]
+        public void TestCustomNodeFromCollapsedNodeHasSpecificTypes_WithConflict()
+        {
+            //load the FFI target lib so we have some namespace conflicts
+            string libraryPath = "FFITarget.dll";
+            if (!CurrentDynamoModel.EngineController.LibraryServices.IsLibraryLoaded(libraryPath))
+            {
+                CurrentDynamoModel.EngineController.LibraryServices.ImportLibrary(libraryPath);
+            }
+
+            var examplePath = Path.Combine(TestDirectory, @"core\CustomNodes\");
+            OpenModel(Path.Combine(examplePath, "simpleGeometry.dyn"));
+
+            // Convert a DSFunction node Line.ByStartPointEndPoint to custom node.
+            var node = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<DSFunction>().First();
+
+            var selectionSet = new List<NodeModel> { node };
+            var ws = CurrentDynamoModel.CustomNodeManager.Collapse(
+                selectionSet,
+                Enumerable.Empty<NoteModel>(),
+                CurrentDynamoModel.CurrentWorkspace,
+                true,
+                new FunctionNamePromptEventArgs
+                {
+                    Category = "Testing",
+                    Description = "",
+                    Name = "__CollapseTest__",
+                    Success = true
+                });
+
+            CurrentDynamoModel.AddCustomNodeWorkspace(ws);
+            CurrentDynamoModel.OpenCustomNodeWorkspace(ws.CustomNodeId);
+            var inputs = CurrentDynamoModel.CurrentWorkspace.Nodes.OfType<Symbol>().ToList();
+            Assert.IsNotNull(inputs);
+
+            inputs.ForEach(x => Assert.NotNull(x));
+
+            Assert.IsTrue(inputs.All(t =>
+            {
+                return t.InputSymbol.EndsWith(":Autodesk.Point");
+            }));
+        }
+
+        [Test]
         public void TestCustomNodeInSyncWithDefinition()
         {
             var basePath = Path.Combine(TestDirectory, @"core\CustomNodes\");

--- a/test/DynamoCoreTests/NodeToCodeTest.cs
+++ b/test/DynamoCoreTests/NodeToCodeTest.cs
@@ -1,23 +1,19 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Collections.Generic;
-using Dynamo.Scheduler;
-using Dynamo.Selection;
-
-using NUnit.Framework;
-using Dynamo.Models;
-using Dynamo.Nodes;
-using Dynamo.Engine;
-using ProtoCore.AST.AssociativeAST;
-using System.Reflection;
-using System.Threading;
-using System.Globalization;
+﻿using Dynamo.Engine;
 using Dynamo.Engine.NodeToCode;
-using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
-using Dynamo.Interfaces;
+using Dynamo.Models;
+using Dynamo.Scheduler;
+using Dynamo.Selection;
+using NUnit.Framework;
+using ProtoCore.AST.AssociativeAST;
+using ProtoCore.Utils;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
 
 namespace Dynamo.Tests
 {
@@ -60,11 +56,11 @@ namespace Dynamo.Tests
             Assert.IsTrue(groups.Count == 2);
             foreach (var group in groups)
             {
-               if (group.Count == 2)
-               {
-                   Assert.IsNotNull(group.Find(n => n.Name == "2"));
-                   Assert.IsNotNull(group.Find(n => n.Name == "3"));
-               } 
+                if (group.Count == 2)
+                {
+                    Assert.IsNotNull(group.Find(n => n.Name == "2"));
+                    Assert.IsNotNull(group.Find(n => n.Name == "3"));
+                }
             }
         }
 
@@ -161,8 +157,8 @@ namespace Dynamo.Tests
             var idents = exprs.Select(e => (e.LeftNode as IdentifierNode).Value);
             var vals = exprs.Select(e => (e.RightNode as IntNode).Value);
 
-            Assert.IsTrue(new [] {"a", "a1", "a2"}.All(x => idents.Contains(x)));
-            Assert.IsTrue(new [] {1, 2, 3}.All(x => vals.Contains(x)));
+            Assert.IsTrue(new[] { "a", "a1", "a2" }.All(x => idents.Contains(x)));
+            Assert.IsTrue(new[] { 1, 2, 3 }.All(x => vals.Contains(x)));
         }
 
         [Test]
@@ -254,10 +250,10 @@ namespace Dynamo.Tests
             // It totally depends on which code block node is compiled firstly.
             // Variables in the first one won't be renamed.
             Assert.IsTrue(
-                ((exprs.Contains("a=1") && exprs.Contains("a1=2") && exprs.Contains("a3=a+a1") 
+                ((exprs.Contains("a=1") && exprs.Contains("a1=2") && exprs.Contains("a3=a+a1")
                 && exprs.Contains("a2=3") && exprs.Contains("a11=4") && exprs.Contains("a21=a2+a11"))
 
-             || ((exprs.Contains("a=3") && exprs.Contains("a1=4") && exprs.Contains("a2=a+a1") 
+             || ((exprs.Contains("a=3") && exprs.Contains("a1=4") && exprs.Contains("a2=a+a1")
                 && exprs.Contains("a3=1") && exprs.Contains("a11=2") && exprs.Contains("a31=a3+a11")))));
         }
 
@@ -428,15 +424,15 @@ namespace Dynamo.Tests
             }
 
             var functionCall = AstFactory.BuildFunctionCall(
-                "Autodesk.DesignScript.Geometry.Point", 
-                "ByCoordinates", 
-                new List<AssociativeNode> { new IntNode(1), new IntNode(2)});
+                "Autodesk.DesignScript.Geometry.Point",
+                "ByCoordinates",
+                new List<AssociativeNode> { new IntNode(1), new IntNode(2) });
             var lhs = AstFactory.BuildIdentifier("lhs");
             var ast = AstFactory.BuildBinaryExpression(lhs, functionCall, ProtoCore.DSASM.Operator.assign);
 
             NodeToCodeCompiler.ReplaceWithShortestQualifiedName(
-                CurrentDynamoModel.EngineController.LibraryServices.LibraryManagementCore.ClassTable, 
-                new [] { ast });
+                CurrentDynamoModel.EngineController.LibraryServices.LibraryManagementCore.ClassTable,
+                new[] { ast });
 
             // Since there is a conflict with FFITarget.DesignScript.Point and FFITarget.Dynamo.Point,
             // node to code generates the shortest unique name, which in this case will be
@@ -617,6 +613,80 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        public void TestShortestQualifiedNameReplacerTypedIdentiferFFITarget()
+        {
+            string libraryPath = "FFITarget.dll";
+            if (!CurrentDynamoModel.EngineController.LibraryServices.IsLibraryLoaded(libraryPath))
+            {
+                CurrentDynamoModel.EngineController.LibraryServices.ImportLibrary(libraryPath);
+            }
+            var typedIdNode = new TypedIdentifierNode
+            {
+                Name = "aName",
+                Value = "aName",
+                datatype = new ProtoCore.Type("FFITarget.Base", 0),
+                TypeAlias = "FFITarget.Base"
+            };
+            var oldTypeName = typedIdNode.datatype.Name;
+
+            var engine = CurrentDynamoModel.EngineController;
+            NodeToCodeCompiler.ReplaceWithShortestQualifiedName(engine.LibraryServices.LibraryManagementCore.ClassTable, new List<AssociativeNode>() { typedIdNode });
+
+            Assert.AreEqual("Base", typedIdNode.TypeAlias);
+            Assert.AreEqual(oldTypeName, typedIdNode.datatype.Name);
+            Assert.AreEqual("aName", typedIdNode.Name);
+            Assert.AreEqual("aName", typedIdNode.Value);
+        }
+
+        [Test]
+        public void TestShortestQualifiedNameReplacerTypedIdentifer()
+        {
+            var typedIdNode = new TypedIdentifierNode
+            {
+                Name = "aName",
+                Value = "aName",
+                datatype = new ProtoCore.Type("Autodesk.DesignScript.Geometry.Geometry", 0),
+                TypeAlias = "Autodesk.DesignScript.Geometry.Geometry"
+            };
+            var oldTypeName = typedIdNode.datatype.Name;
+
+            var engine = CurrentDynamoModel.EngineController;
+            NodeToCodeCompiler.ReplaceWithShortestQualifiedName(engine.LibraryServices.LibraryManagementCore.ClassTable, new List<AssociativeNode>() { typedIdNode });
+
+            Assert.AreEqual("Geometry", typedIdNode.TypeAlias);
+            Assert.AreEqual(oldTypeName, typedIdNode.datatype.Name);
+            Assert.AreEqual("aName", typedIdNode.Name);
+            Assert.AreEqual("aName", typedIdNode.Value);
+        }
+
+        [Test]
+        public void TestShortestQualifiedNameReplacerTypedIdentifer_WithConflict()
+        {
+            string libraryPath = "FFITarget.dll";
+            if (!CurrentDynamoModel.EngineController.LibraryServices.IsLibraryLoaded(libraryPath))
+            {
+                CurrentDynamoModel.EngineController.LibraryServices.ImportLibrary(libraryPath);
+            }
+
+            var typedIdNode = new TypedIdentifierNode
+            {
+                Name = "aName",
+                Value = "aName",
+                datatype = new ProtoCore.Type("Autodesk.DesignScript.Geometry.Point", 0),
+                TypeAlias = "Autodesk.DesignScript.Geometry.Point"
+            };
+            var oldTypeName = typedIdNode.datatype.Name;
+
+            var engine = CurrentDynamoModel.EngineController;
+            NodeToCodeCompiler.ReplaceWithShortestQualifiedName(engine.LibraryServices.LibraryManagementCore.ClassTable, new List<AssociativeNode>() { typedIdNode });
+
+            Assert.AreEqual("Autodesk.Point", typedIdNode.TypeAlias);
+            Assert.AreEqual(oldTypeName, typedIdNode.datatype.Name);
+            Assert.AreEqual("aName", typedIdNode.Name);
+            Assert.AreEqual("aName", typedIdNode.Value);
+        }
+
+        [Test]
         public void TestShortestQualifiedNameReplacerWithDefaultArgument()
         {
             string libraryPath = "FFITarget.dll";
@@ -636,9 +706,9 @@ namespace Dynamo.Tests
             Assert.IsNotNull(result.AstNodes);
 
             var expr1 = result.AstNodes.First() as BinaryExpressionNode;
-            
+
             Assert.IsNotNull(expr1);
-            
+
             // Since there is a conflict with FFITarget.DesignScript.Point and FFITarget.Dynamo.Point,
             // node to code generates the shortest unique name, which in this case will be
             // Autodesk.Point for Autodesk.DesignScript.Geometry.Point
@@ -1166,7 +1236,7 @@ namespace Dynamo.Tests
             Assert.IsNotNull(cbn);
             Assert.IsFalse(cbn.Code.Contains(guid));
         }
-        
+
         [Test]
         [Category("UnitTests")]
         public void TestNameProvider()
@@ -1181,11 +1251,11 @@ namespace Dynamo.Tests
 
             t = ProtoCore.TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.Integer);
             name = nameProvider.GetTypeDependentName(t);
-            Assert.AreEqual("num", name); 
+            Assert.AreEqual("num", name);
 
             t = ProtoCore.TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.Double);
             name = nameProvider.GetTypeDependentName(t);
-            Assert.AreEqual("num", name); 
+            Assert.AreEqual("num", name);
 
             t = ProtoCore.TypeSystem.BuildPrimitiveTypeObject(ProtoCore.PrimitiveType.String);
             name = nameProvider.GetTypeDependentName(t);
@@ -1206,7 +1276,7 @@ namespace Dynamo.Tests
             t.UID = -1;
             name = nameProvider.GetTypeDependentName(t);
             Assert.IsTrue(string.IsNullOrEmpty(name));
-        } 
+        }
 
         private void SelectAll(IEnumerable<NodeModel> nodes)
         {
@@ -1219,7 +1289,7 @@ namespace Dynamo.Tests
         public void TestDoubleValueInDifferentCulture()
         {
             var frCulture = CultureInfo.CreateSpecificCulture("fr-FR");
-            
+
             var currentCulture = Thread.CurrentThread.CurrentCulture;
             var currentUICulture = Thread.CurrentThread.CurrentUICulture;
 
@@ -1281,6 +1351,7 @@ namespace Dynamo.Tests
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
             libraries.Add("ProtoGeometry.dll");
+            libraries.Add("DesignScriptBuiltin.dll");
             base.GetLibrariesToPreload(libraries);
         }
 
@@ -1342,7 +1413,7 @@ namespace Dynamo.Tests
 
             RunModel(dynFilePath);
             // Block until all tasks are executed
-            while (CurrentDynamoModel.Scheduler.HasPendingTasks);
+            while (CurrentDynamoModel.Scheduler.HasPendingTasks) ;
 
             var allNodes = CurrentDynamoModel.CurrentWorkspace.Nodes.Select(n => n.GUID).ToList();
             int nodeCount = allNodes.Count();
@@ -1363,7 +1434,7 @@ namespace Dynamo.Tests
                 var command = new DynamoModel.ConvertNodesToCodeCommand();
                 CurrentDynamoModel.ExecuteCommand(command);
                 // Block until all tasks are executed
-                while (CurrentDynamoModel.Scheduler.HasPendingTasks);
+                while (CurrentDynamoModel.Scheduler.HasPendingTasks) ;
 
                 foreach (var node in otherNodes)
                 {
@@ -1392,5 +1463,15 @@ namespace Dynamo.Tests
                 }
             }
         }
+        /*
+        TODO these tests were disabled because they are not stable and 
+        their random nature makes them randmoly fail.
+        [Test, TestCaseSource("GetFilesForMutation")]
+        public void TestMutation(string fileName)
+        {
+            MutationTest(fileName);
+        }
+        
+     */
     }
 }

--- a/test/DynamoCoreTests/SerializationTests.cs
+++ b/test/DynamoCoreTests/SerializationTests.cs
@@ -11,8 +11,6 @@ using Dynamo.Models;
 using Newtonsoft.Json;
 using Dynamo.Engine;
 using Dynamo.Events;
-using System.Text.RegularExpressions;
-using Dynamo.Graph.Notes;
 using Dynamo.Utilities;
 using Newtonsoft.Json.Linq;
 using System.Globalization;


### PR DESCRIPTION
### Purpose

cherry pick:
https://github.com/DynamoDS/Dynamo/pull/9330

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang  - this looks much better now, matches the change amounts in the original PR.
I think what happened before was that the merge conflicts stopped the full list of commits from being applied, I'm not sure if you can continue a cherry pick on a conflicted squash commit like you can with regular commits - at least git did not tell me I needed to continue after the merge conflicts were fixed, so we should be cautious of cherry picking a squashed commit with conflicts atleast until we look into it a bit more.


