### PR TITLE
do not deserialize camera data that contains NaNs

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Watch3D/HelixWatch3DViewModel.cs
@@ -113,6 +113,16 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                    && Math.Abs(this.FarPlaneDistance - other.FarPlaneDistance) < 0.0001;
         }
 
+        internal bool isNaN()
+        {
+            var numericComponents = new List<double>(){ EyeX, EyeY, EyeZ, LookX, LookY, LookZ, UpX, UpY, UpZ };
+            if (numericComponents.Any(d => (Double.IsNaN(d))))
+            {
+                return true;
+            }
+            return false;
+        }
+
 
     }
 
@@ -637,7 +647,16 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                     try
                     {
                         var camData = DeserializeCamera(cameraNode);
-                        SetCameraData(camData);
+                        //check if the cameraData contains any NaNs
+                        if (camData.isNaN())
+                        {
+                            SetCameraData(new CameraData());
+                        }
+                        else
+                        {
+                            SetCameraData(camData);
+                        }
+                      
                     }
                     catch (Exception ex)
                     {
@@ -668,7 +687,16 @@ namespace Dynamo.Wpf.ViewModels.Watch3D
                 };
 
                 var cameraData = JsonConvert.DeserializeObject<CameraData>(cameraJson, settings);
-                SetCameraData(cameraData);
+
+                //check if the cameraData contains any NaNs
+                if (cameraData.isNaN())
+                {
+                    SetCameraData(new CameraData());
+                }
+                else
+                {
+                    SetCameraData(cameraData);
+                }
             }
         }
 


### PR DESCRIPTION
### Purpose

if a dyn file contains a malformed camera data somehow we should not deserialize it, and instead generate default camera data using our defaults. Angelo reports this was found in a file and results in extremely slow performance as exceptions are raised every frame.

- [ ] add tests

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs
@smangarole @alfarok 