### PR TITLE
[Cherry Pick] DYN-1480 to RC2.1.0

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1459,10 +1459,6 @@ Uninstall the following dependent packages: {1}?</value>
     <value>Show Labels</value>
     <comment>Context menu item - show labels</comment>
   </data>
-  <data name="NodeHelpWindowDynamoDictionary" xml:space="preserve">
-    <value>See more on the Dynamo Dictionary...</value>
-    <comment>Link to http://dictionary.dynamobim.com/ </comment>
-  </data>
   <data name="NodeHelpWindowNodeCategory" xml:space="preserve">
     <value>CATEGORY</value>
     <comment>Category label</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -768,10 +768,6 @@ It does not contain your graph or any personal data</value>
     <value>NODE TYPE</value>
     <comment>Title label</comment>
   </data>
-  <data name="NodeHelpWindowDynamoDictionary" xml:space="preserve">
-    <value>See more on the Dynamo Dictionary...</value>
-    <comment>Link to http://dictionary.dynamobim.com/ </comment>
-  </data>
   <data name="StartPageAsk" xml:space="preserve">
     <value>ASK</value>
   </data>

--- a/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/NodeHelpPrompt.xaml
@@ -73,9 +73,7 @@
 
             </StackPanel>
         </ScrollViewer>
-
-        <TextBlock Name="DynamoDictionary" Grid.Row="1" FontSize="12" Foreground="#2380C0" Margin="10,5,10,5" Text="{x:Static p:Resources.NodeHelpWindowDynamoDictionary}"
-                           Cursor="Hand" MouseLeftButtonUp="OpenDynamoDictionary" />
+        
     </Grid>
 
 


### PR DESCRIPTION
### Purpose

This PR cherry-picks DYN-1480 into the RC2.1.0 branch

That PR removed the Dynamo dictionary link from the bottom of the right-click help context menu dialog to avoid confusion between linking to v1 and v2 of the dictionary. 

Before:
![image](https://user-images.githubusercontent.com/10959111/50987155-cf00be00-14d6-11e9-8f61-7754fe4caa2e.png)

After (red rectangle is just to indicate the difference, not in the code changes):
![image](https://user-images.githubusercontent.com/10959111/50987295-46365200-14d7-11e9-904f-6bb4ebe5acb1.png)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [?] All tests pass using the self-service CI.
- [X] Snapshot of UI changes, if any.
- [X] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

### FYIs

@Racel 
