### PR TITLE
[Cherry-picked] 5909 report bug ux tested (#9393)

### DIFF
--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -97,7 +97,7 @@ namespace Dynamo.Configuration
         /// <summary>
         /// Link to Dynamo's issues on github
         /// </summary>
-        public static string GitHubBugReportingLink = "https://github.com/DynamoDS/Dynamo/issues";
+        public static string GitHubBugReportingLink = "https://github.com/DynamoDS/Dynamo/issues/new";
         #endregion
 
         #region Canvas Configurations

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -206,6 +206,7 @@
       <DependentUpon>PresetPrompt.xaml</DependentUpon>
     </Compile>
     <Compile Include="UI\VisualConfigurations.cs" />
+    <Compile Include="Utilities\CrashUtilities.cs" />
     <Compile Include="Utilities\LibraryDragAndDrop.cs" />
     <Compile Include="Utilities\OnceDisposable.cs" />
     <Compile Include="TestInfrastructure\ConnectorMutator.cs" />

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -748,6 +748,15 @@ namespace Dynamo.Wpf.Properties
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Crash report from Dynamo {0}.
+        /// </summary>
+        public static string CrashPromptGithubNewIssueTitle {
+            get {
+                return ResourceManager.GetString("CrashPromptGithubNewIssueTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Create.
         /// </summary>
         public static string CreateMember {

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1949,10 +1949,10 @@ Do you want to install the latest Dynamo update?</value>
     <value>Package Path Added</value>
   </data>
   <data name="PackagePathAutoAddNotificationShortDescription" xml:space="preserve">
-    <value>A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to "Settings &gt; Manage Node and Package Paths..."</value>
+    <value>A library (*.dll, *.ds) was recently imported into Dynamo. Its path was automatically added to "Settings > Manage Node and Package Paths..."</value>
   </data>
   <data name="PackagePathAutoAddNotificationDetailedDescription" xml:space="preserve">
-    <value>The import path "{0}" was added to "Manage Node and Package Paths". If you want to update or remove this path, please open "Settings &gt; Manage Node and Package Paths..."</value>
+    <value>The import path "{0}" was added to "Manage Node and Package Paths". If you want to update or remove this path, please open "Settings > Manage Node and Package Paths..."</value>
   </data>
   <data name="NodeContextMenuIsInput" xml:space="preserve">
     <value>Is Input</value>
@@ -2183,5 +2183,8 @@ Want to publish a different package?</value>
   <data name="CustomNodePropertyWindowLocationNote" xml:space="preserve">
     <value>Custom Nodes will be placed in the Add-Ons section of the library.</value>
     <comment>Note regarding Custom Node library location</comment>
+  </data>
+  <data name="CrashPromptGithubNewIssueTitle" xml:space="preserve">
+    <value>Crash report from Dynamo {0}</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml.cs
+++ b/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml.cs
@@ -92,7 +92,7 @@ namespace Dynamo.Nodes.Prompts
 
         private void PostOnGithub_Click(object sender, RoutedEventArgs e)
         {
-            DynamoViewModel.ReportABug(null);
+            DynamoViewModel.ReportABug(this.CrashDetailsContent.Text);
         }
 
         private void Details_Click(object sender, RoutedEventArgs e)

--- a/src/DynamoCoreWpf/Utilities/CrashUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashUtilities.cs
@@ -1,0 +1,70 @@
+﻿using Dynamo.Configuration;
+using Dynamo.Utilities;
+using System;
+
+namespace Dynamo.Wpf.Utilities
+{
+    static class CrashUtilities
+    {
+        internal static string GithubNewIssueUrlFromCrashContent(object crashContent)
+        {
+            var baseUri = new UriBuilder(Configurations.GitHubBugReportingLink);
+
+            // provide fallback values for text content in case Resources or Assembly calls fail
+            var issueTitle = Properties.Resources.CrashPromptGithubNewIssueTitle ?? "Crash report from Dynamo {0}";
+            var dynamoVersion = AssemblyHelper.GetDynamoVersion().ToString() ?? "2.1.0+";
+            var content = GitHubCrashReportBody(crashContent);
+
+            // append the title and body to the URL as query parameters
+            // making sure we properly escape content since stack traces may contain characters not suitable
+            // for use in URLs
+            var title = "title=" + Uri.EscapeDataString(string.Format(issueTitle, dynamoVersion));
+            var body = "body=" + Uri.EscapeDataString(content);
+            baseUri.Query = title + "&" + body;
+
+            // this will properly format the string for use as a uri
+            return baseUri.ToString();
+        }
+
+        /// <summary>
+        /// Formats crash details and adds metadata for use in Github issue body
+        /// </summary>
+        /// <param name="details">Crash details, such as a stack trace.</param>
+        /// <returns>A formatted, but not escaped, string to use as issue body.</returns>
+        private static string GitHubCrashReportBody(object details)
+        {
+            var stackTrace = details?.ToString() ?? string.Empty;
+
+            // This functionality was not available prior to version 2.1.0, so it should be the fallback value
+            var dynamoVersion = AssemblyHelper.GetDynamoVersion().ToString() ?? "2.1.0+";
+
+            return BuildMarkdownContent(dynamoVersion, stackTrace);
+        }
+
+        /// <summary>
+        /// Builds a Markdown string that will be posted to our new GitHub issue
+        /// </summary>
+        /// <param name="dynamoVersion">Dynamo version that should be recorded in the issue report</param>
+        /// <param name="stackTrace">The crash stack trace to be included in the issue report</param>
+        /// <returns></returns>
+        internal static string BuildMarkdownContent(string dynamoVersion, string stackTrace)
+        {
+            return
+            "# Issue Description" + Environment.NewLine +
+            "Please fill in the following information to help us reproduce the issue:" + Environment.NewLine +
+            "### What did you do?" + Environment.NewLine +
+            "(Fill in here)" + Environment.NewLine +
+            "### What did you expect to see?" + Environment.NewLine +
+            "(Fill in here)" + Environment.NewLine +
+            "### What did you see instead?" + Environment.NewLine +
+            "(Fill in here)" + Environment.NewLine +
+            "### What packages or external references (if any) were used?" + Environment.NewLine +
+            "(Fill in here)" + Environment.NewLine + Environment.NewLine +
+            "---" + Environment.NewLine +
+            "OS: " + "`" + Environment.OSVersion + "`" + Environment.NewLine +
+            "CLR: " + "`" + Environment.Version + "`" + Environment.NewLine +
+            "Dynamo: " + "`" + dynamoVersion + "`" + Environment.NewLine +
+            "Details: " + Environment.NewLine + "```" + Environment.NewLine + stackTrace + Environment.NewLine + "```";
+        }
+    }
+}

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -815,9 +815,19 @@ namespace Dynamo.ViewModels
             return Model.CustomNodeManager.Contains((Guid)parameters);
         }
 
-        public static void ReportABug(object parameter)
+        /// <summary>
+        /// Opens a new browser window pointing to the Dynamo repo new issue page, pre-filling issue 
+        /// title and content based on crash details. Uses system default browser.
+        /// </summary>
+        /// <param name="bodyContent">Crash details body. If null, nothing will be filled-in.</param>
+        public static void ReportABug(object bodyContent)
         {
-            Process.Start(new ProcessStartInfo("explorer.exe", Configurations.GitHubBugReportingLink));
+            var urlWithParameters = Wpf.Utilities.CrashUtilities.GithubNewIssueUrlFromCrashContent(bodyContent);
+
+            // launching the process using explorer.exe will format the URL incorrectly
+            // and Github will not recognise the query parameters in the URL
+            // so launch with default operating system web browser
+            Process.Start(new ProcessStartInfo(urlWithParameters));
         }
 
         public static void ReportABug()

--- a/test/DynamoCoreWpfTests/CrashReportingTests.cs
+++ b/test/DynamoCoreWpfTests/CrashReportingTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Dynamo.ViewModels;
+using NUnit.Framework;
+
+namespace Dynamo.Tests
+{
+    [TestFixture]
+    public class CrashReportingTests
+    {
+        // This is the stack trace produced by the known crash produced when 
+        // opening the Core.Math sample, selecting all nodes and doing NodeToCode.
+        private string StackTrace = @"
+            Object reference not set to an instance of an object.
+            at Dynamo.Graph.Nodes.CodeBlockNodeModel.GetTypeHintForOutput(Int32 index)
+            at Dynamo.Engine.NodeToCode.NodeToCodeCompiler.GetInputOutputMap(IEnumerable`1 nodes, Dictionary`2& inputMap, Dictionary`2& outputMap, Dictionary`2& renamingMap, Dictionary`2& typeHintMap)
+            at Dynamo.Engine.NodeToCode.NodeToCodeCompiler.NodeToCode(Core core, IEnumerable`1 workspaceNodes, IEnumerable`1 nodes, INamingProvider namingProvider)
+            at Dynamo.Graph.Workspaces.NodesToCodeExtensions.ConvertNodesToCodeInternal(WorkspaceModel workspace, EngineController engineController, INamingProvider namingProvider)
+            at Dynamo.Models.DynamoModel.ConvertNodesToCodeImpl(ConvertNodesToCodeCommand command)
+            at Dynamo.Models.DynamoModel.ExecuteCommand(RecordableCommand command)
+            at MS.Internal.Commands.CommandHelpers.CriticalExecuteCommandSource(ICommandSource commandSource, Boolean userInitiated)
+            at System.Windows.Controls.MenuItem.InvokeClickAfterRender(Object arg)
+            at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
+            at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
+            at System.Windows.Threading.DispatcherOperation.InvokeImpl()
+            at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
+            at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
+            at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
+            at MS.Internal.CulturePreservingExecutionContext.Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, Object state)
+            at System.Windows.Threading.DispatcherOperation.Invoke()
+            at System.Windows.Threading.Dispatcher.ProcessQueue()
+            at System.Windows.Threading.Dispatcher.WndProcHook(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
+            at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
+            at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
+            at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
+            at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
+            at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
+            at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
+            at MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
+            at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
+            at System.Windows.Application.RunDispatcher(Object ignore)
+            at System.Windows.Application.RunInternal(Window window)
+            at DynamoSandbox.DynamoCoreSetup.RunApplication(Application app)";
+
+        [Test]
+        public void CanReportBugWithNoContent()
+        {
+            // Create a crash report to submit
+            var crashReport = Wpf.Utilities.CrashUtilities.BuildMarkdownContent(null, null);
+            Assert.IsNotNullOrEmpty(crashReport);
+
+            // Mock url for request
+            string url = Wpf.Utilities.CrashUtilities.GithubNewIssueUrlFromCrashContent(crashReport);
+            Assert.IsNotNullOrEmpty(url);
+
+            // Report a bug with no details
+            Assert.DoesNotThrow(() => DynamoViewModel.ReportABug());
+        }
+
+        [Test]
+        public void CanReportBugWithContent()
+        {
+            // Mock Dynamo version
+            var dynamoVersion = "2.1.0";
+
+            // Create a crash report to submit
+            var crashReport = Wpf.Utilities.CrashUtilities.BuildMarkdownContent(dynamoVersion, StackTrace);
+            Assert.IsNotNullOrEmpty(crashReport);
+
+            // Report a bug with a stack trace
+            Assert.DoesNotThrow(() => DynamoViewModel.ReportABug(crashReport));
+        }
+
+        [Test]
+        public void StackTraceIncludedInReport()
+        {
+            // Mock Dynamo version
+            var dynamoVersion = "2.1.0";
+
+            // Create a crash report to submit
+            var crashReport = Wpf.Utilities.CrashUtilities.BuildMarkdownContent(dynamoVersion, StackTrace);
+            Assert.IsNotNullOrEmpty(crashReport);
+
+            // Mock url for request
+            string url = Wpf.Utilities.CrashUtilities.GithubNewIssueUrlFromCrashContent(crashReport);
+            Assert.IsNotNullOrEmpty(url);
+
+            // Get body content from request
+            var query = "body=";
+            var startIndex = url.IndexOf(query) + query.Length;
+            var body = url.Substring(startIndex);
+            var decoded = Uri.UnescapeDataString(body);
+
+            // Verify request contains the dynamoVersion
+            Assert.True(decoded.Contains(dynamoVersion));
+
+            // Verify request contains the stack trace
+            Assert.True(decoded.Contains(StackTrace));
+        }
+    }
+}

--- a/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
+++ b/test/DynamoCoreWpfTests/DynamoCoreWpfTests.csproj
@@ -168,6 +168,7 @@
     <Compile Include="PreviewBubbleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PublishPackageViewModelTests.cs" />
+    <Compile Include="CrashReportingTests.cs" />
     <Compile Include="RecentFileTests.cs" />
     <Compile Include="RecordedTests.cs" />
     <Compile Include="RunSettingsTests.cs" />

--- a/test/DynamoCoreWpfTests/Properties/AssemblyInfo.cs
+++ b/test/DynamoCoreWpfTests/Properties/AssemblyInfo.cs
@@ -12,3 +12,4 @@ using NUnit.Framework;
 [assembly: Guid("0e3a9cb1-69eb-4fc1-ab44-5fa36cfaa906")]
 [assembly: RequiresThread(ApartmentState.STA)]
 [assembly: InternalsVisibleTo("WpfVisualizationTests")]
+[assembly: InternalsVisibleTo("CrashReportingTests")]


### PR DESCRIPTION
[Original PR](https://github.com/DynamoDS/Dynamo/pull/9393)

* add /new to GitHubBugReportingLink url

* add bug report title to .resx

* add support for pre-filled new Github issue text when reporting

* Revert resx un-necessary changes

* simplify query construction

since we make a new Uri, it would never have any existing query parameters

* rename variables for legibility

* add fallback values for text to prevent null exceptions

* invert IF logic to bail early

* add XML comment for public method

* get rid of conditional logic :v:

* scaffold unit tests for CrashReporting

* add CrashReportingTests.cs to DynamoCoreWpfTests proj

* remove public access modifiers

* add logged out fallback and make tab detection case-insensitive

* move issue text & url formatting to new CrashUtilities.cs file

* add test for long stack trace

* Revert "Revert resx un-necessary changes"

This reverts commit 01fc93c1079ee8f75de7d1cea959a3486cd62af1.

* add description to issue crash report

* fix XML comments

* further formatting to crash report

* Include issue details from old template

* additional new line required

* remove browser interaction from unit tests

* decrement Dynamo version to make release

* comment spelling

* spelling - GithhubCrashReportBody becomes GitHubCrashReportBody

### FYIs

@QilongTang @smangarole @Racel @radumg 
