### PR TITLE
Fix Opening XMLs with invalid SelectedIndex

### DIFF
--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -83,7 +83,7 @@ namespace CoreNodeModels
             {
                 //do not allow selected index to
                 //go out of range of the items collection
-                if (value > Items.Count - 1 || value == -1)
+                if (value > Items.Count - 1 || value < 0)
                 {
                     selectedIndex = -1;
                     selectedString = String.Empty;
@@ -157,11 +157,14 @@ namespace CoreNodeModels
                 return;
 
             selectedIndex = ParseSelectedIndex(attrib.Value, Items);
-            selectedString = GetSelectedStringFromItem(Items.ElementAt(selectedIndex));
-
             if (selectedIndex < 0)
             {
                 Warning(Dynamo.Properties.Resources.NothingIsSelectedWarning);
+                selectedString = String.Empty;
+            }
+            else
+            {
+                selectedString = selectedIndex > Items.Count - 1? String.Empty: GetSelectedStringFromItem(Items.ElementAt(selectedIndex));
             }
         }
 
@@ -174,8 +177,14 @@ namespace CoreNodeModels
             {
                 selectedIndex = ParseSelectedIndex(value, Items);
                 if (selectedIndex < 0)
+                {
                     Warning(Dynamo.Properties.Resources.NothingIsSelectedWarning);
-                selectedString = GetSelectedStringFromItem(Items.ElementAt(selectedIndex));
+                    selectedString = String.Empty;
+                }
+                else
+                {
+                    selectedString = selectedIndex > Items.Count - 1 ? String.Empty : GetSelectedStringFromItem(Items.ElementAt(selectedIndex));
+                }
                 return true; // UpdateValueCore handled.
             }
 

--- a/test/DynamoCoreTests/Nodes/DropDownTests.cs
+++ b/test/DynamoCoreTests/Nodes/DropDownTests.cs
@@ -97,6 +97,93 @@ namespace Dynamo.Tests.Nodes
             Assert.AreEqual("Cersei", node.GetType().GetProperty("SelectedString").GetValue(node));
         }
 
+        /// <summary>
+        /// This test will make sure when opening an XML DYN containing dropdown
+        /// with invalid SelectedIndex but valid SelectedString can still be opened correctly
+        /// </summary>
+        [Test]
+        public void OpenXmlDYNwithInvalidSelectedIndex()
+        {
+            // Define package loading reference path
+            var dir = SystemTestBase.GetTestDirectory(ExecutingDirectory);
+            var pkgDir = Path.Combine(dir, "pkgs\\Dynamo Samples");
+            var pkgMan = this.CurrentDynamoModel.GetPackageManagerExtension();
+            var loader = pkgMan.PackageLoader;
+            var pkg = loader.ScanPackageDirectory(pkgDir);
+
+            // Load the sample package
+            loader.Load(pkg);
+            // Assert expected package was loaded
+            Assert.AreEqual(pkg.Name, "Dynamo Samples");
+
+            // Run the graph with correct info serialized, node should deserialize to correct selection
+            string path = Path.Combine(TestDirectory, "pkgs", "Dynamo Samples", "extra", "DropDownSample_1Dot3_InvalidSelectedIndex.dyn");
+            RunModel(path);
+
+            var node = CurrentDynamoModel.CurrentWorkspace.Nodes.FirstOrDefault();
+            // Second selection selected
+            Assert.AreEqual(1, node.GetType().GetProperty("SelectedIndex").GetValue(node));
+            Assert.AreEqual("Cersei", node.GetType().GetProperty("SelectedString").GetValue(node));
+        }
+
+        /// <summary>
+        /// This test will make sure when opening an XML DYN containing dropdown
+        /// with negative SelectedIndex can still be opened correctly
+        /// </summary>
+        [Test]
+        public void OpenXmlDYNwithInvalidSelectedIndex2()
+        {
+            // Define package loading reference path
+            var dir = SystemTestBase.GetTestDirectory(ExecutingDirectory);
+            var pkgDir = Path.Combine(dir, "pkgs\\Dynamo Samples");
+            var pkgMan = this.CurrentDynamoModel.GetPackageManagerExtension();
+            var loader = pkgMan.PackageLoader;
+            var pkg = loader.ScanPackageDirectory(pkgDir);
+
+            // Load the sample package
+            loader.Load(pkg);
+            // Assert expected package was loaded
+            Assert.AreEqual(pkg.Name, "Dynamo Samples");
+
+            // Run the graph with correct info serialized, node should deserialize to correct selection
+            string path = Path.Combine(TestDirectory, "pkgs", "Dynamo Samples", "extra", "DropDownSample_1Dot3_InvalidSelectedIndex2.dyn");
+            RunModel(path);
+
+            var node = CurrentDynamoModel.CurrentWorkspace.Nodes.FirstOrDefault();
+            // No selection selected
+            Assert.AreEqual(-1, node.GetType().GetProperty("SelectedIndex").GetValue(node));
+            Assert.AreEqual(String.Empty, node.GetType().GetProperty("SelectedString").GetValue(node));
+        }
+
+        /// <summary>
+        /// This test will make sure when opening an XML DYN containing dropdown
+        /// with SelectedIndex larger than item count can still be opened correctly
+        /// </summary>
+        [Test]
+        public void OpenXmlDYNwithInvalidSelectedIndex3()
+        {
+            // Define package loading reference path
+            var dir = SystemTestBase.GetTestDirectory(ExecutingDirectory);
+            var pkgDir = Path.Combine(dir, "pkgs\\Dynamo Samples");
+            var pkgMan = this.CurrentDynamoModel.GetPackageManagerExtension();
+            var loader = pkgMan.PackageLoader;
+            var pkg = loader.ScanPackageDirectory(pkgDir);
+
+            // Load the sample package
+            loader.Load(pkg);
+            // Assert expected package was loaded
+            Assert.AreEqual(pkg.Name, "Dynamo Samples");
+
+            // Run the graph with correct info serialized, node should deserialize to correct selection
+            string path = Path.Combine(TestDirectory, "pkgs", "Dynamo Samples", "extra", "DropDownSample_1Dot3_InvalidSelectedIndex3.dyn");
+            RunModel(path);
+
+            var node = CurrentDynamoModel.CurrentWorkspace.Nodes.FirstOrDefault();
+            // No selection selected
+            Assert.AreEqual(-1, node.GetType().GetProperty("SelectedIndex").GetValue(node));
+            Assert.AreEqual(String.Empty, node.GetType().GetProperty("SelectedString").GetValue(node));
+        }
+
         [Test]
         public void PopulateItemsShouldNotChangeSelectedIndex()
         {

--- a/test/pkgs/Dynamo Samples/extra/DropDownSample_1Dot3_InvalidSelectedIndex.dyn
+++ b/test/pkgs/Dynamo Samples/extra/DropDownSample_1Dot3_InvalidSelectedIndex.dyn
@@ -1,0 +1,13 @@
+<Workspace Version="1.3.3.4111" X="0" Y="0" zoom="1" ScaleFactor="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <SampleLibraryUI.Examples.DropDownExample guid="7234b6b0-c5ed-4c52-8a10-5b6445e58fd7" type="SampleLibraryUI.Examples.DropDownExample" nickname="Drop Down Example" x="194" y="170.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false" index="-1:Cersei" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>

--- a/test/pkgs/Dynamo Samples/extra/DropDownSample_1Dot3_InvalidSelectedIndex2.dyn
+++ b/test/pkgs/Dynamo Samples/extra/DropDownSample_1Dot3_InvalidSelectedIndex2.dyn
@@ -1,0 +1,13 @@
+<Workspace Version="1.3.3.4111" X="0" Y="0" zoom="1" ScaleFactor="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <SampleLibraryUI.Examples.DropDownExample guid="7234b6b0-c5ed-4c52-8a10-5b6445e58fd7" type="SampleLibraryUI.Examples.DropDownExample" nickname="Drop Down Example" x="194" y="170.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false" index="-1:" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>

--- a/test/pkgs/Dynamo Samples/extra/DropDownSample_1Dot3_InvalidSelectedIndex3.dyn
+++ b/test/pkgs/Dynamo Samples/extra/DropDownSample_1Dot3_InvalidSelectedIndex3.dyn
@@ -1,0 +1,13 @@
+<Workspace Version="1.3.3.4111" X="0" Y="0" zoom="1" ScaleFactor="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <SampleLibraryUI.Examples.DropDownExample guid="7234b6b0-c5ed-4c52-8a10-5b6445e58fd7" type="SampleLibraryUI.Examples.DropDownExample" nickname="Drop Down Example" x="194" y="170.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false" index="100:" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[DYN-1490](https://jira.autodesk.com/browse/DYN-1490)
10 Regressions in D4R 2.1.0

This PR fixes 6 out of the 10 regressions Revit farm caught which are all related to opening XML Dyns with invalid SelectedIndex serialized. 

The reason for this bug is that when SelectedIndex is -1, Items.ElementAt(selectedIndex) will throw exception thus crashing XML file opening. Changed code order to avoid that case and some new unit tests added.

The Json DYN opening is not affected because `DeserializeCore` and `UpdateValueCore` are not called there.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@ZiyunShang 

### FYIs


