### PR TITLE
[WIP] pr for feedback

### DIFF
--- a/src/NodeServices/DynamoServices.csproj
+++ b/src/NodeServices/DynamoServices.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Attributes.cs" />
     <Compile Include="ExecutionEvents.cs" />
     <Compile Include="ExecutionSession.cs" />
+    <Compile Include="ExtensionAppEvents.cs" />
     <Compile Include="GraphicsDataInterfaces.cs" />
     <Compile Include="IAnalyticsClient.cs" />
     <Compile Include="Interfaces.cs" />

--- a/src/NodeServices/ExtensionAppEvents.cs
+++ b/src/NodeServices/ExtensionAppEvents.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Dynamo.Events
+{
+    /// <summary>
+    /// This class is intended to support handling of shutdown and startup of the legacy ExtensionApp classes
+    /// which implements the <see cref="Autodesk.DesignScript.Interfaces.IExtensionApplication"/> interface.
+    /// </summary>
+    public class ExtensionAppEvents
+    {
+
+        public static Action<CancelableExtensionsShutdownArgs> TerminatingExtensionApplication;
+
+        internal static void OnTerminateExtensionApplication(CancelableExtensionsShutdownArgs args)
+        {
+            TerminatingExtensionApplication(args);
+        }
+
+    }
+
+    public class CancelableExtensionsShutdownArgs
+    {
+        public bool CancelShutdown { get; set; } = false;
+        public string ExtensionAppName { get; }
+
+        internal CancelableExtensionsShutdownArgs(string extensionAppName)
+        {
+            ExtensionAppName = extensionAppName;
+        }
+    }
+}

--- a/src/Notifications/NotificationsViewExtension.cs
+++ b/src/Notifications/NotificationsViewExtension.cs
@@ -3,7 +3,9 @@ using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using Dynamo.Events;
 using Dynamo.Wpf.Extensions;
+
 
 namespace Dynamo.Notifications
 {
@@ -67,6 +69,17 @@ namespace Dynamo.Notifications
             (notificationsMenuItem.MenuItem.Parent as ContentControl).Content = null;
             //place the menu into the DynamoMenu
             p.dynamoMenu.Items.Add(notificationsMenuItem.MenuItem);
+
+            //TEST TODO REMMOVE
+            //stop libG from shutting down
+            Dynamo.Events.ExtensionAppEvents.TerminatingExtensionApplication += (CancelableExtensionsShutdownArgs args) =>
+            {
+                if (args.ExtensionAppName.Contains("LibG.ExtensionApplication"))
+                {
+                    args.CancelShutdown = true;
+                };
+
+            };
         }
 
         public void Shutdown()


### PR DESCRIPTION
### Purpose

Expose an API which consumers of DynamoServices can use to stop the shutdown calls to the geometry library if they are going to shut it down later or there is another assembly in process which will shut it down at some other time.

There seems to be an alternative solution which might be even simpler, just avoiding shutting down the geometry library at all, from the libG dlls, since it does not seem this is required.

Will need to think about use cases where this might change behavior. @aparajit-pratap @saintentropy 

Note I tested the use of the API in the notificationsExtension just as a substitute for an "external" client. I will remove it and write a better test if we move forward with this approach. I've verified this fixes the crash when closing revit.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap 

### FYIs

@smangarole 