### PR TITLE
Dropdown Value Xml Escaping and unescaping Exception

### DIFF
--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -240,18 +240,32 @@ namespace CoreNodeModels
 
         protected static string XmlEscape(string unescaped)
         {
-            var doc = new XmlDocument();
-            XmlNode node = doc.CreateElement("root");
-            node.InnerText = unescaped;
-            return node.InnerXml;
+            try
+            {
+                var doc = new XmlDocument();
+                XmlNode node = doc.CreateElement("root");
+                node.InnerText = unescaped;
+                return node.InnerXml;
+            }
+            catch
+            {
+                return unescaped;
+            }
         }
 
         protected static string XmlUnescape(string escaped)
         {
-            var doc = new XmlDocument();
-            XmlNode node = doc.CreateElement("root");
-            node.InnerXml = escaped;
-            return node.InnerText;
+            try
+            {
+                var doc = new XmlDocument();
+                XmlNode node = doc.CreateElement("root");
+                node.InnerXml = escaped;
+                return node.InnerText;
+            }
+            catch
+            {
+                return escaped;
+            }
         }
 
         /// <summary>

--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -165,7 +165,7 @@ namespace CoreNodeModels
             }
             else
             {
-                selectedString = selectedIndex > Items.Count - 1? String.Empty: GetSelectedStringFromItem(Items.ElementAt(selectedIndex));
+                selectedString = selectedIndex > Items.Count - 1 ? String.Empty : GetSelectedStringFromItem(Items.ElementAt(selectedIndex));
             }
         }
 
@@ -200,11 +200,11 @@ namespace CoreNodeModels
         public static int ParseSelectedIndexImpl(string index, IList<DynamoDropDownItem> items)
         {
             int selectedIndex = -1;
+
             var splits = index.Split(':');
             if (splits.Count() > 1)
             {
-
-                var name = System.Web.HttpUtility.HtmlDecode(index.Substring(index.IndexOf(':') + 1));
+                var name = XmlUnescape(index.Substring(index.IndexOf(':') + 1));
                 var item = items.FirstOrDefault(i => i.Name == name);
                 selectedIndex = item != null ?
                     items.IndexOf(item) :
@@ -236,7 +236,33 @@ namespace CoreNodeModels
             }
 
             var item = items[index];
-            return string.Format("{0}:{1}", index, SecurityElement.Escape(item.Name));
+            return string.Format("{0}:{1}", index, XmlEscape(item.Name));
+        }
+
+        /// <summary>
+        /// Escape string which could contain XML forbidden chars.
+        /// </summary>
+        /// <param name="unescaped"></param>
+        /// <returns></returns>
+        protected static string XmlEscape(string unescaped)
+        {
+            // TODO: This function can be simplified in Dynamo 3.0
+            // since it is one line wrapper
+            return SecurityElement.Escape(unescaped);
+        }
+
+        /// <summary>
+        /// Unescape string which could already be escaped before,
+        /// if there is no escaped special char, return as it is
+        /// if there is special char escaped, restore them.
+        /// </summary>
+        /// <param name="escaped"></param>
+        /// <returns></returns>
+        protected static string XmlUnescape(string escaped)
+        {
+            // TODO: This function can be simplified in Dynamo 3.0
+            // since it is one line wrapper
+            return System.Web.HttpUtility.HtmlDecode(escaped);
         }
 
         /// <summary>

--- a/src/Libraries/CoreNodeModels/DropDown.cs
+++ b/src/Libraries/CoreNodeModels/DropDown.cs
@@ -200,21 +200,11 @@ namespace CoreNodeModels
         public static int ParseSelectedIndexImpl(string index, IList<DynamoDropDownItem> items)
         {
             int selectedIndex = -1;
-            string name;
             var splits = index.Split(':');
             if (splits.Count() > 1)
             {
-                // Try unescape serialized string, used for Dynamo 1.X XML deserialization
-                // Try-catch block for DynamoPlayer UpdateValueCore call
-                try
-                {
-                    SecurityElement securityElement = SecurityElement.FromString(index.Substring(index.IndexOf(':') + 1));
-                    name = securityElement.Text;
-                }
-                catch
-                {
-                    name = index.Substring(index.IndexOf(':') + 1);
-                }
+
+                var name = System.Web.HttpUtility.HtmlDecode(index.Substring(index.IndexOf(':') + 1));
                 var item = items.FirstOrDefault(i => i.Name == name);
                 selectedIndex = item != null ?
                     items.IndexOf(item) :

--- a/test/DynamoCoreTests/Nodes/DropDownTests.cs
+++ b/test/DynamoCoreTests/Nodes/DropDownTests.cs
@@ -296,6 +296,18 @@ namespace Dynamo.Tests.Nodes
             Assert.AreEqual(-1, DSDropDownBase.ParseSelectedIndexImpl("2:foo", TestList()));
         }
 
+        [Test]
+        public void Load_SelectionIndexSpecialCharMatch()
+        {
+            Assert.AreEqual(-1, DSDropDownBase.ParseSelectedIndexImpl("2:<foo>", TestList()));
+        }
+
+        [Test]
+        public void Load_SelectionIndexSpecialCharNoMatch()
+        {
+            Assert.AreEqual(2, DSDropDownBase.ParseSelectedIndexImpl("2:<foo>", TestListWithItemWithSpecialChar()));
+        }
+
         private static List<DynamoDropDownItem> TestList()
         {
             var items = new List<DynamoDropDownItem>
@@ -309,5 +321,17 @@ namespace Dynamo.Tests.Nodes
             return items;
         }
 
+        private static List<DynamoDropDownItem> TestListWithItemWithSpecialChar()
+        {
+            var items = new List<DynamoDropDownItem>
+            {
+                new DynamoDropDownItem("cat", "cat"),
+                new DynamoDropDownItem("dog", "dog"),
+                new DynamoDropDownItem("<foo>", "<foo>"),
+                new DynamoDropDownItem("!@#$%%%^&*()", "craziness")
+            };
+
+            return items;
+        }
     }
 }

--- a/test/DynamoCoreTests/Nodes/DropDownTests.cs
+++ b/test/DynamoCoreTests/Nodes/DropDownTests.cs
@@ -267,6 +267,16 @@ namespace Dynamo.Tests.Nodes
         }
 
         [Test]
+        public void Save_SelectedIndexWithSpecialChar()
+        {
+            // This test makes sure that when SaveSelectedIndexImpl() is called with a index
+            // of item with Xml special char in the item.Name, the special char is escaped
+            Assert.AreEqual(
+                "2:&lt;foo&gt;",
+                DSDropDownBase.SaveSelectedIndexImpl(2, TestListWithItemWithSpecialChar()));
+        }
+
+        [Test]
         public void Load_NothingSelected()
         {
             Assert.AreEqual(-1, DSDropDownBase.ParseSelectedIndexImpl("-1", TestList()));
@@ -297,15 +307,21 @@ namespace Dynamo.Tests.Nodes
         }
 
         [Test]
-        public void Load_SelectionIndexSpecialCharMatch()
+        public void Load_SelectionIndexSpecialCharNoMatch()
         {
             Assert.AreEqual(-1, DSDropDownBase.ParseSelectedIndexImpl("2:<foo>", TestList()));
         }
 
         [Test]
-        public void Load_SelectionIndexSpecialCharNoMatch()
+        public void Load_SelectionIndexSpecialCharMatch()
         {
             Assert.AreEqual(2, DSDropDownBase.ParseSelectedIndexImpl("2:<foo>", TestListWithItemWithSpecialChar()));
+        }
+
+        [Test]
+        public void Load_SelectionIndexSpecialCharMatch2()
+        {
+            Assert.AreEqual(2, DSDropDownBase.ParseSelectedIndexImpl("2:&lt;foo&gt;", TestListWithItemWithSpecialChar()));
         }
 
         private static List<DynamoDropDownItem> TestList()


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose
[DYN-1195](https://jira.autodesk.com/browse/DYN-1195)
Dropdown nodes can fail to maintain previous selection in Dynamo Player.

This PR fixes an edge case that when parsing selection which contains special characters in XML doc like **&**, **<**, **>**, etc, our code failed catch the exception causing unescaping to fail silently.

For example, Revit Fill Pattern selection contains <Solid Fill> which contains invalid XML string when parsing. Internally, we escape this string to be
```
"0:&amp;lt;Solid fill&amp;gt;"
```
After unescaping, the string will went back to
```
"0:<Solid Fill>"
```

Behavior after bug fixing
![playerparsingxmlstring](https://user-images.githubusercontent.com/3942418/52836801-2556b300-30ba-11e9-9a93-322a29b5338b.gif)




TODO:
 - [x] Unit Tests

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @aparajit-pratap 

### FYIs

@BogdanZavu @dobriai
