### PR TITLE
GeometryFactoryPath lookup should be more consistent with other preloader utilities.

### DIFF
--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -348,7 +348,7 @@ namespace DynamoShapeManager
         /// <summary>
         /// Call this method to resolve full path to GeometryFactoryAssembly 
         /// assembly, given the root folder and the version. This method throws 
-        /// an exception if either of the folders/assembly cannot be found.
+        /// an exception if either of the folders or the exact version of the assembly cannot be found.
         /// </summary>
         /// <param name="rootFolder">Full path of the directory that contains 
         /// LibG_xxx folder, where 'xxx' represents the library version. In a 
@@ -368,7 +368,7 @@ namespace DynamoShapeManager
         /// <summary>
         /// Call this method to resolve full path to GeometryFactoryAssembly 
         /// assembly, given the root folder and the version. This method throws 
-        /// an exception if either of the folders/assembly cannot be found.
+        /// an exception if either of the folders or the exact version of the assembly cannot be found.
         /// </summary>
         /// <param name="rootFolder">Full path of the directory that contains 
         /// LibG_xxx_y_z folder, where 'xxx y z' represents the library version of asm. In a 
@@ -410,7 +410,21 @@ namespace DynamoShapeManager
 
             return assemblyPath;
         }
-
+        /// <summary>
+        /// This method will return the path to the GeometryFactory assembly location for a requested version of the geometry library.
+        /// This method is tolerant to the requested version in that it will attempt to locate an exact or lower version of the GeometryFactory assembly.
+        /// </summary>
+        /// <param name="rootFolder">Full path of the directory that contains 
+        /// LibG_xxx_y_z folder, where 'xxx y z' represents the library version of asm. In a 
+        /// typical setup this would be the same directory that contains Dynamo 
+        /// core modules. This must represent a valid directory.</param>
+        /// <param name="tolerantVersion">Version number of the targeted geometry library.
+        /// If the resulting assembly does not exist, this method will look for a lower version match.</param>
+        /// <returns>The full path to GeometryFactoryAssembly assembly.</returns>
+        /// 
+        public static string GetGeometryFactoryPathTolerant(string rootFolder, Version tolerantVersion){
+            return Path.Combine(Utilities.GetLibGPreloaderLocation(tolerantVersion, rootFolder), Utilities.GeometryFactoryAssembly);
+        }
 
         private static IEnumerable GetAsmInstallations(string rootFolder)
         {

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -417,13 +417,18 @@ namespace DynamoShapeManager
         /// <param name="rootFolder">Full path of the directory that contains 
         /// LibG_xxx_y_z folder, where 'xxx y z' represents the library version of asm. In a 
         /// typical setup this would be the same directory that contains Dynamo 
-        /// core modules. This must represent a valid directory.</param>
+        /// core modules. This must represent a valid directory - it cannot be null.</param>
         /// <param name="tolerantVersion">Version number of the targeted geometry library.
-        /// If the resulting assembly does not exist, this method will look for a lower version match.</param>
+        /// If the resulting assembly does not exist, this method will look for a lower version match.
+        /// This parameter cannot be null. </param>
         /// <returns>The full path to GeometryFactoryAssembly assembly.</returns>
         /// 
         public static string GetGeometryFactoryPathTolerant(string rootFolder, Version tolerantVersion){
-            return Path.Combine(Utilities.GetLibGPreloaderLocation(tolerantVersion, rootFolder), Utilities.GeometryFactoryAssembly);
+            if(tolerantVersion != null && rootFolder != null)
+            {
+                return Path.Combine(Utilities.GetLibGPreloaderLocation(tolerantVersion, rootFolder), Utilities.GeometryFactoryAssembly);
+            }
+            return string.Empty;
         }
 
         private static IEnumerable GetAsmInstallations(string rootFolder)

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -359,7 +359,7 @@ namespace DynamoShapeManager
         /// FileNotFoundException.</param>
         /// <returns>The full path to GeometryFactoryAssembly assembly.</returns>
         /// 
-        [Obsolete("Please use GetGeometryFactoryPath2(string rootFolder, Version version).")]
+        [Obsolete("Please use GetGeometryFactoryPathTolerant(string rootFolder, Version version).")]
         public static string GetGeometryFactoryPath(string rootFolder, LibraryVersion version)
         {
             return GetGeometryFactoryPath2(rootFolder, Preloader.MapLibGVersionEnumToFullVersion(version));
@@ -379,6 +379,7 @@ namespace DynamoShapeManager
         /// FileNotFoundException.</param>
         /// <returns>The full path to GeometryFactoryAssembly assembly.</returns>
         /// 
+        [Obsolete("Please use GetGeometryFactoryPathTolerant(string rootFolder, Version version).")]
         public static string GetGeometryFactoryPath2(string rootFolder, Version version)
         {
             if (string.IsNullOrEmpty(rootFolder))
@@ -418,17 +419,26 @@ namespace DynamoShapeManager
         /// LibG_xxx_y_z folder, where 'xxx y z' represents the library version of asm. In a 
         /// typical setup this would be the same directory that contains Dynamo 
         /// core modules. This must represent a valid directory - it cannot be null.</param>
-        /// <param name="tolerantVersion">Version number of the targeted geometry library.
+        /// <param name="version">Version number of the targeted geometry library.
         /// If the resulting assembly does not exist, this method will look for a lower version match.
         /// This parameter cannot be null. </param>
         /// <returns>The full path to GeometryFactoryAssembly assembly.</returns>
         /// 
-        public static string GetGeometryFactoryPathTolerant(string rootFolder, Version tolerantVersion){
-            if(tolerantVersion != null && rootFolder != null)
+        public static string GetGeometryFactoryPathTolerant(string rootFolder, Version version){
+            if (string.IsNullOrEmpty(rootFolder))
+                throw new ArgumentNullException("rootFolder");
+
+            if (!Directory.Exists(rootFolder))
             {
-                return Path.Combine(Utilities.GetLibGPreloaderLocation(tolerantVersion, rootFolder), Utilities.GeometryFactoryAssembly);
+                // Root directory must be specified and valid.
+                throw new DirectoryNotFoundException(string.Format(
+                    "Directory not found: {0}", rootFolder));
             }
-            return string.Empty;
+            if (version != null)
+            {
+                return Path.Combine(Utilities.GetLibGPreloaderLocation(version, rootFolder), Utilities.GeometryFactoryAssembly);
+            }
+            throw new ArgumentNullException("version");
         }
 
         private static IEnumerable GetAsmInstallations(string rootFolder)

--- a/src/Tools/DynamoShapeManager/Utilities.cs
+++ b/src/Tools/DynamoShapeManager/Utilities.cs
@@ -346,17 +346,18 @@ namespace DynamoShapeManager
         }
 
         /// <summary>
-        /// Call this method to resolve full path to GeometryFactoryAssembly 
-        /// assembly, given the root folder and the version. This method throws 
-        /// an exception if either of the folders or the exact version of the assembly cannot be found.
+        /// This method will return the path to the GeometryFactory assembly location 
+        /// for a requested version of the geometry library.
+        /// This method is tolerant to the requested version in that it will attempt to 
+        /// locate an exact or lower version of the GeometryFactory assembly.
         /// </summary>
         /// <param name="rootFolder">Full path of the directory that contains 
-        /// LibG_xxx folder, where 'xxx' represents the library version. In a 
+        /// LibG_xxx_y_z folder, where 'xxx y z' represents the library version of asm. In a 
         /// typical setup this would be the same directory that contains Dynamo 
-        /// core modules. This must represent a valid directory.</param>
+        /// core modules. This must represent a valid directory - it cannot be null.</param>
         /// <param name="version">Version number of the targeted geometry library.
-        /// If the resulting folder does not exist, this method throws an 
-        /// FileNotFoundException.</param>
+        /// If the resulting assembly does not exist, this method will look for a lower version match.
+        /// This parameter cannot be null. </param>
         /// <returns>The full path to GeometryFactoryAssembly assembly.</returns>
         /// 
         [Obsolete("Please use GetGeometryFactoryPath2(string rootFolder, Version version).")]
@@ -366,8 +367,10 @@ namespace DynamoShapeManager
         }
 
         /// <summary>
-        /// This method will return the path to the GeometryFactory assembly location for a requested version of the geometry library.
-        /// This method is tolerant to the requested version in that it will attempt to locate an exact or lower version of the GeometryFactory assembly.
+        /// This method will return the path to the GeometryFactory assembly location 
+        /// for a requested version of the geometry library.
+        /// This method is tolerant to the requested version in that it will attempt to 
+        /// locate an exact or lower version of the GeometryFactory assembly.
         /// </summary>
         /// <param name="rootFolder">Full path of the directory that contains 
         /// LibG_xxx_y_z folder, where 'xxx y z' represents the library version of asm. In a 

--- a/test/DynamoCoreTests/libGPreloaderTests.cs
+++ b/test/DynamoCoreTests/libGPreloaderTests.cs
@@ -265,9 +265,8 @@ namespace Dynamo.Tests
             // mock a folder with libASMLibVersionToVersion folders with correct names
             var foundPath = "";
             var rootFolder = Path.Combine(Path.GetTempPath(), "LibGTest");
-            // both versions of libG exist
+            //there is no matching libG for the installed version of asm.
             var libG22500path = System.IO.Directory.CreateDirectory(Path.Combine(rootFolder, "LibG_225_0_0"));
-            var libGTestPath = new DirectoryInfo(Path.Combine(rootFolder, "LibG_224_24_24"));
             var foundVersion = DynamoShapeManager.Utilities.GetInstalledAsmVersion2(
                 versions, ref foundPath, rootFolder, (path) => { return mockedInstalledASMs; });
 

--- a/test/DynamoCoreTests/libGPreloaderTests.cs
+++ b/test/DynamoCoreTests/libGPreloaderTests.cs
@@ -204,6 +204,104 @@ namespace Dynamo.Tests
             libG22500path.Delete(true);
         }
 
+        [Test]
+        public void GetGeometryFactoryPathTolerant_libGVersionFallback()
+        {
+            var versions = new List<Version>()
+            {
+                    new Version(225,0,0)
+            };
+
+            var mockedInstalledASMs = new Dictionary<string, Tuple<int, int, int, int>>()
+            {
+
+                {"revit_2020_InstallLocation" ,Tuple.Create<int,int,int,int>(225,2,0,0)},
+            };
+
+            var targetVersion = new Version(225, 2, 0);
+
+            // mock a folder with libASMLibVersionToVersion folders with correct names
+            var foundPath = "";
+            var rootFolder = Path.Combine(Path.GetTempPath(), "LibGTest");
+            // both versions of libG exist
+            var libG22440path = System.IO.Directory.CreateDirectory(Path.Combine(rootFolder, "LibG_224_4_0"));
+            var libG22500path = System.IO.Directory.CreateDirectory(Path.Combine(rootFolder, "LibG_225_0_0"));
+
+            var foundVersion = DynamoShapeManager.Utilities.GetInstalledAsmVersion2(
+                versions, ref foundPath, rootFolder, (path) => { return mockedInstalledASMs; });
+
+            // The found ASM version in this case is a fallback of lowest version within same major which should be 225.2.0
+            Assert.AreEqual(targetVersion, foundVersion);
+            Assert.AreEqual("revit_2020_InstallLocation", foundPath);
+
+            // The found libG preloader version in this case is another fallback of closest version below 225.3.0
+            Assert.AreEqual(libG22500path.FullName.ToLower(), DynamoShapeManager.Utilities.GetLibGPreloaderLocation(foundVersion, rootFolder).ToLower());
+
+            //assert that the geometryFactoryTolerant method returns the path of the lib225_0_0 path.
+            Assert.AreEqual(Path.Combine(libG22500path.FullName,DynamoShapeManager.Utilities.GeometryFactoryAssembly).ToLower(),
+                DynamoShapeManager.Utilities.GetGeometryFactoryPathTolerant(rootFolder, targetVersion).ToLower());
+            //assert the non tolerant version throws
+            Assert.Throws<DirectoryNotFoundException>(() => { DynamoShapeManager.Utilities.GetGeometryFactoryPath2(rootFolder, targetVersion); });
+
+            // cleanup
+            libG22440path.Delete(true);
+            libG22500path.Delete(true);
+        }
+
+        [Test]
+        public void GetGeometryFactoryPathTolerant_NoMatch()
+        {
+            var versions = new List<Version>()
+            {
+                    new Version(225,0,0)
+            };
+
+            var mockedInstalledASMs = new Dictionary<string, Tuple<int, int, int, int>>()
+            {
+
+                {"someInstallWithNoMatchingASM" ,Tuple.Create<int,int,int,int>(224,0,0,0)},
+            };
+
+            var targetVersion = new Version(225, 2, 0);
+
+            // mock a folder with libASMLibVersionToVersion folders with correct names
+            var foundPath = "";
+            var rootFolder = Path.Combine(Path.GetTempPath(), "LibGTest");
+            // both versions of libG exist
+            var libG22500path = System.IO.Directory.CreateDirectory(Path.Combine(rootFolder, "LibG_225_0_0"));
+            var libGTestPath = new DirectoryInfo(Path.Combine(rootFolder, "LibG_224_24_24"));
+            var foundVersion = DynamoShapeManager.Utilities.GetInstalledAsmVersion2(
+                versions, ref foundPath, rootFolder, (path) => { return mockedInstalledASMs; });
+
+            // There is no match, so found version is null.
+            Assert.AreEqual(null, foundVersion);
+            // There is no match, so path to ASM is null.
+            Assert.AreEqual(string.Empty, foundPath);
+
+            // when passed null as a version, GetLibGPreloaderLocation will return LibG_0_0_0
+            Assert.IsTrue(DynamoShapeManager.Utilities.GetLibGPreloaderLocation(foundVersion, rootFolder).ToLower().Contains("libg_0_0_0"));
+
+
+            //when passed a null version this method should return empty string - as the geometry path was not located
+            Assert.AreEqual(string.Empty,
+                DynamoShapeManager.Utilities.GetGeometryFactoryPathTolerant(rootFolder, null));
+
+            //when passed a null root directory this method should return empty string - as a valid root directory is required.
+            Assert.AreEqual(string.Empty,
+                DynamoShapeManager.Utilities.GetGeometryFactoryPathTolerant(null, new Version(224, 24, 24)));
+
+            // when passed a non null, non matching version this method should return a path to the version that was supplied - 
+            // but it will likely fail later.
+            Assert.AreEqual(Path.Combine(libGTestPath.FullName, DynamoShapeManager.Utilities.GeometryFactoryAssembly).ToLower(),
+                 DynamoShapeManager.Utilities.GetGeometryFactoryPathTolerant(rootFolder, new Version(224,24,24)).ToLower());
+
+            //assert the non tolerant version throws
+            Assert.Throws<DirectoryNotFoundException>(() => { DynamoShapeManager.Utilities.GetGeometryFactoryPath2(rootFolder, new Version(224, 24, 24)); });
+
+            // cleanup
+            libG22500path.Delete(true);
+        }
+
 
         [Test]
         public void GetInstalledASMVersions2_FindsVersionedLibGFolders_WithRootFolderFallback()

--- a/test/DynamoCoreTests/libGPreloaderTests.cs
+++ b/test/DynamoCoreTests/libGPreloaderTests.cs
@@ -234,7 +234,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(targetVersion, foundVersion);
             Assert.AreEqual("revit_2020_InstallLocation", foundPath);
 
-            // The found libG preloader version in this case is another fallback of closest version below 225.3.0
+            // The found libG preloader version in this case is another fallback of closest version below 225.2.0
             Assert.AreEqual(libG22500path.FullName.ToLower(), DynamoShapeManager.Utilities.GetLibGPreloaderLocation(foundVersion, rootFolder).ToLower());
 
             //assert that the geometryFactoryTolerant method returns the path of the lib225_0_0 path.
@@ -262,8 +262,6 @@ namespace Dynamo.Tests
                 {"someInstallWithNoMatchingASM" ,Tuple.Create<int,int,int,int>(224,0,0,0)},
             };
 
-            var targetVersion = new Version(225, 2, 0);
-
             // mock a folder with libASMLibVersionToVersion folders with correct names
             var foundPath = "";
             var rootFolder = Path.Combine(Path.GetTempPath(), "LibGTest");
@@ -281,17 +279,15 @@ namespace Dynamo.Tests
             // when passed null as a version, GetLibGPreloaderLocation will return LibG_0_0_0
             Assert.IsTrue(DynamoShapeManager.Utilities.GetLibGPreloaderLocation(foundVersion, rootFolder).ToLower().Contains("libg_0_0_0"));
 
+            //when passed a null version this method should throw
+            Assert.Throws<ArgumentNullException>(() => { DynamoShapeManager.Utilities.GetGeometryFactoryPathTolerant(rootFolder, null); });
 
-            //when passed a null version this method should return empty string - as the geometry path was not located
-            Assert.AreEqual(string.Empty,
-                DynamoShapeManager.Utilities.GetGeometryFactoryPathTolerant(rootFolder, null));
+            //when passed a null root directory this method should throw - as a valid root directory is required.
+            Assert.Throws<ArgumentNullException>(() => { DynamoShapeManager.Utilities.GetGeometryFactoryPathTolerant(null, new Version(224, 24, 24)); });
 
-            //when passed a null root directory this method should return empty string - as a valid root directory is required.
-            Assert.AreEqual(string.Empty,
-                DynamoShapeManager.Utilities.GetGeometryFactoryPathTolerant(null, new Version(224, 24, 24)));
-
-            // when passed a non null, non matching version this method should return a path to the version that was supplied - 
-            // but it will likely fail later.
+            // when passed a non null, non matching version and existing root directory
+            // this method should return a path to the version that was supplied - 
+            // but it will likely fail later since this path may not exist.
             Assert.AreEqual(Path.Combine(libGTestPath.FullName, DynamoShapeManager.Utilities.GeometryFactoryAssembly).ToLower(),
                  DynamoShapeManager.Utilities.GetGeometryFactoryPathTolerant(rootFolder, new Version(224,24,24)).ToLower());
 


### PR DESCRIPTION
### Purpose

Provide a more tolerant GeometryFactoryPath lookup method that falls back to other libG/ASM version combinations that are <= to the major version requested.

* adds tests for invalid/valid inputs of the new method.
* slightly modifies existing summaries to be more explicit on existing non tolerant methods.



### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @scottmitchell  

### FYIs

@aparajit-pratap 