### PR TITLE
Warn users submitting crash reports that they must be signed into GitHub

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -737,7 +737,18 @@ namespace Dynamo.Wpf.Properties
                 return ResourceManager.GetString("CrashPromptDialogSubmitBugButton", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Submit Bug To Github ToolTip.
+        /// </summary>
+        public static string CrashPromptDialogSubmitBugButtonToolTip
+        {
+            get
+            {
+                return ResourceManager.GetString("CrashPromptDialogSubmitBugButtonToolTip", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to {0} has crashed.
         /// </summary>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -380,7 +380,7 @@ You will get a chance to save your work.</value>
     <comment>Open folder that contains crash report</comment>
   </data>
   <data name="CrashPromptDialogSubmitBugButton" xml:space="preserve">
-    <value>Submit Bug To Github</value>
+    <value>Submit Bug To GitHub</value>
     <comment>Submit a bug on github</comment>
   </data>
   <data name="CrashPromptDialogTitle" xml:space="preserve">
@@ -2183,5 +2183,9 @@ Do you want to install the latest Dynamo update?</value>
   </data>
   <data name="RerunButtonToolTip" xml:space="preserve">
     <value>Rerun the graph.</value>
+  </data>
+  <data name="CrashPromptDialogSubmitBugButtonToolTip" xml:space="preserve">
+    <value>Must be logged into GitHub</value>
+    <comment>Alert user they must be signed into GitHub in order to submit a crash report</comment>
   </data>
 </root>

--- a/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml
@@ -79,13 +79,13 @@
                         Click="PostOnGithub_Click"
                         ToolTipService.InitialShowDelay="0"   
                         >
-                        <Button.ToolTip>
-                            <ToolTip
-                                Content="{x:Static p:Resources.CrashPromptDialogSubmitBugButtonToolTip}"
-                                Placement="Center"
-                                VerticalOffset="-35">
-                            </ToolTip>
-                        </Button.ToolTip>
+                    <Button.ToolTip>
+                        <ToolTip
+                            Content="{x:Static p:Resources.CrashPromptDialogSubmitBugButtonToolTip}"
+                            Placement="Center"
+                            VerticalOffset="-35">
+                        </ToolTip>
+                    </Button.ToolTip>
                 </Button>
 
                 <Button Content="{x:Static p:Resources.ContinueButton}"

--- a/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml
@@ -77,7 +77,6 @@
                         Style="{DynamicResource ResourceKey=STextButton}"
                         Margin="10,0,0,0"
                         Click="PostOnGithub_Click"
-                        Name="SubmitCrashButton"
                         ToolTipService.InitialShowDelay="0"   
                         >
                         <Button.ToolTip>

--- a/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml
@@ -76,7 +76,18 @@
                 <Button Content="{x:Static p:Resources.CrashPromptDialogSubmitBugButton}"
                         Style="{DynamicResource ResourceKey=STextButton}"
                         Margin="10,0,0,0"
-                        Click="PostOnGithub_Click" />
+                        Click="PostOnGithub_Click"
+                        Name="SubmitCrashButton"
+                        ToolTipService.InitialShowDelay="0"   
+                        >
+                        <Button.ToolTip>
+                            <ToolTip
+                                Content="{x:Static p:Resources.CrashPromptDialogSubmitBugButtonToolTip}"
+                                Placement="Center"
+                                VerticalOffset="-35">
+                            </ToolTip>
+                        </Button.ToolTip>
+                </Button>
 
                 <Button Content="{x:Static p:Resources.ContinueButton}"
                         Style="{DynamicResource ResourceKey=STextButton}"

--- a/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml
+++ b/src/DynamoCoreWpf/UI/Prompts/CrashPrompt.xaml
@@ -77,8 +77,7 @@
                         Style="{DynamicResource ResourceKey=STextButton}"
                         Margin="10,0,0,0"
                         Click="PostOnGithub_Click"
-                        ToolTipService.InitialShowDelay="0"   
-                        >
+                        ToolTipService.InitialShowDelay="0">
                     <Button.ToolTip>
                         <ToolTip
                             Content="{x:Static p:Resources.CrashPromptDialogSubmitBugButtonToolTip}"


### PR DESCRIPTION
[DYN-1491](https://jira.autodesk.com/browse/DYN-1491)

This PR adds a tooltip to the `Submit Bug To GitHub` button in the `CrashPrompt` dialog box warning users they must be signed in before attempting to launch a pre-filled crash report on GitHub.  If the user clicks the button and is not logged in they will likely face a `414` or `404` depending on several factors.  This is a result of #9393 as users used to be directed to [issues](https://github.com/DynamoDS/Dynamo/issues) as opposed to [new issues](https://github.com/DynamoDS/Dynamo/issues/new) which requires auth.  The redirect url cannot handle the long content from the crash report often resulting in a `414`.  This could be avoided by using a `GitHubApp` and making a post request.

![submitbugtogithub](https://user-images.githubusercontent.com/13341935/53374921-c7cb2d80-3927-11e9-911c-24a2b5fbf40c.gif)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 
