### PR TITLE
Exclude stack trace from being included in the new GitHub issues request

### DIFF
--- a/src/DynamoCoreWpf/Utilities/CrashUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/CrashUtilities.cs
@@ -51,20 +51,29 @@ namespace Dynamo.Wpf.Utilities
         {
             return
             "# Issue Description" + Environment.NewLine +
-            "Please fill in the following information to help us reproduce the issue:" + Environment.NewLine +
+            "Please fill in the following information to help us reproduce the issue:" + Environment.NewLine + Environment.NewLine +
+
             "### What did you do?" + Environment.NewLine +
-            "(Fill in here)" + Environment.NewLine +
-            "### What did you expect to see?" + Environment.NewLine +
-            "(Fill in here)" + Environment.NewLine +
-            "### What did you see instead?" + Environment.NewLine +
-            "(Fill in here)" + Environment.NewLine +
-            "### What packages or external references (if any) were used?" + Environment.NewLine +
             "(Fill in here)" + Environment.NewLine + Environment.NewLine +
+
+            "### What did you expect to see?" + Environment.NewLine +
+            "(Fill in here)" + Environment.NewLine + Environment.NewLine +
+
+            "### What did you see instead?" + Environment.NewLine +
+            "(Fill in here)" + Environment.NewLine + Environment.NewLine +
+
+            "### What packages or external references (if any) were used?" + Environment.NewLine +
+            "(Fill in here)" + Environment.NewLine + Environment.NewLine + Environment.NewLine +
+
+            "### Stack Trace" + Environment.NewLine +
+            "```" + Environment.NewLine +
+            "(From the Dynamo crash window select 'Details' -> 'Copy' and paste here)" + Environment.NewLine +
+            "```" + Environment.NewLine + Environment.NewLine +
+
             "---" + Environment.NewLine +
             "OS: " + "`" + Environment.OSVersion + "`" + Environment.NewLine +
             "CLR: " + "`" + Environment.Version + "`" + Environment.NewLine +
-            "Dynamo: " + "`" + dynamoVersion + "`" + Environment.NewLine +
-            "Details: " + Environment.NewLine + "```" + Environment.NewLine + stackTrace + Environment.NewLine + "```";
+            "Dynamo: " + "`" + dynamoVersion + "`" + Environment.NewLine;
         }
     }
 }

--- a/test/DynamoCoreWpfTests/CrashReportingTests.cs
+++ b/test/DynamoCoreWpfTests/CrashReportingTests.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading;
 using Dynamo.ViewModels;
+using Dynamo.Utilities;
 using NUnit.Framework;
 
 namespace Dynamo.Tests
@@ -78,7 +75,7 @@ namespace Dynamo.Tests
         public void StackTraceIncludedInReport()
         {
             // Mock Dynamo version
-            var dynamoVersion = "2.1.0";
+            var dynamoVersion = AssemblyHelper.GetDynamoVersion().ToString();
 
             // Create a crash report to submit
             var crashReport = Wpf.Utilities.CrashUtilities.BuildMarkdownContent(dynamoVersion, StackTrace);
@@ -97,8 +94,9 @@ namespace Dynamo.Tests
             // Verify request contains the dynamoVersion
             Assert.True(decoded.Contains(dynamoVersion));
 
+            // TODO - Can be re-added when stack traces are uploaded automatically (currently manual)
             // Verify request contains the stack trace
-            Assert.True(decoded.Contains(StackTrace));
+            // Assert.True(decoded.Contains(StackTrace));
         }
     }
 }


### PR DESCRIPTION
### Purpose

[DYN-1491](https://jira.autodesk.com/browse/DYN-1491)

This PR removes the stack trace data that got appended to the GitHub new issues url.  This was recently introduced in #9393 and has not yet been shipped (only lives in Master not 2.1).  There are several issues with making an authenticated request in a browser window in which we are not prepared to handle.  More details can be found in #9519 and earlier linked PRs.

It has always been the case that users who do not have a GitHub account cannot report issues.  We still gain several improvements with #9393 but automatically copying the stack trace needs to be removed until the team has the bandwidth to implement a more robust solution. 

As previously discussed a future solution could be to use a GitHub app.  The app could handle/post all crash reports tagging the user by their GitHub id but would be optional allowing all users to report issues.  Many in the AEC industry don't use or know much about GitHub.

![image](https://user-images.githubusercontent.com/13341935/53450003-345a3100-39e9-11e9-847d-eb6be9137c93.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @mjkkirschner 

### FYIs

@radumg 
