### PR TITLE
[WIP] DYN-1642: Callsite identifier changes to fix element binding issues with custom nodes 

### DIFF
--- a/src/Engine/ProtoCore/CodeGen.cs
+++ b/src/Engine/ProtoCore/CodeGen.cs
@@ -163,10 +163,10 @@ namespace ProtoCore
             // Build the unique ID for a callsite 
             string callsiteIdentifier =
                 procName + 
-                "_InClassDecl" + globalClassIndex + 
-                "_InFunctionScope" + globalProcIndex + 
-                "_Instance" + functionCallInstance.ToString() + 
-                "_" + graphNode.guid.ToString();
+                Constants.kSingleUnderscore + Constants.kInClassDecl + globalClassIndex + 
+                Constants.kSingleUnderscore + Constants.kInFunctionScope + globalProcIndex +
+                Constants.kSingleUnderscore + Constants.kInstance + functionCallInstance +
+                Constants.kSingleUnderscore + graphNode.guid;
 
             // TODO Jun: Address this in MAGN-3774
             // The current limitation is retrieving the cached trace data for multiple callsites in a single CBN

--- a/src/Engine/ProtoCore/DSASM/Defs.cs
+++ b/src/Engine/ProtoCore/DSASM/Defs.cs
@@ -395,6 +395,10 @@ namespace ProtoCore.DSASM
         public const string kDoubleUnderscores = "__";
         public const string kSingleUnderscore = "_";
         public const string kTempVarForTypedIdentifier = "%tTypedIdent";
+
+        internal const string kInClassDecl = "InClassDecl";
+        internal const string kInFunctionScope = "InFunctionScope";
+        internal const string kInstance = "Instance";
     }
 
     public enum MemoryRegion

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -75,14 +75,12 @@ namespace ProtoCore
 
                     if (HasData)
                         return true;
-                    else
-                    {
-                        //Not empty, and doesn't have data so test recursive
-                        Validity.Assert(NestedData != null,
-                            "Invalid recursion logic, this is a VM bug, please report to the Dynamo Team");
+                    
+                    //Not empty, and doesn't have data so test recursive
+                    Validity.Assert(NestedData != null,
+                        "Invalid recursion logic, this is a VM bug, please report to the Dynamo Team");
 
-                        return NestedData.Any(srtd => srtd.HasAnyNestedData);
-                    }
+                    return NestedData.Any(srtd => srtd.HasAnyNestedData);
                 }
             }
 
@@ -172,26 +170,21 @@ namespace ProtoCore
             {
                 if (HasData)
                     return Data;
-                else
-                {
-                    if (!HasNestedData)
-                        return null;
-                    else
-                    {
+
+                if (!HasNestedData)
+                    return null;
 #if DEBUG
 
-                        Validity.Assert(NestedData != null, "Nested data has changed null status since last check, suspected race");
-                        Validity.Assert(NestedData.Count > 0, "Empty subnested array, please file repo data with @lukechurch, relates to MAGN-4059");
+                Validity.Assert(NestedData != null, "Nested data has changed null status since last check, suspected race");
+                Validity.Assert(NestedData.Count > 0, "Empty subnested array, please file repo data with @lukechurch, relates to MAGN-4059");
 #endif
 
-                        //Safety trap to protect against an empty array, need repro test to figure out why this is getting set with empty arrays
-                        if (NestedData.Count == 0)
-                            return null;
+                //Safety trap to protect against an empty array, need repro test to figure out why this is getting set with empty arrays
+                if (NestedData.Count == 0)
+                    return null;
 
-                        SingleRunTraceData nestedTraceData = NestedData[0];
-                        return nestedTraceData.GetLeftMostData();
-                    }
-                }
+                SingleRunTraceData nestedTraceData = NestedData[0];
+                return nestedTraceData.GetLeftMostData();
             }
 
             public List<SingleRunTraceData> NestedData;
@@ -238,7 +231,7 @@ namespace ProtoCore
 
         /// <summary>
         /// TraceBinder is used to find assemblies to be used for
-        /// deserialization in cases where the exact assemlby that was
+        /// deserialization in cases where the exact assembly that was
         /// used in the serialization is not available. 
         /// </summary>
         internal class TraceBinder : SerializationBinder
@@ -286,7 +279,7 @@ namespace ProtoCore
         /// Normal usage patten is:
         /// 1. Instantiate
         /// 2. Push Trace data from callsite
-        /// 3. Call GetObjectData to serialise it onto a stream
+        /// 3. Call GetObjectData to serialize it onto a stream
         /// 4. Recreate using the special constructor
         /// </summary>
         [Serializable]
@@ -325,14 +318,13 @@ namespace ProtoCore
 #if DEBUG
                         Debug.WriteLine("Deserialization of trace data failed.");
 #endif
-                        continue;
                     }
                 }
 
             }
 
             /// <summary>
-            /// Save the data into the standard serialisation pattern
+            /// Save the data into the standard serialization pattern
             /// </summary>
             public void GetObjectData(SerializationInfo info, StreamingContext context)
             {
@@ -615,7 +607,7 @@ namespace ProtoCore
 
         /// <summary>
         /// Call this method to obtain the Base64 encoded string that 
-        /// represent this instance of CallSite;s trace data
+        /// represents this callsite instance's trace data
         /// </summary>
         /// <returns>Returns the Base64 encoded string that represents the
         /// trace data of this callsite

--- a/src/Engine/ProtoCore/RuntimeData.cs
+++ b/src/Engine/ProtoCore/RuntimeData.cs
@@ -289,7 +289,7 @@ namespace ProtoCore
 
         /// <summary>
         /// Call this method to pop the top-most serialized callsite trace data.
-        /// Note that this call only pops off a signle callsite trace data 
+        /// Note that this call only pops off a single callsite trace data 
         /// belonging to a given UI node denoted by the given node guid.
         /// </summary>
         /// <param name="nodeGuid">The Guid of a given UI node whose top-most 
@@ -344,10 +344,8 @@ namespace ProtoCore
             {
                 return GetAndRemoveTraceDataForNode(nodeGuid, string.Empty);
             }
-            else
-            {
-                return callsiteTraceData;
-            }
+
+            return callsiteTraceData;
         }
 
         #endregion // Trace Data Serialization Methods/Members


### PR DESCRIPTION
### Purpose

The callsite ID and trace data pair serialized to a DYN file are read (if they exist for a node) and stored into TLS only if the ID that's stored in the file matches with the one generated by the compiler for the same node GUID. However if there is a custom node that makes a call to a nested element creation node, the callsite ID generated does not work well. 

This is because the ID is built from a combination of several parameters including the function scope of the creation node itself. In the case of the custom node, the custom node itself is a function in the global scope however the node that it calls into has a non-global function scope, which is the function index of the custom node in the global function table. 

Basing the callsite identifier on something like a function index in the global function table can be very flaky as it could change depending on the order in which global functions (like custom nodes) are compiled and loaded into the table. As a result of this a bug was found where on loading a graph from an older version of Dynamo into a newer version caused element binding to break. This was because the callsite ID serialized to the file did not match with that generated by the compiler.

This PR attempts to fix this situation by ignoring the function scope of the nested method call in the custom node while comparing the callsite ID's.

This change fixes one of the issues with element binding with custom nodes. The replication issue is yet to be addressed.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers



### FYIs

@QilongTang @mjkkirschner 
