### PR TITLE
Provide a strategy for host integrator's to set the python template at startup

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -645,13 +645,13 @@ namespace Dynamo.Models
             // If a custom python template path doesn't already exists in the DynamoSettings.xml
             if(string.IsNullOrEmpty(PreferenceSettings.PythonTemplateFilePath) || !File.Exists(PreferenceSettings.PythonTemplateFilePath))
             {
-                try
+                // To supply a custom python template host integrators should supply a 'DefaultStartConfiguration' config file
+                // or create a new struct that inherits from 'DefaultStartConfiguration' making sure to set the 'PythonTemplatePath'
+                // while passing the config to the 'DynamoModel' constructor.
+                if (config is DefaultStartConfiguration)
                 {
-                    // To supply a custom python template host integrators should supply a 'DefaultStartConfiguration' config file
-                    // or create a new struct that inherits from 'DefaultStartConfiguration' making sure to set the 'PythonTemplatePath'
-                    // while passing the config to the 'DynamoModel' constructor.
-                    var configCast = (DefaultStartConfiguration)config;
-                    var templatePath = configCast.PythonTemplatePath;
+                    var configurationSettings = (DefaultStartConfiguration)config;
+                    var templatePath = configurationSettings.PythonTemplatePath;
 
                     // If a custom python template path was set in the config apply that template
                     if (!string.IsNullOrEmpty(templatePath) && File.Exists(templatePath))
@@ -666,12 +666,14 @@ namespace Dynamo.Models
                         SetDefaultPythonTemplate();
                     }
                 }
-                catch
+
+                else
                 {
                     // Fallback to the default
                     SetDefaultPythonTemplate();
                 }
             }
+
             else
             {
                 // A custom python template path already exists in the DynamoSettings.xml

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -1160,6 +1160,15 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Python template set by host integrator.
+        /// </summary>
+        public static string PythonTemplateDefinedByHost {
+            get {
+                return ResourceManager.GetString("PythonTemplateDefinedByHost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Python template : no valid template found..
         /// </summary>
         public static string PythonTemplateInvalid {
@@ -1167,9 +1176,9 @@ namespace Dynamo.Properties {
                 return ResourceManager.GetString("PythonTemplateInvalid", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to Python template set to user file.
+        ///   Looks up a localized string similar to Python template loaded from DynamoSettings.xml path.
         /// </summary>
         public static string PythonTemplateUserFile {
             get {

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -1151,7 +1151,16 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Python template set to default file.
+        ///   Looks up a localized string similar to Python template loaded from AppData.
+        /// </summary>
+        public static string PythonTemplateAppData {
+            get {
+                return ResourceManager.GetString("PythonTemplateAppData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Python template set to default..
         /// </summary>
         public static string PythonTemplateDefaultFile {
             get {
@@ -1168,15 +1177,6 @@ namespace Dynamo.Properties {
             }
         }
         
-        /// <summary>
-        ///   Looks up a localized string similar to Python template : no valid template found..
-        /// </summary>
-        public static string PythonTemplateInvalid {
-            get {
-                return ResourceManager.GetString("PythonTemplateInvalid", resourceCulture);
-            }
-        }
-
         /// <summary>
         ///   Looks up a localized string similar to Python template loaded from DynamoSettings.xml path.
         /// </summary>

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -688,4 +688,16 @@ The input name should be a valid variable name, without spaces. An input type an
   <data name="InvalidInputSymbolWarningTitle" xml:space="preserve">
     <value>Custom Node Contains Invalid Inputs and Cannot Be Saved.</value>
   </data>
+  <data name="PythonTemplateAppData" xml:space="preserve">
+    <value>Python template loaded from AppData</value>
+  </data>
+  <data name="PythonTemplateDefaultFile" xml:space="preserve">
+    <value>Python template set to default.</value>
+  </data>
+  <data name="PythonTemplateDefinedByHost" xml:space="preserve">
+    <value>Python template set by host integrator</value>
+  </data>
+  <data name="PythonTemplateUserFile" xml:space="preserve">
+    <value>Python template loaded from DynamoSettings.xml path</value>
+  </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -649,11 +649,11 @@ value : bool = false</value>
   <data name="NoneString" xml:space="preserve">
     <value>none</value>
   </data>
-  <data name="PythonTemplateInvalid" xml:space="preserve">
-    <value>Python template : no valid template found.</value>
+  <data name="PythonTemplateAppData" xml:space="preserve">
+    <value>Python template loaded from AppData</value>
   </data>
   <data name="PythonTemplateDefaultFile" xml:space="preserve">
-    <value>Python template set to default file</value>
+    <value>Python template set to default.</value>
   </data>
   <data name="PythonTemplateUserFile" xml:space="preserve">
     <value>Python template loaded from DynamoSettings.xml path</value>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -656,7 +656,7 @@ value : bool = false</value>
     <value>Python template set to default file</value>
   </data>
   <data name="PythonTemplateUserFile" xml:space="preserve">
-    <value>Python template set to user file</value>
+    <value>Python template loaded from DynamoSettings.xml path</value>
   </data>
   <data name="DefaultHomeWorkspaceName" xml:space="preserve">
     <value>Home</value>
@@ -696,5 +696,8 @@ The input name should be a valid variable name, without spaces. An input type an
   </data>
   <data name="InvalidInputSymbolWarningTitle" xml:space="preserve">
     <value>Custom Node Contains Invalid Inputs and Cannot Be Saved.</value>
+  </data>
+  <data name="PythonTemplateDefinedByHost" xml:space="preserve">
+    <value>Python template set by host integrator</value>
   </data>
 </root>

--- a/test/DynamoCoreTests/Settings.cs
+++ b/test/DynamoCoreTests/Settings.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Dynamo.Configuration;
+using Dynamo.Models;
 using NUnit.Framework;
 
 namespace Dynamo.Tests
@@ -53,6 +52,36 @@ namespace Dynamo.Tests
             Assert.IsFalse(File.Exists(settings.PythonTemplateFilePath));
             Assert.IsFalse(File.Exists(pyFile));
             Assert.AreEqual(settings.PythonTemplateFilePath, pyFile);
+        }
+
+        [Test]
+        public void SetPythonTemplateFromConfigWithValidPath()
+        {
+            var templatePath = Path.Combine(SettingDirectory, "PythonTemplate-initial.py");
+
+            var config = new DynamoModel.DefaultStartConfiguration()
+            {
+                PythonTemplatePath = templatePath
+            };
+
+            var model = DynamoModel.Start(config);
+
+            Assert.AreEqual(model.PreferenceSettings.PythonTemplateFilePath, templatePath);
+        }
+
+        [Test]
+        public void SetPythonTemplateFromConfigWithInvalidPath()
+        {
+            var templatePath = Path.Combine(@"C:\Users\SomeDynamoUser\Desktop", "PythonTemplate-initial.py");
+
+            var config = new DynamoModel.DefaultStartConfiguration()
+            {
+                PythonTemplatePath = templatePath
+            };
+
+            var model = DynamoModel.Start(config);
+
+            Assert.AreEqual(model.PreferenceSettings.PythonTemplateFilePath, string.Empty);
         }
 
     }


### PR DESCRIPTION
### Purpose
[DYN-1507](https://jira.autodesk.com/browse/DYN-1507)

This PR provides a strategy for a Dynamo host integrator to programmatically set the path of the Python nodes default template at startup.  This is accomplished by setting the `PythonTemplatePath` on the configuration file that will be passed as a parameter to the `DynamoModel` when instantiated.  It is required that the host integrator uses either the `DefaultStartConfiguration` struct or creates a struct that inherits from `DefaultStartConfiguration`.  For example...

```C#
var config = new DynamoModel.DefaultStartConfiguration()
            {
                PythonTemplatePath = "C:\\Users\\alfarok\\Desktop\\PythonTemplate.py"
            };

var model = DynamoModel.Start(config);
```

Users are still able to override this file if desired by modifying the `<PythonTemplateFilePath>` attribute in the `DynamoSettings.xml` file or adding a a new template file in the appropriate `AppData` location (see below).  To fallback to either host integrator path or the [hard-coded template](https://github.com/DynamoDS/Dynamo/blob/6db61fe4b6c8714f82eed8b0d5a73aa548fcfd54/src/Libraries/PythonNodeModels/PythonNode.cs#L103) provided in Dynamo Core simply remove the path from the settings xml or delete the template file from the `AppData` location.  Lastly, if a invalid path is provided the default Core template will be applied.

### Logging

(In sequential order)

#### Loaded from DynamoSettings.xml
![image](https://user-images.githubusercontent.com/13341935/53990705-de773e80-40f6-11e9-823f-91787bb8ebde.png)

#### Loaded from Host Integrator
![image](https://user-images.githubusercontent.com/13341935/53990729-ed5df100-40f6-11e9-82bf-6f68e52957a2.png)

#### Loaded from AppData
![image](https://user-images.githubusercontent.com/13341935/53990684-d28b7c80-40f6-11e9-9881-182b9f450d24.png)

#### Loaded Default Template
![image](https://user-images.githubusercontent.com/13341935/53990576-922bfe80-40f6-11e9-9f5b-146d8c309125.png)

### Overriding the default or a host integrator template as a USER
Users looking to override the template can do so in the following ways introduced in #8122:
#### Option 1 - Default AppData Location
Add a new python file named `PythonTemplate.py` to the `C:\Users\alfarok\AppData\Roaming\Dynamo\Dynamo Core\2.2` directory

#### Option 2 - Custom Location using DynamoSettings.xml
Add a custom path to the `DynamoSetting.xml` under the `PythonTemplateFilePath` tag such as
`<PythonTemplateFilePath>C:\Users\alfarok\Desktop\PythonTemplate.py</PythonTemplateFilePath>`
(Does NOT require `PythonTemplate.py` naming)

### Testing
Unit tests have been added to verify API usage for valid and invalid template paths.  Additionally, this has been manually tested by modifying the DynamoSandbox startup config to include a `PythonTemplatePath` which is set [here](https://github.com/DynamoDS/Dynamo/blob/224f5df4eb7b7b999ae3818e2e3dba3b789fa493/src/DynamoApplications/StartupUtils.cs#L183) and invoked [here](https://github.com/DynamoDS/Dynamo/blob/8afcde02f859f5dd4f261d21edb32e2b94e9450a/src/DynamoSandbox/DynamoCoreSetup.cs#L40).  Testing coverage for loading the default template as well as a user template already has coverage.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @mjkkirschner 
