### PR TITLE
SelectInRegionCommand Removal in One test

### DIFF
--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1834,6 +1834,8 @@ namespace DynamoCoreWpfTests
         [Category("RegressionTests")]
         public void Defect_MAGN_520_DS()
         {
+            // This test is updated to use DeleteModelCommand instead of SelectInRegionCommand due to instability
+
             // Details are available in defect http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-520
             RunCommandsFromFile("Defect_MAGN_520_DS.xml");
 

--- a/test/core/recorded/Defect_MAGN_520_DS.xml
+++ b/test/core/recorded/Defect_MAGN_520_DS.xml
@@ -15,7 +15,6 @@
   <SelectModelCommand ModelGuid="03107ea4-75db-4826-a12d-9ebf4f23f65c" Modifiers="0" />
   <DragSelectionCommand X="298" Y="219" DragOperation="0" />
   <DragSelectionCommand X="241" Y="208" DragOperation="1" />
-  <SelectModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" Modifiers="0" />
-  <SelectInRegionCommand X="151" Y="355" Width="640" Height="250" IsCrossSelection="false" />
-  <DeleteModelCommand ModelGuid="00000000-0000-0000-0000-000000000000" />
+  <DeleteModelCommand ModelGuid="03107ea4-75db-4826-a12d-9ebf4f23f65c" />
+  <DeleteModelCommand ModelGuid="70c28589-855c-45cf-9ec3-bbf25d478a0d" />
 </Commands>


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

It has been proved that one of the recorded test using  `DeleteModelCommand` following `SelectInRegionCommand` is not stable and could be VM setting dependent (see https://github.com/DynamoDS/Dynamo/pull/3718 ). This PR updates the test to just use `DeleteModelCommand` in this test because `SelectInRegionCommand` has been tested in multiple other tests and we should not have VM setting dependent test in the suite.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @aparajit-pratap 

### FYIs
