### PR TITLE
DYN-1175: Captured image name default to "graph name+timestamp".

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1983,7 +1983,6 @@ namespace Dynamo.ViewModels
                 {
                     AddExtension = true,
                     DefaultExt = ".png",
-                    FileName = Resources.FileDialogDefaultPNGName,
                     Filter = string.Format(Resources.FileDialogPNGFiles, "*.png"),
                     Title = Resources.SaveWorkbenToImageDialogTitle
                 };
@@ -1993,7 +1992,9 @@ namespace Dynamo.ViewModels
             if (!string.IsNullOrEmpty(model.CurrentWorkspace.FileName))
             {
                 var fi = new FileInfo(model.CurrentWorkspace.FileName);
+                var snapshotName = PathHelper.GetSnapshotName(fi);
                 _fileDialog.InitialDirectory = fi.DirectoryName;
+                _fileDialog.FileName = snapshotName;
             }
 
             if (_fileDialog.ShowDialog() != DialogResult.OK) return;

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1992,7 +1992,7 @@ namespace Dynamo.ViewModels
             if (!string.IsNullOrEmpty(model.CurrentWorkspace.FileName))
             {
                 var fi = new FileInfo(model.CurrentWorkspace.FileName);
-                var snapshotName = PathHelper.GetSnapshotName(fi);
+                var snapshotName = PathHelper.GetSnapshotNameFromPath(fi.FullName);
                 _fileDialog.InitialDirectory = fi.DirectoryName;
                 _fileDialog.FileName = snapshotName;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1992,7 +1992,7 @@ namespace Dynamo.ViewModels
             if (!string.IsNullOrEmpty(model.CurrentWorkspace.FileName))
             {
                 var fi = new FileInfo(model.CurrentWorkspace.FileName);
-                var snapshotName = PathHelper.GetSnapshotNameFromPath(fi.FullName);
+                var snapshotName = PathHelper.GetScreenCaptureNameFromPath(fi.FullName);
                 _fileDialog.InitialDirectory = fi.DirectoryName;
                 _fileDialog.FileName = snapshotName;
             }

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -165,7 +165,7 @@ namespace DynamoUtilities
         /// </summary>
         /// <param name="filePath">File path</param>
         /// <returns>Returns a default name(along with the timestamp) for the workspace image</returns>
-        public static String GetSnapshotNameFromPath(String filePath)
+        public static String GetScreenCaptureNameFromPath(String filePath)
         {
             FileInfo fileInfo = new FileInfo(filePath);
             String timeStamp = string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now);

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -163,10 +163,11 @@ namespace DynamoUtilities
         /// <summary>
         /// This is a utility method for generating a default name to the snapshot image. 
         /// </summary>
-        /// <param name="fileInfo">File information</param>
+        /// <param name="filePath">File path</param>
         /// <returns>Returns a default name(along with the timestamp) for the workspace image</returns>
-        public static String GetSnapshotName(FileInfo fileInfo)
+        public static String GetSnapshotNameFromPath(String filePath)
         {
+            FileInfo fileInfo = new FileInfo(filePath);
             String timeStamp = string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now);
             String snapshotName = fileInfo.Name.Replace(fileInfo.Extension, "_") + timeStamp;
             return snapshotName;

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -159,5 +159,12 @@ namespace DynamoUtilities
 
             return false;
         }
+
+        public static String GetSnapshotName(FileInfo fi)
+        {
+            String timeStamp = string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now);
+            String snapshotName = fi.Name.Replace(fi.Extension, "_") + timeStamp;
+            return snapshotName;
+        }
     }
 }

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -160,10 +160,15 @@ namespace DynamoUtilities
             return false;
         }
 
-        public static String GetSnapshotName(FileInfo fi)
+        /// <summary>
+        /// This is a utility method for generating a default name to the snapshot image. 
+        /// </summary>
+        /// <param name="fileInfo">File information</param>
+        /// <returns>Returns a default name(along with the timestamp) for the workspace image</returns>
+        public static String GetSnapshotName(FileInfo fileInfo)
         {
             String timeStamp = string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now);
-            String snapshotName = fi.Name.Replace(fi.Extension, "_") + timeStamp;
+            String snapshotName = fileInfo.Name.Replace(fileInfo.Extension, "_") + timeStamp;
             return snapshotName;
         }
     }

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -832,7 +832,7 @@ namespace Dynamo.Tests
         public void GenerateSnapshotNameTest()
         {
             var examplePath = Path.Combine(TestDirectory, @"core\math", "Add.dyn");
-            var snapshotName = PathHelper.GetSnapshotNameFromPath(examplePath);
+            var snapshotName = PathHelper.GetScreenCaptureNameFromPath(examplePath);
             Assert.AreEqual(snapshotName, "Add_" + string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now));
         }
     }

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -827,6 +827,7 @@ namespace Dynamo.Tests
             Assert.AreEqual(true, InvalidNameError);
         }
 
+        //This test will check for the default name that is set for the workspace snapshot.
         [Test]
         public void GenerateSnapshotNameTest()
         {

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -832,8 +832,7 @@ namespace Dynamo.Tests
         public void GenerateSnapshotNameTest()
         {
             var examplePath = Path.Combine(TestDirectory, @"core\math", "Add.dyn");
-            var fi = new FileInfo(examplePath);
-            var snapshotName = PathHelper.GetSnapshotName(fi);
+            var snapshotName = PathHelper.GetSnapshotNameFromPath(examplePath);
             Assert.AreEqual(snapshotName, "Add_" + string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now));
         }
     }

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -826,5 +826,14 @@ namespace Dynamo.Tests
             }
             Assert.AreEqual(true, InvalidNameError);
         }
+
+        [Test]
+        public void GenerateSnapshotNameTest()
+        {
+            var examplePath = Path.Combine(TestDirectory, @"core\math", "Add.dyn");
+            var fi = new FileInfo(examplePath);
+            var snapshotName = PathHelper.GetSnapshotName(fi);
+            Assert.AreEqual(snapshotName, "Add_" + string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now));
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This PR addresses a minor improvement when the user tries to capture an image of the workspace or the Background 3d image snapshot. 

A user can take a snapshot in the following ways:
1) File => Export Workspace As Image
2) File => Export Background 3D Preview As Image
3) Camera Icon (Top Right) while workspace is active
4) Camera Icon while background preview is active

The snapshot name will default to the graph name along with the timestamp. 

![snapshot name](https://user-images.githubusercontent.com/43763136/53910368-abaf4680-4021-11e9-92e1-c2113f3e7eaa.gif)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang @mjkkirschner 

