### PR TITLE
Cherry Pick DYN-1476: AllowRankReductionAttribute on Zero Touch Properties (#9542)

### DIFF
--- a/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
+++ b/src/Engine/ProtoCore/FFI/CLRDLLModule.cs
@@ -393,7 +393,7 @@ namespace ProtoFFI
             bool isDisposable = typeof(IDisposable).IsAssignableFrom(type);
             MethodInfo[] methods = type.GetMethods(flags);
             bool hasDisposeMethod = false;
-
+            
             foreach (var m in methods)
             {
                 if (SupressesImport(m, mGetterAttributes))
@@ -782,7 +782,10 @@ namespace ProtoFFI
             if (CoreUtils.IsDisposeMethod(functionName))
                 f = new DisposeFunctionPointer(Module, method, retype);
             else if (CoreUtils.IsGetter(functionName))
+            {
                 f = new GetterFunctionPointer(Module, functionName, method, retype);
+                (f as GetterFunctionPointer).ReflectionInfo.CheckForRankReductionAttribute(mGetterAttributes);
+            }
             else
                 f = new CLRFFIFunctionPointer(Module, functionName, method, argTypes, retype);
 

--- a/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
+++ b/src/Engine/ProtoCore/FFI/CLRFFIFunctionPointer.cs
@@ -64,6 +64,31 @@ namespace ProtoFFI
             Info = info;
         }
 
+        /// <summary>
+        /// This method is used to copy the AllowRankReductionAttribute 
+        /// from a Zero Touch property to the property's getter function.
+        /// </summary>
+        /// <param name="getterAttributes"></param>
+        internal void CheckForRankReductionAttribute(Dictionary<MethodInfo, Attribute[]> getterAttributes)
+        {
+            var info = Info as MethodInfo;
+            if (info != null)
+            {
+                Attribute[] attributes = null;
+                if (getterAttributes.TryGetValue(info, out attributes))
+                {
+                    foreach (var attr in attributes)
+                    {
+                        if (attr is AllowRankReductionAttribute)
+                        {
+                            mAllowRankReduction = true;
+                            mRankReducer = attr as AllowRankReductionAttribute;
+                        }
+                    }
+                }
+            }
+        }
+
         public object ReduceReturnedCollectionToSingleton(object collection)
         {
             if (null == mAllowRankReduction)

--- a/src/Libraries/DesignScriptBuiltin/Dictionary.cs
+++ b/src/Libraries/DesignScriptBuiltin/Dictionary.cs
@@ -58,7 +58,8 @@ namespace DesignScript
             ///     Produces the values in a Dictionary.
             /// </summary>
             /// <returns name="values">The values of the Dictionary</returns>
-            [AllowRankReduction]
+            // [AllowRankReduction]
+            // TODO: Consider adding this attribute in 3.0 (DYN-1697)
             public IEnumerable<object> Values => D.Values;
 
             /// <summary>

--- a/test/Engine/FFITarget/TestObjects.cs
+++ b/test/Engine/FFITarget/TestObjects.cs
@@ -457,4 +457,35 @@ namespace FFITarget
         }
     }
 
+    public class TestRankReduce
+    {
+        private string RankReduceTestField;
+
+        [AllowRankReduction]
+        public List<string> RankReduceProperty
+        {
+            get { return new List<string> { RankReduceTestField }; }
+        }
+
+        public List<string> Property
+        {
+            get { return new List<string> { RankReduceTestField }; }
+        }
+
+        public TestRankReduce(string s)
+        {
+            RankReduceTestField = s;
+        }
+        
+        [AllowRankReduction]
+        public List<string> RankReduceMethod()
+        {
+            return new List<string> { RankReduceTestField };
+        }
+
+        public List<string> Method()
+        {
+            return new List<string> { RankReduceTestField };
+        }
+    }
 }

--- a/test/Engine/ProtoTest/FFITests/CSFFITest.cs
+++ b/test/Engine/ProtoTest/FFITests/CSFFITest.cs
@@ -1387,6 +1387,32 @@ value = [u.X, u.Y, u.Z];
             thisTest.Verify("value", new double[] { 1, 2, 3 });
             thisTest.Verify("newPoint", FFITarget.DummyPoint.ByCoordinates(2, 4, 6));
         }
+
+        [Test]
+        public void AllowRankReductionAttributeWorksForProperty()
+        {
+            string code =
+                @"import(""FFITarget.dll"");
+rankReduceTestObject = FFITarget.TestRankReduce(""test"");
+property = rankReduceTestObject.Property; 
+reducedProperty = rankReduceTestObject.RankReduceProperty; ";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("property", new List<string> { "test" });
+            thisTest.Verify("reducedProperty", "test");
+        }
+
+        [Test]
+        public void AllowRankReductionAttributeWorksForMethod()
+        {
+            string code =
+                @"import(""FFITarget.dll"");
+rankReduceTestObject = FFITarget.TestRankReduce(""test"");
+method = rankReduceTestObject.Method(); 
+reducedMethod = rankReduceTestObject.RankReduceMethod(); ";
+            thisTest.RunScriptSource(code);
+            thisTest.Verify("method", new List<string> { "test" });
+            thisTest.Verify("reducedMethod", "test");
+        }
     }
 }
 


### PR DESCRIPTION

* update

* Brought truncated search results and full query search out from behind debug menu. Deleted debug menu items.

* Added CheckForRankReductionAttribute() method to FFIMemberInfo

* Cleaned up CheckForRankReductionAttribute

* Added AllowRankReductionAttribute tests

* Comments. Change method name.

* Update tests, method name

* Corrected test names

* Fixed annoying diff

### Purpose

Cherry Pick [this PR ](https://github.com/DynamoDS/Dynamo/pull/9542) to 2.2.0

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers


### FYIs

