### PR TITLE
[Cherry-pick] Provide a strategy for host integrator's to set the python template at startup

### DIFF
--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -521,6 +521,7 @@ namespace Dynamo.Models
             public IEnumerable<IExtension> Extensions { get; set; }
             public TaskProcessMode ProcessMode { get; set; }
             public bool IsHeadless { get; set; }
+            public string PythonTemplatePath { get; set; }
         }
 
         /// <summary>
@@ -636,21 +637,50 @@ namespace Dynamo.Models
             var userDataFolder = pathManager.GetUserDataFolder(); // Get the default user data path
             AddPackagePath(userDataFolder);
 
-            // Check if the Python template file specified in the settings file exists & it's not empty
-            // If not, check the default filepath for the Python template (userDataFolder\PythonTemplate.py).
-            // If that doesn't exist either or is empty, Dynamo falls back to the hard-coded Python script template.
-            // We log the behaviour to make it easy for users to troubleshoot this.
+            // Load Python Template
+            // The loading pattern is conducted in the following order
+            // 1) Set from DynamoSettings.XML
+            // 2) Set from API via the configuration file
+            // 3) Set from PythonTemplate.py located in 'C:\Users\USERNAME\AppData\Roaming\Dynamo\Dynamo Core\2.X'
+            // 4) Set from OOTB hard-coded default template
+
+            // If a custom python template path doesn't already exists in the DynamoSettings.xml
             if (string.IsNullOrEmpty(PreferenceSettings.PythonTemplateFilePath) || !File.Exists(PreferenceSettings.PythonTemplateFilePath))
             {
-                if (string.IsNullOrEmpty(pathManager.PythonTemplateFilePath) || !File.Exists(pathManager.PythonTemplateFilePath))
-                    Logger.Log(Resources.PythonTemplateInvalid);
+                // To supply a custom python template host integrators should supply a 'DefaultStartConfiguration' config file
+                // or create a new struct that inherits from 'DefaultStartConfiguration' making sure to set the 'PythonTemplatePath'
+                // while passing the config to the 'DynamoModel' constructor.
+                if (config is DefaultStartConfiguration)
+                {
+                    var configurationSettings = (DefaultStartConfiguration)config;
+                    var templatePath = configurationSettings.PythonTemplatePath;
+
+                    // If a custom python template path was set in the config apply that template
+                    if (!string.IsNullOrEmpty(templatePath) && File.Exists(templatePath))
+                    {
+                        PreferenceSettings.PythonTemplateFilePath = templatePath;
+                        Logger.Log(Resources.PythonTemplateDefinedByHost + " : " + PreferenceSettings.PythonTemplateFilePath);
+                    }
+
+                    // Otherwise fallback to the default
+                    else
+                    {
+                        SetDefaultPythonTemplate();
+                    }
+                }
+
                 else
                 {
-                    PreferenceSettings.PythonTemplateFilePath = pathManager.PythonTemplateFilePath;
-                    Logger.Log(Resources.PythonTemplateDefaultFile + " : " + pathManager.PythonTemplateFilePath);
+                    // Fallback to the default
+                    SetDefaultPythonTemplate();
                 }
             }
-            else Logger.Log(Resources.PythonTemplateUserFile + " : " + pathManager.PythonTemplateFilePath);
+
+            else
+            {
+                // A custom python template path already exists in the DynamoSettings.xml
+                Logger.Log(Resources.PythonTemplateUserFile + " : " + PreferenceSettings.PythonTemplateFilePath);
+            }
 
             pathManager.Preferences = PreferenceSettings;
 
@@ -777,6 +807,23 @@ namespace Dynamo.Models
             TraceReconciliationProcessor = this;
             // This event should only be raised at the end of this method.
              DynamoReady(new ReadyParams(this));
+        }
+
+        private void SetDefaultPythonTemplate()
+        {
+            // First check if the default python template is overridden by a PythonTemplate.py file in AppData
+            // This file is always named accordingly and located in 'C:\Users\USERNAME\AppData\Roaming\Dynamo\Dynamo Core\2.X'
+            if (!string.IsNullOrEmpty(pathManager.PythonTemplateFilePath) && File.Exists(pathManager.PythonTemplateFilePath))
+            {
+                PreferenceSettings.PythonTemplateFilePath = pathManager.PythonTemplateFilePath;
+                Logger.Log(Resources.PythonTemplateAppData + " : " + PreferenceSettings.PythonTemplateFilePath);
+            }
+
+            // Otherwise the OOTB hard-coded template is applied
+            else
+            {
+                Logger.Log(Resources.PythonTemplateDefaultFile);
+            }
         }
 
         private void DynamoReadyExtensionHandler(ReadyParams readyParams, IEnumerable<IExtension> extensions) {

--- a/src/DynamoCore/Properties/Resources.Designer.cs
+++ b/src/DynamoCore/Properties/Resources.Designer.cs
@@ -1151,7 +1151,16 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Python template set to default file.
+        ///   Looks up a localized string similar to Python template loaded from AppData.
+        /// </summary>
+        public static string PythonTemplateAppData {
+            get {
+                return ResourceManager.GetString("PythonTemplateAppData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Python template set to default..
         /// </summary>
         public static string PythonTemplateDefaultFile {
             get {
@@ -1160,16 +1169,16 @@ namespace Dynamo.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Python template : no valid template found..
+        ///   Looks up a localized string similar to Python template set by host integrator.
         /// </summary>
-        public static string PythonTemplateInvalid {
+        public static string PythonTemplateDefinedByHost {
             get {
-                return ResourceManager.GetString("PythonTemplateInvalid", resourceCulture);
+                return ResourceManager.GetString("PythonTemplateDefinedByHost", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Python template set to user file.
+        ///   Looks up a localized string similar to Python template loaded from DynamoSettings.xml path.
         /// </summary>
         public static string PythonTemplateUserFile {
             get {

--- a/src/DynamoCore/Properties/Resources.en-US.resx
+++ b/src/DynamoCore/Properties/Resources.en-US.resx
@@ -688,4 +688,16 @@ The input name should be a valid variable name, without spaces. An input type an
   <data name="InvalidInputSymbolWarningTitle" xml:space="preserve">
     <value>Custom Node Contains Invalid Inputs and Cannot Be Saved.</value>
   </data>
+  <data name="PythonTemplateAppData" xml:space="preserve">
+    <value>Python template loaded from AppData</value>
+  </data>
+  <data name="PythonTemplateDefaultFile" xml:space="preserve">
+    <value>Python template set to default.</value>
+  </data>
+  <data name="PythonTemplateDefinedByHost" xml:space="preserve">
+    <value>Python template set by host integrator</value>
+  </data>
+  <data name="PythonTemplateUserFile" xml:space="preserve">
+    <value>Python template loaded from DynamoSettings.xml path</value>
+  </data>
 </root>

--- a/src/DynamoCore/Properties/Resources.resx
+++ b/src/DynamoCore/Properties/Resources.resx
@@ -649,14 +649,14 @@ value : bool = false</value>
   <data name="NoneString" xml:space="preserve">
     <value>none</value>
   </data>
-  <data name="PythonTemplateInvalid" xml:space="preserve">
-    <value>Python template : no valid template found.</value>
+  <data name="PythonTemplateAppData" xml:space="preserve">
+    <value>Python template loaded from AppData</value>
   </data>
   <data name="PythonTemplateDefaultFile" xml:space="preserve">
-    <value>Python template set to default file</value>
+    <value>Python template set to default.</value>
   </data>
   <data name="PythonTemplateUserFile" xml:space="preserve">
-    <value>Python template set to user file</value>
+    <value>Python template loaded from DynamoSettings.xml path</value>
   </data>
   <data name="DefaultHomeWorkspaceName" xml:space="preserve">
     <value>Home</value>
@@ -696,5 +696,8 @@ The input name should be a valid variable name, without spaces. An input type an
   </data>
   <data name="InvalidInputSymbolWarningTitle" xml:space="preserve">
     <value>Custom Node Contains Invalid Inputs and Cannot Be Saved.</value>
+  </data>
+  <data name="PythonTemplateDefinedByHost" xml:space="preserve">
+    <value>Python template set by host integrator</value>
   </data>
 </root>

--- a/test/DynamoCoreTests/Settings.cs
+++ b/test/DynamoCoreTests/Settings.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Dynamo.Configuration;
+using Dynamo.Models;
 using NUnit.Framework;
 
 namespace Dynamo.Tests
@@ -53,6 +52,36 @@ namespace Dynamo.Tests
             Assert.IsFalse(File.Exists(settings.PythonTemplateFilePath));
             Assert.IsFalse(File.Exists(pyFile));
             Assert.AreEqual(settings.PythonTemplateFilePath, pyFile);
+        }
+
+        [Test]
+        public void SetPythonTemplateFromConfigWithValidPath()
+        {
+            var templatePath = Path.Combine(SettingDirectory, "PythonTemplate-initial.py");
+
+            var config = new DynamoModel.DefaultStartConfiguration()
+            {
+                PythonTemplatePath = templatePath
+            };
+
+            var model = DynamoModel.Start(config);
+
+            Assert.AreEqual(model.PreferenceSettings.PythonTemplateFilePath, templatePath);
+        }
+
+        [Test]
+        public void SetPythonTemplateFromConfigWithInvalidPath()
+        {
+            var templatePath = Path.Combine(@"C:\Users\SomeDynamoUser\Desktop", "PythonTemplate-initial.py");
+
+            var config = new DynamoModel.DefaultStartConfiguration()
+            {
+                PythonTemplatePath = templatePath
+            };
+
+            var model = DynamoModel.Start(config);
+
+            Assert.AreEqual(model.PreferenceSettings.PythonTemplateFilePath, string.Empty);
         }
 
     }


### PR DESCRIPTION
Cherry-picked from #9533 

* provide a strategy for host integrators to set Python node template at startup programmatically

* use 'is' as opposed to 'try/catch'

* Fix several bugs around previously existing logging statements

* add unit tests verifying valid and invalid  API usage

### FYIs

@mjkkirschner @QilongTang 
