### PR TITLE
Cherry Pick: Render precision save (#9108)

### DIFF
--- a/src/DynamoCore/Configuration/IPreferences.cs
+++ b/src/DynamoCore/Configuration/IPreferences.cs
@@ -148,6 +148,18 @@ namespace Dynamo.Interfaces
     }
 
     /// <summary>
+    /// Temporary interface to avoid breaking changes.
+    /// TODO: Merge with IPreferences for 3.0 (DYN-1699)
+    /// </summary>
+    public interface IRenderPrecisionPreference
+    {
+        ///<summary>
+        ///Indicate which render precision will be used
+        ///</summary>
+        int RenderPrecision { get; set; }
+    }
+
+    /// <summary>
     /// Represents data about active state of preview background
     /// </summary>
     public class BackgroundPreviewActiveState

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -15,7 +15,7 @@ namespace Dynamo.Configuration
     /// from a XML file from DYNAMO_SETTINGS_FILE.
     /// When GUI is closed, the settings are saved back into the XML file.
     /// </summary>
-    public class PreferenceSettings : NotificationObject, IPreferences
+    public class PreferenceSettings : NotificationObject, IPreferences, IRenderPrecisionPreference
     {
         private string numberFormat;
         private string lastUpdateDownloadPath;
@@ -26,6 +26,11 @@ namespace Dynamo.Configuration
         /// Indicates the maximum number of files shown in Recent Files
         /// </summary>
         internal const int DefaultMaxNumRecentFiles = 10;
+
+        /// <summary>
+        /// Indicates the default render precision, i.e. the maximum number of tessellation divisions
+        /// </summary>
+        internal const int DefaultRenderPrecision = 128;
 
         /// <summary>
         /// Temp PreferenceSetting Location for testing
@@ -154,7 +159,11 @@ namespace Dynamo.Configuration
         }
 
         /// <summary>
-        /// Indicates whether surface and solid edges will 
+        /// Indicate which render precision will be used
+        /// </summary>
+        public int RenderPrecision { get; set; }
+
+        /// Indicates whether surface and solid edges will
         /// be rendered.
         /// </summary>
         public bool ShowEdges { get; set; }
@@ -324,6 +333,7 @@ namespace Dynamo.Configuration
             UseHardwareAcceleration = true;
             PackageDownloadTouAccepted = false;
             maxNumRecentFiles = DefaultMaxNumRecentFiles;
+            RenderPrecision = DefaultRenderPrecision;
             ShowEdges = false;
             OpenFileInManualExecutionMode = false;
             ShowDetailedLayout = true;

--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -80,7 +80,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>Y:\Dynamo\extern\ProtoGeometry\ProtoGeometry.dll</HintPath>
+      <HintPath>..\..\extern\ProtoGeometry\ProtoGeometry.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -601,16 +601,19 @@ namespace Dynamo.ViewModels
 
         private void RenderPackageFactoryViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
+            var factoryVm = (RenderPackageFactoryViewModel)sender;
             switch (e.PropertyName)
             {
                 case "ShowEdges":
-                    var factoryVm = (RenderPackageFactoryViewModel)sender;
                     model.PreferenceSettings.ShowEdges = factoryVm.Factory.TessellationParameters.ShowEdges;
                     // A full regeneration is required to get the edge geometry.
                     foreach (var vm in Watch3DViewModels)
                     {
                         vm.RegenerateAllPackages();
                     }
+                    break;
+                case "MaxTessellationDivisions":
+                    model.PreferenceSettings.RenderPrecision = factoryVm.Factory.TessellationParameters.MaxTessellationDivisions;
                     break;
                 default:
                     return;

--- a/src/DynamoCoreWpf/ViewModels/RenderPackageFactoryViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/RenderPackageFactoryViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using Dynamo.Interfaces;
 using Dynamo.ViewModels;
 using Dynamo.Visualization;
+using Dynamo.Configuration;
 using Dynamo.Wpf.Rendering;
 
 namespace Dynamo.Wpf.ViewModels
@@ -42,12 +43,25 @@ namespace Dynamo.Wpf.ViewModels
             }
         }
 
+        // TODO: Simplify this constructor once IPreferences and IRenderPrecisionPreference have been consolidated in 3.0 (DYN-1699)
         public RenderPackageFactoryViewModel(IPreferences preferenceSettings)
         {
-            this.factory = new HelixRenderPackageFactory()
+            var ps = preferenceSettings as PreferenceSettings;
+            if (ps != null)
             {
-                TessellationParameters = { ShowEdges = preferenceSettings.ShowEdges }
-            };
+                this.factory = new HelixRenderPackageFactory()
+                {
+                    TessellationParameters = { ShowEdges = ps.ShowEdges, MaxTessellationDivisions = ps.RenderPrecision }
+                };
+            }
+            else
+            {
+                this.factory = new HelixRenderPackageFactory()
+                {
+                    TessellationParameters = { ShowEdges = preferenceSettings.ShowEdges}
+                };
+            }
+            
         }
     }
 }

--- a/test/DynamoCoreWpfTests/CoreUITests.cs
+++ b/test/DynamoCoreWpfTests/CoreUITests.cs
@@ -468,6 +468,37 @@ namespace DynamoCoreWpfTests
             #endregion
         }
 
+        [Test, RequiresSTA]
+        [Category("DynamoUI")]
+        public void PreferenceSetting_RenderPrecision()
+        {
+            // Test that RenderPrecision setting works as expected
+            ViewModel.RenderPackageFactoryViewModel.MaxTessellationDivisions = 256;
+            Assert.AreEqual(256, ViewModel.Model.PreferenceSettings.RenderPrecision);
+
+            ViewModel.RenderPackageFactoryViewModel.MaxTessellationDivisions = 128;
+            Assert.AreEqual(128, ViewModel.Model.PreferenceSettings.RenderPrecision);
+
+            // Test serialization of RenderPrecision 
+            string tempPath = System.IO.Path.GetTempPath();
+            tempPath = Path.Combine(tempPath, "userPreference.xml");
+            
+            PreferenceSettings initalSetting = new PreferenceSettings();
+            PreferenceSettings resultSetting;
+
+            initalSetting.RenderPrecision = 256;
+
+            initalSetting.Save(tempPath);
+            resultSetting = PreferenceSettings.Load(tempPath);
+
+            Assert.AreEqual(resultSetting.RenderPrecision, initalSetting.RenderPrecision);
+
+            // Test loading old settings file without render precision attribute
+            var filePath = Path.Combine(GetTestDirectory(ExecutingDirectory), @"settings\DynamoSettings-WithoutRenderPrecision.xml");
+            PreferenceSettings WithoutRenderPrecision = PreferenceSettings.Load(filePath);
+            Assert.AreEqual(WithoutRenderPrecision.RenderPrecision, 128);
+        }
+
         #region PreferenceSettings
         [Test, RequiresSTA]
         [Category("DynamoUI")]

--- a/test/settings/DynamoSettings-WithoutRenderPrecision.xml
+++ b/test/settings/DynamoSettings-WithoutRenderPrecision.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+-
+<PreferenceSettings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<IsFirstRun>
+		true
+	</IsFirstRun>
+	<IsUsageReportingApproved>
+		false
+	</IsUsageReportingApproved>
+	<IsAnalyticsReportingApproved>
+		false
+	</IsAnalyticsReportingApproved>
+	<LibraryWidth>
+		304
+	</LibraryWidth>
+	<ConsoleHeight>
+		0
+	</ConsoleHeight>
+	<ShowPreviewBubbles>
+		true
+	</ShowPreviewBubbles>
+	<ShowConnector>
+		true
+	</ShowConnector>
+	<ConnectorType>
+		BEZIER
+	</ConnectorType>
+	<BackgroundPreviews />
+	<IsBackgroundGridVisible>
+		true
+	</IsBackgroundGridVisible>
+	<ShowEdges>
+		false
+	</ShowEdges>
+	<ShowDetailedLayout>
+		true
+	</ShowDetailedLayout>
+	<WindowX>
+		0
+	</WindowX>
+	<WindowY>
+		0
+	</WindowY>
+	<WindowW>
+		1024
+	</WindowW>
+	<WindowH>
+		768
+	</WindowH>
+	<UseHardwareAcceleration>
+		true
+	</UseHardwareAcceleration>
+	<NumberFormat>
+		f3
+	</NumberFormat>
+	<MaxNumRecentFiles>
+		10
+	</MaxNumRecentFiles>
+	<RecentFiles />
+	<BackupFiles />
+	<CustomPackageFolders />
+	<PackageDirectoriesToUninstall />
+	<PythonTemplateFilePath />
+	<BackupInterval>
+		60000
+	</BackupInterval>
+	<BackupFilesCount>
+		1
+	</BackupFilesCount>
+	<PackageDownloadTouAccepted>
+		false
+	</PackageDownloadTouAccepted>
+	<OpenFileInManualExecutionMode>
+		false
+	</OpenFileInManualExecutionMode>
+</PreferenceSettings>


### PR DESCRIPTION
* ALS-5190 Dynamo: Render Precision setting is not remembered

* Set correct path to ProtoGeometry lib

* Return comment removed by accident

* Add missing line

* Add new interface

* Copy Background Preview test

* Creating RenderPrecision test

* Updated RenderPrecision test

* Removed inheritance I was testing

* Added RenderPackageFactoryViewModel constructor

* Updated constructor

* Add TODO

* Add test that loads settings file that does not contain RenderPrecision

* Added const fro DefaultRenderPrecision

* Added jira task


### Purpose

2.2.0 Cherry pick of [https://github.com/DynamoDS/Dynamo/pull/9108](https://github.com/DynamoDS/Dynamo/pull/9108)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

