### PR TITLE
[Cherry-Pick] DYN-1175: Captured image name default to "graph name+timestamp". (#9546)

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1986,7 +1986,6 @@ namespace Dynamo.ViewModels
                 {
                     AddExtension = true,
                     DefaultExt = ".png",
-                    FileName = Resources.FileDialogDefaultPNGName,
                     Filter = string.Format(Resources.FileDialogPNGFiles, "*.png"),
                     Title = Resources.SaveWorkbenToImageDialogTitle
                 };
@@ -1996,7 +1995,9 @@ namespace Dynamo.ViewModels
             if (!string.IsNullOrEmpty(model.CurrentWorkspace.FileName))
             {
                 var fi = new FileInfo(model.CurrentWorkspace.FileName);
+                var snapshotName = PathHelper.GetScreenCaptureNameFromPath(fi.FullName);
                 _fileDialog.InitialDirectory = fi.DirectoryName;
+                _fileDialog.FileName = snapshotName;
             }
 
             if (_fileDialog.ShowDialog() != DialogResult.OK) return;

--- a/src/DynamoUtilities/PathHelper.cs
+++ b/src/DynamoUtilities/PathHelper.cs
@@ -159,5 +159,18 @@ namespace DynamoUtilities
 
             return false;
         }
+
+        /// <summary>
+        /// This is a utility method for generating a default name to the snapshot image. 
+        /// </summary>
+        /// <param name="filePath">File path</param>
+        /// <returns>Returns a default name(along with the timestamp) for the workspace image</returns>
+        public static String GetScreenCaptureNameFromPath(String filePath)
+        {
+            FileInfo fileInfo = new FileInfo(filePath);
+            String timeStamp = string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now);
+            String snapshotName = fileInfo.Name.Replace(fileInfo.Extension, "_") + timeStamp;
+            return snapshotName;
+        }
     }
 }

--- a/test/DynamoCoreTests/UtilityTests.cs
+++ b/test/DynamoCoreTests/UtilityTests.cs
@@ -826,5 +826,14 @@ namespace Dynamo.Tests
             }
             Assert.AreEqual(true, InvalidNameError);
         }
+
+        //This test will check for the default name that is set for the workspace snapshot.
+        [Test]
+        public void GenerateSnapshotNameTest()
+        {
+            var examplePath = Path.Combine(TestDirectory, @"core\math", "Add.dyn");
+            var snapshotName = PathHelper.GetScreenCaptureNameFromPath(examplePath);
+            Assert.AreEqual(snapshotName, "Add_" + string.Format("{0:yyyy-MM-dd_hh-mm-ss}", DateTime.Now));
+        }
     }
 }


### PR DESCRIPTION
* DYN-1175

Captured image name default to "graph name+timestamp".

* DYN1175

Added comments

* Function API changes

* Changing API name

(cherry picked from commit 88c925e5389e727a1c8439a82988ce6367819a65)

### Purpose

This PR to to cherry-pick the PR (https://github.com/DynamoDS/Dynamo/pull/9546) to the 2.2.0 branch. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
