### PR TITLE
Duplicate connectors using `ctrl + left click` on input ports with testing

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -336,7 +336,7 @@ namespace Dynamo.Models
                 return;
             }
 
-            PortModel portModel = node.InPorts[portIndex];
+            var portModel = node.InPorts[portIndex];
             if (portModel.Connectors.Count == 0)
             {
                 // If the port doesn't have any existing connections, begin connection as per normal

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -270,8 +270,8 @@ namespace Dynamo.Models
                 case MakeConnectionCommand.Mode.EndShiftReconnections:
                     EndShiftReconnections(nodeId, command.PortIndex, command.Type);
                     break;
-                
-                // TODO - can be removed in Dynamo 3.0
+
+                // TODO - can be removed in Dynamo 3.0 - DYN-1729
                 case MakeConnectionCommand.Mode.EndAndStartCtrlConnection:
                     BeginDuplicateConnection(nodeId, command.PortIndex, command.Type);
                     break;

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -270,6 +270,11 @@ namespace Dynamo.Models
                 case MakeConnectionCommand.Mode.EndShiftReconnections:
                     EndShiftReconnections(nodeId, command.PortIndex, command.Type);
                     break;
+                
+                // TODO - can be removed in Dynamo 3.0
+                case MakeConnectionCommand.Mode.EndAndStartCtrlConnection:
+                    BeginDuplicateConnection(nodeId, command.PortIndex, command.Type);
+                    break;
 
                 case MakeConnectionCommand.Mode.BeginDuplicateConnection:
                     BeginDuplicateConnection(nodeId, command.PortIndex, command.Type);

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -52,19 +52,19 @@ namespace Dynamo.Models
             //ClipBoard.Clear();
         }
 
-        void RunCancelImpl(RunCancelCommand command)
+        internal void RunCancelImpl(RunCancelCommand command)
         {
             var model = CurrentWorkspace as HomeWorkspaceModel;
             if (model != null)
                 model.Run();
         }
 
-        void ForceRunCancelImpl(ForceRunCancelCommand command)
+        internal void ForceRunCancelImpl(ForceRunCancelCommand command)
         {
             ForceRun();
         }
 
-        void CreateNodeImpl(CreateNodeCommand command)
+        internal void CreateNodeImpl(CreateNodeCommand command)
         {
             var node = GetNodeFromCommand(command);
             if (node == null)
@@ -79,7 +79,7 @@ namespace Dynamo.Models
             CurrentWorkspace.RecordCreatedModel(node);
         }
 
-        void CreateAndConnectNodeImpl(CreateAndConnectNodeCommand command)
+        internal void CreateAndConnectNodeImpl(CreateAndConnectNodeCommand command)
         {
             using (CurrentWorkspace.UndoRecorder.BeginActionGroup())
             {
@@ -124,7 +124,7 @@ namespace Dynamo.Models
             }
         }
 
-        NodeModel GetNodeFromCommand(CreateNodeCommand command)
+        internal NodeModel GetNodeFromCommand(CreateNodeCommand command)
         {
             if (command.Node != null)
             {
@@ -202,7 +202,7 @@ namespace Dynamo.Models
             return node;
         }
 
-        void CreateNoteImpl(CreateNoteCommand command)
+        internal void CreateNoteImpl(CreateNoteCommand command)
         {
             NoteModel noteModel = CurrentWorkspace.AddNote(
                 command.DefaultPosition,
@@ -214,14 +214,14 @@ namespace Dynamo.Models
             CurrentWorkspace.RecordCreatedModel(noteModel);
         }
 
-        void CreateAnnotationImpl(CreateAnnotationCommand command)
+        internal void CreateAnnotationImpl(CreateAnnotationCommand command)
         {
             AnnotationModel annotationModel = currentWorkspace.AddAnnotation(command.AnnotationText, command.ModelGuid);
             
             CurrentWorkspace.RecordCreatedModel(annotationModel);
         }
 
-        void SelectModelImpl(SelectModelCommand command)
+        internal void SelectModelImpl(SelectModelCommand command)
         {
             // Empty ModelGuid means clear selection.
             if (command.ModelGuid == Guid.Empty)
@@ -249,7 +249,7 @@ namespace Dynamo.Models
             }
         }
 
-        void MakeConnectionImpl(MakeConnectionCommand command)
+        internal void MakeConnectionImpl(MakeConnectionCommand command)
         {
             Guid nodeId = command.ModelGuid;
 
@@ -285,7 +285,7 @@ namespace Dynamo.Models
             }
         }
 
-        void BeginConnection(Guid nodeId, int portIndex, PortType portType)
+        internal void BeginConnection(Guid nodeId, int portIndex, PortType portType)
         {
             bool isInPort = portType == PortType.Input;
             activeStartPorts = null;
@@ -319,7 +319,7 @@ namespace Dynamo.Models
             }
         }
 
-        void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
+        internal void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
         {
             // If the port clicked is an output port, begin connection as per normal
             if (portType == PortType.Output)
@@ -348,7 +348,7 @@ namespace Dynamo.Models
             firstStartPort = portModel.Connectors[0].Start;
         }
 
-        void BeginShiftReconnections(Guid nodeId, int portIndex, PortType portType)
+        internal void BeginShiftReconnections(Guid nodeId, int portIndex, PortType portType)
         {
             if (portType == PortType.Input) return; //only handle multiple connections when the port selected is an output port
             var node = CurrentWorkspace.GetModelInternal(nodeId) as NodeModel;
@@ -376,7 +376,7 @@ namespace Dynamo.Models
             return;
         }
 
-        void EndConnection(Guid nodeId, int portIndex, PortType portType)
+        internal void EndConnection(Guid nodeId, int portIndex, PortType portType)
         {
             // Check if the node from which the connector starts is valid and has not been deleted
             if (activeStartPorts == null || activeStartPorts.Count() <= 0 || activeStartPorts[0].Owner == null) return;
@@ -398,7 +398,7 @@ namespace Dynamo.Models
             firstStartPort = null;
         }
 
-        void EndShiftReconnections(Guid nodeId, int portIndex, PortType portType)
+        internal void EndShiftReconnections(Guid nodeId, int portIndex, PortType portType)
         {
             if (portType == PortType.Input) return; //only handle multiple connections when the port selected is an output port
             if (activeStartPorts == null || activeStartPorts.Count() <= 0) return;
@@ -421,7 +421,7 @@ namespace Dynamo.Models
             return;
         }
 
-        void BeginCreateConnections(Guid nodeId, int portIndex, PortType portType)
+        internal void BeginCreateConnections(Guid nodeId, int portIndex, PortType portType)
         {
             if (portType == PortType.Output) return; // Only handle ctrl connections if selected port is an input port
             if (firstStartPort == null || activeStartPorts == null || activeStartPorts.Count() <= 0) return;
@@ -436,7 +436,7 @@ namespace Dynamo.Models
             activeStartPorts = new PortModel[] { firstStartPort };
         }
 
-        void CancelConnections()
+        internal void CancelConnections()
         {
             CurrentWorkspace.DeleteSavedModels();
             activeStartPorts = null;
@@ -444,7 +444,7 @@ namespace Dynamo.Models
             return;
         }
 
-        static Dictionary<ModelBase, UndoRedoRecorder.UserAction> GetConnectorsToAddAndDelete(
+        internal static Dictionary<ModelBase, UndoRedoRecorder.UserAction> GetConnectorsToAddAndDelete(
             PortModel endPort, PortModel startPort)
         {
             ConnectorModel connectorToRemove = null;
@@ -490,7 +490,7 @@ namespace Dynamo.Models
             return models;
         }
 
-        void DeleteModelImpl(DeleteModelCommand command)
+        internal void DeleteModelImpl(DeleteModelCommand command)
         {
             var modelsToDelete = new List<ModelBase>();
             if (command.ModelGuid == Guid.Empty)
@@ -506,7 +506,7 @@ namespace Dynamo.Models
             DeleteModelInternal(modelsToDelete);
         }
 
-        void UngroupModelImpl(UngroupModelCommand command)
+        internal void UngroupModelImpl(UngroupModelCommand command)
         {
             if (command.ModelGuid == Guid.Empty)
                 return;
@@ -516,7 +516,7 @@ namespace Dynamo.Models
             UngroupModel(modelsToUngroup);
         }
 
-        void AddToGroupImpl(AddModelToGroupCommand command)
+        internal void AddToGroupImpl(AddModelToGroupCommand command)
         {
             if (command.ModelGuid == Guid.Empty)
                 return;
@@ -526,7 +526,7 @@ namespace Dynamo.Models
             AddToGroup(modelsToGroup);
         }
 
-        void UndoRedoImpl(UndoRedoCommand command)
+        internal void UndoRedoImpl(UndoRedoCommand command)
         {
             switch (command.CmdOperation)
             {
@@ -539,7 +539,7 @@ namespace Dynamo.Models
             }
         }
 
-        void SendModelEventImpl(ModelEventCommand command)
+        internal void SendModelEventImpl(ModelEventCommand command)
         {
             foreach (var guid in command.ModelGuids)
             {
@@ -547,7 +547,7 @@ namespace Dynamo.Models
             }
         }
 
-        void UpdateModelValueImpl(UpdateModelValueCommand command)
+        internal void UpdateModelValueImpl(UpdateModelValueCommand command)
         {
             WorkspaceModel targetWorkspace = CurrentWorkspace;
             if (!command.WorkspaceGuid.Equals(Guid.Empty))
@@ -566,7 +566,7 @@ namespace Dynamo.Models
             CurrentWorkspace.HasUnsavedChanges = true;
         }
 
-        void CreateCustomNodeImpl(CreateCustomNodeCommand command)
+        internal void CreateCustomNodeImpl(CreateCustomNodeCommand command)
         {
             var workspace = CustomNodeManager.CreateCustomNode(
                 command.Name,
@@ -578,19 +578,19 @@ namespace Dynamo.Models
             CurrentWorkspace = workspace;
         }
 
-        void SwitchWorkspaceImpl(SwitchTabCommand command)
+        internal void SwitchWorkspaceImpl(SwitchTabCommand command)
         {
             // We don't attempt to null-check here, we need it to fail fast.
             CurrentWorkspace = Workspaces.ElementAt(command.WorkspaceModelIndex);
         }
 
-        void CreatePresetStateImpl(AddPresetCommand command)
+        internal void CreatePresetStateImpl(AddPresetCommand command)
         {
             var preset = this.CurrentWorkspace.AddPreset(command.PresetStateName,command.PresetStateDescription,command.ModelGuids);
 
             CurrentWorkspace.RecordCreatedModel(preset);
         }
-        void SetWorkSpaceToStateImpl(ApplyPresetCommand command)
+        internal void SetWorkSpaceToStateImpl(ApplyPresetCommand command)
         {
             var workspaceToSet = this.Workspaces.Where(x => x.Guid == command.WorkSpaceID).First();
             if (workspaceToSet == null)

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -52,19 +52,19 @@ namespace Dynamo.Models
             //ClipBoard.Clear();
         }
 
-        internal void RunCancelImpl(RunCancelCommand command)
+        private void RunCancelImpl(RunCancelCommand command)
         {
             var model = CurrentWorkspace as HomeWorkspaceModel;
             if (model != null)
                 model.Run();
         }
 
-        internal void ForceRunCancelImpl(ForceRunCancelCommand command)
+        private void ForceRunCancelImpl(ForceRunCancelCommand command)
         {
             ForceRun();
         }
 
-        internal void CreateNodeImpl(CreateNodeCommand command)
+        private void CreateNodeImpl(CreateNodeCommand command)
         {
             var node = GetNodeFromCommand(command);
             if (node == null)
@@ -79,7 +79,7 @@ namespace Dynamo.Models
             CurrentWorkspace.RecordCreatedModel(node);
         }
 
-        internal void CreateAndConnectNodeImpl(CreateAndConnectNodeCommand command)
+        private void CreateAndConnectNodeImpl(CreateAndConnectNodeCommand command)
         {
             using (CurrentWorkspace.UndoRecorder.BeginActionGroup())
             {
@@ -124,7 +124,7 @@ namespace Dynamo.Models
             }
         }
 
-        internal NodeModel GetNodeFromCommand(CreateNodeCommand command)
+        private NodeModel GetNodeFromCommand(CreateNodeCommand command)
         {
             if (command.Node != null)
             {
@@ -202,7 +202,7 @@ namespace Dynamo.Models
             return node;
         }
 
-        internal void CreateNoteImpl(CreateNoteCommand command)
+        private void CreateNoteImpl(CreateNoteCommand command)
         {
             NoteModel noteModel = CurrentWorkspace.AddNote(
                 command.DefaultPosition,
@@ -214,14 +214,14 @@ namespace Dynamo.Models
             CurrentWorkspace.RecordCreatedModel(noteModel);
         }
 
-        internal void CreateAnnotationImpl(CreateAnnotationCommand command)
+        private void CreateAnnotationImpl(CreateAnnotationCommand command)
         {
             AnnotationModel annotationModel = currentWorkspace.AddAnnotation(command.AnnotationText, command.ModelGuid);
             
             CurrentWorkspace.RecordCreatedModel(annotationModel);
         }
 
-        internal void SelectModelImpl(SelectModelCommand command)
+        private void SelectModelImpl(SelectModelCommand command)
         {
             // Empty ModelGuid means clear selection.
             if (command.ModelGuid == Guid.Empty)
@@ -249,7 +249,7 @@ namespace Dynamo.Models
             }
         }
 
-        internal void MakeConnectionImpl(MakeConnectionCommand command)
+        private void MakeConnectionImpl(MakeConnectionCommand command)
         {
             Guid nodeId = command.ModelGuid;
 
@@ -290,7 +290,7 @@ namespace Dynamo.Models
             }
         }
 
-        internal void BeginConnection(Guid nodeId, int portIndex, PortType portType)
+        private void BeginConnection(Guid nodeId, int portIndex, PortType portType)
         {
             bool isInPort = portType == PortType.Input;
             activeStartPorts = null;
@@ -324,7 +324,7 @@ namespace Dynamo.Models
             }
         }
 
-        internal void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
+        private void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
         {
             // If the port clicked is an output port, begin connection as per normal
             if (portType == PortType.Output)
@@ -353,7 +353,7 @@ namespace Dynamo.Models
             firstStartPort = portModel.Connectors[0].Start;
         }
 
-        internal void BeginShiftReconnections(Guid nodeId, int portIndex, PortType portType)
+        private void BeginShiftReconnections(Guid nodeId, int portIndex, PortType portType)
         {
             if (portType == PortType.Input) return; //only handle multiple connections when the port selected is an output port
             var node = CurrentWorkspace.GetModelInternal(nodeId) as NodeModel;
@@ -381,7 +381,7 @@ namespace Dynamo.Models
             return;
         }
 
-        internal void EndConnection(Guid nodeId, int portIndex, PortType portType)
+        private void EndConnection(Guid nodeId, int portIndex, PortType portType)
         {
             // Check if the node from which the connector starts is valid and has not been deleted
             if (activeStartPorts == null || activeStartPorts.Count() <= 0 || activeStartPorts[0].Owner == null) return;
@@ -403,7 +403,7 @@ namespace Dynamo.Models
             firstStartPort = null;
         }
 
-        internal void EndShiftReconnections(Guid nodeId, int portIndex, PortType portType)
+        private void EndShiftReconnections(Guid nodeId, int portIndex, PortType portType)
         {
             if (portType == PortType.Input) return; //only handle multiple connections when the port selected is an output port
             if (activeStartPorts == null || activeStartPorts.Count() <= 0) return;
@@ -426,7 +426,7 @@ namespace Dynamo.Models
             return;
         }
 
-        internal void BeginCreateConnections(Guid nodeId, int portIndex, PortType portType)
+        private void BeginCreateConnections(Guid nodeId, int portIndex, PortType portType)
         {
             if (portType == PortType.Output) return; // Only handle ctrl connections if selected port is an input port
             if (firstStartPort == null || activeStartPorts == null || activeStartPorts.Count() <= 0) return;
@@ -441,7 +441,7 @@ namespace Dynamo.Models
             activeStartPorts = new PortModel[] { firstStartPort };
         }
 
-        internal void CancelConnections()
+        private void CancelConnections()
         {
             CurrentWorkspace.DeleteSavedModels();
             activeStartPorts = null;
@@ -449,7 +449,7 @@ namespace Dynamo.Models
             return;
         }
 
-        internal static Dictionary<ModelBase, UndoRedoRecorder.UserAction> GetConnectorsToAddAndDelete(
+        private static Dictionary<ModelBase, UndoRedoRecorder.UserAction> GetConnectorsToAddAndDelete(
             PortModel endPort, PortModel startPort)
         {
             ConnectorModel connectorToRemove = null;
@@ -495,7 +495,7 @@ namespace Dynamo.Models
             return models;
         }
 
-        internal void DeleteModelImpl(DeleteModelCommand command)
+        private void DeleteModelImpl(DeleteModelCommand command)
         {
             var modelsToDelete = new List<ModelBase>();
             if (command.ModelGuid == Guid.Empty)
@@ -511,7 +511,7 @@ namespace Dynamo.Models
             DeleteModelInternal(modelsToDelete);
         }
 
-        internal void UngroupModelImpl(UngroupModelCommand command)
+        private void UngroupModelImpl(UngroupModelCommand command)
         {
             if (command.ModelGuid == Guid.Empty)
                 return;
@@ -521,7 +521,7 @@ namespace Dynamo.Models
             UngroupModel(modelsToUngroup);
         }
 
-        internal void AddToGroupImpl(AddModelToGroupCommand command)
+        private void AddToGroupImpl(AddModelToGroupCommand command)
         {
             if (command.ModelGuid == Guid.Empty)
                 return;
@@ -531,7 +531,7 @@ namespace Dynamo.Models
             AddToGroup(modelsToGroup);
         }
 
-        internal void UndoRedoImpl(UndoRedoCommand command)
+        private void UndoRedoImpl(UndoRedoCommand command)
         {
             switch (command.CmdOperation)
             {
@@ -544,7 +544,7 @@ namespace Dynamo.Models
             }
         }
 
-        internal void SendModelEventImpl(ModelEventCommand command)
+        private void SendModelEventImpl(ModelEventCommand command)
         {
             foreach (var guid in command.ModelGuids)
             {
@@ -552,7 +552,7 @@ namespace Dynamo.Models
             }
         }
 
-        internal void UpdateModelValueImpl(UpdateModelValueCommand command)
+        private void UpdateModelValueImpl(UpdateModelValueCommand command)
         {
             WorkspaceModel targetWorkspace = CurrentWorkspace;
             if (!command.WorkspaceGuid.Equals(Guid.Empty))
@@ -571,7 +571,7 @@ namespace Dynamo.Models
             CurrentWorkspace.HasUnsavedChanges = true;
         }
 
-        internal void CreateCustomNodeImpl(CreateCustomNodeCommand command)
+        private void CreateCustomNodeImpl(CreateCustomNodeCommand command)
         {
             var workspace = CustomNodeManager.CreateCustomNode(
                 command.Name,
@@ -583,19 +583,19 @@ namespace Dynamo.Models
             CurrentWorkspace = workspace;
         }
 
-        internal void SwitchWorkspaceImpl(SwitchTabCommand command)
+        private void SwitchWorkspaceImpl(SwitchTabCommand command)
         {
             // We don't attempt to null-check here, we need it to fail fast.
             CurrentWorkspace = Workspaces.ElementAt(command.WorkspaceModelIndex);
         }
 
-        internal void CreatePresetStateImpl(AddPresetCommand command)
+        private void CreatePresetStateImpl(AddPresetCommand command)
         {
             var preset = this.CurrentWorkspace.AddPreset(command.PresetStateName,command.PresetStateDescription,command.ModelGuids);
 
             CurrentWorkspace.RecordCreatedModel(preset);
         }
-        internal void SetWorkSpaceToStateImpl(ApplyPresetCommand command)
+        private void SetWorkSpaceToStateImpl(ApplyPresetCommand command)
         {
             var workspaceToSet = this.Workspaces.Where(x => x.Guid == command.WorkSpaceID).First();
             if (workspaceToSet == null)

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1358,9 +1358,13 @@ namespace Dynamo.Models
                 /// </summary>
                 EndShiftReconnections,
                 /// <summary>
-                /// End and start control connections.
+                /// Begin duplicate connection.
                 /// </summary>
-                EndAndStartCtrlConnection,
+                BeginDuplicateConnection,
+                /// <summary>
+                /// End current connection and create new connections.
+                /// </summary>
+                BeginCreateConnections,
                 /// <summary>
                 /// Cancel connection.
                 /// </summary>

--- a/src/DynamoCore/Models/RecordableCommands.cs
+++ b/src/DynamoCore/Models/RecordableCommands.cs
@@ -1358,17 +1358,22 @@ namespace Dynamo.Models
                 /// </summary>
                 EndShiftReconnections,
                 /// <summary>
+                /// End and start control connections.
+                /// </summary>
+                [Obsolete("Replaced with BeginDuplicateConnection")]
+                EndAndStartCtrlConnection,
+                /// <summary>
+                /// Cancel connection.
+                /// </summary>
+                Cancel,
+                /// <summary>
                 /// Begin duplicate connection.
                 /// </summary>
                 BeginDuplicateConnection,
                 /// <summary>
                 /// End current connection and create new connections.
                 /// </summary>
-                BeginCreateConnections,
-                /// <summary>
-                /// Cancel connection.
-                /// </summary>
-                Cancel
+                BeginCreateConnections
             }
 
             void setProperties(int portIndex, PortType portType, Mode mode)

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -222,6 +222,12 @@ namespace Dynamo.ViewModels
                         nodeId, command.PortIndex, command.Type);
                     break;
 
+                // TODO - can be removed in Dynamo 3.0
+                case DynamoModel.MakeConnectionCommand.Mode.EndAndStartCtrlConnection:
+                    CurrentSpaceViewModel.BeginConnection(
+                        nodeId, command.PortIndex, command.Type);
+                    break;
+
                 case DynamoModel.MakeConnectionCommand.Mode.BeginDuplicateConnection:
                     CurrentSpaceViewModel.BeginConnection(
                         nodeId, command.PortIndex, command.Type);

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -222,8 +222,13 @@ namespace Dynamo.ViewModels
                         nodeId, command.PortIndex, command.Type);
                     break;
 
-                case DynamoModel.MakeConnectionCommand.Mode.EndAndStartCtrlConnection:
-                    CurrentSpaceViewModel.EndAndStartCtrlConnection(
+                case DynamoModel.MakeConnectionCommand.Mode.BeginDuplicateConnection:
+                    CurrentSpaceViewModel.BeginConnection(
+                        nodeId, command.PortIndex, command.Type);
+                    break;
+
+                case DynamoModel.MakeConnectionCommand.Mode.BeginCreateConnections:
+                    CurrentSpaceViewModel.BeginCreateConnections(
                         nodeId, command.PortIndex, command.Type);
                     break;
 

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -222,7 +222,7 @@ namespace Dynamo.ViewModels
                         nodeId, command.PortIndex, command.Type);
                     break;
 
-                // TODO - can be removed in Dynamo 3.0
+                // TODO - can be removed in Dynamo 3.0 - DYN-1729
                 case DynamoModel.MakeConnectionCommand.Mode.EndAndStartCtrlConnection:
                     CurrentSpaceViewModel.BeginConnection(
                         nodeId, command.PortIndex, command.Type);

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -225,7 +225,7 @@ namespace Dynamo.ViewModels
             this.SetActiveConnectors(null);
         }
 
-        internal void EndAndStartCtrlConnection(Guid nodeId, int portIndex, PortType portType)
+        internal void BeginCreateConnections(Guid nodeId, int portIndex, PortType portType)
         {
             // Only handle ctrl connections if selected port is an input port
             if (firstStartPort == null || portType == PortType.Output) return; 
@@ -790,6 +790,11 @@ namespace Dynamo.ViewModels
                         multipleConnections = true;
                         mode = DynamoModel.MakeConnectionCommand.Mode.BeginShiftReconnections;
                     }
+                    else if (Keyboard.Modifiers == ModifierKeys.Control)
+                    {
+                        // If the control key is held down, check if there is a need to duplicate connections
+                        mode = DynamoModel.MakeConnectionCommand.Mode.BeginDuplicateConnection;
+                    }
 
                     var command = new DynamoModel.MakeConnectionCommand(nodeId, portIndex, portModel.PortType, mode);
                     owningWorkspace.DynamoViewModel.ExecuteCommand(command);
@@ -819,7 +824,7 @@ namespace Dynamo.ViewModels
                         }
                         else if (Keyboard.Modifiers == ModifierKeys.Control) // If the control key is held down
                         {
-                            mode = DynamoModel.MakeConnectionCommand.Mode.EndAndStartCtrlConnection;
+                            mode = DynamoModel.MakeConnectionCommand.Mode.BeginCreateConnections;
                             this.currentState = State.Connection; // Start a new connection
                             owningWorkspace.CurrentCursor = CursorLibrary.GetCursor(CursorSet.ArcSelect); // Reassign the cursor
                         }

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1169,7 +1169,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(7, workspace.Connectors.Count()); // 2 of which should be executed in the recording using ctrl + click
 
             // Sum of values which is only true if connections are valid downstream
-            AssertPreviewValue("68d76b724b75499b8e96cfc106118107", 12);
+            AssertPreviewValue("995b61e54a7d4c0fae4973f74132bd1b", 12);
         }
 
         /// <summary>
@@ -1186,9 +1186,9 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, workspace.Connectors.Count()); // Only 1 connection should remain after undos
 
             // A value of 25 is passed to all 3 downstream nodes however 2 undos will disconnect the trailing 2 nodes
-            AssertPreviewValue("7778eec752ab48d58c8781143f4bbe8d", 25);
-            AssertPreviewValue("2ae3bd09a363467d91770b095e06580b", null);
-            AssertPreviewValue("51d2916a423049fc869ee093f42c2626", null);
+            AssertPreviewValue("4975adccfc57433aa915e67c03ff6503", 25);
+            AssertPreviewValue("0ddbbdf502344bb2ab5c75e6d6ac7b13", null);
+            AssertPreviewValue("eb839c03d115492d98a6e0d562d44d73", null);
         }
 
         /// <summary>
@@ -1206,9 +1206,9 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(3, workspace.Connectors.Count()); // All 3 connections should remain after 3 undos and 3 redos
 
             // A value of 10 is passed to all 3 downstream nodes
-            AssertPreviewValue("b0b24df604574e4ebaecb88bb467914a", 10);
-            AssertPreviewValue("d0a71324eaae4d25a48de3f8637a16c9", 10);
-            AssertPreviewValue("5fd865db1cd84d2693a64683e7e08486", 10);
+            AssertPreviewValue("3a998ea7ef284e47901db6cd13e77022", 10);
+            AssertPreviewValue("40c505cae1a14a3a9d7043c36c62b013", 10);
+            AssertPreviewValue("5a42348373b94a11920feeaa680834fd", 10);
         }
 
         #endregion

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1155,6 +1155,62 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(2, workspace.Connectors.Count()); 
         }
 
+        /// <summary>
+        /// The following recorded test manually adds a connection between 2 nodes,
+        /// followed by ctrl + clicking to copy this connection to 2 additional nodes.
+        /// The final assertion will only be true if all connections were successfully established.
+        /// </summary>
+        [Test, RequiresSTA]
+        public void TestCtrlClickInputConnections()
+        {
+            RunCommandsFromFile("CtrlClickRecordedTest_Recording.xml");
+
+            Assert.AreEqual(6, workspace.Nodes.Count());
+            Assert.AreEqual(7, workspace.Connectors.Count()); // 2 of which should be executed in the recording using ctrl + click
+
+            // Sum of values which is only true if connections are valid downstream
+            AssertPreviewValue("68d76b724b75499b8e96cfc106118107", 12);
+        }
+
+        /// <summary>
+        /// The following recorded test manually adds a connecting between 2 nodes,
+        /// followed by ctrl + clicking to copy this connection to 2 additional nodes.
+        /// We then call 2 undo commands and verify only our original connection exists.
+        /// </summary>
+        [Test, RequiresSTA]
+        public void TestCtrlClickInputConnectionsUndo()
+        {
+            RunCommandsFromFile("CtrlClickRecordedTestUndo_Recording.xml");
+
+            Assert.AreEqual(4, workspace.Nodes.Count());
+            Assert.AreEqual(1, workspace.Connectors.Count()); // Only 1 connection should remain after undos
+
+            // A value of 25 is passed to all 3 downstream nodes however 2 undos will disconnect the trailing 2 nodes
+            AssertPreviewValue("7778eec752ab48d58c8781143f4bbe8d", 25);
+            AssertPreviewValue("2ae3bd09a363467d91770b095e06580b", null);
+            AssertPreviewValue("51d2916a423049fc869ee093f42c2626", null);
+        }
+
+        /// <summary>
+        /// The following recorded test manually adds a connecting between 2 nodes,
+        /// followed by ctrl + clicking to copy this connection to 2 additional nodes.
+        /// We then call 2 undo commands followed by 2 redo commands and verify all 3 
+        /// connections exist.
+        /// </summary>
+        [Test, RequiresSTA]
+        public void TestCtrlClickInputConnectionsUndoRedo()
+        {
+            RunCommandsFromFile("CtrlClickRecordedTestUndoRedo_Recording.xml");
+
+            Assert.AreEqual(4, workspace.Nodes.Count());
+            Assert.AreEqual(3, workspace.Connectors.Count()); // All 3 connections should remain after 3 undos and 3 redos
+
+            // A value of 10 is passed to all 3 downstream nodes
+            AssertPreviewValue("b0b24df604574e4ebaecb88bb467914a", 10);
+            AssertPreviewValue("d0a71324eaae4d25a48de3f8637a16c9", 10);
+            AssertPreviewValue("5fd865db1cd84d2693a64683e7e08486", 10);
+        }
+
         #endregion
 
         #region General Node Operations Test Cases

--- a/test/DynamoCoreWpfTests/RecordedTests.cs
+++ b/test/DynamoCoreWpfTests/RecordedTests.cs
@@ -1160,7 +1160,7 @@ namespace DynamoCoreWpfTests
         /// followed by ctrl + clicking to copy this connection to 2 additional nodes.
         /// The final assertion will only be true if all connections were successfully established.
         /// </summary>
-        [Test, RequiresSTA]
+        [Test]
         public void TestCtrlClickInputConnections()
         {
             RunCommandsFromFile("CtrlClickRecordedTest_Recording.xml");
@@ -1177,7 +1177,7 @@ namespace DynamoCoreWpfTests
         /// followed by ctrl + clicking to copy this connection to 2 additional nodes.
         /// We then call 2 undo commands and verify only our original connection exists.
         /// </summary>
-        [Test, RequiresSTA]
+        [Test]
         public void TestCtrlClickInputConnectionsUndo()
         {
             RunCommandsFromFile("CtrlClickRecordedTestUndo_Recording.xml");
@@ -1197,7 +1197,7 @@ namespace DynamoCoreWpfTests
         /// We then call 2 undo commands followed by 2 redo commands and verify all 3 
         /// connections exist.
         /// </summary>
-        [Test, RequiresSTA]
+        [Test]
         public void TestCtrlClickInputConnectionsUndoRedo()
         {
             RunCommandsFromFile("CtrlClickRecordedTestUndoRedo_Recording.xml");

--- a/test/core/recorded/CtrlClickRecordedTestUndoRedo_Recording.xml
+++ b/test/core/recorded/CtrlClickRecordedTestUndoRedo_Recording.xml
@@ -2,25 +2,24 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <CreateNodeCommand X="250.5" Y="220" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>81117254-c376-4774-acc4-a31e032eac5e</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="81117254-c376-4774-acc4-a31e032eac5e" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="158" y="189" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="10;" ShouldFocus="false">
+  <CreateNodeCommand X="216.5" Y="226" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>29afdfb9-e0cb-45ab-b5c0-3a046f3ded1a</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="29afdfb9-e0cb-45ab-b5c0-3a046f3ded1a" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="124" y="195" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="10;" ShouldFocus="false">
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </CreateNodeCommand>
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="10;" WorkspaceGuid="3f38a2cf-238f-46d2-aa97-76dfdfc4372e">
-    <ModelGuid>81117254-c376-4774-acc4-a31e032eac5e</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="10" WorkspaceGuid="b16efd26-fc75-4829-b782-72d27614612c">
+    <ModelGuid>29afdfb9-e0cb-45ab-b5c0-3a046f3ded1a</ModelGuid>
   </UpdateModelValueCommand>
-  <SelectInRegionCommand X="303.5" Y="236" Width="2" Height="1" IsCrossSelection="false" />
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <CreateNodeCommand X="385.5" Y="106" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>b0b24df6-0457-4e4e-baec-b88bb467914a</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="b0b24df6-0457-4e4e-baec-b88bb467914a" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="293" y="75" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a;" ShouldFocus="false">
+  <CreateNodeCommand X="377.5" Y="93" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>3a998ea7-ef28-4e47-901d-b6cd13e77022</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="3a998ea7-ef28-4e47-901d-b6cd13e77022" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="285" y="62" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a;" ShouldFocus="false">
       <PortInfo index="0" default="False" name="a" />
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
@@ -28,15 +27,15 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="a;" WorkspaceGuid="3f38a2cf-238f-46d2-aa97-76dfdfc4372e">
-    <ModelGuid>b0b24df6-0457-4e4e-baec-b88bb467914a</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="a" WorkspaceGuid="b16efd26-fc75-4829-b782-72d27614612c">
+    <ModelGuid>3a998ea7-ef28-4e47-901d-b6cd13e77022</ModelGuid>
   </UpdateModelValueCommand>
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <CreateNodeCommand X="341.5" Y="222" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>d0a71324-eaae-4d25-a48d-e3f8637a16c9</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="d0a71324-eaae-4d25-a48d-e3f8637a16c9" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="288" y="181" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="b;" ShouldFocus="false">
+  <CreateNodeCommand X="366.5" Y="222" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>40c505ca-e1a1-4a3a-9d70-43c36c62b013</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="40c505ca-e1a1-4a3a-9d70-43c36c62b013" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="274" y="191" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="b;" ShouldFocus="false">
       <PortInfo index="0" default="False" name="b" />
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
@@ -44,20 +43,16 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="b;" WorkspaceGuid="3f38a2cf-238f-46d2-aa97-76dfdfc4372e">
-    <ModelGuid>d0a71324-eaae-4d25-a48d-e3f8637a16c9</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="b" WorkspaceGuid="b16efd26-fc75-4829-b782-72d27614612c">
+    <ModelGuid>40c505ca-e1a1-4a3a-9d70-43c36c62b013</ModelGuid>
   </UpdateModelValueCommand>
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>d0a71324-eaae-4d25-a48d-e3f8637a16c9</ModelGuid>
-  </SelectModelCommand>
-  <DragSelectionCommand X="298.5" Y="208" DragOperation="0" />
-  <DragSelectionCommand X="337.5" Y="198" DragOperation="1" />
+  <SelectInRegionCommand X="597.5" Y="175" Width="0" Height="0" IsCrossSelection="false" />
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <CreateNodeCommand X="363.5" Y="348" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>5fd865db-1cd8-4d26-93a6-4683e7e08486</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="5fd865db-1cd8-4d26-93a6-4683e7e08486" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="289" y="299" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="c;" ShouldFocus="false">
+  <CreateNodeCommand X="342.5" Y="356" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>5a423483-73b9-4a11-920f-eeaa680834fd</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="5a423483-73b9-4a11-920f-eeaa680834fd" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="250" y="325" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="c;" ShouldFocus="false">
       <PortInfo index="0" default="False" name="c" />
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
@@ -65,33 +60,25 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="c;" WorkspaceGuid="3f38a2cf-238f-46d2-aa97-76dfdfc4372e">
-    <ModelGuid>5fd865db-1cd8-4d26-93a6-4683e7e08486</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="c" WorkspaceGuid="b16efd26-fc75-4829-b782-72d27614612c">
+    <ModelGuid>5a423483-73b9-4a11-920f-eeaa680834fd</ModelGuid>
   </UpdateModelValueCommand>
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>5fd865db-1cd8-4d26-93a6-4683e7e08486</ModelGuid>
-  </SelectModelCommand>
-  <DragSelectionCommand X="318.5" Y="339" DragOperation="0" />
-  <DragSelectionCommand X="336.5" Y="321" DragOperation="1" />
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
-  </SelectModelCommand>
   <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
-    <ModelGuid>81117254-c376-4774-acc4-a31e032eac5e</ModelGuid>
+    <ModelGuid>29afdfb9-e0cb-45ab-b5c0-3a046f3ded1a</ModelGuid>
   </MakeConnectionCommand>
   <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
-    <ModelGuid>b0b24df6-0457-4e4e-baec-b88bb467914a</ModelGuid>
+    <ModelGuid>3a998ea7-ef28-4e47-901d-b6cd13e77022</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="4">
-    <ModelGuid>b0b24df6-0457-4e4e-baec-b88bb467914a</ModelGuid>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="6">
+    <ModelGuid>3a998ea7-ef28-4e47-901d-b6cd13e77022</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
-    <ModelGuid>d0a71324-eaae-4d25-a48d-e3f8637a16c9</ModelGuid>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="7">
+    <ModelGuid>40c505ca-e1a1-4a3a-9d70-43c36c62b013</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
-    <ModelGuid>5fd865db-1cd8-4d26-93a6-4683e7e08486</ModelGuid>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="7">
+    <ModelGuid>5a423483-73b9-4a11-920f-eeaa680834fd</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="6">
+  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="5">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </MakeConnectionCommand>
   <UndoRedoCommand CmdOperation="0" />

--- a/test/core/recorded/CtrlClickRecordedTestUndoRedo_Recording.xml
+++ b/test/core/recorded/CtrlClickRecordedTestUndoRedo_Recording.xml
@@ -1,0 +1,103 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="250.5" Y="220" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>81117254-c376-4774-acc4-a31e032eac5e</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="81117254-c376-4774-acc4-a31e032eac5e" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="158" y="189" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="10;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="10;" WorkspaceGuid="3f38a2cf-238f-46d2-aa97-76dfdfc4372e">
+    <ModelGuid>81117254-c376-4774-acc4-a31e032eac5e</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="303.5" Y="236" Width="2" Height="1" IsCrossSelection="false" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="385.5" Y="106" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>b0b24df6-0457-4e4e-baec-b88bb467914a</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="b0b24df6-0457-4e4e-baec-b88bb467914a" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="293" y="75" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="a" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="a;" WorkspaceGuid="3f38a2cf-238f-46d2-aa97-76dfdfc4372e">
+    <ModelGuid>b0b24df6-0457-4e4e-baec-b88bb467914a</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="341.5" Y="222" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>d0a71324-eaae-4d25-a48d-e3f8637a16c9</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="d0a71324-eaae-4d25-a48d-e3f8637a16c9" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="288" y="181" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="b;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="b" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="b;" WorkspaceGuid="3f38a2cf-238f-46d2-aa97-76dfdfc4372e">
+    <ModelGuid>d0a71324-eaae-4d25-a48d-e3f8637a16c9</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>d0a71324-eaae-4d25-a48d-e3f8637a16c9</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="298.5" Y="208" DragOperation="0" />
+  <DragSelectionCommand X="337.5" Y="198" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="363.5" Y="348" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>5fd865db-1cd8-4d26-93a6-4683e7e08486</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="5fd865db-1cd8-4d26-93a6-4683e7e08486" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="289" y="299" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="c;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="c" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="c;" WorkspaceGuid="3f38a2cf-238f-46d2-aa97-76dfdfc4372e">
+    <ModelGuid>5fd865db-1cd8-4d26-93a6-4683e7e08486</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>5fd865db-1cd8-4d26-93a6-4683e7e08486</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="318.5" Y="339" DragOperation="0" />
+  <DragSelectionCommand X="336.5" Y="321" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>81117254-c376-4774-acc4-a31e032eac5e</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>b0b24df6-0457-4e4e-baec-b88bb467914a</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="4">
+    <ModelGuid>b0b24df6-0457-4e4e-baec-b88bb467914a</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
+    <ModelGuid>d0a71324-eaae-4d25-a48d-e3f8637a16c9</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
+    <ModelGuid>5fd865db-1cd8-4d26-93a6-4683e7e08486</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="6">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </MakeConnectionCommand>
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+  <UndoRedoCommand CmdOperation="1" />
+</Commands>

--- a/test/core/recorded/CtrlClickRecordedTestUndo_Recording.xml
+++ b/test/core/recorded/CtrlClickRecordedTestUndo_Recording.xml
@@ -2,24 +2,24 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <CreateNodeCommand X="355.5" Y="231" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>a472d5fb-bd30-4512-8a8d-7b0cc78a8498</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="a472d5fb-bd30-4512-8a8d-7b0cc78a8498" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="263" y="200" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="25;" ShouldFocus="false">
+  <CreateNodeCommand X="300.5" Y="205" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>16f0fea8-82b2-4620-b92f-5fa814f4992e</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="16f0fea8-82b2-4620-b92f-5fa814f4992e" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="208" y="174" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="25;" ShouldFocus="false">
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </CreateNodeCommand>
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="25;" WorkspaceGuid="c56cd373-d664-41e4-8388-40da05530e77">
-    <ModelGuid>a472d5fb-bd30-4512-8a8d-7b0cc78a8498</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="25;" WorkspaceGuid="c0fb99ee-b733-4056-8ee0-57dd5757504b">
+    <ModelGuid>16f0fea8-82b2-4620-b92f-5fa814f4992e</ModelGuid>
   </UpdateModelValueCommand>
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <CreateNodeCommand X="496.5" Y="197" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>7778eec7-52ab-48d5-8c87-81143f4bbe8d</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="7778eec7-52ab-48d5-8c87-81143f4bbe8d" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="462" y="71" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a;" ShouldFocus="false">
+  <CreateNodeCommand X="438.5" Y="108" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>4975adcc-fc57-433a-a915-e67c03ff6503</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="4975adcc-fc57-433a-a915-e67c03ff6503" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="346" y="77" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a;" ShouldFocus="false">
       <PortInfo index="0" default="False" name="a" />
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
@@ -27,21 +27,15 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="a;" WorkspaceGuid="c56cd373-d664-41e4-8388-40da05530e77">
-    <ModelGuid>7778eec7-52ab-48d5-8c87-81143f4bbe8d</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="a" WorkspaceGuid="c0fb99ee-b733-4056-8ee0-57dd5757504b">
+    <ModelGuid>4975adcc-fc57-433a-a915-e67c03ff6503</ModelGuid>
   </UpdateModelValueCommand>
-  <SelectInRegionCommand X="538.5" Y="203" Width="2" Height="0" IsCrossSelection="false" />
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>7778eec7-52ab-48d5-8c87-81143f4bbe8d</ModelGuid>
-  </SelectModelCommand>
-  <DragSelectionCommand X="433.5" Y="184" DragOperation="0" />
-  <DragSelectionCommand X="491.5" Y="89" DragOperation="1" />
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <CreateNodeCommand X="506.5" Y="269" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>2ae3bd09-a363-467d-9177-0b095e06580b</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="2ae3bd09-a363-467d-9177-0b095e06580b" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="458" y="199" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="b;" ShouldFocus="false">
+  <CreateNodeCommand X="494.5" Y="244" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>0ddbbdf5-0234-4bb2-ab5c-75e6d6ac7b13</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="0ddbbdf5-0234-4bb2-ab5c-75e6d6ac7b13" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="402" y="213" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="b;" ShouldFocus="false">
       <PortInfo index="0" default="False" name="b" />
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
@@ -49,63 +43,41 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="b;" WorkspaceGuid="c56cd373-d664-41e4-8388-40da05530e77">
-    <ModelGuid>2ae3bd09-a363-467d-9177-0b095e06580b</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="b" WorkspaceGuid="c0fb99ee-b733-4056-8ee0-57dd5757504b">
+    <ModelGuid>0ddbbdf5-0234-4bb2-ab5c-75e6d6ac7b13</ModelGuid>
   </UpdateModelValueCommand>
   <SelectModelCommand Modifiers="0">
-    <ModelGuid>2ae3bd09-a363-467d-9177-0b095e06580b</ModelGuid>
-  </SelectModelCommand>
-  <DragSelectionCommand X="456.5" Y="258" DragOperation="0" />
-  <DragSelectionCommand X="500.5" Y="219" DragOperation="1" />
-  <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
-  </SelectModelCommand>
-  <CreateNodeCommand X="593.5" Y="365" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>51d2916a-4230-49fc-869e-e093f42c2626</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="51d2916a-4230-49fc-869e-e093f42c2626" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="454" y="335" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="c;" ShouldFocus="false">
+  <CreateNodeCommand X="465.5" Y="387" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>eb839c03-d115-492d-98a6-e0d562d44d73</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="eb839c03-d115-492d-98a6-e0d562d44d73" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="373" y="356" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="c;" ShouldFocus="false">
       <PortInfo index="0" default="False" name="c" />
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </CreateNodeCommand>
   <SelectModelCommand Modifiers="0">
-    <ModelGuid>51d2916a-4230-49fc-869e-e093f42c2626</ModelGuid>
-  </SelectModelCommand>
-  <DragSelectionCommand X="593.5" Y="365" DragOperation="0" />
-  <DragSelectionCommand X="593.5" Y="365" DragOperation="1" />
-  <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="c;" WorkspaceGuid="c56cd373-d664-41e4-8388-40da05530e77">
-    <ModelGuid>51d2916a-4230-49fc-869e-e093f42c2626</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="c" WorkspaceGuid="c0fb99ee-b733-4056-8ee0-57dd5757504b">
+    <ModelGuid>eb839c03-d115-492d-98a6-e0d562d44d73</ModelGuid>
   </UpdateModelValueCommand>
-  <SelectInRegionCommand X="657.5" Y="348" Width="4" Height="1" IsCrossSelection="false" />
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>51d2916a-4230-49fc-869e-e093f42c2626</ModelGuid>
-  </SelectModelCommand>
-  <DragSelectionCommand X="537.5" Y="361" DragOperation="0" />
-  <DragSelectionCommand X="490.5" Y="362" DragOperation="1" />
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
-  </SelectModelCommand>
   <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
-    <ModelGuid>a472d5fb-bd30-4512-8a8d-7b0cc78a8498</ModelGuid>
+    <ModelGuid>16f0fea8-82b2-4620-b92f-5fa814f4992e</ModelGuid>
   </MakeConnectionCommand>
   <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
-    <ModelGuid>7778eec7-52ab-48d5-8c87-81143f4bbe8d</ModelGuid>
+    <ModelGuid>4975adcc-fc57-433a-a915-e67c03ff6503</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="4">
-    <ModelGuid>7778eec7-52ab-48d5-8c87-81143f4bbe8d</ModelGuid>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="6">
+    <ModelGuid>4975adcc-fc57-433a-a915-e67c03ff6503</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
-    <ModelGuid>2ae3bd09-a363-467d-9177-0b095e06580b</ModelGuid>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="7">
+    <ModelGuid>0ddbbdf5-0234-4bb2-ab5c-75e6d6ac7b13</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
-    <ModelGuid>51d2916a-4230-49fc-869e-e093f42c2626</ModelGuid>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="7">
+    <ModelGuid>eb839c03-d115-492d-98a6-e0d562d44d73</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="6">
+  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="5">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </MakeConnectionCommand>
   <UndoRedoCommand CmdOperation="0" />

--- a/test/core/recorded/CtrlClickRecordedTestUndo_Recording.xml
+++ b/test/core/recorded/CtrlClickRecordedTestUndo_Recording.xml
@@ -1,0 +1,113 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="355.5" Y="231" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>a472d5fb-bd30-4512-8a8d-7b0cc78a8498</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="a472d5fb-bd30-4512-8a8d-7b0cc78a8498" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="263" y="200" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="25;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="25;" WorkspaceGuid="c56cd373-d664-41e4-8388-40da05530e77">
+    <ModelGuid>a472d5fb-bd30-4512-8a8d-7b0cc78a8498</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="496.5" Y="197" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>7778eec7-52ab-48d5-8c87-81143f4bbe8d</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="7778eec7-52ab-48d5-8c87-81143f4bbe8d" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="462" y="71" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="a" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="a;" WorkspaceGuid="c56cd373-d664-41e4-8388-40da05530e77">
+    <ModelGuid>7778eec7-52ab-48d5-8c87-81143f4bbe8d</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="538.5" Y="203" Width="2" Height="0" IsCrossSelection="false" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>7778eec7-52ab-48d5-8c87-81143f4bbe8d</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="433.5" Y="184" DragOperation="0" />
+  <DragSelectionCommand X="491.5" Y="89" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="506.5" Y="269" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>2ae3bd09-a363-467d-9177-0b095e06580b</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="2ae3bd09-a363-467d-9177-0b095e06580b" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="458" y="199" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="b;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="b" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="b;" WorkspaceGuid="c56cd373-d664-41e4-8388-40da05530e77">
+    <ModelGuid>2ae3bd09-a363-467d-9177-0b095e06580b</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>2ae3bd09-a363-467d-9177-0b095e06580b</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="456.5" Y="258" DragOperation="0" />
+  <DragSelectionCommand X="500.5" Y="219" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="593.5" Y="365" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>51d2916a-4230-49fc-869e-e093f42c2626</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="51d2916a-4230-49fc-869e-e093f42c2626" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="454" y="335" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="c;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="c" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>51d2916a-4230-49fc-869e-e093f42c2626</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="593.5" Y="365" DragOperation="0" />
+  <DragSelectionCommand X="593.5" Y="365" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="c;" WorkspaceGuid="c56cd373-d664-41e4-8388-40da05530e77">
+    <ModelGuid>51d2916a-4230-49fc-869e-e093f42c2626</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="657.5" Y="348" Width="4" Height="1" IsCrossSelection="false" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>51d2916a-4230-49fc-869e-e093f42c2626</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="537.5" Y="361" DragOperation="0" />
+  <DragSelectionCommand X="490.5" Y="362" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>a472d5fb-bd30-4512-8a8d-7b0cc78a8498</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>7778eec7-52ab-48d5-8c87-81143f4bbe8d</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="4">
+    <ModelGuid>7778eec7-52ab-48d5-8c87-81143f4bbe8d</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
+    <ModelGuid>2ae3bd09-a363-467d-9177-0b095e06580b</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
+    <ModelGuid>51d2916a-4230-49fc-869e-e093f42c2626</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="6">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </MakeConnectionCommand>
+  <UndoRedoCommand CmdOperation="0" />
+  <UndoRedoCommand CmdOperation="0" />
+</Commands>

--- a/test/core/recorded/CtrlClickRecordedTest_Recording.xml
+++ b/test/core/recorded/CtrlClickRecordedTest_Recording.xml
@@ -2,90 +2,72 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <CreateNodeCommand X="280.5" Y="206" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>28022e9d-2f22-4bf7-83da-cb607f983ce3</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="28022e9d-2f22-4bf7-83da-cb607f983ce3" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="188" y="175" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="2;" ShouldFocus="false">
+  <CreateNodeCommand X="267.5" Y="218" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>8b79535d-078e-4b40-aa51-c0141d86a6bb</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="8b79535d-078e-4b40-aa51-c0141d86a6bb" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="175" y="187" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="4;" ShouldFocus="false">
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </CreateNodeCommand>
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="2" WorkspaceGuid="259e9c10-b6c1-4506-bece-a0b990fa0b69">
-    <ModelGuid>28022e9d-2f22-4bf7-83da-cb607f983ce3</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="4" WorkspaceGuid="428a97fb-e879-43c2-9ea0-2fa0cb9e28b2">
+    <ModelGuid>8b79535d-078e-4b40-aa51-c0141d86a6bb</ModelGuid>
   </UpdateModelValueCommand>
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <CreateNodeCommand X="391.5" Y="132" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="ae7ee942-4a20-4028-bbdc-616064de8661" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="356" y="98" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="1 + x;" ShouldFocus="false">
-      <PortInfo index="0" default="False" name="x" />
+  <CreateNodeCommand X="421.5" Y="78" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>1bb8979c-8bd2-4038-b7ea-e57cd58ad783</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="1bb8979c-8bd2-4038-b7ea-e57cd58ad783" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="329" y="47" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="a" />
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </CreateNodeCommand>
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="1 + x;" WorkspaceGuid="259e9c10-b6c1-4506-bece-a0b990fa0b69">
-    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="a" WorkspaceGuid="428a97fb-e879-43c2-9ea0-2fa0cb9e28b2">
+    <ModelGuid>1bb8979c-8bd2-4038-b7ea-e57cd58ad783</ModelGuid>
   </UpdateModelValueCommand>
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
-  </SelectModelCommand>
-  <DragSelectionCommand X="348.5" Y="165" DragOperation="0" />
-  <DragSelectionCommand X="405.5" Y="162" DragOperation="1" />
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <CreateNodeCommand X="409.5" Y="230" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>65569db5-1cba-4fff-baca-b7fd49f0b81c</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="65569db5-1cba-4fff-baca-b7fd49f0b81c" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="356" y="196" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="2 + x;" ShouldFocus="false">
-      <PortInfo index="0" default="False" name="x" />
+  <CreateNodeCommand X="407.5" Y="228" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>c82b26cd-90bc-4812-af7f-06fb098e89c2</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="c82b26cd-90bc-4812-af7f-06fb098e89c2" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="315" y="197" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="b;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="b" />
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </CreateNodeCommand>
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="2 + x;" WorkspaceGuid="259e9c10-b6c1-4506-bece-a0b990fa0b69">
-    <ModelGuid>65569db5-1cba-4fff-baca-b7fd49f0b81c</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="b" WorkspaceGuid="428a97fb-e879-43c2-9ea0-2fa0cb9e28b2">
+    <ModelGuid>c82b26cd-90bc-4812-af7f-06fb098e89c2</ModelGuid>
   </UpdateModelValueCommand>
   <SelectModelCommand Modifiers="0">
-    <ModelGuid>65569db5-1cba-4fff-baca-b7fd49f0b81c</ModelGuid>
-  </SelectModelCommand>
-  <DragSelectionCommand X="365.5" Y="224" DragOperation="0" />
-  <DragSelectionCommand X="404.5" Y="221" DragOperation="1" />
-  <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
-  </SelectModelCommand>
-  <CreateNodeCommand X="394.5" Y="338" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>50fd55cd-d9d4-4a75-83aa-06419470e8e8</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="50fd55cd-d9d4-4a75-83aa-06419470e8e8" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="349" y="304" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="3 + x;" ShouldFocus="false">
-      <PortInfo index="0" default="False" name="x" />
+  <CreateNodeCommand X="369.5" Y="381" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>05490a49-49fd-40cc-b685-1a191c70a136</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="05490a49-49fd-40cc-b685-1a191c70a136" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="277" y="350" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="c;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="c" />
       <OutPortInfo LineIndex="0" />
     </Dynamo.Graph.Nodes.CodeBlockNodeModel>
   </CreateNodeCommand>
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="3 + x;" WorkspaceGuid="259e9c10-b6c1-4506-bece-a0b990fa0b69">
-    <ModelGuid>50fd55cd-d9d4-4a75-83aa-06419470e8e8</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="c" WorkspaceGuid="428a97fb-e879-43c2-9ea0-2fa0cb9e28b2">
+    <ModelGuid>05490a49-49fd-40cc-b685-1a191c70a136</ModelGuid>
   </UpdateModelValueCommand>
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>50fd55cd-d9d4-4a75-83aa-06419470e8e8</ModelGuid>
-  </SelectModelCommand>
-  <DragSelectionCommand X="365.5" Y="324" DragOperation="0" />
-  <DragSelectionCommand X="412.5" Y="321" DragOperation="1" />
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <CreateNodeCommand X="547.5" Y="227" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="68d76b72-4b75-499b-8e96-cfc106118107" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="517" y="188" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a + b + c;" ShouldFocus="false">
+  <CreateNodeCommand X="559.5" Y="228" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>b79720ef-db82-4ea4-91bd-88e4e61b2fff</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="b79720ef-db82-4ea4-91bd-88e4e61b2fff" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="467" y="197" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="[a, b, c];" ShouldFocus="false">
       <PortInfo index="0" default="False" name="a" />
       <PortInfo index="1" default="False" name="b" />
       <PortInfo index="2" default="False" name="c" />
@@ -95,76 +77,63 @@
   <SelectModelCommand Modifiers="0">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </SelectModelCommand>
-  <UpdateModelValueCommand Name="Code" Value="a + b + c;" WorkspaceGuid="259e9c10-b6c1-4506-bece-a0b990fa0b69">
-    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+  <UpdateModelValueCommand Name="Code" Value="[a, b, c];" WorkspaceGuid="428a97fb-e879-43c2-9ea0-2fa0cb9e28b2">
+    <ModelGuid>b79720ef-db82-4ea4-91bd-88e4e61b2fff</ModelGuid>
   </UpdateModelValueCommand>
-  <SelectInRegionCommand X="688.5" Y="198" Width="0" Height="1" IsCrossSelection="false" />
+  <CreateNodeCommand X="813.5" Y="351" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>995b61e5-4a7d-4c0f-ae49-73f74132bd1b</ModelGuid>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="995b61e5-4a7d-4c0f-ae49-73f74132bd1b" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Math.Sum" x="656.5" y="210" isVisible="true" lacing="Auto" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" assembly="DSCoreNodes.dll" function="DSCore.Math.Sum@double[]">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </CreateNodeCommand>
   <SelectModelCommand Modifiers="0">
-    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+    <ModelGuid>995b61e5-4a7d-4c0f-ae49-73f74132bd1b</ModelGuid>
   </SelectModelCommand>
-  <DragSelectionCommand X="507.5" Y="216" DragOperation="0" />
-  <DragSelectionCommand X="569.5" Y="208" DragOperation="1" />
+  <DragSelectionCommand X="850.5" Y="371" DragOperation="0" />
+  <DragSelectionCommand X="693.5" Y="230" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
   <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
-    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
+    <ModelGuid>1bb8979c-8bd2-4038-b7ea-e57cd58ad783</ModelGuid>
   </MakeConnectionCommand>
   <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
-    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+    <ModelGuid>b79720ef-db82-4ea4-91bd-88e4e61b2fff</ModelGuid>
   </MakeConnectionCommand>
   <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
-    <ModelGuid>65569db5-1cba-4fff-baca-b7fd49f0b81c</ModelGuid>
+    <ModelGuid>c82b26cd-90bc-4812-af7f-06fb098e89c2</ModelGuid>
   </MakeConnectionCommand>
   <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="1">
-    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+    <ModelGuid>b79720ef-db82-4ea4-91bd-88e4e61b2fff</ModelGuid>
   </MakeConnectionCommand>
   <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
-    <ModelGuid>50fd55cd-d9d4-4a75-83aa-06419470e8e8</ModelGuid>
+    <ModelGuid>05490a49-49fd-40cc-b685-1a191c70a136</ModelGuid>
   </MakeConnectionCommand>
   <MakeConnectionCommand PortIndex="2" Type="0" ConnectionMode="1">
-    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+    <ModelGuid>b79720ef-db82-4ea4-91bd-88e4e61b2fff</ModelGuid>
   </MakeConnectionCommand>
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
-  </SelectModelCommand>
-  <CreateNodeCommand X="799.5" Y="304" DefaultPosition="false" TransformCoordinates="true">
-    <ModelGuid>0c01880f-1e78-4fb9-bfb3-32b696a862f3</ModelGuid>
-    <CoreNodeModels.Watch guid="0c01880f-1e78-4fb9-bfb3-32b696a862f3" type="CoreNodeModels.Watch" nickname="Watch" x="671.5" y="185" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false">
-      <PortInfo index="0" default="False" />
-    </CoreNodeModels.Watch>
-  </CreateNodeCommand>
   <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
-    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+    <ModelGuid>b79720ef-db82-4ea4-91bd-88e4e61b2fff</ModelGuid>
   </MakeConnectionCommand>
   <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
-    <ModelGuid>0c01880f-1e78-4fb9-bfb3-32b696a862f3</ModelGuid>
+    <ModelGuid>995b61e5-4a7d-4c0f-ae49-73f74132bd1b</ModelGuid>
   </MakeConnectionCommand>
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>0c01880f-1e78-4fb9-bfb3-32b696a862f3</ModelGuid>
-  </SelectModelCommand>
-  <DragSelectionCommand X="830.5" Y="322" DragOperation="0" />
-  <DragSelectionCommand X="702.5" Y="203" DragOperation="1" />
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
-  </SelectModelCommand>
   <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
-    <ModelGuid>28022e9d-2f22-4bf7-83da-cb607f983ce3</ModelGuid>
+    <ModelGuid>8b79535d-078e-4b40-aa51-c0141d86a6bb</ModelGuid>
   </MakeConnectionCommand>
   <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
-    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
+    <ModelGuid>1bb8979c-8bd2-4038-b7ea-e57cd58ad783</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="4">
-    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="6">
+    <ModelGuid>1bb8979c-8bd2-4038-b7ea-e57cd58ad783</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
-    <ModelGuid>65569db5-1cba-4fff-baca-b7fd49f0b81c</ModelGuid>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="7">
+    <ModelGuid>c82b26cd-90bc-4812-af7f-06fb098e89c2</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
-    <ModelGuid>50fd55cd-d9d4-4a75-83aa-06419470e8e8</ModelGuid>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="7">
+    <ModelGuid>05490a49-49fd-40cc-b685-1a191c70a136</ModelGuid>
   </MakeConnectionCommand>
-  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="6">
+  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="5">
     <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
   </MakeConnectionCommand>
-  <SelectModelCommand Modifiers="0">
-    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
-  </SelectModelCommand>
-  <SelectInRegionCommand X="270.5" Y="347" Width="0" Height="0" IsCrossSelection="false" />
 </Commands>

--- a/test/core/recorded/CtrlClickRecordedTest_Recording.xml
+++ b/test/core/recorded/CtrlClickRecordedTest_Recording.xml
@@ -1,0 +1,170 @@
+<Commands ExitAfterPlayback="true" PauseAfterPlaybackInMs="10" CommandIntervalInMs="20">
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="280.5" Y="206" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>28022e9d-2f22-4bf7-83da-cb607f983ce3</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="28022e9d-2f22-4bf7-83da-cb607f983ce3" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="188" y="175" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="2;" ShouldFocus="false">
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="2" WorkspaceGuid="259e9c10-b6c1-4506-bece-a0b990fa0b69">
+    <ModelGuid>28022e9d-2f22-4bf7-83da-cb607f983ce3</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="391.5" Y="132" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="ae7ee942-4a20-4028-bbdc-616064de8661" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="356" y="98" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="1 + x;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="x" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="1 + x;" WorkspaceGuid="259e9c10-b6c1-4506-bece-a0b990fa0b69">
+    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="348.5" Y="165" DragOperation="0" />
+  <DragSelectionCommand X="405.5" Y="162" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="409.5" Y="230" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>65569db5-1cba-4fff-baca-b7fd49f0b81c</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="65569db5-1cba-4fff-baca-b7fd49f0b81c" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="356" y="196" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="2 + x;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="x" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="2 + x;" WorkspaceGuid="259e9c10-b6c1-4506-bece-a0b990fa0b69">
+    <ModelGuid>65569db5-1cba-4fff-baca-b7fd49f0b81c</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>65569db5-1cba-4fff-baca-b7fd49f0b81c</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="365.5" Y="224" DragOperation="0" />
+  <DragSelectionCommand X="404.5" Y="221" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="394.5" Y="338" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>50fd55cd-d9d4-4a75-83aa-06419470e8e8</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="50fd55cd-d9d4-4a75-83aa-06419470e8e8" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="349" y="304" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="3 + x;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="x" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="3 + x;" WorkspaceGuid="259e9c10-b6c1-4506-bece-a0b990fa0b69">
+    <ModelGuid>50fd55cd-d9d4-4a75-83aa-06419470e8e8</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>50fd55cd-d9d4-4a75-83aa-06419470e8e8</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="365.5" Y="324" DragOperation="0" />
+  <DragSelectionCommand X="412.5" Y="321" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="547.5" Y="227" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="68d76b72-4b75-499b-8e96-cfc106118107" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="517" y="188" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false" CodeText="a + b + c;" ShouldFocus="false">
+      <PortInfo index="0" default="False" name="a" />
+      <PortInfo index="1" default="False" name="b" />
+      <PortInfo index="2" default="False" name="c" />
+      <OutPortInfo LineIndex="0" />
+    </Dynamo.Graph.Nodes.CodeBlockNodeModel>
+  </CreateNodeCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <UpdateModelValueCommand Name="Code" Value="a + b + c;" WorkspaceGuid="259e9c10-b6c1-4506-bece-a0b990fa0b69">
+    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+  </UpdateModelValueCommand>
+  <SelectInRegionCommand X="688.5" Y="198" Width="0" Height="1" IsCrossSelection="false" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="507.5" Y="216" DragOperation="0" />
+  <DragSelectionCommand X="569.5" Y="208" DragOperation="1" />
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>65569db5-1cba-4fff-baca-b7fd49f0b81c</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="1" Type="0" ConnectionMode="1">
+    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>50fd55cd-d9d4-4a75-83aa-06419470e8e8</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="2" Type="0" ConnectionMode="1">
+    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <CreateNodeCommand X="799.5" Y="304" DefaultPosition="false" TransformCoordinates="true">
+    <ModelGuid>0c01880f-1e78-4fb9-bfb3-32b696a862f3</ModelGuid>
+    <CoreNodeModels.Watch guid="0c01880f-1e78-4fb9-bfb3-32b696a862f3" type="CoreNodeModels.Watch" nickname="Watch" x="671.5" y="185" isVisible="true" lacing="Disabled" isSelectedInput="False" isSelectedOutput="False" IsFrozen="false" isPinned="false">
+      <PortInfo index="0" default="False" />
+    </CoreNodeModels.Watch>
+  </CreateNodeCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>68d76b72-4b75-499b-8e96-cfc106118107</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>0c01880f-1e78-4fb9-bfb3-32b696a862f3</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>0c01880f-1e78-4fb9-bfb3-32b696a862f3</ModelGuid>
+  </SelectModelCommand>
+  <DragSelectionCommand X="830.5" Y="322" DragOperation="0" />
+  <DragSelectionCommand X="702.5" Y="203" DragOperation="1" />
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <MakeConnectionCommand PortIndex="0" Type="1" ConnectionMode="0">
+    <ModelGuid>28022e9d-2f22-4bf7-83da-cb607f983ce3</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="1">
+    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="4">
+    <ModelGuid>ae7ee942-4a20-4028-bbdc-616064de8661</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
+    <ModelGuid>65569db5-1cba-4fff-baca-b7fd49f0b81c</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="0" Type="0" ConnectionMode="5">
+    <ModelGuid>50fd55cd-d9d4-4a75-83aa-06419470e8e8</ModelGuid>
+  </MakeConnectionCommand>
+  <MakeConnectionCommand PortIndex="-1" Type="0" ConnectionMode="6">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </MakeConnectionCommand>
+  <SelectModelCommand Modifiers="0">
+    <ModelGuid>00000000-0000-0000-0000-000000000000</ModelGuid>
+  </SelectModelCommand>
+  <SelectInRegionCommand X="270.5" Y="347" Width="0" Height="0" IsCrossSelection="false" />
+</Commands>


### PR DESCRIPTION
### Purpose

![ctrl_click](https://user-images.githubusercontent.com/13341935/54300321-03eec700-4593-11e9-9181-081c7f599e85.gif)

This PR pulls in the work originally completed by @yeexinc in #7850 and adds several tests that leverage recorded commands.  The original work was already reviewed and all active comments were addressed.  The recorded tests verify the proper connections are made when using `ctrl + left click` in order to duplicate a connector that is already currently connected to another nodes input port.  Additionally undo/redo was verified using recorded commands but copy/paste was manually as verified as they are not currently supported as recorded commands.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @aparajit-pratap @QilongTang 

### FYIs

@Amoursol
