### PR TITLE
Enclose Console.WriteLine statements within DEBUG flags

### DIFF
--- a/src/Engine/ProtoCore/BuildStatus.cs
+++ b/src/Engine/ProtoCore/BuildStatus.cs
@@ -158,6 +158,7 @@ namespace ProtoCore
             if (null == message)
                 return;
 
+#if DEBUG
             if (string.IsNullOrEmpty(message.FilePath))
             {
                 // Type: Message
@@ -173,6 +174,7 @@ namespace ProtoCore
                     message.Type.ToString(), message.Message,
                     message.FilePath, message.Line, message.Column));
             }
+#endif
 
             if (message.Type == ProtoCore.OutputMessage.MessageType.Warning)
                 message.Continue = true;
@@ -282,11 +284,13 @@ namespace ProtoCore
         {
             var localizedMessage = LocalizeErrorMessage(msg);
 
+#if DEBUG
             if (logErrors)
             {
                 var message = string.Format("{0}({1},{2}) Error:{3}", fileName, line, col, localizedMessage);
                 System.Console.WriteLine(message);
             }
+#endif
 
             var errorEntry = new BuildData.ErrorEntry
             {
@@ -567,10 +571,12 @@ namespace ProtoCore
 
         public void LogSemanticError(string msg, string fileName = null, int line = -1, int col = -1, AssociativeGraph.GraphNode graphNode = null)
         {
+#if DEBUG
             if (logErrors)
             {
                 System.Console.WriteLine("{0}({1},{2}) Error:{3}", fileName, line, col, msg);
             }
+#endif
 
             if (core.Options.IsDeltaExecution)
             {
@@ -663,7 +669,10 @@ namespace ProtoCore
 
             if (LogWarnings)
             {
+#if DEBUG
+                
                 System.Console.WriteLine("{0}({1},{2}) Warning:{3}", fileName, line, col, message);
+#endif
 
                 OutputMessage outputmessage = new OutputMessage(OutputMessage.MessageType.Warning, message.Trim(), fileName, line, col);
                 if (MessageHandler != null)
@@ -681,7 +690,9 @@ namespace ProtoCore
 
             if (displayBuildResult)
             {
+#if DEBUG
                 System.Console.WriteLine(buildResult);
+#endif
 
                 if (MessageHandler != null)
                 {

--- a/src/Engine/ProtoCore/DSASM/Executive.cs
+++ b/src/Engine/ProtoCore/DSASM/Executive.cs
@@ -912,7 +912,7 @@ namespace ProtoCore.DSASM
             {
                 if (exe.EventSink != null && exe.EventSink.PrintMessage != null)
                 {
-                    exe.EventSink.PrintMessage.Invoke("VMLog: " + msg + "\n");
+                    exe.EventSink.PrintMessage("VMLog: " + msg + "\n");
                 }
             }
         }
@@ -986,7 +986,7 @@ namespace ProtoCore.DSASM
                 if (exe.EventSink != null
                     && exe.EventSink.PrintMessage != null)
                 {
-                    exe.EventSink.PrintMessage.Invoke(lhs + " = " + rhs + "\n");
+                    exe.EventSink.PrintMessage(lhs + " = " + rhs + "\n");
                 }
             }
         }

--- a/src/Engine/ProtoCore/DebuggerProperties.cs
+++ b/src/Engine/ProtoCore/DebuggerProperties.cs
@@ -30,9 +30,12 @@ namespace ProtoCore
             public int delme;
             public ConsoleEventSink()
             {
+#if DEBUG
+                
                 BeginDocument += Console.WriteLine;
                 EndDocument += Console.WriteLine;
                 PrintMessage += Console.WriteLine;
+#endif
             }
         }
     }

--- a/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -971,9 +971,12 @@ namespace ProtoCore.Lang
             //TODO: Change Execution mirror class to have static methods, so that an instance does not have to be created
             ProtoCore.DSASM.Mirror.ExecutionMirror mirror = new DSASM.Mirror.ExecutionMirror(runtime.runtime, runtime.runtime.RuntimeCore);
             string result = mirror.GetStringValue(msg, runtime.runtime.rmem.Heap, 0, true);
+#if DEBUG
+            
             //For Console output
             Console.WriteLine(result);
-            
+#endif
+
             ////For IDE output
             //ProtoCore.Core core = runtime.runtime.Core;
             //OutputMessage t_output = new OutputMessage(result);
@@ -1467,7 +1470,11 @@ namespace ProtoCore.Lang
         internal static StackValue Difference(StackValue sv1, StackValue sv2, ProtoCore.DSASM.Interpreter runtime, ProtoCore.Runtime.Context context)
         {
             if((Rank(sv1, runtime)!=1)||(Rank(sv2, runtime)!=1)){
+#if DEBUG
+                
                 Console.WriteLine("Warning: Both arguments were expected to be one-dimensional array type!");
+#endif
+
                 return DSASM.StackValue.Null;
             }
             if ((!sv1.IsArray) || (!sv1.IsArray))
@@ -1521,7 +1528,11 @@ namespace ProtoCore.Lang
         {
             if ((Rank(sv1, runtime) != 1) || (Rank(sv2, runtime) != 1))
             {
+#if DEBUG
+                
                 Console.WriteLine("Warning: Both arguments were expected to be one-dimensional array type!");
+#endif
+
                 return DSASM.StackValue.Null;
             }
             if ((!sv1.IsArray) || (!sv1.IsArray))

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -1398,7 +1398,12 @@ namespace ProtoCore
                 log.AppendLine("Resolution failed in: " + sw.ElapsedMilliseconds);
 
                 if (runtimeCore.Options.DumpFunctionResolverLogic)
-                    runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
+                {
+                    if (runtimeCore.DSExecutable.EventSink.PrintMessage != null)
+                    {
+                        runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
+                    }
+                }
 
                 return ReportFunctionGroupNotFound(runtimeCore, arguments);
             }
@@ -1449,7 +1454,12 @@ namespace ProtoCore
                 log.AppendLine("Resolution Failed");
 
                 if (runtimeCore.Options.DumpFunctionResolverLogic)
-                    runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
+                {
+                    if (runtimeCore.DSExecutable.EventSink.PrintMessage != null)
+                    {
+                        runtimeCore.DSExecutable.EventSink.PrintMessage(log.ToString());
+                    }
+                }
 
                 return ReportMethodNotFoundForArguments(runtimeCore, funcGroup, arguments);
             }

--- a/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/Replicator.cs
@@ -218,8 +218,10 @@ namespace ProtoCore.Lang.Replication
                     
                     if (!target.IsArray)
                     {
+#if DEBUG
                         System.Console.WriteLine(
                             "WARNING: Replication unbox requested on Singleton. Trap: 437AD20D-9422-40A3-BFFD-DA4BAD7F3E5F");
+#endif
                         continue;
                     }
 
@@ -289,7 +291,9 @@ namespace ProtoCore.Lang.Replication
                     }
                     else
                     {
+#if DEBUG
                         System.Console.WriteLine("WARNING: Replication unbox requested on Singleton. Trap: 437AD20D-9422-40A3-BFFD-DA4BAD7F3E5F");
+#endif
                         reducedSV = target;
                     }
 

--- a/src/Engine/ProtoCore/RuntimeStatus.cs
+++ b/src/Engine/ProtoCore/RuntimeStatus.cs
@@ -129,10 +129,12 @@ namespace ProtoCore
             var warningMsg = string.Format(Resources.kConsoleWarningMessage,
                                            message, filename, line, col);
 
+#if DEBUG
             if (runtimeCore.Options.Verbose)
             {
                 System.Console.WriteLine(warningMsg);
             }
+#endif
 
             if (WebMessageHandler != null)
             {

--- a/src/Engine/ProtoCore/Utils/CompilerUtils.cs
+++ b/src/Engine/ProtoCore/Utils/CompilerUtils.cs
@@ -220,7 +220,10 @@ namespace ProtoCore.Utils
             }
             catch (Exception ex)
             {
+#if DEBUG
                 Console.WriteLine(ex.ToString());
+#endif
+
                 if (!(ex is ProtoCore.BuildHaltException))
                 {
                     throw ex;


### PR DESCRIPTION
### Purpose

JIRA: https://jira.autodesk.com/browse/DYN-1698

![image](https://user-images.githubusercontent.com/5710686/54318931-3e218e00-45be-11e9-916f-df992094f127.png)

There is unfortunately no noticeable performance improvement in this case after skipping the `Console.WriteLine` statements. It is still worth submitting this change so as to avoid unnecessary output to the console when running a release build.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### FYIs

@mjkkirschner 
