### PR TITLE
fix flaky timing test

### DIFF
--- a/test/DynamoCoreTests/HomgeneousListTests.cs
+++ b/test/DynamoCoreTests/HomgeneousListTests.cs
@@ -85,9 +85,9 @@ namespace Dynamo.Tests
             var heterogeneousFirstStdDev = CalculateListStdDev(timeHeterogeneousFirst);
             var heterogeneousLastStdDev = CalculateListStdDev(timeHeterogeneousLast);
 
-            var aveHomogeneous = TrimListOutliers(timeHomogeneous, homogeneousStdDev, 2).Average();
-            var aveHeterogeneousFirstItem = TrimListOutliers(timeHeterogeneousFirst, heterogeneousFirstStdDev, 2).Average();
-            var aveHeterogeneousLastItem = TrimListOutliers(timeHeterogeneousLast, heterogeneousLastStdDev, 2).Average();
+            var aveHomogeneous = TrimListOutliers(timeHomogeneous, homogeneousStdDev).Average();
+            var aveHeterogeneousFirstItem = TrimListOutliers(timeHeterogeneousFirst, heterogeneousFirstStdDev).Average();
+            var aveHeterogeneousLastItem = TrimListOutliers(timeHeterogeneousLast, heterogeneousLastStdDev).Average();
 
             Assert.LessOrEqual(aveHomogeneous, aveHeterogeneousFirstItem);
             Assert.LessOrEqual(aveHomogeneous, aveHeterogeneousLastItem);


### PR DESCRIPTION
### Purpose

This attempts to fix a flaky test that times the performance: `TestMethodResolutionPerformance` in `Dynamo\test\DynamoCoreTests\HomgeneousListTests.cs`. There was a build failure due to this: https://master-15.jenkins.autodesk.com/job/DYN-DynamoCore_master/1868/consoleFull

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@saintentropy 

### FYIs

@mjkkirschner 
@QilongTang 
