### PR TITLE
Remove flaky performance test, add graphs to perf test suite

### DIFF
--- a/test/DynamoCoreTests/HomgeneousListTests.cs
+++ b/test/DynamoCoreTests/HomgeneousListTests.cs
@@ -40,65 +40,6 @@ namespace Dynamo.Tests
         }
 
         [Test]
-        public void TestMethodResolutionPerformance()
-        {
-
-            //Run once to complete initialization
-
-            RunModel(@"core\HomogeneousList\HomogeneousInputs.dyn");
-
-            //Run timed tests of a list of Heterogeneous input types (first item is double vs int).  
-            //Store graph execution time.
-            var timeHeterogeneousFirst = new List<double>();
-            for (int i = 0; i < 50; i++)
-            {
-
-                RunModel(@"core\HomogeneousList\HeterogeneousInputsFirst.dyn");
-
-                timeHeterogeneousFirst.Add(lastExecutionDuration.TotalMilliseconds);
-            }
-
-            //Run timed tests of a list of Heterogeneous input types (last item is double vs int). 
-            //Store graph execution time.
-            var timeHeterogeneousLast = new List<double>();
-            for (int i = 0; i < 50; i++)
-            {
-
-                RunModel(@"core\HomogeneousList\HeterogeneousInputsLast.dyn");
-
-                timeHeterogeneousLast.Add(lastExecutionDuration.TotalMilliseconds);
-            }
-
-            //Run timed tests of a list of Homogeneous input types (all items are int).  
-            //Store graph execution time.
-            var timeHomogeneous = new List<double>();
-            for (int i = 0; i < 50; i++)
-            {  
-                RunModel(@"core\HomogeneousList\HomogeneousInputs.dyn");
-
-                timeHomogeneous.Add(lastExecutionDuration.TotalMilliseconds);
-
-            }
-
-            //Filter time data to remove outliers 
-            var homogeneousStdDev = CalculateListStdDev(timeHomogeneous);
-            var heterogeneousFirstStdDev = CalculateListStdDev(timeHeterogeneousFirst);
-            var heterogeneousLastStdDev = CalculateListStdDev(timeHeterogeneousLast);
-
-            var aveHomogeneous = TrimListOutliers(timeHomogeneous, homogeneousStdDev, 2).Average();
-            var aveHeterogeneousFirstItem = TrimListOutliers(timeHeterogeneousFirst, heterogeneousFirstStdDev, 2).Average();
-            var aveHeterogeneousLastItem = TrimListOutliers(timeHeterogeneousLast, heterogeneousLastStdDev, 2).Average();
-
-            Assert.LessOrEqual(aveHomogeneous, aveHeterogeneousFirstItem);
-            Assert.LessOrEqual(aveHomogeneous, aveHeterogeneousLastItem);
-
-            Console.WriteLine("Homogeneous average execution: " + aveHomogeneous + "ms");
-            Console.WriteLine("Heterogeneous first item average execution: " + aveHeterogeneousFirstItem + "ms");
-            Console.WriteLine("Heterogeneous last item average execution: " + aveHeterogeneousLastItem + "ms");
-
-        }
-
-        [Test]
         public void TestMethodResolutionforHomogeneousListInputs()
         {
 
@@ -132,37 +73,6 @@ namespace Dynamo.Tests
         public void TearDown()
         {
             ExecutionEvents.GraphPostExecution -= ExecutionEvents_GraphPostExecution;
-        }
-
-        /// <summary>
-        /// Determine standard deviation of values in a list.
-        /// </summary>
-        /// <param name="values"></param>
-        /// <returns>Standard deviation.</returns>
-        private double CalculateListStdDev(IEnumerable<double> values)
-        {
-
-            double avg = values.Average();    
-            double sum = values.Sum(d => Math.Pow(d - avg, 2));  
-            var ret = Math.Sqrt((sum) / (values.Count() - 1));
-   
-            return ret;
-        }
-
-        /// <summary>
-        /// Remove outliers from a list based on their difference from the average.
-        /// Use multiple of standard deviation to determine range of exclusion.
-        /// </summary>
-        /// <param name="values"></param>
-        /// <param name="stdDev"></param>
-        /// <param name="multiplier"></param>
-        /// <returns>List of values within the acceptable range of standard deviation.</returns>
-        private List<double> TrimListOutliers(IEnumerable<double> values, double stdDev, int multiplier = 1)
-        {
-            double avg = values.Average();
-            var newList =
-                values.Where(value => value <= avg + stdDev * multiplier && value >= avg - stdDev * multiplier);
-            return newList.ToList();
         }
 
         private void ExecutionEvents_GraphPostExecution(Session.IExecutionSession session)

--- a/tools/Performance/graphs/HeterogeneousInputsFirst.dyn
+++ b/tools/Performance/graphs/HeterogeneousInputsFirst.dyn
@@ -1,0 +1,372 @@
+{
+  "Uuid": "ce26b161-5506-4388-a339-bbdb0f05c27a",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "HeterogeneousInputsFirst",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0..15;",
+      "Id": "f57c39890b734c71bac64bc9dc545309",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "b75df48f77a3448aa24db6dc6eb88a06",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.ReplaceItemAtIndex@var[]..[],int,var[]..[]",
+      "Id": "5a049d4fbeae48d6b1e8e200467e4ee9",
+      "Inputs": [
+        {
+          "Id": "392982d4016e4b37a1ba4e7e8dd202cc",
+          "Name": "list",
+          "Description": "List to replace an item in.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "82e2b7c29f184741b02e5731f4615e7d",
+          "Name": "index",
+          "Description": "Index of the item to be replaced.\n\nint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "dd5c8a48bbe0443f808fe0a394431697",
+          "Name": "item",
+          "Description": "The item to insert.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "aeed3e11fe9a479189100f22b1b17446",
+          "Name": "list",
+          "Description": "A new list with the item replaced.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Replace an item from the given list that's located at the specified index.\n\nList.ReplaceItemAtIndex (list: var[]..[], index: int, item: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "b705cd19e3154d8399dd7d2fd9d05dcd",
+      "Inputs": [
+        {
+          "Id": "14cc48ecb41f4a7b8b34f8c8ee0fad96",
+          "Name": "x",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "28365996868d483794eae44d2bab53f9",
+          "Name": "y",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5ae29ee0e60c49f0b7b4b33c7ef049d5",
+          "Name": "z",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9dfc2affb4dc4be4a182547bcd4df831",
+          "Name": "Point",
+          "Description": "Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "CrossProduct",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0;\n0.5;",
+      "Id": "3405e2c1e8c3496caf38cf2e7b2212e1",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "dc70e9db35f446c0976e68270e4df9e3",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f73b3eb947514989a2b31e292a6e292f",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.ReplaceItemAtIndex@var[]..[],int,var[]..[]",
+      "Id": "04e4bd6a9a55494491920a1455cd611f",
+      "Inputs": [
+        {
+          "Id": "321f004b272a48adaa908a264dabae79",
+          "Name": "list",
+          "Description": "List to replace an item in.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9c141b2c2b2e47cb9f70df35655ccd4d",
+          "Name": "index",
+          "Description": "Index of the item to be replaced.\n\nint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d47a13ce43ab492c966cc7d029255930",
+          "Name": "item",
+          "Description": "The item to insert.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ba0a7f64bf2e418db90d2d7c5ba075db",
+          "Name": "list",
+          "Description": "A new list with the item replaced.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Replace an item from the given list that's located at the specified index.\n\nList.ReplaceItemAtIndex (list: var[]..[], index: int, item: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "15;\n15;",
+      "Id": "442c01de8c4048779c8bb16ae2ffd810",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "6cebe5dbf350411fa38bdbf0eb3cc152",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "47d61a6282d94195944fa784b712cfcf",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "b75df48f77a3448aa24db6dc6eb88a06",
+      "End": "392982d4016e4b37a1ba4e7e8dd202cc",
+      "Id": "af4a0cc2307a473a9df11dd6f17c5aa4"
+    },
+    {
+      "Start": "aeed3e11fe9a479189100f22b1b17446",
+      "End": "321f004b272a48adaa908a264dabae79",
+      "Id": "3dc87b061ec14520ada09c3532384438"
+    },
+    {
+      "Start": "dc70e9db35f446c0976e68270e4df9e3",
+      "End": "82e2b7c29f184741b02e5731f4615e7d",
+      "Id": "94172a4a648343c3bb7916bd4c5fed37"
+    },
+    {
+      "Start": "f73b3eb947514989a2b31e292a6e292f",
+      "End": "dd5c8a48bbe0443f808fe0a394431697",
+      "Id": "1ce02fa6d1544c89b09294d6352d4dc4"
+    },
+    {
+      "Start": "ba0a7f64bf2e418db90d2d7c5ba075db",
+      "End": "5ae29ee0e60c49f0b7b4b33c7ef049d5",
+      "Id": "e378b5990c0346cdb6508735183f13b4"
+    },
+    {
+      "Start": "ba0a7f64bf2e418db90d2d7c5ba075db",
+      "End": "28365996868d483794eae44d2bab53f9",
+      "Id": "20c54ea0499648c394d25f8b2256bf00"
+    },
+    {
+      "Start": "ba0a7f64bf2e418db90d2d7c5ba075db",
+      "End": "14cc48ecb41f4a7b8b34f8c8ee0fad96",
+      "Id": "47381973eb77483cbdfe6f510a649b7a"
+    },
+    {
+      "Start": "6cebe5dbf350411fa38bdbf0eb3cc152",
+      "End": "9c141b2c2b2e47cb9f70df35655ccd4d",
+      "Id": "ffe63f6ad162428698f0c0c9745e6a55"
+    },
+    {
+      "Start": "47d61a6282d94195944fa784b712cfcf",
+      "End": "d47a13ce43ab492c966cc7d029255930",
+      "Id": "1080c295dea14953a7e00015de789419"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.4395",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "f57c39890b734c71bac64bc9dc545309",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -94.498919144200613,
+        "Y": 224.58816065429713
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.ReplaceItemAtIndex",
+        "Id": "5a049d4fbeae48d6b1e8e200467e4ee9",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 66.10086819411265,
+        "Y": 245.72417016794384
+      },
+      {
+        "ShowGeometry": false,
+        "Name": "Point.ByCoordinates",
+        "Id": "b705cd19e3154d8399dd7d2fd9d05dcd",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 533.21810069966477,
+        "Y": 361.01876878658277
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "3405e2c1e8c3496caf38cf2e7b2212e1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -98.7128904403472,
+        "Y": 324.417967813707
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.ReplaceItemAtIndex",
+        "Id": "04e4bd6a9a55494491920a1455cd611f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 284.07465227125954,
+        "Y": 376.6931532842292
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "442c01de8c4048779c8bb16ae2ffd810",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 143.51004303541851,
+        "Y": 432.58628059172418
+      }
+    ],
+    "Annotations": [],
+    "X": 298.99719176475685,
+    "Y": 0.73227064744412473,
+    "Zoom": 1.1375820522947404
+  }
+}

--- a/tools/Performance/graphs/HeterogeneousInputsLast.dyn
+++ b/tools/Performance/graphs/HeterogeneousInputsLast.dyn
@@ -1,0 +1,372 @@
+{
+  "Uuid": "ce26b161-5506-4388-a339-bbdb0f05c27a",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "HeterogeneousInputsLast",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0..15;",
+      "Id": "f57c39890b734c71bac64bc9dc545309",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "b75df48f77a3448aa24db6dc6eb88a06",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.ReplaceItemAtIndex@var[]..[],int,var[]..[]",
+      "Id": "5a049d4fbeae48d6b1e8e200467e4ee9",
+      "Inputs": [
+        {
+          "Id": "392982d4016e4b37a1ba4e7e8dd202cc",
+          "Name": "list",
+          "Description": "List to replace an item in.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "82e2b7c29f184741b02e5731f4615e7d",
+          "Name": "index",
+          "Description": "Index of the item to be replaced.\n\nint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "dd5c8a48bbe0443f808fe0a394431697",
+          "Name": "item",
+          "Description": "The item to insert.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "aeed3e11fe9a479189100f22b1b17446",
+          "Name": "list",
+          "Description": "A new list with the item replaced.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Replace an item from the given list that's located at the specified index.\n\nList.ReplaceItemAtIndex (list: var[]..[], index: int, item: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "b705cd19e3154d8399dd7d2fd9d05dcd",
+      "Inputs": [
+        {
+          "Id": "14cc48ecb41f4a7b8b34f8c8ee0fad96",
+          "Name": "x",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "28365996868d483794eae44d2bab53f9",
+          "Name": "y",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5ae29ee0e60c49f0b7b4b33c7ef049d5",
+          "Name": "z",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9dfc2affb4dc4be4a182547bcd4df831",
+          "Name": "Point",
+          "Description": "Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "CrossProduct",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0;\n0;",
+      "Id": "3405e2c1e8c3496caf38cf2e7b2212e1",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "b09805e0a006465c9c3d6c9329523622",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e51541d5034146b586300dc8a8f7577e",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.ReplaceItemAtIndex@var[]..[],int,var[]..[]",
+      "Id": "04e4bd6a9a55494491920a1455cd611f",
+      "Inputs": [
+        {
+          "Id": "321f004b272a48adaa908a264dabae79",
+          "Name": "list",
+          "Description": "List to replace an item in.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9c141b2c2b2e47cb9f70df35655ccd4d",
+          "Name": "index",
+          "Description": "Index of the item to be replaced.\n\nint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d47a13ce43ab492c966cc7d029255930",
+          "Name": "item",
+          "Description": "The item to insert.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ba0a7f64bf2e418db90d2d7c5ba075db",
+          "Name": "list",
+          "Description": "A new list with the item replaced.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Replace an item from the given list that's located at the specified index.\n\nList.ReplaceItemAtIndex (list: var[]..[], index: int, item: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "15;\n17.5;",
+      "Id": "442c01de8c4048779c8bb16ae2ffd810",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "03d16b19c444412e97ea9b62ef44b19a",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "91c43dc03bd84236927b907572dd5e53",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "b75df48f77a3448aa24db6dc6eb88a06",
+      "End": "392982d4016e4b37a1ba4e7e8dd202cc",
+      "Id": "af4a0cc2307a473a9df11dd6f17c5aa4"
+    },
+    {
+      "Start": "aeed3e11fe9a479189100f22b1b17446",
+      "End": "321f004b272a48adaa908a264dabae79",
+      "Id": "3dc87b061ec14520ada09c3532384438"
+    },
+    {
+      "Start": "b09805e0a006465c9c3d6c9329523622",
+      "End": "82e2b7c29f184741b02e5731f4615e7d",
+      "Id": "97bdb255123446b699fc43cafc864028"
+    },
+    {
+      "Start": "e51541d5034146b586300dc8a8f7577e",
+      "End": "dd5c8a48bbe0443f808fe0a394431697",
+      "Id": "0a6ec3ff297e442f9163e4c1912e33a8"
+    },
+    {
+      "Start": "ba0a7f64bf2e418db90d2d7c5ba075db",
+      "End": "5ae29ee0e60c49f0b7b4b33c7ef049d5",
+      "Id": "e378b5990c0346cdb6508735183f13b4"
+    },
+    {
+      "Start": "ba0a7f64bf2e418db90d2d7c5ba075db",
+      "End": "28365996868d483794eae44d2bab53f9",
+      "Id": "20c54ea0499648c394d25f8b2256bf00"
+    },
+    {
+      "Start": "ba0a7f64bf2e418db90d2d7c5ba075db",
+      "End": "14cc48ecb41f4a7b8b34f8c8ee0fad96",
+      "Id": "47381973eb77483cbdfe6f510a649b7a"
+    },
+    {
+      "Start": "03d16b19c444412e97ea9b62ef44b19a",
+      "End": "9c141b2c2b2e47cb9f70df35655ccd4d",
+      "Id": "c63bc71aafaf43ec8a36be74357f87ca"
+    },
+    {
+      "Start": "91c43dc03bd84236927b907572dd5e53",
+      "End": "d47a13ce43ab492c966cc7d029255930",
+      "Id": "a9f70dc518ac47c0a7385665c6ae01fb"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.4395",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "f57c39890b734c71bac64bc9dc545309",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -94.498919144200613,
+        "Y": 224.58816065429713
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.ReplaceItemAtIndex",
+        "Id": "5a049d4fbeae48d6b1e8e200467e4ee9",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 66.10086819411265,
+        "Y": 245.72417016794384
+      },
+      {
+        "ShowGeometry": false,
+        "Name": "Point.ByCoordinates",
+        "Id": "b705cd19e3154d8399dd7d2fd9d05dcd",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 533.21810069966477,
+        "Y": 361.01876878658277
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "3405e2c1e8c3496caf38cf2e7b2212e1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -98.7128904403472,
+        "Y": 324.417967813707
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.ReplaceItemAtIndex",
+        "Id": "04e4bd6a9a55494491920a1455cd611f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 284.07465227125954,
+        "Y": 376.6931532842292
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "442c01de8c4048779c8bb16ae2ffd810",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 143.51004303541851,
+        "Y": 432.58628059172418
+      }
+    ],
+    "Annotations": [],
+    "X": 298.99719176475685,
+    "Y": 0.73227064744412473,
+    "Zoom": 1.1375820522947404
+  }
+}

--- a/tools/Performance/graphs/HomogeneousInputs.dyn
+++ b/tools/Performance/graphs/HomogeneousInputs.dyn
@@ -1,0 +1,372 @@
+{
+  "Uuid": "ce26b161-5506-4388-a339-bbdb0f05c27a",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "HomogeneousInputs",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0..15;",
+      "Id": "f57c39890b734c71bac64bc9dc545309",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "ed00b2e12ef24423bd67fbb28fe627c8",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.ReplaceItemAtIndex@var[]..[],int,var[]..[]",
+      "Id": "5a049d4fbeae48d6b1e8e200467e4ee9",
+      "Inputs": [
+        {
+          "Id": "392982d4016e4b37a1ba4e7e8dd202cc",
+          "Name": "list",
+          "Description": "List to replace an item in.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "82e2b7c29f184741b02e5731f4615e7d",
+          "Name": "index",
+          "Description": "Index of the item to be replaced.\n\nint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "dd5c8a48bbe0443f808fe0a394431697",
+          "Name": "item",
+          "Description": "The item to insert.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "aeed3e11fe9a479189100f22b1b17446",
+          "Name": "list",
+          "Description": "A new list with the item replaced.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Replace an item from the given list that's located at the specified index.\n\nList.ReplaceItemAtIndex (list: var[]..[], index: int, item: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double",
+      "Id": "b705cd19e3154d8399dd7d2fd9d05dcd",
+      "Inputs": [
+        {
+          "Id": "14cc48ecb41f4a7b8b34f8c8ee0fad96",
+          "Name": "x",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "28365996868d483794eae44d2bab53f9",
+          "Name": "y",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5ae29ee0e60c49f0b7b4b33c7ef049d5",
+          "Name": "z",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9dfc2affb4dc4be4a182547bcd4df831",
+          "Name": "Point",
+          "Description": "Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "CrossProduct",
+      "Description": "Form a Point given 3 cartesian coordinates\n\nPoint.ByCoordinates (x: double = 0, y: double = 0, z: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0;\n0;",
+      "Id": "3405e2c1e8c3496caf38cf2e7b2212e1",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "75449d34285844b5997c1af1dade1dea",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "8c2bfd4a8a3641e5beb71145bdd1fd5d",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.ReplaceItemAtIndex@var[]..[],int,var[]..[]",
+      "Id": "e1a3c9960eda4581ab703f1b0bfe2568",
+      "Inputs": [
+        {
+          "Id": "a5e502e54f014976b061b5099409f92d",
+          "Name": "list",
+          "Description": "List to replace an item in.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0ec0187c138d4cc69f3f7e48782dc2e5",
+          "Name": "index",
+          "Description": "Index of the item to be replaced.\n\nint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "544898333ffb42a89edd193e56a0c02d",
+          "Name": "item",
+          "Description": "The item to insert.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "51e000b32f254730af3ddf03ec14f421",
+          "Name": "list",
+          "Description": "A new list with the item replaced.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Replace an item from the given list that's located at the specified index.\n\nList.ReplaceItemAtIndex (list: var[]..[], index: int, item: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "15;\n15;",
+      "Id": "06a74bf917894cff80e70ddd77c5a8d2",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "f4d6c3b73014465983e7c37a290a950d",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3b16dde3850b47afbb669dedd3ed5ef6",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "ed00b2e12ef24423bd67fbb28fe627c8",
+      "End": "392982d4016e4b37a1ba4e7e8dd202cc",
+      "Id": "7d1f0f8c39f3410489cd9e84ad6752ea"
+    },
+    {
+      "Start": "aeed3e11fe9a479189100f22b1b17446",
+      "End": "a5e502e54f014976b061b5099409f92d",
+      "Id": "d19a42014a994534a91fdfa55f4504e0"
+    },
+    {
+      "Start": "75449d34285844b5997c1af1dade1dea",
+      "End": "82e2b7c29f184741b02e5731f4615e7d",
+      "Id": "a6e2acba112c4a5a89660a74cb1ca79a"
+    },
+    {
+      "Start": "8c2bfd4a8a3641e5beb71145bdd1fd5d",
+      "End": "dd5c8a48bbe0443f808fe0a394431697",
+      "Id": "dfe2206704df4e308e4c025a8a6721bb"
+    },
+    {
+      "Start": "51e000b32f254730af3ddf03ec14f421",
+      "End": "5ae29ee0e60c49f0b7b4b33c7ef049d5",
+      "Id": "877012c87af3425bba2a4c05eb7ff6fa"
+    },
+    {
+      "Start": "51e000b32f254730af3ddf03ec14f421",
+      "End": "28365996868d483794eae44d2bab53f9",
+      "Id": "fc5541286e3a48ed95f84ede4a02ad59"
+    },
+    {
+      "Start": "51e000b32f254730af3ddf03ec14f421",
+      "End": "14cc48ecb41f4a7b8b34f8c8ee0fad96",
+      "Id": "2d4567febda54cb181fe3b8c197ce8b9"
+    },
+    {
+      "Start": "f4d6c3b73014465983e7c37a290a950d",
+      "End": "0ec0187c138d4cc69f3f7e48782dc2e5",
+      "Id": "4843b6ff980b4c10b63bddaa501d3870"
+    },
+    {
+      "Start": "3b16dde3850b47afbb669dedd3ed5ef6",
+      "End": "544898333ffb42a89edd193e56a0c02d",
+      "Id": "09782e6e6a06412ea780a67a436a8700"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.1.0.4395",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "f57c39890b734c71bac64bc9dc545309",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -94.4989191442006,
+        "Y": 224.588160654297
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.ReplaceItemAtIndex",
+        "Id": "5a049d4fbeae48d6b1e8e200467e4ee9",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 66.10086819411265,
+        "Y": 245.72417016794384
+      },
+      {
+        "ShowGeometry": false,
+        "Name": "Point.ByCoordinates",
+        "Id": "b705cd19e3154d8399dd7d2fd9d05dcd",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 572.697659152735,
+        "Y": 321.93302164554041
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "3405e2c1e8c3496caf38cf2e7b2212e1",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -94.50292446440244,
+        "Y": 321.08705930705207
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.ReplaceItemAtIndex",
+        "Id": "e1a3c9960eda4581ab703f1b0bfe2568",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 303.81381592148693,
+        "Y": 348.52016769485783
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "06a74bf917894cff80e70ddd77c5a8d2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 163.24920668564641,
+        "Y": 404.41329500235258
+      }
+    ],
+    "Annotations": [],
+    "X": 243.33431928893191,
+    "Y": 236.13890149512059,
+    "Zoom": 0.71259483262848844
+  }
+}


### PR DESCRIPTION
### Purpose

This removes a flaky test that times the performance: `TestMethodResolutionPerformance` in `Dynamo\test\DynamoCoreTests\HomgeneousListTests.cs`. There was a build failure due to this: https://master-15.jenkins.autodesk.com/job/DYN-DynamoCore_master/1868/consoleFull

Added graphs used in test to new performance test suite being added by @scottmitchell 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### FYIs

@saintentropy @scottmitchell @mjkkirschner @QilongTang 
