### PR TITLE
DYN-1722

### DIFF
--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -826,7 +826,7 @@ namespace ProtoCore
         {
             if (oldOption.Count > 0 && newOption.Count > 0 && oldOption.Count < newOption.Count)
             {
-                if (oldOption[0].ToString().Equals(newOption[0].ToString()))
+                if (oldOption[0].Equals(newOption[0]))
                     return true;
             }
             return false;

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -844,7 +844,7 @@ namespace ProtoCore
         {
             replicationInstructions = null;
             resolvesFeps = null;
-            Boolean flag = false;
+            Boolean matchFound = false;
 
             #region Case 1: Replication guide with exact match 
             {
@@ -874,11 +874,11 @@ namespace ProtoCore
                             //Otherwise we have a cluster of FEPs that can be used to dispatch the array
                             resolvesFeps = new List<FunctionEndPoint>(lookups);
                             replicationInstructions = replicationOption;
-                            flag = true;
+                            matchFound = true;
                         }
                     }
                 }
-                if (flag == true)
+                if (matchFound == true)
                     return;
             }
             #endregion
@@ -906,10 +906,10 @@ namespace ProtoCore
                         {
                             resolvesFeps = new List<FunctionEndPoint>() { compliantTarget };
                             replicationInstructions = replicationOption;
-                            flag = true;
+                            matchFound = true;
                         }
                     }
-                    if (flag == true)
+                    if (matchFound == true)
                         return;
                 }
             }
@@ -943,10 +943,10 @@ namespace ProtoCore
                     {
                         resolvesFeps = new List<FunctionEndPoint>() { compliantTarget };
                         replicationInstructions = replicationOption;
-                        flag = true;
+                        matchFound = true;
                     }
                 }
-                if (flag == true)
+                if (matchFound == true)
                     return;
             }
             #endregion

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -822,7 +822,15 @@ namespace ProtoCore
             return compliantTarget;
         }
 
-        private Boolean IsCompatibleReplicationOption(List<ReplicationInstruction> oldOption, List<ReplicationInstruction> newOption)
+
+        /// <summary>
+        /// This helper function checks if the current replication option is
+        /// similar to the previous option but of a higher rank. 
+        /// Checks if the first entry is same in both the options and the current options count is more. 
+        /// </summary>
+        /// <returns>Returns true or false based on the condition described above. 
+        /// </returns>
+        private Boolean IsSimilarOptionButOfHigherRank(List<ReplicationInstruction> oldOption, List<ReplicationInstruction> newOption)
         {
             if (oldOption.Count > 0 && newOption.Count > 0 && oldOption.Count < newOption.Count)
             {
@@ -869,7 +877,7 @@ namespace ProtoCore
                     HashSet<FunctionEndPoint> lookups;
                     if (funcGroup.CanGetExactMatchStatics(context, reducedParams, stackFrame, runtimeCore, out lookups))
                     {
-                        if (replicationInstructions == null || IsCompatibleReplicationOption(replicationInstructions, replicationOption))
+                        if (replicationInstructions == null || IsSimilarOptionButOfHigherRank(replicationInstructions, replicationOption))
                         {
                             //Otherwise we have a cluster of FEPs that can be used to dispatch the array
                             resolvesFeps = new List<FunctionEndPoint>(lookups);

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -844,7 +844,7 @@ namespace ProtoCore
         {
             replicationInstructions = null;
             resolvesFeps = null;
-            Boolean matchFound = false;
+            var matchFound = false;
 
             #region Case 1: Replication guide with exact match 
             {
@@ -878,7 +878,7 @@ namespace ProtoCore
                         }
                     }
                 }
-                if (matchFound == true)
+                if (matchFound)
                     return;
             }
             #endregion
@@ -909,7 +909,7 @@ namespace ProtoCore
                             matchFound = true;
                         }
                     }
-                    if (matchFound == true)
+                    if (matchFound)
                         return;
                 }
             }
@@ -946,7 +946,7 @@ namespace ProtoCore
                         matchFound = true;
                     }
                 }
-                if (matchFound == true)
+                if (matchFound)
                     return;
             }
             #endregion

--- a/src/Engine/ProtoCore/Lang/CallSite.cs
+++ b/src/Engine/ProtoCore/Lang/CallSite.cs
@@ -847,11 +847,11 @@ namespace ProtoCore
             List<ReplicationInstruction> instructions,
             StackFrame stackFrame,
             RuntimeCore runtimeCore,
-            out List<FunctionEndPoint> resolvesFeps,
+            out List<FunctionEndPoint> resolvedFeps,
             out List<ReplicationInstruction> replicationInstructions)
         {
             replicationInstructions = null;
-            resolvesFeps = null;
+            resolvedFeps = null;
             var matchFound = false;
 
             #region Case 1: Replication guide with exact match 
@@ -859,7 +859,7 @@ namespace ProtoCore
                 FunctionEndPoint fep = GetCompleteMatchFunctionEndPoint(context, arguments, funcGroup, instructions, stackFrame, runtimeCore);
                 if (fep != null)
                 {
-                    resolvesFeps = new List<FunctionEndPoint>() { fep };
+                    resolvedFeps = new List<FunctionEndPoint>() { fep };
                     replicationInstructions = instructions;
                     return;
                 }
@@ -880,7 +880,7 @@ namespace ProtoCore
                         if (replicationInstructions == null || IsSimilarOptionButOfHigherRank(replicationInstructions, replicationOption))
                         {
                             //Otherwise we have a cluster of FEPs that can be used to dispatch the array
-                            resolvesFeps = new List<FunctionEndPoint>(lookups);
+                            resolvedFeps = new List<FunctionEndPoint>(lookups);
                             replicationInstructions = replicationOption;
                             matchFound = true;
                         }
@@ -896,7 +896,7 @@ namespace ProtoCore
                 FunctionEndPoint compliantTarget = GetCompliantFEP(context, arguments, funcGroup, instructions, stackFrame, runtimeCore);
                 if (compliantTarget != null)
                 {
-                    resolvesFeps = new List<FunctionEndPoint>() { compliantTarget };
+                    resolvedFeps = new List<FunctionEndPoint>() { compliantTarget };
                     replicationInstructions = instructions;
                     return;
                 }
@@ -912,7 +912,7 @@ namespace ProtoCore
                         FunctionEndPoint compliantTarget = GetCompliantFEP(context, arguments, funcGroup, replicationOption, stackFrame, runtimeCore);
                         if (compliantTarget != null)
                         {
-                            resolvesFeps = new List<FunctionEndPoint>() { compliantTarget };
+                            resolvedFeps = new List<FunctionEndPoint>() { compliantTarget };
                             replicationInstructions = replicationOption;
                             matchFound = true;
                         }
@@ -934,7 +934,7 @@ namespace ProtoCore
                     FunctionEndPoint compliantTarget = GetCompliantFEP(context, arguments, funcGroup, replicationOption, stackFrame, runtimeCore, true);
                     if (compliantTarget != null)
                     {
-                        resolvesFeps = new List<FunctionEndPoint>() { compliantTarget };
+                        resolvedFeps = new List<FunctionEndPoint>() { compliantTarget };
                         replicationInstructions = replicationOption;
                         return;
                     }
@@ -949,7 +949,7 @@ namespace ProtoCore
                     FunctionEndPoint compliantTarget = GetLooseCompliantFEP(context, arguments, funcGroup, replicationOption, stackFrame, runtimeCore);
                     if (compliantTarget != null)
                     {
-                        resolvesFeps = new List<FunctionEndPoint>() { compliantTarget };
+                        resolvedFeps = new List<FunctionEndPoint>() { compliantTarget };
                         replicationInstructions = replicationOption;
                         matchFound = true;
                     }
@@ -959,7 +959,7 @@ namespace ProtoCore
             }
             #endregion
 
-            resolvesFeps = new List<FunctionEndPoint>();
+            resolvedFeps = new List<FunctionEndPoint>();
             replicationInstructions = instructions;
         }
 

--- a/src/Engine/ProtoCore/Lang/Replication/ReplicationInstruction.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/ReplicationInstruction.cs
@@ -48,15 +48,18 @@ namespace ProtoCore.Lang.Replication
 
         public Boolean Equals(ReplicationInstruction oldOption) {
 
-            if (this.Zipped == oldOption.Zipped)
+            if (this.Zipped == oldOption.Zipped && this.ZipAlgorithm == oldOption.ZipAlgorithm)
             {
                 if (this.ZipIndecies == null && oldOption.ZipIndecies == null)
                     return true;
 
                 if (this.ZipIndecies != null && oldOption.ZipIndecies != null)
                 {
+                    // Fastest way to compare all elements of 2 lists. 
+                    // Excluding one list from another list and checking if the leftover list is empty. 
                     var currentExcludesOldList = this.ZipIndecies.Except(oldOption.ZipIndecies).ToList();
                     var oldExcludescurrentList = oldOption.ZipIndecies.Except(this.ZipIndecies).ToList();
+
                     return !currentExcludesOldList.Any() && !oldExcludescurrentList.Any();
                 }
             }

--- a/src/Engine/ProtoCore/Lang/Replication/ReplicationInstruction.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/ReplicationInstruction.cs
@@ -56,7 +56,8 @@ namespace ProtoCore.Lang.Replication
                 if (this.ZipIndecies != null && oldOption.ZipIndecies != null)
                 {
                     // Fastest way to compare all elements of 2 lists. 
-                    // Excluding one list from another list and checking if the leftover list is empty. 
+                    // Excluding one list from another list and checking if the leftover lists is empty or not. 
+                    // https://stackoverflow.com/questions/12795882/quickest-way-to-compare-two-list
                     var currentExcludesOldList = this.ZipIndecies.Except(oldOption.ZipIndecies).ToList();
                     var oldExcludescurrentList = oldOption.ZipIndecies.Except(this.ZipIndecies).ToList();
 

--- a/src/Engine/ProtoCore/Lang/Replication/ReplicationInstruction.cs
+++ b/src/Engine/ProtoCore/Lang/Replication/ReplicationInstruction.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ProtoCore.Lang.Replication
 {
@@ -43,6 +44,23 @@ namespace ProtoCore.Lang.Replication
                 return "Zipped, indecies: " + indecies;
             }
 
+        }
+
+        public Boolean Equals(ReplicationInstruction oldOption) {
+
+            if (this.Zipped == oldOption.Zipped)
+            {
+                if (this.ZipIndecies == null && oldOption.ZipIndecies == null)
+                    return true;
+
+                if (this.ZipIndecies != null && oldOption.ZipIndecies != null)
+                {
+                    var currentExcludesOldList = this.ZipIndecies.Except(oldOption.ZipIndecies).ToList();
+                    var oldExcludescurrentList = oldOption.ZipIndecies.Except(this.ZipIndecies).ToList();
+                    return !currentExcludesOldList.Any() && !oldExcludescurrentList.Any();
+                }
+            }
+            return false;
         }
     }
 }

--- a/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
+++ b/test/Engine/ProtoTest/Associative/BuiltinMethodsTest.cs
@@ -1069,7 +1069,7 @@ r = Dictionary.ValueAtKey(a, ""nonexist"");
            thisTest.Verify("r", null);
        }
 
-        [Test, Category("Failure")]
+        [Test]
         public void TestTryGetValuesFromDictionary09()
         {
             string code = @"

--- a/test/Engine/ProtoTest/Associative/MethodResolution.cs
+++ b/test/Engine/ProtoTest/Associative/MethodResolution.cs
@@ -396,21 +396,5 @@ z2 = qux2();
             thisTest.Verify("z1", 22);
             thisTest.Verify("z2", 22);
         }
-
-        [Test]
-        public void TestEmptyNestedListsForMethodResolution()
-        {
-            string code = @"import(""FFITarget.dll""); 
-pt = DummyPoint2D.ByCoordinates(0,0);
-l = [[],[pt]];
-px1 = DummyPoint2D.X(l);
-pt = DummyPoint2D.ByCoordinates(0,0);
-l2 = [[pt],[]];
-px2 = DummyPoint2D.X(l2);
-";
-            var mirror = thisTest.RunScriptSource(code);
-            thisTest.Verify("px1", new object[] { new object[] { }, new object[] { 0 } });
-            thisTest.Verify("px2", new object[] { new object[] { 0 }, new object[] { } });
-        }
     }
 }

--- a/test/Engine/ProtoTest/TD/Associative/Replication.cs
+++ b/test/Engine/ProtoTest/TD/Associative/Replication.cs
@@ -4926,7 +4926,66 @@ r = cond<1L> ? vs1<1L> : vs2<1L>;";
             thisTest.RunScriptSource(code);
             thisTest.Verify("r", new object[] { 2, 5, 7 });
         }
-    }
 
+        [Test]
+        public void TestReplicationWithEmptyListInNestedLists()
+        {
+            string code = @"import(""FFITarget.dll""); 
+pt = DummyPoint2D.ByCoordinates(0,0);
+l = [[],[pt]];
+px1 = DummyPoint2D.X(l);
+pt = DummyPoint2D.ByCoordinates(0,0);
+l2 = [[pt],[]];
+px2 = DummyPoint2D.X(l2);
+";
+            var mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("px1", new object[] { new object[] { }, new object[] { 0 } });
+            thisTest.Verify("px2", new object[] { new object[] { 0 }, new object[] { } });
+        }
+
+        [Test]
+        public void TestReplicationWithNullElementInNestedLists()
+        {
+            string code = @"import(""FFITarget.dll""); 
+pt = DummyPoint2D.ByCoordinates(0,0);
+l = [null,[pt]];
+px1 = DummyPoint2D.X(l);
+pt = DummyPoint2D.ByCoordinates(0,0);
+l2 = [[pt],null];
+px2 = DummyPoint2D.X(l2);
+";
+
+            var mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("px1", new object[] { null, new object[] { 0 } });
+            thisTest.Verify("px2", new object[] { new object[] { 0 }, null });
+        }
+
+        [Test]
+        public void TestReplicationWithArraysOfDifferentRanks()
+        {
+            string code = @"import(""FFITarget.dll"");
+t1 = [1, [2]];
+t2 = t1 + 5;
+pt = DummyPoint2D.ByCoordinates(0,0);
+l1 = [[[pt]],[pt]];
+px1 = DummyPoint2D.X(l1);
+l2 = [[pt],[[pt]]];
+px2 = DummyPoint2D.X(l2);
+l3 = [[null],[[pt]]];
+px3 = DummyPoint2D.X(l3);
+l4 = [3.3,[pt],[[pt]]];
+px4 = DummyPoint2D.X(l4);
+l5 = [""test"",[[pt]],[pt]];
+px5 = DummyPoint2D.X(l5);
+";
+            var mirror = thisTest.RunScriptSource(code);
+            thisTest.Verify("t2", new object[] { 6, new object[] { 7 } });
+            thisTest.Verify("px1", new object[] { new object[] { new object[] { 0 } }, new object[] { 0 } });
+            thisTest.Verify("px2", new object[] { new object[] { 0 }, new object[] { new object[] { 0 } } });
+            thisTest.Verify("px3", new object[] { new object[] { null }, new object[] { new object[] { 0 } } });
+            thisTest.Verify("px4", new object[] { null, new object[] { 0 }, new object[] { new object[] { 0 } } });
+            thisTest.Verify("px5", new object[] { null, new object[] { new object[] { 0 } }, new object[] { 0 } });
+        }
+    }
 }
 

--- a/test/Engine/ProtoTest/TD/Associative/Replication.cs
+++ b/test/Engine/ProtoTest/TD/Associative/Replication.cs
@@ -4927,6 +4927,7 @@ r = cond<1L> ? vs1<1L> : vs2<1L>;";
             thisTest.Verify("r", new object[] { 2, 5, 7 });
         }
 
+        // This tests the case 2 block in the computeFeps method(CallSite.cs line:943)
         [Test]
         public void TestReplicationWithEmptyListInNestedLists()
         {
@@ -4943,6 +4944,7 @@ px2 = DummyPoint2D.X(l2);
             thisTest.Verify("px2", new object[] { new object[] { 0 }, new object[] { } });
         }
 
+        // This tests the case 4 block in the computeFeps method(CallSite.cs line:943)
         [Test]
         public void TestReplicationWithNullElementInNestedLists()
         {
@@ -4960,6 +4962,8 @@ px2 = DummyPoint2D.X(l2);
             thisTest.Verify("px2", new object[] { new object[] { 0 }, null });
         }
 
+        // This tests the case:6 block in the computeFeps method(CallSite.cs line:943)
+        // input example for case 6: l4 and l5 lists. 
         [Test]
         public void TestReplicationWithArraysOfDifferentRanks()
         {


### PR DESCRIPTION
### Purpose

This PR is to address a regression issue from 2.0. (https://jira.autodesk.com/browse/DYN-1722)

This also fixes most of the non-regressions from https://jira.autodesk.com/browse/DYN-1496. The only case that is failing would be the second case in the description of the above JIRA. 

Explanation:
Instead of the just returning the first replication option that matches the target function, we check for all the replications that match the target function and then choose the replication option with largest rank. In the case where both cartesian and zipped replication options are possible, we check for the first option that matches the target function and modify the replication option(in next iterations) only if 
a similar replication option, with a higher rank,  is matched with the target function. 

![Replication Fix](https://user-images.githubusercontent.com/43763136/54456834-2e2cba00-4736-11e9-903c-5729d07490a1.gif)

Performance test results on around 11 graphs:

Before the fix:
![before](https://user-images.githubusercontent.com/43763136/54759313-31a3c380-4bc4-11e9-8815-88c5853e79b9.PNG)

After the fix:
![after](https://user-images.githubusercontent.com/43763136/54759339-42543980-4bc4-11e9-8593-35da252d361b.PNG)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@aparajit-pratap @mjkkirschner @QilongTang 

