### PR TITLE
Address refactor bug introduced in #9567

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -273,7 +273,7 @@ namespace Dynamo.Models
 
                 // TODO - can be removed in Dynamo 3.0 - DYN-1729
                 case MakeConnectionCommand.Mode.EndAndStartCtrlConnection:
-                    BeginDuplicateConnection(nodeId, command.PortIndex, command.Type);
+                    BeginCreateConnections(nodeId, command.PortIndex, command.Type);
                     break;
 
                 case MakeConnectionCommand.Mode.BeginDuplicateConnection:

--- a/src/DynamoCoreWpf/Commands/DynamoCommands.cs
+++ b/src/DynamoCoreWpf/Commands/DynamoCommands.cs
@@ -224,7 +224,7 @@ namespace Dynamo.ViewModels
 
                 // TODO - can be removed in Dynamo 3.0 - DYN-1729
                 case DynamoModel.MakeConnectionCommand.Mode.EndAndStartCtrlConnection:
-                    CurrentSpaceViewModel.BeginConnection(
+                    CurrentSpaceViewModel.BeginCreateConnections(
                         nodeId, command.PortIndex, command.Type);
                     break;
 


### PR DESCRIPTION
### Purpose

This PR address a bug introduced in #9567 where the method `EndAndStartCtrlConnection()` in `DynamoModelCommands.cs` was renamed to `BeginCreateConnections()` and where the method `EndAndStartCtrlConnection()` in `StateMachine.cs` was renamed to `BeginCreateConnections()`.  These switch statements were updated to call the wrong methods with similar naming.  All the `RecordedTests` are now passing.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner @QilongTang 

