### PR TITLE
Issue 9577 - Text can be typed whilst the package manager syncs with the server.

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4003,6 +4003,15 @@ namespace Dynamo.Wpf.Properties
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Please wait....
+        /// </summary>
+        public static string PackageSearchViewPleaseWait {
+            get {
+                return ResourceManager.GetString("PackageSearchViewPleaseWait", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Search....
         /// </summary>
         public static string PackageSearchViewSearchTextBox {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4003,20 +4003,20 @@ namespace Dynamo.Wpf.Properties
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Please wait....
-        /// </summary>
-        public static string PackageSearchViewPleaseWait {
-            get {
-                return ResourceManager.GetString("PackageSearchViewPleaseWait", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Search....
         /// </summary>
         public static string PackageSearchViewSearchTextBox {
             get {
                 return ResourceManager.GetString("PackageSearchViewSearchTextBox", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please wait....
+        /// </summary>
+        public static string PackageSearchViewSearchTextBoxSyncing {
+            get {
+                return ResourceManager.GetString("PackageSearchViewSearchTextBoxSyncing", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2184,7 +2184,7 @@ Do you want to install the latest Dynamo update?</value>
   <data name="RerunButtonToolTip" xml:space="preserve">
     <value>Rerun the graph.</value>
   </data>
-  <data name="PackageSearchViewPleaseWait" xml:space="preserve">
+  <data name="PackageSearchViewSearchTextBoxSyncing" xml:space="preserve">
     <value>Please wait...</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2184,4 +2184,7 @@ Do you want to install the latest Dynamo update?</value>
   <data name="RerunButtonToolTip" xml:space="preserve">
     <value>Rerun the graph.</value>
   </data>
+  <data name="PackageSearchViewPleaseWait" xml:space="preserve">
+    <value>Please wait...</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2187,4 +2187,7 @@ Want to publish a different package?</value>
   <data name="CrashPromptGithubNewIssueTitle" xml:space="preserve">
     <value>Crash report from Dynamo {0}</value>
   </data>
+  <data name="PackageSearchViewPleaseWait" xml:space="preserve">
+    <value>Please wait...</value>
+  </data>
 </root>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2187,7 +2187,7 @@ Want to publish a different package?</value>
   <data name="CrashPromptGithubNewIssueTitle" xml:space="preserve">
     <value>Crash report from Dynamo {0}</value>
   </data>
-  <data name="PackageSearchViewPleaseWait" xml:space="preserve">
+  <data name="PackageSearchViewSearchTextBoxSyncing" xml:space="preserve">
     <value>Please wait...</value>
   </data>
 </root>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -88,7 +88,7 @@ namespace Dynamo.PackageManager
             {
                 if(SearchState == PackageSearchState.Syncing)
                 {
-                    return Resources.PackageSearchViewPleaseWait;
+                    return Resources.PackageSearchViewSearchTextBoxSyncing;
                 }
                 return Resources.PackageSearchViewSearchTextBox;
             }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -53,7 +53,7 @@ namespace Dynamo.PackageManager
         /// <value>
         ///     Set which kind of sorting should be used for displaying search results
         /// </value>
-        public PackageSortingKey _sortingKey;
+        public PackageSortingKey _sortingKey; // TODO: Set private for 3.0.
         public PackageSortingKey SortingKey
         {
             get { return _sortingKey; }
@@ -71,7 +71,7 @@ namespace Dynamo.PackageManager
         /// <value>
         ///     Set which kind of sorting should be used for displaying search results
         /// </value>
-        public PackageSortingDirection _sortingDirection;
+        public PackageSortingDirection _sortingDirection; // TODO: Set private for 3.0.
         public PackageSortingDirection SortingDirection
         {
             get { return _sortingDirection; }
@@ -124,7 +124,7 @@ namespace Dynamo.PackageManager
         /// <value>
         ///     This is the core UI for Dynamo, primarily used for logging.
         /// </value>
-        public string _SearchText;
+        public string _SearchText; // TODO: Set private for 3.0.
         public string SearchText
         {
             get { return _SearchText; }
@@ -182,7 +182,7 @@ namespace Dynamo.PackageManager
         }
 
 
-        public PackageSearchState _searchState;
+        public PackageSearchState _searchState; // TODO: Set private for 3.0.
 
         /// <summary>
         /// Gives the current state of search.

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -82,6 +82,33 @@ namespace Dynamo.PackageManager
             }
         }
 
+        public string SearchBoxPrompt
+        {
+            get
+            {
+                if(SearchState == PackageSearchState.Syncing)
+                {
+                    return Resources.PackageSearchViewPleaseWait;
+                }
+                return Resources.PackageSearchViewSearchTextBox;
+            }
+        }
+
+        public bool ShowSearchText
+        {
+            get
+            {
+                if(SearchState == PackageSearchState.Syncing)
+                {
+                    return false;
+                }
+                else
+                {
+                    return true;
+                }
+            }
+        }
+
         /// <summary>
         ///     SearchText property
         /// </summary>
@@ -156,6 +183,8 @@ namespace Dynamo.PackageManager
             {
                 _searchState = value;
                 RaisePropertyChanged("SearchState");
+                RaisePropertyChanged("SearchBoxPrompt");
+                RaisePropertyChanged("ShowSearchText");
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -82,6 +82,9 @@ namespace Dynamo.PackageManager
             }
         }
 
+        /// <summary>
+        /// The string that is displayed in the search box prompt depending on the search state.
+        /// </summary>
         public string SearchBoxPrompt
         {
             get
@@ -94,6 +97,12 @@ namespace Dynamo.PackageManager
             }
         }
 
+        /// <summary>
+        /// Determines whether the the search text box should be displayed.
+        /// <para>
+        /// Returns false if the search state is syncing, 
+        /// </para>
+        /// </summary>
         public bool ShowSearchText
         {
             get
@@ -172,19 +181,21 @@ namespace Dynamo.PackageManager
             get { return this.SearchResults.Count == 0; }
         }
 
+
+        public PackageSearchState _searchState;
+
         /// <summary>
         /// Gives the current state of search.
         /// </summary>
-        public PackageSearchState _searchState;
         public PackageSearchState SearchState
         {
             get { return _searchState; }
             set
             {
                 _searchState = value;
-                RaisePropertyChanged("SearchState");
-                RaisePropertyChanged("SearchBoxPrompt");
-                RaisePropertyChanged("ShowSearchText");
+                RaisePropertyChanged(nameof(this.SearchState));
+                RaisePropertyChanged(nameof(this.SearchBoxPrompt));
+                RaisePropertyChanged(nameof(this.ShowSearchText));
             }
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -142,18 +142,18 @@
 
             <TextBlock Grid.Row ="1" Grid.ZIndex ="1" FontSize="13" HorizontalAlignment="Center" Foreground="Gray" VerticalAlignment="Center" Name="NoResultsIndicator" TextAlignment="Center" Margin="20" Text="{Binding Path=SearchState, Converter={StaticResource PackageSearchStateToStringConverter}}"/>
 
-            <Grid Name="RSearchBoxStackPanel" Grid.Row="0">
+            <Grid Name="RSearchBoxStackPanel" Grid.Row="0" Background="#222">
 
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"></ColumnDefinition>
                     <ColumnDefinition Width="Auto"></ColumnDefinition>
                 </Grid.ColumnDefinitions>
 
-                <TextBox Style="{DynamicResource PackageSearchTextBox}" Grid.Column="0" Name="SearchTextBox" KeyboardNavigation.TabIndex="0" Foreground="WhiteSmoke" Background="#222" BorderThickness="0" FontSize ="13" Padding="10,10,5,10" Margin ="0"
+                <TextBox Style="{DynamicResource PackageSearchTextBox}" Grid.Column="0" Name="SearchTextBox" KeyboardNavigation.TabIndex="0" Foreground="WhiteSmoke" Background="Transparent" CaretBrush="White" BorderThickness="0" FontSize ="13" Padding="10,10,5,10" Margin ="0"
                        IsEnabled="True" TextChanged="SearchTextBox_TextChanged" VerticalAlignment="Stretch" Text="{Binding Path=SearchText, Mode=TwoWay}">
                 </TextBox>
 
-                <TextBlock Style="{DynamicResource PackageSearchTextBlock}" Grid.Column="0" FontSize ="13" Padding="20,10,5,10" Margin ="0" Background="Transparent" 
+                <TextBlock Style="{DynamicResource PackageSearchTextBlock}" Grid.Column="0" FontSize ="13" Padding="20,10,5,10" Margin ="0" Background="Transparent"
                            Foreground="#666" 
                            IsHitTestVisible="False"/>
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -12,6 +12,27 @@
 
     <Window.Resources>
         <ResourceDictionary>
+
+            <Style x:Key="PackageSearchTextBox" TargetType="TextBox">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding SearchState}" Value="Syncing">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style x:Key="PackageSearchTextBlock" TargetType="TextBlock">
+                <Setter Property="Text" Value="{x:Static p:Resources.PackageSearchViewSearchTextBox}"/>
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding SearchState}" Value="Syncing">
+                        <Setter Property="Text" Value="{x:Static p:Resources.PackageSearchViewPleaseWait}"/>
+                    </DataTrigger>
+                    <DataTrigger  Binding="{Binding Path=SearchText, Converter={StaticResource NonEmptyStringToCollapsedConverter}}" Value="Collapsed">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+
             <!-- An unstyled button -->
             <Style x:Key="FlatButton" TargetType="Button">
                 <Setter Property="Background" Value="{x:Null}" />

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -149,15 +149,13 @@
                     <ColumnDefinition Width="Auto"></ColumnDefinition>
                 </Grid.ColumnDefinitions>
 
-                <TextBox Grid.Column="0" Name="SearchTextBox" KeyboardNavigation.TabIndex="0" Foreground="WhiteSmoke" Background="#222" BorderThickness="0" FontSize ="13" Padding="10,10,5,10" Margin ="0"
+                <TextBox Style="{DynamicResource PackageSearchTextBox}" Grid.Column="0" Name="SearchTextBox" KeyboardNavigation.TabIndex="0" Foreground="WhiteSmoke" Background="#222" BorderThickness="0" FontSize ="13" Padding="10,10,5,10" Margin ="0"
                        IsEnabled="True" TextChanged="SearchTextBox_TextChanged" VerticalAlignment="Stretch" Text="{Binding Path=SearchText, Mode=TwoWay}">
                 </TextBox>
 
-                <TextBlock Grid.Column="0" FontSize ="13" Padding="20,10,5,10" Margin ="0" Background="Transparent" 
+                <TextBlock Style="{DynamicResource PackageSearchTextBlock}" Grid.Column="0" FontSize ="13" Padding="20,10,5,10" Margin ="0" Background="Transparent" 
                            Foreground="#666" 
-                           IsHitTestVisible="False"
-                           Visibility="{Binding Path=SearchText, Converter={StaticResource NonEmptyStringToCollapsedConverter}}"
-                           Text="{x:Static p:Resources.PackageSearchViewSearchTextBox}"/>
+                           IsHitTestVisible="False"/>
 
                 <Button Width="auto" MinWidth="80" Grid.Column="1" Click="OnSortButtonClicked"
                         Style="{DynamicResource ResourceKey=STextButton}" Content="{x:Static p:Resources.PackageSearchViewSortByButton}">

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -13,26 +13,6 @@
     <Window.Resources>
         <ResourceDictionary>
 
-            <Style x:Key="PackageSearchTextBox" TargetType="TextBox">
-                <Style.Triggers>
-                    <DataTrigger Binding="{Binding SearchState}" Value="Syncing">
-                        <Setter Property="Visibility" Value="Collapsed"/>
-                    </DataTrigger>
-                </Style.Triggers>
-            </Style>
-
-            <Style x:Key="PackageSearchTextBlock" TargetType="TextBlock">
-                <Setter Property="Text" Value="{x:Static p:Resources.PackageSearchViewSearchTextBox}"/>
-                <Style.Triggers>
-                    <DataTrigger Binding="{Binding SearchState}" Value="Syncing">
-                        <Setter Property="Text" Value="{x:Static p:Resources.PackageSearchViewPleaseWait}"/>
-                    </DataTrigger>
-                    <DataTrigger  Binding="{Binding Path=SearchText, Converter={StaticResource NonEmptyStringToCollapsedConverter}}" Value="Collapsed">
-                        <Setter Property="Visibility" Value="Collapsed"/>
-                    </DataTrigger>
-                </Style.Triggers>
-            </Style>
-
             <!-- An unstyled button -->
             <Style x:Key="FlatButton" TargetType="Button">
                 <Setter Property="Background" Value="{x:Null}" />
@@ -149,13 +129,14 @@
                     <ColumnDefinition Width="Auto"></ColumnDefinition>
                 </Grid.ColumnDefinitions>
 
-                <TextBox Style="{DynamicResource PackageSearchTextBox}" Grid.Column="0" Name="SearchTextBox" KeyboardNavigation.TabIndex="0" Foreground="WhiteSmoke" Background="Transparent" CaretBrush="White" BorderThickness="0" FontSize ="13" Padding="10,10,5,10" Margin ="0"
-                       IsEnabled="True" TextChanged="SearchTextBox_TextChanged" VerticalAlignment="Stretch" Text="{Binding Path=SearchText, Mode=TwoWay}">
+                <TextBox Visibility="{Binding ShowSearchText, Converter={StaticResource BooleanToVisibilityConverter}}" Text="{Binding Path=SearchText, Mode=TwoWay}"
+                         Grid.Column="0" Name="SearchTextBox" KeyboardNavigation.TabIndex="0" Foreground="WhiteSmoke" Background="Transparent" CaretBrush="White" 
+                         BorderThickness="0" FontSize ="13" Padding="10,10,5,10" Margin ="0" TextChanged="SearchTextBox_TextChanged" VerticalAlignment="Stretch">
                 </TextBox>
 
-                <TextBlock Style="{DynamicResource PackageSearchTextBlock}" Grid.Column="0" FontSize ="13" Padding="20,10,5,10" Margin ="0" Background="Transparent"
-                           Foreground="#666" 
-                           IsHitTestVisible="False"/>
+                <TextBlock Text="{Binding SearchBoxPrompt}" Visibility="{Binding Path=SearchText, Converter={StaticResource NonEmptyStringToCollapsedConverter}}" 
+                           Grid.Column="0" FontSize ="13" Padding="20,10,5,10" Margin ="0" Background="Transparent" Foreground="#666" IsHitTestVisible="False">
+                </TextBlock>
 
                 <Button Width="auto" MinWidth="80" Grid.Column="1" Click="OnSortButtonClicked"
                         Style="{DynamicResource ResourceKey=STextButton}" Content="{x:Static p:Resources.PackageSearchViewSortByButton}">

--- a/test/DynamoCoreWpfTests/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpfTests/PackageManagerUITests.cs
@@ -158,6 +158,84 @@ namespace DynamoCoreWpfTests
 
         }
 
+        [Test]
+        public void PackageSearchDialogSearchTextCollapsedWhileSyncing()
+        {
+            // Arrange
+            PackageManagerSearchViewModel searchViewModel = new PackageManagerSearchViewModel();
+
+            // Act
+            searchViewModel.SearchState = PackageManagerSearchViewModel.PackageSearchState.Syncing;
+
+            // Assert
+            Assert.AreEqual(false, searchViewModel.ShowSearchText);
+        }
+
+        [Test]
+        public void PackageSearchDialogSearchTextVisibleWithResults()
+        {
+            // Arrange
+            PackageManagerSearchViewModel searchViewModel = new PackageManagerSearchViewModel();
+
+            // Act
+            searchViewModel.SearchState = PackageManagerSearchViewModel.PackageSearchState.Results;
+
+            // Assert
+            Assert.AreEqual(true, searchViewModel.ShowSearchText);
+        }
+
+        [Test]
+        public void PackageSearchDialogSearchTextVisibleWhenSearching()
+        {
+            // Arrange
+            PackageManagerSearchViewModel searchViewModel = new PackageManagerSearchViewModel();
+
+            // Act
+            searchViewModel.SearchState = PackageManagerSearchViewModel.PackageSearchState.Searching;
+
+            // Assert
+            Assert.AreEqual(true, searchViewModel.ShowSearchText);
+        }
+
+        [Test]
+        public void PackageSearchDialogSearchTextVisibleWhenNoResults()
+        {
+            // Arrange
+            PackageManagerSearchViewModel searchViewModel = new PackageManagerSearchViewModel();
+
+            // Act
+            searchViewModel.SearchState = PackageManagerSearchViewModel.PackageSearchState.NoResults;
+
+            // Assert
+            Assert.AreEqual(true, searchViewModel.ShowSearchText);
+        }
+
+        [Test]
+        public void PackageSearchDialogSearchBoxPromptTextWhileSyncing()
+        {
+            // Arrange
+            PackageManagerSearchViewModel searchViewModel = new PackageManagerSearchViewModel();
+
+            // Act
+            searchViewModel.SearchState = PackageManagerSearchViewModel.PackageSearchState.Syncing;
+
+            // Assert
+            Assert.AreEqual(Dynamo.Wpf.Properties.Resources.PackageSearchViewSearchTextBoxSyncing, searchViewModel.SearchBoxPrompt);
+        }
+
+        [Test]
+        public void PackageSearchDialogSearchBoxPromptTextWhenNotSyncing()
+        {
+            // Arrange
+            PackageManagerSearchViewModel searchViewModel = new PackageManagerSearchViewModel();
+
+            // Act
+            searchViewModel.SearchState = PackageManagerSearchViewModel.PackageSearchState.Results;
+
+            // Assert
+            Assert.AreEqual(Dynamo.Wpf.Properties.Resources.PackageSearchViewSearchTextBox, searchViewModel.SearchBoxPrompt);
+        }
+
         #endregion
 
     }


### PR DESCRIPTION
### Purpose

Fixes [Issue 9577](https://github.com/DynamoDS/Dynamo/issues/9577). The search text box is now collapsed until the package manager has finished syncing with the server. After this the search box functions as before.

![PackageSearchFix](https://user-images.githubusercontent.com/46380195/54523104-a7125880-4966-11e9-8a08-b5d60bae32cf.png)

![PackageSearchFix_AfterSync](https://user-images.githubusercontent.com/46380195/54522320-d3c57080-4964-11e9-9174-f5c665270a59.png)

![PackageSearchFix_AfterType](https://user-images.githubusercontent.com/46380195/54522327-d58f3400-4964-11e9-805a-80b89b42d43a.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
